### PR TITLE
Update tox.ini to ignore integ test data

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ exclude =
     examples/
     *pb2.py
     .tox
-    sagemaker/tests/data/
+    tests/data/
 max-complexity = 10
 
 [testenv]


### PR DESCRIPTION
The current configuration presumes that the test data exists under the `sagemaker` directory, but the `tests` directory has since been moved out of `sagemaker`.