### PR TITLE
Add flake8 within travis build

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,10 @@
 envlist = py27,py35,flake8
 skip_missing_interpreters = False
 
+[travis]
+python =
+  3.5: py35, flake8
+
 [flake8]
 max-line-length = 120
 exclude =


### PR DESCRIPTION
Travis will run flake8 for python 3.5 tests.