### PR TITLE
Add integration tests for basic training failure cases

### DIFF
--- a/tests/data/iris/failure_script.py
+++ b/tests/data/iris/failure_script.py
@@ -1,0 +1,3 @@
+def estimator_fn(run_config, params):
+    """For use with integration tests expecting failures."""
+    raise Exception('This failure is expected.')

--- a/tests/data/mxnet_mnist/failure_script.py
+++ b/tests/data/mxnet_mnist/failure_script.py
@@ -1,0 +1,3 @@
+def train(**kwargs):
+    """For use with integration tests expecting failures."""
+    raise Exception('This failure is expected.')


### PR DESCRIPTION
Just a start toward having a more comprehensive integ test suite - this change adds a simple training failure test for MXNet and TF