### PR TITLE
Correctly handle TooManyBuckets error_code in default_bucket method

### DIFF
--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -170,6 +170,14 @@ class Session(object):
             elif error_code == 'OperationAborted' and 'conflicting conditional operation' in message:
                 # If this bucket is already being concurrently created, we don't need to create it again.
                 pass
+            elif error_code == 'TooManyBuckets':
+                try:
+                    s3.meta.client.head_bucket(Bucket=default_bucket)
+                    LOGGER.info('S3 bucket {} already exists'.format(
+                        default_bucket))
+                    pass
+                except ClientError:
+                    raise
             else:
                 raise
 

--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -171,10 +171,9 @@ class Session(object):
                 # If this bucket is already being concurrently created, we don't need to create it again.
                 pass
             elif error_code == 'TooManyBuckets':
+                # Succeed if the default bucket exists
                 try:
                     s3.meta.client.head_bucket(Bucket=default_bucket)
-                    LOGGER.info('S3 bucket {} already exists'.format(
-                        default_bucket))
                     pass
                 except ClientError:
                     raise


### PR DESCRIPTION
At my organisation we have reached our maximum number of allowed buckets on `s3` and as a direct consequence of that we started getting the following error when using the `sagemaker-python-sdk`:
```
INFO:botocore.vendored.requests.packages.urllib3.connectionpool:Starting new HTTPS connection (1): s3.amazonaws.com
Traceback (most recent call last):
  File "/Users/joan.alabort/miniconda3/envs/beatrix_27/bin/sagemaker", line 6, in <module>
    exec(compile(open(__file__).read(), __file__, 'exec'))
  File "/Users/joan.alabort/cvdev/beatrix/hudl_beatrix/cli/bin/sagemaker", line 6, in <module>
    fire.Fire(component=SageMakerRunner)
  File "/Users/joan.alabort/miniconda3/envs/beatrix_27/lib/python2.7/site-packages/fire/core.py", line 127, in Fire
    component_trace = _Fire(component, args, context, name)
  File "/Users/joan.alabort/miniconda3/envs/beatrix_27/lib/python2.7/site-packages/fire/core.py", line 366, in _Fire
    component, remaining_args)
  File "/Users/joan.alabort/miniconda3/envs/beatrix_27/lib/python2.7/site-packages/fire/core.py", line 542, in _CallCallable
    result = fn(*varargs, **kwargs)
  File "/Users/joan.alabort/cvdev/beatrix/hudl_beatrix/sagemaker/base.py", line 314, in train
    self._train(source_local_path, dataset_s3_path, job_name)
  File "/Users/joan.alabort/cvdev/beatrix/hudl_beatrix/sagemaker/base.py", line 364, in _train
    run_tensorboard_locally=self._run_tensorboard_locally
  File "/Users/joan.alabort/miniconda3/envs/beatrix_27/lib/python2.7/site-packages/sagemaker/tensorflow/estimator.py", line 162, in fit
    fit_super()
  File "/Users/joan.alabort/miniconda3/envs/beatrix_27/lib/python2.7/site-packages/sagemaker/tensorflow/estimator.py", line 154, in fit_super
    super(TensorFlow, self).fit(inputs, wait, logs, job_name)
  File "/Users/joan.alabort/miniconda3/envs/beatrix_27/lib/python2.7/site-packages/sagemaker/estimator.py", line 498, in fit
    code_bucket = self.sagemaker_session.default_bucket()
  File "/Users/joan.alabort/miniconda3/envs/beatrix_27/lib/python2.7/site-packages/sagemaker/session.py", line 159, in default_bucket
    s3.create_bucket(Bucket=default_bucket)
  File "/Users/joan.alabort/miniconda3/envs/beatrix_27/lib/python2.7/site-packages/boto3/resources/factory.py", line 520, in do_action
    response = action(self, *args, **kwargs)
  File "/Users/joan.alabort/miniconda3/envs/beatrix_27/lib/python2.7/site-packages/boto3/resources/action.py", line 83, in __call__
    response = getattr(parent.meta.client, operation_name)(**params)
  File "/Users/joan.alabort/miniconda3/envs/beatrix_27/lib/python2.7/site-packages/botocore/client.py", line 317, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/Users/joan.alabort/miniconda3/envs/beatrix_27/lib/python2.7/site-packages/botocore/client.py", line 615, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.exceptions.ClientError: An error occurred (TooManyBuckets) when calling the CreateBucket operation: You have attempted to create more buckets than allowed
```
This little patch seems to take care of this issue.

I could not find much information in terms of the expected PR structure so I hope this suffices, happy to make the pertinent changes if it does not. 