### PR TITLE
Fixing timeouts for PCA async integration test.

### DIFF
--- a/tests/integ/test_pca.py
+++ b/tests/integ/test_pca.py
@@ -66,7 +66,7 @@ def test_async_pca():
     endpoint_name = name_from_base('pca')
     sagemaker_session = sagemaker.Session(boto_session=boto3.Session(region_name=REGION))
 
-    with timeout(minutes=20):
+    with timeout(minutes=5):
 
         data_path = os.path.join(DATA_DIR, 'one_p_mnist', 'mnist.pkl.gz')
         pickle_args = {} if sys.version_info.major == 2 else {'encoding': 'latin1'}
@@ -88,7 +88,7 @@ def test_async_pca():
         print("Detached from training job. Will re-attach in 20 seconds")
         time.sleep(20)
 
-    with timeout_and_delete_endpoint_by_name(endpoint_name, sagemaker_session, minutes=20):
+    with timeout_and_delete_endpoint_by_name(endpoint_name, sagemaker_session, minutes=35):
         estimator = sagemaker.amazon.pca.PCA.attach(training_job_name=training_job_name,
                                                     sagemaker_session=sagemaker_session)
 

--- a/tests/integ/test_tf_cifar.py
+++ b/tests/integ/test_tf_cifar.py
@@ -51,7 +51,7 @@ def test_cifar(sagemaker_session):
                                base_job_name='test-cifar')
 
         inputs = estimator.sagemaker_session.upload_data(path=dataset_path, key_prefix='data/cifar10')
-        estimator.fit(inputs)
+        estimator.fit(inputs, logs=False)
         print('job succeeded: {}'.format(estimator.latest_training_job.name))
 
     with timeout_and_delete_endpoint(estimator=estimator, minutes=20):


### PR DESCRIPTION
Opting to execute tf_cifar test without logs to eliminate delay to detect that job has finished.