### PR TITLE
Create configurable sagemaker_session fixture for all integ tests

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,13 +2,18 @@
 CHANGELOG
 =========
 
+1.1.dev3
+========
+
+* feature: Tests: create configurable ``sagemaker_session`` pytest fixture for all integration tests
+
 1.1.2
-=======
+=====
 
 * bug-fix: AmazonEstimators: do not call create bucket if data location is provided
 
 1.1.1
-========
+=====
 
 * feature: Estimators: add ``requirements.txt`` support for TensorFlow
 

--- a/tests/integ/__init__.py
+++ b/tests/integ/__init__.py
@@ -12,8 +12,8 @@
 # language governing permissions and limitations under the License.
 import logging
 import os
+
 DATA_DIR = os.path.join(os.path.dirname(__file__), '..', 'data')
-REGION = 'us-west-2'
 
 logging.getLogger('boto3').setLevel(logging.INFO)
 logging.getLogger('botocore').setLevel(logging.INFO)

--- a/tests/integ/test_factorization_machines.py
+++ b/tests/integ/test_factorization_machines.py
@@ -11,24 +11,19 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import gzip
+import os
 import pickle
 import sys
 import time
 
-import boto3
-import os
-
-import sagemaker
 from sagemaker import FactorizationMachines, FactorizationMachinesModel
 from sagemaker.utils import name_from_base
-from tests.integ import DATA_DIR, REGION
+from tests.integ import DATA_DIR
 from tests.integ.timeout import timeout, timeout_and_delete_endpoint_by_name
 
 
-def test_factorization_machines():
-
+def test_factorization_machines(sagemaker_session):
     with timeout(minutes=15):
-        sagemaker_session = sagemaker.Session(boto_session=boto3.Session(region_name=REGION))
         data_path = os.path.join(DATA_DIR, 'one_p_mnist', 'mnist.pkl.gz')
         pickle_args = {} if sys.version_info.major == 2 else {'encoding': 'latin1'}
 
@@ -56,14 +51,11 @@ def test_factorization_machines():
             assert record.label["score"] is not None
 
 
-def test_async_factorization_machines():
-
+def test_async_factorization_machines(sagemaker_session):
     training_job_name = ""
     endpoint_name = name_from_base('factorizationMachines')
-    sagemaker_session = sagemaker.Session(boto_session=boto3.Session(region_name=REGION))
 
     with timeout(minutes=5):
-
         data_path = os.path.join(DATA_DIR, 'one_p_mnist', 'mnist.pkl.gz')
         pickle_args = {} if sys.version_info.major == 2 else {'encoding': 'latin1'}
 

--- a/tests/integ/test_kmeans.py
+++ b/tests/integ/test_kmeans.py
@@ -11,24 +11,19 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import gzip
+import os
 import pickle
 import sys
-
-import boto3
-import os
 import time
 
-import sagemaker
 from sagemaker import KMeans, KMeansModel
 from sagemaker.utils import name_from_base
-from tests.integ import DATA_DIR, REGION
+from tests.integ import DATA_DIR
 from tests.integ.timeout import timeout, timeout_and_delete_endpoint_by_name
 
 
-def test_kmeans():
-
+def test_kmeans(sagemaker_session):
     with timeout(minutes=15):
-        sagemaker_session = sagemaker.Session(boto_session=boto3.Session(region_name=REGION))
         data_path = os.path.join(DATA_DIR, 'one_p_mnist', 'mnist.pkl.gz')
         pickle_args = {} if sys.version_info.major == 2 else {'encoding': 'latin1'}
 
@@ -63,13 +58,11 @@ def test_kmeans():
             assert record.label["distance_to_cluster"] is not None
 
 
-def test_async_kmeans():
-
+def test_async_kmeans(sagemaker_session):
     training_job_name = ""
     endpoint_name = name_from_base('kmeans')
 
     with timeout(minutes=5):
-        sagemaker_session = sagemaker.Session(boto_session=boto3.Session(region_name=REGION))
         data_path = os.path.join(DATA_DIR, 'one_p_mnist', 'mnist.pkl.gz')
         pickle_args = {} if sys.version_info.major == 2 else {'encoding': 'latin1'}
 

--- a/tests/integ/test_lda.py
+++ b/tests/integ/test_lda.py
@@ -10,24 +10,20 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import boto3
-import numpy as np
 import os
 
-import sagemaker
+import numpy as np
+
 from sagemaker import LDA, LDAModel
 from sagemaker.amazon.common import read_records
 from sagemaker.utils import name_from_base
-
-from tests.integ import DATA_DIR, REGION
+from tests.integ import DATA_DIR
 from tests.integ.timeout import timeout, timeout_and_delete_endpoint_by_name
 from tests.integ.record_set import prepare_record_set_from_local_files
 
 
-def test_lda():
-
+def test_lda(sagemaker_session):
     with timeout(minutes=15):
-        sagemaker_session = sagemaker.Session(boto_session=boto3.Session(region_name=REGION))
         data_path = os.path.join(DATA_DIR, 'lda')
         data_filename = 'nips-train_1.pbr'
 

--- a/tests/integ/test_linear_learner.py
+++ b/tests/integ/test_linear_learner.py
@@ -15,21 +15,17 @@ import os
 import pickle
 import sys
 import time
-import pytest  # noqa
-import boto3
+
 import numpy as np
 
-import sagemaker
 from sagemaker.amazon.linear_learner import LinearLearner, LinearLearnerModel
 from sagemaker.utils import name_from_base, sagemaker_timestamp
-
-from tests.integ import DATA_DIR, REGION
+from tests.integ import DATA_DIR
 from tests.integ.timeout import timeout, timeout_and_delete_endpoint_by_name
 
 
-def test_linear_learner():
+def test_linear_learner(sagemaker_session):
     with timeout(minutes=15):
-        sagemaker_session = sagemaker.Session(boto_session=boto3.Session(region_name=REGION))
         data_path = os.path.join(DATA_DIR, 'one_p_mnist', 'mnist.pkl.gz')
         pickle_args = {} if sys.version_info.major == 2 else {'encoding': 'latin1'}
 
@@ -87,14 +83,11 @@ def test_linear_learner():
             assert record.label["score"] is not None
 
 
-def test_async_linear_learner():
-
+def test_async_linear_learner(sagemaker_session):
     training_job_name = ""
     endpoint_name = 'test-linear-learner-async-{}'.format(sagemaker_timestamp())
-    sagemaker_session = sagemaker.Session(boto_session=boto3.Session(region_name=REGION))
 
     with timeout(minutes=5):
-
         data_path = os.path.join(DATA_DIR, 'one_p_mnist', 'mnist.pkl.gz')
         pickle_args = {} if sys.version_info.major == 2 else {'encoding': 'latin1'}
 

--- a/tests/integ/test_mxnet_train.py
+++ b/tests/integ/test_mxnet_train.py
@@ -13,21 +13,14 @@
 import os
 import time
 
-import boto3
 import numpy
 import pytest
-from sagemaker import Session
+
 from sagemaker.mxnet.estimator import MXNet
 from sagemaker.mxnet.model import MXNetModel
 from sagemaker.utils import sagemaker_timestamp
-
-from tests.integ import DATA_DIR, REGION
+from tests.integ import DATA_DIR
 from tests.integ.timeout import timeout, timeout_and_delete_endpoint_by_name
-
-
-@pytest.fixture(scope='module')
-def sagemaker_session():
-    return Session(boto_session=boto3.Session(region_name=REGION))
 
 
 @pytest.fixture(scope='module')

--- a/tests/integ/test_ntm.py
+++ b/tests/integ/test_ntm.py
@@ -10,24 +10,20 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import boto3
-import numpy as np
 import os
 
-import sagemaker
+import numpy as np
+
 from sagemaker import NTM, NTMModel
 from sagemaker.amazon.common import read_records
 from sagemaker.utils import name_from_base
-
-from tests.integ import DATA_DIR, REGION
+from tests.integ import DATA_DIR
 from tests.integ.timeout import timeout, timeout_and_delete_endpoint_by_name
 from tests.integ.record_set import prepare_record_set_from_local_files
 
 
-def test_ntm():
-
+def test_ntm(sagemaker_session):
     with timeout(minutes=15):
-        sagemaker_session = sagemaker.Session(boto_session=boto3.Session(region_name=REGION))
         data_path = os.path.join(DATA_DIR, 'ntm')
         data_filename = 'nips-train_1.pbr'
 

--- a/tests/integ/test_pca.py
+++ b/tests/integ/test_pca.py
@@ -16,20 +16,14 @@ import pickle
 import sys
 import time
 
-import pytest  # noqa
-import boto3
-
-import sagemaker
 import sagemaker.amazon.pca
 from sagemaker.utils import name_from_base
-
-from tests.integ import DATA_DIR, REGION
+from tests.integ import DATA_DIR
 from tests.integ.timeout import timeout, timeout_and_delete_endpoint_by_name
 
 
-def test_pca():
+def test_pca(sagemaker_session):
     with timeout(minutes=15):
-        sagemaker_session = sagemaker.Session(boto_session=boto3.Session(region_name=REGION))
         data_path = os.path.join(DATA_DIR, 'one_p_mnist', 'mnist.pkl.gz')
         pickle_args = {} if sys.version_info.major == 2 else {'encoding': 'latin1'}
 
@@ -60,14 +54,11 @@ def test_pca():
             assert record.label["projection"] is not None
 
 
-def test_async_pca():
-
+def test_async_pca(sagemaker_session):
     training_job_name = ""
     endpoint_name = name_from_base('pca')
-    sagemaker_session = sagemaker.Session(boto_session=boto3.Session(region_name=REGION))
 
     with timeout(minutes=5):
-
         data_path = os.path.join(DATA_DIR, 'one_p_mnist', 'mnist.pkl.gz')
         pickle_args = {} if sys.version_info.major == 2 else {'encoding': 'latin1'}
 

--- a/tests/integ/test_tf.py
+++ b/tests/integ/test_tf.py
@@ -10,22 +10,16 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import boto3
 import os
-import pytest
 import time
 
-from sagemaker import Session
+import pytest
+
 from sagemaker.tensorflow import TensorFlow
-from tests.integ import DATA_DIR, REGION
+from tests.integ import DATA_DIR
 from tests.integ.timeout import timeout_and_delete_endpoint, timeout
 
 DATA_PATH = os.path.join(DATA_DIR, 'iris', 'data')
-
-
-@pytest.fixture(scope='module')
-def sagemaker_session():
-    return Session(boto_session=boto3.Session(region_name=REGION))
 
 
 def test_tf(sagemaker_session, tf_full_version):
@@ -60,7 +54,6 @@ def test_tf(sagemaker_session, tf_full_version):
 
 
 def test_tf_async(sagemaker_session, tf_full_version):
-
     training_job_name = ""
     with timeout(minutes=5):
         script_path = os.path.join(DATA_DIR, 'iris', 'iris-dnn-classifier.py')

--- a/tests/integ/test_tf_cifar.py
+++ b/tests/integ/test_tf_cifar.py
@@ -10,24 +10,16 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import os
 import pickle
 
-import boto3
 import numpy as np
-import os
-import pytest
 
-from sagemaker import Session
 from sagemaker.tensorflow import TensorFlow
-from tests.integ import DATA_DIR, REGION
+from tests.integ import DATA_DIR
 from tests.integ.timeout import timeout_and_delete_endpoint, timeout
 
 PICKLE_CONTENT_TYPE = 'application/python-pickle'
-
-
-@pytest.fixture(scope='module')
-def sagemaker_session():
-    return Session(boto_session=boto3.Session(region_name=REGION))
 
 
 class PickleSerializer(object):


### PR DESCRIPTION
* revised the integ tests so that they're using a common pytest fixture for `sagemaker_session` (does not get created if not used, i.e. during unit tests)
* added configuration options for aforementioned pytest fixture