### PR TITLE
Fix region-handling for integ test sagemaker_session

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,7 +48,8 @@ def boto_config(request):
 def sagemaker_session(sagemaker_client_config, sagemaker_runtime_config, boto_config):
     boto_session = boto3.Session(**boto_config) if boto_config else boto3.Session(region_name=DEFAULT_REGION)
     sagemaker_client = boto_session.client('sagemaker', **sagemaker_client_config) if sagemaker_client_config else None
-    runtime_client = boto_session.client('sagemaker-runtime', **sagemaker_runtime_config) if sagemaker_runtime_config else None
+    runtime_client = (boto_session.client('sagemaker-runtime', **sagemaker_runtime_config) if sagemaker_runtime_config
+                      else None)
 
     return Session(boto_session=boto_session,
                    sagemaker_client=sagemaker_client,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,9 +46,9 @@ def boto_config(request):
 
 @pytest.fixture(scope='session')
 def sagemaker_session(sagemaker_client_config, sagemaker_runtime_config, boto_config):
-    sagemaker_client = boto3.client('sagemaker', **sagemaker_client_config) if sagemaker_client_config else None
-    runtime_client = boto3.client('sagemaker-runtime', **sagemaker_runtime_config) if sagemaker_runtime_config else None
     boto_session = boto3.Session(**boto_config) if boto_config else boto3.Session(region_name=DEFAULT_REGION)
+    sagemaker_client = boto_session.client('sagemaker', **sagemaker_client_config) if sagemaker_client_config else None
+    runtime_client = boto_session.client('sagemaker-runtime', **sagemaker_runtime_config) if sagemaker_runtime_config else None
 
     return Session(boto_session=boto_session,
                    sagemaker_client=sagemaker_client,


### PR DESCRIPTION
there is a bug where if the region is not configured at all on the box, boto3 will be unable to create clients. This change ensures that the region is configured first.