### PR TITLE
Mock scipy and numpy for Read the Docs

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -15,7 +15,8 @@ class Mock(MagicMock):
 
 
 MOCK_MODULES = ['tensorflow', 'tensorflow.core', 'tensorflow.core.framework', 'tensorflow.python',
-                'tensorflow.python.framework', 'tensorflow_serving', 'tensorflow_serving.apis']
+                'tensorflow.python.framework', 'tensorflow_serving', 'tensorflow_serving.apis',
+                'numpy', 'scipy', 'scipy.sparse']
 sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
 version = '1.1.2'


### PR DESCRIPTION
The current docs are failing with `error: no lapack/blas resources found`.

The docs build locally on my machine even without this change, so I unfortunately wasn't able to recreate the exact error.