### PR TITLE
Revert "Mock scipy and numpy for Read the Docs"

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -15,8 +15,7 @@ class Mock(MagicMock):
 
 
 MOCK_MODULES = ['tensorflow', 'tensorflow.core', 'tensorflow.core.framework', 'tensorflow.python',
-                'tensorflow.python.framework', 'tensorflow_serving', 'tensorflow_serving.apis',
-                'numpy', 'scipy', 'scipy.sparse']
+                'tensorflow.python.framework', 'tensorflow_serving', 'tensorflow_serving.apis']
 sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
 version = '1.1.2'


### PR DESCRIPTION
Reverts aws/sagemaker-python-sdk#108

Found another way around the issue (https://github.com/rtfd/readthedocs.org/issues/217), rendering this code change unnecessary.