### PR TITLE
add new hyper-parameters for linear learner

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,11 +2,12 @@
 CHANGELOG
 =========
 
-1.1.dev3
+1.1.3
 ========
 
 * feature: Tests: create configurable ``sagemaker_session`` pytest fixture for all integration tests
 * bug-fix: AmazonEstimators: fix inaccurate hyper-parameters in kmeans, pca and linear learner
+* feature: Add new hyperparameters for linear learner.
 
 1.1.2
 =====

--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,7 @@ You can install from source by cloning this repository and issuing a pip install
 
     git clone https://github.com/aws/sagemaker-python-sdk.git
     python setup.py sdist
-    pip install dist/sagemaker-1.1.2.tar.gz
+    pip install dist/sagemaker-1.1.3.tar.gz
 
 Supported Python versions
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -18,7 +18,7 @@ MOCK_MODULES = ['tensorflow', 'tensorflow.core', 'tensorflow.core.framework', 't
                 'tensorflow.python.framework', 'tensorflow_serving', 'tensorflow_serving.apis']
 sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
-version = '1.1.2'
+version = '1.1.3'
 project = u'sagemaker'
 
 # Add any Sphinx extension module names here, as strings. They can be extensions

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 setup(name="sagemaker",
-      version="1.1.2",
+      version="1.1.3",
       description="Open source library for training and deploying models on Amazon SageMaker.",
       packages=find_packages('src'),
       package_dir={'': 'src'},

--- a/tests/integ/test_linear_learner.py
+++ b/tests/integ/test_linear_learner.py
@@ -42,6 +42,7 @@ def test_linear_learner(sagemaker_session):
         ll.binary_classifier_model_selection_criteria = 'accuracy'
         ll.target_recall = 0.5
         ll.target_precision = 0.5
+        ll.positive_example_weight_mult = 0.1
         ll.epochs = 1
         ll.use_bias = True
         ll.num_models = 1
@@ -67,6 +68,12 @@ def test_linear_learner(sagemaker_session):
         ll.unbias_data = True
         ll.unbias_label = False
         ll.num_point_for_scaler = 10000
+        ll.margin = 1.0
+        ll.quantile = 0.5
+        ll.loss_insensitivity = 0.1
+        ll.huber_delta = 0.1
+        ll.early_stopping_tolerance = 0.0001
+        ll.early_stopping_patience = 3
         ll.fit(ll.record_set(train_set[0][:200], train_set[1][:200]))
 
     endpoint_name = name_from_base('linear-learner')
@@ -102,6 +109,7 @@ def test_async_linear_learner(sagemaker_session):
         ll.binary_classifier_model_selection_criteria = 'accuracy'
         ll.target_recall = 0.5
         ll.target_precision = 0.5
+        ll.positive_example_weight_mult = 0.1
         ll.epochs = 1
         ll.use_bias = True
         ll.num_models = 1
@@ -127,6 +135,12 @@ def test_async_linear_learner(sagemaker_session):
         ll.unbias_data = True
         ll.unbias_label = False
         ll.num_point_for_scaler = 10000
+        ll.margin = 1.0
+        ll.quantile = 0.5
+        ll.loss_insensitivity = 0.1
+        ll.huber_delta = 0.1
+        ll.early_stopping_tolerance = 0.0001
+        ll.early_stopping_patience = 3
         ll.fit(ll.record_set(train_set[0][:200], train_set[1][:200]), wait=False)
         training_job_name = ll.latest_training_job.name
 

--- a/tests/unit/test_linear_learner.py
+++ b/tests/unit/test_linear_learner.py
@@ -70,24 +70,27 @@ def test_all_hyperparameters(sagemaker_session):
     lr = LinearLearner(sagemaker_session=sagemaker_session,
                        binary_classifier_model_selection_criteria='accuracy',
                        target_recall=0.5, target_precision=0.6,
-                       epochs=1, use_bias=True, num_models=5,
-                       num_calibration_samples=6, init_method='uniform', init_scale=-0.1, init_sigma=0.001,
+                       positive_example_weight_mult=0.1, epochs=1, use_bias=True, num_models=5,
+                       num_calibration_samples=6, init_method='uniform', init_scale=0.1, init_sigma=0.001,
                        init_bias=0, optimizer='sgd', loss='logistic', wd=0.4, l1=0.04, momentum=0.1,
                        learning_rate=0.001, beta_1=0.2, beta_2=0.03, bias_lr_mult=5.5, bias_wd_mult=6.6,
                        use_lr_scheduler=False, lr_scheduler_step=2, lr_scheduler_factor=0.03,
                        lr_scheduler_minimum_lr=0.001, normalize_data=False, normalize_label=True,
-                       unbias_data=True, unbias_label=False, num_point_for_scaler=3,
-                       **ALL_REQ_ARGS)
+                       unbias_data=True, unbias_label=False, num_point_for_scaler=3, margin=1.0,
+                       quantile=0.5, loss_insensitivity=0.1, huber_delta=0.1, early_stopping_patience=3,
+                       early_stopping_tolerance=0.001, **ALL_REQ_ARGS)
 
     assert lr.hyperparameters() == dict(
         predictor_type='binary_classifier', binary_classifier_model_selection_criteria='accuracy',
-        target_recall='0.5', target_precision='0.6', epochs='1',
+        target_recall='0.5', target_precision='0.6', positive_example_weight_mult='0.1', epochs='1',
         use_bias='True', num_models='5', num_calibration_samples='6', init_method='uniform',
-        init_scale='-0.1', init_sigma='0.001', init_bias='0.0', optimizer='sgd', loss='logistic',
+        init_scale='0.1', init_sigma='0.001', init_bias='0.0', optimizer='sgd', loss='logistic',
         wd='0.4', l1='0.04', momentum='0.1', learning_rate='0.001', beta_1='0.2', beta_2='0.03',
         bias_lr_mult='5.5', bias_wd_mult='6.6', use_lr_scheduler='False', lr_scheduler_step='2',
         lr_scheduler_factor='0.03', lr_scheduler_minimum_lr='0.001', normalize_data='False',
-        normalize_label='True', unbias_data='True', unbias_label='False', num_point_for_scaler='3',
+        normalize_label='True', unbias_data='True', unbias_label='False', num_point_for_scaler='3', margin='1.0',
+        quantile='0.5', loss_insensitivity='0.1', huber_delta='0.1', early_stopping_patience='3',
+        early_stopping_tolerance='0.001',
     )
 
 
@@ -150,7 +153,13 @@ def test_iterable_hyper_parameters_type(sagemaker_session, iterable_hyper_parame
     ('lr_scheduler_step', 'string'),
     ('lr_scheduler_factor', 'string'),
     ('lr_scheduler_minimum_lr', 'string'),
-    ('num_point_for_scaler', 'string')
+    ('num_point_for_scaler', 'string'),
+    ('margin', 'string'),
+    ('quantile', 'string'),
+    ('loss_insensitivity', 'string'),
+    ('huber_delta', 'string'),
+    ('early_stopping_patience', 'string'),
+    ('early_stopping_tolerance', 'string')
 ])
 def test_optional_hyper_parameters_type(sagemaker_session, optional_hyper_parameters, value):
     with pytest.raises(ValueError):
@@ -169,31 +178,30 @@ def test_optional_hyper_parameters_type(sagemaker_session, optional_hyper_parame
     ('num_models', 0),
     ('num_calibration_samples', 0),
     ('init_method', 'string'),
-    ('init_scale', -1),
-    ('init_scale', 1),
+    ('init_scale', 0),
     ('init_sigma', 0),
-    ('init_sigma', 1),
     ('optimizer', 'string'),
     ('loss', 'string'),
-    ('wd', 0),
-    ('wd', 1),
-    ('l1', 0),
-    ('l1', 1),
-    ('momentum', 0),
+    ('wd', -1),
+    ('l1', -1),
     ('momentum', 1),
     ('learning_rate', 0),
-    ('learning_rate', 1),
-    ('beta_1', 0),
     ('beta_1', 1),
-    ('beta_2', 0),
     ('beta_2', 1),
     ('bias_lr_mult', 0),
-    ('bias_wd_mult', 0),
+    ('bias_wd_mult', -1),
     ('lr_scheduler_step', 0),
     ('lr_scheduler_factor', 0),
     ('lr_scheduler_factor', 1),
     ('lr_scheduler_minimum_lr', 0),
-    ('num_point_for_scaler', 0)
+    ('num_point_for_scaler', 0),
+    ('margin', -1),
+    ('quantile', 0),
+    ('quantile', 1),
+    ('loss_insensitivity', 0),
+    ('huber_delta', -1),
+    ('early_stopping_patience', 0),
+    ('early_stopping_tolerance', 0)
 ])
 def test_optional_hyper_parameters_value(sagemaker_session, optional_hyper_parameters, value):
     with pytest.raises(ValueError):


### PR DESCRIPTION
* adding hyper-parameters for early stopping and new loss types.
* fix hyper-parameter validation ranges
* bump version to 1.1.3

**Testing**

pytest tests/unit/test_linear_learner.py 
pytest tests/integ/test_linear_learner.py
