### PR TITLE
Local mode improvements

### DIFF
--- a/src/sagemaker/local/image.py
+++ b/src/sagemaker/local/image.py
@@ -488,7 +488,10 @@ def _delete_tree(path):
     try:
         shutil.rmtree(path)
     except OSError as exc:
-        # handle permission denied gracefully. Any other error we will raise the exception up.
+        # on Linux, when docker writes to any mounted volume, it uses the container's user. In most cases
+        # this is root. When the container exits and we try to delete them we can't because root owns those
+        # files. We expect this to happen, so we handle EACCESS. Any other error we will raise the
+        # exception up.
         if exc.errno == errno.EACCES:
             logger.warning("Failed to delete: %s Please remove it manually." % path)
         else:

--- a/src/sagemaker/local/local_session.py
+++ b/src/sagemaker/local/local_session.py
@@ -166,3 +166,8 @@ class LocalSession(Session):
             logger.warning("Windows Support for Local Mode is Experimental")
         self.sagemaker_client = LocalSagemakerClient(self)
         self.sagemaker_runtime_client = LocalSagemakerRuntimeClient(self.config)
+
+    def logs_for_job(self, job_name, wait=False, poll=5):
+        # override logs_for_job() as it doesn't need to perform any action
+        # on local mode.
+        pass


### PR DESCRIPTION
Switch local mode to use nvidia-docker2 + docker-compose
instead of nvidia-docker + nvidia-docker-compose.

Also get rid of the log output for billable seconds in local mode as it
doesn't make sense.

Finally, let the users know if we can't cleanup a container directory
but not fail the training job.