### PR TITLE
Increase timeout limit to 20 minutes for tf_cifar test to avoid tests…

### DIFF
--- a/tests/integ/test_tf_cifar.py
+++ b/tests/integ/test_tf_cifar.py
@@ -31,7 +31,7 @@ class PickleSerializer(object):
 
 
 def test_cifar(sagemaker_session, tf_full_version):
-    with timeout(minutes=15):
+    with timeout(minutes=20):
         script_path = os.path.join(DATA_DIR, 'cifar_10', 'source')
 
         dataset_path = os.path.join(DATA_DIR, 'cifar_10', 'data')


### PR DESCRIPTION
Our canary caught tf_cifar tests failed occasionally for timeout in tf 1.6. Increase the timeout to 20 minutes to fix it.

The increase of 5 minute should be enough since we now only get timeout approximately 1 out of 5 runs.