### PR TITLE
Fix local mode not using the right s3 bucket.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 CHANGELOG
 =========
 
+1.2.3-dev
+=========
+* bug-fix: Fix local mode not using the right s3 bucket
+
 1.2.2
 =====
 

--- a/src/sagemaker/local/image.py
+++ b/src/sagemaker/local/image.py
@@ -87,7 +87,6 @@ class _SageMakerContainer(object):
         os.mkdir(os.path.join(self.container_root, 'output'))
 
         data_dir = self._create_tmp_folder()
-        bucket_name = self.sagemaker_session.default_bucket()
         volumes = []
 
         # Set up the channels for the containers. For local data we will
@@ -102,7 +101,8 @@ class _SageMakerContainer(object):
             channel_dir = os.path.join(data_dir, channel_name)
             os.mkdir(channel_dir)
 
-            if uri.lower().startswith("s3://"):
+            if parsed_uri.scheme == 's3':
+                bucket_name = parsed_uri.netloc
                 self._download_folder(bucket_name, key, channel_dir)
             else:
                 volumes.append(_Volume(uri, channel=channel_name))

--- a/tests/unit/test_image.py
+++ b/tests/unit/test_image.py
@@ -16,7 +16,7 @@ import os
 
 import pytest
 import yaml
-from mock import call, patch, Mock, ANY
+from mock import call, patch, Mock
 
 import sagemaker
 from sagemaker.local.image import _SageMakerContainer
@@ -184,21 +184,17 @@ def test_check_output():
 @patch('sagemaker.local.image._SageMakerContainer._download_folder')
 def test_train(_download_folder, _cleanup, _execute_and_stream_output, LocalSession, tmpdir, sagemaker_session):
 
+    directories = [str(tmpdir.mkdir('container-root')), str(tmpdir.mkdir('data'))]
     with patch('sagemaker.local.image._SageMakerContainer._create_tmp_folder',
-               side_effect=[str(tmpdir.mkdir('container-root')), str(tmpdir.mkdir('data'))]):
+               side_effect=directories):
 
         instance_count = 2
         image = 'my-image'
         sagemaker_container = _SageMakerContainer('local', instance_count, image, sagemaker_session=sagemaker_session)
         sagemaker_container.train(INPUT_DATA_CONFIG, HYPERPARAMETERS)
 
-        download_folder_calls = []
-        for channel in INPUT_DATA_CONFIG:
-            s3_uri = channel['DataSource']['S3DataSource']['S3Uri']
-            if 's3://' in s3_uri:
-                bucket, prefix = s3_uri.replace('s3://', '').split('/')
-                download_folder_calls.append(call(bucket, prefix, ANY))
-        _download_folder.assert_called()
+        channel_dir = os.path.join(directories[1], 'b')
+        download_folder_calls = [call('my-own-bucket', 'prefix', channel_dir)]
         _download_folder.assert_has_calls(download_folder_calls)
 
         docker_compose_file = os.path.join(sagemaker_container.container_root, 'docker-compose.yaml')
@@ -239,6 +235,36 @@ def test_serve(up, copy, copytree, tmpdir, sagemaker_session):
             for h in sagemaker_container.hosts:
                 assert config['services'][h]['image'] == image
                 assert config['services'][h]['command'] == 'serve'
+
+
+@patch('os.makedirs')
+def test_download_folder(makedirs):
+    boto_mock = Mock(name='boto_session')
+    boto_mock.client('sts').get_caller_identity.return_value = {'Account': '123'}
+
+    session = sagemaker.Session(boto_session=boto_mock, sagemaker_client=Mock())
+
+    train_data = Mock()
+    validation_data = Mock()
+
+    train_data.bucket_name.return_value = BUCKET_NAME
+    train_data.key = '/prefix/train/train_data.csv'
+    validation_data.bucket_name.return_value = BUCKET_NAME
+    validation_data.key = '/prefix/train/validation_data.csv'
+
+    s3_files = [train_data, validation_data]
+    boto_mock.resource('s3').Bucket(BUCKET_NAME).objects.filter.return_value = s3_files
+
+    obj_mock = Mock()
+    boto_mock.resource('s3').Object.return_value = obj_mock
+
+    sagemaker_container = _SageMakerContainer('local', 2, 'my-image', sagemaker_session=session)
+    sagemaker_container._download_folder(BUCKET_NAME, '/prefix', '/tmp')
+
+    obj_mock.download_file.assert_called()
+    calls = [call(os.path.join('/tmp', 'train/train_data.csv')),
+             call(os.path.join('/tmp', 'train/validation_data.csv'))]
+    obj_mock.download_file.assert_has_calls(calls)
 
 
 def test_ecr_login_non_ecr():


### PR DESCRIPTION
*Description of changes:*
Local Mode should honor the inputs instead of wrongly assuming that
everyone is using the default bucket. Fixes #137 #145 

## Merge Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have updated the [changelog](https://github.com/aws/sagemaker-python-sdk/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
