### PR TITLE
Correctly pass boto3 Session while creating Estimator

### DIFF
--- a/src/sagemaker/estimator.py
+++ b/src/sagemaker/estimator.py
@@ -85,7 +85,7 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):
             if self.train_instance_type == 'local_gpu' and self.train_instance_count > 1:
                 raise RuntimeError("Distributed Training in Local GPU is not supported")
 
-            self.sagemaker_session = LocalSession()
+            self.sagemaker_session = sagemaker_session or LocalSession()
         else:
             self.local_mode = False
             self.sagemaker_session = sagemaker_session or Session()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

In the current implementation, when the `Estimator` is executed in the local mode, the underlying `sagemaker_session` is created via a default `LocalSession()` call. Therefore, if the user wants to create their own `boto3.Session()` with a custom profile name or region name, the information would get lost at this stage and S3 data downloading would fail.

In this PR I've made a simple fix.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated the [changelog](https://github.com/aws/sagemaker-python-sdk/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
