### PR TITLE
Test stability - increase retries on cloudwatch log client + set training timeout for test_cifar

### DIFF
--- a/tests/integ/test_tf_cifar.py
+++ b/tests/integ/test_tf_cifar.py
@@ -39,7 +39,7 @@ def test_cifar(sagemaker_session, tf_full_version):
         estimator = TensorFlow(entry_point='resnet_cifar_10.py', source_dir=script_path, role='SageMakerRole',
                                framework_version=tf_full_version, training_steps=20, evaluation_steps=5,
                                train_instance_count=2, train_instance_type='ml.p2.xlarge',
-                               sagemaker_session=sagemaker_session,
+                               sagemaker_session=sagemaker_session, train_max_run=20 * 60,
                                base_job_name='test-cifar')
 
         inputs = estimator.sagemaker_session.upload_data(path=dataset_path, key_prefix='data/cifar10')


### PR DESCRIPTION
* Our tests regularly fail due to throttling on DescribeLogStreams - this should mitigate that.
* Sometimes, test_cifar takes a long time to complete and the test times out. This is obviously a problem in of itself, but setting the training timeout is a quick fix to release the training instances when the test fails due to client timeout. I'll still need to deep dive on the test itself.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have updated the [changelog](https://github.com/aws/sagemaker-python-sdk/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [x] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
