### PR TITLE
Increase # training steps for test_tf_cifar to mitigate race condition

### DIFF
--- a/tests/integ/test_tf_cifar.py
+++ b/tests/integ/test_tf_cifar.py
@@ -37,7 +37,7 @@ def test_cifar(sagemaker_session, tf_full_version):
         dataset_path = os.path.join(DATA_DIR, 'cifar_10', 'data')
 
         estimator = TensorFlow(entry_point='resnet_cifar_10.py', source_dir=script_path, role='SageMakerRole',
-                               framework_version=tf_full_version, training_steps=20, evaluation_steps=5,
+                               framework_version=tf_full_version, training_steps=500, evaluation_steps=5,
                                train_instance_count=2, train_instance_type='ml.p2.xlarge',
                                sagemaker_session=sagemaker_session, train_max_run=20 * 60,
                                base_job_name='test-cifar')


### PR DESCRIPTION
We have a known issue with multi-machine TF training where, if the master finishes before the worker initializes, the training job hangs indefinitely. (This generally only happens with very small datasets / # of training steps.) While it's an issue that we should fix, it's more urgent to fix our integ test to prevent false positives, which is what this change does.

By increasing the number of training steps, the training consistently avoids this race condition. The job still finishes in ~8 minutes counting SageMaker startup time, which is about the same as what it was before, so it shouldn't affect test runtime noticeably.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have updated the [changelog](https://github.com/aws/sagemaker-python-sdk/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [x] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
