### PR TITLE
Local mode support for file:// URI as the input for training data, by…

### DIFF
--- a/src/sagemaker/estimator.py
+++ b/src/sagemaker/estimator.py
@@ -12,6 +12,7 @@
 # language governing permissions and limitations under the License.
 from __future__ import print_function, absolute_import
 
+import os
 import json
 import logging
 from abc import ABCMeta
@@ -21,13 +22,18 @@ from six import with_metaclass, string_types
 from sagemaker.fw_utils import tar_and_upload_dir
 from sagemaker.fw_utils import parse_s3_url
 from sagemaker.fw_utils import UploadedCode
-from sagemaker.local.local_session import LocalSession
+
+from sagemaker.local.local_session import LocalSession, file_input
+
 from sagemaker.model import Model
 from sagemaker.model import (SCRIPT_PARAM_NAME, DIR_PARAM_NAME, CLOUDWATCH_METRICS_PARAM_NAME,
                              CONTAINER_LOG_LEVEL_PARAM_NAME, JOB_NAME_PARAM_NAME, SAGEMAKER_REGION_PARAM_NAME)
+
 from sagemaker.predictor import RealTimePredictor
+
 from sagemaker.session import Session
 from sagemaker.session import s3_input
+
 from sagemaker.utils import base_name_from_image, name_from_base
 
 
@@ -321,6 +327,13 @@ class _TrainingJob(object):
             sagemaker.estimator.Framework: Constructed object that captures all information about the started job.
         """
 
+        local_mode = estimator.local_mode
+
+        # Allow file:// input only in local mode
+        if isinstance(inputs, str) and inputs.startswith('file://'):
+            if not local_mode:
+                raise ValueError('File URIs are supported in local mode only. Please use a S3 URI instead.')
+
         input_config = _TrainingJob._format_inputs_to_input_config(inputs)
         role = estimator.sagemaker_session.expand_role(estimator.role)
         output_config = _TrainingJob._prepare_output_config(estimator.output_path, estimator.output_kms_key)
@@ -343,12 +356,14 @@ class _TrainingJob(object):
     def _format_inputs_to_input_config(inputs):
         input_dict = {}
         if isinstance(inputs, string_types):
-            input_dict['training'] = _TrainingJob._format_s3_uri_input(inputs)
+            input_dict['training'] = _TrainingJob._format_string_uri_input(inputs)
         elif isinstance(inputs, s3_input):
+            input_dict['training'] = inputs
+        elif isinstance(input, file_input):
             input_dict['training'] = inputs
         elif isinstance(inputs, dict):
             for k, v in inputs.items():
-                input_dict[k] = _TrainingJob._format_s3_uri_input(v)
+                input_dict[k] = _TrainingJob._format_string_uri_input(v)
         else:
             raise ValueError('Cannot format input {}. Expecting one of str, dict or s3_input'.format(inputs))
 
@@ -360,15 +375,20 @@ class _TrainingJob(object):
         return channels
 
     @staticmethod
-    def _format_s3_uri_input(input):
+    def _format_string_uri_input(input):
         if isinstance(input, str):
-            if not input.startswith('s3://'):
-                raise ValueError('Training input data must be a valid S3 URI and must start with "s3://"')
-            return s3_input(input)
-        if isinstance(input, s3_input):
+            if input.startswith('s3://'):
+                return s3_input(input)
+            elif input.startswith('file://'):
+                return file_input(input)
+            else:
+                raise ValueError('Training input data must be a valid S3 or FILE URI and must start with "s3://" or "file://"')
+        elif isinstance(input, s3_input):
+            return input
+        elif isinstance(input, file_input):
             return input
         else:
-            raise ValueError('Cannot format input {}. Expecting one of str or s3_input'.format(input))
+            raise ValueError('Cannot format input {}. Expecting one of str, s3_input, or file_input'.format(input))
 
     @staticmethod
     def _prepare_output_config(s3_path, kms_key_id):

--- a/src/sagemaker/local/local_session.py
+++ b/src/sagemaker/local/local_session.py
@@ -56,7 +56,14 @@ class LocalSagemakerClient(object):
                                                    AlgorithmSpecification['TrainingImage'], self.sagemaker_session)
 
         for channel in InputDataConfig:
-            data_distribution = channel['DataSource']['S3DataSource']['S3DataDistributionType']
+
+            if channel['DataSource'] and 'S3DataSource' in channel['DataSource']:
+                data_distribution = channel['DataSource']['S3DataSource']['S3DataDistributionType']
+            elif channel['DataSource'] and 'FileDataSource' in channel['DataSource']:
+                data_distribution = channel['DataSource']['FileDataSource']['FileDataDistributionType']
+            else:
+                raise ValueError('Need channel[\'DataSource\'] to have [\'S3DataSource\'] or [\'FileDataSource\']')
+
             if data_distribution != 'FullyReplicated':
                 raise RuntimeError("DataDistribution: %s is not currently supported in Local Mode" %
                                    data_distribution)
@@ -64,7 +71,7 @@ class LocalSagemakerClient(object):
         self.s3_model_artifacts = self.train_container.train(InputDataConfig, HyperParameters)
 
     def describe_training_job(self, TrainingJobName):
-        """Describe a local traininig job.
+        """Describe a local training job.
 
         Args:
             TrainingJobName (str): Not used in this implmentation.
@@ -171,3 +178,43 @@ class LocalSession(Session):
         # override logs_for_job() as it doesn't need to perform any action
         # on local mode.
         pass
+
+# TODO Naming consistent with session.s3_input. May want to change both
+# (e.g. S3Input and FileInput)
+class file_input(object):
+    """Amazon SageMaker channel configuration for FILE data sources, used in local mode.
+
+    Attributes:
+        config (dict[str, dict]): A SageMaker ``DataSource`` referencing a SageMaker ``S3DataSource``.
+    """
+
+    def __init__(self, fileUri):
+        """Create a definition for input data used by an SageMaker training job in local mode.
+        """
+
+        """TODO Keeping this consistent with s3_input data structure. May be
+        better to have a Type key under DataSource, but that really would mess
+        with the standard implementation....
+        """
+
+        self.config = {
+            'DataSource': {
+                'FileDataSource': {
+                    # TODO Ok to hardcode this here or allow input?
+                    'FileDataDistributionType': 'FullyReplicated',
+                    'FileUri': fileUri
+                }
+            }
+        }
+
+        # As per docs, leave unset in FILE mode
+        # if compression is not None:
+        #     self.config['CompressionType'] = compression
+
+        # if content_type is not None:
+        #     self.config['ContentType'] = content_type
+
+        # As per docs, leave unset in FILE mode
+        # if record_wrapping is not None:
+        #     self.config['RecordWrapperType'] = record_wrapping
+


### PR DESCRIPTION
…passing uploading to/downloading from S3.

*Issue #, if available:*

*Description of changes:*

SDK now supports using training data stored on the local filesystem rather than expecting the data to be on s3.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated the [changelog](https://github.com/aws/sagemaker-python-sdk/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
