### PR TITLE
Add TF CIFAR test to continuous testing set

### DIFF
--- a/tests/integ/test_tf_cifar.py
+++ b/tests/integ/test_tf_cifar.py
@@ -14,6 +14,7 @@ import os
 import pickle
 
 import numpy as np
+import pytest
 
 from sagemaker.tensorflow import TensorFlow
 from tests.integ import DATA_DIR
@@ -30,6 +31,7 @@ class PickleSerializer(object):
         return pickle.dumps(data, protocol=2)
 
 
+@pytest.mark.continuous_testing
 def test_cifar(sagemaker_session, tf_full_version):
     with timeout(minutes=20):
         script_path = os.path.join(DATA_DIR, 'cifar_10', 'source')


### PR DESCRIPTION
*Description of changes:*
Though this test has historically been relatively flaky, there was a recent change to the training steps that helped stabilize it, so it should be fine to include this test with our continuous testing. This test is important because it's currently our only one that tests distributed training and the only one to run on GPU instances.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated the [changelog](https://github.com/aws/sagemaker-python-sdk/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
