### PR TITLE
Allow Local Mode to work with a local training script.

### DIFF
--- a/src/sagemaker/fw_utils.py
+++ b/src/sagemaker/fw_utils.py
@@ -68,6 +68,27 @@ def create_image_uri(region, framework, instance_type, framework_version, py_ver
         .format(account, region, framework, tag)
 
 
+def validate_source_dir(script, directory):
+    """Validate that the source directory exists and it contains the user script
+
+    Args:
+        script (str):  Script filename.
+        directory (str): Directory containing the source file.
+
+    Raises:
+        ValueError: If ``directory`` does not exist, is not a directory, or does not contain ``script``.
+    """
+    if directory:
+        if not os.path.exists(directory):
+            raise ValueError('"{}" does not exist.'.format(directory))
+        if not os.path.isdir(directory):
+            raise ValueError('"{}" is not a directory.'.format(directory))
+        if script not in os.listdir(directory):
+            raise ValueError('No file named "{}" was found in directory "{}".'.format(script, directory))
+
+    return True
+
+
 def tar_and_upload_dir(session, bucket, s3_key_prefix, script, directory):
     """Pack and upload source files to S3 only if directory is empty or local.
 
@@ -83,21 +104,13 @@ def tar_and_upload_dir(session, bucket, s3_key_prefix, script, directory):
 
     Returns:
         sagemaker.fw_utils.UserCode: An object with the S3 bucket and key (S3 prefix) and script name.
-
-    Raises:
-        ValueError: If ``directory`` does not exist, is not a directory, or does not contain ``script``.
     """
     if directory:
         if directory.lower().startswith("s3://"):
             return UploadedCode(s3_prefix=directory, script_name=os.path.basename(script))
-        if not os.path.exists(directory):
-            raise ValueError('"{}" does not exist.'.format(directory))
-        if not os.path.isdir(directory):
-            raise ValueError('"{}" is not a directory.'.format(directory))
-        if script not in os.listdir(directory):
-            raise ValueError('No file named "{}" was found in directory "{}".'.format(script, directory))
-        script_name = script
-        source_files = [os.path.join(directory, name) for name in os.listdir(directory)]
+        else:
+            script_name = script
+            source_files = [os.path.join(directory, name) for name in os.listdir(directory)]
     else:
         # If no directory is specified, the script parameter needs to be a valid relative path.
         os.path.exists(script)

--- a/src/sagemaker/fw_utils.py
+++ b/src/sagemaker/fw_utils.py
@@ -79,11 +79,7 @@ def validate_source_dir(script, directory):
         ValueError: If ``directory`` does not exist, is not a directory, or does not contain ``script``.
     """
     if directory:
-        if not os.path.exists(directory):
-            raise ValueError('"{}" does not exist.'.format(directory))
-        if not os.path.isdir(directory):
-            raise ValueError('"{}" is not a directory.'.format(directory))
-        if script not in os.listdir(directory):
+        if not os.path.isfile(os.path.join(directory, script)):
             raise ValueError('No file named "{}" was found in directory "{}".'.format(script, directory))
 
     return True

--- a/src/sagemaker/local/image.py
+++ b/src/sagemaker/local/image.py
@@ -86,6 +86,7 @@ class _SageMakerContainer(object):
         """
         self.container_root = self._create_tmp_folder()
         os.mkdir(os.path.join(self.container_root, 'output'))
+        os.mkdir(os.path.join(self.container_root, 'shared'))
 
         data_dir = self._create_tmp_folder()
         volumes = []
@@ -121,8 +122,8 @@ class _SageMakerContainer(object):
         training_dir = json.loads(hyperparameters[sagemaker.estimator.DIR_PARAM_NAME])
         parsed_uri = urlparse(training_dir)
         if parsed_uri.scheme == 'file':
-            print('appended Volume')
             volumes.append(_Volume(parsed_uri.path, '/opt/ml/code'))
+            volumes.append(_Volume(os.path.join(self.container_root, 'shared'), '/opt/ml/shared'))
 
         # Create the configuration files for each container that we will create
         # Each container will map the additional local volumes (if any).
@@ -179,7 +180,16 @@ class _SageMakerContainer(object):
 
         _ecr_login_if_needed(self.sagemaker_session.boto_session, self.image)
 
-        self._generate_compose_file('serve', additional_env_vars=env_vars)
+        # If the user script was passed as a file:// mount it to the container.
+        script_dir = primary_container['Environment'][sagemaker.estimator.DIR_PARAM_NAME.upper()]
+        parsed_uri = urlparse(script_dir)
+        volumes = []
+        if parsed_uri.scheme == 'file':
+            volumes.append(_Volume(parsed_uri.path, '/opt/ml/code'))
+
+        self._generate_compose_file('serve',
+                                    additional_env_vars=env_vars,
+                                    additional_volumes=volumes)
         compose_command = self._compose()
         self.container = _HostingContainer(compose_command)
         self.container.up()
@@ -573,6 +583,10 @@ def _ecr_login_if_needed(boto_session, image):
     # do we have the image?
     if _check_output('docker images -q %s' % image).strip():
         return
+
+    if not boto_session:
+        raise RuntimeError('A boto session is required to login to ECR.'
+                           'Please pull the image: %s manually.' % image)
 
     ecr = boto_session.client('ecr')
     auth = ecr.get_authorization_token(registryIds=[image.split('.')[0]])

--- a/src/sagemaker/local/local_session.py
+++ b/src/sagemaker/local/local_session.py
@@ -190,6 +190,7 @@ class LocalSession(Session):
 
         self.sagemaker_client = LocalSagemakerClient(self)
         self.sagemaker_runtime_client = LocalSagemakerRuntimeClient(self.config)
+        self.local_mode = True
 
     def logs_for_job(self, job_name, wait=False, poll=5):
         # override logs_for_job() as it doesn't need to perform any action

--- a/src/sagemaker/local/local_session.py
+++ b/src/sagemaker/local/local_session.py
@@ -15,11 +15,13 @@ import logging
 import platform
 import time
 
+import boto3
 import urllib3
 from botocore.exceptions import ClientError
 
 from sagemaker.local.image import _SageMakerContainer
 from sagemaker.session import Session
+from sagemaker.utils import get_config_value
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.WARNING)
@@ -115,9 +117,7 @@ class LocalSagemakerClient(object):
 
         i = 0
         http = urllib3.PoolManager()
-        serving_port = 8080
-        if self.sagemaker_session.config and 'local' in self.sagemaker_session.config:
-            serving_port = self.sagemaker_session.config['local'].get('serving_port', 8080)
+        serving_port = get_config_value('local.serving_port', self.sagemaker_session.config) or 8080
         endpoint_url = "http://localhost:%s/ping" % serving_port
         while True:
             i += 1
@@ -153,8 +153,8 @@ class LocalSagemakerRuntimeClient(object):
         """
         self.http = urllib3.PoolManager()
         self.serving_port = 8080
-        if config and 'local' in config:
-            self.serving_port = config['local'].get('serving_port', 8080)
+        self.config = config
+        self.serving_port = get_config_value('local.serving_port', config) or 8080
 
     def invoke_endpoint(self, Body, EndpointName, ContentType, Accept):
         url = "http://localhost:%s/invocations" % self.serving_port
@@ -171,6 +171,23 @@ class LocalSession(Session):
 
         if platform.system() == 'Windows':
             logger.warning("Windows Support for Local Mode is Experimental")
+
+    def _initialize(self, boto_session, sagemaker_client, sagemaker_runtime_client):
+        """Initialize a boto session for this Local SageMaker Session."""
+        if get_config_value('local.no_internet', self.config):
+            # if no_internet is set to True in the config file then we won't create a boto_session
+            # this will make any component that defaults to using S3 utilize a local file instead.
+            self.boto_session = None
+            self.region_name = get_config_value('local.region_name', self.config)
+            if self.region_name is None:
+                raise ValueError('Must setup region_name in the sagemaker config file. See <Link to Readme Here>')
+        else:
+            self.boto_session = boto_session or boto3.Session()
+            self.region_name = self.boto_session.region_name
+
+            if self.region_name is None:
+                raise ValueError('Must setup local AWS configuration with a region supported by SageMaker.')
+
         self.sagemaker_client = LocalSagemakerClient(self)
         self.sagemaker_runtime_client = LocalSagemakerRuntimeClient(self.config)
 

--- a/src/sagemaker/local/local_session.py
+++ b/src/sagemaker/local/local_session.py
@@ -173,20 +173,13 @@ class LocalSession(Session):
             logger.warning("Windows Support for Local Mode is Experimental")
 
     def _initialize(self, boto_session, sagemaker_client, sagemaker_runtime_client):
-        """Initialize a boto session for this Local SageMaker Session."""
-        if get_config_value('local.no_internet', self.config):
-            # if no_internet is set to True in the config file then we won't create a boto_session
-            # this will make any component that defaults to using S3 utilize a local file instead.
-            self.boto_session = None
-            self.region_name = get_config_value('local.region_name', self.config)
-            if self.region_name is None:
-                raise ValueError('Must setup region_name in the sagemaker config file. See <Link to Readme Here>')
-        else:
-            self.boto_session = boto_session or boto3.Session()
-            self.region_name = self.boto_session.region_name
+        """Initialize this Local SageMaker Session."""
 
-            if self.region_name is None:
-                raise ValueError('Must setup local AWS configuration with a region supported by SageMaker.')
+        self.boto_session = boto_session or boto3.Session()
+        self._region_name = self.boto_session.region_name
+
+        if self._region_name is None:
+            raise ValueError('Must setup local AWS configuration with a region supported by SageMaker.')
 
         self.sagemaker_client = LocalSagemakerClient(self)
         self.sagemaker_runtime_client = LocalSagemakerRuntimeClient(self.config)

--- a/src/sagemaker/model.py
+++ b/src/sagemaker/model.py
@@ -16,7 +16,7 @@ import sagemaker
 
 from sagemaker.fw_utils import tar_and_upload_dir, parse_s3_url
 from sagemaker.session import Session
-from sagemaker.utils import name_from_image
+from sagemaker.utils import name_from_image, get_config_value
 
 
 class Model(object):
@@ -160,7 +160,11 @@ class FrameworkModel(Model):
         Returns:
             dict[str, str]: A container definition object usable with the CreateModel API.
         """
-        self._upload_code(self.key_prefix or self.name or name_from_image(self.image))
+        no_internet = get_config_value('local.no_internet', self.sagemaker_session.config)
+        if self.sagemaker_session.local_mode and no_internet:
+            self.uploaded_code = None
+        else:
+            self._upload_code(self.key_prefix or self.name or name_from_image(self.image))
         deploy_env = dict(self.env)
         deploy_env.update(self._framework_env_vars())
         return sagemaker.container_def(self.image, self.model_data, deploy_env)
@@ -173,8 +177,17 @@ class FrameworkModel(Model):
                                                 directory=self.source_dir)
 
     def _framework_env_vars(self):
-        return {SCRIPT_PARAM_NAME.upper(): self.uploaded_code.script_name,
-                DIR_PARAM_NAME.upper(): self.uploaded_code.s3_prefix,
-                CLOUDWATCH_METRICS_PARAM_NAME.upper(): str(self.enable_cloudwatch_metrics).lower(),
-                CONTAINER_LOG_LEVEL_PARAM_NAME.upper(): str(self.container_log_level),
-                SAGEMAKER_REGION_PARAM_NAME.upper(): self.sagemaker_session.boto_session.region_name}
+        if self.uploaded_code:
+            script_name = self.uploaded_code.script_name
+            dir_name = self.uploaded_code.s3_prefix
+        else:
+            script_name = self.entry_point
+            dir_name = 'file://' + self.source_dir
+
+        return {
+            SCRIPT_PARAM_NAME.upper(): script_name,
+            DIR_PARAM_NAME.upper(): dir_name,
+            CLOUDWATCH_METRICS_PARAM_NAME.upper(): str(self.enable_cloudwatch_metrics).lower(),
+            CONTAINER_LOG_LEVEL_PARAM_NAME.upper(): str(self.container_log_level),
+            SAGEMAKER_REGION_PARAM_NAME.upper(): self.sagemaker_session.region_name
+        }

--- a/src/sagemaker/mxnet/estimator.py
+++ b/src/sagemaker/mxnet/estimator.py
@@ -65,7 +65,7 @@ class MXNet(Framework):
         Returns:
             str: The URI of the Docker image.
         """
-        return create_image_uri(self.sagemaker_session.boto_session.region_name, self.__framework_name__,
+        return create_image_uri(self.sagemaker_session.region_name, self.__framework_name__,
                                 self.train_instance_type, framework_version=self.framework_version,
                                 py_version=self.py_version)
 

--- a/src/sagemaker/mxnet/estimator.py
+++ b/src/sagemaker/mxnet/estimator.py
@@ -65,7 +65,7 @@ class MXNet(Framework):
         Returns:
             str: The URI of the Docker image.
         """
-        return create_image_uri(self.sagemaker_session.region_name, self.__framework_name__,
+        return create_image_uri(self.sagemaker_session.boto_region_name, self.__framework_name__,
                                 self.train_instance_type, framework_version=self.framework_version,
                                 py_version=self.py_version)
 

--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -70,10 +70,25 @@ class Session(object):
                 If not provided, one will be created using this instance's ``boto_session``.
         """
         self._default_bucket = None
+
+        sagemaker_config_file = os.path.join(os.path.expanduser('~'), '.sagemaker', 'config.yaml')
+        if os.path.exists(sagemaker_config_file):
+            self.config = yaml.load(open(sagemaker_config_file, 'r'))
+        else:
+            self.config = None
+
+        self._initialize(boto_session, sagemaker_client, sagemaker_runtime_client)
+
+    def _initialize(self, boto_session, sagemaker_client, sagemaker_runtime_client):
+        """Initialize this SageMaker Session.
+
+        Creates or uses a boto_session, sagemaker_client and sagemaker_runtime_client.
+        Sets the region_name.
+        """
         self.boto_session = boto_session or boto3.Session()
 
-        region = self.boto_session.region_name
-        if region is None:
+        self.region = self.boto_session.region_name
+        if self.region is None:
             raise ValueError('Must setup local AWS configuration with a region supported by SageMaker.')
 
         self.sagemaker_client = sagemaker_client or self.boto_session.client('sagemaker')
@@ -81,12 +96,6 @@ class Session(object):
 
         self.sagemaker_runtime_client = sagemaker_runtime_client or self.boto_session.client('runtime.sagemaker')
         prepend_user_agent(self.sagemaker_runtime_client)
-
-        sagemaker_config_file = os.path.join(os.path.expanduser('~'), '.sagemaker', 'config.yaml')
-        if os.path.exists(sagemaker_config_file):
-            self.config = yaml.load(open(sagemaker_config_file, 'r'))
-        else:
-            self.config = None
 
     @property
     def boto_region_name(self):

--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -87,8 +87,8 @@ class Session(object):
         """
         self.boto_session = boto_session or boto3.Session()
 
-        self.region = self.boto_session.region_name
-        if self.region is None:
+        self.region_name = self.boto_session.region_name
+        if self.region_name is None:
             raise ValueError('Must setup local AWS configuration with a region supported by SageMaker.')
 
         self.sagemaker_client = sagemaker_client or self.boto_session.client('sagemaker')
@@ -96,6 +96,8 @@ class Session(object):
 
         self.sagemaker_runtime_client = sagemaker_runtime_client or self.boto_session.client('runtime.sagemaker')
         prepend_user_agent(self.sagemaker_runtime_client)
+
+        self.local_mode = False
 
     @property
     def boto_region_name(self):

--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -87,8 +87,8 @@ class Session(object):
         """
         self.boto_session = boto_session or boto3.Session()
 
-        self.region_name = self.boto_session.region_name
-        if self.region_name is None:
+        self._region_name = self.boto_session.region_name
+        if self._region_name is None:
             raise ValueError('Must setup local AWS configuration with a region supported by SageMaker.')
 
         self.sagemaker_client = sagemaker_client or self.boto_session.client('sagemaker')
@@ -101,7 +101,7 @@ class Session(object):
 
     @property
     def boto_region_name(self):
-        return self.boto_session.region_name
+        return self._region_name
 
     def upload_data(self, path, bucket=None, key_prefix='data'):
         """Upload local file or directory to S3.

--- a/src/sagemaker/tensorflow/estimator.py
+++ b/src/sagemaker/tensorflow/estimator.py
@@ -20,6 +20,7 @@ import threading
 
 from sagemaker.estimator import Framework
 from sagemaker.fw_utils import create_image_uri, framework_name_from_image, framework_version_from_tag
+from sagemaker.utils import get_config_value
 
 from sagemaker.tensorflow.defaults import TF_VERSION
 from sagemaker.tensorflow.model import TensorFlowModel
@@ -305,7 +306,12 @@ class TensorFlow(Framework):
         hyperparameters = super(TensorFlow, self).hyperparameters()
 
         if not self.checkpoint_path:
-            self.checkpoint_path = os.path.join(self.output_path, self._current_job_name, 'checkpoints')
+            no_internet = get_config_value('local.no_internet', self.sagemaker_session.config)
+            if self.sagemaker_session.local_mode and no_internet:
+                self.checkpoint_path = '/opt/ml/shared/checkpoints'
+            else:
+                self.checkpoint_path = os.path.join(self.output_path,
+                                                    self._current_job_name, 'checkpoints')
 
         additional_hyperparameters = {'checkpoint_path': self.checkpoint_path,
                                       'training_steps': self.training_steps,

--- a/src/sagemaker/tensorflow/estimator.py
+++ b/src/sagemaker/tensorflow/estimator.py
@@ -278,7 +278,7 @@ class TensorFlow(Framework):
         Returns:
             str: The URI of the Docker image.
         """
-        return create_image_uri(self.sagemaker_session.boto_session.region_name, self.__framework_name__,
+        return create_image_uri(self.sagemaker_session.region_name, self.__framework_name__,
                                 self.train_instance_type, self.framework_version, py_version=self.py_version)
 
     def create_model(self, model_server_workers=None):

--- a/src/sagemaker/tensorflow/estimator.py
+++ b/src/sagemaker/tensorflow/estimator.py
@@ -279,7 +279,7 @@ class TensorFlow(Framework):
         Returns:
             str: The URI of the Docker image.
         """
-        return create_image_uri(self.sagemaker_session.region_name, self.__framework_name__,
+        return create_image_uri(self.sagemaker_session.boto_region_name, self.__framework_name__,
                                 self.train_instance_type, self.framework_version, py_version=self.py_version)
 
     def create_model(self, model_server_workers=None):
@@ -306,8 +306,8 @@ class TensorFlow(Framework):
         hyperparameters = super(TensorFlow, self).hyperparameters()
 
         if not self.checkpoint_path:
-            no_internet = get_config_value('local.no_internet', self.sagemaker_session.config)
-            if self.sagemaker_session.local_mode and no_internet:
+            local_code = get_config_value('local.local_code', self.sagemaker_session.config)
+            if self.sagemaker_session.local_mode and local_code:
                 self.checkpoint_path = '/opt/ml/shared/checkpoints'
             else:
                 self.checkpoint_path = os.path.join(self.output_path,

--- a/src/sagemaker/tensorflow/model.py
+++ b/src/sagemaker/tensorflow/model.py
@@ -16,7 +16,7 @@ from sagemaker.model import FrameworkModel, MODEL_SERVER_WORKERS_PARAM_NAME
 from sagemaker.predictor import RealTimePredictor
 from sagemaker.tensorflow.defaults import TF_VERSION
 from sagemaker.tensorflow.predictor import tf_json_serializer, tf_json_deserializer
-from sagemaker.utils import name_from_image, get_config_value
+from sagemaker.utils import name_from_image
 
 
 class TensorFlowPredictor(RealTimePredictor):
@@ -83,18 +83,13 @@ class TensorFlowModel(FrameworkModel):
         """
         deploy_image = self.image
         if not deploy_image:
-            region_name = self.sagemaker_session.region_name
+            region_name = self.sagemaker_session.boto_region_name
             deploy_image = create_image_uri(region_name, self.__framework_name__, instance_type,
                                             self.framework_version, self.py_version)
 
         deploy_key_prefix = self.key_prefix or self.name or name_from_image(deploy_image)
 
-        no_internet = get_config_value('local.no_internet', self.sagemaker_session.config)
-        print('no_internet: %s  local_mode: %s' % (no_internet, self.sagemaker_session.local_mode))
-        if self.sagemaker_session.local_mode and no_internet:
-            self.uploaded_code = None
-        else:
-            self._upload_code(deploy_key_prefix)
+        self._upload_code(deploy_key_prefix)
         deploy_env = dict(self.env)
         deploy_env.update(self._framework_env_vars())
 

--- a/src/sagemaker/utils.py
+++ b/src/sagemaker/utils.py
@@ -76,3 +76,17 @@ def debug(func):
         return func(*args, **kwargs)
 
     return wrapper
+
+
+def get_config_value(key_path, config):
+    if config is None:
+        return None
+
+    current_section = config
+    for key in key_path.split('.'):
+        if key in current_section:
+            current_section = current_section[key]
+        else:
+            return None
+
+    return current_section

--- a/tests/component/test_mxnet_estimator.py
+++ b/tests/component/test_mxnet_estimator.py
@@ -34,7 +34,9 @@ SOURCE_DIR = 's3://fefergerger'
 @pytest.fixture()
 def sagemaker_session():
     boto_mock = Mock(name='boto_session', region_name=REGION)
-    ims = Mock(name='sagemaker_session', boto_session=boto_mock)
+    ims = Mock(name='sagemaker_session', boto_session=boto_mock,
+               config=None, local_mode=False, region_name=REGION)
+
     ims.default_bucket = Mock(name='default_bucket', return_value=BUCKET_NAME)
     ims.expand_role = Mock(name="expand_role", return_value=ROLE)
     ims.sagemaker_client.describe_training_job = Mock(return_value={'ModelArtifacts':

--- a/tests/component/test_tf_estimator.py
+++ b/tests/component/test_tf_estimator.py
@@ -34,7 +34,8 @@ SOURCE_DIR = 's3://fefergerger'
 @pytest.fixture()
 def sagemaker_session():
     boto_mock = Mock(name='boto_session', region_name=REGION)
-    ims = Mock(name='sagemaker_session', boto_session=boto_mock)
+    ims = Mock(name='sagemaker_session', boto_session=boto_mock, config=None,
+               local_mode=False, region_name=REGION)
     ims.default_bucket = Mock(name='default_bucket', return_value=BUCKET_NAME)
     ims.expand_role = Mock(name="expand_role", return_value=ROLE)
     ims.sagemaker_client.describe_training_job = Mock(return_value={'ModelArtifacts':
@@ -62,6 +63,7 @@ def test_deploy(sagemaker_session, tf_version):
          {'SAGEMAKER_ENABLE_CLOUDWATCH_METRICS': 'false',
           'SAGEMAKER_CONTAINER_LOG_LEVEL': '20',
           'SAGEMAKER_SUBMIT_DIRECTORY': SOURCE_DIR,
+          'SAGEMAKER_REQUIREMENTS': '',
           'SAGEMAKER_REGION': REGION,
           'SAGEMAKER_PROGRAM': SCRIPT},
          'Image': image,

--- a/tests/unit/test_amazon_estimator.py
+++ b/tests/unit/test_amazon_estimator.py
@@ -28,7 +28,8 @@ TIMESTAMP = '2017-11-06-14:14:15.671'
 @pytest.fixture()
 def sagemaker_session():
     boto_mock = Mock(name='boto_session', region_name=REGION)
-    sms = Mock(name='sagemaker_session', boto_session=boto_mock)
+    sms = Mock(name='sagemaker_session', boto_session=boto_mock,
+               region_name=REGION, config=None, local_mode=False)
     sms.boto_region_name = REGION
     sms.default_bucket = Mock(name='default_bucket', return_value=BUCKET_NAME)
     returned_job_description = {'AlgorithmSpecification': {'TrainingInputMode': 'File',

--- a/tests/unit/test_estimator.py
+++ b/tests/unit/test_estimator.py
@@ -89,7 +89,7 @@ class DummyFrameworkModel(FrameworkModel):
 @pytest.fixture()
 def sagemaker_session():
     boto_mock = Mock(name='boto_session', region_name=REGION)
-    ims = Mock(name='sagemaker_session', boto_session=boto_mock)
+    ims = Mock(name='sagemaker_session', boto_session=boto_mock, region_name=REGION)
     ims.default_bucket = Mock(name='default_bucket', return_value=BUCKET_NAME)
     ims.sagemaker_client.describe_training_job = Mock(name='describe_training_job',
                                                       return_value=DESCRIBE_TRAINING_JOB_RESULT)

--- a/tests/unit/test_fm.py
+++ b/tests/unit/test_fm.py
@@ -39,7 +39,8 @@ DESCRIBE_TRAINING_JOB_RESULT = {
 @pytest.fixture()
 def sagemaker_session():
     boto_mock = Mock(name='boto_session', region_name=REGION)
-    sms = Mock(name='sagemaker_session', boto_session=boto_mock)
+    sms = Mock(name='sagemaker_session', boto_session=boto_mock,
+               region_name=REGION, config=None, local_mode=False)
     sms.boto_region_name = REGION
     sms.default_bucket = Mock(name='default_bucket', return_value=BUCKET_NAME)
     sms.sagemaker_client.describe_training_job = Mock(name='describe_training_job',

--- a/tests/unit/test_fw_utils.py
+++ b/tests/unit/test_fw_utils.py
@@ -93,25 +93,22 @@ def test_tar_and_upload_dir_s3(sagemaker_session):
 def test_validate_source_dir_does_not_exits(sagemaker_session):
     script = 'mnist.py'
     directory = ' !@#$%^&*()path probably in not there.!@#$%^&*()'
-    with pytest.raises(ValueError) as error:
+    with pytest.raises(ValueError):
         validate_source_dir(script, directory)
-    assert 'does not exist' in str(error)
 
 
 def test_validate_source_dir_is_not_directory(sagemaker_session):
     script = 'mnist.py'
     directory = inspect.getfile(inspect.currentframe())
-    with pytest.raises(ValueError) as error:
+    with pytest.raises(ValueError):
         validate_source_dir(script, directory)
-    assert 'is not a directory' in str(error)
 
 
 def test_validate_source_dir_file_not_in_dir():
     script = ' !@#$%^&*() .myscript. !@#$%^&*() '
     directory = '.'
-    with pytest.raises(ValueError) as error:
+    with pytest.raises(ValueError):
         validate_source_dir(script, directory)
-    assert 'No file named' in str(error)
 
 
 def test_tar_and_upload_dir_not_s3(sagemaker_session):

--- a/tests/unit/test_fw_utils.py
+++ b/tests/unit/test_fw_utils.py
@@ -14,7 +14,7 @@ import inspect
 from mock import Mock
 import os
 from sagemaker.fw_utils import create_image_uri, framework_name_from_image, framework_version_from_tag
-from sagemaker.fw_utils import tar_and_upload_dir, parse_s3_url, UploadedCode
+from sagemaker.fw_utils import tar_and_upload_dir, parse_s3_url, UploadedCode, validate_source_dir
 import pytest
 
 
@@ -110,13 +110,11 @@ def test_tar_and_upload_dir_is_not_directory(sagemaker_session):
     assert 'is not a directory' in str(error)
 
 
-def test_tar_and_upload_dir_file_not_in_dir(sagemaker_session):
-    bucket = 'mybucker'
-    s3_key_prefix = 'something/source'
+def test_validate_source_dir_file_not_in_dir():
     script = ' !@#$%^&*() .myscript. !@#$%^&*() '
     directory = '.'
     with pytest.raises(ValueError) as error:
-        tar_and_upload_dir(sagemaker_session, bucket, s3_key_prefix, script, directory)
+        validate_source_dir(script, directory)
     assert 'No file named' in str(error)
 
 

--- a/tests/unit/test_fw_utils.py
+++ b/tests/unit/test_fw_utils.py
@@ -90,23 +90,19 @@ def test_tar_and_upload_dir_s3(sagemaker_session):
     assert result == UploadedCode('s3://m', 'mnist.py')
 
 
-def test_tar_and_upload_dir_does_not_exits(sagemaker_session):
-    bucket = 'mybucker'
-    s3_key_prefix = 'something/source'
+def test_validate_source_dir_does_not_exits(sagemaker_session):
     script = 'mnist.py'
     directory = ' !@#$%^&*()path probably in not there.!@#$%^&*()'
     with pytest.raises(ValueError) as error:
-        tar_and_upload_dir(sagemaker_session, bucket, s3_key_prefix, script, directory)
+        validate_source_dir(script, directory)
     assert 'does not exist' in str(error)
 
 
-def test_tar_and_upload_dir_is_not_directory(sagemaker_session):
-    bucket = 'mybucker'
-    s3_key_prefix = 'something/source'
+def test_validate_source_dir_is_not_directory(sagemaker_session):
     script = 'mnist.py'
     directory = inspect.getfile(inspect.currentframe())
     with pytest.raises(ValueError) as error:
-        tar_and_upload_dir(sagemaker_session, bucket, s3_key_prefix, script, directory)
+        validate_source_dir(script, directory)
     assert 'is not a directory' in str(error)
 
 

--- a/tests/unit/test_image.py
+++ b/tests/unit/test_image.py
@@ -49,6 +49,10 @@ HYPERPARAMETERS = {'a': 1,
                    'b': 'bee',
                    'sagemaker_submit_directory': json.dumps('s3://my_bucket/code')}
 
+LOCAL_CODE_HYPERPARAMETERS = {'a': 1,
+                              'b': 2,
+                              'sagemaker_submit_directory': json.dumps('file:///tmp/code')}
+
 
 @pytest.fixture()
 def sagemaker_session():
@@ -216,6 +220,37 @@ def test_train(_download_folder, _cleanup, _execute_and_stream_output, LocalSess
                 assert config['services'][h]['command'] == 'train'
 
 
+@patch('sagemaker.local.local_session.LocalSession')
+@patch('sagemaker.local.image._execute_and_stream_output')
+@patch('sagemaker.local.image._SageMakerContainer._cleanup')
+@patch('sagemaker.local.image._SageMakerContainer._download_folder')
+def test_train_local_code(_download_folder, _cleanup, _execute_and_stream_output,
+                          _local_session, tmpdir, sagemaker_session):
+    directories = [str(tmpdir.mkdir('container-root')), str(tmpdir.mkdir('data'))]
+    with patch('sagemaker.local.image._SageMakerContainer._create_tmp_folder',
+               side_effect=directories):
+        instance_count = 2
+        image = 'my-image'
+        sagemaker_container = _SageMakerContainer('local', instance_count, image,
+                                                  sagemaker_session=sagemaker_session)
+
+        sagemaker_container.train(INPUT_DATA_CONFIG, LOCAL_CODE_HYPERPARAMETERS)
+
+        docker_compose_file = os.path.join(sagemaker_container.container_root,
+                                           'docker-compose.yaml')
+        shared_folder_path = os.path.join(sagemaker_container.container_root, 'shared')
+
+        with open(docker_compose_file, 'r') as f:
+            config = yaml.load(f)
+            assert len(config['services']) == instance_count
+            for h in sagemaker_container.hosts:
+                assert config['services'][h]['image'] == image
+                assert config['services'][h]['command'] == 'train'
+                volumes = config['services'][h]['volumes']
+                assert '%s:/opt/ml/code' % '/tmp/code' in volumes
+                assert '%s:/opt/ml/shared' % shared_folder_path in volumes
+
+
 @patch('sagemaker.local.image._HostingContainer.up')
 @patch('shutil.copy')
 @patch('shutil.copytree')
@@ -242,6 +277,38 @@ def test_serve(up, copy, copytree, tmpdir, sagemaker_session):
             for h in sagemaker_container.hosts:
                 assert config['services'][h]['image'] == image
                 assert config['services'][h]['command'] == 'serve'
+
+
+@patch('sagemaker.local.image._HostingContainer.up')
+@patch('shutil.copy')
+@patch('shutil.copytree')
+def test_serve_local_code(up, copy, copytree, tmpdir, sagemaker_session):
+
+    with patch('sagemaker.local.image._SageMakerContainer._create_tmp_folder',
+               return_value=str(tmpdir.mkdir('container-root'))):
+
+        image = 'my-image'
+        sagemaker_container = _SageMakerContainer('local', 1, image, sagemaker_session=sagemaker_session)
+        primary_container = {'ModelDataUrl': '/some/model/path',
+                             'Environment': {'env1': 1,
+                                             'env2': 'b',
+                                             'SAGEMAKER_SUBMIT_DIRECTORY': 'file:///tmp/code'
+                                             }
+                             }
+
+        sagemaker_container.serve(primary_container)
+        docker_compose_file = os.path.join(sagemaker_container.container_root,
+                                           'docker-compose.yaml')
+
+        with open(docker_compose_file, 'r') as f:
+            config = yaml.load(f)
+
+            for h in sagemaker_container.hosts:
+                assert config['services'][h]['image'] == image
+                assert config['services'][h]['command'] == 'serve'
+
+                volumes = config['services'][h]['volumes']
+                assert '%s:/opt/ml/code' % '/tmp/code' in volumes
 
 
 @patch('os.makedirs')

--- a/tests/unit/test_image.py
+++ b/tests/unit/test_image.py
@@ -21,6 +21,7 @@ from mock import call, patch, Mock
 import sagemaker
 from sagemaker.local.image import _SageMakerContainer
 
+REGION = 'us-west-2'
 BUCKET_NAME = 'mybucket'
 EXPANDED_ROLE = 'arn:aws:iam::111111111111:role/ExpandedRole'
 INPUT_DATA_CONFIG = [
@@ -44,12 +45,14 @@ INPUT_DATA_CONFIG = [
         }
     }
 ]
-HYPERPARAMETERS = {'a': 1, 'b': "bee"}
+HYPERPARAMETERS = {'a': 1,
+                   'b': 'bee',
+                   'sagemaker_submit_directory': json.dumps('s3://my_bucket/code')}
 
 
 @pytest.fixture()
 def sagemaker_session():
-    boto_mock = Mock(name='boto_session')
+    boto_mock = Mock(name='boto_session', region_name=REGION)
     boto_mock.client('sts').get_caller_identity.return_value = {'Account': '123'}
     boto_mock.resource('s3').Bucket(BUCKET_NAME).objects.filter.return_value = []
 

--- a/tests/unit/test_image.py
+++ b/tests/unit/test_image.py
@@ -226,7 +226,12 @@ def test_serve(up, copy, copytree, tmpdir, sagemaker_session):
 
         image = 'my-image'
         sagemaker_container = _SageMakerContainer('local', 1, image, sagemaker_session=sagemaker_session)
-        primary_container = {'ModelDataUrl': '/some/model/path', 'Environment': {'env1': 1, 'env2': 'b'}}
+        primary_container = {'ModelDataUrl': '/some/model/path',
+                             'Environment': {'env1': 1,
+                                             'env2': 'b',
+                                             'SAGEMAKER_SUBMIT_DIRECTORY': 's3://some/path'
+                                             }
+                             }
 
         sagemaker_container.serve(primary_container)
         docker_compose_file = os.path.join(sagemaker_container.container_root, 'docker-compose.yaml')

--- a/tests/unit/test_kmeans.py
+++ b/tests/unit/test_kmeans.py
@@ -38,7 +38,8 @@ DESCRIBE_TRAINING_JOB_RESULT = {
 @pytest.fixture()
 def sagemaker_session():
     boto_mock = Mock(name='boto_session', region_name=REGION)
-    sms = Mock(name='sagemaker_session', boto_session=boto_mock)
+    sms = Mock(name='sagemaker_session', boto_session=boto_mock,
+               region_name=REGION, config=None, local_mode=False)
     sms.boto_region_name = REGION
     sms.default_bucket = Mock(name='default_bucket', return_value=BUCKET_NAME)
     sms.sagemaker_client.describe_training_job = Mock(name='describe_training_job',

--- a/tests/unit/test_lda.py
+++ b/tests/unit/test_lda.py
@@ -37,7 +37,8 @@ DESCRIBE_TRAINING_JOB_RESULT = {
 @pytest.fixture()
 def sagemaker_session():
     boto_mock = Mock(name='boto_session', region_name=REGION)
-    sms = Mock(name='sagemaker_session', boto_session=boto_mock)
+    sms = Mock(name='sagemaker_session', boto_session=boto_mock,
+               region_name=REGION, config=None, local_mode=False)
     sms.boto_region_name = REGION
     sms.default_bucket = Mock(name='default_bucket', return_value=BUCKET_NAME)
     sms.sagemaker_client.describe_training_job = Mock(name='describe_training_job',

--- a/tests/unit/test_lda.py
+++ b/tests/unit/test_lda.py
@@ -37,8 +37,7 @@ DESCRIBE_TRAINING_JOB_RESULT = {
 @pytest.fixture()
 def sagemaker_session():
     boto_mock = Mock(name='boto_session', region_name=REGION)
-    sms = Mock(name='sagemaker_session', boto_session=boto_mock,
-               region_name=REGION, config=None, local_mode=False)
+    sms = Mock(name='sagemaker_session', boto_session=boto_mock, config=None, local_mode=False)
     sms.boto_region_name = REGION
     sms.default_bucket = Mock(name='default_bucket', return_value=BUCKET_NAME)
     sms.sagemaker_client.describe_training_job = Mock(name='describe_training_job',

--- a/tests/unit/test_linear_learner.py
+++ b/tests/unit/test_linear_learner.py
@@ -39,7 +39,8 @@ DESCRIBE_TRAINING_JOB_RESULT = {
 @pytest.fixture()
 def sagemaker_session():
     boto_mock = Mock(name='boto_session', region_name=REGION)
-    sms = Mock(name='sagemaker_session', boto_session=boto_mock)
+    sms = Mock(name='sagemaker_session', boto_session=boto_mock,
+               region_name=REGION, config=None, local_mode=False)
     sms.boto_region_name = REGION
     sms.default_bucket = Mock(name='default_bucket', return_value=BUCKET_NAME)
     sms.sagemaker_client.describe_training_job = Mock(name='describe_training_job',

--- a/tests/unit/test_local_session.py
+++ b/tests/unit/test_local_session.py
@@ -201,7 +201,8 @@ def test_create_endpoint(serve, request, LocalSession):
 @patch('sagemaker.local.image._SageMakerContainer.serve')
 @patch('urllib3.PoolManager.request', return_value=BAD_RESPONSE)
 @patch('sagemaker.local.local_session.LocalSession')
-def test_create_endpoint_fails(serve, request, LocalSession):
+@patch('time.sleep')
+def test_create_endpoint_fails(*args):
     local_sagemaker_client = sagemaker.local.local_session.LocalSagemakerClient()
     local_sagemaker_client.variants = [{'InstanceType': 'ml.c4.99xlarge', 'InitialInstanceCount': 10}]
     local_sagemaker_client.primary_container = {'ModelDataUrl': '/some/model/path',

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -46,9 +46,10 @@ class DummyFrameworkModel(FrameworkModel):
 @pytest.fixture()
 def sagemaker_session():
     boto_mock = Mock(name='boto_session', region_name=REGION)
-    ims = Mock(name='sagemaker_session', boto_session=boto_mock)
-    ims.default_bucket = Mock(name='default_bucket', return_value=BUCKET_NAME)
-    return ims
+    sms = Mock(name='sagemaker_session', boto_session=boto_mock,
+               region_name=REGION, config=None, local_mode=False)
+    sms.default_bucket = Mock(name='default_bucket', return_value=BUCKET_NAME)
+    return sms
 
 
 @patch('tarfile.open')

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -47,7 +47,7 @@ class DummyFrameworkModel(FrameworkModel):
 def sagemaker_session():
     boto_mock = Mock(name='boto_session', region_name=REGION)
     sms = Mock(name='sagemaker_session', boto_session=boto_mock,
-               region_name=REGION, config=None, local_mode=False)
+               boto_region_name=REGION, config=None, local_mode=False)
     sms.default_bucket = Mock(name='default_bucket', return_value=BUCKET_NAME)
     return sms
 

--- a/tests/unit/test_mxnet.py
+++ b/tests/unit/test_mxnet.py
@@ -42,7 +42,7 @@ CPU = 'ml.c4.xlarge'
 @pytest.fixture()
 def sagemaker_session():
     boto_mock = Mock(name='boto_session', region_name=REGION)
-    ims = Mock(name='sagemaker_session', boto_session=boto_mock)
+    ims = Mock(name='sagemaker_session', boto_session=boto_mock, region_name=REGION)
     ims.sagemaker_client.describe_training_job = Mock(return_value={'ModelArtifacts':
                                                                     {'S3ModelArtifacts': 's3://m/m.tar.gz'}})
     ims.default_bucket = Mock(name='default_bucket', return_value=BUCKET_NAME)

--- a/tests/unit/test_mxnet.py
+++ b/tests/unit/test_mxnet.py
@@ -43,7 +43,7 @@ CPU = 'ml.c4.xlarge'
 def sagemaker_session():
     boto_mock = Mock(name='boto_session', region_name=REGION)
     sms = Mock(name='sagemaker_session', boto_session=boto_mock,
-               region_name=REGION, config=None, local_mode=False)
+               boto_region_name=REGION, config=None, local_mode=False)
     sms.sagemaker_client.describe_training_job = Mock(return_value={'ModelArtifacts':
                                                                     {'S3ModelArtifacts': 's3://m/m.tar.gz'}})
     sms.default_bucket = Mock(name='default_bucket', return_value=BUCKET_NAME)

--- a/tests/unit/test_mxnet.py
+++ b/tests/unit/test_mxnet.py
@@ -42,12 +42,13 @@ CPU = 'ml.c4.xlarge'
 @pytest.fixture()
 def sagemaker_session():
     boto_mock = Mock(name='boto_session', region_name=REGION)
-    ims = Mock(name='sagemaker_session', boto_session=boto_mock, region_name=REGION)
-    ims.sagemaker_client.describe_training_job = Mock(return_value={'ModelArtifacts':
+    sms = Mock(name='sagemaker_session', boto_session=boto_mock,
+               region_name=REGION, config=None, local_mode=False)
+    sms.sagemaker_client.describe_training_job = Mock(return_value={'ModelArtifacts':
                                                                     {'S3ModelArtifacts': 's3://m/m.tar.gz'}})
-    ims.default_bucket = Mock(name='default_bucket', return_value=BUCKET_NAME)
-    ims.expand_role = Mock(name="expand_role", return_value=ROLE)
-    return ims
+    sms.default_bucket = Mock(name='default_bucket', return_value=BUCKET_NAME)
+    sms.expand_role = Mock(name="expand_role", return_value=ROLE)
+    return sms
 
 
 def _get_full_image_uri(version):

--- a/tests/unit/test_ntm.py
+++ b/tests/unit/test_ntm.py
@@ -38,7 +38,8 @@ DESCRIBE_TRAINING_JOB_RESULT = {
 @pytest.fixture()
 def sagemaker_session():
     boto_mock = Mock(name='boto_session', region_name=REGION)
-    sms = Mock(name='sagemaker_session', boto_session=boto_mock)
+    sms = Mock(name='sagemaker_session', boto_session=boto_mock,
+               region_name=REGION, config=None, local_mode=False)
     sms.boto_region_name = REGION
     sms.default_bucket = Mock(name='default_bucket', return_value=BUCKET_NAME)
     sms.sagemaker_client.describe_training_job = Mock(name='describe_training_job',

--- a/tests/unit/test_pca.py
+++ b/tests/unit/test_pca.py
@@ -38,7 +38,8 @@ DESCRIBE_TRAINING_JOB_RESULT = {
 @pytest.fixture()
 def sagemaker_session():
     boto_mock = Mock(name='boto_session', region_name=REGION)
-    sms = Mock(name='sagemaker_session', boto_session=boto_mock)
+    sms = Mock(name='sagemaker_session', boto_session=boto_mock,
+               region_name=REGION, config=None, local_mode=False)
     sms.boto_region_name = REGION
     sms.default_bucket = Mock(name='default_bucket', return_value=BUCKET_NAME)
     sms.sagemaker_client.describe_training_job = Mock(name='describe_training_job',

--- a/tests/unit/test_randomcutforest.py
+++ b/tests/unit/test_randomcutforest.py
@@ -40,7 +40,8 @@ DESCRIBE_TRAINING_JOB_RESULT = {
 @pytest.fixture()
 def sagemaker_session():
     boto_mock = Mock(name='boto_session', region_name=REGION)
-    sms = Mock(name='sagemaker_session', boto_session=boto_mock)
+    sms = Mock(name='sagemaker_session', boto_session=boto_mock,
+               region_name=REGION, config=None, local_mode=False)
     sms.boto_region_name = REGION
     sms.default_bucket = Mock(name='default_bucket', return_value=BUCKET_NAME)
     sms.sagemaker_client.describe_training_job = Mock(name='describe_training_job',

--- a/tests/unit/test_tf_estimator.py
+++ b/tests/unit/test_tf_estimator.py
@@ -42,14 +42,14 @@ IMAGE_URI_FORMAT_STRING = "520713654638.dkr.ecr.{}.amazonaws.com/{}:{}-{}-{}"
 @pytest.fixture()
 def sagemaker_session():
     boto_mock = Mock(name='boto_session', region_name=REGION)
-    ims = Mock(name='sagemaker_session', boto_session=boto_mock, region_name=REGION,
-               config=None, local_mode=False)
-    ims.default_bucket = Mock(name='default_bucket', return_value=BUCKET_NAME)
-    ims.expand_role = Mock(name="expand_role", return_value=ROLE)
-    ims.sagemaker_client.describe_training_job = Mock(return_value={'ModelArtifacts':
+    sms = Mock(name='sagemaker_session', boto_session=boto_mock,
+               boto_region_name=REGION, config=None, local_mode=False)
+    sms.default_bucket = Mock(name='default_bucket', return_value=BUCKET_NAME)
+    sms.expand_role = Mock(name="expand_role", return_value=ROLE)
+    sms.sagemaker_client.describe_training_job = Mock(return_value={'ModelArtifacts':
                                                                     {'S3ModelArtifacts': 's3://m/m.tar.gz'}
                                                                     })
-    return ims
+    return sms
 
 
 def _get_full_cpu_image_uri(version):

--- a/tests/unit/test_tf_estimator.py
+++ b/tests/unit/test_tf_estimator.py
@@ -42,7 +42,8 @@ IMAGE_URI_FORMAT_STRING = "520713654638.dkr.ecr.{}.amazonaws.com/{}:{}-{}-{}"
 @pytest.fixture()
 def sagemaker_session():
     boto_mock = Mock(name='boto_session', region_name=REGION)
-    ims = Mock(name='sagemaker_session', boto_session=boto_mock, region_name=REGION)
+    ims = Mock(name='sagemaker_session', boto_session=boto_mock, region_name=REGION,
+               config=None, local_mode=False)
     ims.default_bucket = Mock(name='default_bucket', return_value=BUCKET_NAME)
     ims.expand_role = Mock(name="expand_role", return_value=ROLE)
     ims.sagemaker_client.describe_training_job = Mock(return_value={'ModelArtifacts':

--- a/tests/unit/test_tf_estimator.py
+++ b/tests/unit/test_tf_estimator.py
@@ -42,7 +42,7 @@ IMAGE_URI_FORMAT_STRING = "520713654638.dkr.ecr.{}.amazonaws.com/{}:{}-{}-{}"
 @pytest.fixture()
 def sagemaker_session():
     boto_mock = Mock(name='boto_session', region_name=REGION)
-    ims = Mock(name='sagemaker_session', boto_session=boto_mock)
+    ims = Mock(name='sagemaker_session', boto_session=boto_mock, region_name=REGION)
     ims.default_bucket = Mock(name='default_bucket', return_value=BUCKET_NAME)
     ims.expand_role = Mock(name="expand_role", return_value=ROLE)
     ims.sagemaker_client.describe_training_job = Mock(return_value={'ModelArtifacts':

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -10,7 +10,26 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from .local_session import (file_input, LocalSession, LocalSagemakerRuntimeClient,
-                            LocalSagemakerClient)
+from sagemaker.utils import get_config_value
 
-__all__ = [file_input, LocalSession, LocalSagemakerClient, LocalSagemakerRuntimeClient]
+
+def test_get_config_value():
+
+    config = {
+        'local': {
+            'region_name': 'us-west-2',
+            'port': '123'
+        },
+        'other': {
+            'key': 1
+        }
+    }
+
+    assert get_config_value('local.region_name', config) == 'us-west-2'
+    assert get_config_value('local', config) == {
+            'region_name': 'us-west-2',
+            'port': '123'
+        }
+
+    assert get_config_value('does_not.exist', config) is None
+    assert get_config_value('other.key', None) is None


### PR DESCRIPTION
This change works when ~/.sagemaker/config.yaml has

local:
   local_code: True

It depends on the container image supporting a local training script
instead of an s3 location.

*Issue #, if available:*

*Description of changes:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated the [changelog](https://github.com/aws/sagemaker-python-sdk/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
