### PR TITLE
Fix non-ascii chars in README.rst that broke pip install (issue #169)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,7 +56,7 @@ SageMaker Python SDK is tested on: \* Python 2.7 \* Python 3.5
 
 Licensing
 ~~~~~~~~~
-SageMaker Python SDK is licensed under the Apache 2.0 License. It is copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved. The license is available at:  
+SageMaker Python SDK is licensed under the Apache 2.0 License. It is copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved. The license is available at:
 http://aws.amazon.com/apache2.0/
 
 Running tests
@@ -148,7 +148,7 @@ Local Mode
 ~~~~~~~~~~
 
 The SageMaker Python SDK now supports local mode, which allows you to create TensorFlow, MXNet and BYO estimators and
-deploy to your local environment. This is a great way to test your deep learning script before running in
+deploy to your local environment. This is a great way to test your deep learning script before running in
 SageMaker's managed training or hosting environments.
 
 We can take the example in  `Estimator Usage <#estimator-usage>`__ , and use either ``local`` or ``local_gpu`` as the
@@ -188,7 +188,7 @@ A few important notes:
 
 - Only one local mode endpoint can be running at a time
 - If you are using s3 data as input, it will be pulled from S3 to your local environment, please ensure you have sufficient space.
-- If you run into problems, this is often due to different docker containers conflicting.  Killing these containers and re-running often solves your problems.
+- If you run into problems, this is often due to different docker containers conflicting. Killing these containers and re-running often solves your problems.
 - Local Mode requires docker-compose and `nvidia-docker2 <https://github.com/NVIDIA/nvidia-docker>`__ for ``local_gpu``.
 - Distributed training is not yet supported for ``local_gpu``.
 


### PR DESCRIPTION
*Issue #169*

*Description of changes:* 
Removed non-ascii (128) characters from README.rst that caused pip install to fail. Two non-breakable spaces (0xA0) were replaced by normal spaces.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated the [changelog](https://github.com/aws/sagemaker-python-sdk/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [x] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
