### PR TITLE
Fix kmeans max_iterations hyperparameter

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ CHANGELOG
 1.3.dev1
 ========
 
-* bug-fix: Change max_iterations hyperparameter key for kmeans
+* bug-fix: Estimators: Change max_iterations hyperparameter key for KMeans
 
 1.3.0
 =====

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,13 +2,18 @@
 CHANGELOG
 =========
 
+1.3.dev1
+========
+
+* bug-fix: Change max_iterations hyperparameter key for kmeans
+
 1.3.0
-=======
+=====
 
 * feature: Add chainer
 
 1.2.5
-========
+=====
 
 * bug-fix: Change module names to string type in __all__
 * feature: Save training output files in local mode

--- a/src/sagemaker/amazon/kmeans.py
+++ b/src/sagemaker/amazon/kmeans.py
@@ -28,7 +28,7 @@ class KMeans(AmazonAlgorithmEstimatorBase):
 
     k = hp('k', gt(1), 'An integer greater-than 1', int)
     init_method = hp('init_method', isin('random', 'kmeans++'), 'One of "random", "kmeans++"', str)
-    max_iterations = hp('local_lloyd_max_iterations', gt(0), 'An integer greater-than 0', int)
+    max_iterations = hp('local_lloyd_max_iter', gt(0), 'An integer greater-than 0', int)
     tol = hp('local_lloyd_tol', (ge(0), le(1)), 'An float in [0, 1]', float)
     num_trials = hp('local_lloyd_num_trials', gt(0), 'An integer greater-than 0', int)
     local_init_method = hp('local_lloyd_init_method', isin('random', 'kmeans++'), 'One of "random", "kmeans++"', str)

--- a/tests/integ/test_kmeans.py
+++ b/tests/integ/test_kmeans.py
@@ -59,7 +59,7 @@ def test_kmeans(sagemaker_session):
             epochs=str(kmeans.epochs),
             extra_center_factor=str(kmeans.center_factor),
             k=str(kmeans.k),
-            force_dense='True'
+            force_dense='True',
         )
 
         kmeans.fit(kmeans.record_set(train_set[0][:100]))
@@ -111,7 +111,7 @@ def test_async_kmeans(sagemaker_session):
             epochs=str(kmeans.epochs),
             extra_center_factor=str(kmeans.center_factor),
             k=str(kmeans.k),
-            force_dense='True'
+            force_dense='True',
         )
 
         kmeans.fit(kmeans.record_set(train_set[0][:100]), wait=False)

--- a/tests/integ/test_kmeans.py
+++ b/tests/integ/test_kmeans.py
@@ -41,13 +41,26 @@ def test_kmeans(sagemaker_session):
                         k=10, sagemaker_session=sagemaker_session, base_job_name='test-kmeans')
 
         kmeans.init_method = 'random'
-        kmeans.max_iterators = 1
+        kmeans.max_iterations = 1
         kmeans.tol = 1
         kmeans.num_trials = 1
         kmeans.local_init_method = 'kmeans++'
         kmeans.half_life_time_size = 1
         kmeans.epochs = 1
         kmeans.center_factor = 1
+
+        assert kmeans.hyperparameters() == dict(
+            init_method=kmeans.init_method,
+            local_lloyd_max_iter=str(kmeans.max_iterations),
+            local_lloyd_tol=str(kmeans.tol),
+            local_lloyd_num_trials=str(kmeans.num_trials),
+            local_lloyd_init_method=kmeans.local_init_method,
+            half_life_time_size=str(kmeans.half_life_time_size),
+            epochs=str(kmeans.epochs),
+            extra_center_factor=str(kmeans.center_factor),
+            k=str(kmeans.k),
+            force_dense='True'
+        )
 
         kmeans.fit(kmeans.record_set(train_set[0][:100]))
 
@@ -80,13 +93,26 @@ def test_async_kmeans(sagemaker_session):
                         k=10, sagemaker_session=sagemaker_session, base_job_name='test-kmeans')
 
         kmeans.init_method = 'random'
-        kmeans.max_iterators = 1
+        kmeans.max_iterations = 1
         kmeans.tol = 1
         kmeans.num_trials = 1
         kmeans.local_init_method = 'kmeans++'
         kmeans.half_life_time_size = 1
         kmeans.epochs = 1
         kmeans.center_factor = 1
+
+        assert kmeans.hyperparameters() == dict(
+            init_method=kmeans.init_method,
+            local_lloyd_max_iter=str(kmeans.max_iterations),
+            local_lloyd_tol=str(kmeans.tol),
+            local_lloyd_num_trials=str(kmeans.num_trials),
+            local_lloyd_init_method=kmeans.local_init_method,
+            half_life_time_size=str(kmeans.half_life_time_size),
+            epochs=str(kmeans.epochs),
+            extra_center_factor=str(kmeans.center_factor),
+            k=str(kmeans.k),
+            force_dense='True'
+        )
 
         kmeans.fit(kmeans.record_set(train_set[0][:100]), wait=False)
         training_job_name = kmeans.latest_training_job.name

--- a/tests/unit/test_kmeans.py
+++ b/tests/unit/test_kmeans.py
@@ -82,7 +82,7 @@ def test_all_hyperparameters(sagemaker_session):
         epochs='10',
         extra_center_factor='2',
         eval_metrics='[\'msd\', \'ssd\']',
-        force_dense='True'
+        force_dense='True',
     )
 
 

--- a/tests/unit/test_kmeans.py
+++ b/tests/unit/test_kmeans.py
@@ -74,7 +74,7 @@ def test_all_hyperparameters(sagemaker_session):
     assert kmeans.hyperparameters() == dict(
         k=str(ALL_REQ_ARGS['k']),
         init_method='random',
-        local_lloyd_max_iterations='3',
+        local_lloyd_max_iter='3',
         local_lloyd_tol='0.5',
         local_lloyd_num_trials='5',
         local_lloyd_init_method='kmeans++',


### PR DESCRIPTION
*Issue #, if available:*
The 1P KMeans algorithm is expecting the hyperparameter 'local_lloyd_max_iter' instead of 'local_lloyd_max_iterations', which we do currently. This causes the training to fail due to an invalid hyperparameter provided. The integration test never caught this because the correct class variable wasn't updated, which would have caught this. The variable that contains the value for the hyperparameter isn't an instance of the hyperparameter class, thus it ends up never calling the __set__ method within hyperparameter.py, which is used to correctly populate the _hyperparameters dict used within the hyperparameters().

*Description of changes:*
Change hyperparameter key name to local_lloyd_max_iter. Add additional test within integration test asserting the hyperparameters matches what is expected.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have updated the [changelog](https://github.com/aws/sagemaker-python-sdk/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [x] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
