### PR TITLE
Allow Local Serving of Models in S3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,8 +5,8 @@ CHANGELOG
 1.4.2dev
 ========
 
-* bug-fix: Unit Tests: Improve unit test runtime
 * bug-fix: Estimators: Fix attach for LDA
+* feature: Allow Local Serving of Models in S3
 
 1.4.1
 =====

--- a/src/sagemaker/predictor.py
+++ b/src/sagemaker/predictor.py
@@ -94,9 +94,8 @@ class RealTimePredictor(object):
         return data
 
     def delete_endpoint(self):
-        def delete_endpoint(self):
-            """Delete an Amazon SageMaker ``Endpoint``.
-            """
+        """Delete the Amazon SageMaker endpoint backing this predictor.
+        """
         self.sagemaker_session.delete_endpoint(self.endpoint)
 
 

--- a/src/sagemaker/predictor.py
+++ b/src/sagemaker/predictor.py
@@ -93,6 +93,12 @@ class RealTimePredictor(object):
         response_body.close()
         return data
 
+    def delete_endpoint(self):
+        def delete_endpoint(self):
+            """Delete an Amazon SageMaker ``Endpoint``.
+            """
+        self.sagemaker_session.delete_endpoint(self.endpoint)
+
 
 class _CsvSerializer(object):
     def __init__(self):


### PR DESCRIPTION
if a model is located in S3, download and extract it and then start
serving as usual. By overriding the SageMaker Session on any Model
Object, local serving is possible on pre-trained models.

*Issue #, if available:*

*Description of changes:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated the [changelog](https://github.com/aws/sagemaker-python-sdk/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
