### PR TITLE
Allow Framework Estimators to use custom image

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ CHANGELOG
 
 * bug-fix: Unit Tests: Improve unit test runtime
 * bug-fix: Estimators: Fix attach for LDA
+* feature: Allow Chainer, Tensorflow and MXNet estimators to use a custom docker image.
 
 1.4.1
 =====

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,7 @@ CHANGELOG
 * enhancement: Let Framework models reuse code uploaded by Framework estimators
 * enhancement: Unify generation of model uploaded code location
 * feature: Change minimum required scipy from 1.0.0 to 0.19.0
-* feature: Allow Chainer, Tensorflow and MXNet estimators to use a custom docker image.
+* feature: Allow all Framework Estimators to use a custom docker image.
 
 1.5.0
 =====

--- a/src/sagemaker/chainer/README.rst
+++ b/src/sagemaker/chainer/README.rst
@@ -175,6 +175,12 @@ The following are optional arguments. When you create a ``Chainer`` object, you 
 -  ``job_name`` Name to assign for the training job that the fit()
    method launches. If not specified, the estimator generates a default
    job name, based on the training image name and current timestamp
+-  ``image_name`` An alternative docker image to use for training and
+    serving.  If specified, the estimator will use this image for training and
+    hosting, instead of selecting the appropriate SageMaker official image based on
+    framework_version and py_version. Refer to: `SageMaker Chainer Docker Containers
+    <#sagemaker-chainer-docker-containers>`_ for details on what the Official images support
+    and where to find the source code to build your custom image.
 
 
 Distributed Chainer Training
@@ -655,6 +661,9 @@ You can select version of Chainer by passing a framework_version keyword arg to 
 Currently supported versions are listed in the above table. You can also set framework_version to only specify major and
 minor version, which will cause your training script to be run on the latest supported patch version of that minor
 version.
+
+Alternatively, you can build your own image by following the instructions in the SageMaker Chainer containers
+repository, and passing ``image_name`` to the Chainer Estimator constructor.
 
 You can visit the SageMaker Chainer containers repository here: https://github.com/aws/sagemaker-chainer-containers/
 

--- a/src/sagemaker/chainer/README.rst
+++ b/src/sagemaker/chainer/README.rst
@@ -176,11 +176,11 @@ The following are optional arguments. When you create a ``Chainer`` object, you 
    method launches. If not specified, the estimator generates a default
    job name, based on the training image name and current timestamp
 -  ``image_name`` An alternative docker image to use for training and
-    serving.  If specified, the estimator will use this image for training and
-    hosting, instead of selecting the appropriate SageMaker official image based on
-    framework_version and py_version. Refer to: `SageMaker Chainer Docker Containers
-    <#sagemaker-chainer-docker-containers>`_ for details on what the Official images support
-    and where to find the source code to build your custom image.
+   serving.  If specified, the estimator will use this image for training and
+   hosting, instead of selecting the appropriate SageMaker official image based on
+   framework_version and py_version. Refer to: `SageMaker Chainer Docker Containers
+   <#sagemaker-chainer-docker-containers>`_ for details on what the Official images support
+   and where to find the source code to build your custom image.
 
 
 Distributed Chainer Training

--- a/src/sagemaker/chainer/estimator.py
+++ b/src/sagemaker/chainer/estimator.py
@@ -69,8 +69,10 @@ class Chainer(Framework):
                 List of supported versions https://github.com/aws/sagemaker-python-sdk#chainer-sagemaker-estimators
             image_name (str): If specified, the estimator will use this image for training and hosting, instead of
                 selecting the appropriate SageMaker official image based on framework_version and py_version. It can
-                be an ECR url or dockerhub image and tag: 123.dkr.ecr.us-west-2.amazonaws.com/my-custom-image:1.0,
-                custom-image:latest.
+                be an ECR url or dockerhub image and tag.
+                Examples:
+                    123.dkr.ecr.us-west-2.amazonaws.com/my-custom-image:1.0
+                    custom-image:latest.
             **kwargs: Additional kwargs passed to the :class:`~sagemaker.estimator.Framework` constructor.
         """
         super(Chainer, self).__init__(entry_point, source_dir, hyperparameters,

--- a/src/sagemaker/chainer/estimator.py
+++ b/src/sagemaker/chainer/estimator.py
@@ -67,8 +67,10 @@ class Chainer(Framework):
                               One of 'py2' or 'py3'.
             framework_version (str): Chainer version you want to use for executing your model training code.
                 List of supported versions https://github.com/aws/sagemaker-python-sdk#chainer-sagemaker-estimators
-            image_name (str): The container image to use for training. This will override py_version and
-                framework_version. The image is expected to be a modification of the SageMaker Chainer image.
+            image_name (str): If specified, the estimator will use this image for training and hosting, instead of
+                selecting the appropriate SageMaker official image based on framework_version and py_version. It can
+                be an ECR url or dockerhub image and tag: 123.dkr.ecr.us-west-2.amazonaws.com/my-custom-image:1.0,
+                custom-image:latest.
             **kwargs: Additional kwargs passed to the :class:`~sagemaker.estimator.Framework` constructor.
         """
         super(Chainer, self).__init__(entry_point, source_dir, hyperparameters,

--- a/src/sagemaker/chainer/estimator.py
+++ b/src/sagemaker/chainer/estimator.py
@@ -13,7 +13,7 @@
 from __future__ import absolute_import
 
 from sagemaker.estimator import Framework
-from sagemaker.fw_utils import create_image_uri, framework_name_from_image, framework_version_from_tag
+from sagemaker.fw_utils import framework_name_from_image, framework_version_from_tag
 from sagemaker.chainer.defaults import CHAINER_VERSION
 from sagemaker.chainer.model import ChainerModel
 
@@ -31,7 +31,7 @@ class Chainer(Framework):
 
     def __init__(self, entry_point, use_mpi=None, num_processes=None, process_slots_per_host=None,
                  additional_mpi_options=None, source_dir=None, hyperparameters=None, py_version='py3',
-                 framework_version=CHAINER_VERSION, **kwargs):
+                 framework_version=CHAINER_VERSION, image_name=None, **kwargs):
         """
         This ``Estimator`` executes an Chainer script in a managed Chainer execution environment, within a SageMaker
         Training Job. The managed Chainer environment is an Amazon-built Docker container that executes functions
@@ -67,9 +67,12 @@ class Chainer(Framework):
                               One of 'py2' or 'py3'.
             framework_version (str): Chainer version you want to use for executing your model training code.
                 List of supported versions https://github.com/aws/sagemaker-python-sdk#chainer-sagemaker-estimators
+            image_name (str): The container image to use for training. This will override py_version and
+                framework_version. The image is expected to be a modification of the SageMaker Chainer image.
             **kwargs: Additional kwargs passed to the :class:`~sagemaker.estimator.Framework` constructor.
         """
-        super(Chainer, self).__init__(entry_point, source_dir, hyperparameters, **kwargs)
+        super(Chainer, self).__init__(entry_point, source_dir, hyperparameters,
+                                      image_name=image_name, **kwargs)
         self.py_version = py_version
         self.framework_version = framework_version
         self.use_mpi = use_mpi
@@ -91,20 +94,6 @@ class Chainer(Framework):
         hyperparameters.update(Framework._json_encode_hyperparameters(additional_hyperparameters))
         return hyperparameters
 
-    def train_image(self):
-        """Return the Docker image to use for training.
-
-        The :meth:`~sagemaker.estimator.EstimatorBase.fit` method, which does the model training, calls this method to
-        find the image to use for model training.
-
-        Returns:
-            str: The URI of the Docker image.
-        """
-
-        return create_image_uri(self.sagemaker_session.boto_session.region_name, self.__framework_name__,
-                                self.train_instance_type, framework_version=self.framework_version,
-                                py_version=self.py_version)
-
     def create_model(self, model_server_workers=None):
         """Create a SageMaker ``ChainerModel`` object that can be deployed to an ``Endpoint``.
 
@@ -120,7 +109,8 @@ class Chainer(Framework):
                             enable_cloudwatch_metrics=self.enable_cloudwatch_metrics, name=self._current_job_name,
                             container_log_level=self.container_log_level, code_location=self.code_location,
                             py_version=self.py_version, framework_version=self.framework_version,
-                            model_server_workers=model_server_workers, sagemaker_session=self.sagemaker_session)
+                            model_server_workers=model_server_workers, image=self.image_name,
+                            sagemaker_session=self.sagemaker_session)
 
     @classmethod
     def _prepare_init_params_from_job_description(cls, job_details):
@@ -142,7 +132,14 @@ class Chainer(Framework):
             if value:
                 init_params[argument[len('sagemaker_'):]] = value
 
-        framework, py_version, tag = framework_name_from_image(init_params.pop('image'))
+        image_name = init_params.pop('image')
+        framework, py_version, tag = framework_name_from_image(image_name)
+
+        if not framework:
+            # If we were unable to parse the framework name from the image it is not one of our
+            # officially supported images, in this case just add the image to the init params.
+            init_params['image_name'] = image_name
+            return init_params
 
         init_params['py_version'] = py_version
         init_params['framework_version'] = framework_version_from_tag(tag)

--- a/src/sagemaker/estimator.py
+++ b/src/sagemaker/estimator.py
@@ -227,7 +227,6 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):
         job_details = sagemaker_session.sagemaker_client.describe_training_job(TrainingJobName=training_job_name)
         init_params = cls._prepare_init_params_from_job_description(job_details)
 
-        print(init_params)
         estimator = cls(sagemaker_session=sagemaker_session, **init_params)
         estimator.latest_training_job = _TrainingJob(sagemaker_session=sagemaker_session,
                                                      training_job_name=init_params['base_job_name'])
@@ -527,8 +526,6 @@ class Framework(EstimatorBase):
         self._hyperparameters = hyperparameters or {}
         self.code_location = code_location
         self.image_name = image_name
-        print(self.image_name)
-        print(kwargs)
 
     def _prepare_for_training(self, job_name=None):
         """Set hyperparameters needed for training. This method will also validate ``source_dir``.

--- a/src/sagemaker/mxnet/README.rst
+++ b/src/sagemaker/mxnet/README.rst
@@ -153,6 +153,12 @@ The following are optional arguments. When you create an ``MXNet`` object, you c
 -  ``job_name`` Name to assign for the training job that the fit()
    method launches. If not specified, the estimator generates a default
    job name, based on the training image name and current timestamp
+-  ``image_name`` An alternative docker image to use for training and
+    serving.  If specified, the estimator will use this image for training and
+    hosting, instead of selecting the appropriate SageMaker official image based on
+    framework_version and py_version. Refer to: `SageMaker MXNet Docker Containers
+    <#sagemaker-mxnet-docker-containers>`_ for details on what the Official images support
+    and where to find the source code to build your custom image.
 
 Calling fit
 ^^^^^^^^^^^
@@ -595,5 +601,6 @@ The Docker images have the following dependencies installed:
 The Docker images extend Ubuntu 16.04.
 
 You can select version of MXNet by passing a ``framework_version`` keyword arg to the MXNet Estimator constructor. Currently supported versions are listed in the above table. You can also set ``framework_version`` to only specify major and minor version, e.g ``1.1``, which will cause your training script to be run on the latest supported patch version of that minor version, which in this example would be 1.1.0.
+Alternatively, you can build your own image by following the instructions in the SageMaker MXNet containers repository, and passing ``image_name`` to the MXNet Estimator constructor.
 
 You can visit the SageMaker MXNet containers repository here: https://github.com/aws/sagemaker-mxnet-containers/

--- a/src/sagemaker/mxnet/README.rst
+++ b/src/sagemaker/mxnet/README.rst
@@ -154,11 +154,11 @@ The following are optional arguments. When you create an ``MXNet`` object, you c
    method launches. If not specified, the estimator generates a default
    job name, based on the training image name and current timestamp
 -  ``image_name`` An alternative docker image to use for training and
-    serving.  If specified, the estimator will use this image for training and
-    hosting, instead of selecting the appropriate SageMaker official image based on
-    framework_version and py_version. Refer to: `SageMaker MXNet Docker Containers
-    <#sagemaker-mxnet-docker-containers>`_ for details on what the Official images support
-    and where to find the source code to build your custom image.
+   serving.  If specified, the estimator will use this image for training and
+   hosting, instead of selecting the appropriate SageMaker official image based on
+   framework_version and py_version. Refer to: `SageMaker MXNet Docker Containers
+   <#sagemaker-mxnet-docker-containers>`_ for details on what the Official images support
+   and where to find the source code to build your custom image.
 
 Calling fit
 ^^^^^^^^^^^

--- a/src/sagemaker/mxnet/estimator.py
+++ b/src/sagemaker/mxnet/estimator.py
@@ -54,8 +54,10 @@ class MXNet(Framework):
                 List of supported versions https://github.com/aws/sagemaker-python-sdk#mxnet-sagemaker-estimators
             image_name (str): If specified, the estimator will use this image for training and hosting, instead of
                 selecting the appropriate SageMaker official image based on framework_version and py_version. It can
-                be an ECR url or dockerhub image and tag: 123.dkr.ecr.us-west-2.amazonaws.com/my-custom-image:1.0,
-                custom-image:latest.
+                be an ECR url or dockerhub image and tag.
+                    Examples:
+                        123.dkr.ecr.us-west-2.amazonaws.com/my-custom-image:1.0
+                        custom-image:latest.
             **kwargs: Additional kwargs passed to the :class:`~sagemaker.estimator.Framework` constructor.
         """
         super(MXNet, self).__init__(entry_point, source_dir, hyperparameters,

--- a/src/sagemaker/mxnet/estimator.py
+++ b/src/sagemaker/mxnet/estimator.py
@@ -52,8 +52,10 @@ class MXNet(Framework):
                               One of 'py2' or 'py3'.
             framework_version (str): MXNet version you want to use for executing your model training code.
                 List of supported versions https://github.com/aws/sagemaker-python-sdk#mxnet-sagemaker-estimators
-            image_name (str): The container image to use for training. This will override py_version and
-                framework_version. The image is expected to be a modification of the SageMaker MXNet image.
+            image_name (str): If specified, the estimator will use this image for training and hosting, instead of
+                selecting the appropriate SageMaker official image based on framework_version and py_version. It can
+                be an ECR url or dockerhub image and tag: 123.dkr.ecr.us-west-2.amazonaws.com/my-custom-image:1.0,
+                custom-image:latest.
             **kwargs: Additional kwargs passed to the :class:`~sagemaker.estimator.Framework` constructor.
         """
         super(MXNet, self).__init__(entry_point, source_dir, hyperparameters,

--- a/src/sagemaker/mxnet/estimator.py
+++ b/src/sagemaker/mxnet/estimator.py
@@ -13,7 +13,7 @@
 from __future__ import absolute_import
 
 from sagemaker.estimator import Framework
-from sagemaker.fw_utils import create_image_uri, framework_name_from_image, framework_version_from_tag
+from sagemaker.fw_utils import framework_name_from_image, framework_version_from_tag
 from sagemaker.mxnet.defaults import MXNET_VERSION
 from sagemaker.mxnet.model import MXNetModel
 
@@ -24,7 +24,7 @@ class MXNet(Framework):
     __framework_name__ = "mxnet"
 
     def __init__(self, entry_point, source_dir=None, hyperparameters=None, py_version='py2',
-                 framework_version=MXNET_VERSION, **kwargs):
+                 framework_version=MXNET_VERSION, image_name=None, **kwargs):
         """
         This ``Estimator`` executes an MXNet script in a managed MXNet execution environment, within a SageMaker
         Training Job. The managed MXNet environment is an Amazon-built Docker container that executes functions
@@ -52,24 +52,14 @@ class MXNet(Framework):
                               One of 'py2' or 'py3'.
             framework_version (str): MXNet version you want to use for executing your model training code.
                 List of supported versions https://github.com/aws/sagemaker-python-sdk#mxnet-sagemaker-estimators
+            image_name (str): The container image to use for training. This will override py_version and
+                framework_version. The image is expected to be a modification of the SageMaker MXNet image.
             **kwargs: Additional kwargs passed to the :class:`~sagemaker.estimator.Framework` constructor.
         """
-        super(MXNet, self).__init__(entry_point, source_dir, hyperparameters, **kwargs)
+        super(MXNet, self).__init__(entry_point, source_dir, hyperparameters,
+                                    image_name=image_name, **kwargs)
         self.py_version = py_version
         self.framework_version = framework_version
-
-    def train_image(self):
-        """Return the Docker image to use for training.
-
-        The :meth:`~sagemaker.estimator.EstimatorBase.fit` method, which does the model training, calls this method to
-        find the image to use for model training.
-
-        Returns:
-            str: The URI of the Docker image.
-        """
-        return create_image_uri(self.sagemaker_session.boto_region_name, self.__framework_name__,
-                                self.train_instance_type, framework_version=self.framework_version,
-                                py_version=self.py_version)
 
     def create_model(self, model_server_workers=None):
         """Create a SageMaker ``MXNetModel`` object that can be deployed to an ``Endpoint``.
@@ -82,11 +72,16 @@ class MXNet(Framework):
             sagemaker.mxnet.model.MXNetModel: A SageMaker ``MXNetModel`` object.
                 See :func:`~sagemaker.mxnet.model.MXNetModel` for full details.
         """
+        kwargs = {}
+        # pass our custom image if there is one.
+        if self.image_name:
+            kwargs['image'] = self.image_name
+
         return MXNetModel(self.model_data, self.role, self.entry_point, source_dir=self.source_dir,
                           enable_cloudwatch_metrics=self.enable_cloudwatch_metrics, name=self._current_job_name,
                           container_log_level=self.container_log_level, code_location=self.code_location,
                           py_version=self.py_version, framework_version=self.framework_version,
-                          model_server_workers=model_server_workers, sagemaker_session=self.sagemaker_session)
+                          model_server_workers=model_server_workers, sagemaker_session=self.sagemaker_session, **kwargs)
 
     @classmethod
     def _prepare_init_params_from_job_description(cls, job_details):
@@ -100,7 +95,14 @@ class MXNet(Framework):
 
         """
         init_params = super(MXNet, cls)._prepare_init_params_from_job_description(job_details)
-        framework, py_version, tag = framework_name_from_image(init_params.pop('image'))
+        image_name = init_params.pop('image')
+        framework, py_version, tag = framework_name_from_image(image_name)
+
+        if not framework:
+            # If we were unable to parse the framework name from the image it is not one of our
+            # officially supported images, in this case just add the image to the init params.
+            init_params['image_name'] = image_name
+            return init_params
 
         init_params['py_version'] = py_version
 

--- a/src/sagemaker/mxnet/estimator.py
+++ b/src/sagemaker/mxnet/estimator.py
@@ -76,16 +76,11 @@ class MXNet(Framework):
             sagemaker.mxnet.model.MXNetModel: A SageMaker ``MXNetModel`` object.
                 See :func:`~sagemaker.mxnet.model.MXNetModel` for full details.
         """
-        kwargs = {}
-        # pass our custom image if there is one.
-        if self.image_name:
-            kwargs['image'] = self.image_name
-
         return MXNetModel(self.model_data, self.role, self.entry_point, source_dir=self._model_source_dir(),
                           enable_cloudwatch_metrics=self.enable_cloudwatch_metrics, name=self._current_job_name,
-                          container_log_level=self.container_log_level, code_location=self.code_location, image=self.image_name,
-                          py_version=self.py_version, framework_version=self.framework_version,
-                          model_server_workers=model_server_workers, sagemaker_session=self.sagemaker_session, **kwargs)
+                          container_log_level=self.container_log_level, code_location=self.code_location,
+                          py_version=self.py_version, framework_version=self.framework_version, image=self.image_name,
+                          model_server_workers=model_server_workers, sagemaker_session=self.sagemaker_session)
 
     @classmethod
     def _prepare_init_params_from_job_description(cls, job_details):

--- a/src/sagemaker/pytorch/README.rst
+++ b/src/sagemaker/pytorch/README.rst
@@ -204,7 +204,12 @@ The following are optional arguments. When you create a ``PyTorch`` object, you 
 -  ``job_name`` Name to assign for the training job that the ``fit```
    method launches. If not specified, the estimator generates a default
    job name, based on the training image name and current timestamp
-
+-  ``image_name`` An alternative docker image to use for training and
+   serving.  If specified, the estimator will use this image for training and
+   hosting, instead of selecting the appropriate SageMaker official image based on
+   framework_version and py_version. Refer to: `SageMaker PyTorch Docker Containers
+   <#sagemaker-pytorch-docker-containers>`_ for details on what the Official images support
+   and where to find the source code to build your custom image.
 
 Calling fit
 ~~~~~~~~~~~
@@ -704,5 +709,8 @@ You can select version of PyTorch by passing a ``framework_version`` keyword arg
 Currently supported versions are listed in the above table. You can also set ``framework_version`` to only specify major and
 minor version, which will cause your training script to be run on the latest supported patch version of that minor
 version.
+
+Alternatively, you can build your own image by following the instructions in the SageMaker Chainer containers
+repository, and passing ``image_name`` to the Chainer Estimator constructor.
 
 You can visit `the SageMaker PyTorch containers repository <https://github.com/aws/sagemaker-pytorch-containers>`_.

--- a/src/sagemaker/pytorch/estimator.py
+++ b/src/sagemaker/pytorch/estimator.py
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 from __future__ import absolute_import
 from sagemaker.estimator import Framework
-from sagemaker.fw_utils import create_image_uri, framework_name_from_image, framework_version_from_tag
+from sagemaker.fw_utils import framework_name_from_image, framework_version_from_tag
 from sagemaker.pytorch.defaults import PYTORCH_VERSION, PYTHON_VERSION
 from sagemaker.pytorch.model import PyTorchModel
 
@@ -23,7 +23,7 @@ class PyTorch(Framework):
     __framework_name__ = "pytorch"
 
     def __init__(self, entry_point, source_dir=None, hyperparameters=None, py_version=PYTHON_VERSION,
-                 framework_version=PYTORCH_VERSION, **kwargs):
+                 framework_version=PYTORCH_VERSION, image_name=None, **kwargs):
         """
         This ``Estimator`` executes an PyTorch script in a managed PyTorch execution environment, within a SageMaker
         Training Job. The managed PyTorch environment is an Amazon-built Docker container that executes functions
@@ -51,24 +51,17 @@ class PyTorch(Framework):
                               One of 'py2' or 'py3'.
             framework_version (str): PyTorch version you want to use for executing your model training code.
                 List of supported versions https://github.com/aws/sagemaker-python-sdk#pytorch-sagemaker-estimators
+            image_name (str): If specified, the estimator will use this image for training and hosting, instead of
+                selecting the appropriate SageMaker official image based on framework_version and py_version. It can
+                be an ECR url or dockerhub image and tag.
+                Examples:
+                    123.dkr.ecr.us-west-2.amazonaws.com/my-custom-image:1.0
+                    custom-image:latest.
             **kwargs: Additional kwargs passed to the :class:`~sagemaker.estimator.Framework` constructor.
         """
-        super(PyTorch, self).__init__(entry_point, source_dir, hyperparameters, **kwargs)
+        super(PyTorch, self).__init__(entry_point, source_dir, hyperparameters, image_name=image_name, **kwargs)
         self.py_version = py_version
         self.framework_version = framework_version
-
-    def train_image(self):
-        """Return the Docker image to use for training.
-
-        The :meth:`~sagemaker.estimator.EstimatorBase.fit` method, which does the model training, calls this method to
-        find the image to use for model training.
-
-        Returns:
-            str: The URI of the Docker image.
-        """
-        return create_image_uri(self.sagemaker_session.boto_session.region_name, self.__framework_name__,
-                                self.train_instance_type, framework_version=self.framework_version,
-                                py_version=self.py_version)
 
     def create_model(self, model_server_workers=None):
         """Create a SageMaker ``PyTorchModel`` object that can be deployed to an ``Endpoint``.
@@ -84,7 +77,7 @@ class PyTorch(Framework):
         return PyTorchModel(self.model_data, self.role, self.entry_point, source_dir=self._model_source_dir(),
                             enable_cloudwatch_metrics=self.enable_cloudwatch_metrics, name=self._current_job_name,
                             container_log_level=self.container_log_level, code_location=self.code_location,
-                            py_version=self.py_version, framework_version=self.framework_version,
+                            py_version=self.py_version, framework_version=self.framework_version, image=self.image_name,
                             model_server_workers=model_server_workers, sagemaker_session=self.sagemaker_session)
 
     @classmethod
@@ -99,7 +92,14 @@ class PyTorch(Framework):
 
         """
         init_params = super(PyTorch, cls)._prepare_init_params_from_job_description(job_details)
-        framework, py_version, tag = framework_name_from_image(init_params.pop('image'))
+        image_name = init_params.pop('image')
+        framework, py_version, tag = framework_name_from_image(image_name)
+
+        if not framework:
+            # If we were unable to parse the framework name from the image it is not one of our
+            # officially supported images, in this case just add the image to the init params.
+            init_params['image_name'] = image_name
+            return init_params
 
         init_params['py_version'] = py_version
         init_params['framework_version'] = framework_version_from_tag(tag)

--- a/src/sagemaker/tensorflow/README.rst
+++ b/src/sagemaker/tensorflow/README.rst
@@ -434,11 +434,11 @@ you can specify these as keyword arguments.
    method launches. If not specified, the estimator generates a default
    job name, based on the training image name and current timestamp.
 -  ``image_name`` An alternative docker image to use for training and
-    serving.  If specified, the estimator will use this image for training and
-    hosting, instead of selecting the appropriate SageMaker official image based on
-    framework_version and py_version. Refer to: `SageMaker TensorFlow Docker Containers
-    <#sagemaker-tensorflow-docker-containers>`_ for details on what the Official images support
-    and where to find the source code to build your custom image.
+   serving.  If specified, the estimator will use this image for training and
+   hosting, instead of selecting the appropriate SageMaker official image based on
+   framework_version and py_version. Refer to: `SageMaker TensorFlow Docker Containers
+   <#sagemaker-tensorflow-docker-containers>`_ for details on what the Official images support
+   and where to find the source code to build your custom image.
 
 
 Optional Hyperparameters

--- a/src/sagemaker/tensorflow/README.rst
+++ b/src/sagemaker/tensorflow/README.rst
@@ -433,6 +433,12 @@ you can specify these as keyword arguments.
 -  ``base_job_name`` Name to assign for the training job that the ``fit``
    method launches. If not specified, the estimator generates a default
    job name, based on the training image name and current timestamp.
+-  ``image_name`` An alternative docker image to use for training and
+    serving.  If specified, the estimator will use this image for training and
+    hosting, instead of selecting the appropriate SageMaker official image based on
+    framework_version and py_version. Refer to: `SageMaker TensorFlow Docker Containers
+    <#sagemaker-tensorflow-docker-containers>`_ for details on what the Official images support
+    and where to find the source code to build your custom image.
 
 
 Optional Hyperparameters
@@ -785,5 +791,8 @@ The TensorFlow Docker images support Python 2.7 and have the following Python mo
 The Docker images extend Ubuntu 16.04.
 
 You can select version of TensorFlow by passing a ``framework_version`` keyword arg to the TensorFlow Estimator constructor. Currently supported versions are listed in the table above. You can also set ``framework_version`` to only specify major and minor version, e.g ``1.6``, which will cause your training script to be run on the latest supported patch version of that minor version, which in this example would be 1.6.0.
+Alternatively, you can build your own image by following the instructions in the SageMaker TensorFlow containers
+repository, and passing ``image_name`` to the TensorFlow Estimator constructor.
+
 
 You can visit the SageMaker TensorFlow containers repository here: https://github.com/aws/sagemaker-tensorflow-containers/

--- a/src/sagemaker/tensorflow/estimator.py
+++ b/src/sagemaker/tensorflow/estimator.py
@@ -173,8 +173,10 @@ class TensorFlow(Framework):
                 `Pip User Guide <https://pip.pypa.io/en/stable/reference/pip_install/#requirements-file-format>`_.
             image_name (str): If specified, the estimator will use this image for training and hosting, instead of
                 selecting the appropriate SageMaker official image based on framework_version and py_version. It can
-                be an ECR url or dockerhub image and tag: 123.dkr.ecr.us-west-2.amazonaws.com/my-custom-image:1.0,
-                custom-image:latest.
+                be an ECR url or dockerhub image and tag.
+                    Examples:
+                        123.dkr.ecr.us-west-2.amazonaws.com/my-custom-image:1.0
+                        custom-image:latest.
             **kwargs: Additional kwargs passed to the Framework constructor.
         """
         super(TensorFlow, self).__init__(image_name=image_name, **kwargs)

--- a/src/sagemaker/tensorflow/estimator.py
+++ b/src/sagemaker/tensorflow/estimator.py
@@ -171,8 +171,10 @@ class TensorFlow(Framework):
             requirements_file (str): Path to a ``requirements.txt`` file (default: ''). The path should be within and
                 relative to ``source_dir``. Details on the format can be found in the
                 `Pip User Guide <https://pip.pypa.io/en/stable/reference/pip_install/#requirements-file-format>`_.
-            image_name (str): The container image to use for training. This will override py_version and
-                framework_version. The image is expected to be a modification of the SageMaker TensorFlow image.
+            image_name (str): If specified, the estimator will use this image for training and hosting, instead of
+                selecting the appropriate SageMaker official image based on framework_version and py_version. It can
+                be an ECR url or dockerhub image and tag: 123.dkr.ecr.us-west-2.amazonaws.com/my-custom-image:1.0,
+                custom-image:latest.
             **kwargs: Additional kwargs passed to the Framework constructor.
         """
         super(TensorFlow, self).__init__(image_name=image_name, **kwargs)

--- a/tests/unit/test_chainer.py
+++ b/tests/unit/test_chainer.py
@@ -235,7 +235,6 @@ def test_create_model(sagemaker_session, chainer_version):
     job_name = 'new_name'
     chainer.fit(inputs='s3://mybucket/train', job_name='new_name')
     model = chainer.create_model()
-    chainer.container_log_level
 
     assert model.sagemaker_session == sagemaker_session
     assert model.framework_version == chainer_version
@@ -259,19 +258,10 @@ def test_create_model_with_custom_image(sagemaker_session):
                       py_version=PYTHON_VERSION, base_job_name='job', source_dir=source_dir,
                       enable_cloudwatch_metrics=enable_cloudwatch_metrics)
 
-    job_name = 'new_name'
     chainer.fit(inputs='s3://mybucket/train', job_name='new_name')
     model = chainer.create_model()
-    chainer.container_log_level
 
-    assert model.sagemaker_session == sagemaker_session
     assert model.image == custom_image
-    assert model.entry_point == SCRIPT_PATH
-    assert model.role == ROLE
-    assert model.name == job_name
-    assert model.container_log_level == container_log_level
-    assert model.source_dir == source_dir
-    assert model.enable_cloudwatch_metrics == enable_cloudwatch_metrics
 
 
 @patch('time.strftime', return_value=TIMESTAMP)
@@ -450,15 +440,5 @@ def test_attach_custom_image(sagemaker_session):
                                                                     return_value=returned_job_description)
 
     estimator = Chainer.attach(training_job_name='neo', sagemaker_session=sagemaker_session)
-    assert estimator.latest_training_job.job_name == 'neo'
-    assert estimator.role == 'arn:aws:iam::366:role/SageMakerRole'
-    assert estimator.train_instance_count == 1
-    assert estimator.train_max_run == 24 * 60 * 60
-    assert estimator.input_mode == 'File'
-    assert estimator.base_job_name == 'neo'
-    assert estimator.output_path == 's3://place/output/neo'
-    assert estimator.output_kms_key == ''
-    assert estimator.hyperparameters()['training_steps'] == '100'
-    assert estimator.source_dir == 's3://some/sourcedir.tar.gz'
-    assert estimator.entry_point == 'iris-dnn-classifier.py'
+    assert estimator.image_name == training_image
     assert estimator.train_image() == training_image

--- a/tests/unit/test_mxnet.py
+++ b/tests/unit/test_mxnet.py
@@ -350,15 +350,5 @@ def test_attach_custom_image(sagemaker_session):
                                                                     return_value=returned_job_description)
 
     estimator = MXNet.attach(training_job_name='neo', sagemaker_session=sagemaker_session)
-    assert estimator.latest_training_job.job_name == 'neo'
     assert estimator.image_name == training_image
-    assert estimator.role == 'arn:aws:iam::366:role/SageMakerRole'
-    assert estimator.train_instance_count == 1
-    assert estimator.train_max_run == 24 * 60 * 60
-    assert estimator.input_mode == 'File'
-    assert estimator.base_job_name == 'neo'
-    assert estimator.output_path == 's3://place/output/neo'
-    assert estimator.output_kms_key == ''
-    assert estimator.hyperparameters()['training_steps'] == '100'
-    assert estimator.source_dir == 's3://some/sourcedir.tar.gz'
-    assert estimator.entry_point == 'iris-dnn-classifier.py'
+    assert estimator.train_image() == training_image

--- a/tests/unit/test_pytorch.py
+++ b/tests/unit/test_pytorch.py
@@ -128,11 +128,34 @@ def test_create_model(sagemaker_session, pytorch_version):
     job_name = 'new_name'
     pytorch.fit(inputs='s3://mybucket/train', job_name='new_name')
     model = pytorch.create_model()
-    pytorch.container_log_level
 
     assert model.sagemaker_session == sagemaker_session
     assert model.framework_version == pytorch_version
     assert model.py_version == pytorch.py_version
+    assert model.entry_point == SCRIPT_PATH
+    assert model.role == ROLE
+    assert model.name == job_name
+    assert model.container_log_level == container_log_level
+    assert model.source_dir == source_dir
+    assert model.enable_cloudwatch_metrics == enable_cloudwatch_metrics
+
+
+def test_create_model_with_custom_image(sagemaker_session):
+    container_log_level = '"logging.INFO"'
+    source_dir = 's3://mybucket/source'
+    enable_cloudwatch_metrics = 'true'
+    image = 'pytorch:9000'
+    pytorch = PyTorch(entry_point=SCRIPT_PATH, role=ROLE, sagemaker_session=sagemaker_session,
+                      train_instance_count=INSTANCE_COUNT, train_instance_type=INSTANCE_TYPE,
+                      container_log_level=container_log_level, image_name=image,
+                      base_job_name='job', source_dir=source_dir, enable_cloudwatch_metrics=enable_cloudwatch_metrics)
+
+    job_name = 'new_name'
+    pytorch.fit(inputs='s3://mybucket/train', job_name='new_name')
+    model = pytorch.create_model()
+
+    assert model.sagemaker_session == sagemaker_session
+    assert model.image == image
     assert model.entry_point == SCRIPT_PATH
     assert model.role == ROLE
     assert model.name == job_name
@@ -286,3 +309,37 @@ def test_attach_wrong_framework(sagemaker_session):
     with pytest.raises(ValueError) as error:
         PyTorch.attach(training_job_name='neo', sagemaker_session=sagemaker_session)
     assert "didn't use image for requested framework" in str(error)
+
+
+def test_attach_custom_image(sagemaker_session):
+    training_image = 'pytorch:latest'
+    returned_job_description = {'AlgorithmSpecification':
+                                {'TrainingInputMode': 'File',
+                                 'TrainingImage': training_image},
+                                'HyperParameters':
+                                    {'sagemaker_submit_directory': '"s3://some/sourcedir.tar.gz"',
+                                     'sagemaker_program': '"iris-dnn-classifier.py"',
+                                     'sagemaker_s3_uri_training': '"sagemaker-3/integ-test-data/tf_iris"',
+                                     'sagemaker_enable_cloudwatch_metrics': 'false',
+                                     'sagemaker_container_log_level': '"logging.INFO"',
+                                     'sagemaker_job_name': '"neo"',
+                                     'training_steps': '100',
+                                     'sagemaker_region': '"us-west-2"'},
+                                'RoleArn': 'arn:aws:iam::366:role/SageMakerRole',
+                                'ResourceConfig':
+                                    {'VolumeSizeInGB': 30,
+                                     'InstanceCount': 1,
+                                     'InstanceType': 'ml.c4.xlarge'},
+                                'StoppingCondition': {'MaxRuntimeInSeconds': 24 * 60 * 60},
+                                'TrainingJobName': 'neo',
+                                'TrainingJobStatus': 'Completed',
+                                'OutputDataConfig': {'KmsKeyId': '',
+                                                     'S3OutputPath': 's3://place/output/neo'},
+                                'TrainingJobOutput': {'S3TrainingJobOutput': 's3://here/output.tar.gz'}}
+    sagemaker_session.sagemaker_client.describe_training_job = Mock(name='describe_training_job',
+                                                                    return_value=returned_job_description)
+
+    estimator = PyTorch.attach(training_job_name='neo', sagemaker_session=sagemaker_session)
+    assert estimator.latest_training_job.job_name == 'neo'
+    assert estimator.image_name == training_image
+    assert estimator.train_image() == training_image

--- a/tests/unit/test_tf_estimator.py
+++ b/tests/unit/test_tf_estimator.py
@@ -205,6 +205,31 @@ def test_create_model(sagemaker_session, tf_version):
     assert model.enable_cloudwatch_metrics == enable_cloudwatch_metrics
 
 
+def test_create_model_with_custom_image(sagemaker_session):
+    container_log_level = '"logging.INFO"'
+    source_dir = 's3://mybucket/source'
+    enable_cloudwatch_metrics = 'true'
+    custom_image = 'tensorflow:1.0'
+    tf = TensorFlow(entry_point=SCRIPT_PATH, role=ROLE, sagemaker_session=sagemaker_session,
+                    training_steps=1000, evaluation_steps=10, train_instance_count=INSTANCE_COUNT,
+                    train_instance_type=INSTANCE_TYPE, image_name=custom_image,
+                    container_log_level=container_log_level, base_job_name='job',
+                    source_dir=source_dir, enable_cloudwatch_metrics=enable_cloudwatch_metrics)
+
+    job_name = 'doing something'
+    tf.fit(inputs='s3://mybucket/train', job_name=job_name)
+    model = tf.create_model()
+
+    assert model.sagemaker_session == sagemaker_session
+    assert model.image == custom_image
+    assert model.entry_point == SCRIPT_PATH
+    assert model.role == ROLE
+    assert model.name == job_name
+    assert model.container_log_level == container_log_level
+    assert model.source_dir == source_dir
+    assert model.enable_cloudwatch_metrics == enable_cloudwatch_metrics
+
+
 @patch('time.strftime', return_value=TIMESTAMP)
 @patch('time.time', return_value=TIME)
 @patch('sagemaker.estimator.tar_and_upload_dir')
@@ -557,3 +582,49 @@ def test_attach_wrong_framework(sagemaker_session):
     with pytest.raises(ValueError) as error:
         TensorFlow.attach(training_job_name='neo', sagemaker_session=sagemaker_session)
     assert "didn't use image for requested framework" in str(error)
+
+
+def test_attach_custom_image(sagemaker_session):
+    training_image = '1.dkr.ecr.us-west-2.amazonaws.com/tensorflow_with_custom_binary:1.0'
+    rjd = {
+        'AlgorithmSpecification': {
+            'TrainingInputMode': 'File',
+            'TrainingImage': training_image},
+        'HyperParameters': {
+            'sagemaker_submit_directory': '"s3://some/sourcedir.tar.gz"',
+            'checkpoint_path': '"s3://other/1508872349"',
+            'sagemaker_program': '"iris-dnn-classifier.py"',
+            'sagemaker_enable_cloudwatch_metrics': 'false',
+            'sagemaker_container_log_level': '"logging.INFO"',
+            'sagemaker_job_name': '"neo"',
+            'training_steps': '100',
+            'evaluation_steps': '10'},
+        'RoleArn': 'arn:aws:iam::366:role/SageMakerRole',
+        'ResourceConfig': {
+            'VolumeSizeInGB': 30,
+            'InstanceCount': 1,
+            'InstanceType': 'ml.c4.xlarge'},
+        'StoppingCondition': {'MaxRuntimeInSeconds': 24 * 60 * 60},
+        'TrainingJobName': 'neo',
+        'TrainingJobStatus': 'Completed',
+        'OutputDataConfig': {'KmsKeyId': '', 'S3OutputPath': 's3://place/output/neo'},
+        'TrainingJobOutput': {'S3TrainingJobOutput': 's3://here/output.tar.gz'}}
+    sagemaker_session.sagemaker_client.describe_training_job = Mock(name='describe_training_job', return_value=rjd)
+
+    estimator = TensorFlow.attach(training_job_name='neo', sagemaker_session=sagemaker_session)
+    assert estimator.latest_training_job.job_name == 'neo'
+    assert estimator.role == 'arn:aws:iam::366:role/SageMakerRole'
+    assert estimator.train_instance_count == 1
+    assert estimator.train_max_run == 24 * 60 * 60
+    assert estimator.input_mode == 'File'
+    assert estimator.training_steps == 100
+    assert estimator.evaluation_steps == 10
+    assert estimator.input_mode == 'File'
+    assert estimator.base_job_name == 'neo'
+    assert estimator.output_path == 's3://place/output/neo'
+    assert estimator.output_kms_key == ''
+    assert estimator.hyperparameters()['training_steps'] == '100'
+    assert estimator.source_dir == 's3://some/sourcedir.tar.gz'
+    assert estimator.entry_point == 'iris-dnn-classifier.py'
+    assert estimator.checkpoint_path == 's3://other/1508872349'
+    assert estimator.train_image() == training_image

--- a/tests/unit/test_tf_estimator.py
+++ b/tests/unit/test_tf_estimator.py
@@ -220,14 +220,7 @@ def test_create_model_with_custom_image(sagemaker_session):
     tf.fit(inputs='s3://mybucket/train', job_name=job_name)
     model = tf.create_model()
 
-    assert model.sagemaker_session == sagemaker_session
     assert model.image == custom_image
-    assert model.entry_point == SCRIPT_PATH
-    assert model.role == ROLE
-    assert model.name == job_name
-    assert model.container_log_level == container_log_level
-    assert model.source_dir == source_dir
-    assert model.enable_cloudwatch_metrics == enable_cloudwatch_metrics
 
 
 @patch('time.strftime', return_value=TIMESTAMP)
@@ -612,19 +605,5 @@ def test_attach_custom_image(sagemaker_session):
     sagemaker_session.sagemaker_client.describe_training_job = Mock(name='describe_training_job', return_value=rjd)
 
     estimator = TensorFlow.attach(training_job_name='neo', sagemaker_session=sagemaker_session)
-    assert estimator.latest_training_job.job_name == 'neo'
-    assert estimator.role == 'arn:aws:iam::366:role/SageMakerRole'
-    assert estimator.train_instance_count == 1
-    assert estimator.train_max_run == 24 * 60 * 60
-    assert estimator.input_mode == 'File'
-    assert estimator.training_steps == 100
-    assert estimator.evaluation_steps == 10
-    assert estimator.input_mode == 'File'
-    assert estimator.base_job_name == 'neo'
-    assert estimator.output_path == 's3://place/output/neo'
-    assert estimator.output_kms_key == ''
-    assert estimator.hyperparameters()['training_steps'] == '100'
-    assert estimator.source_dir == 's3://some/sourcedir.tar.gz'
-    assert estimator.entry_point == 'iris-dnn-classifier.py'
-    assert estimator.checkpoint_path == 's3://other/1508872349'
+    assert estimator.image_name == training_image
     assert estimator.train_image() == training_image


### PR DESCRIPTION
Chainer, Tensorflow and MXNet estimators can now pass
an image_name argument to the constructor to use that image
instead of the default sagemaker ones.

*Issue #, if available:*

*Description of changes:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have updated the [changelog](https://github.com/aws/sagemaker-python-sdk/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [x] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
