### PR TITLE
Allow code_location to have no key prefix

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ CHANGELOG
 
 * bug-fix: Unit Tests: Improve unit test runtime
 * bug-fix: Estimators: Fix attach for LDA
+* bug-fix: Estimators: allow code_location to have no key prefix
 
 1.4.1
 =====

--- a/src/sagemaker/estimator.py
+++ b/src/sagemaker/estimator.py
@@ -571,7 +571,7 @@ class Framework(EstimatorBase):
             code_s3_prefix = '{}/source'.format(self._current_job_name)
         else:
             code_bucket, key_prefix = parse_s3_url(self.code_location)
-            code_s3_prefix = '{}/{}/source'.format(key_prefix, self._current_job_name)
+            code_s3_prefix = '/'.join(filter(None, [key_prefix, self._current_job_name, 'source']))
 
         return tar_and_upload_dir(session=self.sagemaker_session.boto_session,
                                   bucket=code_bucket,

--- a/tests/unit/test_estimator.py
+++ b/tests/unit/test_estimator.py
@@ -126,6 +126,7 @@ def test_custom_code_bucket(time, sagemaker_session):
     _, _, train_kwargs = sagemaker_session.train.mock_calls[0]
     assert train_kwargs['hyperparameters']['sagemaker_submit_directory'] == json.dumps(expected_submit_dir)
 
+
 @patch('time.strftime', return_value=TIMESTAMP)
 def test_custom_code_bucket_without_prefix(time, sagemaker_session):
     code_bucket = 'codebucket'

--- a/tests/unit/test_estimator.py
+++ b/tests/unit/test_estimator.py
@@ -126,6 +126,23 @@ def test_custom_code_bucket(time, sagemaker_session):
     _, _, train_kwargs = sagemaker_session.train.mock_calls[0]
     assert train_kwargs['hyperparameters']['sagemaker_submit_directory'] == json.dumps(expected_submit_dir)
 
+@patch('time.strftime', return_value=TIMESTAMP)
+def test_custom_code_bucket_without_prefix(time, sagemaker_session):
+    code_bucket = 'codebucket'
+    code_location = 's3://{}'.format(code_bucket)
+    t = DummyFramework(entry_point=SCRIPT_PATH, role=ROLE, sagemaker_session=sagemaker_session,
+                       train_instance_count=INSTANCE_COUNT, train_instance_type=INSTANCE_TYPE,
+                       code_location=code_location)
+    t.fit('s3://bucket/mydata')
+
+    expected_key = '{}/source/sourcedir.tar.gz'.format(JOB_NAME)
+    _, s3_args, _ = sagemaker_session.boto_session.resource('s3').Object.mock_calls[0]
+    assert s3_args == (code_bucket, expected_key)
+
+    expected_submit_dir = 's3://{}/{}'.format(code_bucket, expected_key)
+    _, _, train_kwargs = sagemaker_session.train.mock_calls[0]
+    assert train_kwargs['hyperparameters']['sagemaker_submit_directory'] == json.dumps(expected_submit_dir)
+
 
 def test_invalid_custom_code_bucket(sagemaker_session):
     code_location = 'thisllworkright?'


### PR DESCRIPTION
Optionally, enable matching the behaviour when using sagemaker's default bucket where a key prefix is not permitted

*Issue #, if available:* 226

*Description of changes:* Addressing item 2.a on the issue

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [ x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ x] I have updated the [changelog](https://github.com/aws/sagemaker-python-sdk/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [ x] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
