### PR TITLE
Unify generation of model uploaded code location

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 CHANGELOG
 =========
 
++1.5.1dev
++========
+
+* enhancement: Unify generation of model uploaded code location
+
 1.5.0
 =====
 * feature: Add Support for PyTorch Framework

--- a/src/sagemaker/chainer/model.py
+++ b/src/sagemaker/chainer/model.py
@@ -13,11 +13,10 @@
 from __future__ import absolute_import
 
 import sagemaker
-from sagemaker.fw_utils import create_image_uri
+from sagemaker.fw_utils import create_image_uri, model_code_key_prefix
 from sagemaker.model import FrameworkModel, MODEL_SERVER_WORKERS_PARAM_NAME
 from sagemaker.chainer.defaults import CHAINER_VERSION
 from sagemaker.predictor import RealTimePredictor, npy_serializer, numpy_deserializer
-from sagemaker.utils import name_from_image
 
 
 class ChainerPredictor(RealTimePredictor):
@@ -85,7 +84,8 @@ class ChainerModel(FrameworkModel):
             region_name = self.sagemaker_session.boto_session.region_name
             deploy_image = create_image_uri(region_name, self.__framework_name__, instance_type,
                                             self.framework_version, self.py_version)
-        deploy_key_prefix = self.key_prefix or self.name or name_from_image(deploy_image)
+
+        deploy_key_prefix = model_code_key_prefix(self.key_prefix, self.name, deploy_image)
         self._upload_code(deploy_key_prefix)
         deploy_env = dict(self.env)
         deploy_env.update(self._framework_env_vars())

--- a/src/sagemaker/fw_utils.py
+++ b/src/sagemaker/fw_utils.py
@@ -19,6 +19,8 @@ import tempfile
 from collections import namedtuple
 from six.moves.urllib.parse import urlparse
 
+from sagemaker.utils import name_from_image
+
 """This module contains utility functions shared across ``Framework`` components."""
 
 
@@ -199,3 +201,21 @@ def parse_s3_url(url):
     if parsed_url.scheme != "s3":
         raise ValueError("Expecting 's3' scheme, got: {} in {}".format(parsed_url.scheme, url))
     return parsed_url.netloc, parsed_url.path.lstrip('/')
+
+
+def model_code_key_prefix(code_location_key_prefix, model_name, image):
+    """Returns the s3 key prefix for uploading code during model deployment
+
+    The location returned is a potential concatenation of 2 parts
+        1. code_location_key_prefix if it exists
+        2. model_name or a name derived from the image
+
+    Args:
+        code_location_key_prefix (str): the s3 key prefix from code_location
+        model_name (str): the name of the model
+        image (str): the image from which a default name can be extracted
+
+    Returns:
+        str: the key prefix to be used in uploading code
+    """
+    return '/'.join(filter(None, [code_location_key_prefix, model_name or name_from_image(image)]))

--- a/src/sagemaker/model.py
+++ b/src/sagemaker/model.py
@@ -17,7 +17,7 @@ import logging
 import sagemaker
 
 from sagemaker.local import LocalSession
-from sagemaker.fw_utils import tar_and_upload_dir, parse_s3_url
+from sagemaker.fw_utils import tar_and_upload_dir, parse_s3_url, model_code_key_prefix
 from sagemaker.session import Session
 from sagemaker.utils import name_from_image, get_config_value
 
@@ -169,7 +169,8 @@ class FrameworkModel(Model):
         Returns:
             dict[str, str]: A container definition object usable with the CreateModel API.
         """
-        self._upload_code(self.key_prefix or self.name or name_from_image(self.image))
+        deploy_key_prefix = model_code_key_prefix(self.key_prefix, self.name, self.image)
+        self._upload_code(deploy_key_prefix)
         deploy_env = dict(self.env)
         deploy_env.update(self._framework_env_vars())
         return sagemaker.container_def(self.image, self.model_data, deploy_env)

--- a/src/sagemaker/mxnet/model.py
+++ b/src/sagemaker/mxnet/model.py
@@ -13,11 +13,10 @@
 from __future__ import absolute_import
 
 import sagemaker
-from sagemaker.fw_utils import create_image_uri
+from sagemaker.fw_utils import create_image_uri, model_code_key_prefix
 from sagemaker.model import FrameworkModel, MODEL_SERVER_WORKERS_PARAM_NAME
 from sagemaker.mxnet.defaults import MXNET_VERSION
 from sagemaker.predictor import RealTimePredictor, json_serializer, json_deserializer
-from sagemaker.utils import name_from_image
 
 
 class MXNetPredictor(RealTimePredictor):
@@ -85,7 +84,8 @@ class MXNetModel(FrameworkModel):
             region_name = self.sagemaker_session.boto_session.region_name
             deploy_image = create_image_uri(region_name, self.__framework_name__, instance_type,
                                             self.framework_version, self.py_version)
-        deploy_key_prefix = self.key_prefix or self.name or name_from_image(deploy_image)
+
+        deploy_key_prefix = model_code_key_prefix(self.key_prefix, self.name, deploy_image)
         self._upload_code(deploy_key_prefix)
         deploy_env = dict(self.env)
         deploy_env.update(self._framework_env_vars())

--- a/src/sagemaker/pytorch/model.py
+++ b/src/sagemaker/pytorch/model.py
@@ -12,11 +12,10 @@
 # language governing permissions and limitations under the License.
 from __future__ import absolute_import
 import sagemaker
-from sagemaker.fw_utils import create_image_uri
+from sagemaker.fw_utils import create_image_uri, model_code_key_prefix
 from sagemaker.model import FrameworkModel, MODEL_SERVER_WORKERS_PARAM_NAME
 from sagemaker.pytorch.defaults import PYTORCH_VERSION, PYTHON_VERSION
 from sagemaker.predictor import RealTimePredictor, npy_serializer, numpy_deserializer
-from sagemaker.utils import name_from_image
 
 
 class PyTorchPredictor(RealTimePredictor):
@@ -84,7 +83,7 @@ class PyTorchModel(FrameworkModel):
             region_name = self.sagemaker_session.boto_session.region_name
             deploy_image = create_image_uri(region_name, self.__framework_name__, instance_type,
                                             self.framework_version, self.py_version)
-        deploy_key_prefix = self.key_prefix or self.name or name_from_image(deploy_image)
+        deploy_key_prefix = model_code_key_prefix(self.key_prefix, self.name, deploy_image)
         self._upload_code(deploy_key_prefix)
         deploy_env = dict(self.env)
         deploy_env.update(self._framework_env_vars())

--- a/src/sagemaker/tensorflow/model.py
+++ b/src/sagemaker/tensorflow/model.py
@@ -13,12 +13,11 @@
 from __future__ import absolute_import
 
 import sagemaker
-from sagemaker.fw_utils import create_image_uri
+from sagemaker.fw_utils import create_image_uri, model_code_key_prefix
 from sagemaker.model import FrameworkModel, MODEL_SERVER_WORKERS_PARAM_NAME
 from sagemaker.predictor import RealTimePredictor
 from sagemaker.tensorflow.defaults import TF_VERSION
 from sagemaker.tensorflow.predictor import tf_json_serializer, tf_json_deserializer
-from sagemaker.utils import name_from_image
 
 
 class TensorFlowPredictor(RealTimePredictor):
@@ -89,8 +88,7 @@ class TensorFlowModel(FrameworkModel):
             deploy_image = create_image_uri(region_name, self.__framework_name__, instance_type,
                                             self.framework_version, self.py_version)
 
-        deploy_key_prefix = self.key_prefix or self.name or name_from_image(deploy_image)
-
+        deploy_key_prefix = model_code_key_prefix(self.key_prefix, self.name, deploy_image)
         self._upload_code(deploy_key_prefix)
         deploy_env = dict(self.env)
         deploy_env.update(self._framework_env_vars())

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -80,7 +80,7 @@ def test_create_no_defaults(tfopen, exists, isdir, listdir, time, sagemaker_sess
 
     assert model.prepare_container_def(INSTANCE_TYPE) == {
         'Environment': {'SAGEMAKER_PROGRAM': 'blah.py',
-                        'SAGEMAKER_SUBMIT_DIRECTORY': 's3://cb/cp/sourcedir.tar.gz',
+                        'SAGEMAKER_SUBMIT_DIRECTORY': 's3://cb/cp/name/sourcedir.tar.gz',
                         'SAGEMAKER_CONTAINER_LOG_LEVEL': '55',
                         'SAGEMAKER_REGION': 'us-west-2',
                         'SAGEMAKER_ENABLE_CLOUDWATCH_METRICS': 'true',


### PR DESCRIPTION
- Extract repeated key_prefix calculation in different models (base, mxnet, tensorflow, chainer) into a common utility method in fw_utils.py
- The generated location now always respects the code_location prefix if present but it also concatenates either the model name or image-derived name to it
- This is related to 2.b in https://github.com/aws/sagemaker-python-sdk/issues/226

*Issue #, if available:* 226 point 2.b

*Description of changes:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have updated the [changelog](https://github.com/aws/sagemaker-python-sdk/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [x] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
