### PR TITLE
Let Framework models reuse code uploaded by Framework estimators

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ CHANGELOG
 * feature: Allow Local Serving of Models in S3
 * enhancement: Allow option for ``HyperparameterTuner`` to not include estimator metadata in job
 * bug-fix: Estimators: Join tensorboard thread after fitting
+* enhancement: Let Framework models reuse code uploaded by Framework estimators
 
 1.4.2
 =====

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,15 +2,20 @@
 CHANGELOG
 =========
 
+1.5.1dev
+========
+
+* enhancement: Let Framework models reuse code uploaded by Framework estimators
+
 1.5.0
 =====
+
 * feature: Add Support for PyTorch Framework
 * feature: Estimators: add support for TensorFlow 1.7.0
 * feature: Estimators: add support for TensorFlow 1.8.0
 * feature: Allow Local Serving of Models in S3
 * enhancement: Allow option for ``HyperparameterTuner`` to not include estimator metadata in job
 * bug-fix: Estimators: Join tensorboard thread after fitting
-* enhancement: Let Framework models reuse code uploaded by Framework estimators
 
 1.4.2
 =====

--- a/src/sagemaker/chainer/estimator.py
+++ b/src/sagemaker/chainer/estimator.py
@@ -116,7 +116,7 @@ class Chainer(Framework):
             sagemaker.chainer.model.ChainerModel: A SageMaker ``ChainerModel`` object.
                 See :func:`~sagemaker.chainer.model.ChainerModel` for full details.
         """
-        return ChainerModel(self.model_data, self.role, self.entry_point, source_dir=self.source_dir,
+        return ChainerModel(self.model_data, self.role, self.entry_point, source_dir=self._model_source_dir(),
                             enable_cloudwatch_metrics=self.enable_cloudwatch_metrics, name=self._current_job_name,
                             container_log_level=self.container_log_level, code_location=self.code_location,
                             py_version=self.py_version, framework_version=self.framework_version,

--- a/src/sagemaker/estimator.py
+++ b/src/sagemaker/estimator.py
@@ -579,6 +579,14 @@ class Framework(EstimatorBase):
                                   script=self.entry_point,
                                   directory=self.source_dir)
 
+    def _model_source_dir(self):
+        """ Gets the appropriate value to pass as source_dir to model constructor on deploying
+
+        Returns:
+            str: Either a local or an S3 path pointing to the source_dir to be used for code by the model to be deployed
+        """
+        return self.source_dir if self.sagemaker_session.local_mode else self.uploaded_code.s3_prefix
+
     def hyperparameters(self):
         """Return the hyperparameters as a dictionary to use for training.
 

--- a/src/sagemaker/estimator.py
+++ b/src/sagemaker/estimator.py
@@ -561,7 +561,7 @@ class Framework(EstimatorBase):
         self._hyperparameters[SAGEMAKER_REGION_PARAM_NAME] = self.sagemaker_session.boto_region_name
 
     def _stage_user_code_in_s3(self):
-        """ Upload the user training script to s3 and return the location.
+        """Upload the user training script to s3 and return the location.
 
         Returns: s3 uri
 
@@ -580,7 +580,7 @@ class Framework(EstimatorBase):
                                   directory=self.source_dir)
 
     def _model_source_dir(self):
-        """ Gets the appropriate value to pass as source_dir to model constructor on deploying
+        """Get the appropriate value to pass as source_dir to model constructor on deploying
 
         Returns:
             str: Either a local or an S3 path pointing to the source_dir to be used for code by the model to be deployed

--- a/src/sagemaker/model.py
+++ b/src/sagemaker/model.py
@@ -132,6 +132,7 @@ class FrameworkModel(Model):
             source_dir (str): Path (absolute or relative) to a directory with any other training
                 source code dependencies aside from tne entry point file (default: None). Structure within this
                 directory will be preserved when training on SageMaker.
+                If the directory points to S3, no code will be uploaded and the S3 location will be used instead.
             predictor_cls (callable[string, sagemaker.session.Session]): A function to call to create
                a predictor (default: None). If not None, ``deploy`` will return the result of invoking
                this function on the created endpoint name.

--- a/src/sagemaker/mxnet/estimator.py
+++ b/src/sagemaker/mxnet/estimator.py
@@ -82,7 +82,7 @@ class MXNet(Framework):
             sagemaker.mxnet.model.MXNetModel: A SageMaker ``MXNetModel`` object.
                 See :func:`~sagemaker.mxnet.model.MXNetModel` for full details.
         """
-        return MXNetModel(self.model_data, self.role, self.entry_point, source_dir=self.source_dir,
+        return MXNetModel(self.model_data, self.role, self.entry_point, source_dir=self._model_source_dir(),
                           enable_cloudwatch_metrics=self.enable_cloudwatch_metrics, name=self._current_job_name,
                           container_log_level=self.container_log_level, code_location=self.code_location,
                           py_version=self.py_version, framework_version=self.framework_version,

--- a/src/sagemaker/pytorch/estimator.py
+++ b/src/sagemaker/pytorch/estimator.py
@@ -81,7 +81,7 @@ class PyTorch(Framework):
             sagemaker.pytorch.model.PyTorchModel: A SageMaker ``PyTorchModel`` object.
                 See :func:`~sagemaker.pytorch.model.PyTorchModel` for full details.
         """
-        return PyTorchModel(self.model_data, self.role, self.entry_point, source_dir=self.source_dir,
+        return PyTorchModel(self.model_data, self.role, self.entry_point, source_dir=self._model_source_dir(),
                             enable_cloudwatch_metrics=self.enable_cloudwatch_metrics, name=self._current_job_name,
                             container_log_level=self.container_log_level, code_location=self.code_location,
                             py_version=self.py_version, framework_version=self.framework_version,

--- a/src/sagemaker/tensorflow/estimator.py
+++ b/src/sagemaker/tensorflow/estimator.py
@@ -300,7 +300,7 @@ class TensorFlow(Framework):
                 See :func:`~sagemaker.tensorflow.model.TensorFlowModel` for full details.
         """
         env = {'SAGEMAKER_REQUIREMENTS': self.requirements_file}
-        return TensorFlowModel(self.model_data, self.role, self.entry_point, source_dir=self.source_dir,
+        return TensorFlowModel(self.model_data, self.role, self.entry_point, source_dir=self._model_source_dir(),
                                enable_cloudwatch_metrics=self.enable_cloudwatch_metrics, env=env,
                                name=self._current_job_name, container_log_level=self.container_log_level,
                                code_location=self.code_location, py_version=self.py_version,

--- a/tests/unit/test_chainer.py
+++ b/tests/unit/test_chainer.py
@@ -274,7 +274,7 @@ def test_chainer(strftime, sagemaker_session, chainer_version):
     expected_image_base = '520713654638.dkr.ecr.us-west-2.amazonaws.com/sagemaker-chainer:{}-gpu-{}'
     assert {'Environment':
             {'SAGEMAKER_SUBMIT_DIRECTORY':
-             's3://mybucket/sagemaker-chainer-{}/sourcedir.tar.gz'.format(TIMESTAMP),
+             's3://mybucket/sagemaker-chainer-{}/source/sourcedir.tar.gz'.format(TIMESTAMP),
              'SAGEMAKER_PROGRAM': 'dummy_script.py',
              'SAGEMAKER_ENABLE_CLOUDWATCH_METRICS': 'false',
              'SAGEMAKER_REGION': 'us-west-2',

--- a/tests/unit/test_mxnet.py
+++ b/tests/unit/test_mxnet.py
@@ -149,7 +149,7 @@ def test_mxnet(strftime, sagemaker_session, mxnet_version):
     expected_image_base = '520713654638.dkr.ecr.us-west-2.amazonaws.com/sagemaker-mxnet:{}-gpu-py2'
     environment = {
         'Environment': {
-            'SAGEMAKER_SUBMIT_DIRECTORY': 's3://mybucket/sagemaker-mxnet-{}/sourcedir.tar.gz'.format(TIMESTAMP),
+            'SAGEMAKER_SUBMIT_DIRECTORY': 's3://mybucket/sagemaker-mxnet-{}/source/sourcedir.tar.gz'.format(TIMESTAMP),
             'SAGEMAKER_PROGRAM': 'dummy_script.py', 'SAGEMAKER_ENABLE_CLOUDWATCH_METRICS': 'false',
             'SAGEMAKER_REGION': 'us-west-2', 'SAGEMAKER_CONTAINER_LOG_LEVEL': '20'
         },

--- a/tests/unit/test_pytorch.py
+++ b/tests/unit/test_pytorch.py
@@ -167,7 +167,7 @@ def test_pytorch(strftime, sagemaker_session, pytorch_version):
     expected_image_base = '520713654638.dkr.ecr.us-west-2.amazonaws.com/sagemaker-pytorch:{}-gpu-{}'
     assert {'Environment':
             {'SAGEMAKER_SUBMIT_DIRECTORY':
-             's3://mybucket/sagemaker-pytorch-{}/sourcedir.tar.gz'.format(TIMESTAMP),
+             's3://mybucket/sagemaker-pytorch-{}/source/sourcedir.tar.gz'.format(TIMESTAMP),
              'SAGEMAKER_PROGRAM': 'dummy_script.py',
              'SAGEMAKER_ENABLE_CLOUDWATCH_METRICS': 'false',
              'SAGEMAKER_REGION': 'us-west-2',


### PR DESCRIPTION
- This addresses problem 1 in https://github.com/aws/sagemaker-python-sdk/issues/226
- This relies on the tar_and_upload_dir's behaviour when given S3 paths for directory
- This updates MXNet, TensorFlow and Chainer frameworks

*Issue #, if available:* #226 

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have updated the [changelog](https://github.com/aws/sagemaker-python-sdk/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [x] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
