### PR TITLE
Fix expand-role to use boto_session field

### DIFF
--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -679,7 +679,7 @@ class Session(object):
         if '/' in role:
             return role
         else:
-            return boto3.resource("iam").Role(role).arn
+            return self.boto_session.resource('iam').Role(role).arn
 
     def get_caller_identity_arn(self):
         """Returns the ARN user or role whose credentials are used to call the API.


### PR DESCRIPTION
*Description of changes:*

sagemaker.Session's expand_role method needs to use its boto_session field to call IAM, so it can use the configuration passed in by the user.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated the [changelog](https://github.com/aws/sagemaker-python-sdk/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
