### PR TITLE
Change minimum required scipy dependency from 1.0.0 to 0.19.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ CHANGELOG
 
 * bug-fix: Unit Tests: Improve unit test runtime
 * bug-fix: Estimators: Fix attach for LDA
+* Change minimum required scipy from 1.0.0 to 0.19.0
 
 1.4.1
 =====

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(name="sagemaker",
       ],
 
       # Declare minimal set for installation
-      install_requires=['boto3>=1.4.8', 'numpy>=1.9.0', 'protobuf>=3.1', 'scipy>=1.0.0', 'urllib3>=1.2',
+      install_requires=['boto3>=1.4.8', 'numpy>=1.9.0', 'protobuf>=3.1', 'scipy>=0.19.0', 'urllib3>=1.2',
                         'PyYAML>=3.2'],
 
       extras_require={


### PR DESCRIPTION
*Description of changes:*
Hi, I'm on a team at Amazon.

We've been successfully using sagemaker-1.1.3 with scipy 0.19.0. Now we'd like to continue using scipy 0.19.0 with the newest version of sagemaker.

This PR changes the minimum required scipy dependency from 1.0.0 to 0.19.0. We've applied this change to the internal Amazon Python-sagemaker (see version 1.1.3's 01_use_scipy_0_19_0_in_setup_py.patch file). We'd like the change applied to the github code so that we don't have to keep patching the code after it is pulled in to Amazon's package repo.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [X] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works (if appropriate)
existing unit tests pass:
```
tox tests/unit
________________________________________________________ summary ________________________________________________________
  py27: commands succeeded
  py35: commands succeeded
  flake8: commands succeeded
  congratulations :)

```

- [X] I have updated the [changelog](https://github.com/aws/sagemaker-python-sdk/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [X] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
