### PR TITLE
Fix unit test stability with testing job name generation

### DIFF
--- a/tests/unit/test_estimator.py
+++ b/tests/unit/test_estimator.py
@@ -15,6 +15,7 @@ from __future__ import absolute_import
 import logging
 import json
 import os
+from time import sleep
 
 import pytest
 from mock import Mock, patch
@@ -386,6 +387,7 @@ def test_prepare_for_training_unique_job_name_generation(sagemaker_session):
     fw._prepare_for_training()
     first_job_name = fw._current_job_name
 
+    sleep(0.1)
     fw._prepare_for_training()
     second_job_name = fw._current_job_name
 


### PR DESCRIPTION
Since the job name generation depends on timestamps being unique, if the two names were generated quickly enough, the names could end up being the same despite the code's logic being correct. Adding a sleep statement in the test should fix this.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated the [changelog](https://github.com/aws/sagemaker-python-sdk/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [x] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
