### PR TITLE
skip object download if its a folder [Bug fix] (Local mode)

### DIFF
--- a/src/sagemaker/local/image.py
+++ b/src/sagemaker/local/image.py
@@ -263,7 +263,7 @@ class _SageMakerContainer(object):
 
         for obj_sum in bucket.objects.filter(Prefix=prefix):
             # if obj_sum is a folder object skip it.
-            if obj_sum.key != "" and obj_sum.key[-1] == '/':
+            if obj_sum.key != '' and obj_sum.key[-1] == '/':
                 continue
             obj = s3.Object(obj_sum.bucket_name, obj_sum.key)
             s3_relative_path = obj_sum.key[len(prefix):].lstrip('/')

--- a/src/sagemaker/local/image.py
+++ b/src/sagemaker/local/image.py
@@ -262,6 +262,9 @@ class _SageMakerContainer(object):
         bucket = s3.Bucket(bucket_name)
 
         for obj_sum in bucket.objects.filter(Prefix=prefix):
+            # if obj_sum is a folder object skip it.
+            if obj_sum.key != "" and obj_sum.key[-1] == '/':
+                continue
             obj = s3.Object(obj_sum.bucket_name, obj_sum.key)
             s3_relative_path = obj_sum.key[len(prefix):].lstrip('/')
             file_path = os.path.join(target, s3_relative_path)


### PR DESCRIPTION
resolves #245 

*Description of changes:*
When training locally the `train_data_location` (s3 uri) provided in the `.fit` method of estimator is downloaded recursively. While downloading if any folders is present in `train_data_location` we get an error as mentioned in #245. this PR fixes this issue

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated the [changelog](https://github.com/aws/sagemaker-python-sdk/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [x] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
