### PR TITLE
Add tags on endpoints

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ CHANGELOG
 * enhancement: Let Framework models reuse code uploaded by Framework estimators
 * enhancement: Unify generation of model uploaded code location
 * feature: Change minimum required scipy from 1.0.0 to 0.19.0
+* feature: Option to add Tags on SageMaker Endpoints
 
 1.5.0
 =====

--- a/src/sagemaker/model.py
+++ b/src/sagemaker/model.py
@@ -66,7 +66,7 @@ class Model(object):
         """
         return sagemaker.container_def(self.image, self.model_data, self.env)
 
-    def deploy(self, initial_instance_count, instance_type, endpoint_name=None):
+    def deploy(self, initial_instance_count, instance_type, endpoint_name=None, tags=None):
         """Deploy this ``Model`` to an ``Endpoint`` and optionally return a ``Predictor``.
 
         Create a SageMaker ``Model`` and ``EndpointConfig``, and deploy an ``Endpoint`` from this ``Model``.
@@ -82,6 +82,7 @@ class Model(object):
                 ``Endpoint`` created from this ``Model``.
             endpoint_name (str): The name of the endpoint to create (default: None).
                 If not specified, a unique endpoint name will be created.
+            tags (list[dict[str, str]]): A list of key-value pairs for tagging the endpoint (default: None).
 
         Returns:
             callable[string, sagemaker.session.Session] or None: Invocation of ``self.predictor_cls`` on
@@ -98,7 +99,7 @@ class Model(object):
         self.sagemaker_session.create_model(model_name, self.role, container_def)
         production_variant = sagemaker.production_variant(model_name, instance_type, initial_instance_count)
         self.endpoint_name = endpoint_name or model_name
-        self.sagemaker_session.endpoint_from_production_variants(self.endpoint_name, [production_variant])
+        self.sagemaker_session.endpoint_from_production_variants(self.endpoint_name, [production_variant], tags)
         if self.predictor_cls:
             return self.predictor_cls(self.endpoint_name, self.sagemaker_session)
 

--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -646,12 +646,13 @@ class Session(object):
         self.create_endpoint(endpoint_name=name, config_name=name, wait=wait)
         return name
 
-    def endpoint_from_production_variants(self, name, production_variants, wait=True):
+    def endpoint_from_production_variants(self, name, production_variants, tags=None, wait=True):
         """Create an SageMaker ``Endpoint`` from a list of production variants.
 
         Args:
             name (str): The name of the ``Endpoint`` to create.
             production_variants (list[dict[str, str]]): The list of production variants to deploy.
+            tags (list[dict[str, str]]): A list of key-value pairs for tagging the endpoint (default: None).
             wait (bool): Whether to wait for the endpoint deployment to complete before returning (default: True).
 
         Returns:
@@ -660,8 +661,11 @@ class Session(object):
 
         if not _deployment_entity_exists(
                 lambda: self.sagemaker_client.describe_endpoint_config(EndpointConfigName=name)):
-            self.sagemaker_client.create_endpoint_config(
-                EndpointConfigName=name, ProductionVariants=production_variants)
+            config_options = {'EndpointConfigName': name, 'ProductionVariants': production_variants}
+            if tags:
+                config_options['Tags'] = tags
+
+            self.sagemaker_client.create_endpoint_config(**config_options)
         return self.create_endpoint(endpoint_name=name, config_name=name, wait=wait)
 
     def expand_role(self, role):

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -100,7 +100,8 @@ def test_deploy(tfo, time, sagemaker_session):
           'ModelName': 'mi-2017-10-10-14-14-15',
           'InstanceType': INSTANCE_TYPE,
           'InitialInstanceCount': 1,
-          'VariantName': 'AllTraffic'}])
+          'VariantName': 'AllTraffic'}],
+        None)
 
 
 @patch('tarfile.open')
@@ -114,7 +115,24 @@ def test_deploy_endpoint_name(tfo, time, sagemaker_session):
           'ModelName': 'mi-2017-10-10-14-14-15',
           'InstanceType': INSTANCE_TYPE,
           'InitialInstanceCount': 55,
-          'VariantName': 'AllTraffic'}])
+          'VariantName': 'AllTraffic'}],
+        None)
+
+
+@patch('tarfile.open')
+@patch('time.strftime', return_value=TIMESTAMP)
+def test_deploy_tags(tfo, time, sagemaker_session):
+    model = DummyFrameworkModel(sagemaker_session)
+    tags = [{'ModelName': 'TestModel'}]
+    model.deploy(instance_type=INSTANCE_TYPE, initial_instance_count=1, tags=tags)
+    sagemaker_session.endpoint_from_production_variants.assert_called_with(
+        'mi-2017-10-10-14-14-15',
+        [{'InitialVariantWeight': 1,
+          'ModelName': 'mi-2017-10-10-14-14-15',
+          'InstanceType': INSTANCE_TYPE,
+          'InitialInstanceCount': 1,
+          'VariantName': 'AllTraffic'}],
+        tags)
 
 
 @patch('sagemaker.model.Session')


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Option to add Tags on SageMaker Endpoints. I'd like this option so that to tag endpoints for auditing and linking IDs of trained models to endpoints. The latter is very important because I can know which models are dpeloyed in production.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have updated the [changelog](https://github.com/aws/sagemaker-python-sdk/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
