### PR TITLE
Lower learning rate for TF cifar integ test

### DIFF
--- a/tests/data/cifar_10/source/resnet_cifar_10.py
+++ b/tests/data/cifar_10/source/resnet_cifar_10.py
@@ -33,8 +33,8 @@ RESNET_SIZE = 32
 BATCH_SIZE = 1
 
 # Scale the learning rate linearly with the batch size. When the batch size is
-# 128, the learning rate should be 0.1.
-_INITIAL_LEARNING_RATE = 0.1 * BATCH_SIZE / 128
+# 128, the learning rate should be 0.05.
+_INITIAL_LEARNING_RATE = 0.05 * BATCH_SIZE / 128
 _MOMENTUM = 0.9
 
 # We use a weight decay of 0.0002, which performs better than the 0.0001 that


### PR DESCRIPTION
We've been seeing a lot of errors that say failure due to NaN loss. One suggestion from https://stackoverflow.com/questions/40050397/deep-learning-nan-loss-reasons is to use a lower number for learning rate.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated the [changelog](https://github.com/aws/sagemaker-python-sdk/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
