### PR TITLE
Fix local mode error message

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ CHANGELOG
 ========
 
 * bug-fix: Session: include role path in ``get_execution_role()`` result
+* bug-fix: Local Mode: fix RuntimeError handling
 
 1.5.2
 =====

--- a/src/sagemaker/local/image.py
+++ b/src/sagemaker/local/image.py
@@ -112,7 +112,7 @@ class _SageMakerContainer(object):
         except RuntimeError as e:
             # _stream_output() doesn't have the command line. We will handle the exception
             # which contains the exit code and append the command line to it.
-            msg = "Failed to run: %s, %s" % (compose_command, e.message)
+            msg = "Failed to run: %s, %s" % (compose_command, str(e))
             raise RuntimeError(msg)
 
         s3_artifacts = self.retrieve_artifacts(compose_data)
@@ -516,7 +516,7 @@ class _HostingContainer(Thread):
         except RuntimeError as e:
             # _stream_output() doesn't have the command line. We will handle the exception
             # which contains the exit code and append the command line to it.
-            msg = "Failed to run: %s, %s" % (self.command, e.message)
+            msg = "Failed to run: %s, %s" % (self.command, str(e))
             raise RuntimeError(msg)
 
     def down(self):

--- a/tests/unit/test_image.py
+++ b/tests/unit/test_image.py
@@ -247,6 +247,25 @@ def test_train(_download_folder, _cleanup, popen, _stream_output, LocalSession,
 
 
 @patch('sagemaker.local.local_session.LocalSession')
+@patch('sagemaker.local.image._stream_output', side_effect=RuntimeError('this is expected'))
+@patch('subprocess.Popen')
+@patch('sagemaker.local.image._SageMakerContainer._cleanup')
+@patch('sagemaker.local.image._SageMakerContainer._download_folder')
+def test_train_error(_download_folder, _cleanup, popen, _stream_output, LocalSession, tmpdir, sagemaker_session):
+    directories = [str(tmpdir.mkdir('container-root')), str(tmpdir.mkdir('data'))]
+
+    with patch('sagemaker.local.image._SageMakerContainer._create_tmp_folder', side_effect=directories):
+        instance_count = 2
+        image = 'my-image'
+        sagemaker_container = _SageMakerContainer('local', instance_count, image, sagemaker_session=sagemaker_session)
+
+        with pytest.raises(RuntimeError) as e:
+            sagemaker_container.train(INPUT_DATA_CONFIG, HYPERPARAMETERS)
+
+        assert 'this is expected' in str(e)
+
+
+@patch('sagemaker.local.local_session.LocalSession')
 @patch('sagemaker.local.image._stream_output')
 @patch('subprocess.Popen')
 @patch('sagemaker.local.image._SageMakerContainer._cleanup')


### PR DESCRIPTION
*Issue #, if available:*
#261 

*Description of changes:*
In the local mode image code, we were incorrectly calling `e.message`, which doesn't work in Python. This change is to remedy that so RuntimeErrors get handled correctly.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have updated the [changelog](https://github.com/aws/sagemaker-python-sdk/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
