### PR TITLE
Make the metric_names list optional in TrainingJobAnalytics object.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ CHANGELOG
 1.5.3dev
 ========
 
+* bug-fix: Can create TrainingJobAnalytics object without specifying metric_names.
 * bug-fix: Session: include role path in ``get_execution_role()`` result
 
 1.5.2

--- a/src/sagemaker/estimator.py
+++ b/src/sagemaker/estimator.py
@@ -324,7 +324,7 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):
         """
         if self._current_job_name is None:
             raise ValueError('Estimator is not associated with a TrainingJob')
-        return TrainingJobAnalytics(self._current_job_name)
+        return TrainingJobAnalytics(self._current_job_name, sagemaker_session=self.sagemaker_session)
 
 
 class _TrainingJob(_Job):

--- a/src/sagemaker/utils.py
+++ b/src/sagemaker/utils.py
@@ -120,6 +120,16 @@ def to_str(value):
         return str(value)
 
 
+def extract_name_from_job_arn(arn):
+    """Returns the name used in the API given a full ARN for a training job
+    or hyperparameter tuning job.
+    """
+    slash_pos = arn.find('/')
+    if slash_pos == -1:
+        raise ValueError("Cannot parse invalid ARN: %s" % arn)
+    return arn[(slash_pos + 1):]
+
+
 class DeferredError(object):
     """Stores an exception and raises it at a later time anytime this
     object is accessed in any way.  Useful to allow soft-dependencies on imports,

--- a/tests/unit/test_estimator.py
+++ b/tests/unit/test_estimator.py
@@ -594,6 +594,47 @@ def test_generic_to_deploy(sagemaker_session):
     assert predictor.sagemaker_session == sagemaker_session
 
 
+def test_generic_training_job_analytics(sagemaker_session):
+    sagemaker_session.sagemaker_client.describe_training_job = Mock(name='describe_training_job', return_value={
+        'TuningJobArn': 'arn:aws:sagemaker:us-west-2:968277160000:hyper-parameter-tuning-job/mock-tuner',
+        'TrainingStartTime': 1530562991.299,
+    })
+    sagemaker_session.sagemaker_client.describe_hyper_parameter_tuning_job = Mock(
+        name='describe_hyper_parameter_tuning_job',
+        return_value={
+            'TrainingJobDefinition': {
+                "AlgorithmSpecification": {
+                    "TrainingImage": "some-image-url",
+                    "TrainingInputMode": "File",
+                    "MetricDefinitions": [
+                        {
+                            "Name": "train:loss",
+                            "Regex": "train_loss=([0-9]+\\.[0-9]+)"
+                        },
+                        {
+                            "Name": "validation:loss",
+                            "Regex": "valid_loss=([0-9]+\\.[0-9]+)"
+                        }
+                    ]
+                }
+            }
+        }
+    )
+
+    e = Estimator(IMAGE_NAME, ROLE, INSTANCE_COUNT, INSTANCE_TYPE, output_path='s3://bucket/prefix',
+                  sagemaker_session=sagemaker_session)
+
+    with pytest.raises(ValueError) as err:  # noqa: F841
+        # No training job yet
+        a = e.training_job_analytics
+        assert a is not None  # This line is never reached
+
+    e.set_hyperparameters(**HYPERPARAMS)
+    e.fit({'train': 's3://bucket/training-prefix'})
+    a = e.training_job_analytics
+    assert a is not None
+
+
 @patch('sagemaker.estimator.LocalSession')
 @patch('sagemaker.estimator.Session')
 def test_local_mode(session_class, local_session_class):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -17,7 +17,7 @@ from __future__ import absolute_import
 import pytest
 from mock import patch
 
-from sagemaker.utils import get_config_value, name_from_base, to_str, DeferredError
+from sagemaker.utils import get_config_value, name_from_base, to_str, DeferredError, extract_name_from_job_arn
 
 NAME = 'base_name'
 
@@ -77,3 +77,15 @@ def test_to_str_with_native_string():
 def test_to_str_with_unicode_string():
     value = u'åñøthér strîng'
     assert to_str(value) == value
+
+
+def test_name_from_tuning_arn():
+    arn = 'arn:aws:sagemaker:us-west-2:968277160000:hyper-parameter-tuning-job/resnet-sgd-tuningjob-11-07-34-11'
+    name = extract_name_from_job_arn(arn)
+    assert name == 'resnet-sgd-tuningjob-11-07-34-11'
+
+
+def test_name_from_training_arn():
+    arn = 'arn:aws:sagemaker:us-west-2:968277160000:training-job/resnet-sgd-tuningjob-11-22-38-46-002-2927640b'
+    name = extract_name_from_job_arn(arn)
+    assert name == 'resnet-sgd-tuningjob-11-22-38-46-002-2927640b'


### PR DESCRIPTION
*Issue* #273 

*Description of changes:*  When TrainingJobAnalytics object, the metric_names list is now optional.  If not specified, it will use all configured metrics.  To discover them, it looks for a hyperparameter tuning job associated with the training job, and finds the metric definitions there.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have updated the [changelog](https://github.com/aws/sagemaker-python-sdk/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [x] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
