### PR TITLE
Add an example for local mode deployment of models

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -192,6 +192,30 @@ instance type.
     mxnet_estimator.delete_endpoint()
 
 
+If you have an existing model and would like to deploy it locally you can do that as well. If you don't
+specify a sagemaker_session argument to the MXNetModel constructor, the right session will be generated
+when calling model.deploy()
+
+Here is an end to end example:
+
+.. code:: python
+
+    import numpy
+    from sagemaker.mxnet import MXNetModel
+
+    model_location = 's3://mybucket/my_model.tar.gz'
+    code_location = 's3://mybucket/sourcedir.tar.gz'
+    s3_model = MXNetModel(model_data=model_location, role='SageMakerRole',
+                          entry_point='mnist.py', source_dir=code_location)
+
+    predictor = s3_model.deploy(initial_instance_count=1, instance_type='local')
+    data = numpy.zeros(shape=(1, 1, 28, 28))
+    predictor.predict(data)
+
+    # Tear down the endpoint container
+    predictor.delete_endpoint()
+
+
 For detailed examples of running docker in local mode, see:
 
 - `TensorFlow local mode example notebook <https://github.com/awslabs/amazon-sagemaker-examples/blob/master/sagemaker-python-sdk/tensorflow_distributed_mnist/tensorflow_local_mode_mnist.ipynb>`__.


### PR DESCRIPTION
If there is an existing model it can be deployed locally
using local mode. This feature is already present but there
is no example in the README.

*Issue #, if available:*

*Description of changes:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated the [changelog](https://github.com/aws/sagemaker-python-sdk/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
