### PR TITLE
Mock time.sleep in unit tests

### DIFF
--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -592,7 +592,8 @@ def test_endpoint_from_production_variants_with_tags(sagemaker_session):
         Tags=tags)
 
 
-def test_wait_for_tuning_job(sagemaker_session):
+@patch('time.sleep')
+def test_wait_for_tuning_job(sleep, sagemaker_session):
     hyperparameter_tuning_job_desc = {'HyperParameterTuningJobStatus': 'Completed'}
     sagemaker_session.sagemaker_client.describe_hyper_parameter_tuning_job = Mock(
         name='describe_hyper_parameter_tuning_job', return_value=hyperparameter_tuning_job_desc)
@@ -621,7 +622,8 @@ def test_tune_job_status_none(sagemaker_session):
     assert result is None
 
 
-def test_wait_for_transform_job_completed(sagemaker_session):
+@patch('time.sleep')
+def test_wait_for_transform_job_completed(sleep, sagemaker_session):
     transform_job_desc = {'TransformJobStatus': 'Completed'}
     sagemaker_session.sagemaker_client.describe_transform_job = Mock(
         name='describe_transform_job', return_value=transform_job_desc)
@@ -629,7 +631,8 @@ def test_wait_for_transform_job_completed(sagemaker_session):
     assert sagemaker_session.wait_for_transform_job(JOB_NAME)['TransformJobStatus'] == 'Completed'
 
 
-def test_wait_for_transform_job_in_progress(sagemaker_session):
+@patch('time.sleep')
+def test_wait_for_transform_job_in_progress(sleep, sagemaker_session):
     transform_job_desc_in_progress = {'TransformJobStatus': 'InProgress'}
     transform_job_desc_in_completed = {'TransformJobStatus': 'Completed'}
     sagemaker_session.sagemaker_client.describe_transform_job = Mock(

--- a/tests/unit/test_tf_estimator.py
+++ b/tests/unit/test_tf_estimator.py
@@ -312,7 +312,8 @@ def test_run_tensorboard_locally_without_awscli_binary(time, strftime, popen, ca
 @patch('subprocess.Popen')
 @patch('time.strftime', return_value=TIMESTAMP)
 @patch('time.time', return_value=TIME)
-def test_run_tensorboard_locally(time, strftime, popen, call, access, rmtree, mkdtemp, sync, sagemaker_session):
+@patch('time.sleep')
+def test_run_tensorboard_locally(sleep, time, strftime, popen, call, access, rmtree, mkdtemp, sync, sagemaker_session):
     tf = TensorFlow(entry_point=SCRIPT_PATH, role=ROLE, sagemaker_session=sagemaker_session,
                     train_instance_count=INSTANCE_COUNT, train_instance_type=INSTANCE_TYPE)
 
@@ -322,8 +323,7 @@ def test_run_tensorboard_locally(time, strftime, popen, call, access, rmtree, mk
 
     popen.assert_called_with(['tensorboard', '--logdir', '/my/temp/folder', '--host', 'localhost', '--port', '6006'],
                              stderr=-1,
-                             stdout=-1
-                             )
+                             stdout=-1)
 
 
 @patch('sagemaker.tensorflow.estimator.Tensorboard._sync_directories')
@@ -335,7 +335,8 @@ def test_run_tensorboard_locally(time, strftime, popen, call, access, rmtree, mk
 @patch('subprocess.Popen')
 @patch('time.strftime', return_value=TIMESTAMP)
 @patch('time.time', return_value=TIME)
-def test_run_tensorboard_locally_port_in_use(time, strftime, popen, call, access, socket, rmtree, mkdtemp, sync,
+@patch('time.sleep')
+def test_run_tensorboard_locally_port_in_use(sleep, time, strftime, popen, call, access, socket, rmtree, mkdtemp, sync,
                                              sagemaker_session):
     tf = TensorFlow(entry_point=SCRIPT_PATH, role=ROLE, sagemaker_session=sagemaker_session,
                     train_instance_count=INSTANCE_COUNT, train_instance_type=INSTANCE_TYPE)


### PR DESCRIPTION
*Description of changes:*
This change speeds up our unit tests.

Current test-run duration:
real    0m49.736s
user    0m6.219s
sys     0m1.089s

With this change:
real    0m9.447s
user    0m6.856s
sys     0m1.115s

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated the [changelog](https://github.com/aws/sagemaker-python-sdk/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
