### PR TITLE
Allow Model and Transformer to use a different role from the Estimator

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ CHANGELOG
 ========
 
 * bug-fix: Session: use existing model instead of failing during ``create_model()``
+* enhancement: Estimator: allow for different role from the Estimator's when creating a Model or Transformer
 
 1.7.0
 =====

--- a/src/sagemaker/chainer/estimator.py
+++ b/src/sagemaker/chainer/estimator.py
@@ -98,7 +98,7 @@ class Chainer(Framework):
         hyperparameters.update(Framework._json_encode_hyperparameters(additional_hyperparameters))
         return hyperparameters
 
-    def create_model(self, role=None, model_server_workers=None):
+    def create_model(self, model_server_workers=None, role=None):
         """Create a SageMaker ``ChainerModel`` object that can be deployed to an ``Endpoint``.
 
         Args:

--- a/src/sagemaker/chainer/estimator.py
+++ b/src/sagemaker/chainer/estimator.py
@@ -98,10 +98,12 @@ class Chainer(Framework):
         hyperparameters.update(Framework._json_encode_hyperparameters(additional_hyperparameters))
         return hyperparameters
 
-    def create_model(self, model_server_workers=None):
+    def create_model(self, role=None, model_server_workers=None):
         """Create a SageMaker ``ChainerModel`` object that can be deployed to an ``Endpoint``.
 
         Args:
+            role (str): The ``ExecutionRoleArn`` IAM Role ARN for the ``Model``, which is also used during
+                transform jobs. If not specified, the role from the Estimator will be used.
             model_server_workers (int): Optional. The number of worker processes used by the inference server.
                 If None, server will use one worker per vCPU.
 
@@ -109,7 +111,8 @@ class Chainer(Framework):
             sagemaker.chainer.model.ChainerModel: A SageMaker ``ChainerModel`` object.
                 See :func:`~sagemaker.chainer.model.ChainerModel` for full details.
         """
-        return ChainerModel(self.model_data, self.role, self.entry_point, source_dir=self._model_source_dir(),
+        role = role or self.role
+        return ChainerModel(self.model_data, role, self.entry_point, source_dir=self._model_source_dir(),
                             enable_cloudwatch_metrics=self.enable_cloudwatch_metrics, name=self._current_job_name,
                             container_log_level=self.container_log_level, code_location=self.code_location,
                             py_version=self.py_version, framework_version=self.framework_version,

--- a/src/sagemaker/mxnet/estimator.py
+++ b/src/sagemaker/mxnet/estimator.py
@@ -65,10 +65,12 @@ class MXNet(Framework):
         self.py_version = py_version
         self.framework_version = framework_version
 
-    def create_model(self, model_server_workers=None):
+    def create_model(self, role=None, model_server_workers=None):
         """Create a SageMaker ``MXNetModel`` object that can be deployed to an ``Endpoint``.
 
         Args:
+            role (str): The ``ExecutionRoleArn`` IAM Role ARN for the ``Model``, which is also used during
+                transform jobs. If not specified, the role from the Estimator will be used.
             model_server_workers (int): Optional. The number of worker processes used by the inference server.
                 If None, server will use one worker per vCPU.
 
@@ -76,7 +78,8 @@ class MXNet(Framework):
             sagemaker.mxnet.model.MXNetModel: A SageMaker ``MXNetModel`` object.
                 See :func:`~sagemaker.mxnet.model.MXNetModel` for full details.
         """
-        return MXNetModel(self.model_data, self.role, self.entry_point, source_dir=self._model_source_dir(),
+        role = role or self.role
+        return MXNetModel(self.model_data, role, self.entry_point, source_dir=self._model_source_dir(),
                           enable_cloudwatch_metrics=self.enable_cloudwatch_metrics, name=self._current_job_name,
                           container_log_level=self.container_log_level, code_location=self.code_location,
                           py_version=self.py_version, framework_version=self.framework_version, image=self.image_name,

--- a/src/sagemaker/mxnet/estimator.py
+++ b/src/sagemaker/mxnet/estimator.py
@@ -65,7 +65,7 @@ class MXNet(Framework):
         self.py_version = py_version
         self.framework_version = framework_version
 
-    def create_model(self, role=None, model_server_workers=None):
+    def create_model(self, model_server_workers=None, role=None):
         """Create a SageMaker ``MXNetModel`` object that can be deployed to an ``Endpoint``.
 
         Args:

--- a/src/sagemaker/pytorch/estimator.py
+++ b/src/sagemaker/pytorch/estimator.py
@@ -63,7 +63,7 @@ class PyTorch(Framework):
         self.py_version = py_version
         self.framework_version = framework_version
 
-    def create_model(self, role=None, model_server_workers=None):
+    def create_model(self, model_server_workers=None, role=None):
         """Create a SageMaker ``PyTorchModel`` object that can be deployed to an ``Endpoint``.
 
         Args:

--- a/src/sagemaker/pytorch/estimator.py
+++ b/src/sagemaker/pytorch/estimator.py
@@ -63,10 +63,12 @@ class PyTorch(Framework):
         self.py_version = py_version
         self.framework_version = framework_version
 
-    def create_model(self, model_server_workers=None):
+    def create_model(self, role=None, model_server_workers=None):
         """Create a SageMaker ``PyTorchModel`` object that can be deployed to an ``Endpoint``.
 
         Args:
+            role (str): The ``ExecutionRoleArn`` IAM Role ARN for the ``Model``, which is also used during
+                transform jobs. If not specified, the role from the Estimator will be used.
             model_server_workers (int): Optional. The number of worker processes used by the inference server.
                 If None, server will use one worker per vCPU.
 
@@ -74,7 +76,8 @@ class PyTorch(Framework):
             sagemaker.pytorch.model.PyTorchModel: A SageMaker ``PyTorchModel`` object.
                 See :func:`~sagemaker.pytorch.model.PyTorchModel` for full details.
         """
-        return PyTorchModel(self.model_data, self.role, self.entry_point, source_dir=self._model_source_dir(),
+        role = role or self.role
+        return PyTorchModel(self.model_data, role, self.entry_point, source_dir=self._model_source_dir(),
                             enable_cloudwatch_metrics=self.enable_cloudwatch_metrics, name=self._current_job_name,
                             container_log_level=self.container_log_level, code_location=self.code_location,
                             py_version=self.py_version, framework_version=self.framework_version, image=self.image_name,

--- a/src/sagemaker/tensorflow/estimator.py
+++ b/src/sagemaker/tensorflow/estimator.py
@@ -289,7 +289,7 @@ class TensorFlow(Framework):
 
         return init_params
 
-    def create_model(self, role=None, model_server_workers=None):
+    def create_model(self, model_server_workers=None, role=None):
         """Create a SageMaker ``TensorFlowModel`` object that can be deployed to an ``Endpoint``.
 
         Args:

--- a/src/sagemaker/tensorflow/estimator.py
+++ b/src/sagemaker/tensorflow/estimator.py
@@ -289,10 +289,12 @@ class TensorFlow(Framework):
 
         return init_params
 
-    def create_model(self, model_server_workers=None):
+    def create_model(self, role=None, model_server_workers=None):
         """Create a SageMaker ``TensorFlowModel`` object that can be deployed to an ``Endpoint``.
 
         Args:
+            role (str): The ``ExecutionRoleArn`` IAM Role ARN for the ``Model``, which is also used during
+                transform jobs. If not specified, the role from the Estimator will be used.
             model_server_workers (int): Optional. The number of worker processes used by the inference server.
                 If None, server will use one worker per vCPU.
 
@@ -301,7 +303,8 @@ class TensorFlow(Framework):
                 See :func:`~sagemaker.tensorflow.model.TensorFlowModel` for full details.
         """
         env = {'SAGEMAKER_REQUIREMENTS': self.requirements_file}
-        return TensorFlowModel(self.model_data, self.role, self.entry_point, source_dir=self._model_source_dir(),
+        role = role or self.role
+        return TensorFlowModel(self.model_data, role, self.entry_point, source_dir=self._model_source_dir(),
                                enable_cloudwatch_metrics=self.enable_cloudwatch_metrics, env=env, image=self.image_name,
                                name=self._current_job_name, container_log_level=self.container_log_level,
                                code_location=self.code_location, py_version=self.py_version,

--- a/tests/unit/test_chainer.py
+++ b/tests/unit/test_chainer.py
@@ -233,7 +233,7 @@ def test_create_model(sagemaker_session, chainer_version):
                       enable_cloudwatch_metrics=enable_cloudwatch_metrics)
 
     job_name = 'new_name'
-    chainer.fit(inputs='s3://mybucket/train', job_name='new_name')
+    chainer.fit(inputs='s3://mybucket/train', job_name=job_name)
     model = chainer.create_model()
 
     assert model.sagemaker_session == sagemaker_session
@@ -245,6 +245,25 @@ def test_create_model(sagemaker_session, chainer_version):
     assert model.container_log_level == container_log_level
     assert model.source_dir == source_dir
     assert model.enable_cloudwatch_metrics == enable_cloudwatch_metrics
+
+
+def test_create_model_with_optional_params(sagemaker_session):
+    container_log_level = '"logging.INFO"'
+    source_dir = 's3://mybucket/source'
+    enable_cloudwatch_metrics = 'true'
+    chainer = Chainer(entry_point=SCRIPT_PATH, role=ROLE, sagemaker_session=sagemaker_session,
+                      train_instance_count=INSTANCE_COUNT, train_instance_type=INSTANCE_TYPE,
+                      container_log_level=container_log_level, py_version=PYTHON_VERSION, base_job_name='job',
+                      source_dir=source_dir, enable_cloudwatch_metrics=enable_cloudwatch_metrics)
+
+    chainer.fit(inputs='s3://mybucket/train', job_name='new_name')
+
+    new_role = 'role'
+    model_server_workers = 2
+    model = chainer.create_model(role=new_role, model_server_workers=model_server_workers)
+
+    assert model.role == new_role
+    assert model.model_server_workers == model_server_workers
 
 
 def test_create_model_with_custom_image(sagemaker_session):

--- a/tests/unit/test_mxnet.py
+++ b/tests/unit/test_mxnet.py
@@ -108,7 +108,7 @@ def test_create_model(sagemaker_session, mxnet_version):
                base_job_name='job', source_dir=source_dir, enable_cloudwatch_metrics=enable_cloudwatch_metrics)
 
     job_name = 'new_name'
-    mx.fit(inputs='s3://mybucket/train', job_name='new_name')
+    mx.fit(inputs='s3://mybucket/train', job_name=job_name)
     model = mx.create_model()
 
     assert model.sagemaker_session == sagemaker_session
@@ -120,6 +120,25 @@ def test_create_model(sagemaker_session, mxnet_version):
     assert model.container_log_level == container_log_level
     assert model.source_dir == source_dir
     assert model.enable_cloudwatch_metrics == enable_cloudwatch_metrics
+
+
+def test_create_model_with_optional_params(sagemaker_session):
+    container_log_level = '"logging.INFO"'
+    source_dir = 's3://mybucket/source'
+    enable_cloudwatch_metrics = 'true'
+    mx = MXNet(entry_point=SCRIPT_PATH, role=ROLE, sagemaker_session=sagemaker_session,
+               train_instance_count=INSTANCE_COUNT, train_instance_type=INSTANCE_TYPE,
+               container_log_level=container_log_level, base_job_name='job', source_dir=source_dir,
+               enable_cloudwatch_metrics=enable_cloudwatch_metrics)
+
+    mx.fit(inputs='s3://mybucket/train', job_name='new_name')
+
+    new_role = 'role'
+    model_server_workers = 2
+    model = mx.create_model(role=new_role, model_server_workers=model_server_workers)
+
+    assert model.role == new_role
+    assert model.model_server_workers == model_server_workers
 
 
 def test_create_model_with_custom_image(sagemaker_session):

--- a/tests/unit/test_pytorch.py
+++ b/tests/unit/test_pytorch.py
@@ -140,6 +140,25 @@ def test_create_model(sagemaker_session, pytorch_version):
     assert model.enable_cloudwatch_metrics == enable_cloudwatch_metrics
 
 
+def test_create_model_with_optional_params(sagemaker_session):
+    container_log_level = '"logging.INFO"'
+    source_dir = 's3://mybucket/source'
+    enable_cloudwatch_metrics = 'true'
+    pytorch = PyTorch(entry_point=SCRIPT_PATH, role=ROLE, sagemaker_session=sagemaker_session,
+                      train_instance_count=INSTANCE_COUNT, train_instance_type=INSTANCE_TYPE,
+                      container_log_level=container_log_level, base_job_name='job', source_dir=source_dir,
+                      enable_cloudwatch_metrics=enable_cloudwatch_metrics)
+
+    pytorch.fit(inputs='s3://mybucket/train', job_name='new_name')
+
+    new_role = 'role'
+    model_server_workers = 2
+    model = pytorch.create_model(role=new_role, model_server_workers=model_server_workers)
+
+    assert model.role == new_role
+    assert model.model_server_workers == model_server_workers
+
+
 def test_create_model_with_custom_image(sagemaker_session):
     container_log_level = '"logging.INFO"'
     source_dir = 's3://mybucket/source'

--- a/tests/unit/test_tf_estimator.py
+++ b/tests/unit/test_tf_estimator.py
@@ -205,6 +205,26 @@ def test_create_model(sagemaker_session, tf_version):
     assert model.enable_cloudwatch_metrics == enable_cloudwatch_metrics
 
 
+def test_create_model_with_optional_params(sagemaker_session):
+    container_log_level = '"logging.INFO"'
+    source_dir = 's3://mybucket/source'
+    enable_cloudwatch_metrics = 'true'
+    tf = TensorFlow(entry_point=SCRIPT_PATH, role=ROLE, sagemaker_session=sagemaker_session,
+                    training_steps=1000, evaluation_steps=10, train_instance_count=INSTANCE_COUNT,
+                    train_instance_type=INSTANCE_TYPE, container_log_level=container_log_level, base_job_name='job',
+                    source_dir=source_dir, enable_cloudwatch_metrics=enable_cloudwatch_metrics)
+
+    job_name = 'doing something'
+    tf.fit(inputs='s3://mybucket/train', job_name=job_name)
+
+    new_role = 'role'
+    model_server_workers = 2
+    model = tf.create_model(role=new_role, model_server_workers=2)
+
+    assert model.role == new_role
+    assert model.model_server_workers == model_server_workers
+
+
 def test_create_model_with_custom_image(sagemaker_session):
     container_log_level = '"logging.INFO"'
     source_dir = 's3://mybucket/source'


### PR DESCRIPTION
*Issue #, if available:*
#303 

*Description of changes:*
This change allows for a different role to be specified when creating a `Model` or `Transformer` from an `Estimator`. Still defaults to the estimator's role if nothing's specified.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have updated the [changelog](https://github.com/aws/sagemaker-python-sdk/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
