### PR TITLE
modify cifar test to avoid timeouts

### DIFF
--- a/tests/integ/test_tf_cifar.py
+++ b/tests/integ/test_tf_cifar.py
@@ -35,7 +35,7 @@ class PickleSerializer(object):
 
 @pytest.mark.continuous_testing
 def test_cifar(sagemaker_session, tf_full_version):
-    with timeout(minutes=20):
+    with timeout(minutes=45):
         script_path = os.path.join(DATA_DIR, 'cifar_10', 'source')
 
         dataset_path = os.path.join(DATA_DIR, 'cifar_10', 'data')


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* This test frequently fails in FRA, seemingly due to difficulty getting p2.xlarge (takes more than 20 minutes to start in some cases), causing spurious canary failures.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated the [changelog](https://github.com/aws/sagemaker-python-sdk/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
