### PR TITLE
Add missing arg to Tuner docstring

### DIFF
--- a/src/sagemaker/tuner.py
+++ b/src/sagemaker/tuner.py
@@ -245,6 +245,10 @@ class HyperparameterTuner(object):
 
             job_name (str): Tuning job name. If not specified, the tuner generates a default job name,
                 based on the training image name and current timestamp.
+            include_cls_metadata (bool): Whether or not the hyperparameter tuning job should include information about
+                the estimator class (default: True). This information is passed as a hyperparameter, so if
+                the algorithm you are using cannot handle unknown hyperparameters (e.g. an Amazon ML algorithm that
+                does not have a custom estimator in the Python SDK), then set ``include_cls_metadata`` to ``False``.
             **kwargs: Other arguments needed for training. Please refer to the ``fit()`` method of the associated
                 estimator to see what other arguments are needed.
         """


### PR DESCRIPTION
*Description of changes:*
One of the docstrings was missing an arg that got added later, though its usage is already documented in the README

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated the [changelog](https://github.com/aws/sagemaker-python-sdk/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [x] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
