### PR TITLE
Generate better training job status report

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,9 +2,11 @@
 CHANGELOG
 =========
 
-1.7.2.dev
-=========
+1.7.2
+=====
+
 * bug-fix: Prediction output for the TF_JSON_SERIALIZER
+* enhancement: Add better training job status report
 
 1.7.1
 =====

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -17,7 +17,12 @@ from __future__ import absolute_import
 import pytest
 from mock import patch
 
-from sagemaker.utils import get_config_value, name_from_base, to_str, DeferredError, extract_name_from_job_arn
+from sagemaker.utils import get_config_value, name_from_base,\
+    to_str, DeferredError, extract_name_from_job_arn, secondary_training_status_changed,\
+    secondary_training_status_message
+
+from datetime import datetime
+import time
 
 NAME = 'base_name'
 
@@ -89,3 +94,48 @@ def test_name_from_training_arn():
     arn = 'arn:aws:sagemaker:us-west-2:968277160000:training-job/resnet-sgd-tuningjob-11-22-38-46-002-2927640b'
     name = extract_name_from_job_arn(arn)
     assert name == 'resnet-sgd-tuningjob-11-22-38-46-002-2927640b'
+
+
+MESSAGE = 'message'
+STATUS = 'status'
+TRAINING_JOB_DESCRIPTION_1 = {
+    'SecondaryStatusTransitions': [{'StatusMessage': MESSAGE, 'Status': STATUS}]
+}
+TRAINING_JOB_DESCRIPTION_2 = {
+    'SecondaryStatusTransitions': [{'StatusMessage': 'different message', 'Status': STATUS}]
+}
+TRAINING_JOB_DESCRIPTION_EMPTY = {
+    'SecondaryStatusTransitions': []
+}
+
+
+def test_secondary_training_status_changed_true():
+    changed = secondary_training_status_changed(TRAINING_JOB_DESCRIPTION_1, TRAINING_JOB_DESCRIPTION_2)
+    assert changed is True
+
+
+def test_secondary_training_status_changed_false():
+    changed = secondary_training_status_changed(TRAINING_JOB_DESCRIPTION_1, TRAINING_JOB_DESCRIPTION_1)
+    assert changed is False
+
+
+def test_secondary_training_status_changed_empty():
+    changed = secondary_training_status_changed(TRAINING_JOB_DESCRIPTION_EMPTY, TRAINING_JOB_DESCRIPTION_1)
+    assert changed is False
+
+
+def test_secondary_training_status_message_status_changed():
+    now = datetime.now()
+    TRAINING_JOB_DESCRIPTION_1['SecondaryStatusTransitions'][-1]['StartTime'] = now
+    expected = '{} {} - {}'.format(
+        datetime.utcfromtimestamp(time.mktime(now.timetuple())).strftime('%Y-%m-%d %H:%M:%S'),
+        STATUS,
+        MESSAGE
+    )
+    assert secondary_training_status_message(TRAINING_JOB_DESCRIPTION_1, TRAINING_JOB_DESCRIPTION_EMPTY) == expected
+
+
+def test_secondary_training_status_message_status_not_changed():
+    now = datetime.now()
+    TRAINING_JOB_DESCRIPTION_1['SecondaryStatusTransitions'][-1]['StartTime'] = now
+    assert secondary_training_status_message(TRAINING_JOB_DESCRIPTION_1, TRAINING_JOB_DESCRIPTION_2) == MESSAGE


### PR DESCRIPTION
* Generate better training job status report

With this feature while waiting for a training job to finish user will be able
see more detailed status from the output.

The output is in the format of '<StarTime> <SecondaryStatus> <StatusMessage>...'

*Issue #, if available:*

*Description of changes:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated the [changelog](https://github.com/aws/sagemaker-python-sdk/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
