### PR TITLE
Fix default input channel name in mxnet README

### DIFF
--- a/src/sagemaker/mxnet/README.rst
+++ b/src/sagemaker/mxnet/README.rst
@@ -171,7 +171,7 @@ Required argument
 -  ``inputs``: This can take one of the following forms: A string
    s3 URI, for example ``s3://my-bucket/my-training-data``. In this
    case, the s3 objects rooted at the ``my-training-data`` prefix will
-   be available in the default ``train`` channel. A dict from
+   be available in the default ``training`` channel. A dict from
    string channel names to s3 URIs. In this case, the objects rooted at
    each s3 prefix will available as files in each channel directory.
 


### PR DESCRIPTION
* Change the default channel name from 'train' to 'training'

*Issue #332, if available:*

*Description of changes:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated the [changelog](https://github.com/aws/sagemaker-python-sdk/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
