### PR TITLE
Make record serializer accept one-dimensional arrays (#320)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 CHANGELOG
 =========
 
+1.8.1dev
+=====
+* bug-fix: Estimators: Fix serialization of single records
+
 1.8.0
 =====
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ CHANGELOG
 =========
 
 1.8.1dev
-=====
+========
 * bug-fix: Estimators: Fix serialization of single records
 
 1.8.0

--- a/src/sagemaker/amazon/common.py
+++ b/src/sagemaker/amazon/common.py
@@ -29,7 +29,7 @@ class numpy_to_record_serializer(object):
 
     def __call__(self, array):
         if len(array.shape) == 1:
-            array.reshape(1, array.shape[0])
+            array = array.reshape(1, array.shape[0])
         assert len(array.shape) == 2, "Expecting a 1 or 2 dimensional array"
         buf = io.BytesIO()
         write_numpy_to_dense_tensor(buf, array)

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -32,6 +32,16 @@ def test_serializer():
         assert record.features["values"].float64_tensor.values == expected
 
 
+def test_serializer_accepts_one_dimensional_array():
+    s = numpy_to_record_serializer()
+    array_data = [1.0, 2.0, 3.0]
+    buf = s(np.array(array_data))
+    record_data = next(_read_recordio(buf))
+    record = Record()
+    record.ParseFromString(record_data)
+    assert record.features["values"].float64_tensor.values == array_data
+
+
 def test_deserializer():
     array_data = [[1.0, 2.0, 3.0], [10.0, 20.0, 30.0]]
     s = numpy_to_record_serializer()


### PR DESCRIPTION
*Issue #, if available:*
#320 

*Description of changes:*
The record serializer processes reshaped arrays.
A unit test for the corresponding one-dimensional case added.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [ x ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ x ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ x ] I have updated the [changelog](https://github.com/aws/sagemaker-python-sdk/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
