### PR TITLE
Wrap training timeout for integ tests

### DIFF
--- a/tests/integ/test_byo_estimator.py
+++ b/tests/integ/test_byo_estimator.py
@@ -29,7 +29,7 @@ from sagemaker.amazon.common import write_numpy_to_dense_tensor
 from sagemaker.estimator import Estimator
 from sagemaker.utils import name_from_base
 from tests.integ import DATA_DIR
-from tests.integ.timeout import timeout, timeout_and_delete_endpoint_by_name
+from tests.integ.timeout import timeout_training, timeout_and_delete_endpoint_by_name
 
 
 @pytest.fixture(scope='module')
@@ -58,7 +58,7 @@ def test_byo_estimator(sagemaker_session, region):
     """
     image_name = registry(region) + "/factorization-machines:1"
 
-    with timeout(minutes=15):
+    with timeout_training():
         data_path = os.path.join(DATA_DIR, 'one_p_mnist', 'mnist.pkl.gz')
         pickle_args = {} if sys.version_info.major == 2 else {'encoding': 'latin1'}
 
@@ -113,7 +113,7 @@ def test_async_byo_estimator(sagemaker_session, region):
     endpoint_name = name_from_base('byo')
     training_job_name = ""
 
-    with timeout(minutes=5):
+    with timeout_training(minutes=5):
         data_path = os.path.join(DATA_DIR, 'one_p_mnist', 'mnist.pkl.gz')
         pickle_args = {} if sys.version_info.major == 2 else {'encoding': 'latin1'}
 

--- a/tests/integ/test_chainer_train.py
+++ b/tests/integ/test_chainer_train.py
@@ -23,7 +23,7 @@ from sagemaker.chainer.estimator import Chainer
 from sagemaker.chainer.model import ChainerModel
 from sagemaker.utils import sagemaker_timestamp
 from tests.integ import DATA_DIR
-from tests.integ.timeout import timeout, timeout_and_delete_endpoint_by_name
+from tests.integ.timeout import timeout_training, timeout_and_delete_endpoint_by_name
 
 
 @pytest.fixture(scope='module')
@@ -40,7 +40,7 @@ def test_distributed_gpu_training(sagemaker_session, chainer_full_version):
 
 
 def test_training_with_additional_hyperparameters(sagemaker_session, chainer_full_version):
-    with timeout(minutes=15):
+    with timeout_training():
         script_path = os.path.join(DATA_DIR, 'chainer_mnist', 'mnist.py')
         data_path = os.path.join(DATA_DIR, 'chainer_mnist')
 
@@ -86,7 +86,7 @@ def test_deploy_model(chainer_training_job, sagemaker_session):
 def test_async_fit(sagemaker_session):
     endpoint_name = 'test-chainer-attach-deploy-{}'.format(sagemaker_timestamp())
 
-    with timeout(minutes=5):
+    with timeout_training(minutes=5):
         training_job_name = _run_mnist_training_job(sagemaker_session, "ml.c4.xlarge", 1,
                                                     chainer_full_version=CHAINER_VERSION, wait=False)
 
@@ -101,7 +101,7 @@ def test_async_fit(sagemaker_session):
 
 
 def test_failed_training_job(sagemaker_session, chainer_full_version):
-    with timeout(minutes=15):
+    with timeout_training():
         script_path = os.path.join(DATA_DIR, 'chainer_mnist', 'failure_script.py')
         data_path = os.path.join(DATA_DIR, 'chainer_mnist')
 
@@ -119,7 +119,7 @@ def test_failed_training_job(sagemaker_session, chainer_full_version):
 
 def _run_mnist_training_job(sagemaker_session, instance_type, instance_count,
                             chainer_full_version, wait=True):
-    with timeout(minutes=15):
+    with timeout_training():
 
         script_path = os.path.join(DATA_DIR, 'chainer_mnist', 'mnist.py') if instance_type == 1 else \
             os.path.join(DATA_DIR, 'chainer_mnist', 'distributed_mnist.py')

--- a/tests/integ/test_factorization_machines.py
+++ b/tests/integ/test_factorization_machines.py
@@ -23,12 +23,12 @@ import pytest
 from sagemaker import FactorizationMachines, FactorizationMachinesModel
 from sagemaker.utils import name_from_base
 from tests.integ import DATA_DIR
-from tests.integ.timeout import timeout, timeout_and_delete_endpoint_by_name
+from tests.integ.timeout import timeout_training, timeout_and_delete_endpoint_by_name
 
 
 @pytest.mark.continuous_testing
 def test_factorization_machines(sagemaker_session):
-    with timeout(minutes=15):
+    with timeout_training():
         data_path = os.path.join(DATA_DIR, 'one_p_mnist', 'mnist.pkl.gz')
         pickle_args = {} if sys.version_info.major == 2 else {'encoding': 'latin1'}
 
@@ -60,7 +60,7 @@ def test_async_factorization_machines(sagemaker_session):
     training_job_name = ""
     endpoint_name = name_from_base('factorizationMachines')
 
-    with timeout(minutes=5):
+    with timeout_training(minutes=5):
         data_path = os.path.join(DATA_DIR, 'one_p_mnist', 'mnist.pkl.gz')
         pickle_args = {} if sys.version_info.major == 2 else {'encoding': 'latin1'}
 

--- a/tests/integ/test_kmeans.py
+++ b/tests/integ/test_kmeans.py
@@ -23,12 +23,12 @@ import pytest
 from sagemaker import KMeans, KMeansModel
 from sagemaker.utils import name_from_base
 from tests.integ import DATA_DIR
-from tests.integ.timeout import timeout, timeout_and_delete_endpoint_by_name
+from tests.integ.timeout import timeout_training, timeout_and_delete_endpoint_by_name
 
 
 @pytest.mark.continuous_testing
 def test_kmeans(sagemaker_session):
-    with timeout(minutes=15):
+    with timeout_training():
         data_path = os.path.join(DATA_DIR, 'one_p_mnist', 'mnist.pkl.gz')
         pickle_args = {} if sys.version_info.major == 2 else {'encoding': 'latin1'}
 
@@ -80,7 +80,7 @@ def test_async_kmeans(sagemaker_session):
     training_job_name = ""
     endpoint_name = name_from_base('kmeans')
 
-    with timeout(minutes=5):
+    with timeout_training(minutes=5):
         data_path = os.path.join(DATA_DIR, 'one_p_mnist', 'mnist.pkl.gz')
         pickle_args = {} if sys.version_info.major == 2 else {'encoding': 'latin1'}
 

--- a/tests/integ/test_knn.py
+++ b/tests/integ/test_knn.py
@@ -23,12 +23,12 @@ import pytest
 from sagemaker import KNN, KNNModel
 from sagemaker.utils import name_from_base
 from tests.integ import DATA_DIR
-from tests.integ.timeout import timeout, timeout_and_delete_endpoint_by_name
+from tests.integ.timeout import timeout_training, timeout_and_delete_endpoint_by_name
 
 
 @pytest.mark.continuous_testing
 def test_knn_regressor(sagemaker_session):
-    with timeout(minutes=15):
+    with timeout_training():
         data_path = os.path.join(DATA_DIR, 'one_p_mnist', 'mnist.pkl.gz')
         pickle_args = {} if sys.version_info.major == 2 else {'encoding': 'latin1'}
 
@@ -59,7 +59,7 @@ def test_async_knn_classifier(sagemaker_session):
     training_job_name = ""
     endpoint_name = name_from_base('knn')
 
-    with timeout(minutes=5):
+    with timeout_training(minutes=5):
         data_path = os.path.join(DATA_DIR, 'one_p_mnist', 'mnist.pkl.gz')
         pickle_args = {} if sys.version_info.major == 2 else {'encoding': 'latin1'}
 

--- a/tests/integ/test_lda.py
+++ b/tests/integ/test_lda.py
@@ -21,13 +21,13 @@ from sagemaker import LDA, LDAModel
 from sagemaker.amazon.common import read_records
 from sagemaker.utils import name_from_base
 from tests.integ import DATA_DIR
-from tests.integ.timeout import timeout, timeout_and_delete_endpoint_by_name
+from tests.integ.timeout import timeout_training, timeout_and_delete_endpoint_by_name
 from tests.integ.record_set import prepare_record_set_from_local_files
 
 
 @pytest.mark.continuous_testing
 def test_lda(sagemaker_session):
-    with timeout(minutes=15):
+    with timeout_training():
         data_path = os.path.join(DATA_DIR, 'lda')
         data_filename = 'nips-train_1.pbr'
 

--- a/tests/integ/test_linear_learner.py
+++ b/tests/integ/test_linear_learner.py
@@ -24,12 +24,12 @@ import pytest
 from sagemaker.amazon.linear_learner import LinearLearner, LinearLearnerModel
 from sagemaker.utils import name_from_base, sagemaker_timestamp
 from tests.integ import DATA_DIR
-from tests.integ.timeout import timeout, timeout_and_delete_endpoint_by_name
+from tests.integ.timeout import timeout_training, timeout_and_delete_endpoint_by_name
 
 
 @pytest.mark.continuous_testing
 def test_linear_learner(sagemaker_session):
-    with timeout(minutes=15):
+    with timeout_training():
         data_path = os.path.join(DATA_DIR, 'one_p_mnist', 'mnist.pkl.gz')
         pickle_args = {} if sys.version_info.major == 2 else {'encoding': 'latin1'}
 
@@ -93,7 +93,7 @@ def test_linear_learner(sagemaker_session):
 
 
 def test_linear_learner_multiclass(sagemaker_session):
-    with timeout(minutes=15):
+    with timeout_training():
         data_path = os.path.join(DATA_DIR, 'one_p_mnist', 'mnist.pkl.gz')
         pickle_args = {} if sys.version_info.major == 2 else {'encoding': 'latin1'}
 
@@ -125,7 +125,7 @@ def test_async_linear_learner(sagemaker_session):
     training_job_name = ""
     endpoint_name = 'test-linear-learner-async-{}'.format(sagemaker_timestamp())
 
-    with timeout(minutes=5):
+    with timeout_training():
         data_path = os.path.join(DATA_DIR, 'one_p_mnist', 'mnist.pkl.gz')
         pickle_args = {} if sys.version_info.major == 2 else {'encoding': 'latin1'}
 

--- a/tests/integ/test_local_mode.py
+++ b/tests/integ/test_local_mode.py
@@ -25,7 +25,7 @@ from sagemaker.mxnet import MXNet, MXNetModel
 from sagemaker.tensorflow import TensorFlow
 from sagemaker.fw_utils import tar_and_upload_dir
 from tests.integ import DATA_DIR
-from tests.integ.timeout import timeout
+from tests.integ.timeout import timeout_training
 
 DATA_PATH = os.path.join(DATA_DIR, 'iris', 'data')
 LOCK_PATH = os.path.join(DATA_DIR, 'local_mode_lock')
@@ -78,7 +78,7 @@ def mxnet_model(sagemaker_local_session):
 def test_tf_local_mode(tf_full_version, sagemaker_local_session):
     local_mode_lock_fd = open(LOCK_PATH, 'w')
     local_mode_lock = local_mode_lock_fd.fileno()
-    with timeout(minutes=5):
+    with timeout_training(minutes=5):
         script_path = os.path.join(DATA_DIR, 'iris', 'iris-dnn-classifier.py')
 
         estimator = TensorFlow(entry_point=script_path,
@@ -123,7 +123,7 @@ def test_tf_local_mode(tf_full_version, sagemaker_local_session):
 def test_tf_distributed_local_mode(sagemaker_local_session):
     local_mode_lock_fd = open(LOCK_PATH, 'w')
     local_mode_lock = local_mode_lock_fd.fileno()
-    with timeout(minutes=5):
+    with timeout_training(minutes=5):
         script_path = os.path.join(DATA_DIR, 'iris', 'iris-dnn-classifier.py')
 
         estimator = TensorFlow(entry_point=script_path,
@@ -167,7 +167,7 @@ def test_tf_distributed_local_mode(sagemaker_local_session):
 def test_tf_local_data(sagemaker_local_session):
     local_mode_lock_fd = open(LOCK_PATH, 'w')
     local_mode_lock = local_mode_lock_fd.fileno()
-    with timeout(minutes=5):
+    with timeout_training(minutes=5):
         script_path = os.path.join(DATA_DIR, 'iris', 'iris-dnn-classifier.py')
 
         estimator = TensorFlow(entry_point=script_path,
@@ -209,7 +209,7 @@ def test_tf_local_data(sagemaker_local_session):
 def test_tf_local_data_local_script():
     local_mode_lock_fd = open(LOCK_PATH, 'w')
     local_mode_lock = local_mode_lock_fd.fileno()
-    with timeout(minutes=5):
+    with timeout_training(minutes=5):
 
         script_path = os.path.join(DATA_DIR, 'iris', 'iris-dnn-classifier.py')
 

--- a/tests/integ/test_mxnet_train.py
+++ b/tests/integ/test_mxnet_train.py
@@ -22,12 +22,12 @@ from sagemaker.mxnet.estimator import MXNet
 from sagemaker.mxnet.model import MXNetModel
 from sagemaker.utils import sagemaker_timestamp
 from tests.integ import DATA_DIR
-from tests.integ.timeout import timeout, timeout_and_delete_endpoint_by_name
+from tests.integ.timeout import timeout_training, timeout_and_delete_endpoint_by_name
 
 
 @pytest.fixture(scope='module')
 def mxnet_training_job(sagemaker_session, mxnet_full_version):
-    with timeout(minutes=15):
+    with timeout_training():
         script_path = os.path.join(DATA_DIR, 'mxnet_mnist', 'mnist.py')
         data_path = os.path.join(DATA_DIR, 'mxnet_mnist')
 
@@ -72,7 +72,7 @@ def test_deploy_model(mxnet_training_job, sagemaker_session):
 def test_async_fit(sagemaker_session):
     endpoint_name = 'test-mxnet-attach-deploy-{}'.format(sagemaker_timestamp())
 
-    with timeout(minutes=5):
+    with timeout_training(minutes=5):
         script_path = os.path.join(DATA_DIR, 'mxnet_mnist', 'mnist.py')
         data_path = os.path.join(DATA_DIR, 'mxnet_mnist')
 
@@ -100,7 +100,7 @@ def test_async_fit(sagemaker_session):
 
 
 def test_failed_training_job(sagemaker_session, mxnet_full_version):
-    with timeout(minutes=15):
+    with timeout_training():
         script_path = os.path.join(DATA_DIR, 'mxnet_mnist', 'failure_script.py')
         data_path = os.path.join(DATA_DIR, 'mxnet_mnist')
 

--- a/tests/integ/test_ntm.py
+++ b/tests/integ/test_ntm.py
@@ -21,13 +21,13 @@ from sagemaker import NTM, NTMModel
 from sagemaker.amazon.common import read_records
 from sagemaker.utils import name_from_base
 from tests.integ import DATA_DIR
-from tests.integ.timeout import timeout, timeout_and_delete_endpoint_by_name
+from tests.integ.timeout import timeout_training, timeout_and_delete_endpoint_by_name
 from tests.integ.record_set import prepare_record_set_from_local_files
 
 
 @pytest.mark.continuous_testing
 def test_ntm(sagemaker_session):
-    with timeout(minutes=15):
+    with timeout_training():
         data_path = os.path.join(DATA_DIR, 'ntm')
         data_filename = 'nips-train_1.pbr'
 

--- a/tests/integ/test_pca.py
+++ b/tests/integ/test_pca.py
@@ -23,12 +23,12 @@ import pytest
 import sagemaker.amazon.pca
 from sagemaker.utils import name_from_base
 from tests.integ import DATA_DIR
-from tests.integ.timeout import timeout, timeout_and_delete_endpoint_by_name
+from tests.integ.timeout import timeout_training, timeout_and_delete_endpoint_by_name
 
 
 @pytest.mark.continuous_testing
 def test_pca(sagemaker_session):
-    with timeout(minutes=15):
+    with timeout_training():
         data_path = os.path.join(DATA_DIR, 'one_p_mnist', 'mnist.pkl.gz')
         pickle_args = {} if sys.version_info.major == 2 else {'encoding': 'latin1'}
 
@@ -63,7 +63,7 @@ def test_async_pca(sagemaker_session):
     training_job_name = ""
     endpoint_name = name_from_base('pca')
 
-    with timeout(minutes=5):
+    with timeout_training(minutes=5):
         data_path = os.path.join(DATA_DIR, 'one_p_mnist', 'mnist.pkl.gz')
         pickle_args = {} if sys.version_info.major == 2 else {'encoding': 'latin1'}
 

--- a/tests/integ/test_pytorch_train.py
+++ b/tests/integ/test_pytorch_train.py
@@ -20,7 +20,7 @@ from sagemaker.pytorch.estimator import PyTorch
 from sagemaker.pytorch.model import PyTorchModel
 from sagemaker.utils import sagemaker_timestamp
 from tests.integ import DATA_DIR
-from tests.integ.timeout import timeout, timeout_and_delete_endpoint_by_name
+from tests.integ.timeout import timeout_training, timeout_and_delete_endpoint_by_name
 
 MNIST_DIR = os.path.join(DATA_DIR, 'pytorch_mnist')
 MNIST_SCRIPT = os.path.join(MNIST_DIR, 'mnist.py')
@@ -30,7 +30,7 @@ PYTHON_VERSION = 'py' + str(sys.version_info.major)
 @pytest.fixture(scope='module', name='pytorch_training_job')
 def fixture_training_job(sagemaker_session, pytorch_full_version):
     instance_type = 'ml.c4.xlarge'
-    with timeout(minutes=15):
+    with timeout_training():
         pytorch = _get_pytorch_estimator(sagemaker_session, pytorch_full_version, instance_type)
 
         pytorch.fit({'training': _upload_training_data(pytorch)})
@@ -75,7 +75,7 @@ def test_async_fit_deploy(sagemaker_session, pytorch_full_version):
     # TODO: add tests against local mode when it's ready to be used
     instance_type = 'ml.p2.xlarge'
 
-    with timeout(minutes=10):
+    with timeout_training(minutes=10):
         pytorch = _get_pytorch_estimator(sagemaker_session, pytorch_full_version, instance_type)
 
         pytorch.fit({'training': _upload_training_data(pytorch)}, wait=False)
@@ -103,7 +103,7 @@ def test_async_fit_deploy(sagemaker_session, pytorch_full_version):
 def test_failed_training_job(sagemaker_session, pytorch_full_version):
     script_path = os.path.join(MNIST_DIR, 'failure_script.py')
 
-    with timeout(minutes=15):
+    with timeout_training():
         pytorch = _get_pytorch_estimator(sagemaker_session, pytorch_full_version, entry_point=script_path)
 
         with pytest.raises(ValueError) as e:

--- a/tests/integ/test_randomcutforest.py
+++ b/tests/integ/test_randomcutforest.py
@@ -17,12 +17,12 @@ import pytest
 
 from sagemaker import RandomCutForest, RandomCutForestModel
 from sagemaker.utils import name_from_base
-from tests.integ.timeout import timeout, timeout_and_delete_endpoint_by_name
+from tests.integ.timeout import timeout_training, timeout_and_delete_endpoint_by_name
 
 
 @pytest.mark.continuous_testing
 def test_randomcutforest(sagemaker_session):
-    with timeout(minutes=15):
+    with timeout_training():
         # Generate a thousand 14-dimensional datapoints.
         feature_num = 14
         train_input = np.random.rand(1000, feature_num)

--- a/tests/integ/test_tf.py
+++ b/tests/integ/test_tf.py
@@ -19,14 +19,14 @@ import pytest
 
 from sagemaker.tensorflow import TensorFlow
 from tests.integ import DATA_DIR
-from tests.integ.timeout import timeout_and_delete_endpoint_by_name, timeout
+from tests.integ.timeout import timeout_and_delete_endpoint_by_name, timeout_training
 
 DATA_PATH = os.path.join(DATA_DIR, 'iris', 'data')
 
 
 @pytest.mark.continuous_testing
 def test_tf(sagemaker_session, tf_full_version):
-    with timeout(minutes=15):
+    with timeout_training():
         script_path = os.path.join(DATA_DIR, 'iris', 'iris-dnn-classifier.py')
 
         estimator = TensorFlow(entry_point=script_path,
@@ -59,7 +59,7 @@ def test_tf(sagemaker_session, tf_full_version):
 
 
 def test_tf_async(sagemaker_session):
-    with timeout(minutes=5):
+    with timeout_training():
         script_path = os.path.join(DATA_DIR, 'iris', 'iris-dnn-classifier.py')
 
         estimator = TensorFlow(entry_point=script_path,
@@ -88,7 +88,7 @@ def test_tf_async(sagemaker_session):
 
 
 def test_failed_tf_training(sagemaker_session, tf_full_version):
-    with timeout(minutes=15):
+    with timeout_training():
         script_path = os.path.join(DATA_DIR, 'iris', 'failure_script.py')
         estimator = TensorFlow(entry_point=script_path,
                                role='SageMakerRole',

--- a/tests/integ/test_tf_cifar.py
+++ b/tests/integ/test_tf_cifar.py
@@ -20,7 +20,7 @@ import pytest
 
 from sagemaker.tensorflow import TensorFlow
 from tests.integ import DATA_DIR
-from tests.integ.timeout import timeout_and_delete_endpoint_by_name, timeout
+from tests.integ.timeout import timeout_and_delete_endpoint_by_name, timeout_training
 
 PICKLE_CONTENT_TYPE = 'application/python-pickle'
 
@@ -35,7 +35,7 @@ class PickleSerializer(object):
 
 @pytest.mark.continuous_testing
 def test_cifar(sagemaker_session, tf_full_version):
-    with timeout(minutes=45):
+    with timeout_training(minutes=45):
         script_path = os.path.join(DATA_DIR, 'cifar_10', 'source')
 
         dataset_path = os.path.join(DATA_DIR, 'cifar_10', 'data')

--- a/tests/integ/test_tuner.py
+++ b/tests/integ/test_tuner.py
@@ -36,14 +36,14 @@ from sagemaker.tensorflow import TensorFlow
 from sagemaker.tuner import IntegerParameter, ContinuousParameter, CategoricalParameter, HyperparameterTuner
 from tests.integ import DATA_DIR
 from tests.integ.record_set import prepare_record_set_from_local_files
-from tests.integ.timeout import timeout, timeout_and_delete_endpoint_by_name
+from tests.integ.timeout import timeout_tuning, timeout_and_delete_endpoint_by_name
 
 DATA_PATH = os.path.join(DATA_DIR, 'iris', 'data')
 
 
 @pytest.mark.continuous_testing
 def test_tuning_kmeans(sagemaker_session):
-    with timeout(minutes=20):
+    with timeout_tuning():
         data_path = os.path.join(DATA_DIR, 'one_p_mnist', 'mnist.pkl.gz')
         pickle_args = {} if sys.version_info.major == 2 else {'encoding': 'latin1'}
 
@@ -98,7 +98,7 @@ def test_tuning_kmeans(sagemaker_session):
 
 
 def test_tuning_lda(sagemaker_session):
-    with timeout(minutes=20):
+    with timeout_tuning():
         data_path = os.path.join(DATA_DIR, 'lda')
         data_filename = 'nips-train_1.pbr'
 
@@ -184,7 +184,7 @@ def test_stop_tuning_job(sagemaker_session):
 
 @pytest.mark.continuous_testing
 def test_tuning_mxnet(sagemaker_session):
-    with timeout(minutes=15):
+    with timeout_tuning():
         script_path = os.path.join(DATA_DIR, 'mxnet_mnist', 'tuning.py')
         data_path = os.path.join(DATA_DIR, 'mxnet_mnist')
 
@@ -221,7 +221,7 @@ def test_tuning_mxnet(sagemaker_session):
 
 @pytest.mark.continuous_testing
 def test_tuning_tf(sagemaker_session):
-    with timeout(minutes=15):
+    with timeout_tuning():
         script_path = os.path.join(DATA_DIR, 'iris', 'iris-dnn-classifier.py')
 
         estimator = TensorFlow(entry_point=script_path,
@@ -265,7 +265,7 @@ def test_tuning_tf(sagemaker_session):
 
 @pytest.mark.continuous_testing
 def test_tuning_chainer(sagemaker_session):
-    with timeout(minutes=15):
+    with timeout_tuning():
         script_path = os.path.join(DATA_DIR, 'chainer_mnist', 'mnist.py')
         data_path = os.path.join(DATA_DIR, 'chainer_mnist')
 
@@ -323,7 +323,7 @@ def test_attach_tuning_pytorch(sagemaker_session):
     estimator = PyTorch(entry_point=mnist_script, role='SageMakerRole', train_instance_count=1,
                         train_instance_type='ml.c4.xlarge', sagemaker_session=sagemaker_session)
 
-    with timeout(minutes=15):
+    with timeout_tuning():
         objective_metric_name = 'evaluation-accuracy'
         metric_definitions = [{'Name': 'evaluation-accuracy', 'Regex': 'Overall test accuracy: (\d+)'}]
         hyperparameter_ranges = {'batch-size': IntegerParameter(50, 100)}
@@ -369,7 +369,7 @@ def test_tuning_byo_estimator(sagemaker_session):
     """
     image_name = registry(sagemaker_session.boto_session.region_name) + '/factorization-machines:1'
 
-    with timeout(minutes=15):
+    with timeout_tuning():
         data_path = os.path.join(DATA_DIR, 'one_p_mnist', 'mnist.pkl.gz')
         pickle_args = {} if sys.version_info.major == 2 else {'encoding': 'latin1'}
 

--- a/tests/integ/timeout.py
+++ b/tests/integ/timeout.py
@@ -60,6 +60,18 @@ def timeout(seconds=0, minutes=0, hours=0):
 
 
 @contextmanager
+def timeout_training(seconds=0, minutes=20, hours=0):
+    with timeout(seconds=seconds, minutes=minutes, hours=hours) as t:
+        yield [t]
+
+
+@contextmanager
+def timeout_tuning(seconds=0, minutes=20, hours=0):
+    with timeout(seconds=seconds, minutes=minutes, hours=hours) as t:
+        yield [t]
+
+
+@contextmanager
 def timeout_and_delete_endpoint_by_name(endpoint_name, sagemaker_session, seconds=0, minutes=35, hours=0):
     with timeout(seconds=seconds, minutes=minutes, hours=hours) as t:
         no_errors = False


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Some training takes about 16-18 minutes and the tests failed several times a week. So I want to increase the timeout to 20 minutes. But for special tests like async or local mode, I did not change the timeout since it worked fine so far.

And to make it easier for future change, I create timeout wrappers for training and tuning.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated the [changelog](https://github.com/aws/sagemaker-python-sdk/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
