### PR TITLE
Increase max_runtime for tf cifar

### DIFF
--- a/tests/integ/test_tf_cifar.py
+++ b/tests/integ/test_tf_cifar.py
@@ -43,7 +43,7 @@ def test_cifar(sagemaker_session, tf_full_version):
         estimator = TensorFlow(entry_point='resnet_cifar_10.py', source_dir=script_path, role='SageMakerRole',
                                framework_version=tf_full_version, training_steps=500, evaluation_steps=5,
                                train_instance_count=2, train_instance_type='ml.p2.xlarge',
-                               sagemaker_session=sagemaker_session, train_max_run=20 * 60,
+                               sagemaker_session=sagemaker_session, train_max_run=45 * 60,
                                base_job_name='test-cifar')
 
         inputs = estimator.sagemaker_session.upload_data(path=dataset_path, key_prefix='data/cifar10')


### PR DESCRIPTION
Increasing training timeout to be consistent with overall timeout.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
