### PR TITLE
Create output/data directory in local mode.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 CHANGELOG
 =========
 
+1.9.2dev
+========
+
+* bug-fix: Local Mode: Create output/data directory expected by SageMaker Container.
+
 1.9.1
 =====
 

--- a/src/sagemaker/local/image.py
+++ b/src/sagemaker/local/image.py
@@ -85,6 +85,8 @@ class _SageMakerContainer(object):
         """
         self.container_root = self._create_tmp_folder()
         os.mkdir(os.path.join(self.container_root, 'output'))
+        # create output/data folder since sagemaker-containers 2.0 expects it
+        os.mkdir(os.path.join(self.container_root, 'output', 'data'))
         # A shared directory for all the containers. It is only mounted if the training script is
         # Local.
         shared_dir = os.path.join(self.container_root, 'shared')

--- a/tests/unit/test_image.py
+++ b/tests/unit/test_image.py
@@ -245,6 +245,10 @@ def test_train(_download_folder, _cleanup, popen, _stream_output, LocalSession,
                 assert config['services'][h]['image'] == image
                 assert config['services'][h]['command'] == 'train'
 
+        # assert that expected by sagemaker container output directories exist
+        assert os.path.exists(os.path.join(sagemaker_container.container_root, 'output'))
+        assert os.path.exists(os.path.join(sagemaker_container.container_root, 'output/data'))
+
 
 @patch('sagemaker.local.local_session.LocalSession')
 @patch('sagemaker.local.image._stream_output', side_effect=RuntimeError('this is expected'))


### PR DESCRIPTION
Create output/data directory expected by sagemaker containers when running in local mode.

https://github.com/awslabs/amazon-sagemaker-examples/issues/368

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [X] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [X] I have updated the [changelog](https://github.com/aws/sagemaker-python-sdk/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [X] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
