### PR TITLE
Correct docs to reflect that upload_data would create only default bucket.

### DIFF
--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -119,8 +119,8 @@ class Session(object):
         Args:
             path (str): Path (absolute or relative) of local file or directory to upload.
             bucket (str): Name of the S3 Bucket to upload to (default: None). If not specified, the
-                default bucket of the ``Session`` is used. If the bucket does not exist, the ``Session``
-                creates the bucket.
+                default bucket of the ``Session`` is used (if default bucket does not exist, the ``Session``
+                creates it).
             key_prefix (str): Optional S3 object key name prefix (default: 'data'). S3 uses the prefix to
                 create a directory structure for the bucket content that it display in the S3 console.
 


### PR DESCRIPTION
Correct docs to reflect that upload_data would create only default bucket.

Issue #371 

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated the [changelog](https://github.com/aws/sagemaker-python-sdk/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [x] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
