### PR TITLE
Document upcoming MXNet training script format

### DIFF
--- a/src/sagemaker/mxnet/README.rst
+++ b/src/sagemaker/mxnet/README.rst
@@ -603,6 +603,7 @@ We recommend using an `argument parser <https://docs.python.org/3.5/howto/argpar
 Using the ``argparse`` library as an example, this part of the code would look something like this:
 
 .. code:: python
+
     parser = argparse.ArgumentParser()
 
     # hyperparameters sent by the client are passed as command-line arguments to the script.
@@ -624,6 +625,7 @@ Note now that saving the model will not be done by default; this must be done by
 If you were previously relying on the default save method, here is one you can copy into your code:
 
 .. code:: python
+
     def save(model_dir, model):
         model.symbol.save(os.path.join(model_dir, 'model-symbol.json'))
         model.save_params(os.path.join(model_dir, 'model-0000.params'))

--- a/src/sagemaker/mxnet/README.rst
+++ b/src/sagemaker/mxnet/README.rst
@@ -30,13 +30,11 @@ In the following sections, we'll discuss how to prepare a training script for ex
 Preparing the MXNet training script
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-+-------------------------------------------------------------------------------------------------------------------------------+
-| **WARNING**                                                                                                                   |
-+-------------------------------------------------------------------------------------------------------------------------------+
-| This required structure for training scripts will be deprecated with the next major release of MXNet images.                  |
-| The ``train`` function will no longer be required; instead the training script must be able to be run as a standalone script. |
-| For more information, see `Updating your MXNet training script <#updating-your-mxnet-training-script>__`                      |
-+-------------------------------------------------------------------------------------------------------------------------------+
+===================================================================================================================================================================================================================================================================================================================================================
+WARNING
+===================================================================================================================================================================================================================================================================================================================================================
+This required structure for training scripts will be deprecated with the next major release of MXNet images. The ``train`` function will no longer be required; instead the training script must be able to be run as a standalone script. For more information, see `Updating your MXNet training script <#updating-your-mxnet-training-script>__`
+===================================================================================================================================================================================================================================================================================================================================================
 
 Your MXNet training script must be a Python 2.7 or 3.5 compatible source file. The MXNet training script must contain a function ``train``, which SageMaker invokes to run training. You can include other functions as well, but it must contain a ``train`` function.
 

--- a/src/sagemaker/mxnet/README.rst
+++ b/src/sagemaker/mxnet/README.rst
@@ -30,11 +30,13 @@ In the following sections, we'll discuss how to prepare a training script for ex
 Preparing the MXNet training script
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-===================================================================================================================================================================================================================================================================================================================================================
-WARNING
-===================================================================================================================================================================================================================================================================================================================================================
-This required structure for training scripts will be deprecated with the next major release of MXNet images. The ``train`` function will no longer be required; instead the training script must be able to be run as a standalone script. For more information, see `Updating your MXNet training script <#updating-your-mxnet-training-script>__`
-===================================================================================================================================================================================================================================================================================================================================================
++-------------------------------------------------------------------------------------------------------------------------------+
+| **WARNING**                                                                                                                   |
++-------------------------------------------------------------------------------------------------------------------------------+
+| This required structure for training scripts will be deprecated with the next major release of MXNet images.                  |
+| The ``train`` function will no longer be required; instead the training script must be able to be run as a standalone script. |
+| For more information, see `Updating your MXNet training script <#updating-your-mxnet-training-script>__`                      |
++-------------------------------------------------------------------------------------------------------------------------------+
 
 Your MXNet training script must be a Python 2.7 or 3.5 compatible source file. The MXNet training script must contain a function ``train``, which SageMaker invokes to run training. You can include other functions as well, but it must contain a ``train`` function.
 

--- a/src/sagemaker/mxnet/README.rst
+++ b/src/sagemaker/mxnet/README.rst
@@ -31,7 +31,8 @@ Preparing the MXNet training script
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 +-------------------------------------------------------------------------------------------------------------------------------+
-| **WARNING**                                                                                                                   |
+| .. class:: center                                                                                                             |
+|     **WARNING**                                                                                                               |
 +-------------------------------------------------------------------------------------------------------------------------------+
 | This required structure for training scripts will be deprecated with the next major release of MXNet images.                  |
 | The ``train`` function will no longer be required; instead the training script must be able to be run as a standalone script. |

--- a/src/sagemaker/mxnet/README.rst
+++ b/src/sagemaker/mxnet/README.rst
@@ -31,9 +31,8 @@ Preparing the MXNet training script
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 +-------------------------------------------------------------------------------------------------------------------------------+
-| .. class:: center                                                                                                             |
-|     **WARNING**                                                                                                               |
-+-------------------------------------------------------------------------------------------------------------------------------+
+| WARNING                                                                                                                       |
++===============================================================================================================================+
 | This required structure for training scripts will be deprecated with the next major release of MXNet images.                  |
 | The ``train`` function will no longer be required; instead the training script must be able to be run as a standalone script. |
 | For more information, see `Updating your MXNet training script <#updating-your-mxnet-training-script>`__.                     |

--- a/src/sagemaker/mxnet/README.rst
+++ b/src/sagemaker/mxnet/README.rst
@@ -30,11 +30,11 @@ In the following sections, we'll discuss how to prepare a training script for ex
 Preparing the MXNet training script
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. warning::
+.. attention::
 
     This required structure for training scripts will be deprecated with the next major release of MXNet images.
     The ``train`` function will no longer be required; instead the training script must be able to be run as a standalone script.
-    For more information, see later section.
+    For more information, see `Updating your MXNet training script <#updating-your-mxnet-training-script>__`
 
 Your MXNet training script must be a Python 2.7 or 3.5 compatible source file. The MXNet training script must contain a function ``train``, which SageMaker invokes to run training. You can include other functions as well, but it must contain a ``train`` function.
 

--- a/src/sagemaker/mxnet/README.rst
+++ b/src/sagemaker/mxnet/README.rst
@@ -33,7 +33,6 @@ Preparing the MXNet training script
 +-------------------------------------------------------------------------------------------------------------------------------+
 | WARNING                                                                                                                       |
 +===============================================================================================================================+
-+-------------------------------------------------------------------------------------------------------------------------------+
 | This required structure for training scripts will be deprecated with the next major release of MXNet images.                  |
 | The ``train`` function will no longer be required; instead the training script must be able to be run as a standalone script. |
 | For more information, see `Updating your MXNet training script <#updating-your-mxnet-training-script>`__.                     |

--- a/src/sagemaker/mxnet/README.rst
+++ b/src/sagemaker/mxnet/README.rst
@@ -31,7 +31,7 @@ Preparing the MXNet training script
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 +-------------------------------------------------------------------------------------------------------------------------------+
-| Warning                                                                                                                       |
+| **WARNING**                                                                                                                   |
 +-------------------------------------------------------------------------------------------------------------------------------+
 | This required structure for training scripts will be deprecated with the next major release of MXNet images.                  |
 | The ``train`` function will no longer be required; instead the training script must be able to be run as a standalone script. |

--- a/src/sagemaker/mxnet/README.rst
+++ b/src/sagemaker/mxnet/README.rst
@@ -589,18 +589,19 @@ The ``train`` function will no longer be required; instead the training script m
 In this way, the training script will become similar to a training script you might run outside of SageMaker.
 
 There are a few steps needed to make a training script with the old format compatible with the new format.
-You don't need to do this yet, but it's documented here for future reference.
+You don't need to do this yet, but it's documented here for future reference, as this change is coming soon.
 
 First, add a `main guard <https://docs.python.org/3/library/__main__.html>`__ (``if __name__ == '__main__':``).
 The code executed from your main guard needs to:
 
-1. Set hyperparameters and other variables
+1. Set hyperparameters and directory locations
 2. Initiate training
 3. Save the model
 
-Hyperparameters will now be passed as command-line arguments to your training script.
-We recommend using an `argument parser <https://docs.python.org/3.5/howto/argparse.html>`__ to aid with this.
-Using the ``argparse`` library as an example, this part of the code would look something like this:
+Hyperparameters will be passed as command-line arguments to your training script.
+In addition, the locations for finding input data and saving the model and output data will need to be defined.
+We recommend using `an argument parser <https://docs.python.org/3.5/howto/argparse.html>`__ for this part.
+Using the ``argparse`` library as an example, the code would look something like this:
 
 .. code:: python
 
@@ -614,8 +615,7 @@ Using the ``argparse`` library as an example, this part of the code would look s
         parser.add_argument('--batch-size', type=int, default=100)
         parser.add_argument('--learning-rate', type=float, default=0.1)
 
-        # data, model, and output directories
-        parser.add_argument('--output-data-dir', type=str, default='opt/ml/output/data')
+        # input data and model directories
         parser.add_argument('--model-dir', type=str, default='opt/ml/model')
         parser.add_argument('--train', type=str, default='opt/ml/input/data/train')
         parser.add_argument('--test', type=str, default='opt/ml/input/data/test')
@@ -623,8 +623,17 @@ Using the ``argparse`` library as an example, this part of the code would look s
         args, _ = parser.parse_known_args()
 
 The code in the main guard should also take care of training and saving the model.
-(This can be as simple as just calling the methods used with the previous training script format.)
-Note now that saving the model will not be done by default; this must be done by the training script.
+This can be as simple as just calling the methods used with the previous training script format:
+
+.. code:: python
+
+    if __name__ == '__main__':
+        # arg parsing (shown above) goes here
+
+        model = train(args.batch_size, args.epochs, args.learning_rate, args.train, args.test)
+        save(args.model_dir, model)
+
+Note that saving the model will no longer be done by default; this must be done by the training script.
 If you were previously relying on the default save method, here is one you can copy into your code:
 
 .. code:: python

--- a/src/sagemaker/mxnet/README.rst
+++ b/src/sagemaker/mxnet/README.rst
@@ -35,7 +35,7 @@ Preparing the MXNet training script
 +===============================================================================================================================+
 | This required structure for training scripts will be deprecated with the next major release of MXNet images.                  |
 | The ``train`` function will no longer be required; instead the training script must be able to be run as a standalone script. |
-| For more information, see `Updating your MXNet training script <#updating-your-mxnet-training-script>`__.                     |
+| For more information, see `"Updating your MXNet training script" <#updating-your-mxnet-training-script>`__.                   |
 +-------------------------------------------------------------------------------------------------------------------------------+
 
 Your MXNet training script must be a Python 2.7 or 3.5 compatible source file. The MXNet training script must contain a function ``train``, which SageMaker invokes to run training. You can include other functions as well, but it must contain a ``train`` function.
@@ -604,20 +604,23 @@ Using the ``argparse`` library as an example, this part of the code would look s
 
 .. code:: python
 
-    parser = argparse.ArgumentParser()
+    import argparse
 
-    # hyperparameters sent by the client are passed as command-line arguments to the script.
-    parser.add_argument('--epochs', type=int, default=10)
-    parser.add_argument('--batch-size', type=int, default=100)
-    parser.add_argument('--learning-rate', type=float, default=0.1)
+    if __name__ == '__main__':
+        parser = argparse.ArgumentParser()
 
-    # data, model, and output directories
-    parser.add_argument('--output-data-dir', type=str, default='opt/ml/output/data')
-    parser.add_argument('--model-dir', type=str, default='opt/ml/model')
-    parser.add_argument('--train', type=str, default='opt/ml/input/data/train')
-    parser.add_argument('--test', type=str, default='opt/ml/input/data/test')
+        # hyperparameters sent by the client are passed as command-line arguments to the script.
+        parser.add_argument('--epochs', type=int, default=10)
+        parser.add_argument('--batch-size', type=int, default=100)
+        parser.add_argument('--learning-rate', type=float, default=0.1)
 
-    args, _ = parser.parse_known_args()
+        # data, model, and output directories
+        parser.add_argument('--output-data-dir', type=str, default='opt/ml/output/data')
+        parser.add_argument('--model-dir', type=str, default='opt/ml/model')
+        parser.add_argument('--train', type=str, default='opt/ml/input/data/train')
+        parser.add_argument('--test', type=str, default='opt/ml/input/data/test')
+
+        args, _ = parser.parse_known_args()
 
 The code in the main guard should also take care of training and saving the model.
 (This can be as simple as just calling the methods used with the previous training script format.)
@@ -625,6 +628,9 @@ Note now that saving the model will not be done by default; this must be done by
 If you were previously relying on the default save method, here is one you can copy into your code:
 
 .. code:: python
+
+    import json
+    import os
 
     def save(model_dir, model):
         model.symbol.save(os.path.join(model_dir, 'model-symbol.json'))
@@ -634,6 +640,9 @@ If you were previously relying on the default save method, here is one you can c
                      for data_desc in model.data_shapes]
         with open(os.path.join(model_dir, 'model-shapes.json'), 'w') as f:
             json.dump(signature, f)
+
+These changes will make training with MXNet similar to training with Chainer or PyTorch on SageMaker.
+For more information about those experiences, see `"Preparing the Chainer training script" <https://github.com/aws/sagemaker-python-sdk/tree/master/src/sagemaker/chainer#preparing-the-chainer-training-script>`__ and `"Preparing the PyTorch Training Script" <https://github.com/aws/sagemaker-python-sdk/tree/master/src/sagemaker/pytorch#preparing-the-pytorch-training-script>`__.
 
 
 SageMaker MXNet Containers

--- a/src/sagemaker/mxnet/README.rst
+++ b/src/sagemaker/mxnet/README.rst
@@ -35,7 +35,7 @@ Preparing the MXNet training script
 +-------------------------------------------------------------------------------------------------------------------------------+
 | This required structure for training scripts will be deprecated with the next major release of MXNet images.                  |
 | The ``train`` function will no longer be required; instead the training script must be able to be run as a standalone script. |
-| For more information, see `Updating your MXNet training script <#updating-your-mxnet-training-script>__`                      |
+| For more information, see `Updating your MXNet training script <#updating-your-mxnet-training-script>`__                      |
 +-------------------------------------------------------------------------------------------------------------------------------+
 
 Your MXNet training script must be a Python 2.7 or 3.5 compatible source file. The MXNet training script must contain a function ``train``, which SageMaker invokes to run training. You can include other functions as well, but it must contain a ``train`` function.

--- a/src/sagemaker/mxnet/README.rst
+++ b/src/sagemaker/mxnet/README.rst
@@ -599,7 +599,7 @@ The code executed from your main guard needs to:
 3. Save the model
 
 Hyperparameters will be passed as command-line arguments to your training script.
-In addition, the locations for finding input data and saving the model and output data will be provided as environment variables rather than as arguments to a function.
+In addition, the container will define the locations of input data and where to save the model artifacts and output data as environment variables rather than passing that information as arguments to the ``train`` function.
 You can find the full list of available environment variables in the `SageMaker Containers README <https://github.com/aws/sagemaker-containers#list-of-provided-environment-variables-by-sagemaker-containers>`__.
 
 We recommend using `an argument parser <https://docs.python.org/3.5/howto/argparse.html>`__ for this part.
@@ -626,7 +626,7 @@ Using the ``argparse`` library as an example, the code would look something like
         args, _ = parser.parse_known_args()
 
 The code in the main guard should also take care of training and saving the model.
-This can be as simple as just calling the methods used with the previous training script format:
+This can be as simple as just calling the ``train`` and ``save`` methods used in the previous training script format:
 
 .. code:: python
 

--- a/src/sagemaker/mxnet/README.rst
+++ b/src/sagemaker/mxnet/README.rst
@@ -33,6 +33,7 @@ Preparing the MXNet training script
 +-------------------------------------------------------------------------------------------------------------------------------+
 | WARNING                                                                                                                       |
 +===============================================================================================================================+
++-------------------------------------------------------------------------------------------------------------------------------+
 | This required structure for training scripts will be deprecated with the next major release of MXNet images.                  |
 | The ``train`` function will no longer be required; instead the training script must be able to be run as a standalone script. |
 | For more information, see `Updating your MXNet training script <#updating-your-mxnet-training-script>`__.                     |

--- a/src/sagemaker/mxnet/README.rst
+++ b/src/sagemaker/mxnet/README.rst
@@ -30,11 +30,13 @@ In the following sections, we'll discuss how to prepare a training script for ex
 Preparing the MXNet training script
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. attention::
-
-    This required structure for training scripts will be deprecated with the next major release of MXNet images.
-    The ``train`` function will no longer be required; instead the training script must be able to be run as a standalone script.
-    For more information, see `Updating your MXNet training script <#updating-your-mxnet-training-script>__`
++-------------------------------------------------------------------------------------------------------------------------------+
+| Warning                                                                                                                       |
++-------------------------------------------------------------------------------------------------------------------------------+
+| This required structure for training scripts will be deprecated with the next major release of MXNet images.                  |
+| The ``train`` function will no longer be required; instead the training script must be able to be run as a standalone script. |
+| For more information, see `Updating your MXNet training script <#updating-your-mxnet-training-script>__`                      |
++-------------------------------------------------------------------------------------------------------------------------------+
 
 Your MXNet training script must be a Python 2.7 or 3.5 compatible source file. The MXNet training script must contain a function ``train``, which SageMaker invokes to run training. You can include other functions as well, but it must contain a ``train`` function.
 

--- a/src/sagemaker/mxnet/README.rst
+++ b/src/sagemaker/mxnet/README.rst
@@ -1,4 +1,3 @@
-
 =====================================
 MXNet SageMaker Estimators and Models
 =====================================
@@ -30,6 +29,11 @@ In the following sections, we'll discuss how to prepare a training script for ex
 
 Preparing the MXNet training script
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. warning::
+    This required structure for training scripts will be deprecated with the next major release of MXNet images.
+    The ``train`` function will no longer be required; instead the training script must be able to be run as a standalone script.
+    For more information, see `Updating your MXNet training script <#updating-your-mxnet-training-script>__`
 
 Your MXNet training script must be a Python 2.7 or 3.5 compatible source file. The MXNet training script must contain a function ``train``, which SageMaker invokes to run training. You can include other functions as well, but it must contain a ``train`` function.
 
@@ -572,6 +576,14 @@ Amazon provides several example Jupyter notebooks that demonstrate end-to-end tr
 https://github.com/awslabs/amazon-sagemaker-examples/tree/master/sagemaker-python-sdk
 
 These are also available in SageMaker Notebook Instance hosted Jupyter notebooks under the "sample notebooks" folder.
+
+
+Updating your MXNet training script
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The required structure for training scripts will be deprecated with the next major release of MXNet images.
+The ``train`` function will no longer be required; instead the training script must be able to be run as a standalone script.
+In this way, the training script will become similar to a training script you might run outside of SageMaker.
 
 
 SageMaker MXNet Containers

--- a/src/sagemaker/mxnet/README.rst
+++ b/src/sagemaker/mxnet/README.rst
@@ -599,13 +599,16 @@ The code executed from your main guard needs to:
 3. Save the model
 
 Hyperparameters will be passed as command-line arguments to your training script.
-In addition, the locations for finding input data and saving the model and output data will need to be defined.
+In addition, the locations for finding input data and saving the model and output data will be provided as environment variables rather than as arguments to a function.
+You can find the full list of available environment variables in the `SageMaker Containers README <https://github.com/aws/sagemaker-containers#list-of-provided-environment-variables-by-sagemaker-containers>`__.
+
 We recommend using `an argument parser <https://docs.python.org/3.5/howto/argparse.html>`__ for this part.
 Using the ``argparse`` library as an example, the code would look something like this:
 
 .. code:: python
 
     import argparse
+    import os
 
     if __name__ == '__main__':
         parser = argparse.ArgumentParser()
@@ -616,9 +619,9 @@ Using the ``argparse`` library as an example, the code would look something like
         parser.add_argument('--learning-rate', type=float, default=0.1)
 
         # input data and model directories
-        parser.add_argument('--model-dir', type=str, default='opt/ml/model')
-        parser.add_argument('--train', type=str, default='opt/ml/input/data/train')
-        parser.add_argument('--test', type=str, default='opt/ml/input/data/test')
+        parser.add_argument('--model-dir', type=str, default=os.environ['SM_MODEL_DIR'])
+        parser.add_argument('--train', type=str, default=os.environ['SM_CHANNEL_TRAIN'])
+        parser.add_argument('--test', type=str, default=os.environ['SM_CHANNEL_TEST'])
 
         args, _ = parser.parse_known_args()
 

--- a/src/sagemaker/mxnet/README.rst
+++ b/src/sagemaker/mxnet/README.rst
@@ -31,9 +31,10 @@ Preparing the MXNet training script
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. warning::
+
     This required structure for training scripts will be deprecated with the next major release of MXNet images.
     The ``train`` function will no longer be required; instead the training script must be able to be run as a standalone script.
-    For more information, see `Updating your MXNet training script <#updating-your-mxnet-training-script>__`
+    For more information, see later section.
 
 Your MXNet training script must be a Python 2.7 or 3.5 compatible source file. The MXNet training script must contain a function ``train``, which SageMaker invokes to run training. You can include other functions as well, but it must contain a ``train`` function.
 

--- a/src/sagemaker/mxnet/README.rst
+++ b/src/sagemaker/mxnet/README.rst
@@ -35,7 +35,7 @@ Preparing the MXNet training script
 +-------------------------------------------------------------------------------------------------------------------------------+
 | This required structure for training scripts will be deprecated with the next major release of MXNet images.                  |
 | The ``train`` function will no longer be required; instead the training script must be able to be run as a standalone script. |
-| For more information, see `Updating your MXNet training script <#updating-your-mxnet-training-script>`__                      |
+| For more information, see `Updating your MXNet training script <#updating-your-mxnet-training-script>`__.                     |
 +-------------------------------------------------------------------------------------------------------------------------------+
 
 Your MXNet training script must be a Python 2.7 or 3.5 compatible source file. The MXNet training script must contain a function ``train``, which SageMaker invokes to run training. You can include other functions as well, but it must contain a ``train`` function.
@@ -587,6 +587,18 @@ Updating your MXNet training script
 The required structure for training scripts will be deprecated with the next major release of MXNet images.
 The ``train`` function will no longer be required; instead the training script must be able to be run as a standalone script.
 In this way, the training script will become similar to a training script you might run outside of SageMaker.
+
+There are a few steps needed to make a training script with the old format compatible with the new format.
+You don't need to do this yet, but it's documented here for future reference.
+
+First, add a `main guard <https://docs.python.org/3/library/__main__.html>`__ (``if __name__ == '__main__':``).
+The code executed from your main guard needs to:
+
+1. Set hyperparameters and other variables
+2. Initiate training
+3. Save the model
+
+Hyperparameters will now be passed as command-line arguments to your training script.
 
 
 SageMaker MXNet Containers


### PR DESCRIPTION
*Description of changes:*
This change adds a warning to the README about the upcoming MXNet training script format, in addition to basic instructions of what kind of changes will be needed once the format is changed.

I didn't use a ReST admonition for the warning because [GitHub won't render them](https://github.com/github/markup/issues/68).

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated the [changelog](https://github.com/aws/sagemaker-python-sdk/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [x] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
