### PR TITLE
Allow TensorFlow json serializer to accept dicts with ndarray values

### DIFF
--- a/tests/unit/test_predictor.py
+++ b/tests/unit/test_predictor.py
@@ -40,11 +40,8 @@ def test_json_serializer_numpy_valid_2dimensional():
     assert result == '[[1, 2, 3], [3, 4, 5]]'
 
 
-def test_json_serializer_numpy_invalid_empty():
-    with pytest.raises(ValueError) as invalid_input:
-        json_serializer(np.array([]))
-
-    assert "empty array" in str(invalid_input)
+def test_json_serializer_empty():
+    assert json_serializer(np.array([])) == '[]'
 
 
 def test_json_serializer_python_array():
@@ -62,15 +59,11 @@ def test_json_serializer_python_dictionary():
 
 
 def test_json_serializer_python_invalid_empty():
-    with pytest.raises(ValueError) as error:
-        json_serializer([])
-    assert "empty array" in str(error)
+    assert json_serializer([]) == '[]'
 
 
 def test_json_serializer_python_dictionary_invalid_empty():
-    with pytest.raises(ValueError) as error:
-        json_serializer({})
-    assert "empty dictionary" in str(error)
+    assert json_serializer({}) == '{}'
 
 
 def test_json_serializer_csv_buffer():

--- a/tests/unit/test_tf_predictor.py
+++ b/tests/unit/test_tf_predictor.py
@@ -336,3 +336,24 @@ def mock_response(expected_response, sagemaker_session, content_type):
     sagemaker_session.sagemaker_runtime_client.invoke_endpoint.return_value = {
         'ContentType': content_type,
         'Body': io.BytesIO(expected_response)}
+
+
+def test_json_serialize_dict():
+    data = {'tensor1': [1, 2, 3], 'tensor2': [4, 5, 6]}
+    serialized = tf_json_serializer(data)
+    # deserialize again for assertion, since dict order is not guaranteed
+    deserialized = json.loads(serialized)
+    assert deserialized == data
+
+
+def test_json_serialize_dict_with_numpy():
+    data = {'tensor1': np.asarray([1, 2, 3]), 'tensor2': np.asarray([4, 5, 6])}
+    serialized = tf_json_serializer(data)
+    # deserialize again for assertion, since dict order is not guaranteed
+    deserialized = json.loads(serialized)
+    assert deserialized == {'tensor1': [1, 2, 3], 'tensor2': [4, 5, 6]}
+
+
+def test_json_serialize_numpy():
+    data = np.asarray([[1, 2, 3], [4, 5, 6]])
+    assert tf_json_serializer(data) == '[[1, 2, 3], [4, 5, 6]]'


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/sagemaker-python-sdk/issues/394

*Description of changes:*
Allows the tf json serializer (which is the default for the tf predictor) to accept dicts with ndarray values. This only makes sense, since currently we accept lists, dicts of lists, and ndarrays, but not dicts of ndarrays.

Also did a small refactor to remove redundancy from the existing implementation of the Json serializer class.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated the [changelog](https://github.com/aws/sagemaker-python-sdk/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
