### PR TITLE
Local mode pass training env var

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 CHANGELOG
 =========
 
+1.11.1dev
+=========
+
+* enhancement: Local Mode: add training environment variables for AWS region and job name
+
 1.11.0
 ======
 

--- a/src/sagemaker/local/image.py
+++ b/src/sagemaker/local/image.py
@@ -107,7 +107,7 @@ class _SageMakerContainer(object):
             shutil.copytree(data_dir, os.path.join(self.container_root, host, 'input', 'data'))
 
         training_env_vars = {
-            REGION_ENV_NAME: self.sagemaker_session.boto_session.region_name,
+            REGION_ENV_NAME: self.sagemaker_session.boto_region_name,
             TRAINING_JOB_NAME_ENV_NAME: json.loads(hyperparameters.get(sagemaker.model.JOB_NAME_PARAM_NAME)),
         }
         compose_data = self._generate_compose_file('train', additional_volumes=volumes,

--- a/tests/unit/test_image.py
+++ b/tests/unit/test_image.py
@@ -49,12 +49,14 @@ INPUT_DATA_CONFIG = [
     }
 ]
 HYPERPARAMETERS = {'a': 1,
-                   'b': 'bee',
-                   'sagemaker_submit_directory': json.dumps('s3://my_bucket/code')}
+                   'b': json.dumps('bee'),
+                   'sagemaker_submit_directory': json.dumps('s3://my_bucket/code'),
+                   'sagemaker_job_name': json.dumps('my-job')}
 
 LOCAL_CODE_HYPERPARAMETERS = {'a': 1,
                               'b': 2,
-                              'sagemaker_submit_directory': json.dumps('file:///tmp/code')}
+                              'sagemaker_submit_directory': json.dumps('file:///tmp/code'),
+                              'sagemaker_job_name': json.dumps('my-job')}
 
 
 @pytest.fixture()
@@ -244,6 +246,8 @@ def test_train(_download_folder, _cleanup, popen, _stream_output, LocalSession,
             for h in sagemaker_container.hosts:
                 assert config['services'][h]['image'] == image
                 assert config['services'][h]['command'] == 'train'
+                assert 'AWS_REGION={}'.format(REGION) in config['services'][h]['environment']
+                assert 'TRAINING_JOB_NAME=my-job' in config['services'][h]['environment']
 
         # assert that expected by sagemaker container output directories exist
         assert os.path.exists(os.path.join(sagemaker_container.container_root, 'output'))


### PR DESCRIPTION
*Description of changes:*
SageMaker Training sets various environment variables for every training job, while Local Mode replicates none of these. This change adds the environment variables for the AWS region and training job name.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have updated the [changelog](https://github.com/aws/sagemaker-python-sdk/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
