### PR TITLE
Enable setting VPC config when creating/deploying models

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,8 @@
 CHANGELOG
 =========
 
+* enhancement: Enable setting VPC config when creating/deploying models
+
 1.10.1
 ======
 

--- a/src/sagemaker/amazon/factorization_machines.py
+++ b/src/sagemaker/amazon/factorization_machines.py
@@ -19,6 +19,7 @@ from sagemaker.amazon.validation import gt, isin, ge
 from sagemaker.predictor import RealTimePredictor
 from sagemaker.model import Model
 from sagemaker.session import Session
+from sagemaker.utils import vpc_config_dict
 
 
 class FactorizationMachines(AmazonAlgorithmEstimatorBase):
@@ -163,11 +164,19 @@ class FactorizationMachines(AmazonAlgorithmEstimatorBase):
         self.factors_init_sigma = factors_init_sigma
         self.factors_init_value = factors_init_value
 
-    def create_model(self):
+    def create_model(self, vpc_config=None):
         """Return a :class:`~sagemaker.amazon.FactorizationMachinesModel` referencing the latest
-        s3 model data produced by this Estimator."""
+        s3 model data produced by this Estimator.
 
-        return FactorizationMachinesModel(self.model_data, self.role, sagemaker_session=self.sagemaker_session)
+        Args:
+            vpc_config (dict[str, list[str]]): Overrides VpcConfig set on the model.
+                If None, defaults to VpcConfig used for training (default: None)
+                * 'Subnets' (list[str]): List of subnet ids.
+                * 'SecurityGroupIds' (list[str]): List of security group ids.
+        """
+        vpc_config = vpc_config or vpc_config_dict(self.subnets, self.security_group_ids)
+        return FactorizationMachinesModel(self.model_data, self.role, sagemaker_session=self.sagemaker_session,
+                                          vpc_config=vpc_config)
 
 
 class FactorizationMachinesPredictor(RealTimePredictor):
@@ -195,7 +204,7 @@ class FactorizationMachinesModel(Model):
     """Reference S3 model data created by FactorizationMachines estimator. Calling :meth:`~sagemaker.model.Model.deploy`
     creates an Endpoint and returns :class:`FactorizationMachinesPredictor`."""
 
-    def __init__(self, model_data, role, sagemaker_session=None):
+    def __init__(self, model_data, role, sagemaker_session=None, **kwargs):
         sagemaker_session = sagemaker_session or Session()
         repo = '{}:{}'.format(FactorizationMachines.repo_name, FactorizationMachines.repo_version)
         image = '{}/{}'.format(registry(sagemaker_session.boto_session.region_name), repo)
@@ -203,4 +212,5 @@ class FactorizationMachinesModel(Model):
                                                          image,
                                                          role,
                                                          predictor_cls=FactorizationMachinesPredictor,
-                                                         sagemaker_session=sagemaker_session)
+                                                         sagemaker_session=sagemaker_session,
+                                                         **kwargs)

--- a/src/sagemaker/amazon/lda.py
+++ b/src/sagemaker/amazon/lda.py
@@ -19,6 +19,7 @@ from sagemaker.amazon.validation import gt
 from sagemaker.predictor import RealTimePredictor
 from sagemaker.model import Model
 from sagemaker.session import Session
+from sagemaker.utils import vpc_config_dict
 
 
 class LDA(AmazonAlgorithmEstimatorBase):
@@ -89,11 +90,19 @@ class LDA(AmazonAlgorithmEstimatorBase):
         self.max_iterations = max_iterations
         self.tol = tol
 
-    def create_model(self):
+    def create_model(self, vpc_config=None):
         """Return a :class:`~sagemaker.amazon.LDAModel` referencing the latest
-        s3 model data produced by this Estimator."""
+        s3 model data produced by this Estimator.
 
-        return LDAModel(self.model_data, self.role, sagemaker_session=self.sagemaker_session)
+        Args:
+            vpc_config (dict[str, list[str]]): Overrides VpcConfig set on the model.
+                If None, defaults to VpcConfig used for training (default: None)
+                * 'Subnets' (list[str]): List of subnet ids.
+                * 'SecurityGroupIds' (list[str]): List of security group ids.
+        """
+        vpc_config = vpc_config or vpc_config_dict(self.subnets, self.security_group_ids)
+        return LDAModel(self.model_data, self.role, sagemaker_session=self.sagemaker_session,
+                        vpc_config=vpc_config)
 
     def _prepare_for_training(self, records, mini_batch_size, job_name=None):
         # mini_batch_size is required, prevent explicit calls with None
@@ -124,9 +133,9 @@ class LDAModel(Model):
     """Reference LDA s3 model data. Calling :meth:`~sagemaker.model.Model.deploy` creates an Endpoint and return
     a Predictor that transforms vectors to a lower-dimensional representation."""
 
-    def __init__(self, model_data, role, sagemaker_session=None):
+    def __init__(self, model_data, role, sagemaker_session=None, **kwargs):
         sagemaker_session = sagemaker_session or Session()
         repo = '{}:{}'.format(LDA.repo_name, LDA.repo_version)
         image = '{}/{}'.format(registry(sagemaker_session.boto_session.region_name, LDA.repo_name), repo)
         super(LDAModel, self).__init__(model_data, image, role, predictor_cls=LDAPredictor,
-                                       sagemaker_session=sagemaker_session)
+                                       sagemaker_session=sagemaker_session, **kwargs)

--- a/src/sagemaker/amazon/ntm.py
+++ b/src/sagemaker/amazon/ntm.py
@@ -19,6 +19,7 @@ from sagemaker.amazon.validation import ge, le, isin
 from sagemaker.predictor import RealTimePredictor
 from sagemaker.model import Model
 from sagemaker.session import Session
+from sagemaker.utils import vpc_config_dict
 
 
 class NTM(AmazonAlgorithmEstimatorBase):
@@ -107,11 +108,18 @@ class NTM(AmazonAlgorithmEstimatorBase):
         self.weight_decay = weight_decay
         self.learning_rate = learning_rate
 
-    def create_model(self):
+    def create_model(self, vpc_config=None):
         """Return a :class:`~sagemaker.amazon.NTMModel` referencing the latest
-        s3 model data produced by this Estimator."""
+        s3 model data produced by this Estimator.
 
-        return NTMModel(self.model_data, self.role, sagemaker_session=self.sagemaker_session)
+        vpc_config (dict[str, list[str]]): Overrides VpcConfig set on the model.
+                If None, defaults to VpcConfig used for training (default: None)
+                * 'Subnets' (list[str]): List of subnet ids.
+                * 'SecurityGroupIds' (list[str]): List of security group ids.
+        """
+        vpc_config = vpc_config or vpc_config_dict(self.subnets, self.security_group_ids)
+        return NTMModel(self.model_data, self.role, sagemaker_session=self.sagemaker_session,
+                        vpc_config=vpc_config)
 
     def _prepare_for_training(self, records, mini_batch_size, job_name=None):
         if mini_batch_size is not None and (mini_batch_size < 1 or mini_batch_size > 10000):
@@ -140,9 +148,10 @@ class NTMModel(Model):
     """Reference NTM s3 model data. Calling :meth:`~sagemaker.model.Model.deploy` creates an Endpoint and return
     a Predictor that transforms vectors to a lower-dimensional representation."""
 
-    def __init__(self, model_data, role, sagemaker_session=None):
+    def __init__(self, model_data, role, sagemaker_session=None, **kwargs):
         sagemaker_session = sagemaker_session or Session()
         repo = '{}:{}'.format(NTM.repo_name, NTM.repo_version)
         image = '{}/{}'.format(registry(sagemaker_session.boto_session.region_name, NTM.repo_name), repo)
         super(NTMModel, self).__init__(model_data, image, role, predictor_cls=NTMPredictor,
-                                       sagemaker_session=sagemaker_session)
+                                       sagemaker_session=sagemaker_session,
+                                       **kwargs)

--- a/src/sagemaker/amazon/pca.py
+++ b/src/sagemaker/amazon/pca.py
@@ -19,6 +19,7 @@ from sagemaker.amazon.validation import gt, isin
 from sagemaker.predictor import RealTimePredictor
 from sagemaker.model import Model
 from sagemaker.session import Session
+from sagemaker.utils import vpc_config_dict
 
 
 class PCA(AmazonAlgorithmEstimatorBase):
@@ -86,11 +87,18 @@ class PCA(AmazonAlgorithmEstimatorBase):
         self.subtract_mean = subtract_mean
         self.extra_components = extra_components
 
-    def create_model(self):
+    def create_model(self, vpc_config=None):
         """Return a :class:`~sagemaker.amazon.pca.PCAModel` referencing the latest
-        s3 model data produced by this Estimator."""
+        s3 model data produced by this Estimator.
 
-        return PCAModel(self.model_data, self.role, sagemaker_session=self.sagemaker_session)
+        vpc_config (dict[str, list[str]]): Overrides VpcConfig set on the model.
+                If None, defaults to VpcConfig used for training (default: None)
+                * 'Subnets' (list[str]): List of subnet ids.
+                * 'SecurityGroupIds' (list[str]): List of security group ids.
+        """
+        vpc_config = vpc_config or vpc_config_dict(self.subnets, self.security_group_ids)
+        return PCAModel(self.model_data, self.role, sagemaker_session=self.sagemaker_session,
+                        vpc_config=vpc_config)
 
     def _prepare_for_training(self, records, mini_batch_size=None, job_name=None):
         """Set hyperparameters needed for training.
@@ -142,9 +150,10 @@ class PCAModel(Model):
     """Reference PCA s3 model data. Calling :meth:`~sagemaker.model.Model.deploy` creates an Endpoint and return
     a Predictor that transforms vectors to a lower-dimensional representation."""
 
-    def __init__(self, model_data, role, sagemaker_session=None):
+    def __init__(self, model_data, role, sagemaker_session=None, **kwargs):
         sagemaker_session = sagemaker_session or Session()
         repo = '{}:{}'.format(PCA.repo_name, PCA.repo_version)
         image = '{}/{}'.format(registry(sagemaker_session.boto_session.region_name), repo)
         super(PCAModel, self).__init__(model_data, image, role, predictor_cls=PCAPredictor,
-                                       sagemaker_session=sagemaker_session)
+                                       sagemaker_session=sagemaker_session,
+                                       **kwargs)

--- a/src/sagemaker/chainer/estimator.py
+++ b/src/sagemaker/chainer/estimator.py
@@ -16,6 +16,7 @@ from sagemaker.estimator import Framework
 from sagemaker.fw_utils import framework_name_from_image, framework_version_from_tag
 from sagemaker.chainer.defaults import CHAINER_VERSION
 from sagemaker.chainer.model import ChainerModel
+from sagemaker.utils import vpc_config_dict
 
 
 class Chainer(Framework):
@@ -98,7 +99,7 @@ class Chainer(Framework):
         hyperparameters.update(Framework._json_encode_hyperparameters(additional_hyperparameters))
         return hyperparameters
 
-    def create_model(self, model_server_workers=None, role=None):
+    def create_model(self, model_server_workers=None, role=None, vpc_config=None):
         """Create a SageMaker ``ChainerModel`` object that can be deployed to an ``Endpoint``.
 
         Args:
@@ -106,18 +107,23 @@ class Chainer(Framework):
                 transform jobs. If not specified, the role from the Estimator will be used.
             model_server_workers (int): Optional. The number of worker processes used by the inference server.
                 If None, server will use one worker per vCPU.
+            vpc_config (dict[str, list[str]]): Overrides VpcConfig set on the model.
+                If None, defaults to VpcConfig used for training (default: None)
+                * 'Subnets' (list[str]): List of subnet ids.
+                * 'SecurityGroupIds' (list[str]): List of security group ids.
 
         Returns:
             sagemaker.chainer.model.ChainerModel: A SageMaker ``ChainerModel`` object.
                 See :func:`~sagemaker.chainer.model.ChainerModel` for full details.
         """
         role = role or self.role
+        vpc_config = vpc_config or vpc_config_dict(self.subnets, self.security_group_ids)
         return ChainerModel(self.model_data, role, self.entry_point, source_dir=self._model_source_dir(),
                             enable_cloudwatch_metrics=self.enable_cloudwatch_metrics, name=self._current_job_name,
                             container_log_level=self.container_log_level, code_location=self.code_location,
                             py_version=self.py_version, framework_version=self.framework_version,
                             model_server_workers=model_server_workers, image=self.image_name,
-                            sagemaker_session=self.sagemaker_session)
+                            sagemaker_session=self.sagemaker_session, vpc_config=vpc_config)
 
     @classmethod
     def _prepare_init_params_from_job_description(cls, job_details):

--- a/src/sagemaker/job.py
+++ b/src/sagemaker/job.py
@@ -17,6 +17,7 @@ from six import string_types
 
 from sagemaker.local import file_input
 from sagemaker.session import s3_input
+from sagemaker.utils import vpc_config_dict
 
 
 class _Job(object):
@@ -60,7 +61,7 @@ class _Job(object):
                                                         estimator.train_volume_size,
                                                         estimator.train_volume_kms_key)
         stop_condition = _Job._prepare_stop_condition(estimator.train_max_run)
-        vpc_config = _Job._prepare_vpc_config(estimator.subnets, estimator.security_group_ids)
+        vpc_config = vpc_config_dict(estimator.subnets, estimator.security_group_ids)
 
         return {'input_config': input_config,
                 'role': role,
@@ -149,13 +150,6 @@ class _Job(object):
             resource_config['VolumeKmsKeyId'] = train_volume_kms_key
 
         return resource_config
-
-    @staticmethod
-    def _prepare_vpc_config(subnets, security_group_ids):
-        if subnets is None or security_group_ids is None:
-            return None
-        return {'Subnets': subnets,
-                'SecurityGroupIds': security_group_ids}
 
     @staticmethod
     def _prepare_stop_condition(max_run):

--- a/src/sagemaker/mxnet/estimator.py
+++ b/src/sagemaker/mxnet/estimator.py
@@ -16,6 +16,7 @@ from sagemaker.estimator import Framework
 from sagemaker.fw_utils import framework_name_from_image, framework_version_from_tag
 from sagemaker.mxnet.defaults import MXNET_VERSION
 from sagemaker.mxnet.model import MXNetModel
+from sagemaker.utils import vpc_config_dict
 
 
 class MXNet(Framework):
@@ -65,7 +66,7 @@ class MXNet(Framework):
         self.py_version = py_version
         self.framework_version = framework_version
 
-    def create_model(self, model_server_workers=None, role=None):
+    def create_model(self, model_server_workers=None, role=None, vpc_config=None):
         """Create a SageMaker ``MXNetModel`` object that can be deployed to an ``Endpoint``.
 
         Args:
@@ -73,17 +74,23 @@ class MXNet(Framework):
                 transform jobs. If not specified, the role from the Estimator will be used.
             model_server_workers (int): Optional. The number of worker processes used by the inference server.
                 If None, server will use one worker per vCPU.
+            vpc_config (dict[str, list[str]]): Overrides VpcConfig set on the model.
+                If None, defaults to VpcConfig used for training (default: None)
+                * 'Subnets' (list[str]): List of subnet ids.
+                * 'SecurityGroupIds' (list[str]): List of security group ids.
 
         Returns:
             sagemaker.mxnet.model.MXNetModel: A SageMaker ``MXNetModel`` object.
                 See :func:`~sagemaker.mxnet.model.MXNetModel` for full details.
         """
         role = role or self.role
+        vpc_config = vpc_config or vpc_config_dict(self.subnets, self.security_group_ids)
         return MXNetModel(self.model_data, role, self.entry_point, source_dir=self._model_source_dir(),
                           enable_cloudwatch_metrics=self.enable_cloudwatch_metrics, name=self._current_job_name,
                           container_log_level=self.container_log_level, code_location=self.code_location,
                           py_version=self.py_version, framework_version=self.framework_version, image=self.image_name,
-                          model_server_workers=model_server_workers, sagemaker_session=self.sagemaker_session)
+                          model_server_workers=model_server_workers, sagemaker_session=self.sagemaker_session,
+                          vpc_config=vpc_config)
 
     @classmethod
     def _prepare_init_params_from_job_description(cls, job_details):

--- a/src/sagemaker/utils.py
+++ b/src/sagemaker/utils.py
@@ -88,6 +88,13 @@ def debug(func):
     return wrapper
 
 
+def vpc_config_dict(subnets, security_group_ids):
+    if subnets is None or security_group_ids is None:
+        return None
+    return {'Subnets': subnets,
+            'SecurityGroupIds': security_group_ids}
+
+
 def get_config_value(key_path, config):
     if config is None:
         return None

--- a/tests/integ/test_tf.py
+++ b/tests/integ/test_tf.py
@@ -20,10 +20,8 @@ import pytest
 from sagemaker.tensorflow import TensorFlow
 from tests.integ import DATA_DIR, TRAINING_DEFAULT_TIMEOUT_MINUTES, PYTHON_VERSION
 from tests.integ.timeout import timeout_and_delete_endpoint_by_name, timeout
-from tests.integ.vpc_utils import get_or_create_subnet_and_security_group
 
 DATA_PATH = os.path.join(DATA_DIR, 'iris', 'data')
-VPC_NAME = 'training-job-test'
 
 
 @pytest.mark.continuous_testing
@@ -96,8 +94,6 @@ def test_tf_async(sagemaker_session):
 def test_failed_tf_training(sagemaker_session, tf_full_version):
     with timeout(minutes=TRAINING_DEFAULT_TIMEOUT_MINUTES):
         script_path = os.path.join(DATA_DIR, 'iris', 'failure_script.py')
-        ec2_client = sagemaker_session.boto_session.client('ec2')
-        subnet, security_group_id = get_or_create_subnet_and_security_group(ec2_client, VPC_NAME)
         estimator = TensorFlow(entry_point=script_path,
                                role='SageMakerRole',
                                framework_version=tf_full_version,
@@ -106,17 +102,10 @@ def test_failed_tf_training(sagemaker_session, tf_full_version):
                                hyperparameters={'input_tensor_name': 'inputs'},
                                train_instance_count=1,
                                train_instance_type='ml.c4.xlarge',
-                               sagemaker_session=sagemaker_session,
-                               subnets=[subnet],
-                               security_group_ids=[security_group_id])
+                               sagemaker_session=sagemaker_session)
 
         inputs = estimator.sagemaker_session.upload_data(path=DATA_PATH, key_prefix='integ-test-data/tf-failure')
 
         with pytest.raises(ValueError) as e:
             estimator.fit(inputs)
         assert 'This failure is expected' in str(e.value)
-
-        job_desc = estimator.sagemaker_session.sagemaker_client.describe_training_job(
-            TrainingJobName=estimator.latest_training_job.name)
-        assert [subnet] == job_desc['VpcConfig']['Subnets']
-        assert [security_group_id] == job_desc['VpcConfig']['SecurityGroupIds']

--- a/tests/integ/test_vpc.py
+++ b/tests/integ/test_vpc.py
@@ -1,0 +1,364 @@
+# Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from __future__ import absolute_import
+
+import gzip
+import json
+import os
+import pickle
+import sys
+
+import pytest
+
+from sagemaker import KNN
+from sagemaker.amazon.amazon_estimator import registry
+from sagemaker.chainer import Chainer
+from sagemaker.estimator import Estimator
+from sagemaker.mxnet import MXNet
+from sagemaker.predictor import json_deserializer
+from sagemaker.pytorch import PyTorch
+from sagemaker.tensorflow import TensorFlow
+from tests.integ import DATA_DIR, TRAINING_DEFAULT_TIMEOUT_MINUTES, PYTHON_VERSION
+from tests.integ.timeout import timeout_and_delete_endpoint_by_name, timeout
+from tests.integ.vpc_utils import get_or_create_subnets_and_security_group
+
+DATA_PATH = os.path.join(DATA_DIR, 'iris', 'data')
+
+
+@pytest.mark.skipif(PYTHON_VERSION != 'py2', reason="TensorFlow image supports only python 2.")
+def test_vpc_tf(sagemaker_session, tf_full_version):
+    instance_type = 'ml.c4.xlarge'
+
+    train_input = sagemaker_session.upload_data(path=DATA_PATH, key_prefix='integ-test-data/tf_iris')
+    script_path = os.path.join(DATA_DIR, 'iris', 'iris-dnn-classifier.py')
+
+    ec2_client = sagemaker_session.boto_session.client('ec2')
+    subnet_ids, security_group_id = get_or_create_subnets_and_security_group(ec2_client,
+                                                                             sagemaker_session.boto_session.region_name)
+
+    estimator = TensorFlow(entry_point=script_path,
+                           role='SageMakerRole',
+                           framework_version=tf_full_version,
+                           training_steps=1,
+                           evaluation_steps=1,
+                           hyperparameters={'input_tensor_name': 'inputs'},
+                           train_instance_count=1,
+                           train_instance_type=instance_type,
+                           sagemaker_session=sagemaker_session,
+                           base_job_name='test-vpc-tf',
+                           subnets=subnet_ids,
+                           security_group_ids=[security_group_id])
+
+    with timeout(minutes=TRAINING_DEFAULT_TIMEOUT_MINUTES):
+        estimator.fit(train_input)
+        print('training job succeeded: {}'.format(estimator.latest_training_job.name))
+
+    job_desc = sagemaker_session.sagemaker_client.describe_training_job(
+        TrainingJobName=estimator.latest_training_job.name)
+    assert set(subnet_ids) == set(job_desc['VpcConfig']['Subnets'])
+    assert [security_group_id] == job_desc['VpcConfig']['SecurityGroupIds']
+
+    endpoint_name = estimator.latest_training_job.name
+    with timeout_and_delete_endpoint_by_name(endpoint_name, sagemaker_session):
+        model = estimator.create_model()
+        json_predictor = model.deploy(initial_instance_count=1, instance_type='ml.c4.xlarge',
+                                      endpoint_name=endpoint_name)
+
+        features = [6.4, 3.2, 4.5, 1.5]
+        dict_result = json_predictor.predict({'inputs': features})
+        print('predict result: {}'.format(dict_result))
+        list_result = json_predictor.predict(features)
+        print('predict result: {}'.format(list_result))
+
+        assert dict_result == list_result
+
+        model_desc = sagemaker_session.sagemaker_client.describe_model(ModelName=model.name)
+        assert set(subnet_ids) == set(model_desc['VpcConfig']['Subnets'])
+        assert [security_group_id] == model_desc['VpcConfig']['SecurityGroupIds']
+
+
+def test_vpc_mxnet(sagemaker_session, mxnet_full_version):
+    script_path = os.path.join(DATA_DIR, 'mxnet_mnist', 'mnist.py')
+    data_path = os.path.join(DATA_DIR, 'mxnet_mnist')
+
+    train_input = sagemaker_session.upload_data(path=os.path.join(data_path, 'train'),
+                                                key_prefix='integ-test-data/mxnet_mnist/train')
+    test_input = sagemaker_session.upload_data(path=os.path.join(data_path, 'test'),
+                                               key_prefix='integ-test-data/mxnet_mnist/test')
+
+    ec2_client = sagemaker_session.boto_session.client('ec2')
+    subnet_ids, security_group_id = get_or_create_subnets_and_security_group(ec2_client,
+                                                                             sagemaker_session.boto_session.region_name)
+
+    estimator = MXNet(entry_point=script_path,
+                      role='SageMakerRole',
+                      framework_version=mxnet_full_version,
+                      py_version=PYTHON_VERSION,
+                      train_instance_count=1,
+                      train_instance_type='ml.c4.xlarge',
+                      sagemaker_session=sagemaker_session,
+                      base_job_name='test-vpc-mxnet',
+                      subnets=subnet_ids,
+                      security_group_ids=[security_group_id])
+
+    with timeout(minutes=TRAINING_DEFAULT_TIMEOUT_MINUTES):
+        estimator.fit({'train': train_input, 'test': test_input})
+        print('training job succeeded: {}'.format(estimator.latest_training_job.name))
+
+    job_desc = sagemaker_session.sagemaker_client.describe_training_job(
+        TrainingJobName=estimator.latest_training_job.name)
+    assert set(subnet_ids) == set(job_desc['VpcConfig']['Subnets'])
+    assert [security_group_id] == job_desc['VpcConfig']['SecurityGroupIds']
+
+    endpoint_name = estimator.latest_training_job.name
+    with timeout_and_delete_endpoint_by_name(endpoint_name, sagemaker_session):
+        model = estimator.create_model()
+        json_predictor = model.deploy(initial_instance_count=1, instance_type='ml.c4.xlarge',
+                                      endpoint_name=endpoint_name)
+
+        model_desc = sagemaker_session.sagemaker_client.describe_model(ModelName=model.name)
+        assert set(subnet_ids) == set(model_desc['VpcConfig']['Subnets'])
+        assert [security_group_id] == model_desc['VpcConfig']['SecurityGroupIds']
+
+        features = [6.4, 3.2, 4.5, 1.5]
+        dict_result = json_predictor.predict({'inputs': features})
+        print('predict result: {}'.format(dict_result))
+        list_result = json_predictor.predict(features)
+        print('predict result: {}'.format(list_result))
+
+        assert dict_result == list_result
+
+
+def test_vpc_pytorch(sagemaker_session, pytorch_full_version):
+    instance_type = 'ml.c4.xlarge'
+    mnist_dir = os.path.join(DATA_DIR, 'pytorch_mnist')
+    mnist_script = os.path.join(mnist_dir, 'mnist.py')
+
+    train_input = sagemaker_session.upload_data(path=os.path.join(mnist_dir, 'training'),
+                                                key_prefix='integ-test-data/pytorch_mnist/training')
+
+    ec2_client = sagemaker_session.boto_session.client('ec2')
+    subnet_ids, security_group_id = get_or_create_subnets_and_security_group(ec2_client,
+                                                                             sagemaker_session.boto_session.region_name)
+
+    estimator = PyTorch(entry_point=mnist_script,
+                        role='SageMakerRole',
+                        framework_version=pytorch_full_version,
+                        py_version=PYTHON_VERSION,
+                        train_instance_count=1,
+                        train_instance_type=instance_type,
+                        sagemaker_session=sagemaker_session,
+                        base_job_name='test-vpc-pytorch',
+                        subnets=subnet_ids,
+                        security_group_ids=[security_group_id])
+
+    with timeout(minutes=TRAINING_DEFAULT_TIMEOUT_MINUTES):
+        estimator.fit({'training': train_input})
+        print('training job succeeded: {}'.format(estimator.latest_training_job.name))
+
+    job_desc = sagemaker_session.sagemaker_client.describe_training_job(
+        TrainingJobName=estimator.latest_training_job.name)
+    assert set(subnet_ids) == set(job_desc['VpcConfig']['Subnets'])
+    assert [security_group_id] == job_desc['VpcConfig']['SecurityGroupIds']
+
+    endpoint_name = estimator.latest_training_job.name
+    with timeout_and_delete_endpoint_by_name(endpoint_name, sagemaker_session):
+        model = estimator.create_model()
+        json_predictor = model.deploy(initial_instance_count=1, instance_type=instance_type,
+                                      endpoint_name=endpoint_name)
+
+        model_desc = sagemaker_session.sagemaker_client.describe_model(ModelName=model.name)
+        assert set(subnet_ids) == set(model_desc['VpcConfig']['Subnets'])
+        assert [security_group_id] == model_desc['VpcConfig']['SecurityGroupIds']
+
+        features = [6.4, 3.2, 4.5, 1.5]
+        dict_result = json_predictor.predict({'inputs': features})
+        print('predict result: {}'.format(dict_result))
+        list_result = json_predictor.predict(features)
+        print('predict result: {}'.format(list_result))
+
+        assert dict_result == list_result
+
+
+def test_vpc_chainer(sagemaker_session, chainer_full_version):
+    instance_type = 'ml.c4.xlarge'
+
+    script_path = os.path.join(DATA_DIR, 'chainer_mnist', 'mnist.py')
+    data_path = os.path.join(DATA_DIR, 'chainer_mnist')
+
+    train_input = sagemaker_session.upload_data(path=os.path.join(data_path, 'train'),
+                                                key_prefix='integ-test-data/chainer_mnist/train')
+    test_input = sagemaker_session.upload_data(path=os.path.join(data_path, 'test'),
+                                               key_prefix='integ-test-data/chainer_mnist/test')
+
+    ec2_client = sagemaker_session.boto_session.client('ec2')
+    subnet_ids, security_group_id = get_or_create_subnets_and_security_group(ec2_client,
+                                                                             sagemaker_session.boto_session.region_name)
+
+    estimator = Chainer(entry_point=script_path,
+                        role='SageMakerRole',
+                        framework_version=chainer_full_version,
+                        py_version=PYTHON_VERSION,
+                        train_instance_count=1,
+                        train_instance_type=instance_type,
+                        sagemaker_session=sagemaker_session,
+                        hyperparameters={'epochs': 1},
+                        base_job_name='test-vpc-chainer',
+                        subnets=subnet_ids,
+                        security_group_ids=[security_group_id])
+
+    with timeout(minutes=TRAINING_DEFAULT_TIMEOUT_MINUTES):
+        estimator.fit({'train': train_input, 'test': test_input})
+        print('training job succeeded: {}'.format(estimator.latest_training_job.name))
+
+    job_desc = sagemaker_session.sagemaker_client.describe_training_job(
+        TrainingJobName=estimator.latest_training_job.name)
+    assert set(subnet_ids) == set(job_desc['VpcConfig']['Subnets'])
+    assert [security_group_id] == job_desc['VpcConfig']['SecurityGroupIds']
+
+    endpoint_name = estimator.latest_training_job.name
+    with timeout_and_delete_endpoint_by_name(endpoint_name, sagemaker_session):
+        model = estimator.create_model()
+        json_predictor = model.deploy(initial_instance_count=1, instance_type=instance_type,
+                                      endpoint_name=endpoint_name)
+
+        model_desc = sagemaker_session.sagemaker_client.describe_model(ModelName=model.name)
+        assert set(subnet_ids) == set(model_desc['VpcConfig']['Subnets'])
+        assert [security_group_id] == model_desc['VpcConfig']['SecurityGroupIds']
+
+        features = [6.4, 3.2, 4.5, 1.5]
+        dict_result = json_predictor.predict({'inputs': features})
+        print('predict result: {}'.format(dict_result))
+        list_result = json_predictor.predict(features)
+        print('predict result: {}'.format(list_result))
+
+        assert dict_result == list_result
+
+
+def test_vpc_knn_multi(sagemaker_session):
+    instance_type = 'ml.c4.xlarge'
+    train_instance_count = 2
+
+    data_path = os.path.join(DATA_DIR, 'one_p_mnist', 'mnist.pkl.gz')
+    pickle_args = {} if sys.version_info.major == 2 else {'encoding': 'latin1'}
+    # Load the data into memory as numpy arrays
+    with gzip.open(data_path, 'rb') as f:
+        train_set, _, _ = pickle.load(f, **pickle_args)
+
+    ec2_client = sagemaker_session.boto_session.client('ec2')
+    subnet_ids, security_group_id = get_or_create_subnets_and_security_group(ec2_client,
+                                                                             sagemaker_session.boto_session.region_name)
+
+    estimator = KNN(role='SageMakerRole',
+                    train_instance_count=train_instance_count,
+                    train_instance_type=instance_type,
+                    k=10,
+                    predictor_type='regressor',
+                    sample_size=500,
+                    sagemaker_session=sagemaker_session,
+                    base_job_name='test-vpc-knn',
+                    subnets=subnet_ids,
+                    security_group_ids=[security_group_id])
+
+    with timeout(minutes=TRAINING_DEFAULT_TIMEOUT_MINUTES):
+        # training labels must be 'float32'
+        estimator.fit(estimator.record_set(train_set[0][:200], train_set[1][:200].astype('float32')))
+        print('training job succeeded: {}'.format(estimator.latest_training_job.name))
+
+    job_desc = sagemaker_session.sagemaker_client.describe_training_job(
+        TrainingJobName=estimator.latest_training_job.name)
+    assert set(subnet_ids) == set(job_desc['VpcConfig']['Subnets'])
+    assert [security_group_id] == job_desc['VpcConfig']['SecurityGroupIds']
+
+    endpoint_name = estimator.latest_training_job.name
+    with timeout_and_delete_endpoint_by_name(endpoint_name, sagemaker_session):
+        model = estimator.create_model()
+        predictor = model.deploy(initial_instance_count=1, instance_type=instance_type, endpoint_name=endpoint_name)
+
+        model_desc = sagemaker_session.sagemaker_client.describe_model(ModelName=model.name)
+        assert set(subnet_ids) == set(model_desc['VpcConfig']['Subnets'])
+        assert [security_group_id] == model_desc['VpcConfig']['SecurityGroupIds']
+
+        result = predictor.predict(train_set[0][:10])
+        print('predict result: {}'.format(result))
+
+        assert len(result) == 10
+        for record in result:
+            assert record.label["score"] is not None
+
+
+def test_vpc_byo(sagemaker_session):
+    instance_type = 'ml.c4.xlarge'
+    image_name = registry(sagemaker_session.boto_session.region_name) + "/factorization-machines:1"
+
+    data_path = os.path.join(DATA_DIR, 'one_p_mnist', 'mnist.pkl.gz')
+    pickle_args = {} if sys.version_info.major == 2 else {'encoding': 'latin1'}
+    with gzip.open(data_path, 'rb') as f:
+        test_set, _, _ = pickle.load(f, **pickle_args)
+
+    training_data_path = os.path.join(DATA_DIR, 'dummy_tensor')
+    prefix = 'test_byo_estimator'
+    key = 'recordio-pb-data'
+    s3_train_data = sagemaker_session.upload_data(path=training_data_path,
+                                                  key_prefix=os.path.join(prefix, 'train', key))
+
+    ec2_client = sagemaker_session.boto_session.client('ec2')
+    subnet_ids, security_group_id = get_or_create_subnets_and_security_group(ec2_client,
+                                                                             sagemaker_session.boto_session.region_name)
+
+    estimator = Estimator(image_name=image_name,
+                          role='SageMakerRole',
+                          train_instance_count=1,
+                          train_instance_type=instance_type,
+                          sagemaker_session=sagemaker_session,
+                          base_job_name='test-vpc-byo-fm',
+                          subnets=subnet_ids,
+                          security_group_ids=[security_group_id])
+    estimator.set_hyperparameters(num_factors=10,
+                                  feature_dim=784,
+                                  mini_batch_size=100,
+                                  predictor_type='binary_classifier')
+
+    with timeout(minutes=TRAINING_DEFAULT_TIMEOUT_MINUTES):
+        estimator.fit({'train': s3_train_data})
+        print('training job succeeded: {}'.format(estimator.latest_training_job.name))
+
+    job_desc = sagemaker_session.sagemaker_client.describe_training_job(
+        TrainingJobName=estimator.latest_training_job.name)
+    assert set(subnet_ids) == set(job_desc['VpcConfig']['Subnets'])
+    assert [security_group_id] == job_desc['VpcConfig']['SecurityGroupIds']
+
+    endpoint_name = estimator.latest_training_job.name
+    with timeout_and_delete_endpoint_by_name(endpoint_name, sagemaker_session):
+        model = estimator.create_model()
+        predictor = model.deploy(1, 'ml.m4.xlarge', endpoint_name=endpoint_name)
+        predictor.serializer = fm_serializer
+        predictor.content_type = 'application/json'
+        predictor.deserializer = json_deserializer
+
+        model_desc = sagemaker_session.sagemaker_client.describe_model(ModelName=model.name)
+        assert set(subnet_ids) == set(model_desc['VpcConfig']['Subnets'])
+        assert [security_group_id] == model_desc['VpcConfig']['SecurityGroupIds']
+
+        result = predictor.predict(test_set[0][:10])
+
+        assert len(result['predictions']) == 10
+        for prediction in result['predictions']:
+            assert prediction['score'] is not None
+
+
+def fm_serializer(data):
+    js = {'instances': []}
+    for row in data:
+        js['instances'].append({'features': row.tolist()})
+    return json.dumps(js)

--- a/tests/unit/test_create_deploy_entities.py
+++ b/tests/unit/test_create_deploy_entities.py
@@ -24,6 +24,7 @@ ROLE = 'myimrole'
 EXPANDED_ROLE = 'arn:aws:iam::111111111111:role/ExpandedRole'
 IMAGE = 'myimage'
 FULL_CONTAINER_DEF = {'Environment': {}, 'Image': IMAGE, 'ModelDataUrl': 's3://mybucket/mymodel'}
+VPC_CONFIG = {'Subnets': ['subnet-foo'], 'SecurityGroups': ['sg-foo']}
 INITIAL_INSTANCE_COUNT = 1
 INSTANCE_TYPE = 'ml.c4.xlarge'
 REGION = 'us-west-2'
@@ -38,14 +39,15 @@ def sagemaker_session():
 
 
 def test_create_model(sagemaker_session):
-
-    returned_name = sagemaker_session.create_model(name=MODEL_NAME, role=ROLE, primary_container=FULL_CONTAINER_DEF)
+    returned_name = sagemaker_session.create_model(name=MODEL_NAME, role=ROLE, primary_container=FULL_CONTAINER_DEF,
+                                                   vpc_config=VPC_CONFIG)
 
     assert returned_name == MODEL_NAME
     sagemaker_session.sagemaker_client.create_model.assert_called_once_with(
         ModelName=MODEL_NAME,
         PrimaryContainer=FULL_CONTAINER_DEF,
-        ExecutionRoleArn=EXPANDED_ROLE)
+        ExecutionRoleArn=EXPANDED_ROLE,
+        VpcConfig=VPC_CONFIG)
 
 
 def test_create_model_expand_primary_container(sagemaker_session):

--- a/tests/unit/test_endpoint_from_job.py
+++ b/tests/unit/test_endpoint_from_job.py
@@ -33,6 +33,7 @@ TRAINING_JOB_RESPONSE = {
     "RoleArn": TRAIN_ROLE
 }
 FULL_CONTAINER_DEF = {'Environment': {}, 'Image': IMAGE, 'ModelDataUrl': S3_MODEL_ARTIFACTS}
+VPC_CONFIG = {'Subnets': ['subnet-foo'], 'SecurityGroups': ['sg-foo']}
 DEPLOY_IMAGE = 'mydeployimage'
 DEPLOY_ROLE = 'mydeployrole'
 NEW_ENTITY_NAME = 'mynewendpoint'
@@ -64,6 +65,7 @@ def test_all_defaults_no_existing_entities(sagemaker_session):
     expected_args['role'] = TRAIN_ROLE
     expected_args['name'] = JOB_NAME
     expected_args['model_environment_vars'] = None
+    expected_args['model_vpc_config'] = None
     sagemaker_session.endpoint_from_model_data.assert_called_once_with(**expected_args)
     assert returned_name == ENDPOINT_FROM_MODEL_RETURNED_NAME
 
@@ -71,7 +73,8 @@ def test_all_defaults_no_existing_entities(sagemaker_session):
 def test_no_defaults_no_existing_entities(sagemaker_session):
     original_args = {'job_name': JOB_NAME, 'initial_instance_count': INITIAL_INSTANCE_COUNT,
                      'instance_type': INSTANCE_TYPE, 'deployment_image': DEPLOY_IMAGE, 'role': DEPLOY_ROLE,
-                     'name': NEW_ENTITY_NAME, 'model_environment_vars': ENV_VARS, 'wait': False}
+                     'name': NEW_ENTITY_NAME, 'model_environment_vars': ENV_VARS, 'model_vpc_config': VPC_CONFIG,
+                     'wait': False}
 
     returned_name = sagemaker_session.endpoint_from_job(**original_args)
 

--- a/tests/unit/test_endpoint_from_model_data.py
+++ b/tests/unit/test_endpoint_from_model_data.py
@@ -25,6 +25,7 @@ INSTANCE_TYPE = 'ml.c4.xlarge'
 S3_MODEL_ARTIFACTS = 's3://mybucket/mymodel'
 DEPLOY_IMAGE = 'mydeployimage'
 FULL_CONTAINER_DEF = {'Environment': {}, 'Image': DEPLOY_IMAGE, 'ModelDataUrl': S3_MODEL_ARTIFACTS}
+VPC_CONFIG = {'Subnets': ['subnet-foo'], 'SecurityGroups': ['sg-foo']}
 DEPLOY_ROLE = 'mydeployrole'
 NEW_ENTITY_NAME = 'mynewendpoint'
 ENV_VARS = {'PYTHONUNBUFFERED': 'TRUE', 'some': 'nonsense'}
@@ -62,7 +63,8 @@ def test_all_defaults_no_existing_entities(name_from_image_mock, sagemaker_sessi
         EndpointConfigName=NAME_FROM_IMAGE)
     sagemaker_session.create_model.assert_called_once_with(name=NAME_FROM_IMAGE,
                                                            role=DEPLOY_ROLE,
-                                                           primary_container=FULL_CONTAINER_DEF)
+                                                           primary_container=FULL_CONTAINER_DEF,
+                                                           vpc_config=None)
     sagemaker_session.create_endpoint_config.assert_called_once_with(name=NAME_FROM_IMAGE,
                                                                      model_name=NAME_FROM_IMAGE,
                                                                      initial_instance_count=INITIAL_INSTANCE_COUNT,


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Previous commits (#353 , #370 ) enabled users to set VpcConfig on Estimators/Training Jobs. The same VpcConfig can be set on Models in order to protect network traffic in inference use cases (see [docs](https://docs.aws.amazon.com/sagemaker/latest/dg/host-vpc.html)). 

In this PR I've added the optional parameter `vpc_config` to `Model` constructors and `Session` methods, and modified most `create_model` and `deploy` implementations to pass forward the same VPC config used in training, or take an override from the optional parameter `vpc_config`. 

To ensure the functionality works for both training and inference, I've improved the integ tests to cover VPC features for a variety of models. **Note that name and resource configurations belonging to the test VPC have changed. Before running the integ tests in your account, you should delete the existing test VPC.**

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have updated the [changelog](https://github.com/aws/sagemaker-python-sdk/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [x] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
