### PR TITLE
Add timestamp to secondary status for traning job logs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ CHANGELOG
 =========
 
 * feature: Local Mode: Add support for Batch Inference
+* feature: Add timestamp to secondary status in training job output
 
 1.11.2
 ======

--- a/src/sagemaker/utils.py
+++ b/src/sagemaker/utils.py
@@ -181,18 +181,17 @@ def secondary_training_status_message(job_description, prev_description):
         if prev_description_secondary_transitions is not None else 0
     current_transitions = job_description['SecondaryStatusTransitions']
 
-    if len(current_transitions) == prev_transitions_num:
-        return current_transitions[-1]['StatusMessage']
-    else:
-        transitions_to_print = current_transitions[prev_transitions_num - len(current_transitions):]
-        status_strs = []
-        for transition in transitions_to_print:
-            message = transition['StatusMessage']
-            time_str = datetime.utcfromtimestamp(
-                time.mktime(transition['StartTime'].timetuple())).strftime('%Y-%m-%d %H:%M:%S')
-            status_strs.append('{} {} - {}'.format(time_str, transition['Status'], message))
+    transitions_to_print = current_transitions[-1:] if len(current_transitions) == prev_transitions_num else \
+        current_transitions[prev_transitions_num - len(current_transitions):]
 
-        return '\n'.join(status_strs)
+    status_strs = []
+    for transition in transitions_to_print:
+        message = transition['StatusMessage']
+        time_str = datetime.utcfromtimestamp(
+            time.mktime(job_description['LastModifiedTime'].timetuple())).strftime('%Y-%m-%d %H:%M:%S')
+        status_strs.append('{} {} - {}'.format(time_str, transition['Status'], message))
+
+    return '\n'.join(status_strs)
 
 
 def download_folder(bucket_name, prefix, target, sagemaker_session):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -146,7 +146,7 @@ def test_secondary_training_status_changed_empty():
 
 def test_secondary_training_status_message_status_changed():
     now = datetime.now()
-    TRAINING_JOB_DESCRIPTION_1['SecondaryStatusTransitions'][-1]['StartTime'] = now
+    TRAINING_JOB_DESCRIPTION_1['LastModifiedTime'] = now
     expected = '{} {} - {}'.format(
         datetime.utcfromtimestamp(time.mktime(now.timetuple())).strftime('%Y-%m-%d %H:%M:%S'),
         STATUS,
@@ -157,13 +157,18 @@ def test_secondary_training_status_message_status_changed():
 
 def test_secondary_training_status_message_status_not_changed():
     now = datetime.now()
-    TRAINING_JOB_DESCRIPTION_1['SecondaryStatusTransitions'][-1]['StartTime'] = now
-    assert secondary_training_status_message(TRAINING_JOB_DESCRIPTION_1, TRAINING_JOB_DESCRIPTION_2) == MESSAGE
+    TRAINING_JOB_DESCRIPTION_1['LastModifiedTime'] = now
+    expected = '{} {} - {}'.format(
+        datetime.utcfromtimestamp(time.mktime(now.timetuple())).strftime('%Y-%m-%d %H:%M:%S'),
+        STATUS,
+        MESSAGE
+    )
+    assert secondary_training_status_message(TRAINING_JOB_DESCRIPTION_1, TRAINING_JOB_DESCRIPTION_2) == expected
 
 
 def test_secondary_training_status_message_prev_missing():
     now = datetime.now()
-    TRAINING_JOB_DESCRIPTION_1['SecondaryStatusTransitions'][-1]['StartTime'] = now
+    TRAINING_JOB_DESCRIPTION_1['LastModifiedTime'] = now
     expected = '{} {} - {}'.format(
         datetime.utcfromtimestamp(time.mktime(now.timetuple())).strftime('%Y-%m-%d %H:%M:%S'),
         STATUS,


### PR DESCRIPTION
*Issue #, if available

*Description of changes:*

After this change the output of training job looks like this:

INFO:sagemaker:Creating training-job with name: sagemaker-mxnet-2018-10-11-22-39-27-822
2018-10-11 22:39:29 Starting - Starting the training job...
2018-10-11 22:39:29 Starting - Launching requested ML instances......
2018-10-11 22:40:30 Starting - Preparing the instances for training......
2018-10-11 22:41:53 Downloading - Downloading input data..

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated the [changelog](https://github.com/aws/sagemaker-python-sdk/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
