### PR TITLE
add PEP-396 version attribute to sagemaker module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,10 +12,19 @@
 # language governing permissions and limitations under the License.
 from __future__ import absolute_import
 
-from glob import glob
 import os
+import re
+from glob import glob
 
 from setuptools import setup, find_packages
+
+
+def get_version():
+    root = os.path.dirname(__file__)
+    version_re = re.compile(r'''__version__ = ['"]([0-9.]+)['"]''')
+
+    init = read(os.path.join(root, 'src/sagemaker', '__init__.py'))
+    return version_re.search(init).group(1)
 
 
 def read(fname):
@@ -23,7 +32,7 @@ def read(fname):
 
 
 setup(name="sagemaker",
-      version="1.11.3",
+      version=get_version(),
       description="Open source library for training and deploying models on Amazon SageMaker.",
       packages=find_packages('src'),
       package_dir={'': 'src'},
@@ -44,7 +53,8 @@ setup(name="sagemaker",
       ],
 
       # Declare minimal set for installation
-      install_requires=['boto3>=1.4.8', 'numpy>=1.9.0', 'protobuf>=3.1', 'scipy>=0.19.0', 'urllib3 >=1.21, <1.23',
+      install_requires=['boto3>=1.4.8', 'numpy>=1.9.0', 'protobuf>=3.1', 'scipy>=0.19.0',
+                        'urllib3 >=1.21, <1.23',
                         'PyYAML>=3.2', 'protobuf3-to-dict>=0.1.5', 'docker-compose>=1.21.0'],
 
       extras_require={

--- a/src/sagemaker/__init__.py
+++ b/src/sagemaker/__init__.py
@@ -34,3 +34,5 @@ from sagemaker.session import container_def  # noqa: F401
 from sagemaker.session import production_variant  # noqa: F401
 from sagemaker.session import s3_input  # noqa: F401
 from sagemaker.session import get_execution_role  # noqa: F401
+
+__version__ = '1.11.3'

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -1,0 +1,19 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from __future__ import absolute_import
+
+import sagemaker
+
+
+def test_version():
+    assert sagemaker.__version__


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/sagemaker-python-sdk/issues/434

*Description of changes:*

add PEP-396 version attribute to sagemaker module

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated the [changelog](https://github.com/aws/sagemaker-python-sdk/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
