### PR TITLE
local mode: support output_path

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 CHANGELOG
 =========
 
+1.12.1dev
+=========
+* enhancement: Local Mode: support output_path. Can be either file:// or s3://
+
 1.12.0
 ======
 

--- a/src/sagemaker/estimator.py
+++ b/src/sagemaker/estimator.py
@@ -104,6 +104,9 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):
 
         self.base_job_name = base_job_name
         self._current_job_name = None
+        if (not self.sagemaker_session.local_mode
+                and output_path and output_path.startswith('file://')):
+            raise RuntimeError('file:// output paths are only supported in Local Mode')
         self.output_path = output_path
         self.output_kms_key = output_kms_key
         self.latest_training_job = None

--- a/src/sagemaker/local/data.py
+++ b/src/sagemaker/local/data.py
@@ -13,6 +13,7 @@
 from __future__ import absolute_import
 
 import os
+import platform
 import sys
 import tempfile
 from abc import ABCMeta
@@ -162,6 +163,12 @@ class S3DataSource(DataSource):
             root_dir = os.path.abspath(root_dir)
 
         working_dir = tempfile.mkdtemp(dir=root_dir)
+        # Docker cannot mount Mac OS /var folder properly see
+        # https://forums.docker.com/t/var-folders-isnt-mounted-properly/9600
+        # Only apply this workaround if the user didn't provide an alternate storage root dir.
+        if root_dir is None and platform.system() == 'Darwin':
+            working_dir = '/private{}'.format(working_dir)
+
         sagemaker.utils.download_folder(bucket, prefix, working_dir, sagemaker_session)
         self.files = LocalFileDataSource(working_dir)
 

--- a/src/sagemaker/local/image.py
+++ b/src/sagemaker/local/image.py
@@ -262,9 +262,15 @@ class _SageMakerContainer(object):
             'hosts': self.hosts
         }
 
-        json_input_data_config = {
-            c['ChannelName']: {'ContentType': 'application/octet-stream'} for c in input_data_config
-        }
+        print(input_data_config)
+        json_input_data_config = {}
+        for c in input_data_config:
+            channel_name = c['ChannelName']
+            json_input_data_config[channel_name] = {
+                'TrainingInputMode': 'File'
+            }
+            if 'ContentType' in c:
+                json_input_data_config[channel_name]['ContentType'] = c['ContentType']
 
         _write_json_file(os.path.join(config_path, 'hyperparameters.json'), hyperparameters)
         _write_json_file(os.path.join(config_path, 'resourceconfig.json'), resource_config)

--- a/src/sagemaker/local/local_session.py
+++ b/src/sagemaker/local/local_session.py
@@ -71,7 +71,7 @@ class LocalSagemakerClient(object):
                                         AlgorithmSpecification['TrainingImage'], self.sagemaker_session)
         training_job = _LocalTrainingJob(container)
         hyperparameters = kwargs['HyperParameters'] if 'HyperParameters' in kwargs else {}
-        training_job.start(InputDataConfig, hyperparameters, TrainingJobName)
+        training_job.start(InputDataConfig, OutputDataConfig, hyperparameters, TrainingJobName)
 
         LocalSagemakerClient._training_jobs[TrainingJobName] = training_job
 

--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -134,7 +134,6 @@ class Session(object):
         files = []
         key_suffix = None
         if os.path.isdir(path):
-            print('%s is dir!' % path)
             for dirpath, dirnames, filenames in os.walk(path):
                 for name in filenames:
                     local_path = os.path.join(dirpath, name)
@@ -151,7 +150,6 @@ class Session(object):
         s3 = self.boto_session.resource('s3')
 
         for local_path, s3_key in files:
-            print("%s -> %s" % (local_path, s3_key))
             s3.Object(bucket, s3_key).upload_file(local_path)
 
         s3_uri = 's3://{}/{}'.format(bucket, key_prefix)

--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -134,6 +134,7 @@ class Session(object):
         files = []
         key_suffix = None
         if os.path.isdir(path):
+            print('%s is dir!' % path)
             for dirpath, dirnames, filenames in os.walk(path):
                 for name in filenames:
                     local_path = os.path.join(dirpath, name)
@@ -150,6 +151,7 @@ class Session(object):
         s3 = self.boto_session.resource('s3')
 
         for local_path, s3_key in files:
+            print("%s -> %s" % (local_path, s3_key))
             s3.Object(bucket, s3_key).upload_file(local_path)
 
         s3_uri = 's3://{}/{}'.format(bucket, key_prefix)

--- a/src/sagemaker/utils.py
+++ b/src/sagemaker/utils.py
@@ -16,6 +16,8 @@ import errno
 import os
 import re
 import sys
+import tarfile
+import tempfile
 import time
 
 from datetime import datetime
@@ -240,6 +242,28 @@ def download_folder(bucket_name, prefix, target, sagemaker_session):
                 raise
             pass
         obj.download_file(file_path)
+
+
+def create_tar_file(source_files, target=None):
+    """Create a tar file containing all the source_files
+
+    Args:
+        source_files (List[str]): List of file paths that will be contained in the tar file
+
+    Returns:
+         (str): path to created tar file
+
+    """
+    if target:
+        filename = target
+    else:
+        _, filename = tempfile.mkstemp()
+
+    with tarfile.open(filename, mode='w:gz') as t:
+        for sf in source_files:
+            # Add all files from the directory into the root of the directory structure of the tar
+            t.add(sf, arcname=os.path.basename(sf))
+    return filename
 
 
 def download_file(bucket_name, path, target, sagemaker_session):

--- a/tests/integ/test_local_mode.py
+++ b/tests/integ/test_local_mode.py
@@ -21,9 +21,8 @@ import numpy
 import pytest
 
 from sagemaker.local import LocalSession, LocalSagemakerRuntimeClient, LocalSagemakerClient
-from sagemaker.mxnet import MXNet, MXNetModel
+from sagemaker.mxnet import MXNet
 from sagemaker.tensorflow import TensorFlow
-from sagemaker.fw_utils import tar_and_upload_dir
 from tests.integ import DATA_DIR, PYTHON_VERSION
 from tests.integ.timeout import timeout
 
@@ -58,21 +57,24 @@ class LocalNoS3Session(LocalSession):
 
 @pytest.fixture(scope='module')
 def mxnet_model(sagemaker_local_session):
-    script_path = os.path.join(DATA_DIR, 'mxnet_mnist', 'mnist.py')
-    data_path = os.path.join(DATA_DIR, 'mxnet_mnist')
+    def _create_model(output_path):
+        script_path = os.path.join(DATA_DIR, 'mxnet_mnist', 'mnist.py')
+        data_path = os.path.join(DATA_DIR, 'mxnet_mnist')
 
-    mx = MXNet(entry_point=script_path, role='SageMakerRole',
-               train_instance_count=1, train_instance_type='local',
-               sagemaker_session=sagemaker_local_session)
+        mx = MXNet(entry_point=script_path, role='SageMakerRole',
+                   train_instance_count=1, train_instance_type='local',
+                   output_path=output_path,
+                   sagemaker_session=sagemaker_local_session)
 
-    train_input = mx.sagemaker_session.upload_data(path=os.path.join(data_path, 'train'),
-                                                   key_prefix='integ-test-data/mxnet_mnist/train')
-    test_input = mx.sagemaker_session.upload_data(path=os.path.join(data_path, 'test'),
-                                                  key_prefix='integ-test-data/mxnet_mnist/test')
+        train_input = mx.sagemaker_session.upload_data(path=os.path.join(data_path, 'train'),
+                                                       key_prefix='integ-test-data/mxnet_mnist/train')
+        test_input = mx.sagemaker_session.upload_data(path=os.path.join(data_path, 'test'),
+                                                      key_prefix='integ-test-data/mxnet_mnist/test')
 
-    mx.fit({'train': train_input, 'test': test_input})
-    model = mx.create_model(1)
-    return model
+        mx.fit({'train': train_input, 'test': test_input})
+        model = mx.create_model(1)
+        return model
+    return _create_model
 
 
 @pytest.mark.skipif(PYTHON_VERSION != 'py2', reason="TensorFlow image supports only python 2.")
@@ -259,15 +261,9 @@ def test_local_mode_serving_from_s3_model(sagemaker_local_session, mxnet_model):
     local_mode_lock_fd = open(LOCK_PATH, 'w')
     local_mode_lock = local_mode_lock_fd.fileno()
 
-    model_data = mxnet_model.model_data
-    boto_session = sagemaker_local_session.boto_session
-    default_bucket = sagemaker_local_session.default_bucket()
-    uploaded_data = tar_and_upload_dir(boto_session, default_bucket,
-                                       'test_mxnet_local_mode', '', model_data)
-
-    s3_model = MXNetModel(model_data=uploaded_data.s3_prefix, role='SageMakerRole',
-                          entry_point=mxnet_model.entry_point, image=mxnet_model.image,
-                          sagemaker_session=sagemaker_local_session)
+    path = 's3://%s' % sagemaker_local_session.default_bucket()
+    s3_model = mxnet_model(path)
+    s3_model.sagemaker_session = sagemaker_local_session
 
     predictor = None
     try:
@@ -285,7 +281,7 @@ def test_local_mode_serving_from_s3_model(sagemaker_local_session, mxnet_model):
         fcntl.lockf(local_mode_lock, fcntl.LOCK_UN)
 
 
-def test_local_mode_serving_from_local_model(sagemaker_local_session, mxnet_model):
+def test_local_mode_serving_from_local_model(tmpdir, sagemaker_local_session, mxnet_model):
     local_mode_lock_fd = open(LOCK_PATH, 'w')
     local_mode_lock = local_mode_lock_fd.fileno()
     predictor = None
@@ -295,8 +291,10 @@ def test_local_mode_serving_from_local_model(sagemaker_local_session, mxnet_mode
         # to allow concurrent test execution. The serving test is really fast so it still
         # makes sense to allow this behavior.
         fcntl.lockf(local_mode_lock, fcntl.LOCK_EX)
-        mxnet_model.sagemaker_session = sagemaker_local_session
-        predictor = mxnet_model.deploy(initial_instance_count=1, instance_type='local')
+        path = 'file://%s' % (str(tmpdir))
+        model = mxnet_model(path)
+        model.sagemaker_session = sagemaker_local_session
+        predictor = model.deploy(initial_instance_count=1, instance_type='local')
         data = numpy.zeros(shape=(1, 1, 28, 28))
         predictor.predict(data)
     finally:

--- a/tests/unit/test_estimator.py
+++ b/tests/unit/test_estimator.py
@@ -867,4 +867,24 @@ def test_distributed_gpu_local_mode(LocalSession):
     with pytest.raises(RuntimeError):
         Estimator(IMAGE_NAME, ROLE, 3, 'local_gpu', output_path=OUTPUT_PATH)
 
+
+@patch('sagemaker.estimator.LocalSession')
+def test_local_mode_file_output_path(local_session_class):
+    local_session = Mock()
+    local_session.local_mode = True
+    local_session_class.return_value = local_session
+
+    e = Estimator(IMAGE_NAME, ROLE, INSTANCE_COUNT, 'local', output_path='file:///tmp/model/')
+    assert e.output_path == 'file:///tmp/model/'
+
+
+@patch('sagemaker.estimator.Session')
+def test_file_output_path_not_supported_outside_local_mode(session_class):
+    session = Mock()
+    session.local_mode = False
+    session_class.return_value = session
+
+    with pytest.raises(RuntimeError):
+        Estimator(IMAGE_NAME, ROLE, INSTANCE_COUNT, INSTANCE_TYPE, output_path='file:///tmp/model')
+
 #################################################################################

--- a/tests/unit/test_local_entities.py
+++ b/tests/unit/test_local_entities.py
@@ -157,7 +157,7 @@ def test_local_transform_job_perform_batch_inference(get_config_value, move_to_d
 
     local_transform_job._perform_batch_inference(input_data, output_data, **transform_kwargs)
 
-    dir, output, session = move_to_destination.call_args[0]
+    dir, output, job_name, session = move_to_destination.call_args[0]
     assert output == 's3://bucket/output'
     output_files = os.listdir(dir)
     assert len(output_files) == 2

--- a/tests/unit/test_local_utils.py
+++ b/tests/unit/test_local_utils.py
@@ -15,7 +15,7 @@ from __future__ import absolute_import
 import pytest
 from mock import patch, Mock
 
-import sagemaker
+import sagemaker.local.utils
 
 BUCKET_NAME = 'some-nice-bucket'
 
@@ -24,14 +24,15 @@ BUCKET_NAME = 'some-nice-bucket'
 @patch('sagemaker.local.utils.recursive_copy')
 def test_move_to_destination(recursive_copy):
     # local files will just be recursive copied
-    sagemaker.local.utils.move_to_destination('/tmp/data', 'file:///target/dir/', None)
+    sagemaker.local.utils.move_to_destination('/tmp/data', 'file:///target/dir/', 'job', None)
     recursive_copy.assert_called()
 
     # s3 destination will upload to S3
     sms = Mock()
-    sagemaker.local.utils.move_to_destination('/tmp/data', 's3://bucket/path', sms)
+    sagemaker.local.utils.move_to_destination('/tmp/data', 's3://bucket/path', 'job', sms)
     sms.upload_data.assert_called()
 
-    # weird destination, should raise an exception
+
+def test_move_to_destination_illegal_destination():
     with pytest.raises(ValueError):
-        sagemaker.local.utils.move_to_destination('/tmp/data', 'ftp://ftp/in/2018', None)
+        sagemaker.local.utils.move_to_destination('/tmp/data', 'ftp://ftp/in/2018', 'job', None)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -252,3 +252,24 @@ def test_download_file():
                                   '/tmp/file.tar.gz', session)
 
     bucket_mock.download_file.assert_called_with('prefix/path/file.tar.gz', '/tmp/file.tar.gz')
+
+
+@patch('tarfile.open')
+def test_create_tar_file_with_provided_path(open):
+    open.return_value = open
+    open.__enter__ = Mock()
+    open.__exit__ = Mock(return_value=None)
+    file_list = ['/tmp/a', '/tmp/b']
+    path = sagemaker.utils.create_tar_file(file_list, target='/my/custom/path.tar.gz')
+    assert path == '/my/custom/path.tar.gz'
+
+
+@patch('tarfile.open')
+@patch('tempfile.mkstemp', Mock(return_value=(None, '/auto/generated/path')))
+def test_create_tar_file_with_auto_generated_path(open):
+    open.return_value = open
+    open.__enter__ = Mock()
+    open.__exit__ = Mock(return_value=None)
+    file_list = ['/tmp/a', '/tmp/b']
+    path = sagemaker.utils.create_tar_file(file_list)
+    assert path == '/auto/generated/path'

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,8 @@ ignore =
     FI54,
     FI55,
     FI56,
-    FI57
+    FI57,
+    W503
 
 require-code = True
 


### PR DESCRIPTION
Can be either file:// or s3:// - This also changes the default
behavior of local mode to use the SDK provided default S3 bucket
if nothing is passed. This makes it easier for customers to create
models in SageMaker too since their Model Artifacts will already be
a tarfile in S3.

*Issue #, if available:*

*Description of changes:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have updated the [changelog](https://github.com/aws/sagemaker-python-sdk/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [x] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
