### PR TITLE
Add model parameters to Estimator, and bump library version to 1.13.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 CHANGELOG
 =========
 
+1.13.0
+======
+
+* feature: Estimator: add input mode to training channels
+* feature: Estimator: add model_uri and model_channel_name parameters
+
 1.12.0
 ======
 

--- a/README.rst
+++ b/README.rst
@@ -266,7 +266,7 @@ A few important notes:
 Incremental Training
 ~~~~~~~~~~~~~~~~~~~~
 
-Incremental training allows you to bring a pre-trained model into a SageMaker training job, to use as a starting point for a new model.
+Incremental training allows you to bring a pre-trained model into a SageMaker training job and use it as a starting point for a new model.
 There are several situations where you might want to do this:
 
 - You want to perform additional training on a model to improve its fit on your data set.

--- a/src/sagemaker/__init__.py
+++ b/src/sagemaker/__init__.py
@@ -35,4 +35,4 @@ from sagemaker.session import production_variant  # noqa: F401
 from sagemaker.session import s3_input  # noqa: F401
 from sagemaker.session import get_execution_role  # noqa: F401
 
-__version__ = '1.12.0'
+__version__ = '1.13.0'

--- a/src/sagemaker/amazon/amazon_estimator.py
+++ b/src/sagemaker/amazon/amazon_estimator.py
@@ -70,17 +70,19 @@ class AmazonAlgorithmEstimatorBase(EstimatorBase):
         self._data_location = data_location
 
     @classmethod
-    def _prepare_init_params_from_job_description(cls, job_details):
+    def _prepare_init_params_from_job_description(cls, job_details, model_channel_name=None):
         """Convert the job description to init params that can be handled by the class constructor
 
         Args:
             job_details: the returned job details from a describe_training_job API call.
+            model_channel_name (str): Name of the channel where pre-trained model data will be downloaded.
 
         Returns:
              dictionary: The transformed init_params
 
         """
-        init_params = super(AmazonAlgorithmEstimatorBase, cls)._prepare_init_params_from_job_description(job_details)
+        init_params = super(AmazonAlgorithmEstimatorBase, cls)._prepare_init_params_from_job_description(
+            job_details, model_channel_name)
 
         # The hyperparam names may not be the same as the class attribute that holds them,
         # for instance: local_lloyd_init_method is called local_init_method. We need to map these

--- a/src/sagemaker/chainer/estimator.py
+++ b/src/sagemaker/chainer/estimator.py
@@ -134,17 +134,18 @@ class Chainer(Framework):
                             vpc_config=self.get_vpc_config(vpc_config_override))
 
     @classmethod
-    def _prepare_init_params_from_job_description(cls, job_details):
+    def _prepare_init_params_from_job_description(cls, job_details, model_channel_name=None):
         """Convert the job description to init params that can be handled by the class constructor
 
         Args:
             job_details: the returned job details from a describe_training_job API call.
+            model_channel_name (str): Name of the channel where pre-trained model data will be downloaded.
 
         Returns:
              dictionary: The transformed init_params
 
         """
-        init_params = super(Chainer, cls)._prepare_init_params_from_job_description(job_details)
+        init_params = super(Chainer, cls)._prepare_init_params_from_job_description(job_details, model_channel_name)
 
         for argument in [Chainer._use_mpi, Chainer._num_processes, Chainer._process_slots_per_host,
                          Chainer._additional_mpi_options]:

--- a/src/sagemaker/estimator.py
+++ b/src/sagemaker/estimator.py
@@ -644,7 +644,6 @@ class Framework(EstimatorBase):
                 Valid values are defined in the Python logging module.
             code_location (str): Name of the S3 bucket where custom code is uploaded (default: None).
                 If not specified, default bucket created by ``sagemaker.session.Session`` is used.
-            **kwargs: Additional kwargs passed to the ``EstimatorBase`` constructor.
             image_name (str): An alternate image name to use instead of the official Sagemaker image
                 for the framework. This is useful to run one of the Sagemaker supported frameworks
                 with an image containing custom dependencies.

--- a/src/sagemaker/estimator.py
+++ b/src/sagemaker/estimator.py
@@ -19,6 +19,7 @@ import warnings
 from abc import ABCMeta
 from abc import abstractmethod
 from six import with_metaclass
+from six import string_types
 
 from sagemaker.analytics import TrainingJobAnalytics
 from sagemaker.fw_utils import (create_image_uri, tar_and_upload_dir, parse_s3_url, UploadedCode,
@@ -49,7 +50,7 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):
     def __init__(self, role, train_instance_count, train_instance_type,
                  train_volume_size=30, train_volume_kms_key=None, train_max_run=24 * 60 * 60, input_mode='File',
                  output_path=None, output_kms_key=None, base_job_name=None, sagemaker_session=None, tags=None,
-                 subnets=None, security_group_ids=None):
+                 subnets=None, security_group_ids=None, model_uri=None, model_channel_name='model'):
         """Initialize an ``EstimatorBase`` instance.
 
         Args:
@@ -69,6 +70,7 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):
             input_mode (str): The input mode that the algorithm supports (default: 'File'). Valid modes:
                 'File' - Amazon SageMaker copies the training dataset from the S3 location to a local directory.
                 'Pipe' - Amazon SageMaker streams data directly from S3 to the container via a Unix-named pipe.
+                This argument can be overriden on a per-channel basis using ``sagemaker.session.s3_input.input_mode``.
             output_path (str): S3 location for saving the trainig result (model artifacts and output files).
                 If not specified, results are stored to a default bucket. If the bucket with the specific name
                 does not exist, the estimator creates the bucket during the
@@ -85,6 +87,16 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):
             subnets (list[str]): List of subnet ids. If not specified training job will be created without VPC config.
             security_group_ids (list[str]): List of security group ids. If not specified training job will be created
                 without VPC config.
+            model_uri (str): URI where a pre-trained model is stored, either locally or in S3 (default: None). If
+                specified, the estimator will create a channel pointing to the model so the training job can download
+                it. This model can be a 'model.tar.gz' from a previous training job, or other artifacts coming from a
+                different source.
+
+                In local mode, this should point to the path in which the model is located and not the file itself, as
+                local Docker containers will try to mount the URI as a volume.
+
+                More information: https://docs.aws.amazon.com/sagemaker/latest/dg/cdf-training.html#td-deserialization
+            model_channel_name (str): Name of the channel where 'model_uri' will be downloaded (default: 'model').
         """
         self.role = role
         self.train_instance_count = train_instance_count
@@ -94,6 +106,8 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):
         self.train_max_run = train_max_run
         self.input_mode = input_mode
         self.tags = tags
+        self.model_uri = model_uri
+        self.model_channel_name = model_channel_name
 
         if self.train_instance_type in ('local', 'local_gpu'):
             if self.train_instance_type == 'local_gpu' and self.train_instance_count > 1:
@@ -209,7 +223,7 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):
         raise NotImplementedError()
 
     @classmethod
-    def attach(cls, training_job_name, sagemaker_session=None):
+    def attach(cls, training_job_name, sagemaker_session=None, model_channel_name='model'):
         """Attach to an existing training job.
 
         Create an Estimator bound to an existing training job, each subclass is responsible to implement
@@ -225,6 +239,8 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):
             sagemaker_session (sagemaker.session.Session): Session object which manages interactions with
                 Amazon SageMaker APIs and any other AWS services needed. If not specified, the estimator creates one
                 using the default AWS configuration chain.
+            model_channel_name (str): Name of the channel where pre-trained model data will be downloaded (default:
+                'model'). If no channel with the same name exists in the training job, this option will be ignored.
 
         Examples:
             >>> my_estimator.fit(wait=False)
@@ -239,7 +255,7 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):
         sagemaker_session = sagemaker_session or Session()
 
         job_details = sagemaker_session.sagemaker_client.describe_training_job(TrainingJobName=training_job_name)
-        init_params = cls._prepare_init_params_from_job_description(job_details)
+        init_params = cls._prepare_init_params_from_job_description(job_details, model_channel_name)
 
         estimator = cls(sagemaker_session=sagemaker_session, **init_params)
         estimator.latest_training_job = _TrainingJob(sagemaker_session=sagemaker_session,
@@ -294,11 +310,12 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):
         pass
 
     @classmethod
-    def _prepare_init_params_from_job_description(cls, job_details):
+    def _prepare_init_params_from_job_description(cls, job_details, model_channel_name=None):
         """Convert the job description to init params that can be handled by the class constructor
 
         Args:
             job_details: the returned job details from a describe_training_job API call.
+            model_channel_name (str): Name of the channel where pre-trained model data will be downloaded.
 
         Returns:
              dictionary: The transformed init_params
@@ -324,6 +341,13 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):
             init_params['subnets'] = subnets
         if security_group_ids:
             init_params['security_group_ids'] = security_group_ids
+
+        if 'InputDataConfig' in job_details and model_channel_name:
+            for channel in job_details['InputDataConfig']:
+                if channel['ChannelName'] == model_channel_name:
+                    init_params['model_channel_name'] = model_channel_name
+                    init_params['model_uri'] = channel['DataSource']['S3DataSource']['S3Uri']
+                    break
 
         return init_params
 
@@ -415,9 +439,10 @@ class _TrainingJob(_Job):
         """
 
         local_mode = estimator.sagemaker_session.local_mode
+        model_uri = estimator.model_uri
 
         # Allow file:// input only in local mode
-        if isinstance(inputs, str) and inputs.startswith('file://'):
+        if cls._is_local_channel(inputs) or cls._is_local_channel(model_uri):
             if not local_mode:
                 raise ValueError('File URIs are supported in local mode only. Please use a S3 URI instead.')
 
@@ -435,6 +460,10 @@ class _TrainingJob(_Job):
 
         return cls(estimator.sagemaker_session, estimator._current_job_name)
 
+    @classmethod
+    def _is_local_channel(cls, input_uri):
+        return isinstance(input_uri, string_types) and input_uri.startswith('file://')
+
     def wait(self, logs=True):
         if logs:
             self.sagemaker_session.logs_for_job(self.job_name, wait=True)
@@ -451,7 +480,8 @@ class Estimator(EstimatorBase):
     def __init__(self, image_name, role, train_instance_count, train_instance_type,
                  train_volume_size=30, train_volume_kms_key=None, train_max_run=24 * 60 * 60,
                  input_mode='File', output_path=None, output_kms_key=None, base_job_name=None,
-                 sagemaker_session=None, hyperparameters=None, tags=None, subnets=None, security_group_ids=None):
+                 sagemaker_session=None, hyperparameters=None, tags=None, subnets=None, security_group_ids=None,
+                 model_uri=None, model_channel_name='model'):
         """Initialize an ``Estimator`` instance.
 
         Args:
@@ -474,6 +504,7 @@ class Estimator(EstimatorBase):
                 * 'File' - Amazon SageMaker copies the training dataset from the S3 location to a local directory.
                 * 'Pipe' - Amazon SageMaker streams data directly from S3 to the container via a Unix-named pipe.
 
+                This argument can be overriden on a per-channel basis using ``sagemaker.session.s3_input.input_mode``.
             output_path (str): S3 location for saving the trainig result (model artifacts and output files).
                 If not specified, results are stored to a default bucket. If the bucket with the specific name
                 does not exist, the estimator creates the bucket during the
@@ -491,13 +522,24 @@ class Estimator(EstimatorBase):
             subnets (list[str]): List of subnet ids. If not specified training job will be created without VPC config.
             security_group_ids (list[str]): List of security group ids. If not specified training job will be created
                 without VPC config.
+            model_uri (str): URI where a pre-trained model is stored, either locally or in S3 (default: None). If
+                specified, the estimator will create a channel pointing to the model so the training job can download
+                it. This model can be a 'model.tar.gz' from a previous training job, or other artifacts coming from a
+                different source.
+
+                In local mode, this should point to the path in which the model is located and not the file itself,
+                as local Docker containers will try to mount the URI as a volume.
+
+                More information: https://docs.aws.amazon.com/sagemaker/latest/dg/cdf-training.html#td-deserialization
+            model_channel_name (str): Name of the channel where 'model_uri' will be downloaded (default: 'model').
         """
         self.image_name = image_name
         self.hyperparam_dict = hyperparameters.copy() if hyperparameters else {}
         super(Estimator, self).__init__(role, train_instance_count, train_instance_type,
                                         train_volume_size, train_volume_kms_key, train_max_run, input_mode,
                                         output_path, output_kms_key, base_job_name, sagemaker_session,
-                                        tags, subnets, security_group_ids)
+                                        tags, subnets, security_group_ids, model_uri=model_uri,
+                                        model_channel_name=model_channel_name)
 
     def train_image(self):
         """
@@ -558,17 +600,18 @@ class Estimator(EstimatorBase):
                      sagemaker_session=self.sagemaker_session, predictor_cls=predictor_cls, **kwargs)
 
     @classmethod
-    def _prepare_init_params_from_job_description(cls, job_details):
+    def _prepare_init_params_from_job_description(cls, job_details, model_channel_name=None):
         """Convert the job description to init params that can be handled by the class constructor
 
         Args:
             job_details: the returned job details from a describe_training_job API call.
+            model_channel_name (str): Name of the channel where pre-trained model data will be downloaded
 
         Returns:
              dictionary: The transformed init_params
 
         """
-        init_params = super(Estimator, cls)._prepare_init_params_from_job_description(job_details)
+        init_params = super(Estimator, cls)._prepare_init_params_from_job_description(job_details, model_channel_name)
 
         init_params['image_name'] = init_params.pop('image')
         return init_params
@@ -601,6 +644,7 @@ class Framework(EstimatorBase):
                 Valid values are defined in the Python logging module.
             code_location (str): Name of the S3 bucket where custom code is uploaded (default: None).
                 If not specified, default bucket created by ``sagemaker.session.Session`` is used.
+            **kwargs: Additional kwargs passed to the ``EstimatorBase`` constructor.
             image_name (str): An alternate image name to use instead of the official Sagemaker image
                 for the framework. This is useful to run one of the Sagemaker supported frameworks
                 with an image containing custom dependencies.
@@ -695,17 +739,18 @@ class Framework(EstimatorBase):
         return self._json_encode_hyperparameters(self._hyperparameters)
 
     @classmethod
-    def _prepare_init_params_from_job_description(cls, job_details):
+    def _prepare_init_params_from_job_description(cls, job_details, model_channel_name=None):
         """Convert the job description to init params that can be handled by the class constructor
 
         Args:
             job_details: the returned job details from a describe_training_job API call.
+            model_channel_name (str): Name of the channel where pre-trained model data will be downloaded
 
         Returns:
              dictionary: The transformed init_params
 
         """
-        init_params = super(Framework, cls)._prepare_init_params_from_job_description(job_details)
+        init_params = super(Framework, cls)._prepare_init_params_from_job_description(job_details, model_channel_name)
 
         init_params['entry_point'] = json.loads(init_params['hyperparameters'].get(SCRIPT_PARAM_NAME))
         init_params['source_dir'] = json.loads(init_params['hyperparameters'].get(DIR_PARAM_NAME))
@@ -744,7 +789,7 @@ class Framework(EstimatorBase):
                                     self.train_instance_type, self.framework_version, py_version=self.py_version)
 
     @classmethod
-    def attach(cls, training_job_name, sagemaker_session=None):
+    def attach(cls, training_job_name, sagemaker_session=None, model_channel_name='model'):
         """Attach to an existing training job.
 
         Create an Estimator bound to an existing training job, each subclass is responsible to implement
@@ -760,6 +805,8 @@ class Framework(EstimatorBase):
             sagemaker_session (sagemaker.session.Session): Session object which manages interactions with
                 Amazon SageMaker APIs and any other AWS services needed. If not specified, the estimator creates one
                 using the default AWS configuration chain.
+            model_channel_name (str): Name of the channel where pre-trained model data will be downloaded (default:
+                'model'). If no channel with the same name exists in the training job, this option will be ignored.
 
         Examples:
             >>> my_estimator.fit(wait=False)
@@ -771,7 +818,7 @@ class Framework(EstimatorBase):
         Returns:
             Instance of the calling ``Estimator`` Class with the attached training job.
         """
-        estimator = super(Framework, cls).attach(training_job_name, sagemaker_session)
+        estimator = super(Framework, cls).attach(training_job_name, sagemaker_session, model_channel_name)
         estimator.uploaded_code = UploadedCode(estimator.source_dir, estimator.entry_point)
         return estimator
 

--- a/src/sagemaker/mxnet/estimator.py
+++ b/src/sagemaker/mxnet/estimator.py
@@ -100,17 +100,18 @@ class MXNet(Framework):
                           vpc_config=self.get_vpc_config(vpc_config_override))
 
     @classmethod
-    def _prepare_init_params_from_job_description(cls, job_details):
+    def _prepare_init_params_from_job_description(cls, job_details, model_channel_name=None):
         """Convert the job description to init params that can be handled by the class constructor
 
         Args:
             job_details: the returned job details from a describe_training_job API call.
+            model_channel_name (str): Name of the channel where pre-trained model data will be downloaded.
 
         Returns:
              dictionary: The transformed init_params
 
         """
-        init_params = super(MXNet, cls)._prepare_init_params_from_job_description(job_details)
+        init_params = super(MXNet, cls)._prepare_init_params_from_job_description(job_details, model_channel_name)
         image_name = init_params.pop('image')
         framework, py_version, tag = framework_name_from_image(image_name)
 

--- a/src/sagemaker/pytorch/estimator.py
+++ b/src/sagemaker/pytorch/estimator.py
@@ -99,17 +99,18 @@ class PyTorch(Framework):
                             vpc_config=self.get_vpc_config(vpc_config_override))
 
     @classmethod
-    def _prepare_init_params_from_job_description(cls, job_details):
+    def _prepare_init_params_from_job_description(cls, job_details, model_channel_name=None):
         """Convert the job description to init params that can be handled by the class constructor
 
         Args:
             job_details: the returned job details from a describe_training_job API call.
+            model_channel_name (str): Name of the channel where pre-trained model data will be downloaded.
 
         Returns:
              dictionary: The transformed init_params
 
         """
-        init_params = super(PyTorch, cls)._prepare_init_params_from_job_description(job_details)
+        init_params = super(PyTorch, cls)._prepare_init_params_from_job_description(job_details, model_channel_name)
         image_name = init_params.pop('image')
         framework, py_version, tag = framework_name_from_image(image_name)
 

--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -1009,7 +1009,8 @@ class s3_input(object):
     """
 
     def __init__(self, s3_data, distribution='FullyReplicated', compression=None,
-                 content_type=None, record_wrapping=None, s3_data_type='S3Prefix'):
+                 content_type=None, record_wrapping=None, s3_data_type='S3Prefix',
+                 input_mode=None):
         """Create a definition for input data used by an SageMaker training job.
 
         See AWS documentation on the ``CreateTrainingJob`` API for more details on the parameters.
@@ -1026,6 +1027,12 @@ class s3_input(object):
                 be used to train. If 'ManifestFile', then ``s3_data`` defines a single s3 manifest file, listing
                 each s3 object to train on. The Manifest file format is described in the SageMaker API documentation:
                 https://docs.aws.amazon.com/sagemaker/latest/dg/API_S3DataSource.html
+            input_mode (str): Optional override for this channel's input mode (default: None). By default, channels will
+                use the input mode defined on ``sagemaker.estimator.EstimatorBase.input_mode``, but they will ignore
+                that setting if this parameter is set.
+                * None - Amazon SageMaker will use the input mode specified in the ``Estimator``.
+                * 'File' - Amazon SageMaker copies the training dataset from the S3 location to a local directory.
+                * 'Pipe' - Amazon SageMaker streams data directly from S3 to the container via a Unix-named pipe.
         """
         self.config = {
             'DataSource': {
@@ -1043,6 +1050,8 @@ class s3_input(object):
             self.config['ContentType'] = content_type
         if record_wrapping is not None:
             self.config['RecordWrapperType'] = record_wrapping
+        if input_mode is not None:
+            self.config['InputMode'] = input_mode
 
 
 def _deployment_entity_exists(describe_fn):

--- a/src/sagemaker/tensorflow/estimator.py
+++ b/src/sagemaker/tensorflow/estimator.py
@@ -253,7 +253,7 @@ class TensorFlow(Framework):
             fit_super()
 
     @classmethod
-    def _prepare_init_params_from_job_description(cls, job_details):
+    def _prepare_init_params_from_job_description(cls, job_details, model_channel_name=None):
         """Convert the job description to init params that can be handled by the class constructor
 
         Args:
@@ -263,7 +263,7 @@ class TensorFlow(Framework):
              dictionary: The transformed init_params
 
         """
-        init_params = super(TensorFlow, cls)._prepare_init_params_from_job_description(job_details)
+        init_params = super(TensorFlow, cls)._prepare_init_params_from_job_description(job_details, model_channel_name)
 
         # Move some of the tensorflow specific init params from hyperparameters into the main init params.
         for argument in ['checkpoint_path', 'training_steps', 'evaluation_steps']:

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -147,7 +147,8 @@ def test_s3_input_all_arguments():
     content_type = 'text/csv'
     record_wrapping = 'RecordIO'
     s3_data_type = 'Manifestfile'
-    result = s3_input(s3_data=prefix, distribution=distribution, compression=compression,
+    input_mode = 'Pipe'
+    result = s3_input(s3_data=prefix, distribution=distribution, compression=compression, input_mode=input_mode,
                       content_type=content_type, record_wrapping=record_wrapping, s3_data_type=s3_data_type)
     expected = \
         {'DataSource': {
@@ -159,7 +160,8 @@ def test_s3_input_all_arguments():
         },
             'CompressionType': compression,
             'ContentType': content_type,
-            'RecordWrapperType': record_wrapping
+            'RecordWrapperType': record_wrapping,
+            'InputMode': input_mode
         }
 
     assert result.config == expected


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This code change adds the following changes to Estimators:
- Added the ability to set the input mode on each channel. The input mode will default to whatever's set on the Estimator, but if a channel specifies its own input mode it will override that value.
- Added two new parameters to the Estimator class: model_uri, which points to pre-existing model artifacts in S3 or locally, and model_channel_name (default: 'model'). When both are set and a user calls Estimator.fit(), the estimator will create a new input channel under that name, pointing to the contents of model_uri and using SageMaker's recommended settings for model artifact consumption.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have updated the [changelog](https://github.com/aws/sagemaker-python-sdk/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [x] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
