### PR TITLE
Updating Cloudwatch namespace for metrics in TrainingJobsAnalytics

### DIFF
--- a/src/sagemaker/analytics.py
+++ b/src/sagemaker/analytics.py
@@ -199,7 +199,7 @@ class TrainingJobAnalytics(AnalyticsMetricsBase):
     """Fetch training curve data from CloudWatch Metrics for a specific training job.
     """
 
-    CLOUDWATCH_NAMESPACE = '/aws/sagemaker/HyperParameterTuningJobs'
+    CLOUDWATCH_NAMESPACE = '/aws/sagemaker/TrainingJobs'
 
     def __init__(self, training_job_name, metric_names=None, sagemaker_session=None):
         """Initialize a ``TrainingJobAnalytics`` instance.


### PR DESCRIPTION
*Issue #, if available:* none

*Description of changes:*
`TrainingJobAnalytics` class was looking in the wrong namespace for cloudwatch metrics.  This has been updated.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have updated the [changelog](https://github.com/aws/sagemaker-python-sdk/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [x] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
