### PR TITLE
Add airflow module that could export training config

### DIFF
--- a/src/sagemaker/job.py
+++ b/src/sagemaker/job.py
@@ -114,14 +114,13 @@ class _Job(object):
     @staticmethod
     def _format_string_uri_input(uri_input, validate_uri=True):
         if isinstance(uri_input, str):
-            if validate_uri:
-                if uri_input.startswith('s3://'):
-                    return s3_input(uri_input)
-                elif uri_input.startswith('file://'):
-                    return file_input(uri_input)
-                else:
-                    raise ValueError('Training input data must be a valid S3 or FILE URI: must start with "s3://" or '
-                                     '"file://"')
+            if validate_uri and uri_input.startswith('s3://'):
+                return s3_input(uri_input)
+            elif validate_uri and uri_input.startswith('file://'):
+                return file_input(uri_input)
+            elif validate_uri:
+                raise ValueError('Training input data must be a valid S3 or FILE URI: must start with "s3://" or '
+                                 '"file://"')
             else:
                 return s3_input(uri_input)
         elif isinstance(uri_input, s3_input):
@@ -151,15 +150,14 @@ class _Job(object):
     @staticmethod
     def _format_model_uri_input(model_uri, validate_uri=True):
         if isinstance(model_uri, string_types):
-            if validate_uri:
-                if model_uri.startswith('s3://'):
-                    return s3_input(model_uri, input_mode='File', distribution='FullyReplicated',
-                                    content_type='application/x-sagemaker-model')
-                elif model_uri.startswith('file://'):
-                    return file_input(model_uri)
-                else:
-                    raise ValueError('Model URI must be a valid S3 or FILE URI: must start with "s3://" or '
-                                     '"file://')
+            if validate_uri and model_uri.startswith('s3://'):
+                return s3_input(model_uri, input_mode='File', distribution='FullyReplicated',
+                                content_type='application/x-sagemaker-model')
+            elif validate_uri and model_uri.startswith('file://'):
+                return file_input(model_uri)
+            elif validate_uri:
+                raise ValueError('Model URI must be a valid S3 or FILE URI: must start with "s3://" or '
+                                 '"file://')
             else:
                 return s3_input(model_uri, input_mode='File', distribution='FullyReplicated',
                                 content_type='application/x-sagemaker-model')

--- a/src/sagemaker/job.py
+++ b/src/sagemaker/job.py
@@ -51,9 +51,9 @@ class _Job(object):
         pass
 
     @staticmethod
-    def _load_config(inputs, estimator):
-        input_config = _Job._format_inputs_to_input_config(inputs)
-        role = estimator.sagemaker_session.expand_role(estimator.role)
+    def _load_config(inputs, estimator, expand_role=True, validate_uri=True):
+        input_config = _Job._format_inputs_to_input_config(inputs, validate_uri)
+        role = estimator.sagemaker_session.expand_role(estimator.role) if expand_role else estimator.role
         output_config = _Job._prepare_output_config(estimator.output_path, estimator.output_kms_key)
         resource_config = _Job._prepare_resource_config(estimator.train_instance_count,
                                                         estimator.train_instance_type,
@@ -62,7 +62,8 @@ class _Job(object):
         stop_condition = _Job._prepare_stop_condition(estimator.train_max_run)
         vpc_config = estimator.get_vpc_config()
 
-        model_channel = _Job._prepare_model_channel(input_config, estimator.model_uri, estimator.model_channel_name)
+        model_channel = _Job._prepare_model_channel(input_config, estimator.model_uri, estimator.model_channel_name,
+                                                    validate_uri)
         if model_channel:
             input_config = [] if input_config is None else input_config
             input_config.append(model_channel)
@@ -75,7 +76,7 @@ class _Job(object):
                 'vpc_config': vpc_config}
 
     @staticmethod
-    def _format_inputs_to_input_config(inputs):
+    def _format_inputs_to_input_config(inputs, validate_uri=True):
         if inputs is None:
             return None
 
@@ -86,14 +87,14 @@ class _Job(object):
 
         input_dict = {}
         if isinstance(inputs, string_types):
-            input_dict['training'] = _Job._format_string_uri_input(inputs)
+            input_dict['training'] = _Job._format_string_uri_input(inputs, validate_uri)
         elif isinstance(inputs, s3_input):
             input_dict['training'] = inputs
         elif isinstance(inputs, file_input):
             input_dict['training'] = inputs
         elif isinstance(inputs, dict):
             for k, v in inputs.items():
-                input_dict[k] = _Job._format_string_uri_input(v)
+                input_dict[k] = _Job._format_string_uri_input(v, validate_uri)
         elif isinstance(inputs, list):
             input_dict = _Job._format_record_set_list_input(inputs)
         else:
@@ -111,15 +112,18 @@ class _Job(object):
         return channel_config
 
     @staticmethod
-    def _format_string_uri_input(uri_input):
+    def _format_string_uri_input(uri_input, validate_uri=True):
         if isinstance(uri_input, str):
-            if uri_input.startswith('s3://'):
-                return s3_input(uri_input)
-            elif uri_input.startswith('file://'):
-                return file_input(uri_input)
+            if validate_uri:
+                if uri_input.startswith('s3://'):
+                    return s3_input(uri_input)
+                elif uri_input.startswith('file://'):
+                    return file_input(uri_input)
+                else:
+                    raise ValueError('Training input data must be a valid S3 or FILE URI: must start with "s3://" or '
+                                     '"file://"')
             else:
-                raise ValueError('Training input data must be a valid S3 or FILE URI: must start with "s3://" or '
-                                 '"file://"')
+                return s3_input(uri_input)
         elif isinstance(uri_input, s3_input):
             return uri_input
         elif isinstance(uri_input, file_input):
@@ -128,7 +132,7 @@ class _Job(object):
             raise ValueError('Cannot format input {}. Expecting one of str, s3_input, or file_input'.format(uri_input))
 
     @staticmethod
-    def _prepare_model_channel(input_config, model_uri=None, model_channel_name=None):
+    def _prepare_model_channel(input_config, model_uri=None, model_channel_name=None, validate_uri=True):
         if not model_uri:
             return
         elif not model_channel_name:
@@ -139,22 +143,26 @@ class _Job(object):
                 if channel['ChannelName'] == model_channel_name:
                     raise ValueError('Duplicate channels not allowed.')
 
-        model_input = _Job._format_model_uri_input(model_uri)
+        model_input = _Job._format_model_uri_input(model_uri, validate_uri)
         model_channel = _Job._convert_input_to_channel(model_channel_name, model_input)
 
         return model_channel
 
     @staticmethod
-    def _format_model_uri_input(model_uri):
+    def _format_model_uri_input(model_uri, validate_uri=True):
         if isinstance(model_uri, string_types):
-            if model_uri.startswith('s3://'):
+            if validate_uri:
+                if model_uri.startswith('s3://'):
+                    return s3_input(model_uri, input_mode='File', distribution='FullyReplicated',
+                                    content_type='application/x-sagemaker-model')
+                elif model_uri.startswith('file://'):
+                    return file_input(model_uri)
+                else:
+                    raise ValueError('Model URI must be a valid S3 or FILE URI: must start with "s3://" or '
+                                     '"file://')
+            else:
                 return s3_input(model_uri, input_mode='File', distribution='FullyReplicated',
                                 content_type='application/x-sagemaker-model')
-            elif model_uri.startswith('file://'):
-                return file_input(model_uri)
-            else:
-                raise ValueError('Model URI must be a valid S3 or FILE URI: must start with "s3://" or '
-                                 '"file://')
         else:
             raise ValueError('Cannot format model URI {}. Expecting str'.format(model_uri))
 

--- a/src/sagemaker/job.py
+++ b/src/sagemaker/job.py
@@ -113,16 +113,15 @@ class _Job(object):
 
     @staticmethod
     def _format_string_uri_input(uri_input, validate_uri=True):
-        if isinstance(uri_input, str):
-            if validate_uri and uri_input.startswith('s3://'):
-                return s3_input(uri_input)
-            elif validate_uri and uri_input.startswith('file://'):
-                return file_input(uri_input)
-            elif validate_uri:
-                raise ValueError('Training input data must be a valid S3 or FILE URI: must start with "s3://" or '
-                                 '"file://"')
-            else:
-                return s3_input(uri_input)
+        if isinstance(uri_input, str) and validate_uri and uri_input.startswith('s3://'):
+            return s3_input(uri_input)
+        elif isinstance(uri_input, str) and validate_uri and uri_input.startswith('file://'):
+            return file_input(uri_input)
+        elif isinstance(uri_input, str) and validate_uri:
+            raise ValueError('Training input data must be a valid S3 or FILE URI: must start with "s3://" or '
+                             '"file://"')
+        elif isinstance(uri_input, str):
+            return s3_input(uri_input)
         elif isinstance(uri_input, s3_input):
             return uri_input
         elif isinstance(uri_input, file_input):
@@ -149,18 +148,17 @@ class _Job(object):
 
     @staticmethod
     def _format_model_uri_input(model_uri, validate_uri=True):
-        if isinstance(model_uri, string_types):
-            if validate_uri and model_uri.startswith('s3://'):
-                return s3_input(model_uri, input_mode='File', distribution='FullyReplicated',
-                                content_type='application/x-sagemaker-model')
-            elif validate_uri and model_uri.startswith('file://'):
-                return file_input(model_uri)
-            elif validate_uri:
-                raise ValueError('Model URI must be a valid S3 or FILE URI: must start with "s3://" or '
-                                 '"file://')
-            else:
-                return s3_input(model_uri, input_mode='File', distribution='FullyReplicated',
-                                content_type='application/x-sagemaker-model')
+        if isinstance(model_uri, string_types)and validate_uri and model_uri.startswith('s3://'):
+            return s3_input(model_uri, input_mode='File', distribution='FullyReplicated',
+                            content_type='application/x-sagemaker-model')
+        elif isinstance(model_uri, string_types) and validate_uri and model_uri.startswith('file://'):
+            return file_input(model_uri)
+        elif isinstance(model_uri, string_types) and validate_uri:
+            raise ValueError('Model URI must be a valid S3 or FILE URI: must start with "s3://" or '
+                             '"file://')
+        elif isinstance(model_uri, string_types):
+            return s3_input(model_uri, input_mode='File', distribution='FullyReplicated',
+                            content_type='application/x-sagemaker-model')
         else:
             raise ValueError('Cannot format model URI {}. Expecting str'.format(model_uri))
 

--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -169,11 +169,11 @@ class Session(object):
         if self._default_bucket:
             return self._default_bucket
 
-        s3 = self.boto_session.resource('s3')
         account = self.boto_session.client('sts').get_caller_identity()['Account']
         region = self.boto_session.region_name
         default_bucket = 'sagemaker-{}-{}'.format(region, account)
 
+        s3 = self.boto_session.resource('s3')
         try:
             # 'us-east-1' cannot be specified because it is the default region:
             # https://github.com/boto/boto3/issues/125

--- a/src/sagemaker/utils.py
+++ b/src/sagemaker/utils.py
@@ -61,9 +61,6 @@ def name_from_base(base, max_length=63, short=False):
 def airflow_name_from_base(base):
     """Append airflow execution_date macro to the provided string.
 
-    This function assures that the total length of the resulting string is not
-    longer than the specified max length, trimming the input parameter if necessary.
-
     Args:
         base (str): String used as prefix to generate the unique name.
 

--- a/src/sagemaker/utils.py
+++ b/src/sagemaker/utils.py
@@ -26,6 +26,8 @@ from functools import wraps
 import six
 
 
+AIRFLOW_TIME_MACRO = "{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}"
+
 # Use the base name of the image as the job name if the user doesn't give us one
 def name_from_image(image):
     """Create a training job name based on the image name and a timestamp.
@@ -61,14 +63,18 @@ def name_from_base(base, max_length=63, short=False):
 def airflow_name_from_base(base):
     """Append airflow execution_date macro to the provided string.
 
+    This is the right way to have the return value be the same in different
+    Airflow operators.
+    https://airflow.apache.org/code.html?#macros
+
     Args:
         base (str): String used as prefix to generate the unique name.
 
     Returns:
         str: Input parameter with appended macro.
     """
-    macro = "{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}"
-    return "{}-{}".format(base, macro)
+
+    return "{}-{}".format(base, AIRFLOW_TIME_MACRO)
 
 
 def base_name_from_image(image):

--- a/src/sagemaker/utils.py
+++ b/src/sagemaker/utils.py
@@ -58,6 +58,22 @@ def name_from_base(base, max_length=63, short=False):
     return '{}-{}'.format(trimmed_base, timestamp)
 
 
+def airflow_name_from_base(base):
+    """Append airflow execution_date macro to the provided string.
+
+    This function assures that the total length of the resulting string is not
+    longer than the specified max length, trimming the input parameter if necessary.
+
+    Args:
+        base (str): String used as prefix to generate the unique name.
+
+    Returns:
+        str: Input parameter with appended macro.
+    """
+    macro = "{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}"
+    return "{}-{}".format(base, macro)
+
+
 def base_name_from_image(image):
     """Extract the base name of the image to use as the 'algorithm name' for the job.
 

--- a/src/sagemaker/utils.py
+++ b/src/sagemaker/utils.py
@@ -28,6 +28,7 @@ import six
 
 AIRFLOW_TIME_MACRO = "{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}"
 
+
 # Use the base name of the image as the job name if the user doesn't give us one
 def name_from_image(image):
     """Create a training job name based on the image name and a timestamp.

--- a/src/sagemaker/utils.py
+++ b/src/sagemaker/utils.py
@@ -61,11 +61,9 @@ def name_from_base(base, max_length=63, short=False):
 
 
 def airflow_name_from_base(base):
-    """Append airflow execution_date macro to the provided string.
-
-    This is the right way to have the return value be the same in different
-    Airflow operators.
-    https://airflow.apache.org/code.html?#macros
+    """Append airflow execution_date macro (https://airflow.apache.org/code.html?#macros)
+    to the provided string. The macro will beevaluated in Airflow operator runtime.
+    This guarantees that different operators will have same name returned by this function.
 
     Args:
         base (str): String used as prefix to generate the unique name.

--- a/src/sagemaker/workflow/__init__.py
+++ b/src/sagemaker/workflow/__init__.py
@@ -1,0 +1,12 @@
+# Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.

--- a/src/sagemaker/workflow/airflow.py
+++ b/src/sagemaker/workflow/airflow.py
@@ -19,9 +19,8 @@ from sagemaker.amazon import amazon_estimator
 
 
 def prepare_framework(estimator, s3_operations):
-    """
-    Prepare S3 operations (specify where to upload source_dir) and environment variables
-        related to framework.
+    """Prepare S3 operations (specify where to upload source_dir) and environment variables
+    related to framework.
 
     Args:
         estimator (sagemaker.estimator.Estimator): The framework estimator to get information from and update.
@@ -49,11 +48,11 @@ def prepare_framework(estimator, s3_operations):
 
 
 def prepare_amazon_algorithm_estimator(estimator, inputs):
-    """
-    Set up amazon algorithm estimator, adding the required feature_dim hyperparameter from training data.
+    """ Set up amazon algorithm estimator, adding the required `feature_dim` hyperparameter from training data.
+
     Args:
         estimator (sagemaker.amazon.amazon_estimator.AmazonAlgorithmEstimatorBase):
-            The Amazon algorithm estimator to get information from and update.
+            An estimator for a built-in Amazon algorithm to get information from and update.
         inputs (single or list of sagemaker.amazon.amazon_estimator.RecordSet):
             The training data, must be in RecordSet format.
     """
@@ -69,14 +68,15 @@ def prepare_amazon_algorithm_estimator(estimator, inputs):
 
 
 def training_config(estimator, inputs=None, job_name=None):
-    """
-    Export Airflow training config from an estimator
+    """Export Airflow training config from an estimator
 
     Args:
-        estimator: The estimator to export training config from. Can be a BYO estimator,
+        estimator (sagemaker.estimator.EstimatroBase):
+            The estimator to export training config from. Can be a BYO estimator,
             Framework estimator or Amazon algorithm estimator.
-        inputs: The training data.
-        job_name: Specify a training job name if needed.
+        inputs (str, dict, single or list of sagemaker.amazon.amazon_estimator.RecordSet):
+            The training data.
+        job_name (str): Specify a training job name if needed.
 
     Returns:
         A dict of training config that can be directly used by SageMakerTrainingOperator

--- a/src/sagemaker/workflow/airflow.py
+++ b/src/sagemaker/workflow/airflow.py
@@ -1,0 +1,109 @@
+# Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+import os
+
+from sagemaker.estimator import Framework
+from sagemaker.amazon.amazon_estimator import AmazonAlgorithmEstimatorBase, RecordSet
+from sagemaker.job import _Job
+from sagemaker.utils import base_name_from_image, airflow_name_from_base
+from sagemaker.model import DIR_PARAM_NAME, SCRIPT_PARAM_NAME, CLOUDWATCH_METRICS_PARAM_NAME, \
+    CONTAINER_LOG_LEVEL_PARAM_NAME, JOB_NAME_PARAM_NAME, SAGEMAKER_REGION_PARAM_NAME
+
+
+def prepare_framework(estimator, s3_operations, default_bucket):
+    bucket = estimator.code_location if estimator.code_location else default_bucket
+    key = '{}/source/sourcedir.tar.gz'.format(estimator._current_job_name)
+    script = os.path.basename(estimator.entry_point)
+    if estimator.source_dir and estimator.source_dir.lower().startswith('s3://'):
+        code_dir = estimator.source_dir
+    else:
+        code_dir = 's3://{}/{}'.format(bucket, key)
+        s3_operations['S3Upload'] = [{
+            'Path': estimator.source_dir or script,
+            'Bucket': bucket,
+            'Key': key,
+            'Tar': True
+        }]
+    estimator._hyperparameters[DIR_PARAM_NAME] = code_dir
+    estimator._hyperparameters[SCRIPT_PARAM_NAME] = script
+    estimator._hyperparameters[CLOUDWATCH_METRICS_PARAM_NAME] = estimator.enable_cloudwatch_metrics
+    estimator._hyperparameters[CONTAINER_LOG_LEVEL_PARAM_NAME] = estimator.container_log_level
+    estimator._hyperparameters[JOB_NAME_PARAM_NAME] = estimator._current_job_name
+    estimator._hyperparameters[SAGEMAKER_REGION_PARAM_NAME] = estimator.sagemaker_session.boto_region_name
+
+
+def prepare_amazon_algorithm_estimator(estimator, inputs):
+    if isinstance(inputs, list):
+        for record in inputs:
+            if isinstance(record, RecordSet) and record.channel == 'train':
+                estimator.feature_dim = record.feature_dim
+                break
+    elif isinstance(inputs, RecordSet):
+        estimator.feature_dim = inputs.feature_dim
+    else:
+        raise TypeError('The training data of Amazon Algorithm estimator is not represented by RecordSet.')
+
+
+def get_training_config(estimator, inputs=None, job_name=None):
+    default_bucket = estimator.sagemaker_session.default_bucket()
+    s3_operations = {}
+
+    if job_name is not None:
+        estimator._current_job_name = job_name
+    else:
+        base_name = estimator.base_job_name or base_name_from_image(estimator.train_image())
+        estimator._current_job_name = airflow_name_from_base(base_name)
+
+    if estimator.output_path is None:
+        estimator.output_path = 's3://{}/'.format(default_bucket)
+
+    if isinstance(estimator, Framework):
+        prepare_framework(estimator, s3_operations, default_bucket)
+
+    elif isinstance(estimator, AmazonAlgorithmEstimatorBase):
+        prepare_amazon_algorithm_estimator(estimator, inputs)
+
+    job_config = _Job._load_config(inputs, estimator, expand_role=False, validate_uri=False)
+
+    train_config = {
+        'AlgorithmSpecification': {
+            'TrainingImage': estimator.train_image(),
+            'TrainingInputMode': estimator.input_mode
+        },
+        'OutputDataConfig': job_config['output_config'],
+        'TrainingJobName': estimator._current_job_name,
+        'StoppingCondition': job_config['stop_condition'],
+        'ResourceConfig': job_config['resource_config'],
+        'RoleArn': job_config['role'],
+    }
+
+    if job_config['input_config'] is not None:
+        train_config['InputDataConfig'] = job_config['input_config']
+
+    if job_config['vpc_config'] is not None:
+        train_config['VpcConfig'] = job_config['vpc_config']
+
+    if estimator.hyperparameters() is not None:
+        hyperparameters = {str(k): str(v) for (k, v) in estimator.hyperparameters().items()}
+
+    if hyperparameters and len(hyperparameters) > 0:
+        train_config['HyperParameters'] = hyperparameters
+
+    if estimator.tags is not None:
+        train_config['Tags'] = estimator.tags
+
+    if s3_operations:
+        train_config['S3Operations'] = s3_operations
+
+    return train_config

--- a/src/sagemaker/workflow/airflow.py
+++ b/src/sagemaker/workflow/airflow.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+from __future__ import print_function, absolute_import
 
 import os
 
@@ -67,7 +68,7 @@ def prepare_amazon_algorithm_estimator(estimator, inputs):
         raise TypeError('Training data must be represented in RecordSet or list of RecordSets')
 
 
-def training_config(estimator, inputs=None, job_name=None):
+def training_config(estimator, inputs=None, job_name=None):  # noqa: C901 - suppress complexity warning for this method
     """Export Airflow training config from an estimator
 
     Args:

--- a/src/sagemaker/workflow/airflow.py
+++ b/src/sagemaker/workflow/airflow.py
@@ -22,6 +22,15 @@ from sagemaker.model import DIR_PARAM_NAME, SCRIPT_PARAM_NAME, CLOUDWATCH_METRIC
 
 
 def prepare_framework(estimator, s3_operations, default_bucket):
+    """
+    Prepare S3 operations (specify where to upload source_dir) and environment variables
+        related to framework.
+
+    Args:
+        estimator: The framework estimator to get information from and update.
+        s3_operations: The dict to specify s3 operations (upload source_dir).
+        default_bucket: The default bucket to use in training.
+    """
     bucket = estimator.code_location if estimator.code_location else default_bucket
     key = '{}/source/sourcedir.tar.gz'.format(estimator._current_job_name)
     script = os.path.basename(estimator.entry_point)
@@ -44,6 +53,12 @@ def prepare_framework(estimator, s3_operations, default_bucket):
 
 
 def prepare_amazon_algorithm_estimator(estimator, inputs):
+    """
+    Set up amazon algorithm estimator, adding the required feature_dim hyperparameter from training data.
+    Args:
+        estimator: The Amazon algorithm estimator to get information from and update.
+        inputs: The training data, must be in RecordSet format.
+    """
     if isinstance(inputs, list):
         for record in inputs:
             if isinstance(record, RecordSet) and record.channel == 'train':
@@ -56,6 +71,19 @@ def prepare_amazon_algorithm_estimator(estimator, inputs):
 
 
 def get_training_config(estimator, inputs=None, job_name=None):
+    """
+    Export Airflow training config from an estimator
+
+    Args:
+        estimator: The estimator to export training config from. Can be a BYO estimator,
+            Framework estimator or Amazon algorithm estimator.
+        inputs: The training data.
+        job_name: Specify a training job name if needed.
+
+    Returns:
+        A dict of training config that can be directly used by SageMakerTrainingOperator
+            in Airflow.
+    """
     default_bucket = estimator.sagemaker_session.default_bucket()
     s3_operations = {}
 

--- a/tests/unit/test_airflow.py
+++ b/tests/unit/test_airflow.py
@@ -99,7 +99,7 @@ def test_byo_training_config_all_args(sagemaker_session):
         output_path="{{ output_path }}",
         output_kms_key="{{ output_volume_kms_key }}",
         base_job_name="{{ base_job_name }}",
-        tags=[{"{{ key }}":"{{ value }}"}],
+        tags=[{"{{ key }}": "{{ value }}"}],
         subnets=["{{ subnet }}"],
         security_group_ids=["{{ security_group_ids }}"],
         model_uri="{{ model_uri }}",

--- a/tests/unit/test_airflow.py
+++ b/tests/unit/test_airflow.py
@@ -108,10 +108,7 @@ def test_byo_training_config_all_args(sagemaker_session):
                             feature_dim=1024,
                             mini_batch_size=256)
 
-    data = {
-        'train': "{{ training_data }}",
-        'evaluation': "{{ eval_data }}"
-    }
+    data = {'train': "{{ training_data }}"}
 
     training_config = get_training_config(byo, data)
     expected_config = {
@@ -144,16 +141,6 @@ def test_byo_training_config_all_args(sagemaker_session):
                     }
                 },
                 'ChannelName': 'train'
-            },
-            {
-                'DataSource': {
-                    'S3DataSource': {
-                        'S3DataDistributionType': 'FullyReplicated',
-                        'S3DataType': 'S3Prefix',
-                        'S3Uri': '{{ eval_data }}'
-                    }
-                },
-                'ChannelName': 'evaluation'
             },
             {
                 'DataSource': {

--- a/tests/unit/test_airflow.py
+++ b/tests/unit/test_airflow.py
@@ -30,7 +30,7 @@ BUCKET_NAME = 'output'
 def sagemaker_session():
     boto_mock = mock.Mock(name='boto_session', region_name=REGION)
     session = mock.Mock(name='sagemaker_session', boto_session=boto_mock,
-                   boto_region_name=REGION, config=None, local_mode=False)
+                        boto_region_name=REGION, config=None, local_mode=False)
     session.default_bucket = mock.Mock(name='default_bucket', return_value=BUCKET_NAME)
     session._default_bucket = BUCKET_NAME
     return session

--- a/tests/unit/test_airflow.py
+++ b/tests/unit/test_airflow.py
@@ -1,0 +1,440 @@
+# Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+from __future__ import absolute_import
+
+from mock import Mock, patch
+
+from sagemaker.workflow.airflow import get_training_config
+from sagemaker.estimator import Estimator
+from sagemaker.tensorflow import TensorFlow
+from sagemaker.amazon.amazon_estimator import RecordSet
+from sagemaker.amazon.ntm import NTM
+
+
+@patch('sagemaker.session.Session.default_bucket', return_value='output')
+def test_byo_training_config_required_args(default_bucket):
+    byo = Estimator(image_name="byo",
+                    role="{{ role }}",
+                    train_instance_count="{{ instance_count }}",
+                    train_instance_type="ml.c4.2xlarge")
+
+    byo.set_hyperparameters(epochs=32,
+                            feature_dim=1024,
+                            mini_batch_size=256)
+
+    data = {'train': "{{ training_data }}"}
+
+    training_config = get_training_config(byo, data)
+    expected_config = {
+        'AlgorithmSpecification': {
+            'TrainingImage': 'byo',
+            'TrainingInputMode': 'File'
+        },
+        'OutputDataConfig': {
+            'S3OutputPath': 's3://output/'
+        },
+        'TrainingJobName': "byo-{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}",
+        'StoppingCondition': {
+            'MaxRuntimeInSeconds': 86400
+        },
+        'ResourceConfig': {
+            'InstanceCount': '{{ instance_count }}',
+            'InstanceType': 'ml.c4.2xlarge',
+            'VolumeSizeInGB': 30
+        },
+        'RoleArn': '{{ role }}',
+        'InputDataConfig': [{
+            'DataSource': {
+                'S3DataSource': {
+                    'S3DataDistributionType': 'FullyReplicated',
+                    'S3DataType': 'S3Prefix',
+                    'S3Uri': '{{ training_data }}'
+                }
+            }, 'ChannelName': 'train'
+        }],
+        'HyperParameters': {
+            'epochs': '32',
+            'feature_dim': '1024',
+            'mini_batch_size': '256'}
+    }
+    assert training_config == expected_config
+
+
+def test_byo_training_config_all_args():
+    byo = Estimator(image_name="byo",
+                    role="{{ role }}",
+                    train_instance_count="{{ instance_count }}",
+                    train_instance_type="ml.c4.2xlarge",
+                    train_volume_size="{{ train_volume_size }}",
+                    train_volume_kms_key="{{ train_volume_kms_key }}",
+                    train_max_run="{{ train_max_run }}",
+                    input_mode='Pipe',
+                    output_path="{{ output_path }}",
+                    output_kms_key="{{ output_volume_kms_key }}",
+                    base_job_name="{{ base_job_name }}",
+                    tags=[{"{{ key }}":"{{ value }}"}],
+                    subnets=["{{ subnet }}"],
+                    security_group_ids=["{{ security_group_ids }}"],
+                    model_uri="{{ model_uri }}",
+                    model_channel_name="{{ model_chanel }}")
+
+    byo.set_hyperparameters(epochs=32,
+                            feature_dim=1024,
+                            mini_batch_size=256)
+
+    data = {
+        'train': "{{ training_data }}",
+        'evaluation': "{{ eval_data }}"
+    }
+
+    training_config = get_training_config(byo, data)
+    expected_config = {
+        'AlgorithmSpecification': {
+            'TrainingImage': 'byo',
+            'TrainingInputMode': 'Pipe'
+        },
+        'OutputDataConfig': {
+            'S3OutputPath': '{{ output_path }}',
+            'KmsKeyId': '{{ output_volume_kms_key }}'
+        },
+        'TrainingJobName': "{{ base_job_name }}-{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}",
+        'StoppingCondition': {
+            'MaxRuntimeInSeconds': '{{ train_max_run }}'
+        },
+        'ResourceConfig': {
+            'InstanceCount': '{{ instance_count }}',
+            'InstanceType': 'ml.c4.2xlarge',
+            'VolumeSizeInGB': '{{ train_volume_size }}',
+            'VolumeKmsKeyId': '{{ train_volume_kms_key }}'
+        },
+        'RoleArn': '{{ role }}',
+        'InputDataConfig': [
+            {
+                'DataSource': {
+                    'S3DataSource': {
+                        'S3DataDistributionType': 'FullyReplicated',
+                        'S3DataType': 'S3Prefix',
+                        'S3Uri': '{{ training_data }}'
+                    }
+                },
+                'ChannelName': 'train'
+            },
+            {
+                'DataSource': {
+                    'S3DataSource': {
+                        'S3DataDistributionType': 'FullyReplicated',
+                        'S3DataType': 'S3Prefix',
+                        'S3Uri': '{{ eval_data }}'
+                    }
+                },
+                'ChannelName': 'evaluation'
+            },
+            {
+                'DataSource': {
+                    'S3DataSource': {
+                        'S3DataDistributionType': 'FullyReplicated',
+                        'S3DataType': 'S3Prefix',
+                        'S3Uri': '{{ model_uri }}'
+                    }
+                },
+                'ContentType': 'application/x-sagemaker-model',
+                'InputMode': 'File',
+                'ChannelName': '{{ model_chanel }}'
+            }
+        ],
+        'VpcConfig': {
+            'Subnets': ['{{ subnet }}'],
+            'SecurityGroupIds': ['{{ security_group_ids }}']
+        },
+        'HyperParameters': {
+            'epochs': '32',
+            'feature_dim': '1024',
+            'mini_batch_size': '256'},
+        'Tags': [{'{{ key }}': '{{ value }}'}]
+    }
+    assert training_config == expected_config
+
+
+@patch('sagemaker.session.Session.default_bucket', return_value='output')
+def test_framework_training_config_required_args(default_bucket):
+    tf = TensorFlow(entry_point="{{ entry_point }}",
+                    framework_version='1.10.0',
+                    training_steps=1000,
+                    evaluation_steps=100,
+                    role="{{ role }}",
+                    train_instance_count="{{ instance_count }}",
+                    train_instance_type="ml.c4.2xlarge")
+
+    data = "{{ training_data }}"
+
+    training_config = get_training_config(tf, data)
+    expected_config = {
+        'AlgorithmSpecification': {
+            'TrainingImage': '520713654638.dkr.ecr.us-west-2.amazonaws.com/sagemaker-tensorflow:1.10.0-cpu-py2',
+            'TrainingInputMode': 'File'
+        },
+        'OutputDataConfig': {
+            'S3OutputPath': 's3://output/'
+        },
+        'TrainingJobName': "sagemaker-tensorflow-{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}",
+        'StoppingCondition': {
+            'MaxRuntimeInSeconds': 86400
+        },
+        'ResourceConfig': {
+            'InstanceCount': '{{ instance_count }}',
+            'InstanceType': 'ml.c4.2xlarge',
+            'VolumeSizeInGB': 30
+        },
+        'RoleArn': '{{ role }}',
+        'InputDataConfig': [{
+            'DataSource': {
+                'S3DataSource': {
+                    'S3DataDistributionType': 'FullyReplicated',
+                    'S3DataType': 'S3Prefix',
+                    'S3Uri': '{{ training_data }}'
+                }
+            },
+            'ChannelName': 'training'
+        }],
+        'HyperParameters': {
+            'sagemaker_submit_directory': '"s3://output/sagemaker-tensorflow-'
+                                          '{{ execution_date.strftime(\'%Y-%m-%d-%H-%M-%S\') }}'
+                                          '/source/sourcedir.tar.gz"',
+            'sagemaker_program': '"{{ entry_point }}"',
+            'sagemaker_enable_cloudwatch_metrics': 'false',
+            'sagemaker_container_log_level': '20',
+            'sagemaker_job_name': '"sagemaker-tensorflow-{{ execution_date.strftime(\'%Y-%m-%d-%H-%M-%S\') }}"',
+            'sagemaker_region': '"us-west-2"',
+            'checkpoint_path': '"s3://output/sagemaker-tensorflow-{{ execution_date.strftime(\'%Y-%m-%d-%H-%M-%S\') }}'
+                               '/checkpoints"',
+            'training_steps': '1000',
+            'evaluation_steps': '100',
+            'sagemaker_requirements': '""'},
+        'S3Operations': {
+            'S3Upload': [{
+                'Path': '{{ entry_point }}',
+                'Bucket': 'output',
+                'Key': "sagemaker-tensorflow-{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}"
+                       "/source/sourcedir.tar.gz",
+                'Tar': True}]
+        }
+    }
+    assert training_config == expected_config
+
+
+def test_framework_training_config_all_args():
+    tf = TensorFlow(entry_point="{{ entry_point }}",
+                    source_dir="{{ source_dir }}",
+                    enable_cloudwatch_metrics=False,
+                    container_log_level="{{ log_level }}",
+                    code_location="{{ bucket_name }}",
+                    training_steps=1000,
+                    evaluation_steps=100,
+                    checkpoint_path="{{ checkpoint_path }}",
+                    py_version='py2',
+                    framework_version='1.10.0',
+                    requirements_file="",
+                    role="{{ role }}",
+                    train_instance_count="{{ instance_count }}",
+                    train_instance_type="ml.c4.2xlarge",
+                    train_volume_size="{{ train_volume_size }}",
+                    train_volume_kms_key="{{ train_volume_kms_key }}",
+                    train_max_run="{{ train_max_run }}",
+                    input_mode='Pipe',
+                    output_path="{{ output_path }}",
+                    output_kms_key="{{ output_volume_kms_key }}",
+                    base_job_name="{{ base_job_name }}",
+                    tags=[{"{{ key }}": "{{ value }}"}],
+                    subnets=["{{ subnet }}"],
+                    security_group_ids=["{{ security_group_ids }}"])
+
+    data = "{{ training_data }}"
+
+    training_config = get_training_config(tf, data)
+    expected_config = {
+        'AlgorithmSpecification': {
+            'TrainingImage': '520713654638.dkr.ecr.us-west-2.amazonaws.com/sagemaker-tensorflow:1.10.0-cpu-py2',
+            'TrainingInputMode': 'Pipe'
+        },
+        'OutputDataConfig': {
+            'S3OutputPath': '{{ output_path }}',
+            'KmsKeyId': '{{ output_volume_kms_key }}'
+        },
+        'TrainingJobName': "{{ base_job_name }}-{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}",
+        'StoppingCondition': {
+            'MaxRuntimeInSeconds': '{{ train_max_run }}'
+        },
+        'ResourceConfig': {
+            'InstanceCount': '{{ instance_count }}',
+            'InstanceType': 'ml.c4.2xlarge',
+            'VolumeSizeInGB': '{{ train_volume_size }}',
+            'VolumeKmsKeyId': '{{ train_volume_kms_key }}'
+        },
+        'RoleArn': '{{ role }}',
+        'InputDataConfig': [{
+            'DataSource': {
+                'S3DataSource': {
+                    'S3DataDistributionType': 'FullyReplicated',
+                    'S3DataType': 'S3Prefix',
+                    'S3Uri': '{{ training_data }}'
+                }
+            },
+            'ChannelName': 'training'
+        }],
+        'VpcConfig': {
+            'Subnets': ['{{ subnet }}'],
+            'SecurityGroupIds': ['{{ security_group_ids }}']
+        },
+        'HyperParameters': {
+            'sagemaker_submit_directory': '"s3://{{ bucket_name }}/{{ base_job_name }}-'
+                                          '{{ execution_date.strftime(\'%Y-%m-%d-%H-%M-%S\') }}'
+                                          '/source/sourcedir.tar.gz"',
+            'sagemaker_program': '"{{ entry_point }}"',
+            'sagemaker_enable_cloudwatch_metrics': 'false',
+            'sagemaker_container_log_level': '"{{ log_level }}"',
+            'sagemaker_job_name': '"{{ base_job_name }}-{{ execution_date.strftime(\'%Y-%m-%d-%H-%M-%S\') }}"',
+            'sagemaker_region': '"us-west-2"',
+            'checkpoint_path': '"{{ checkpoint_path }}"',
+            'training_steps': '1000',
+            'evaluation_steps': '100',
+            'sagemaker_requirements': '""'
+        },
+        'Tags': [{'{{ key }}': '{{ value }}'}],
+        'S3Operations': {
+            'S3Upload': [{
+                'Path': '{{ source_dir }}',
+                'Bucket': '{{ bucket_name }}',
+                'Key': "{{ base_job_name }}-{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}"
+                       "/source/sourcedir.tar.gz",
+                'Tar': True}]
+        }
+    }
+    assert training_config == expected_config
+
+
+@patch('sagemaker.session.Session.default_bucket', return_value='output')
+def test_amazon_alg_training_config_required_args(default_bucket):
+    ntm = NTM(role="{{ role }}",
+              num_topics=10,
+              train_instance_count="{{ instance_count }}",
+              train_instance_type="ml.c4.2xlarge")
+
+    ntm.epochs = 32
+    ntm.mini_batch_size = 256
+
+    record = RecordSet("{{ record }}", 10000, 100, 'S3Prefix')
+
+    training_config = get_training_config(ntm, record)
+    expected_config = {
+        'AlgorithmSpecification': {
+            'TrainingImage': '174872318107.dkr.ecr.us-west-2.amazonaws.com/ntm:1',
+            'TrainingInputMode': 'File'
+        },
+        'OutputDataConfig': {
+            'S3OutputPath': 's3://output/'
+        },
+        'TrainingJobName': "ntm-{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}",
+        'StoppingCondition': {'MaxRuntimeInSeconds': 86400},
+        'ResourceConfig': {
+            'InstanceCount': '{{ instance_count }}',
+            'InstanceType': 'ml.c4.2xlarge',
+            'VolumeSizeInGB': 30
+        },
+        'RoleArn': '{{ role }}',
+        'InputDataConfig': [{
+            'DataSource': {
+                'S3DataSource': {
+                    'S3DataDistributionType': 'ShardedByS3Key',
+                    'S3DataType': 'S3Prefix',
+                    'S3Uri': '{{ record }}'
+                }
+            },
+            'ChannelName': 'train'
+        }],
+        'HyperParameters': {
+            'num_topics': '10',
+            'epochs': '32',
+            'mini_batch_size': '256',
+            'feature_dim': '100'
+        }
+    }
+    assert training_config == expected_config
+
+
+def test_amazon_alg_training_config_all_args():
+    ntm = NTM(role="{{ role }}",
+              num_topics=10,
+              train_instance_count="{{ instance_count }}",
+              train_instance_type="ml.c4.2xlarge",
+              train_volume_size="{{ train_volume_size }}",
+              train_volume_kms_key="{{ train_volume_kms_key }}",
+              train_max_run="{{ train_max_run }}",
+              input_mode='Pipe',
+              output_path="{{ output_path }}",
+              output_kms_key="{{ output_volume_kms_key }}",
+              base_job_name="{{ base_job_name }}",
+              tags=[{"{{ key }}": "{{ value }}"}],
+              subnets=["{{ subnet }}"],
+              security_group_ids=["{{ security_group_ids }}"])
+
+    ntm.epochs = 32
+    ntm.mini_batch_size = 256
+
+    record = RecordSet("{{ record }}", 10000, 100, 'S3Prefix')
+
+    training_config = get_training_config(ntm, record)
+    expected_config = {
+        'AlgorithmSpecification': {
+            'TrainingImage': '174872318107.dkr.ecr.us-west-2.amazonaws.com/ntm:1',
+            'TrainingInputMode': 'Pipe'
+        },
+        'OutputDataConfig': {
+            'S3OutputPath': '{{ output_path }}',
+            'KmsKeyId': '{{ output_volume_kms_key }}'
+        },
+        'TrainingJobName': "{{ base_job_name }}-{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}",
+        'StoppingCondition': {
+            'MaxRuntimeInSeconds': '{{ train_max_run }}'
+        },
+        'ResourceConfig': {
+            'InstanceCount': '{{ instance_count }}',
+            'InstanceType': 'ml.c4.2xlarge',
+            'VolumeSizeInGB': '{{ train_volume_size }}',
+            'VolumeKmsKeyId': '{{ train_volume_kms_key }}'
+        },
+        'RoleArn': '{{ role }}',
+        'InputDataConfig': [{
+            'DataSource': {
+                'S3DataSource': {
+                    'S3DataDistributionType': 'ShardedByS3Key',
+                    'S3DataType': 'S3Prefix',
+                    'S3Uri': '{{ record }}'
+                }
+            },
+            'ChannelName': 'train'
+        }],
+        'VpcConfig': {
+            'Subnets': ['{{ subnet }}'],
+            'SecurityGroupIds': ['{{ security_group_ids }}']
+        },
+        'HyperParameters': {
+            'num_topics': '10',
+            'epochs': '32',
+            'mini_batch_size': '256',
+            'feature_dim': '100'
+        },
+        'Tags': [{'{{ key }}': '{{ value }}'}]
+    }
+
+    assert training_config == expected_config


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Add sagemaker.workflow.airflow module that has function get_training_config to export boto create_training_job config from python sdk estimator.
2. Add corresponding unit tests that test the config exported from BYO Estimator, 1P Estimator and Framework.
3. Bypass some validations in job.py to enable usage of Jinja templating in arguments.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated the [changelog](https://github.com/aws/sagemaker-python-sdk/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
