### PR TITLE
Remove MetricDefinition lookup via tuning job in TrainingJobAnalytics

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ CHANGELOG
 * enhancement: Session: remove hardcoded 'training' from job status error message
 * bug-fix: Updated Cloudwatch namespace for metrics in TrainingJobsAnalytics
 * bug-fix: Changes to use correct s3 bucket and time range for dataframes in TrainingJobAnalytics.
+* enhancement: Remove MetricDefinition lookup via tuning job in TrainingJobAnalytics
 
 
 1.14.1

--- a/src/sagemaker/analytics.py
+++ b/src/sagemaker/analytics.py
@@ -20,7 +20,7 @@ import logging
 from six import with_metaclass
 
 from sagemaker.session import Session
-from sagemaker.utils import DeferredError, extract_name_from_job_arn
+from sagemaker.utils import DeferredError
 
 try:
     import pandas as pd

--- a/src/sagemaker/analytics.py
+++ b/src/sagemaker/analytics.py
@@ -310,18 +310,9 @@ class TrainingJobAnalytics(AnalyticsMetricsBase):
     def _metric_names_for_training_job(self):
         """Helper method to discover the metrics defined for a training job.
         """
-        # First look up the tuning job
         training_description = self._sage_client.describe_training_job(TrainingJobName=self._training_job_name)
-        tuning_job_arn = training_description.get('TuningJobArn', None)
-        if not tuning_job_arn:
-            raise ValueError(
-                "No metrics available. Training Job Analytics only available through Hyperparameter Tuning Jobs"
-            )
-        tuning_job_name = extract_name_from_job_arn(tuning_job_arn)
-        tuning_job_description = self._sage_client.describe_hyper_parameter_tuning_job(
-            HyperParameterTuningJobName=tuning_job_name
-        )
-        training_job_definition = tuning_job_description['TrainingJobDefinition']
-        metric_definitions = training_job_definition['AlgorithmSpecification']['MetricDefinitions']
+
+        metric_definitions = training_description['AlgorithmSpecification']['MetricDefinitions']
         metric_names = [md['Name'] for md in metric_definitions]
+
         return metric_names

--- a/tests/unit/test_estimator.py
+++ b/tests/unit/test_estimator.py
@@ -824,28 +824,21 @@ def test_generic_training_job_analytics(sagemaker_session):
     sagemaker_session.sagemaker_client.describe_training_job = Mock(name='describe_training_job', return_value={
         'TuningJobArn': 'arn:aws:sagemaker:us-west-2:968277160000:hyper-parameter-tuning-job/mock-tuner',
         'TrainingStartTime': 1530562991.299,
-    })
-    sagemaker_session.sagemaker_client.describe_hyper_parameter_tuning_job = Mock(
-        name='describe_hyper_parameter_tuning_job',
-        return_value={
-            'TrainingJobDefinition': {
-                "AlgorithmSpecification": {
-                    "TrainingImage": "some-image-url",
-                    "TrainingInputMode": "File",
-                    "MetricDefinitions": [
-                        {
-                            "Name": "train:loss",
-                            "Regex": "train_loss=([0-9]+\\.[0-9]+)"
-                        },
-                        {
-                            "Name": "validation:loss",
-                            "Regex": "valid_loss=([0-9]+\\.[0-9]+)"
-                        }
-                    ]
+        "AlgorithmSpecification": {
+            "TrainingImage": "some-image-url",
+            "TrainingInputMode": "File",
+            "MetricDefinitions": [
+                {
+                    "Name": "train:loss",
+                    "Regex": "train_loss=([0-9]+\\.[0-9]+)"
+                },
+                {
+                    "Name": "validation:loss",
+                    "Regex": "valid_loss=([0-9]+\\.[0-9]+)"
                 }
-            }
-        }
-    )
+            ]
+        },
+    })
 
     e = Estimator(IMAGE_NAME, ROLE, INSTANCE_COUNT, INSTANCE_TYPE, output_path=OUTPUT_PATH,
                   sagemaker_session=sagemaker_session)


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Remove MetricDefinition lookup via tuning job in TrainingJobAnalytics. MetricDefinition is now available on all built-in algorithms.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have updated the [changelog](https://github.com/aws/sagemaker-python-sdk/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [x] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
