### PR TITLE
Add airflow tuning config export API

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ CHANGELOG
 
 * bug-fix: Changes to use correct S3 bucket and time range for dataframes in TrainingJobAnalytics.
 * bug-fix: Local Mode: correctly handle the case where the model output folder doesn't exist yet
+* feature: Add APIs to export Airflow training and tuning config
 
 1.14.2
 ======

--- a/src/sagemaker/utils.py
+++ b/src/sagemaker/utils.py
@@ -27,6 +27,9 @@ import six
 
 
 AIRFLOW_TIME_MACRO = "{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}"
+AIRFLOW_TIME_MACRO_LEN = 19
+AIRFLOW_TIME_MACRO_SHORT = "{{ execution_date.strftime('%y%m%d-%H%M') }}"
+AIRFLOW_TIME_MACRO_SHORT_LEN = 11
 
 
 # Use the base name of the image as the job name if the user doesn't give us one
@@ -61,19 +64,23 @@ def name_from_base(base, max_length=63, short=False):
     return '{}-{}'.format(trimmed_base, timestamp)
 
 
-def airflow_name_from_base(base):
+def airflow_name_from_base(base, max_length=63, short=False):
     """Append airflow execution_date macro (https://airflow.apache.org/code.html?#macros)
     to the provided string. The macro will beevaluated in Airflow operator runtime.
     This guarantees that different operators will have same name returned by this function.
 
     Args:
         base (str): String used as prefix to generate the unique name.
+        max_length (int): Maximum length for the resulting string.
+        short (bool): Whether or not to use a truncated timestamp.
 
     Returns:
         str: Input parameter with appended macro.
     """
-
-    return "{}-{}".format(base, AIRFLOW_TIME_MACRO)
+    macro = AIRFLOW_TIME_MACRO_SHORT if short else AIRFLOW_TIME_MACRO
+    length = AIRFLOW_TIME_MACRO_SHORT_LEN if short else AIRFLOW_TIME_MACRO_LEN
+    trimmed_base = base[:max_length - length - 1]
+    return "{}-{}".format(trimmed_base, macro)
 
 
 def base_name_from_image(image):

--- a/src/sagemaker/workflow/airflow.py
+++ b/src/sagemaker/workflow/airflow.py
@@ -74,7 +74,7 @@ def prepare_amazon_algorithm_estimator(estimator, inputs, mini_batch_size=None):
     estimator.mini_batch_size = mini_batch_size
 
 
-def training_config(estimator, inputs=None, job_name=None, **kargs):  # noqa: C901
+def training_config(estimator, inputs=None, job_name=None, mini_batch_size=None):  # noqa: C901
     """Export Airflow training config from an estimator
 
     Args:
@@ -99,6 +99,8 @@ def training_config(estimator, inputs=None, job_name=None, **kargs):  # noqa: C9
                 a different channel of training data.
 
         job_name (str): Specify a training job name if needed.
+        mini_batch_size (int): Specify this argument only when estimator is a built-in estimator of an
+            Amazon algorithm. For other estimators, batch size should be specified in the estimator.
 
     Returns:
         A dict of training config that can be directly used by SageMakerTrainingOperator
@@ -120,7 +122,7 @@ def training_config(estimator, inputs=None, job_name=None, **kargs):  # noqa: C9
         prepare_framework(estimator, s3_operations)
 
     elif isinstance(estimator, amazon_estimator.AmazonAlgorithmEstimatorBase):
-        prepare_amazon_algorithm_estimator(estimator, inputs, **kargs)
+        prepare_amazon_algorithm_estimator(estimator, inputs, mini_batch_size)
 
     job_config = job._Job._load_config(inputs, estimator, expand_role=False, validate_uri=False)
 

--- a/src/sagemaker/workflow/airflow.py
+++ b/src/sagemaker/workflow/airflow.py
@@ -78,7 +78,7 @@ def training_base_config(estimator, inputs=None, job_name=None, mini_batch_size=
     """Export Airflow base training config from an estimator
 
     Args:
-        estimator (sagemaker.estimator.EstimatroBase):
+        estimator (sagemaker.estimator.EstimatorBase):
             The estimator to export training config from. Can be a BYO estimator,
             Framework estimator or Amazon algorithm estimator.
         inputs: Information about the training data. Please refer to the ``fit()`` method of
@@ -102,9 +102,8 @@ def training_base_config(estimator, inputs=None, job_name=None, mini_batch_size=
         mini_batch_size (int): Specify this argument only when estimator is a built-in estimator of an
             Amazon algorithm. For other estimators, batch size should be specified in the estimator.
 
-    Returns:
-        A dict of training config that can be directly used by SageMakerTrainingOperator
-            in Airflow.
+    Returns (dict):
+        Training config that can be directly used by SageMakerTrainingOperator in Airflow.
     """
     default_bucket = estimator.sagemaker_session.default_bucket()
     s3_operations = {}
@@ -154,11 +153,11 @@ def training_base_config(estimator, inputs=None, job_name=None, mini_batch_size=
     return train_config
 
 
-def training_config(estimator, inputs=None, job_name=None, mini_batch_size=None):  # noqa: C901
+def training_config(estimator, inputs=None, job_name=None, mini_batch_size=None):
     """Export Airflow training config from an estimator
 
     Args:
-        estimator (sagemaker.estimator.EstimatroBase):
+        estimator (sagemaker.estimator.EstimatorBase):
             The estimator to export training config from. Can be a BYO estimator,
             Framework estimator or Amazon algorithm estimator.
         inputs: Information about the training data. Please refer to the ``fit()`` method of
@@ -182,9 +181,8 @@ def training_config(estimator, inputs=None, job_name=None, mini_batch_size=None)
         mini_batch_size (int): Specify this argument only when estimator is a built-in estimator of an
             Amazon algorithm. For other estimators, batch size should be specified in the estimator.
 
-    Returns:
-        A dict of training config that can be directly used by SageMakerTrainingOperator
-            in Airflow.
+    Returns (dict):
+        Training config that can be directly used by SageMakerTrainingOperator in Airflow.
     """
 
     train_config = training_base_config(estimator, inputs, job_name, mini_batch_size)
@@ -198,6 +196,32 @@ def training_config(estimator, inputs=None, job_name=None, mini_batch_size=None)
 
 
 def tuning_config(tuner, inputs, job_name=None):
+    """Export Airflow tuning config from an estimator
+
+    Args:
+        tuner (sagemaker.tuner.HyperparameterTuner): The tuner to export tuning config from.
+        inputs: Information about the training data. Please refer to the ``fit()`` method of
+                the associated estimator in the tuner, as this can take any of the following forms:
+
+            * (str) - The S3 location where training data is saved.
+            * (dict[str, str] or dict[str, sagemaker.session.s3_input]) - If using multiple channels for
+                training data, you can specify a dict mapping channel names
+                to strings or :func:`~sagemaker.session.s3_input` objects.
+            * (sagemaker.session.s3_input) - Channel configuration for S3 data sources that can provide
+                additional information about the training dataset. See :func:`sagemaker.session.s3_input`
+                for full details.
+            * (sagemaker.amazon.amazon_estimator.RecordSet) - A collection of
+                Amazon :class:~`Record` objects serialized and stored in S3.
+                For use with an estimator for an Amazon algorithm.
+            * (list[sagemaker.amazon.amazon_estimator.RecordSet]) - A list of
+                :class:~`sagemaker.amazon.amazon_estimator.RecordSet` objects, where each instance is
+                a different channel of training data.
+
+        job_name (str): Specify a tuning job name if needed.
+
+    Returns (dict):
+        Tuning config that can be directly used by SageMakerTuningOperator in Airflow.
+    """
     train_config = training_base_config(tuner.estimator, inputs)
     hyperparameters = train_config.pop('HyperParameters', None)
     s3_operations = train_config.pop('S3Operations', None)

--- a/src/sagemaker/workflow/airflow.py
+++ b/src/sagemaker/workflow/airflow.py
@@ -48,14 +48,19 @@ def prepare_framework(estimator, s3_operations):
     estimator._hyperparameters[model.SAGEMAKER_REGION_PARAM_NAME] = estimator.sagemaker_session.boto_region_name
 
 
-def prepare_amazon_algorithm_estimator(estimator, inputs):
+def prepare_amazon_algorithm_estimator(estimator, inputs, mini_batch_size=None):
     """ Set up amazon algorithm estimator, adding the required `feature_dim` hyperparameter from training data.
 
     Args:
         estimator (sagemaker.amazon.amazon_estimator.AmazonAlgorithmEstimatorBase):
             An estimator for a built-in Amazon algorithm to get information from and update.
-        inputs (single or list of sagemaker.amazon.amazon_estimator.RecordSet):
-            The training data, must be in RecordSet format.
+        inputs: The training data.
+            * (sagemaker.amazon.amazon_estimator.RecordSet) - A collection of
+                Amazon :class:~`Record` objects serialized and stored in S3.
+                For use with an estimator for an Amazon algorithm.
+            * (list[sagemaker.amazon.amazon_estimator.RecordSet]) - A list of
+                :class:~`sagemaker.amazon.amazon_estimator.RecordSet` objects, where each instance is
+                a different channel of training data.
     """
     if isinstance(inputs, list):
         for record in inputs:
@@ -66,17 +71,33 @@ def prepare_amazon_algorithm_estimator(estimator, inputs):
         estimator.feature_dim = inputs.feature_dim
     else:
         raise TypeError('Training data must be represented in RecordSet or list of RecordSets')
+    estimator.mini_batch_size = mini_batch_size
 
 
-def training_config(estimator, inputs=None, job_name=None):  # noqa: C901 - suppress complexity warning for this method
+def training_config(estimator, inputs=None, job_name=None, **kargs):  # noqa: C901 - suppress complexity warning for this method
     """Export Airflow training config from an estimator
 
     Args:
         estimator (sagemaker.estimator.EstimatroBase):
             The estimator to export training config from. Can be a BYO estimator,
             Framework estimator or Amazon algorithm estimator.
-        inputs (str, dict, single or list of sagemaker.amazon.amazon_estimator.RecordSet):
-            The training data.
+        inputs: Information about the training data. Please refer to the ``fit()`` method of
+                the associated estimator, as this can take any of the following forms:
+
+            * (str) - The S3 location where training data is saved.
+            * (dict[str, str] or dict[str, sagemaker.session.s3_input]) - If using multiple channels for
+                training data, you can specify a dict mapping channel names
+                to strings or :func:`~sagemaker.session.s3_input` objects.
+            * (sagemaker.session.s3_input) - Channel configuration for S3 data sources that can provide
+                additional information about the training dataset. See :func:`sagemaker.session.s3_input`
+                for full details.
+            * (sagemaker.amazon.amazon_estimator.RecordSet) - A collection of
+                Amazon :class:~`Record` objects serialized and stored in S3.
+                For use with an estimator for an Amazon algorithm.
+            * (list[sagemaker.amazon.amazon_estimator.RecordSet]) - A list of
+                :class:~`sagemaker.amazon.amazon_estimator.RecordSet` objects, where each instance is
+                a different channel of training data.
+
         job_name (str): Specify a training job name if needed.
 
     Returns:
@@ -99,7 +120,7 @@ def training_config(estimator, inputs=None, job_name=None):  # noqa: C901 - supp
         prepare_framework(estimator, s3_operations)
 
     elif isinstance(estimator, amazon_estimator.AmazonAlgorithmEstimatorBase):
-        prepare_amazon_algorithm_estimator(estimator, inputs)
+        prepare_amazon_algorithm_estimator(estimator, inputs, **kargs)
 
     job_config = job._Job._load_config(inputs, estimator, expand_role=False, validate_uri=False)
 
@@ -134,3 +155,56 @@ def training_config(estimator, inputs=None, job_name=None):  # noqa: C901 - supp
         train_config['S3Operations'] = s3_operations
 
     return train_config
+
+
+def tuning_config(tuner, inputs, job_name=None):
+    train_config = training_config(tuner.estimator, inputs, job_name)
+
+    train_config.pop('Tags', None)
+    train_config.pop('TrainingJobName', None)
+    s3_operations = train_config.pop('S3Operations', None)
+    hyperparameters = train_config.pop('HyperParameters', None)
+
+    if hyperparameters and len(hyperparameters) > 0:
+        tuner.static_hyperparameters = \
+            {utils.to_str(k): utils.to_str(v) for (k, v) in hyperparameters.items()}
+
+    if job_name is not None:
+        tuner._current_job_name = job_name
+    else:
+        base_name = tuner.base_tuning_job_name or utils.base_name_from_image(tuner.estimator.train_image())
+        tuner._current_job_name = utils.airflow_name_from_base(base_name, tuner.TUNING_JOB_NAME_MAX_LENGTH, True)
+
+    for hyperparameter_name in tuner._hyperparameter_ranges.keys():
+        tuner.static_hyperparameters.pop(hyperparameter_name, None)
+
+    train_config['StaticHyperParameters'] = tuner.static_hyperparameters
+
+    tune_config = {
+        'HyperParameterTuningJobName': tuner._current_job_name,
+        'HyperParameterTuningJobConfig': {
+            'Strategy': tuner.strategy,
+            'HyperParameterTuningJobObjective': {
+                'Type': tuner.objective_type,
+                'MetricName': tuner.objective_metric_name,
+            },
+            'ResourceLimits': {
+                'MaxNumberOfTrainingJobs': tuner.max_jobs,
+                'MaxParallelTrainingJobs': tuner.max_parallel_jobs,
+            },
+            'ParameterRanges': tuner.hyperparameter_ranges(),
+        },
+        'TrainingJobDefinition': train_config
+    }
+
+    if tuner.metric_definitions is not None:
+        tune_config['TrainingJobDefinition']['AlgorithmSpecification']['MetricDefinitions'] = \
+            tuner.metric_definitions
+
+    if tuner.tags is not None:
+        tune_config['Tags'] = tuner.tags
+
+    if s3_operations is not None:
+        tune_config['S3Operations'] = s3_operations
+
+    return tune_config

--- a/src/sagemaker/workflow/airflow.py
+++ b/src/sagemaker/workflow/airflow.py
@@ -74,7 +74,7 @@ def prepare_amazon_algorithm_estimator(estimator, inputs, mini_batch_size=None):
     estimator.mini_batch_size = mini_batch_size
 
 
-def training_config(estimator, inputs=None, job_name=None, **kargs):  # noqa: C901 - suppress complexity warning for this method
+def training_config(estimator, inputs=None, job_name=None, **kargs):  # noqa: C901
     """Export Airflow training config from an estimator
 
     Args:

--- a/src/sagemaker/workflow/airflow.py
+++ b/src/sagemaker/workflow/airflow.py
@@ -15,7 +15,7 @@ from __future__ import print_function, absolute_import
 import os
 
 import sagemaker
-from sagemaker import job, utils, model
+from sagemaker import job, model, utils
 from sagemaker.amazon import amazon_estimator
 
 
@@ -74,8 +74,8 @@ def prepare_amazon_algorithm_estimator(estimator, inputs, mini_batch_size=None):
     estimator.mini_batch_size = mini_batch_size
 
 
-def training_config(estimator, inputs=None, job_name=None, mini_batch_size=None):  # noqa: C901
-    """Export Airflow training config from an estimator
+def training_base_config(estimator, inputs=None, job_name=None, mini_batch_size=None):
+    """Export Airflow base training config from an estimator
 
     Args:
         estimator (sagemaker.estimator.EstimatroBase):
@@ -123,7 +123,6 @@ def training_config(estimator, inputs=None, job_name=None, mini_batch_size=None)
 
     elif isinstance(estimator, amazon_estimator.AmazonAlgorithmEstimatorBase):
         prepare_amazon_algorithm_estimator(estimator, inputs, mini_batch_size)
-
     job_config = job._Job._load_config(inputs, estimator, expand_role=False, validate_uri=False)
 
     train_config = {
@@ -132,7 +131,6 @@ def training_config(estimator, inputs=None, job_name=None, mini_batch_size=None)
             'TrainingInputMode': estimator.input_mode
         },
         'OutputDataConfig': job_config['output_config'],
-        'TrainingJobName': estimator._current_job_name,
         'StoppingCondition': job_config['stop_condition'],
         'ResourceConfig': job_config['resource_config'],
         'RoleArn': job_config['role'],
@@ -150,22 +148,59 @@ def training_config(estimator, inputs=None, job_name=None, mini_batch_size=None)
     if hyperparameters and len(hyperparameters) > 0:
         train_config['HyperParameters'] = hyperparameters
 
-    if estimator.tags is not None:
-        train_config['Tags'] = estimator.tags
-
     if s3_operations:
         train_config['S3Operations'] = s3_operations
 
     return train_config
 
 
-def tuning_config(tuner, inputs, job_name=None):
-    train_config = training_config(tuner.estimator, inputs, job_name)
+def training_config(estimator, inputs=None, job_name=None, mini_batch_size=None):  # noqa: C901
+    """Export Airflow training config from an estimator
 
-    train_config.pop('Tags', None)
-    train_config.pop('TrainingJobName', None)
-    s3_operations = train_config.pop('S3Operations', None)
+    Args:
+        estimator (sagemaker.estimator.EstimatroBase):
+            The estimator to export training config from. Can be a BYO estimator,
+            Framework estimator or Amazon algorithm estimator.
+        inputs: Information about the training data. Please refer to the ``fit()`` method of
+                the associated estimator, as this can take any of the following forms:
+
+            * (str) - The S3 location where training data is saved.
+            * (dict[str, str] or dict[str, sagemaker.session.s3_input]) - If using multiple channels for
+                training data, you can specify a dict mapping channel names
+                to strings or :func:`~sagemaker.session.s3_input` objects.
+            * (sagemaker.session.s3_input) - Channel configuration for S3 data sources that can provide
+                additional information about the training dataset. See :func:`sagemaker.session.s3_input`
+                for full details.
+            * (sagemaker.amazon.amazon_estimator.RecordSet) - A collection of
+                Amazon :class:~`Record` objects serialized and stored in S3.
+                For use with an estimator for an Amazon algorithm.
+            * (list[sagemaker.amazon.amazon_estimator.RecordSet]) - A list of
+                :class:~`sagemaker.amazon.amazon_estimator.RecordSet` objects, where each instance is
+                a different channel of training data.
+
+        job_name (str): Specify a training job name if needed.
+        mini_batch_size (int): Specify this argument only when estimator is a built-in estimator of an
+            Amazon algorithm. For other estimators, batch size should be specified in the estimator.
+
+    Returns:
+        A dict of training config that can be directly used by SageMakerTrainingOperator
+            in Airflow.
+    """
+
+    train_config = training_base_config(estimator, inputs, job_name, mini_batch_size)
+
+    train_config['TrainingJobName'] = estimator._current_job_name
+
+    if estimator.tags is not None:
+        train_config['Tags'] = estimator.tags
+
+    return train_config
+
+
+def tuning_config(tuner, inputs, job_name=None):
+    train_config = training_base_config(tuner.estimator, inputs)
     hyperparameters = train_config.pop('HyperParameters', None)
+    s3_operations = train_config.pop('S3Operations', None)
 
     if hyperparameters and len(hyperparameters) > 0:
         tuner.static_hyperparameters = \

--- a/tests/unit/test_airflow.py
+++ b/tests/unit/test_airflow.py
@@ -478,7 +478,7 @@ def test_framework_tuning_config(sagemaker_session):
         max_jobs="{{ max_job }}",
         max_parallel_jobs="{{ max_parallel_job }}",
         tags=[{'{{ key }}': '{{ value }}'}],
-        base_tuning_job_name= "{{ base_job_name }}")
+        base_tuning_job_name="{{ base_job_name }}")
 
     data = "{{ training_data }}"
 
@@ -562,5 +562,5 @@ def test_framework_tuning_config(sagemaker_session):
                 'Tar': True}]
         }
     }
-    
+
     assert config == expected_config

--- a/tests/unit/test_airflow.py
+++ b/tests/unit/test_airflow.py
@@ -16,7 +16,7 @@ from __future__ import absolute_import
 import pytest
 import mock
 
-from sagemaker import estimator, tensorflow, mxnet, tuner
+from sagemaker import estimator, mxnet, tensorflow, tuner
 from sagemaker.workflow import airflow
 from sagemaker.amazon import amazon_estimator
 from sagemaker.amazon import ntm
@@ -452,7 +452,7 @@ def test_framework_tuning_config(sagemaker_session):
     mxnet_estimator = mxnet.MXNet(
         entry_point="{{ entry_point }}",
         source_dir="{{ source_dir }}",
-        py_version='py2',
+        py_version='py3',
         framework_version='1.3.0',
         role="{{ role }}",
         train_instance_count=1,
@@ -512,7 +512,7 @@ def test_framework_tuning_config(sagemaker_session):
             }},
         'TrainingJobDefinition': {
             'AlgorithmSpecification': {
-                'TrainingImage': '520713654638.dkr.ecr.us-west-2.amazonaws.com/sagemaker-mxnet:1.3.0-cpu-py2',
+                'TrainingImage': '520713654638.dkr.ecr.us-west-2.amazonaws.com/sagemaker-mxnet:1.3.0-cpu-py3',
                 'TrainingInputMode': 'File',
                 'MetricDefinitions': [{
                     'Name': 'Validation-accuracy',
@@ -559,7 +559,8 @@ def test_framework_tuning_config(sagemaker_session):
                 'Bucket': 'output',
                 'Key': "{{ base_job_name }}-"
                        "{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}/source/sourcedir.tar.gz",
-                'Tar': True}]
+                'Tar': True
+            }]
         }
     }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Improve airflow_name_from_base, add limits for length and auto trim naming to fit length.
2. Fix missing hyperparameter mini_batch_size from training config.
3. Add tuning_config API to export tuning config from a tuner.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated the [changelog](https://github.com/aws/sagemaker-python-sdk/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
