### PR TITLE
Add the estimator base classes to API docs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ CHANGELOG
 
 * bug-fix: Changes to use correct S3 bucket and time range for dataframes in TrainingJobAnalytics.
 * bug-fix: Local Mode: correctly handle the case where the model output folder doesn't exist yet
+* doc-fix: Add estimator base classes to API docs
 
 1.14.2
 ======

--- a/doc/estimators.rst
+++ b/doc/estimators.rst
@@ -1,9 +1,21 @@
 Estimators
---------------------
+----------
 
 A high level interface for SageMaker training
 
+.. autoclass:: sagemaker.estimator.EstimatorBase
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :inherited-members:
+
 .. autoclass:: sagemaker.estimator.Estimator
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :inherited-members:
+
+.. autoclass:: sagemaker.estimator.Framework
     :members:
     :undoc-members:
     :show-inheritance:


### PR DESCRIPTION
*Description of changes:*
Given our use of `**kwargs` with our estimators, we need to have our base classes in our API docs

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have updated the [changelog](https://github.com/aws/sagemaker-python-sdk/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [x] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
