### PR TITLE
Add support for automatic model tuner's warm start jobs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ CHANGELOG
 
 * bug-fix: Changes to use correct S3 bucket and time range for dataframes in TrainingJobAnalytics.
 * bug-fix: Local Mode: correctly handle the case where the model output folder doesn't exist yet
+* feature: SageMaker Automatic Model Tuning's Warm Start jobs integration
 
 1.14.2
 ======
@@ -58,7 +59,6 @@ CHANGELOG
 * bug-fix: Local Mode: Set correct default values for additional_volumes and additional_env_vars
 * enhancement: Local Mode: support nvidia-docker2 natively
 * warning: Frameworks: add warning for upcoming breaking change that makes framework_version required
-* feature: SageMaker Automatic Model Tuning's Warm Start jobs integration
 
 1.11.2
 ======

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -58,6 +58,7 @@ CHANGELOG
 * bug-fix: Local Mode: Set correct default values for additional_volumes and additional_env_vars
 * enhancement: Local Mode: support nvidia-docker2 natively
 * warning: Frameworks: add warning for upcoming breaking change that makes framework_version required
+* feature: SageMaker Automatic Model Tuning's Warm Start jobs integration
 
 1.11.2
 ======

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,6 @@ CHANGELOG
 
 * bug-fix: Changes to use correct S3 bucket and time range for dataframes in TrainingJobAnalytics.
 * bug-fix: Local Mode: correctly handle the case where the model output folder doesn't exist yet
-* feature: SageMaker Automatic Model Tuning's Warm Start jobs integration
 * doc-fix: Fix typos in tensorflow serving documentation
 * doc-fix: Add estimator base classes to API docs
 * feature: SageMaker Automatic Model Tuning's Warm Start jobs integration

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ CHANGELOG
 * feature: SageMaker Automatic Model Tuning's Warm Start jobs integration
 * doc-fix: Fix typos in tensorflow serving documentation
 * doc-fix: Add estimator base classes to API docs
+* feature: SageMaker Automatic Model Tuning's Warm Start jobs integration
 
 
 1.14.2

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,7 @@ CHANGELOG
 * feature: Add APIs to export Airflow training and tuning config
 * doc-fix: Fix typos in tensorflow serving documentation
 * doc-fix: Add estimator base classes to API docs
-* feature: Add support for automatic model tuner's warm start jobs
+* feature: HyperparameterTuner: add support for Automatic Model Tuning's Warm Start Jobs
 
 1.14.2
 ======

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,7 @@ CHANGELOG
 * bug-fix: Local Mode: correctly handle the case where the model output folder doesn't exist yet
 * doc-fix: Fix typos in tensorflow serving documentation
 * doc-fix: Add estimator base classes to API docs
-* feature: SageMaker Automatic Model Tuning's Warm Start jobs integration
+* feature: Add support for automatic model tuner's warm start jobs
 
 1.14.2
 ======

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,7 +11,6 @@ CHANGELOG
 * doc-fix: Add estimator base classes to API docs
 * feature: SageMaker Automatic Model Tuning's Warm Start jobs integration
 
-
 1.14.2
 ======
 

--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -279,7 +279,8 @@ class Session(object):
     def tune(self, job_name, strategy, objective_type, objective_metric_name,
              max_jobs, max_parallel_jobs, parameter_ranges,
              static_hyperparameters, image, input_mode, metric_definitions,
-             role, input_config, output_config, resource_config, stop_condition, tags):
+             role, input_config, output_config, resource_config, stop_condition, tags,
+             warm_start_config):
         """Create an Amazon SageMaker hyperparameter tuning job
 
         Args:
@@ -323,6 +324,8 @@ class Session(object):
             stop_condition (dict): When training should finish, e.g. ``MaxRuntimeInSeconds``.
             tags (list[dict]): List of tags for labeling the tuning job. For more, see
                 https://docs.aws.amazon.com/sagemaker/latest/dg/API_Tag.html.
+            warm_start_config (dict): Configuration defining the type of warm start and
+                other required configurations.
         """
         tune_request = {
             'HyperParameterTuningJobName': job_name,
@@ -351,6 +354,9 @@ class Session(object):
                 'StoppingCondition': stop_condition,
             }
         }
+
+        if warm_start_config:
+            tune_request['WarmStartConfig'] = warm_start_config
 
         if metric_definitions is not None:
             tune_request['TrainingJobDefinition']['AlgorithmSpecification']['MetricDefinitions'] = metric_definitions

--- a/src/sagemaker/tuner.py
+++ b/src/sagemaker/tuner.py
@@ -605,7 +605,7 @@ class HyperparameterTuner(object):
                         pass
 
     def transfer_learning_tuner(self, additional_parents=None, estimator=None):
-        """Creates a new ``HyperarameterTuner`` by copying the request fields from the provided parent to the new
+        """Creates a new ``HyperparameterTuner`` by copying the request fields from the provided parent to the new
         instance of ``HyperparameterTuner``. Followed by addition of warm start configuration with the type as
         "TransferLearning" and parents as the union of provided list of ``additional_parents`` and the ``self``.
         Also, training image in the new tuner's estimator is updated with the provided ``training_image``.
@@ -632,8 +632,8 @@ class HyperparameterTuner(object):
                                              estimator=estimator)
 
     def identical_dataset_and_algorithm_tuner(self, additional_parents=None):
-        """Creates a new ``HyperarameterTuner`` by copying the request fields from the provided parent to the new
-        instance of ``HyperarameterTuner``. Followed by addition of warm start configuration with the type as
+        """Creates a new ``HyperparameterTuner`` by copying the request fields from the provided parent to the new
+        instance of ``HyperparameterTuner``. Followed by addition of warm start configuration with the type as
         "IdenticalDataAndAlgorithm" and parents as the union of provided list of ``additional_parents`` and the ``self``
 
         Args:
@@ -725,7 +725,7 @@ class _TuningJob(_Job):
 
 def create_identical_dataset_and_algorithm_tuner(parent, additional_parents=None, sagemaker_session=None):
     """Creates a new tuner by copying the request fields from the provided parent to the new instance of
-        ``HyperarameterTuner`` followed by addition of warm start configuration with the type as
+        ``HyperparameterTuner`` followed by addition of warm start configuration with the type as
         "IdenticalDataAndAlgorithm" and ``parents`` as the union of provided list of ``additional_parents`` and the
         ``parent``.
 
@@ -748,7 +748,7 @@ def create_identical_dataset_and_algorithm_tuner(parent, additional_parents=None
 
 def create_transfer_learning_tuner(parent, additional_parents=None, estimator=None, sagemaker_session=None):
     """Creates a new ``HyperParameterTuner`` by copying the request fields from the provided parent to the new instance
-        of ``HyperarameterTuner`` followed by addition of warm start configuration with the type as "TransferLearning"
+        of ``HyperparameterTuner`` followed by addition of warm start configuration with the type as "TransferLearning"
         and ``parents`` as the union of provided list of ``additional_parents`` and the ``parent``.
 
     Args:

--- a/src/sagemaker/tuner.py
+++ b/src/sagemaker/tuner.py
@@ -164,13 +164,15 @@ class WarmStartConfig(object):
         """Initializes the WarmStartConfig with the provided WarmStartType and parents.
 
         Args:
-            warm_start_type (sagemaker.tuner.WarmStartTypes): This should be one of the supported warm start types in WarmStartType
+            warm_start_type (sagemaker.tuner.WarmStartTypes): This should be one of the supported warm start types
+            in WarmStartType
             parents (set{str}): Set of parent tuning jobs which will be used to warm start the new tuning job.
         """
 
         if warm_start_type not in WarmStartTypes:
             raise ValueError(
-                "Invalid type: {}, valid warm start types are: [{}]".format(warm_start_type, [t for t in WarmStartTypes]))
+                "Invalid type: {}, valid warm start types are: [{}]".format(warm_start_type,
+                                                                            [t for t in WarmStartTypes]))
 
         if not parents:
             raise ValueError("Invalid parents: {}, parents should not be None/empty".format(parents))

--- a/src/sagemaker/tuner.py
+++ b/src/sagemaker/tuner.py
@@ -286,8 +286,8 @@ class HyperparameterTuner(object):
             base_tuning_job_name (str): Prefix for the hyperparameter tuning job name when the
                 :meth:`~sagemaker.tuner.HyperparameterTuner.fit` method launches. If not specified,
                 a default job name is generaged, based on the training image name and current timestamp.
-            warm_start_config (sagemaker.tuner.WarmStartConfig): A ``WarmStartConfig`` object that has been initialized with
-                the configuration defining the nature of warm start tuning job.
+            warm_start_config (sagemaker.tuner.WarmStartConfig): A ``WarmStartConfig`` object that has been initialized
+                with the configuration defining the nature of warm start tuning job.
         """
         self._hyperparameter_ranges = hyperparameter_ranges
         if self._hyperparameter_ranges is None or len(self._hyperparameter_ranges) == 0:

--- a/src/sagemaker/tuner.py
+++ b/src/sagemaker/tuner.py
@@ -150,7 +150,8 @@ class WarmStartTypes(Enum):
 
 
 class WarmStartConfig(object):
-    """Warm Start Configuration which defines the nature of the warm start tuner, with type and parents for warm start.
+    """Warm Start Configuration which defines the nature of the warm start ``HyperparameterTuner``, with type and
+    parents for warm start.
 
     Examples:
         >>> warm_start_config = WarmStartConfig(type=WarmStartTypes.TransferLearning, parents={"p1","p2"})
@@ -161,7 +162,7 @@ class WarmStartConfig(object):
     """
 
     def __init__(self, warm_start_type, parents):
-        """Initializes the WarmStartConfig with the provided WarmStartType and parents.
+        """Initializes the ``WarmStartConfig`` with the provided ``WarmStartTypes`` and parents.
 
         Args:
             warm_start_type (sagemaker.tuner.WarmStartTypes): This should be one of the supported warm start types
@@ -285,7 +286,7 @@ class HyperparameterTuner(object):
             base_tuning_job_name (str): Prefix for the hyperparameter tuning job name when the
                 :meth:`~sagemaker.tuner.HyperparameterTuner.fit` method launches. If not specified,
                 a default job name is generaged, based on the training image name and current timestamp.
-            warm_start_config (sagemaker.tuner.WarmStartConfig): A WarmStartConfig object that has been initialized with
+            warm_start_config (sagemaker.tuner.WarmStartConfig): A ``WarmStartConfig`` object that has been initialized with
                 the configuration defining the nature of warm start tuning job.
         """
         self._hyperparameter_ranges = hyperparameter_ranges
@@ -604,10 +605,10 @@ class HyperparameterTuner(object):
                         pass
 
     def transfer_learning_tuner(self, additional_parents=None, estimator=None):
-        """Creates a new tuner by copying the request fields from the provided parent to the new instance of
-        ``HyperparameterTuner``. Followed by addition of warm start configuration with the type as "TransferLearning"
-        and parents as the union of provided list of ``additional_parents`` and the ``self``. Also, training image in
-        the new tuner's estimator is updated with the provided ``training_image``.
+        """Creates a new ``HyperarameterTuner`` by copying the request fields from the provided parent to the new
+        instance of ``HyperparameterTuner``. Followed by addition of warm start configuration with the type as
+        "TransferLearning" and parents as the union of provided list of ``additional_parents`` and the ``self``.
+        Also, training image in the new tuner's estimator is updated with the provided ``training_image``.
 
         Args:
             additional_parents (set{str}): Set of additional parents along with the self to be used in warm starting
@@ -625,15 +626,14 @@ class HyperparameterTuner(object):
             Later On:
             >>> transfer_learning_tuner.fit(inputs={})
         """
-        _transfer_learning_tuner = self._create_warm_start_tuner(additional_parents=additional_parents,
-                                                                 warm_start_type=WarmStartTypes.TRANSFER_LEARNING,
-                                                                 estimator=estimator)
 
-        return _transfer_learning_tuner
+        return self._create_warm_start_tuner(additional_parents=additional_parents,
+                                             warm_start_type=WarmStartTypes.TRANSFER_LEARNING,
+                                             estimator=estimator)
 
     def identical_dataset_and_algorithm_tuner(self, additional_parents=None):
-        """Creates a new tuner by copying the request fields from the provided parent to the new instance of
-        ``HyperarameterTuner``. Followed by addition of warm start configuration with the type as
+        """Creates a new ``HyperarameterTuner`` by copying the request fields from the provided parent to the new
+        instance of ``HyperarameterTuner``. Followed by addition of warm start configuration with the type as
         "IdenticalDataAndAlgorithm" and parents as the union of provided list of ``additional_parents`` and the ``self``
 
         Args:
@@ -656,8 +656,8 @@ class HyperparameterTuner(object):
                                              warm_start_type=WarmStartTypes.IDENTICAL_DATA_AND_ALGORITHM)
 
     def _create_warm_start_tuner(self, additional_parents, warm_start_type, estimator=None):
-        """Creates a new HyperparameterTuner with WarmStartConfig, where type will be equal to warm_start_type and
-        parents would be equal to union of additional_parents and self.
+        """Creates a new ``HyperparameterTuner`` with ``WarmStartConfig``, where type will be equal to
+        ``warm_start_type`` and``parents`` would be equal to union of ``additional_parents`` and self.
 
         Args:
             additional_parents (set{str}): Additional parents along with self, to be used for warm starting.
@@ -725,8 +725,9 @@ class _TuningJob(_Job):
 
 def create_identical_dataset_and_algorithm_tuner(parent, additional_parents=None, sagemaker_session=None):
     """Creates a new tuner by copying the request fields from the provided parent to the new instance of
-        HyperarameterTuner. Followed by addition of warm start configuration with the type as
-        "IdenticalDataAndAlgorithm" and parents as the union of provided list of additional_parents and the parent.
+        ``HyperarameterTuner`` followed by addition of warm start configuration with the type as
+        "IdenticalDataAndAlgorithm" and ``parents`` as the union of provided list of ``additional_parents`` and the
+        ``parent``.
 
     Args:
         parent (str): Primary parent tuning job's name from which the Tuner and Estimator configuration has to be copied
@@ -737,7 +738,8 @@ def create_identical_dataset_and_algorithm_tuner(parent, additional_parents=None
                 using the default AWS configuration chain.
 
     Returns:
-        sagemaker.tuner.HyperparameterTuner: New instance of warm started HyperparameterTuner
+        sagemaker.tuner.HyperparameterTuner: a new ``HyperparameterTuner`` object for the warm-started
+        hyperparameter tuning job
     """
 
     parent_tuner = HyperparameterTuner.attach(tuning_job_name=parent, sagemaker_session=sagemaker_session)
@@ -745,10 +747,9 @@ def create_identical_dataset_and_algorithm_tuner(parent, additional_parents=None
 
 
 def create_transfer_learning_tuner(parent, additional_parents=None, estimator=None, sagemaker_session=None):
-    """Creates a new tuner by copying the request fields from the provided parent to the new instance of
-        HyperarameterTuner.
-        Followed by addition of warm start configuration with the type as "TransferLearning" and parents as the
-        union of provided list of additional_parents and the parent.
+    """Creates a new ``HyperParameterTuner`` by copying the request fields from the provided parent to the new instance
+        of ``HyperarameterTuner`` followed by addition of warm start configuration with the type as "TransferLearning"
+        and ``parents`` as the union of provided list of ``additional_parents`` and the ``parent``.
 
     Args:
         parent (str): Primary parent tuning job's name from which the Tuner and Estimator configuration has to be copied

--- a/src/sagemaker/tuner.py
+++ b/src/sagemaker/tuner.py
@@ -15,6 +15,7 @@ from __future__ import absolute_import
 import importlib
 import inspect
 import json
+from enum import Enum
 
 from sagemaker.amazon.amazon_estimator import AmazonAlgorithmEstimatorBase, RecordSet
 from sagemaker.amazon.hyperparameter import Hyperparameter as hp  # noqa
@@ -35,6 +36,9 @@ AMAZON_ESTIMATOR_CLS_NAMES = {
     'knn': 'KNN',
     'object2vec': 'Object2Vec',
 }
+HYPERPARAMETER_TUNING_JOB_NAME = 'HyperParameterTuningJobName'
+PARENT_HYPERPARAMETER_TUNING_JOBS = 'ParentHyperParameterTuningJobs'
+WARM_START_TYPE = 'WarmStartType'
 
 
 class _ParameterRange(object):
@@ -134,6 +138,110 @@ class IntegerParameter(_ParameterRange):
     __name__ = 'Integer'
 
 
+class WarmStartTypes(Enum):
+    """Warm Start Configuration type. There can be two types of warm start jobs:
+        * IdenticalDataAndAlgorithm: Type of warm start that allows users to reuse training results from existing
+        tuning jobs that have the same algorithm code and datasets.
+        * TransferLearning: Type of warm start that allows users to reuse training results from existing tuning jobs
+        that have similar algorithm code and datasets.
+    """
+    IDENTICAL_DATA_AND_ALGORITHM = "IdenticalDataAndAlgorithm"
+    TRANSFER_LEARNING = "TransferLearning"
+
+
+class WarmStartConfig(object):
+    """Warm Start Configuration which defines the nature of the warm start tuner, with type and parents for warm start.
+
+    Examples:
+        >>> warm_start_config = WarmStartConfig(type=WarmStartTypes.TransferLearning, parents={"p1","p2"})
+        >>> warm_start_config.type
+        "TransferLearning"
+        >>> warm_start_config.parents
+        {"p1","p2"}
+    """
+
+    def __init__(self, type, parents):
+        """Initializes the WarmStartConfig with the provided WarmStartType and parents.
+
+        Args:
+            type (sagemaker.tuner.WarmStartTypes): This should be one of the supported warm start types in WarmStartType
+            parents (set{str}): Set of parent tuning jobs which will be used to warm start the new tuning job.
+        """
+
+        if type not in WarmStartTypes:
+            raise ValueError(
+                "Invalid type: {}, valid warm start types are: [{}]".format(type, [t for t in WarmStartTypes]))
+
+        if not parents:
+            raise ValueError("Invalid parents: {}, parents should not be None/empty".format(parents))
+
+        self.type = type
+        self.parents = set(parents)
+
+    @classmethod
+    def from_job_desc(cls, warm_start_config):
+        """Creates an instance of ``WarmStartConfig`` class, from warm start configuration response from
+        DescribeTrainingJob.
+
+        Args:
+            warm_start_config (dict): The expected format of the ``warm_start_config`` contains two first-class
+            fields:
+                * "type": Type of warm start tuner, currently two supported types - "IdenticalDataAndAlgorithm" and
+                "TransferLearning".
+                * "parents": List of tuning job names from which the warm start should be done.
+
+        Returns:
+            sagemaker.tuner.WarmStartConfig: De-serialized instance of WarmStartConfig containing the type and parents
+            provided as part of ``warm_start_config``.
+
+        Examples:
+            >>> warm_start_config = WarmStartConfig.from_job_desc(warm_start_config={
+            >>>    "WarmStartType":"TransferLearning",
+            >>>    "ParentHyperParameterTuningJobs": [
+            >>>        {'HyperParameterTuningJobName': "p1"},
+            >>>        {'HyperParameterTuningJobName': "p2"},
+            >>>    ]
+            >>>})
+            >>> warm_start_config.type
+            "TransferLearning"
+            >>> warm_start_config.parents
+            ["p1","p2"]
+        """
+        if not warm_start_config or \
+                WARM_START_TYPE not in warm_start_config or \
+                PARENT_HYPERPARAMETER_TUNING_JOBS not in warm_start_config:
+            return None
+
+        parents = []
+        for parent in warm_start_config[PARENT_HYPERPARAMETER_TUNING_JOBS]:
+            parents.append(parent[HYPERPARAMETER_TUNING_JOB_NAME])
+
+        return cls(type=WarmStartTypes(warm_start_config[WARM_START_TYPE]),
+                   parents=parents)
+
+    def to_input_req(self):
+        """Converts the ``self`` instance to the desired input request format.
+
+        Returns:
+            dict: Containing the "WarmStartType" and "ParentHyperParameterTuningJobs" as the first class fields.
+
+        Examples:
+            >>> warm_start_config = WarmStartConfig(type=WarmStartTypes.TransferLearning,parents=["p1,p2"])
+            >>> warm_start_config.to_input_req()
+            {
+                "WarmStartType":"TransferLearning",
+                "ParentHyperParameterTuningJobs": [
+                    {'HyperParameterTuningJobName': "p1"},
+                    {'HyperParameterTuningJobName': "p2"},
+                ]
+            }
+        """
+        return {
+            WARM_START_TYPE: self.type.value,
+            PARENT_HYPERPARAMETER_TUNING_JOBS: [{HYPERPARAMETER_TUNING_JOB_NAME: parent} for parent in self.parents]
+        }
+
+
 class HyperparameterTuner(object):
     """A class for creating and interacting with Amazon SageMaker hyperparameter tuning jobs, as well as
     deploying the resulting model(s).
@@ -148,7 +256,7 @@ class HyperparameterTuner(object):
 
     def __init__(self, estimator, objective_metric_name, hyperparameter_ranges, metric_definitions=None,
                  strategy='Bayesian', objective_type='Maximize', max_jobs=1, max_parallel_jobs=1,
-                 tags=None, base_tuning_job_name=None):
+                 tags=None, base_tuning_job_name=None, warm_start_config=None):
         """Initialize a ``HyperparameterTuner``. It takes an estimator to obtain configuration information
         for training jobs that are created as the result of a hyperparameter tuning job.
 
@@ -175,6 +283,8 @@ class HyperparameterTuner(object):
             base_tuning_job_name (str): Prefix for the hyperparameter tuning job name when the
                 :meth:`~sagemaker.tuner.HyperparameterTuner.fit` method launches. If not specified,
                 a default job name is generaged, based on the training image name and current timestamp.
+            warm_start_config (sagemaker.tuner.WarmStartConfig): A WarmStartConfig object that has been initialized with
+                the configuration defining the nature of warm start tuning job.
         """
         self._hyperparameter_ranges = hyperparameter_ranges
         if self._hyperparameter_ranges is None or len(self._hyperparameter_ranges) == 0:
@@ -194,6 +304,7 @@ class HyperparameterTuner(object):
         self.base_tuning_job_name = base_tuning_job_name
         self._current_job_name = None
         self.latest_tuning_job = None
+        self.warm_start_config = warm_start_config
 
     def _prepare_for_training(self, job_name=None, include_cls_metadata=True):
         if job_name is not None:
@@ -419,6 +530,7 @@ class HyperparameterTuner(object):
             'strategy': tuning_config['Strategy'],
             'max_jobs': tuning_config['ResourceLimits']['MaxNumberOfTrainingJobs'],
             'max_parallel_jobs': tuning_config['ResourceLimits']['MaxParallelTrainingJobs'],
+            'warm_start_config': WarmStartConfig.from_job_desc(job_details.get('WarmStartConfig', None))
         }
 
     @classmethod
@@ -489,6 +601,83 @@ class HyperparameterTuner(object):
                     except KeyError:
                         pass
 
+    def transfer_learning_tuner(self, additional_parents={}, estimator=None):
+        """Creates a new tuner by copying the request fields from the provided parent to the new instance of
+        ``HyperparameterTuner``. Followed by addition of warm start configuration with the type as "TransferLearning"
+        and parents as the union of provided list of ``additional_parents`` and the ``self``. Also, training image in
+        the new tuner's estimator is updated with the provided ``training_image``.
+
+        Args:
+            additional_parents (set{str}): Set of additional parents along with the self to be used in warm starting
+            the transfer learning tuner.
+            estimator (sagemaker.estimator.EstimatorBase): An estimator object that has been initialized with
+                the desired configuration. There does not need to be a training job associated with this instance.
+
+        Returns:
+            sagemaker.tuner.HyperparameterTuner: ``HyperparameterTuner`` instance which can be used to launch transfer
+            learning tuning job.
+
+        Examples:
+            >>> parent_tuner = HyperparameterTuner.attach(tuning_job_name="parent-job-1")
+            >>> transfer_learning_tuner = parent_tuner.transfer_learning_tuner(additional_parents={"parent-job-2"})
+            Later On:
+            >>> transfer_learning_tuner.fit(inputs={})
+        """
+        _transfer_learning_tuner = self._create_warm_start_tuner(additional_parents=additional_parents,
+                                                                 warm_start_type=WarmStartTypes.TRANSFER_LEARNING,
+                                                                 estimator=estimator)
+
+        return _transfer_learning_tuner
+
+    def identical_dataset_and_algorithm_tuner(self, additional_parents={}):
+        """Creates a new tuner by copying the request fields from the provided parent to the new instance of
+        ``HyperarameterTuner``. Followed by addition of warm start configuration with the type as
+        "IdenticalDataAndAlgorithm" and parents as the union of provided list of ``additional_parents`` and the ``self``
+
+        Args:
+            additional_parents (set{str}): Set of additional parents along with the self to be used in warm starting
+            the identical dataset and algorithm tuner.
+
+        Returns:
+            sagemaker.tuner.HyperparameterTuner: HyperparameterTuner instance which can be used to launch identical
+            dataset and algorithm tuning job.
+
+        Examples:
+            >>> parent_tuner = HyperparameterTuner.attach(tuning_job_name="parent-job-1")
+            >>> identical_dataset_algo_tuner = parent_tuner.identical_dataset_and_algorithm_tuner(
+            >>>                                                             additional_parents={"parent-job-2"})
+            Later On:
+            >>> identical_dataset_algo_tuner.fit(inputs={})
+        """
+
+        return self._create_warm_start_tuner(additional_parents=additional_parents,
+                                             warm_start_type=WarmStartTypes.IDENTICAL_DATA_AND_ALGORITHM)
+
+    def _create_warm_start_tuner(self, additional_parents, warm_start_type, estimator=None):
+        """Creates a new HyperparameterTuner with WarmStartConfig, where type will be equal to warm_start_type and
+        parents would be equal to union of additional_parents and self.
+
+        Args:
+            additional_parents (set{str}): Additional parents along with self, to be used for warm starting.
+            warm_start_type (sagemaker.tuner.WarmStartTypes): Type of warm start job.
+
+        Returns:
+            sagemaker.tuner.HyperparameterTuner: Instance with the request fields copied from self along with the
+            warm start configuration
+        """
+        all_parents = {self.latest_tuning_job.name}
+        if additional_parents:
+            all_parents = all_parents.union(additional_parents)
+
+        return HyperparameterTuner(estimator=estimator if estimator else self.estimator,
+                                   objective_metric_name=self.objective_metric_name,
+                                   hyperparameter_ranges=self._hyperparameter_ranges,
+                                   objective_type=self.objective_type,
+                                   max_jobs=self.max_jobs,
+                                   max_parallel_jobs=self.max_parallel_jobs,
+                                   warm_start_config=WarmStartConfig(type=warm_start_type,
+                                                                     parents=all_parents))
+
 
 class _TuningJob(_Job):
     @classmethod
@@ -504,6 +693,10 @@ class _TuningJob(_Job):
         """
         config = _Job._load_config(inputs, tuner.estimator)
 
+        warm_start_config_req = None
+        if tuner.warm_start_config:
+            warm_start_config_req = tuner.warm_start_config.to_input_req()
+
         tuner.estimator.sagemaker_session.tune(job_name=tuner._current_job_name, strategy=tuner.strategy,
                                                objective_type=tuner.objective_type,
                                                objective_metric_name=tuner.objective_metric_name,
@@ -516,7 +709,8 @@ class _TuningJob(_Job):
                                                role=(config['role']), input_config=(config['input_config']),
                                                output_config=(config['output_config']),
                                                resource_config=(config['resource_config']),
-                                               stop_condition=(config['stop_condition']), tags=tuner.tags)
+                                               stop_condition=(config['stop_condition']), tags=tuner.tags,
+                                               warm_start_config=warm_start_config_req)
 
         return cls(tuner.sagemaker_session, tuner._current_job_name)
 
@@ -525,3 +719,49 @@ class _TuningJob(_Job):
 
     def wait(self):
         self.sagemaker_session.wait_for_tuning_job(self.name)
+
+
+def create_identical_dataset_and_algorithm_tuner(parent, additional_parents=None, sagemaker_session=None):
+    """Creates a new tuner by copying the request fields from the provided parent to the new instance of
+        HyperarameterTuner. Followed by addition of warm start configuration with the type as
+        "IdenticalDataAndAlgorithm" and parents as the union of provided list of additional_parents and the parent.
+
+    Args:
+        parent (str): Primary parent tuning job's name from which the Tuner and Estimator configuration has to be copied
+        additional_parents (set{str}): Set of additional parent tuning job's names along with the primary parent tuning
+            job name to be used in warm starting the transfer learning tuner.
+        sagemaker_session (sagemaker.session.Session): Session object which manages interactions with
+                Amazon SageMaker APIs and any other AWS services needed. If not specified, one is created
+                using the default AWS configuration chain.
+
+    Returns:
+        sagemaker.tuner.HyperparameterTuner: New instance of warm started HyperparameterTuner
+    """
+
+    parent_tuner = HyperparameterTuner.attach(tuning_job_name=parent, sagemaker_session=sagemaker_session)
+    return parent_tuner.identical_dataset_and_algorithm_tuner(additional_parents=additional_parents)
+
+
+def create_transfer_learning_tuner(parent, additional_parents=None, estimator=None, sagemaker_session=None):
+    """Creates a new tuner by copying the request fields from the provided parent to the new instance of
+        HyperarameterTuner.
+        Followed by addition of warm start configuration with the type as "TransferLearning" and parents as the
+        union of provided list of additional_parents and the parent.
+
+    Args:
+        parent (str): Primary parent tuning job's name from which the Tuner and Estimator configuration has to be copied
+        additional_parents (set{str}): Set of additional parent tuning job's names along with the primary parent tuning
+            job name to be used in warm starting the identical dataset and algorithm tuner.
+        estimator (sagemaker.estimator.EstimatorBase): An estimator object that has been initialized with
+                the desired configuration. There does not need to be a training job associated with this instance.
+        sagemaker_session (sagemaker.session.Session): Session object which manages interactions with
+                Amazon SageMaker APIs and any other AWS services needed. If not specified, one is created
+                using the default AWS configuration chain.
+
+    Returns:
+        sagemaker.tuner.HyperparameterTuner: New instance of warm started HyperparameterTuner
+    """
+
+    parent_tuner = HyperparameterTuner.attach(tuning_job_name=parent, sagemaker_session=sagemaker_session)
+    return parent_tuner.transfer_learning_tuner(additional_parents=additional_parents,
+                                                estimator=estimator)

--- a/src/sagemaker/tuner.py
+++ b/src/sagemaker/tuner.py
@@ -160,22 +160,22 @@ class WarmStartConfig(object):
         {"p1","p2"}
     """
 
-    def __init__(self, type, parents):
+    def __init__(self, warm_start_type, parents):
         """Initializes the WarmStartConfig with the provided WarmStartType and parents.
 
         Args:
-            type (sagemaker.tuner.WarmStartTypes): This should be one of the supported warm start types in WarmStartType
+            warm_start_type (sagemaker.tuner.WarmStartTypes): This should be one of the supported warm start types in WarmStartType
             parents (set{str}): Set of parent tuning jobs which will be used to warm start the new tuning job.
         """
 
-        if type not in WarmStartTypes:
+        if warm_start_type not in WarmStartTypes:
             raise ValueError(
-                "Invalid type: {}, valid warm start types are: [{}]".format(type, [t for t in WarmStartTypes]))
+                "Invalid type: {}, valid warm start types are: [{}]".format(warm_start_type, [t for t in WarmStartTypes]))
 
         if not parents:
             raise ValueError("Invalid parents: {}, parents should not be None/empty".format(parents))
 
-        self.type = type
+        self.type = warm_start_type
         self.parents = set(parents)
 
     @classmethod
@@ -216,7 +216,7 @@ class WarmStartConfig(object):
         for parent in warm_start_config[PARENT_HYPERPARAMETER_TUNING_JOBS]:
             parents.append(parent[HYPERPARAMETER_TUNING_JOB_NAME])
 
-        return cls(type=WarmStartTypes(warm_start_config[WARM_START_TYPE]),
+        return cls(warm_start_type=WarmStartTypes(warm_start_config[WARM_START_TYPE]),
                    parents=parents)
 
     def to_input_req(self):
@@ -226,7 +226,7 @@ class WarmStartConfig(object):
             dict: Containing the "WarmStartType" and "ParentHyperParameterTuningJobs" as the first class fields.
 
         Examples:
-            >>> warm_start_config = WarmStartConfig(type=WarmStartTypes.TransferLearning,parents=["p1,p2"])
+            >>> warm_start_config = WarmStartConfig(warm_start_type=WarmStartTypes.TransferLearning,parents=["p1,p2"])
             >>> warm_start_config.to_input_req()
             {
                 "WarmStartType":"TransferLearning",
@@ -601,7 +601,7 @@ class HyperparameterTuner(object):
                     except KeyError:
                         pass
 
-    def transfer_learning_tuner(self, additional_parents={}, estimator=None):
+    def transfer_learning_tuner(self, additional_parents=None, estimator=None):
         """Creates a new tuner by copying the request fields from the provided parent to the new instance of
         ``HyperparameterTuner``. Followed by addition of warm start configuration with the type as "TransferLearning"
         and parents as the union of provided list of ``additional_parents`` and the ``self``. Also, training image in
@@ -629,7 +629,7 @@ class HyperparameterTuner(object):
 
         return _transfer_learning_tuner
 
-    def identical_dataset_and_algorithm_tuner(self, additional_parents={}):
+    def identical_dataset_and_algorithm_tuner(self, additional_parents=None):
         """Creates a new tuner by copying the request fields from the provided parent to the new instance of
         ``HyperarameterTuner``. Followed by addition of warm start configuration with the type as
         "IdenticalDataAndAlgorithm" and parents as the union of provided list of ``additional_parents`` and the ``self``
@@ -675,7 +675,7 @@ class HyperparameterTuner(object):
                                    objective_type=self.objective_type,
                                    max_jobs=self.max_jobs,
                                    max_parallel_jobs=self.max_parallel_jobs,
-                                   warm_start_config=WarmStartConfig(type=warm_start_type,
+                                   warm_start_config=WarmStartConfig(warm_start_type=warm_start_type,
                                                                      parents=all_parents))
 
 

--- a/tests/integ/test_tuner.py
+++ b/tests/integ/test_tuner.py
@@ -143,7 +143,7 @@ def test_tuning_kmeans_identical_dataset_algorithm_tuner_raw(sagemaker_session,
           hyperparameter_ranges=hyperparameter_ranges, max_parallel_jobs=1, max_jobs=1)
     child_tuner = _tune(kmeans_estimator, kmeans_train_set, job_name=child_tuning_job_name,
                         hyperparameter_ranges=hyperparameter_ranges,
-                        warm_start_config=WarmStartConfig(type=WarmStartTypes.IDENTICAL_DATA_AND_ALGORITHM,
+                        warm_start_config=WarmStartConfig(warm_start_type=WarmStartTypes.IDENTICAL_DATA_AND_ALGORITHM,
                                                           parents=[parent_tuning_job_name]), max_parallel_jobs=1,
                         max_jobs=1)
 

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -24,6 +24,11 @@ from mock import Mock, patch, call
 import sagemaker
 from sagemaker import s3_input, Session, get_execution_role
 from sagemaker.session import _tuning_job_status, _transform_job_status, _train_done
+from sagemaker.tuner import WarmStartConfig, WarmStartTypes
+
+STATIC_HPs = {"feature_dim": "784", }
+
+SAMPLE_PARAM_RANGES = [{"Name": "mini_batch_size", "MinValue": "10", "MaxValue": "100"}]
 
 REGION = 'us-west-2'
 
@@ -267,6 +272,114 @@ def test_train_pack_to_request(sagemaker_session):
 
     assert sagemaker_session.sagemaker_client.method_calls[0] == (
         'create_training_job', (), DEFAULT_EXPECTED_TRAIN_JOB_ARGS)
+
+
+SAMPLE_STOPPING_CONDITION = {'MaxRuntimeInSeconds': MAX_TIME}
+
+RESOURCE_CONFIG = {'InstanceCount': INSTANCE_COUNT, 'InstanceType': INSTANCE_TYPE, 'VolumeSizeInGB': MAX_SIZE}
+
+SAMPLE_INPUT = [{'DataSource': {
+    'S3DataSource': {'S3DataDistributionType': 'FullyReplicated', 'S3DataType': 'S3Prefix', 'S3Uri': S3_INPUT_URI}},
+    'ChannelName': 'training'}]
+
+SAMPLE_OUTPUT = {'S3OutputPath': S3_OUTPUT}
+
+SAMPLE_OBJECTIVE = {'Type': "Maximize", 'MetricName': "val-score", }
+
+SAMPLE_METRIC_DEF = [{"Name": "train:progress", "Regex": "regex-1"}]
+
+SAMPLE_TUNING_JOB_REQUEST = {
+    'HyperParameterTuningJobName': 'dummy-tuning-1',
+    'HyperParameterTuningJobConfig': {
+        'Strategy': "Bayesian",
+        'HyperParameterTuningJobObjective': SAMPLE_OBJECTIVE,
+        'ResourceLimits': {
+            'MaxNumberOfTrainingJobs': 100,
+            'MaxParallelTrainingJobs': 5,
+        },
+        'ParameterRanges': SAMPLE_PARAM_RANGES,
+    },
+    'TrainingJobDefinition': {
+        'StaticHyperParameters': STATIC_HPs,
+        'AlgorithmSpecification': {
+            'TrainingImage': "dummy-image-1",
+            'TrainingInputMode': "File",
+            'MetricDefinitions': SAMPLE_METRIC_DEF
+        },
+        'RoleArn': EXPANDED_ROLE,
+        'InputDataConfig': SAMPLE_INPUT,
+        'OutputDataConfig': SAMPLE_OUTPUT,
+
+        'ResourceConfig': RESOURCE_CONFIG,
+        'StoppingCondition': SAMPLE_STOPPING_CONDITION
+    }
+}
+
+
+@pytest.mark.parametrize('warm_start_type, parents', [
+    ("IdenticalDataAndAlgorithm", {"p1", "p2", "p3"}),
+    ("TransferLearning", {"p1", "p2", "p3"}),
+])
+def test_tune_warm_start(sagemaker_session, warm_start_type, parents):
+
+    def assert_create_tuning_job_request(**kwrags):
+        assert kwrags["HyperParameterTuningJobConfig"] == SAMPLE_TUNING_JOB_REQUEST["HyperParameterTuningJobConfig"]
+        assert kwrags["HyperParameterTuningJobName"] == "dummy-tuning-1"
+        assert kwrags["TrainingJobDefinition"] == SAMPLE_TUNING_JOB_REQUEST["TrainingJobDefinition"]
+        assert kwrags["WarmStartConfig"] == {
+            'WarmStartType': warm_start_type,
+            'ParentHyperParameterTuningJobs': [{'HyperParameterTuningJobName': parent} for parent in parents]
+        }
+
+    sagemaker_session.sagemaker_client.create_hyper_parameter_tuning_job.side_effect = assert_create_tuning_job_request
+    sagemaker_session.tune(job_name="dummy-tuning-1",
+                           strategy="Bayesian",
+                           objective_type="Maximize",
+                           objective_metric_name="val-score",
+                           max_jobs=100,
+                           max_parallel_jobs=5,
+                           parameter_ranges=SAMPLE_PARAM_RANGES,
+                           static_hyperparameters=STATIC_HPs,
+                           image="dummy-image-1",
+                           input_mode="File",
+                           metric_definitions=SAMPLE_METRIC_DEF,
+                           role=EXPANDED_ROLE,
+                           input_config=SAMPLE_INPUT,
+                           output_config=SAMPLE_OUTPUT,
+                           resource_config=RESOURCE_CONFIG,
+                           stop_condition=SAMPLE_STOPPING_CONDITION,
+                           tags=None,
+                           warm_start_config=WarmStartConfig(type=WarmStartTypes(warm_start_type),
+                                                             parents=parents).to_input_req())
+
+
+def test_tune(sagemaker_session):
+
+    def assert_create_tuning_job_request(**kwrags):
+        assert kwrags["HyperParameterTuningJobConfig"] == SAMPLE_TUNING_JOB_REQUEST["HyperParameterTuningJobConfig"]
+        assert kwrags["HyperParameterTuningJobName"] == "dummy-tuning-1"
+        assert kwrags["TrainingJobDefinition"] == SAMPLE_TUNING_JOB_REQUEST["TrainingJobDefinition"]
+        assert kwrags.get("WarmStartConfig", None) is None
+
+    sagemaker_session.sagemaker_client.create_hyper_parameter_tuning_job.side_effect = assert_create_tuning_job_request
+    sagemaker_session.tune(job_name="dummy-tuning-1",
+                           strategy="Bayesian",
+                           objective_type="Maximize",
+                           objective_metric_name="val-score",
+                           max_jobs=100,
+                           max_parallel_jobs=5,
+                           parameter_ranges=SAMPLE_PARAM_RANGES,
+                           static_hyperparameters=STATIC_HPs,
+                           image="dummy-image-1",
+                           input_mode="File",
+                           metric_definitions=SAMPLE_METRIC_DEF,
+                           role=EXPANDED_ROLE,
+                           input_config=SAMPLE_INPUT,
+                           output_config=SAMPLE_OUTPUT,
+                           resource_config=RESOURCE_CONFIG,
+                           stop_condition=SAMPLE_STOPPING_CONDITION,
+                           tags=None,
+                           warm_start_config=None)
 
 
 def test_stop_tuning_job(sagemaker_session):

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -349,7 +349,7 @@ def test_tune_warm_start(sagemaker_session, warm_start_type, parents):
                            resource_config=RESOURCE_CONFIG,
                            stop_condition=SAMPLE_STOPPING_CONDITION,
                            tags=None,
-                           warm_start_config=WarmStartConfig(type=WarmStartTypes(warm_start_type),
+                           warm_start_config=WarmStartConfig(warm_start_type=WarmStartTypes(warm_start_type),
                                                              parents=parents).to_input_req())
 
 

--- a/tests/unit/test_tuner.py
+++ b/tests/unit/test_tuner.py
@@ -23,7 +23,8 @@ from sagemaker.amazon.pca import PCA
 from sagemaker.amazon.amazon_estimator import RecordSet
 from sagemaker.estimator import Estimator
 from sagemaker.tuner import _ParameterRange, ContinuousParameter, IntegerParameter, CategoricalParameter, \
-    HyperparameterTuner, _TuningJob
+    HyperparameterTuner, _TuningJob, WarmStartConfig, create_identical_dataset_and_algorithm_tuner, \
+    create_transfer_learning_tuner, WarmStartTypes
 from sagemaker.mxnet import MXNet
 MODEL_DATA = "s3://bucket/model.tar.gz"
 
@@ -300,6 +301,20 @@ def test_attach_with_no_specified_estimator(sagemaker_session):
     assert isinstance(tuner.estimator, Estimator)
 
 
+def test_attach_with_warm_start_config(sagemaker_session):
+    warm_start_config = WarmStartConfig(type=WarmStartTypes.TRANSFER_LEARNING,
+                                        parents={"p1", "p2"})
+    job_details = copy.deepcopy(TUNING_JOB_DETAILS)
+    job_details["WarmStartConfig"] = warm_start_config.to_input_req()
+
+    sagemaker_session.sagemaker_client.describe_hyper_parameter_tuning_job = Mock(name='describe_tuning_job',
+                                                                                  return_value=job_details)
+
+    tuner = HyperparameterTuner.attach(JOB_NAME, sagemaker_session=sagemaker_session)
+    assert tuner.warm_start_config.type == warm_start_config.type
+    assert tuner.warm_start_config.parents == warm_start_config.parents
+
+
 def test_serialize_parameter_ranges(tuner):
     hyperparameter_ranges = tuner.hyperparameter_ranges()
 
@@ -474,8 +489,44 @@ def test_delete_endpoint(tuner):
     tuner.sagemaker_session.delete_endpoint.assert_called_with(JOB_NAME)
 
 
+def test_identical_dataset_and_algorithm_tuner(sagemaker_session):
+    job_details = copy.deepcopy(TUNING_JOB_DETAILS)
+    sagemaker_session.sagemaker_client.describe_hyper_parameter_tuning_job = Mock(name='describe_tuning_job',
+                                                                                  return_value=job_details)
+
+    tuner = HyperparameterTuner.attach(JOB_NAME, sagemaker_session=sagemaker_session)
+    parent_tuner = tuner.identical_dataset_and_algorithm_tuner(additional_parents={"p1", "p2"})
+    assert parent_tuner.warm_start_config.type == WarmStartTypes.IDENTICAL_DATA_AND_ALGORITHM
+    assert parent_tuner.warm_start_config.parents == {tuner.latest_tuning_job.name, "p1", "p2"}
+
+
+def test_transfer_learning_tuner_with_estimator(sagemaker_session, estimator):
+    job_details = copy.deepcopy(TUNING_JOB_DETAILS)
+    sagemaker_session.sagemaker_client.describe_hyper_parameter_tuning_job = Mock(name='describe_tuning_job',
+                                                                                  return_value=job_details)
+
+    tuner = HyperparameterTuner.attach(JOB_NAME, sagemaker_session=sagemaker_session)
+    parent_tuner = tuner.transfer_learning_tuner(additional_parents={"p1", "p2"}, estimator=estimator)
+
+    assert parent_tuner.warm_start_config.type == WarmStartTypes.TRANSFER_LEARNING
+    assert parent_tuner.warm_start_config.parents == {tuner.latest_tuning_job.name, "p1", "p2"}
+    assert parent_tuner.estimator == estimator and parent_tuner.estimator != tuner.estimator
+
+
+def test_transfer_learning_tuner(sagemaker_session):
+    job_details = copy.deepcopy(TUNING_JOB_DETAILS)
+    sagemaker_session.sagemaker_client.describe_hyper_parameter_tuning_job = Mock(name='describe_tuning_job',
+                                                                                  return_value=job_details)
+
+    tuner = HyperparameterTuner.attach(JOB_NAME, sagemaker_session=sagemaker_session)
+    parent_tuner = tuner.transfer_learning_tuner(additional_parents={"p1", "p2"})
+
+    assert parent_tuner.warm_start_config.type == WarmStartTypes.TRANSFER_LEARNING
+    assert parent_tuner.warm_start_config.parents == {tuner.latest_tuning_job.name, "p1", "p2"}
+    assert parent_tuner.estimator == tuner.estimator
 #################################################################################
 # _ParameterRange Tests
+
 
 def test_continuous_parameter():
     cont_param = ContinuousParameter(0.1, 1e-2)
@@ -561,3 +612,93 @@ def test_tuning_job_wait(sagemaker_session):
     tuning_job.wait()
 
     sagemaker_session.wait_for_tuning_job.assert_called_once_with(JOB_NAME)
+
+
+#################################################################################
+# WarmStartConfig Tests
+
+@pytest.mark.parametrize('type, parents', [
+    (WarmStartTypes.IDENTICAL_DATA_AND_ALGORITHM, {"p1", "p2", "p3"}),
+    (WarmStartTypes.IDENTICAL_DATA_AND_ALGORITHM, {"p1", "p3", "p3"}),
+    (WarmStartTypes.TRANSFER_LEARNING, {"p3"}),
+])
+def test_warm_start_config_init(type, parents):
+    warm_start_config = WarmStartConfig(type=type,
+                                        parents=parents)
+
+    assert warm_start_config.type == type, "Warm start type initialization failed."
+    assert warm_start_config.parents == set(parents), "Warm start parents config initialization failed."
+
+    warm_start_config_req = warm_start_config.to_input_req()
+    assert warm_start_config.type == WarmStartTypes(warm_start_config_req["WarmStartType"])
+    for parent in warm_start_config_req["ParentHyperParameterTuningJobs"]:
+        assert parent['HyperParameterTuningJobName'] in parents
+
+
+@pytest.mark.parametrize('type, parents', [
+    ("InvalidType", {"p1", "p2", "p3"}),
+    (None, {"p1", "p2", "p3"}),
+    ("", {"p1", "p2", "p3"}),
+    (WarmStartTypes.TRANSFER_LEARNING, None),
+    (WarmStartTypes.TRANSFER_LEARNING, {}),
+])
+def test_warm_start_config_init_negative(type, parents):
+    with pytest.raises(ValueError):
+        WarmStartConfig(type=type, parents=parents)
+
+
+@pytest.mark.parametrize('warm_start_config_req', [
+    ({}),
+    (None),
+    ({'WarmStartType': 'TransferLearning'}),
+    ({'ParentHyperParameterTuningJobs': []}),
+])
+def test_prepare_warm_start_config_cls_negative(warm_start_config_req):
+    warm_start_config = WarmStartConfig.from_job_desc(warm_start_config_req)
+    assert warm_start_config is None, "Warm start config should be None for invalid type/parents"
+
+
+@pytest.mark.parametrize('warm_start_config_req', [
+    ({'WarmStartType': 'TransferLearning', 'ParentHyperParameterTuningJobs': [{'HyperParameterTuningJobName': 'p1'},
+                                                                              {'HyperParameterTuningJobName': 'p2'}]}),
+    ({'WarmStartType': 'IdenticalDataAndAlgorithm',
+      'ParentHyperParameterTuningJobs': [{'HyperParameterTuningJobName': 'p1'},
+                                         {'HyperParameterTuningJobName': 'p1'}]}),
+])
+def test_prepare_warm_start_config_cls(warm_start_config_req):
+    warm_start_config = WarmStartConfig.from_job_desc(warm_start_config_req)
+
+    assert warm_start_config.type == WarmStartTypes(
+        warm_start_config_req["WarmStartType"]), "Warm start type initialization failed."
+
+    for p in warm_start_config_req["ParentHyperParameterTuningJobs"]:
+        assert p['HyperParameterTuningJobName'] in warm_start_config.parents, \
+            "Warm start parents config initialization failed."
+
+
+def test_create_identical_dataset_and_algorithm_tuner(sagemaker_session):
+    job_details = copy.deepcopy(TUNING_JOB_DETAILS)
+    sagemaker_session.sagemaker_client.describe_hyper_parameter_tuning_job = Mock(name='describe_tuning_job',
+                                                                                  return_value=job_details)
+
+    parent_tuner = create_identical_dataset_and_algorithm_tuner(parent=JOB_NAME,
+                                                                additional_parents={"p1", "p2"},
+                                                                sagemaker_session=sagemaker_session)
+
+    assert parent_tuner.warm_start_config.type == WarmStartTypes.IDENTICAL_DATA_AND_ALGORITHM
+    assert parent_tuner.warm_start_config.parents == {JOB_NAME, "p1", "p2"}
+
+
+def test_create_transfer_learning_tuner(sagemaker_session, estimator):
+    job_details = copy.deepcopy(TUNING_JOB_DETAILS)
+    sagemaker_session.sagemaker_client.describe_hyper_parameter_tuning_job = Mock(name='describe_tuning_job',
+                                                                                  return_value=job_details)
+
+    parent_tuner = create_transfer_learning_tuner(parent=JOB_NAME,
+                                                  additional_parents={"p1", "p2"},
+                                                  sagemaker_session=sagemaker_session,
+                                                  estimator=estimator)
+
+    assert parent_tuner.warm_start_config.type == WarmStartTypes.TRANSFER_LEARNING
+    assert parent_tuner.warm_start_config.parents == {JOB_NAME, "p1", "p2"}
+    assert parent_tuner.estimator == estimator

--- a/tests/unit/test_tuner.py
+++ b/tests/unit/test_tuner.py
@@ -696,8 +696,8 @@ def test_create_identical_dataset_and_algorithm_tuner(sagemaker_session, additio
         assert tuner.warm_start_config.parents == {JOB_NAME}
 
 
-@pytest.mark.parametrize('additional_parents',[
-    {"p1","p2"},
+@pytest.mark.parametrize('additional_parents', [
+    {"p1", "p2"},
     {},
     None,
 ])


### PR DESCRIPTION
*Description of changes:*
This change adds sdk support for:
* Transfer Learning Warm Start Tuning Job
* Identical Data and Algorithm Warm Start Tuning Job

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have updated the [changelog](https://github.com/aws/sagemaker-python-sdk/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
