### PR TITLE
Add support for additional libraries in the Estimator

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 CHANGELOG
 =========
 
+1.15.1dev
+=========
+
+* feature: Estimators: lib_dirs attribute allows export of additional libraries into the container
+
 1.15.0
 ======
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ CHANGELOG
 1.15.1dev
 =========
 
-* feature: Estimators: lib_dirs attribute allows export of additional libraries into the container
+* feature: Estimators: dependencies attribute allows export of additional libraries into the container
 * feature: Add APIs to export Airflow transform and deploy config
 
 1.15.0

--- a/src/sagemaker/chainer/README.rst
+++ b/src/sagemaker/chainer/README.rst
@@ -149,14 +149,14 @@ The following are optional arguments. When you create a ``Chainer`` object, you 
    other training source code dependencies including the entry point
    file. Structure within this directory will be preserved when training
    on SageMaker.
-- ``lib_dirs (list[str])`` A list of paths to directories (absolute or relative) with
+- ``dependencies (list[str])`` A list of paths to directories (absolute or relative) with
         any additional libraries that will be exported to the container (default: []).
         The library folders will be copied to SageMaker in the same folder where the entrypoint is copied.
         If the ```source_dir``` points to S3, code will be uploaded and the S3 location will be used
         instead. Example:
 
             The following call
-            >>> Estimator(entry_point='train.py', lib_dirs=['my/libs/common', 'virtual-env'])
+            >>> Chainer(entry_point='train.py', dependencies=['my/libs/common', 'virtual-env'])
             results in the following inside the container:
 
             >>> $ ls

--- a/src/sagemaker/chainer/README.rst
+++ b/src/sagemaker/chainer/README.rst
@@ -149,6 +149,23 @@ The following are optional arguments. When you create a ``Chainer`` object, you 
    other training source code dependencies including the entry point
    file. Structure within this directory will be preserved when training
    on SageMaker.
+- ``lib_dirs (list[str])`` A list of paths to directories (absolute or relative) with
+        any additional libraries that will be exported to the container (default: []).
+        The library folders will be copied to SageMaker in the same folder where the entrypoint is copied.
+        If the ```source_dir``` points to S3, code will be uploaded and the S3 location will be used
+        instead. Example:
+
+            The following call
+            >>> Estimator(entry_point='train.py', lib_dirs=['my/libs/common', 'virtual-env'])
+            results in the following inside the container:
+
+            >>> $ ls
+
+            >>> opt/ml/code
+            >>>     ├── train.py
+            >>>     ├── common
+            >>>     └── virtual-env
+
 -  ``hyperparameters`` Hyperparameters that will be used for training.
    Will be made accessible as a dict[str, str] to the training code on
    SageMaker. For convenience, accepts other types besides str, but

--- a/src/sagemaker/chainer/estimator.py
+++ b/src/sagemaker/chainer/estimator.py
@@ -133,7 +133,7 @@ class Chainer(Framework):
                             py_version=self.py_version, framework_version=self.framework_version,
                             model_server_workers=model_server_workers, image=self.image_name,
                             sagemaker_session=self.sagemaker_session,
-                            vpc_config=self.get_vpc_config(vpc_config_override), lib_dirs=self.lib_dirs)
+                            vpc_config=self.get_vpc_config(vpc_config_override), dependencies=self.dependencies)
 
     @classmethod
     def _prepare_init_params_from_job_description(cls, job_details, model_channel_name=None):

--- a/src/sagemaker/chainer/estimator.py
+++ b/src/sagemaker/chainer/estimator.py
@@ -133,7 +133,7 @@ class Chainer(Framework):
                             py_version=self.py_version, framework_version=self.framework_version,
                             model_server_workers=model_server_workers, image=self.image_name,
                             sagemaker_session=self.sagemaker_session,
-                            vpc_config=self.get_vpc_config(vpc_config_override))
+                            vpc_config=self.get_vpc_config(vpc_config_override), lib_dirs=self.lib_dirs)
 
     @classmethod
     def _prepare_init_params_from_job_description(cls, job_details, model_channel_name=None):

--- a/src/sagemaker/estimator.py
+++ b/src/sagemaker/estimator.py
@@ -637,7 +637,7 @@ class Framework(EstimatorBase):
     LAUNCH_PS_ENV_NAME = 'sagemaker_parameter_server_enabled'
 
     def __init__(self, entry_point, source_dir=None, hyperparameters=None, enable_cloudwatch_metrics=False,
-                 container_log_level=logging.INFO, code_location=None, image_name=None, lib_dirs=None, **kwargs):
+                 container_log_level=logging.INFO, code_location=None, image_name=None, dependencies=None, **kwargs):
         """Base class initializer. Subclasses which override ``__init__`` should invoke ``super()``
 
         Args:
@@ -646,13 +646,13 @@ class Framework(EstimatorBase):
             source_dir (str): Path (absolute or relative) to a directory with any other training
                 source code dependencies aside from tne entry point file (default: None). Structure within this
                 directory are preserved when training on Amazon SageMaker.
-            lib_dirs (list[str]): A list of paths to directories (absolute or relative) with
+            dependencies (list[str]): A list of paths to directories (absolute or relative) with
                 any additional libraries that will be exported to the container (default: []).
                 The library folders will be copied to SageMaker in the same folder where the entrypoint is copied.
                 Example:
 
                     The following call
-                    >>> Estimator(entry_point='train.py', lib_dirs=['my/libs/common', 'virtual-env'])
+                    >>> Estimator(entry_point='train.py', dependencies=['my/libs/common', 'virtual-env'])
                     results in the following inside the container:
 
                     >>> $ ls
@@ -679,7 +679,7 @@ class Framework(EstimatorBase):
         """
         super(Framework, self).__init__(**kwargs)
         self.source_dir = source_dir
-        self.lib_dirs = lib_dirs or []
+        self.dependencies = dependencies or []
         self.entry_point = entry_point
         if enable_cloudwatch_metrics:
             warnings.warn('enable_cloudwatch_metrics is now deprecated and will be removed in the future.',
@@ -747,7 +747,7 @@ class Framework(EstimatorBase):
                                   s3_key_prefix=code_s3_prefix,
                                   script=self.entry_point,
                                   directory=self.source_dir,
-                                  lib_dirs=self.lib_dirs)
+                                  dependencies=self.dependencies)
 
     def _model_source_dir(self):
         """Get the appropriate value to pass as source_dir to model constructor on deploying

--- a/src/sagemaker/fw_utils.py
+++ b/src/sagemaker/fw_utils.py
@@ -14,10 +14,14 @@ from __future__ import absolute_import
 
 import os
 import re
+import shutil
+import tempfile
 from collections import namedtuple
 from six.moves.urllib.parse import urlparse
 
 import sagemaker.utils
+
+_TAR_SOURCE_FILENAME = 'source.tar.gz'
 
 UploadedCode = namedtuple('UserCode', ['s3_prefix', 'script_name'])
 """sagemaker.fw_utils.UserCode: An object containing the S3 prefix and script name.
@@ -107,7 +111,7 @@ def validate_source_dir(script, directory):
     return True
 
 
-def tar_and_upload_dir(session, bucket, s3_key_prefix, script, directory):
+def tar_and_upload_dir(session, bucket, s3_key_prefix, script, directory, lib_dirs=None):
     """Pack and upload source files to S3 only if directory is empty or local.
 
     Note:
@@ -118,31 +122,48 @@ def tar_and_upload_dir(session, bucket, s3_key_prefix, script, directory):
         bucket (str): S3 bucket to which the compressed file is uploaded.
         s3_key_prefix (str): Prefix for the S3 key.
         script (str): Script filename.
-        directory (str): Directory containing the source file. If it starts with "s3://", no action is taken.
+        directory (str or None): Directory containing the source file. If it starts with
+                                    "s3://", no action is taken.
+        lib_dirs (List[str]): A list of paths to directories (absolute or relative)
+                                containing additional libraries that will be copied into
+                                /opt/ml/lib
 
     Returns:
         sagemaker.fw_utils.UserCode: An object with the S3 bucket and key (S3 prefix) and script name.
     """
-    if directory:
-        if directory.lower().startswith("s3://"):
-            return UploadedCode(s3_prefix=directory, script_name=os.path.basename(script))
-        else:
-            script_name = script
-            source_files = [os.path.join(directory, name) for name in os.listdir(directory)]
+    lib_dirs = lib_dirs or []
+    key = '%s/sourcedir.tar.gz' % s3_key_prefix
+
+    if directory and directory.lower().startswith('s3://'):
+        return UploadedCode(s3_prefix=directory, script_name=os.path.basename(script))
     else:
-        # If no directory is specified, the script parameter needs to be a valid relative path.
-        os.path.exists(script)
-        script_name = os.path.basename(script)
-        source_files = [script]
+        tmp = tempfile.mkdtemp()
 
-    s3 = session.resource('s3')
-    key = '{}/{}'.format(s3_key_prefix, 'sourcedir.tar.gz')
+        try:
+            source_files = list(_expand_files_to_compress(script, directory))
 
-    tar_file = sagemaker.utils.create_tar_file(source_files)
-    s3.Object(bucket, key).upload_file(tar_file)
-    os.remove(tar_file)
+            tar_file = sagemaker.utils.create_tar_file(source_files + lib_dirs, os.path.join(tmp, _TAR_SOURCE_FILENAME))
 
-    return UploadedCode(s3_prefix='s3://{}/{}'.format(bucket, key), script_name=script_name)
+            session.resource('s3').Object(bucket, key).upload_file(tar_file)
+
+        finally:
+            shutil.rmtree(tmp)
+
+        script_name = script if directory else os.path.basename(script)
+        return UploadedCode(s3_prefix='s3://%s/%s' % (bucket, key), script_name=script_name)
+
+
+def _expand_files_to_compress(script, directory, additional_files=None):
+    additional_files = additional_files or []
+    basedir = directory if directory else os.path.dirname(script)
+    files = [basedir] + additional_files
+
+    for file in files:
+        if os.path.isfile(file):
+            yield file
+        else:
+            for name in os.listdir(file):
+                yield os.path.join(file, name)
 
 
 def framework_name_from_image(image_name):

--- a/src/sagemaker/fw_utils.py
+++ b/src/sagemaker/fw_utils.py
@@ -111,7 +111,7 @@ def validate_source_dir(script, directory):
     return True
 
 
-def tar_and_upload_dir(session, bucket, s3_key_prefix, script, directory, lib_dirs=None):
+def tar_and_upload_dir(session, bucket, s3_key_prefix, script, directory, dependencies=None):
     """Pack and upload source files to S3 only if directory is empty or local.
 
     Note:
@@ -124,14 +124,14 @@ def tar_and_upload_dir(session, bucket, s3_key_prefix, script, directory, lib_di
         script (str): Script filename.
         directory (str or None): Directory containing the source file. If it starts with
                                     "s3://", no action is taken.
-        lib_dirs (List[str]): A list of paths to directories (absolute or relative)
+        dependencies (List[str]): A list of paths to directories (absolute or relative)
                                 containing additional libraries that will be copied into
                                 /opt/ml/lib
 
     Returns:
         sagemaker.fw_utils.UserCode: An object with the S3 bucket and key (S3 prefix) and script name.
     """
-    lib_dirs = lib_dirs or []
+    dependencies = dependencies or []
     key = '%s/sourcedir.tar.gz' % s3_key_prefix
 
     if directory and directory.lower().startswith('s3://'):
@@ -140,7 +140,7 @@ def tar_and_upload_dir(session, bucket, s3_key_prefix, script, directory, lib_di
         tmp = tempfile.mkdtemp()
 
         try:
-            source_files = _list_files_to_compress(script, directory) + lib_dirs
+            source_files = _list_files_to_compress(script, directory) + dependencies
             tar_file = sagemaker.utils.create_tar_file(source_files, os.path.join(tmp, _TAR_SOURCE_FILENAME))
 
             session.resource('s3').Object(bucket, key).upload_file(tar_file)

--- a/src/sagemaker/model.py
+++ b/src/sagemaker/model.py
@@ -16,10 +16,10 @@ import logging
 
 import sagemaker
 
-from sagemaker.local import LocalSession
-from sagemaker.fw_utils import tar_and_upload_dir, parse_s3_url, model_code_key_prefix
-from sagemaker.session import Session
-from sagemaker.utils import name_from_image, get_config_value
+from sagemaker import local
+from sagemaker import fw_utils
+from sagemaker import session
+from sagemaker import utils
 
 
 class Model(object):
@@ -96,12 +96,12 @@ class Model(object):
         """
         if not self.sagemaker_session:
             if instance_type in ('local', 'local_gpu'):
-                self.sagemaker_session = LocalSession()
+                self.sagemaker_session = local.LocalSession()
             else:
-                self.sagemaker_session = Session()
+                self.sagemaker_session = session.Session()
 
         container_def = self.prepare_container_def(instance_type)
-        self.name = self.name or name_from_image(container_def['Image'])
+        self.name = self.name or utils.name_from_image(container_def['Image'])
         self.sagemaker_session.create_model(self.name, self.role, container_def, vpc_config=self.vpc_config)
         production_variant = sagemaker.production_variant(self.name, instance_type, initial_instance_count)
         self.endpoint_name = endpoint_name or self.name
@@ -127,7 +127,7 @@ class FrameworkModel(Model):
 
     def __init__(self, model_data, image, role, entry_point, source_dir=None, predictor_cls=None, env=None, name=None,
                  enable_cloudwatch_metrics=False, container_log_level=logging.INFO, code_location=None,
-                 sagemaker_session=None, lib_dirs=None, **kwargs):
+                 sagemaker_session=None, dependencies=None, **kwargs):
         """Initialize a ``FrameworkModel``.
 
         Args:
@@ -140,14 +140,14 @@ class FrameworkModel(Model):
                 source code dependencies aside from tne entry point file (default: None). Structure within this
                 directory will be preserved when training on SageMaker.
                 If the directory points to S3, no code will be uploaded and the S3 location will be used instead.
-            lib_dirs (list[str]): A list of paths to directories (absolute or relative) with
+            dependencies (list[str]): A list of paths to directories (absolute or relative) with
                 any additional libraries that will be exported to the container (default: []).
                 The library folders will be copied to SageMaker in the same folder where the entrypoint is copied.
                 If the ```source_dir``` points to S3, code will be uploaded and the S3 location will be used
                 instead. Example:
 
                     The following call
-                    >>> Estimator(entry_point='train.py', lib_dirs=['my/libs/common', 'virtual-env'])
+                    >>> Estimator(entry_point='train.py', dependencies=['my/libs/common', 'virtual-env'])
                     results in the following inside the container:
 
                     >>> $ ls
@@ -177,11 +177,11 @@ class FrameworkModel(Model):
                                              sagemaker_session=sagemaker_session, **kwargs)
         self.entry_point = entry_point
         self.source_dir = source_dir
-        self.lib_dirs = lib_dirs or []
+        self.dependencies = dependencies or []
         self.enable_cloudwatch_metrics = enable_cloudwatch_metrics
         self.container_log_level = container_log_level
         if code_location:
-            self.bucket, self.key_prefix = parse_s3_url(code_location)
+            self.bucket, self.key_prefix = fw_utils.parse_s3_url(code_location)
         else:
             self.bucket, self.key_prefix = None, None
         self.uploaded_code = None
@@ -197,23 +197,24 @@ class FrameworkModel(Model):
         Returns:
             dict[str, str]: A container definition object usable with the CreateModel API.
         """
-        deploy_key_prefix = model_code_key_prefix(self.key_prefix, self.name, self.image)
+        deploy_key_prefix = fw_utils.model_code_key_prefix(self.key_prefix, self.name, self.image)
         self._upload_code(deploy_key_prefix)
         deploy_env = dict(self.env)
         deploy_env.update(self._framework_env_vars())
         return sagemaker.container_def(self.image, self.model_data, deploy_env)
 
     def _upload_code(self, key_prefix):
-        local_code = get_config_value('local.local_code', self.sagemaker_session.config)
+        local_code = utils.get_config_value('local.local_code', self.sagemaker_session.config)
         if self.sagemaker_session.local_mode and local_code:
             self.uploaded_code = None
         else:
-            self.uploaded_code = tar_and_upload_dir(session=self.sagemaker_session.boto_session,
-                                                    bucket=self.bucket or self.sagemaker_session.default_bucket(),
-                                                    s3_key_prefix=key_prefix,
-                                                    script=self.entry_point,
-                                                    directory=self.source_dir,
-                                                    lib_dirs=self.lib_dirs)
+            bucket = self.bucket or self.sagemaker_session.default_bucket()
+            self.uploaded_code = fw_utils.tar_and_upload_dir(session=self.sagemaker_session.boto_session,
+                                                             bucket=bucket,
+                                                             s3_key_prefix=key_prefix,
+                                                             script=self.entry_point,
+                                                             directory=self.source_dir,
+                                                             dependencies=self.dependencies)
 
     def _framework_env_vars(self):
         if self.uploaded_code:

--- a/src/sagemaker/mxnet/README.rst
+++ b/src/sagemaker/mxnet/README.rst
@@ -271,14 +271,14 @@ The following are optional arguments. When you create an ``MXNet`` object, you c
    other training source code dependencies including the entry point
    file. Structure within this directory will be preserved when training
    on SageMaker.
-- ``lib_dirs (list[str])`` A list of paths to directories (absolute or relative) with
+- ``dependencies (list[str])`` A list of paths to directories (absolute or relative) with
         any additional libraries that will be exported to the container (default: []).
         The library folders will be copied to SageMaker in the same folder where the entrypoint is copied.
         If the ```source_dir``` points to S3, code will be uploaded and the S3 location will be used
         instead. Example:
 
             The following call
-            >>> Estimator(entry_point='train.py', lib_dirs=['my/libs/common', 'virtual-env'])
+            >>> MXNet(entry_point='train.py', dependencies=['my/libs/common', 'virtual-env'])
             results in the following inside the container:
 
             >>> $ ls

--- a/src/sagemaker/mxnet/README.rst
+++ b/src/sagemaker/mxnet/README.rst
@@ -271,6 +271,23 @@ The following are optional arguments. When you create an ``MXNet`` object, you c
    other training source code dependencies including the entry point
    file. Structure within this directory will be preserved when training
    on SageMaker.
+- ``lib_dirs (list[str])`` A list of paths to directories (absolute or relative) with
+        any additional libraries that will be exported to the container (default: []).
+        The library folders will be copied to SageMaker in the same folder where the entrypoint is copied.
+        If the ```source_dir``` points to S3, code will be uploaded and the S3 location will be used
+        instead. Example:
+
+            The following call
+            >>> Estimator(entry_point='train.py', lib_dirs=['my/libs/common', 'virtual-env'])
+            results in the following inside the container:
+
+            >>> $ ls
+
+            >>> opt/ml/code
+            >>>     ├── train.py
+            >>>     ├── common
+            >>>     └── virtual-env
+
 -  ``hyperparameters`` Hyperparameters that will be used for training.
    Will be made accessible as a dict[str, str] to the training code on
    SageMaker. For convenience, accepts other types besides str, but

--- a/src/sagemaker/mxnet/estimator.py
+++ b/src/sagemaker/mxnet/estimator.py
@@ -115,7 +115,7 @@ class MXNet(Framework):
                           container_log_level=self.container_log_level, code_location=self.code_location,
                           py_version=self.py_version, framework_version=self.framework_version, image=self.image_name,
                           model_server_workers=model_server_workers, sagemaker_session=self.sagemaker_session,
-                          vpc_config=self.get_vpc_config(vpc_config_override))
+                          vpc_config=self.get_vpc_config(vpc_config_override), lib_dirs=self.lib_dirs)
 
     @classmethod
     def _prepare_init_params_from_job_description(cls, job_details, model_channel_name=None):

--- a/src/sagemaker/mxnet/estimator.py
+++ b/src/sagemaker/mxnet/estimator.py
@@ -115,7 +115,7 @@ class MXNet(Framework):
                           container_log_level=self.container_log_level, code_location=self.code_location,
                           py_version=self.py_version, framework_version=self.framework_version, image=self.image_name,
                           model_server_workers=model_server_workers, sagemaker_session=self.sagemaker_session,
-                          vpc_config=self.get_vpc_config(vpc_config_override), lib_dirs=self.lib_dirs)
+                          vpc_config=self.get_vpc_config(vpc_config_override), dependencies=self.dependencies)
 
     @classmethod
     def _prepare_init_params_from_job_description(cls, job_details, model_channel_name=None):

--- a/src/sagemaker/pytorch/README.rst
+++ b/src/sagemaker/pytorch/README.rst
@@ -175,14 +175,14 @@ The following are optional arguments. When you create a ``PyTorch`` object, you 
    other training source code dependencies including the entry point
    file. Structure within this directory will be preserved when training
    on SageMaker.
-- ``lib_dirs (list[str])`` A list of paths to directories (absolute or relative) with
+- ``dependencies (list[str])`` A list of paths to directories (absolute or relative) with
         any additional libraries that will be exported to the container (default: []).
         The library folders will be copied to SageMaker in the same folder where the entrypoint is copied.
         If the ```source_dir``` points to S3, code will be uploaded and the S3 location will be used
         instead. Example:
 
             The following call
-            >>> Estimator(entry_point='train.py', lib_dirs=['my/libs/common', 'virtual-env'])
+            >>> PyTorch(entry_point='train.py', dependencies=['my/libs/common', 'virtual-env'])
             results in the following inside the container:
 
             >>> $ ls

--- a/src/sagemaker/pytorch/README.rst
+++ b/src/sagemaker/pytorch/README.rst
@@ -175,6 +175,23 @@ The following are optional arguments. When you create a ``PyTorch`` object, you 
    other training source code dependencies including the entry point
    file. Structure within this directory will be preserved when training
    on SageMaker.
+- ``lib_dirs (list[str])`` A list of paths to directories (absolute or relative) with
+        any additional libraries that will be exported to the container (default: []).
+        The library folders will be copied to SageMaker in the same folder where the entrypoint is copied.
+        If the ```source_dir``` points to S3, code will be uploaded and the S3 location will be used
+        instead. Example:
+
+            The following call
+            >>> Estimator(entry_point='train.py', lib_dirs=['my/libs/common', 'virtual-env'])
+            results in the following inside the container:
+
+            >>> $ ls
+
+            >>> opt/ml/code
+            >>>     ├── train.py
+            >>>     ├── common
+            >>>     └── virtual-env
+
 -  ``hyperparameters`` Hyperparameters that will be used for training.
    Will be made accessible as a dict[str, str] to the training code on
    SageMaker. For convenience, accepts other types besides strings, but

--- a/src/sagemaker/pytorch/estimator.py
+++ b/src/sagemaker/pytorch/estimator.py
@@ -96,7 +96,7 @@ class PyTorch(Framework):
                             container_log_level=self.container_log_level, code_location=self.code_location,
                             py_version=self.py_version, framework_version=self.framework_version, image=self.image_name,
                             model_server_workers=model_server_workers, sagemaker_session=self.sagemaker_session,
-                            vpc_config=self.get_vpc_config(vpc_config_override), lib_dirs=self.lib_dirs)
+                            vpc_config=self.get_vpc_config(vpc_config_override), dependencies=self.dependencies)
 
     @classmethod
     def _prepare_init_params_from_job_description(cls, job_details, model_channel_name=None):

--- a/src/sagemaker/pytorch/estimator.py
+++ b/src/sagemaker/pytorch/estimator.py
@@ -96,7 +96,7 @@ class PyTorch(Framework):
                             container_log_level=self.container_log_level, code_location=self.code_location,
                             py_version=self.py_version, framework_version=self.framework_version, image=self.image_name,
                             model_server_workers=model_server_workers, sagemaker_session=self.sagemaker_session,
-                            vpc_config=self.get_vpc_config(vpc_config_override))
+                            vpc_config=self.get_vpc_config(vpc_config_override), lib_dirs=self.lib_dirs)
 
     @classmethod
     def _prepare_init_params_from_job_description(cls, job_details, model_channel_name=None):

--- a/src/sagemaker/tensorflow/README.rst
+++ b/src/sagemaker/tensorflow/README.rst
@@ -409,6 +409,23 @@ you can specify these as keyword arguments.
    other training source code dependencies including the entry point
    file. Structure within this directory will be preserved when training
    on SageMaker.
+- ``lib_dirs (list[str])`` A list of paths to directories (absolute or relative) with
+        any additional libraries that will be exported to the container (default: []).
+        The library folders will be copied to SageMaker in the same folder where the entrypoint is copied.
+        If the ```source_dir``` points to S3, code will be uploaded and the S3 location will be used
+        instead. Example:
+
+            The following call
+            >>> Estimator(entry_point='train.py', lib_dirs=['my/libs/common', 'virtual-env'])
+            results in the following inside the container:
+
+            >>> $ ls
+
+            >>> opt/ml/code
+            >>>     ├── train.py
+            >>>     ├── common
+            >>>     └── virtual-env
+
 -  ``requirements_file (str)`` Path to a ``requirements.txt`` file. The path should
    be within and relative to ``source_dir``. This is a file containing a list of items to be
    installed using pip install. Details on the format can be found in the

--- a/src/sagemaker/tensorflow/README.rst
+++ b/src/sagemaker/tensorflow/README.rst
@@ -409,14 +409,14 @@ you can specify these as keyword arguments.
    other training source code dependencies including the entry point
    file. Structure within this directory will be preserved when training
    on SageMaker.
-- ``lib_dirs (list[str])`` A list of paths to directories (absolute or relative) with
+- ``dependencies (list[str])`` A list of paths to directories (absolute or relative) with
         any additional libraries that will be exported to the container (default: []).
         The library folders will be copied to SageMaker in the same folder where the entrypoint is copied.
         If the ```source_dir``` points to S3, code will be uploaded and the S3 location will be used
         instead. Example:
 
             The following call
-            >>> Estimator(entry_point='train.py', lib_dirs=['my/libs/common', 'virtual-env'])
+            >>> TensorFlow(entry_point='train.py', dependencies=['my/libs/common', 'virtual-env'])
             results in the following inside the container:
 
             >>> $ ls

--- a/src/sagemaker/tensorflow/estimator.py
+++ b/src/sagemaker/tensorflow/estimator.py
@@ -412,7 +412,7 @@ class TensorFlow(Framework):
                                model_server_workers=model_server_workers,
                                sagemaker_session=self.sagemaker_session,
                                vpc_config=self.get_vpc_config(vpc_config_override),
-                               lib_dirs=self.lib_dirs)
+                               dependencies=self.dependencies)
 
     def hyperparameters(self):
         """Return hyperparameters used by your custom TensorFlow code during model training."""

--- a/src/sagemaker/tensorflow/estimator.py
+++ b/src/sagemaker/tensorflow/estimator.py
@@ -411,7 +411,8 @@ class TensorFlow(Framework):
                                framework_version=self.framework_version,
                                model_server_workers=model_server_workers,
                                sagemaker_session=self.sagemaker_session,
-                               vpc_config=self.get_vpc_config(vpc_config_override))
+                               vpc_config=self.get_vpc_config(vpc_config_override),
+                               lib_dirs=self.lib_dirs)
 
     def hyperparameters(self):
         """Return hyperparameters used by your custom TensorFlow code during model training."""

--- a/tests/data/pytorch_source_dirs/train.py
+++ b/tests/data/pytorch_source_dirs/train.py
@@ -10,31 +10,21 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-# import os
-# import sys
-# import tarfile
-#
-# lib_dir = '/opt/ml/lib'
-#
-# if not os.path.exists(lib_dir):
-#     os.makedirs(lib_dir)
-#
-# with tarfile.open(name=os.path.join(os.path.dirname(__file__), 'opt_ml_lib.tar.gz'), mode='r:gz') as t:
-#     t.extractall(path=lib_dir)
-#
-# sys.path.insert(0, lib_dir)
-
 import alexa
+import json
+
+MODEL = '/opt/ml/model/answer'
 
 
 def model_fn(anything):
-    return alexa
+    with open(MODEL) as model:
+        return json.load(model)
 
 
 def predict_fn(input_object, model):
-    return input_object
+    return input_object + model
 
 
 if __name__ == '__main__':
-    with open('/opt/ml/model/answer', 'w') as model:
-        model.write(str(alexa.question('How many roads must a man walk down?')))
+    with open(MODEL, 'w') as model:
+        json.dump(alexa.question('How many roads must a man walk down?'), model)

--- a/tests/data/pytorch_source_dirs/train.py
+++ b/tests/data/pytorch_source_dirs/train.py
@@ -1,0 +1,40 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+# import os
+# import sys
+# import tarfile
+#
+# lib_dir = '/opt/ml/lib'
+#
+# if not os.path.exists(lib_dir):
+#     os.makedirs(lib_dir)
+#
+# with tarfile.open(name=os.path.join(os.path.dirname(__file__), 'opt_ml_lib.tar.gz'), mode='r:gz') as t:
+#     t.extractall(path=lib_dir)
+#
+# sys.path.insert(0, lib_dir)
+
+import alexa
+
+
+def model_fn(anything):
+    return alexa
+
+
+def predict_fn(input_object, model):
+    return input_object
+
+
+if __name__ == '__main__':
+    with open('/opt/ml/model/answer', 'w') as model:
+        model.write(str(alexa.question('How many roads must a man walk down?')))

--- a/tests/integ/test_source_dirs.py
+++ b/tests/integ/test_source_dirs.py
@@ -18,7 +18,7 @@ from sagemaker.pytorch.estimator import PyTorch
 from tests.integ import DATA_DIR, PYTHON_VERSION
 
 
-def test_source_dirs(sagemaker_session, tmpdir):
+def test_source_dirs(sagemaker_session, tmpdir, sagemaker_local_session):
     source_dir = os.path.join(DATA_DIR, 'pytorch_source_dirs')
     lib = os.path.join(str(tmpdir), 'alexa.py')
 
@@ -26,7 +26,8 @@ def test_source_dirs(sagemaker_session, tmpdir):
         f.write('def question(to_anything): return 42')
 
     estimator = PyTorch(entry_point='train.py', role='SageMakerRole', source_dir=source_dir, dependencies=[lib],
-                        py_version=PYTHON_VERSION, train_instance_count=1, train_instance_type='local')
+                        py_version=PYTHON_VERSION, train_instance_count=1, train_instance_type='local',
+                        sagemaker_session=sagemaker_local_session)
     try:
 
         estimator.fit()

--- a/tests/integ/test_source_dirs.py
+++ b/tests/integ/test_source_dirs.py
@@ -25,7 +25,7 @@ def test_source_dirs(sagemaker_session, tmpdir):
     with open(lib, 'w') as f:
         f.write('def question(to_anything): return 42')
 
-    estimator = PyTorch(entry_point='train.py', role='SageMakerRole', source_dir=source_dir, lib_dirs=[lib],
+    estimator = PyTorch(entry_point='train.py', role='SageMakerRole', source_dir=source_dir, dependencies=[lib],
                         py_version=PYTHON_VERSION, train_instance_count=1, train_instance_type='local')
     try:
 
@@ -33,8 +33,8 @@ def test_source_dirs(sagemaker_session, tmpdir):
 
         predictor = estimator.deploy(initial_instance_count=1, instance_type='local')
 
-        predict_response = predictor.predict([24])
+        predict_response = predictor.predict([7])
 
-        assert predict_response == [24]
+        assert predict_response == [49]
     finally:
         estimator.delete_endpoint()

--- a/tests/integ/test_source_dirs.py
+++ b/tests/integ/test_source_dirs.py
@@ -1,0 +1,40 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from __future__ import absolute_import
+
+import os
+
+from sagemaker.pytorch.estimator import PyTorch
+from tests.integ import DATA_DIR, PYTHON_VERSION
+
+
+def test_source_dirs(sagemaker_session, tmpdir):
+    source_dir = os.path.join(DATA_DIR, 'pytorch_source_dirs')
+    lib = os.path.join(str(tmpdir), 'alexa.py')
+
+    with open(lib, 'w') as f:
+        f.write('def question(to_anything): return 42')
+
+    estimator = PyTorch(entry_point='train.py', role='SageMakerRole', source_dir=source_dir, lib_dirs=[lib],
+                        py_version=PYTHON_VERSION, train_instance_count=1, train_instance_type='local')
+    try:
+
+        estimator.fit()
+
+        predictor = estimator.deploy(initial_instance_count=1, instance_type='local')
+
+        predict_response = predictor.predict([24])
+
+        assert predict_response == [24]
+    finally:
+        estimator.delete_endpoint()

--- a/tests/integ/test_source_dirs.py
+++ b/tests/integ/test_source_dirs.py
@@ -18,7 +18,7 @@ from sagemaker.pytorch.estimator import PyTorch
 from tests.integ import DATA_DIR, PYTHON_VERSION
 
 
-def test_source_dirs(sagemaker_session, tmpdir, sagemaker_local_session):
+def test_source_dirs(tmpdir, sagemaker_local_session):
     source_dir = os.path.join(DATA_DIR, 'pytorch_source_dirs')
     lib = os.path.join(str(tmpdir), 'alexa.py')
 

--- a/tests/unit/test_chainer.py
+++ b/tests/unit/test_chainer.py
@@ -18,7 +18,7 @@ import os
 import pytest
 import sys
 from distutils.util import strtobool
-from mock import Mock
+from mock import MagicMock, Mock
 from mock import patch
 
 
@@ -282,6 +282,7 @@ def test_create_model_with_custom_image(sagemaker_session):
     assert model.image == custom_image
 
 
+@patch('sagemaker.utils.create_tar_file', MagicMock())
 @patch('time.strftime', return_value=TIMESTAMP)
 def test_chainer(strftime, sagemaker_session, chainer_version):
     chainer = Chainer(entry_point=SCRIPT_PATH, role=ROLE, sagemaker_session=sagemaker_session,
@@ -321,6 +322,7 @@ def test_chainer(strftime, sagemaker_session, chainer_version):
     assert isinstance(predictor, ChainerPredictor)
 
 
+@patch('sagemaker.utils.create_tar_file', MagicMock())
 def test_model(sagemaker_session):
     model = ChainerModel("s3://some/data.tar.gz", role=ROLE, entry_point=SCRIPT_PATH,
                          sagemaker_session=sagemaker_session)

--- a/tests/unit/test_estimator.py
+++ b/tests/unit/test_estimator.py
@@ -18,7 +18,7 @@ import os
 from time import sleep
 
 import pytest
-from mock import Mock, patch
+from mock import MagicMock, Mock, patch
 
 from sagemaker.estimator import Estimator, Framework, _TrainingJob
 from sagemaker.model import FrameworkModel
@@ -125,6 +125,12 @@ class DummyFrameworkModel(FrameworkModel):
 
     def prepare_container_def(self, instance_type):
         return MODEL_CONTAINER_DEF
+
+
+@pytest.fixture(autouse=True)
+def mock_create_tar_file():
+    with patch('sagemaker.utils.create_tar_file', MagicMock()) as create_tar_file:
+        yield create_tar_file
 
 
 @pytest.fixture()

--- a/tests/unit/test_fw_utils.py
+++ b/tests/unit/test_fw_utils.py
@@ -14,6 +14,7 @@ from __future__ import absolute_import
 
 import inspect
 import os
+import tarfile
 
 import pytest
 from mock import Mock, patch
@@ -141,6 +142,134 @@ def test_tar_and_upload_dir_not_s3(sagemaker_session):
     result = tar_and_upload_dir(sagemaker_session, bucket, s3_key_prefix, script, directory)
     assert result == UploadedCode('s3://{}/{}/sourcedir.tar.gz'.format(bucket, s3_key_prefix),
                                   script)
+
+
+def file_tree(tmpdir, files=None, folders=None):
+    files = files or []
+    folders = folders or []
+    for file in files:
+        tmpdir.join(file).ensure(file=True)
+
+    for folder in folders:
+        tmpdir.join(folder).ensure(dir=True)
+
+    return str(tmpdir)
+
+
+def test_tar_and_upload_dir_no_directory(sagemaker_session, tmpdir):
+    source_dir = file_tree(tmpdir, ['train.py'])
+    entrypoint = os.path.join(source_dir, 'train.py')
+
+    with patch('shutil.rmtree'):
+        result = tar_and_upload_dir(sagemaker_session, 'bucket', 'prefix', entrypoint, None)
+
+    assert result == UploadedCode(s3_prefix='s3://bucket/prefix/sourcedir.tar.gz',
+                                  script_name='train.py')
+
+    assert {'/train.py'} == list_source_dir_files(sagemaker_session, tmpdir)
+
+
+def test_tar_and_upload_dir_with_directory(sagemaker_session, tmpdir):
+    file_tree(tmpdir, ['src-dir/train.py'])
+    source_dir = os.path.join(str(tmpdir), 'src-dir')
+
+    with patch('shutil.rmtree'):
+        result = tar_and_upload_dir(sagemaker_session, 'bucket', 'prefix', 'train.py', source_dir)
+
+    assert result == UploadedCode(s3_prefix='s3://bucket/prefix/sourcedir.tar.gz',
+                                  script_name='train.py')
+
+    assert {'/train.py'} == list_source_dir_files(sagemaker_session, tmpdir)
+
+
+def test_tar_and_upload_dir_with_subdirectory(sagemaker_session, tmpdir):
+    file_tree(tmpdir, ['src-dir/sub/train.py'])
+    source_dir = os.path.join(str(tmpdir), 'src-dir')
+
+    with patch('shutil.rmtree'):
+        result = tar_and_upload_dir(sagemaker_session, 'bucket', 'prefix', 'train.py', source_dir)
+
+    assert result == UploadedCode(s3_prefix='s3://bucket/prefix/sourcedir.tar.gz',
+                                  script_name='train.py')
+
+    assert {'/sub/train.py'} == list_source_dir_files(sagemaker_session, tmpdir)
+
+
+def test_tar_and_upload_dir_with_directory_and_files(sagemaker_session, tmpdir):
+    file_tree(tmpdir, ['src-dir/train.py', 'src-dir/laucher', 'src-dir/module/__init__.py'])
+    source_dir = os.path.join(str(tmpdir), 'src-dir')
+
+    with patch('shutil.rmtree'):
+        result = tar_and_upload_dir(sagemaker_session, 'bucket', 'prefix', 'train.py', source_dir)
+
+    assert result == UploadedCode(s3_prefix='s3://bucket/prefix/sourcedir.tar.gz',
+                                  script_name='train.py')
+
+    assert {'/laucher', '/module/__init__.py', '/train.py'} == list_source_dir_files(sagemaker_session, tmpdir)
+
+
+def test_tar_and_upload_dir_with_directories_and_files(sagemaker_session, tmpdir):
+    file_tree(tmpdir, ['src-dir/a/b', 'src-dir/a/b2', 'src-dir/x/y', 'src-dir/x/y2', 'src-dir/z'])
+    source_dir = os.path.join(str(tmpdir), 'src-dir')
+
+    with patch('shutil.rmtree'):
+        result = tar_and_upload_dir(sagemaker_session, 'bucket', 'prefix', 'a/b', source_dir)
+
+    assert result == UploadedCode(s3_prefix='s3://bucket/prefix/sourcedir.tar.gz',
+                                  script_name='a/b')
+
+    assert {'/a/b', '/a/b2', '/x/y', '/x/y2', '/z'} == list_source_dir_files(sagemaker_session, tmpdir)
+
+
+def test_tar_and_upload_dir_with_many_folders(sagemaker_session, tmpdir):
+    file_tree(tmpdir, ['src-dir/a/b', 'src-dir/a/b2', 'common/x/y', 'common/x/y2', 't/y/z'])
+    source_dir = os.path.join(str(tmpdir), 'src-dir')
+    lib_dirs = [os.path.join(str(tmpdir), 'common'), os.path.join(str(tmpdir), 't', 'y', 'z')]
+
+    with patch('shutil.rmtree'):
+        result = tar_and_upload_dir(sagemaker_session, 'bucket', 'prefix', 'model.py', source_dir, lib_dirs)
+
+    assert result == UploadedCode(s3_prefix='s3://bucket/prefix/sourcedir.tar.gz',
+                                  script_name='model.py')
+
+    assert {'/a/b', '/a/b2', '/common/x/y', '/common/x/y2', '/z'} == list_source_dir_files(sagemaker_session, tmpdir)
+
+
+def test_test_tar_and_upload_dir_with_subfolders(sagemaker_session, tmpdir):
+    file_tree(tmpdir, ['a/b/c', 'a/b/c2'])
+    root = file_tree(tmpdir, ['x/y/z', 'x/y/z2'])
+
+    with patch('shutil.rmtree'):
+        result = tar_and_upload_dir(sagemaker_session, 'bucket', 'prefix', 'b/c',
+                                    os.path.join(root, 'a'), [os.path.join(root, 'x')])
+
+    assert result == UploadedCode(s3_prefix='s3://bucket/prefix/sourcedir.tar.gz',
+                                  script_name='b/c')
+
+    assert {'/b/c', '/b/c2', '/x/y/z', '/x/y/z2'} == list_source_dir_files(sagemaker_session, tmpdir)
+
+
+def list_source_dir_files(sagemaker_session, tmpdir):
+    source_dir_tar = sagemaker_session.resource('s3').Object().upload_file.call_args[0][0]
+
+    source_dir_files = list_tar_files('/opt/ml/code/', source_dir_tar, tmpdir)
+    return source_dir_files
+
+
+def list_tar_files(folder, tar_ball, tmpdir):
+    startpath = str(tmpdir.ensure(folder, dir=True))
+
+    with tarfile.open(name=tar_ball, mode='r:gz') as t:
+        t.extractall(path=startpath)
+
+    def walk():
+        for root, dirs, files in os.walk(startpath):
+            path = root.replace(startpath, '')
+            for f in files:
+                yield '%s/%s' % (path, f)
+
+    result = set(walk())
+    return result if result else {}
 
 
 def test_framework_name_from_image_mxnet():

--- a/tests/unit/test_fw_utils.py
+++ b/tests/unit/test_fw_utils.py
@@ -19,10 +19,7 @@ import tarfile
 import pytest
 from mock import Mock, patch
 
-from sagemaker.fw_utils import create_image_uri, framework_name_from_image, \
-    framework_version_from_tag, \
-    model_code_key_prefix
-from sagemaker.fw_utils import tar_and_upload_dir, parse_s3_url, UploadedCode, validate_source_dir
+from sagemaker import fw_utils
 from sagemaker.utils import name_from_image
 
 DATA_DIR = 'data_dir'
@@ -45,62 +42,62 @@ def sagemaker_session():
 
 
 def test_create_image_uri_cpu():
-    image_uri = create_image_uri('mars-south-3', 'mlfw', 'ml.c4.large', '1.0rc', 'py2', '23')
+    image_uri = fw_utils.create_image_uri('mars-south-3', 'mlfw', 'ml.c4.large', '1.0rc', 'py2', '23')
     assert image_uri == '23.dkr.ecr.mars-south-3.amazonaws.com/sagemaker-mlfw:1.0rc-cpu-py2'
 
-    image_uri = create_image_uri('mars-south-3', 'mlfw', 'local', '1.0rc', 'py2', '23')
+    image_uri = fw_utils.create_image_uri('mars-south-3', 'mlfw', 'local', '1.0rc', 'py2', '23')
     assert image_uri == '23.dkr.ecr.mars-south-3.amazonaws.com/sagemaker-mlfw:1.0rc-cpu-py2'
 
 
 def test_create_image_uri_no_python():
-    image_uri = create_image_uri('mars-south-3', 'mlfw', 'ml.c4.large', '1.0rc', account='23')
+    image_uri = fw_utils.create_image_uri('mars-south-3', 'mlfw', 'ml.c4.large', '1.0rc', account='23')
     assert image_uri == '23.dkr.ecr.mars-south-3.amazonaws.com/sagemaker-mlfw:1.0rc-cpu'
 
 
 def test_create_image_uri_bad_python():
     with pytest.raises(ValueError):
-        create_image_uri('mars-south-3', 'mlfw', 'ml.c4.large', '1.0rc', 'py0')
+        fw_utils.create_image_uri('mars-south-3', 'mlfw', 'ml.c4.large', '1.0rc', 'py0')
 
 
 def test_create_image_uri_gpu():
-    image_uri = create_image_uri('mars-south-3', 'mlfw', 'ml.p3.2xlarge', '1.0rc', 'py3', '23')
+    image_uri = fw_utils.create_image_uri('mars-south-3', 'mlfw', 'ml.p3.2xlarge', '1.0rc', 'py3', '23')
     assert image_uri == '23.dkr.ecr.mars-south-3.amazonaws.com/sagemaker-mlfw:1.0rc-gpu-py3'
 
-    image_uri = create_image_uri('mars-south-3', 'mlfw', 'local_gpu', '1.0rc', 'py3', '23')
+    image_uri = fw_utils.create_image_uri('mars-south-3', 'mlfw', 'local_gpu', '1.0rc', 'py3', '23')
     assert image_uri == '23.dkr.ecr.mars-south-3.amazonaws.com/sagemaker-mlfw:1.0rc-gpu-py3'
 
 
 def test_create_image_uri_default_account():
-    image_uri = create_image_uri('mars-south-3', 'mlfw', 'ml.p3.2xlarge', '1.0rc', 'py3')
+    image_uri = fw_utils.create_image_uri('mars-south-3', 'mlfw', 'ml.p3.2xlarge', '1.0rc', 'py3')
     assert image_uri == '520713654638.dkr.ecr.mars-south-3.amazonaws.com/sagemaker-mlfw:1.0rc-gpu-py3'
 
 
 def test_create_image_uri_gov_cloud():
-    image_uri = create_image_uri('us-gov-west-1', 'mlfw', 'ml.p3.2xlarge', '1.0rc', 'py3')
+    image_uri = fw_utils.create_image_uri('us-gov-west-1', 'mlfw', 'ml.p3.2xlarge', '1.0rc', 'py3')
     assert image_uri == '246785580436.dkr.ecr.us-gov-west-1.amazonaws.com/sagemaker-mlfw:1.0rc-gpu-py3'
 
 
 def test_invalid_instance_type():
     # instance type is missing 'ml.' prefix
     with pytest.raises(ValueError):
-        create_image_uri('mars-south-3', 'mlfw', 'p3.2xlarge', '1.0.0', 'py3')
+        fw_utils.create_image_uri('mars-south-3', 'mlfw', 'p3.2xlarge', '1.0.0', 'py3')
 
 
 def test_optimized_family():
-    image_uri = create_image_uri('mars-south-3', 'mlfw', 'ml.p3.2xlarge', '1.0.0', 'py3',
-                                 optimized_families=['c5', 'p3'])
+    image_uri = fw_utils.create_image_uri('mars-south-3', 'mlfw', 'ml.p3.2xlarge', '1.0.0', 'py3',
+                                          optimized_families=['c5', 'p3'])
     assert image_uri == '520713654638.dkr.ecr.mars-south-3.amazonaws.com/sagemaker-mlfw:1.0.0-p3-py3'
 
 
 def test_unoptimized_cpu_family():
-    image_uri = create_image_uri('mars-south-3', 'mlfw', 'ml.m4.xlarge', '1.0.0', 'py3',
-                                 optimized_families=['c5', 'p3'])
+    image_uri = fw_utils.create_image_uri('mars-south-3', 'mlfw', 'ml.m4.xlarge', '1.0.0', 'py3',
+                                          optimized_families=['c5', 'p3'])
     assert image_uri == '520713654638.dkr.ecr.mars-south-3.amazonaws.com/sagemaker-mlfw:1.0.0-cpu-py3'
 
 
 def test_unoptimized_gpu_family():
-    image_uri = create_image_uri('mars-south-3', 'mlfw', 'ml.p2.xlarge', '1.0.0', 'py3',
-                                 optimized_families=['c5', 'p3'])
+    image_uri = fw_utils.create_image_uri('mars-south-3', 'mlfw', 'ml.p2.xlarge', '1.0.0', 'py3',
+                                          optimized_families=['c5', 'p3'])
     assert image_uri == '520713654638.dkr.ecr.mars-south-3.amazonaws.com/sagemaker-mlfw:1.0.0-gpu-py3'
 
 
@@ -109,29 +106,29 @@ def test_tar_and_upload_dir_s3(sagemaker_session):
     s3_key_prefix = 'something/source'
     script = 'mnist.py'
     directory = 's3://m'
-    result = tar_and_upload_dir(sagemaker_session, bucket, s3_key_prefix, script, directory)
-    assert result == UploadedCode('s3://m', 'mnist.py')
+    result = fw_utils.tar_and_upload_dir(sagemaker_session, bucket, s3_key_prefix, script, directory)
+    assert result == fw_utils.UploadedCode('s3://m', 'mnist.py')
 
 
 def test_validate_source_dir_does_not_exits(sagemaker_session):
     script = 'mnist.py'
     directory = ' !@#$%^&*()path probably in not there.!@#$%^&*()'
     with pytest.raises(ValueError):
-        validate_source_dir(script, directory)
+        fw_utils.validate_source_dir(script, directory)
 
 
 def test_validate_source_dir_is_not_directory(sagemaker_session):
     script = 'mnist.py'
     directory = inspect.getfile(inspect.currentframe())
     with pytest.raises(ValueError):
-        validate_source_dir(script, directory)
+        fw_utils.validate_source_dir(script, directory)
 
 
 def test_validate_source_dir_file_not_in_dir():
     script = ' !@#$%^&*() .myscript. !@#$%^&*() '
     directory = '.'
     with pytest.raises(ValueError):
-        validate_source_dir(script, directory)
+        fw_utils.validate_source_dir(script, directory)
 
 
 def test_tar_and_upload_dir_not_s3(sagemaker_session):
@@ -139,9 +136,9 @@ def test_tar_and_upload_dir_not_s3(sagemaker_session):
     s3_key_prefix = 'something/source'
     script = os.path.basename(__file__)
     directory = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
-    result = tar_and_upload_dir(sagemaker_session, bucket, s3_key_prefix, script, directory)
-    assert result == UploadedCode('s3://{}/{}/sourcedir.tar.gz'.format(bucket, s3_key_prefix),
-                                  script)
+    result = fw_utils.tar_and_upload_dir(sagemaker_session, bucket, s3_key_prefix, script, directory)
+    assert result == fw_utils.UploadedCode('s3://{}/{}/sourcedir.tar.gz'.format(bucket, s3_key_prefix),
+                                           script)
 
 
 def file_tree(tmpdir, files=None, folders=None):
@@ -161,10 +158,10 @@ def test_tar_and_upload_dir_no_directory(sagemaker_session, tmpdir):
     entrypoint = os.path.join(source_dir, 'train.py')
 
     with patch('shutil.rmtree'):
-        result = tar_and_upload_dir(sagemaker_session, 'bucket', 'prefix', entrypoint, None)
+        result = fw_utils.tar_and_upload_dir(sagemaker_session, 'bucket', 'prefix', entrypoint, None)
 
-    assert result == UploadedCode(s3_prefix='s3://bucket/prefix/sourcedir.tar.gz',
-                                  script_name='train.py')
+    assert result == fw_utils.UploadedCode(s3_prefix='s3://bucket/prefix/sourcedir.tar.gz',
+                                           script_name='train.py')
 
     assert {'/train.py'} == list_source_dir_files(sagemaker_session, tmpdir)
 
@@ -174,10 +171,10 @@ def test_tar_and_upload_dir_with_directory(sagemaker_session, tmpdir):
     source_dir = os.path.join(str(tmpdir), 'src-dir')
 
     with patch('shutil.rmtree'):
-        result = tar_and_upload_dir(sagemaker_session, 'bucket', 'prefix', 'train.py', source_dir)
+        result = fw_utils.tar_and_upload_dir(sagemaker_session, 'bucket', 'prefix', 'train.py', source_dir)
 
-    assert result == UploadedCode(s3_prefix='s3://bucket/prefix/sourcedir.tar.gz',
-                                  script_name='train.py')
+    assert result == fw_utils.UploadedCode(s3_prefix='s3://bucket/prefix/sourcedir.tar.gz',
+                                           script_name='train.py')
 
     assert {'/train.py'} == list_source_dir_files(sagemaker_session, tmpdir)
 
@@ -187,10 +184,10 @@ def test_tar_and_upload_dir_with_subdirectory(sagemaker_session, tmpdir):
     source_dir = os.path.join(str(tmpdir), 'src-dir')
 
     with patch('shutil.rmtree'):
-        result = tar_and_upload_dir(sagemaker_session, 'bucket', 'prefix', 'train.py', source_dir)
+        result = fw_utils.tar_and_upload_dir(sagemaker_session, 'bucket', 'prefix', 'train.py', source_dir)
 
-    assert result == UploadedCode(s3_prefix='s3://bucket/prefix/sourcedir.tar.gz',
-                                  script_name='train.py')
+    assert result == fw_utils.UploadedCode(s3_prefix='s3://bucket/prefix/sourcedir.tar.gz',
+                                           script_name='train.py')
 
     assert {'/sub/train.py'} == list_source_dir_files(sagemaker_session, tmpdir)
 
@@ -200,10 +197,10 @@ def test_tar_and_upload_dir_with_directory_and_files(sagemaker_session, tmpdir):
     source_dir = os.path.join(str(tmpdir), 'src-dir')
 
     with patch('shutil.rmtree'):
-        result = tar_and_upload_dir(sagemaker_session, 'bucket', 'prefix', 'train.py', source_dir)
+        result = fw_utils.tar_and_upload_dir(sagemaker_session, 'bucket', 'prefix', 'train.py', source_dir)
 
-    assert result == UploadedCode(s3_prefix='s3://bucket/prefix/sourcedir.tar.gz',
-                                  script_name='train.py')
+    assert result == fw_utils.UploadedCode(s3_prefix='s3://bucket/prefix/sourcedir.tar.gz',
+                                           script_name='train.py')
 
     assert {'/laucher', '/module/__init__.py', '/train.py'} == list_source_dir_files(sagemaker_session, tmpdir)
 
@@ -213,10 +210,10 @@ def test_tar_and_upload_dir_with_directories_and_files(sagemaker_session, tmpdir
     source_dir = os.path.join(str(tmpdir), 'src-dir')
 
     with patch('shutil.rmtree'):
-        result = tar_and_upload_dir(sagemaker_session, 'bucket', 'prefix', 'a/b', source_dir)
+        result = fw_utils.tar_and_upload_dir(sagemaker_session, 'bucket', 'prefix', 'a/b', source_dir)
 
-    assert result == UploadedCode(s3_prefix='s3://bucket/prefix/sourcedir.tar.gz',
-                                  script_name='a/b')
+    assert result == fw_utils.UploadedCode(s3_prefix='s3://bucket/prefix/sourcedir.tar.gz',
+                                           script_name='a/b')
 
     assert {'/a/b', '/a/b2', '/x/y', '/x/y2', '/z'} == list_source_dir_files(sagemaker_session, tmpdir)
 
@@ -224,13 +221,14 @@ def test_tar_and_upload_dir_with_directories_and_files(sagemaker_session, tmpdir
 def test_tar_and_upload_dir_with_many_folders(sagemaker_session, tmpdir):
     file_tree(tmpdir, ['src-dir/a/b', 'src-dir/a/b2', 'common/x/y', 'common/x/y2', 't/y/z'])
     source_dir = os.path.join(str(tmpdir), 'src-dir')
-    lib_dirs = [os.path.join(str(tmpdir), 'common'), os.path.join(str(tmpdir), 't', 'y', 'z')]
+    dependencies = [os.path.join(str(tmpdir), 'common'), os.path.join(str(tmpdir), 't', 'y', 'z')]
 
     with patch('shutil.rmtree'):
-        result = tar_and_upload_dir(sagemaker_session, 'bucket', 'prefix', 'model.py', source_dir, lib_dirs)
+        result = fw_utils.tar_and_upload_dir(sagemaker_session, 'bucket', 'prefix',
+                                             'model.py', source_dir, dependencies)
 
-    assert result == UploadedCode(s3_prefix='s3://bucket/prefix/sourcedir.tar.gz',
-                                  script_name='model.py')
+    assert result == fw_utils.UploadedCode(s3_prefix='s3://bucket/prefix/sourcedir.tar.gz',
+                                           script_name='model.py')
 
     assert {'/a/b', '/a/b2', '/common/x/y', '/common/x/y2', '/z'} == list_source_dir_files(sagemaker_session, tmpdir)
 
@@ -240,11 +238,11 @@ def test_test_tar_and_upload_dir_with_subfolders(sagemaker_session, tmpdir):
     root = file_tree(tmpdir, ['x/y/z', 'x/y/z2'])
 
     with patch('shutil.rmtree'):
-        result = tar_and_upload_dir(sagemaker_session, 'bucket', 'prefix', 'b/c',
-                                    os.path.join(root, 'a'), [os.path.join(root, 'x')])
+        result = fw_utils.tar_and_upload_dir(sagemaker_session, 'bucket', 'prefix', 'b/c',
+                                             os.path.join(root, 'a'), [os.path.join(root, 'x')])
 
-    assert result == UploadedCode(s3_prefix='s3://bucket/prefix/sourcedir.tar.gz',
-                                  script_name='b/c')
+    assert result == fw_utils.UploadedCode(s3_prefix='s3://bucket/prefix/sourcedir.tar.gz',
+                                           script_name='b/c')
 
     assert {'/b/c', '/b/c2', '/x/y/z', '/x/y/z2'} == list_source_dir_files(sagemaker_session, tmpdir)
 
@@ -274,24 +272,24 @@ def list_tar_files(folder, tar_ball, tmpdir):
 
 def test_framework_name_from_image_mxnet():
     image_name = '123.dkr.ecr.us-west-2.amazonaws.com/sagemaker-mxnet:1.1-gpu-py3'
-    assert ('mxnet', 'py3', '1.1-gpu-py3') == framework_name_from_image(image_name)
+    assert ('mxnet', 'py3', '1.1-gpu-py3') == fw_utils.framework_name_from_image(image_name)
 
 
 def test_framework_name_from_image_tf():
     image_name = '123.dkr.ecr.us-west-2.amazonaws.com/sagemaker-tensorflow:1.6-cpu-py2'
-    assert ('tensorflow', 'py2', '1.6-cpu-py2') == framework_name_from_image(image_name)
+    assert ('tensorflow', 'py2', '1.6-cpu-py2') == fw_utils.framework_name_from_image(image_name)
 
 
 def test_legacy_name_from_framework_image():
     image_name = '123.dkr.ecr.us-west-2.amazonaws.com/sagemaker-mxnet-py3-gpu:2.5.6-gpu-py2'
-    framework, py_ver, tag = framework_name_from_image(image_name)
+    framework, py_ver, tag = fw_utils.framework_name_from_image(image_name)
     assert framework == 'mxnet'
     assert py_ver == 'py3'
     assert tag == '2.5.6-gpu-py2'
 
 
 def test_legacy_name_from_wrong_framework():
-    framework, py_ver, tag = framework_name_from_image(
+    framework, py_ver, tag = fw_utils.framework_name_from_image(
         '123.dkr.ecr.us-west-2.amazonaws.com/sagemaker-myown-py2-gpu:1')
     assert framework is None
     assert py_ver is None
@@ -299,7 +297,7 @@ def test_legacy_name_from_wrong_framework():
 
 
 def test_legacy_name_from_wrong_python():
-    framework, py_ver, tag = framework_name_from_image(
+    framework, py_ver, tag = fw_utils.framework_name_from_image(
         '123.dkr.ecr.us-west-2.amazonaws.com/sagemaker-myown-py4-gpu:1')
     assert framework is None
     assert py_ver is None
@@ -307,7 +305,7 @@ def test_legacy_name_from_wrong_python():
 
 
 def test_legacy_name_from_wrong_device():
-    framework, py_ver, tag = framework_name_from_image(
+    framework, py_ver, tag = fw_utils.framework_name_from_image(
         '123.dkr.ecr.us-west-2.amazonaws.com/sagemaker-myown-py4-gpu:1')
     assert framework is None
     assert py_ver is None
@@ -316,63 +314,63 @@ def test_legacy_name_from_wrong_device():
 
 def test_legacy_name_from_image_any_tag():
     image_name = '123.dkr.ecr.us-west-2.amazonaws.com/sagemaker-tensorflow-py2-cpu:any-tag'
-    framework, py_ver, tag = framework_name_from_image(image_name)
+    framework, py_ver, tag = fw_utils.framework_name_from_image(image_name)
     assert framework == 'tensorflow'
     assert py_ver == 'py2'
     assert tag == 'any-tag'
 
 
 def test_framework_version_from_tag():
-    version = framework_version_from_tag('1.5rc-keras-gpu-py2')
+    version = fw_utils.framework_version_from_tag('1.5rc-keras-gpu-py2')
     assert version == '1.5rc-keras'
 
 
 def test_framework_version_from_tag_other():
-    version = framework_version_from_tag('weird-tag-py2')
+    version = fw_utils.framework_version_from_tag('weird-tag-py2')
     assert version is None
 
 
 def test_parse_s3_url():
-    bucket, key_prefix = parse_s3_url('s3://bucket/code_location')
+    bucket, key_prefix = fw_utils.parse_s3_url('s3://bucket/code_location')
     assert 'bucket' == bucket
     assert 'code_location' == key_prefix
 
 
 def test_parse_s3_url_fail():
     with pytest.raises(ValueError) as error:
-        parse_s3_url('t3://code_location')
+        fw_utils.parse_s3_url('t3://code_location')
     assert 'Expecting \'s3\' scheme' in str(error)
 
 
 def test_model_code_key_prefix_with_all_values_present():
-    key_prefix = model_code_key_prefix('prefix', 'model_name', 'image_name')
+    key_prefix = fw_utils.model_code_key_prefix('prefix', 'model_name', 'image_name')
     assert key_prefix == 'prefix/model_name'
 
 
 def test_model_code_key_prefix_with_no_prefix_and_all_other_values_present():
-    key_prefix = model_code_key_prefix(None, 'model_name', 'image_name')
+    key_prefix = fw_utils.model_code_key_prefix(None, 'model_name', 'image_name')
     assert key_prefix == 'model_name'
 
 
 @patch('time.strftime', return_value=TIMESTAMP)
 def test_model_code_key_prefix_with_only_image_present(time):
-    key_prefix = model_code_key_prefix(None, None, 'image_name')
+    key_prefix = fw_utils.model_code_key_prefix(None, None, 'image_name')
     assert key_prefix == name_from_image('image_name')
 
 
 @patch('time.strftime', return_value=TIMESTAMP)
 def test_model_code_key_prefix_and_image_present(time):
-    key_prefix = model_code_key_prefix('prefix', None, 'image_name')
+    key_prefix = fw_utils.model_code_key_prefix('prefix', None, 'image_name')
     assert key_prefix == 'prefix/' + name_from_image('image_name')
 
 
 def test_model_code_key_prefix_with_prefix_present_and_others_none_fail():
     with pytest.raises(TypeError) as error:
-        model_code_key_prefix('prefix', None, None)
+        fw_utils.model_code_key_prefix('prefix', None, None)
     assert 'expected string' in str(error)
 
 
 def test_model_code_key_prefix_with_all_none_fail():
     with pytest.raises(TypeError) as error:
-        model_code_key_prefix(None, None, None)
+        fw_utils.model_code_key_prefix(None, None, None)
     assert 'expected string' in str(error)

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -54,9 +54,9 @@ def sagemaker_session():
     return sms
 
 
-@patch('tarfile.open')
+@patch('sagemaker.utils.create_tar_file', MagicMock())
 @patch('time.strftime', return_value=TIMESTAMP)
-def test_prepare_container_def(tfopen, time, sagemaker_session):
+def test_prepare_container_def(time, sagemaker_session):
     model = DummyFrameworkModel(sagemaker_session)
     assert model.prepare_container_def(INSTANCE_TYPE) == {
         'Environment': {'SAGEMAKER_PROGRAM': 'blah.py',
@@ -68,12 +68,13 @@ def test_prepare_container_def(tfopen, time, sagemaker_session):
         'ModelDataUrl': 's3://bucket/model.tar.gz'}
 
 
-@patch('tarfile.open')
-@patch('os.path.exists', return_value=True)
-@patch('os.path.isdir', return_value=True)
-@patch('os.listdir', return_value=['blah.py'])
-@patch('time.strftime', return_value=TIMESTAMP)
-def test_create_no_defaults(tfopen, exists, isdir, listdir, time, sagemaker_session):
+@patch('shutil.rmtree', MagicMock())
+@patch('tarfile.open', MagicMock())
+@patch('os.path.exists', MagicMock(return_value=True))
+@patch('os.path.isdir', MagicMock(return_value=True))
+@patch('os.listdir', MagicMock(return_value=['blah.py']))
+@patch('time.strftime', MagicMock(return_value=TIMESTAMP))
+def test_create_no_defaults(sagemaker_session):
     model = DummyFrameworkModel(sagemaker_session, source_dir="sd", env={"a": "a"}, name="name",
                                 enable_cloudwatch_metrics=True, container_log_level=55,
                                 code_location="s3://cb/cp")
@@ -89,10 +90,10 @@ def test_create_no_defaults(tfopen, exists, isdir, listdir, time, sagemaker_sess
         'ModelDataUrl': 's3://bucket/model.tar.gz'}
 
 
-@patch('tarfile.open')
-@patch('time.strftime', return_value=TIMESTAMP)
-def test_deploy(tfo, time, sagemaker_session):
-    model = DummyFrameworkModel(sagemaker_session)
+@patch('sagemaker.utils.create_tar_file', MagicMock())
+@patch('time.strftime', MagicMock(return_value=TIMESTAMP))
+def test_deploy(sagemaker_session, tmpdir):
+    model = DummyFrameworkModel(sagemaker_session, source_dir=str(tmpdir))
     model.deploy(instance_type=INSTANCE_TYPE, initial_instance_count=1)
     sagemaker_session.endpoint_from_production_variants.assert_called_with(
         'mi-2017-10-10-14-14-15',
@@ -104,10 +105,10 @@ def test_deploy(tfo, time, sagemaker_session):
         None)
 
 
-@patch('tarfile.open')
-@patch('time.strftime', return_value=TIMESTAMP)
-def test_deploy_endpoint_name(tfo, time, sagemaker_session):
-    model = DummyFrameworkModel(sagemaker_session)
+@patch('sagemaker.utils.create_tar_file', MagicMock())
+@patch('time.strftime', MagicMock(return_value=TIMESTAMP))
+def test_deploy_endpoint_name(sagemaker_session, tmpdir):
+    model = DummyFrameworkModel(sagemaker_session, source_dir=str(tmpdir))
     model.deploy(endpoint_name='blah', instance_type=INSTANCE_TYPE, initial_instance_count=55)
     sagemaker_session.endpoint_from_production_variants.assert_called_with(
         'blah',
@@ -119,10 +120,10 @@ def test_deploy_endpoint_name(tfo, time, sagemaker_session):
         None)
 
 
-@patch('tarfile.open')
-@patch('time.strftime', return_value=TIMESTAMP)
-def test_deploy_tags(tfo, time, sagemaker_session):
-    model = DummyFrameworkModel(sagemaker_session)
+@patch('sagemaker.utils.create_tar_file', MagicMock())
+@patch('time.strftime', MagicMock(return_value=TIMESTAMP))
+def test_deploy_tags(sagemaker_session, tmpdir):
+    model = DummyFrameworkModel(sagemaker_session, source_dir=str(tmpdir))
     tags = [{'ModelName': 'TestModel'}]
     model.deploy(instance_type=INSTANCE_TYPE, initial_instance_count=1, tags=tags)
     sagemaker_session.endpoint_from_production_variants.assert_called_with(
@@ -137,15 +138,14 @@ def test_deploy_tags(tfo, time, sagemaker_session):
 
 @patch('sagemaker.model.Session')
 @patch('sagemaker.model.LocalSession')
-@patch('tarfile.open', MagicMock())
-def test_deploy_creates_correct_session(local_session, session):
-
+@patch('sagemaker.utils.create_tar_file', MagicMock())
+def test_deploy_creates_correct_session(local_session, session, tmpdir):
     # We expect a LocalSession when deploying to instance_type = 'local'
-    model = DummyFrameworkModel(sagemaker_session=None)
+    model = DummyFrameworkModel(sagemaker_session=None, source_dir=str(tmpdir))
     model.deploy(endpoint_name='blah', instance_type='local', initial_instance_count=1)
     assert model.sagemaker_session == local_session.return_value
 
     # We expect a real Session when deploying to instance_type != local/local_gpu
-    model = DummyFrameworkModel(sagemaker_session=None)
+    model = DummyFrameworkModel(sagemaker_session=None, source_dir=str(tmpdir))
     model.deploy(endpoint_name='remote_endpoint', instance_type='ml.m4.4xlarge', initial_instance_count=2)
     assert model.sagemaker_session == session.return_value

--- a/tests/unit/test_mxnet.py
+++ b/tests/unit/test_mxnet.py
@@ -17,7 +17,7 @@ import logging
 import json
 import os
 import pytest
-from mock import Mock
+from mock import MagicMock, Mock
 from mock import patch
 
 from sagemaker.mxnet import defaults
@@ -101,6 +101,7 @@ def _create_train_job(version):
     }
 
 
+@patch('sagemaker.utils.create_tar_file', MagicMock())
 def test_create_model(sagemaker_session, mxnet_version):
     container_log_level = '"logging.INFO"'
     source_dir = 's3://mybucket/source'
@@ -168,6 +169,7 @@ def test_create_model_with_custom_image(sagemaker_session):
     assert model.source_dir == source_dir
 
 
+@patch('sagemaker.utils.create_tar_file', MagicMock())
 @patch('time.strftime', return_value=TIMESTAMP)
 def test_mxnet(strftime, sagemaker_session, mxnet_version):
     mx = MXNet(entry_point=SCRIPT_PATH, role=ROLE, sagemaker_session=sagemaker_session,
@@ -207,6 +209,7 @@ def test_mxnet(strftime, sagemaker_session, mxnet_version):
     assert isinstance(predictor, MXNetPredictor)
 
 
+@patch('sagemaker.utils.create_tar_file', MagicMock())
 def test_model(sagemaker_session):
     model = MXNetModel("s3://some/data.tar.gz", role=ROLE, entry_point=SCRIPT_PATH,
                        sagemaker_session=sagemaker_session)

--- a/tests/unit/test_pytorch.py
+++ b/tests/unit/test_pytorch.py
@@ -17,7 +17,7 @@ import json
 import os
 import pytest
 import sys
-from mock import Mock
+from mock import MagicMock, Mock
 from mock import patch
 
 from sagemaker.pytorch import defaults
@@ -184,6 +184,7 @@ def test_create_model_with_custom_image(sagemaker_session):
     assert model.source_dir == source_dir
 
 
+@patch('sagemaker.utils.create_tar_file', MagicMock())
 @patch('time.strftime', return_value=TIMESTAMP)
 def test_pytorch(strftime, sagemaker_session, pytorch_version):
     pytorch = PyTorch(entry_point=SCRIPT_PATH, role=ROLE, sagemaker_session=sagemaker_session,
@@ -223,6 +224,7 @@ def test_pytorch(strftime, sagemaker_session, pytorch_version):
     assert isinstance(predictor, PyTorchPredictor)
 
 
+@patch('sagemaker.utils.create_tar_file', MagicMock())
 def test_model(sagemaker_session):
     model = PyTorchModel("s3://some/data.tar.gz", role=ROLE, entry_point=SCRIPT_PATH,
                          sagemaker_session=sagemaker_session)

--- a/tests/unit/test_transformer.py
+++ b/tests/unit/test_transformer.py
@@ -13,7 +13,7 @@
 from __future__ import absolute_import
 
 import pytest
-from mock import Mock, patch
+from mock import MagicMock, Mock, patch
 
 from sagemaker.transformer import Transformer, _TransformJob
 
@@ -38,6 +38,12 @@ INIT_PARAMS = {
     'instance_type': INSTANCE_TYPE,
     'base_transform_job_name': JOB_NAME
 }
+
+
+@pytest.fixture(autouse=True)
+def mock_create_tar_file():
+    with patch('sagemaker.utils.create_tar_file', MagicMock()) as create_tar_file:
+        yield create_tar_file
 
 
 @pytest.fixture()


### PR DESCRIPTION
*Description of changes:*
Introduces the following argument in the Estimator and Model classes.

- ``**dependencies** (list[str])`` A list of paths to directories (absolute or relative) with
        any additional libraries that will be exported to the container (default: []).
        The library folders will be copied to SageMaker in the same folder where the entrypoint is copied.
        If the ```source_dir``` points to S3, code will be uploaded and the S3 location will be used
        instead. Example:

            The following call
            >>> Estimator(entry_point='train.py', lib_dirs=['my/libs/common', 'virtual-env'])
            results in the following inside the container:

            >>> $ ls

            >>> opt/ml/code
            >>>     ├── train.py
            >>>     ├── common
            >>>     └── virtual-env

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [X] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ X I have updated the [changelog](https://github.com/aws/sagemaker-python-sdk/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [X] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
