### PR TITLE
Update PyYAML version restriction according to requirement in docker-…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ def read(fname):
 
 # Declare minimal set for installation
 required_packages = ['boto3>=1.9.55', 'numpy>=1.9.0', 'protobuf>=3.1', 'scipy>=0.19.0',
-                     'urllib3>=1.21', 'PyYAML>=3.2', 'protobuf3-to-dict>=0.1.5',
+                     'urllib3>=1.21', 'PyYAML>=3.2, <4', 'protobuf3-to-dict>=0.1.5',
                      'docker-compose>=1.23.0']
 
 # enum is introduced in Python 3.4. Installing enum back port


### PR DESCRIPTION
…compose

*Issue #, if available:*

*Description of changes:*
https://github.com/docker/compose/blob/master/setup.py
docker-compose has this version restriction of PyYAML and we don't have the upper bound here. Our API docs https://sagemaker.readthedocs.io/en/latest/index.html then will install version 4.2b and failed to build.
So this PR made the version restriction of PyYAML consistent with docker-compose.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated the [changelog](https://github.com/aws/sagemaker-python-sdk/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
