### PR TITLE
increase docker-compose timeout to 120 and ping interval to 5

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 CHANGELOG
 =========
 
+1.16.2dev
+======
+
+* bug-fix: Increase docker-compose http timeout and health check timeout to 120.
+
 1.16.1.post1
 ============
 

--- a/src/sagemaker/local/entities.py
+++ b/src/sagemaker/local/entities.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.WARNING)
 
 _UNUSED_ARN = 'local:arn-does-not-matter'
-HEALTH_CHECK_TIMEOUT_LIMIT = 30
+HEALTH_CHECK_TIMEOUT_LIMIT = 120
 
 
 class _LocalTrainingJob(object):
@@ -405,7 +405,7 @@ def _wait_for_serving_container(serving_port):
 
     endpoint_url = 'http://localhost:%s/ping' % serving_port
     while True:
-        i += 1
+        i += 5
         if i >= HEALTH_CHECK_TIMEOUT_LIMIT:
             raise RuntimeError('Giving up, endpoint didn\'t launch correctly')
 
@@ -416,7 +416,7 @@ def _wait_for_serving_container(serving_port):
         else:
             return
 
-        time.sleep(1)
+        time.sleep(5)
 
 
 def _perform_request(endpoint_url, pool_manager=None):

--- a/src/sagemaker/local/image.py
+++ b/src/sagemaker/local/image.py
@@ -36,10 +36,11 @@ import sagemaker
 import sagemaker.local.data
 import sagemaker.local.utils
 import sagemaker.utils
-from sagemaker.local.entities import HEALTH_CHECK_TIMEOUT_LIMIT
 
 CONTAINER_PREFIX = 'algo'
 DOCKER_COMPOSE_FILENAME = 'docker-compose.yaml'
+DOCKER_COMPOSE_HTTP_TIMEOUT_ENV = 'COMPOSE_HTTP_TIMEOUT'
+DOCKER_COMPOSE_HTTP_TIMEOUT = '120'
 
 
 # Environment variables to be set during training
@@ -361,8 +362,8 @@ class _SageMakerContainer(object):
         additional_env_var_list = ['{}={}'.format(k, v) for k, v in additional_env_vars.items()]
         environment.extend(additional_env_var_list)
 
-        if os.environ.get('COMPOSE_HTTP_TIMEOUT') is None:
-            os.environ['COMPOSE_HTTP_TIMEOUT'] = str(HEALTH_CHECK_TIMEOUT_LIMIT)
+        if os.environ.get(DOCKER_COMPOSE_HTTP_TIMEOUT_ENV) is None:
+            os.environ[DOCKER_COMPOSE_HTTP_TIMEOUT_ENV] = DOCKER_COMPOSE_HTTP_TIMEOUT
 
         if command == 'train':
             optml_dirs = {'output', 'output/data', 'input'}

--- a/src/sagemaker/local/image.py
+++ b/src/sagemaker/local/image.py
@@ -36,9 +36,11 @@ import sagemaker
 import sagemaker.local.data
 import sagemaker.local.utils
 import sagemaker.utils
+from sagemaker.local.entities import HEALTH_CHECK_TIMEOUT_LIMIT
 
 CONTAINER_PREFIX = 'algo'
 DOCKER_COMPOSE_FILENAME = 'docker-compose.yaml'
+
 
 # Environment variables to be set during training
 REGION_ENV_NAME = 'AWS_REGION'
@@ -358,6 +360,9 @@ class _SageMakerContainer(object):
 
         additional_env_var_list = ['{}={}'.format(k, v) for k, v in additional_env_vars.items()]
         environment.extend(additional_env_var_list)
+
+        if os.environ.get('COMPOSE_HTTP_TIMEOUT') is None:
+            os.environ['COMPOSE_HTTP_TIMEOUT'] = str(HEALTH_CHECK_TIMEOUT_LIMIT)
 
         if command == 'train':
             optml_dirs = {'output', 'output/data', 'input'}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Increase timeout of docker-compose to 120 along with ping for serving. Increase the interval between pings from 1 to 5.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated the [changelog](https://github.com/aws/sagemaker-python-sdk/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
