### PR TITLE
Removing the logic of skipping inference pipeline integration test

### DIFF
--- a/tests/integ/test_inference_pipeline.py
+++ b/tests/integ/test_inference_pipeline.py
@@ -31,7 +31,6 @@ from tests.integ.timeout import timeout_and_delete_endpoint_by_name
 
 @pytest.mark.continuous_testing
 @pytest.mark.regional_testing
-@pytest.mark.skip(reason="This should be enabled along with the Boto SDK release for CreateModel API changes")
 def test_inference_pipeline_model_deploy(sagemaker_session):
     # Creates a Pipeline model comprising of SparkML (serialized by MLeap) and XGBoost and deploys to one endpoint
     sparkml_data_path = os.path.join(DATA_DIR, 'sparkml_model')


### PR DESCRIPTION
Removing the logic of skipping the integration test for Inference Pipeline.

I have run the integration test for both Python version locally and both ran fine.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
