### PR TITLE
Fix __all__ in sagemaker.rl

### DIFF
--- a/src/sagemaker/rl/__init__.py
+++ b/src/sagemaker/rl/__init__.py
@@ -12,7 +12,8 @@
 # language governing permissions and limitations under the License.
 from __future__ import absolute_import
 
+__all__ = [
+    'RLEstimator', 'RLToolkit', 'RLFramework', 'TOOLKIT_FRAMEWORK_VERSION_MAP']
+
 from sagemaker.rl.estimator import (RLEstimator, RLToolkit, RLFramework,
                                     TOOLKIT_FRAMEWORK_VERSION_MAP)
-
-__all__ = [RLEstimator, RLToolkit, RLFramework, TOOLKIT_FRAMEWORK_VERSION_MAP]


### PR DESCRIPTION
`__all__` should be a list of names (str), not objects.
Moreover it

> should be placed after the module docstring but before any import statements except from `__future__` imports (PEP8)

I confirm that my contribution is made under the terms of the Apache 2.0 license.
