### PR TITLE
Append retry id to default Airflow job name to avoid naming collision in retry

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 CHANGELOG
 =========
 
+1.16.3.dev
+==========
+
+* bug-fix: Append retry id to default Airflow job name to avoid name collisions in retry
+
 1.16.2
 ======
 

--- a/src/sagemaker/utils.py
+++ b/src/sagemaker/utils.py
@@ -27,10 +27,11 @@ from functools import wraps
 import six
 
 
-AIRFLOW_TIME_MACRO = "{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}"
-AIRFLOW_TIME_MACRO_LEN = 19
-AIRFLOW_TIME_MACRO_SHORT = "{{ execution_date.strftime('%y%m%d-%H%M') }}"
-AIRFLOW_TIME_MACRO_SHORT_LEN = 11
+AIRFLOW_RETRY_MACRO = "{{ task_instance.try_number }}"
+AIRFLOW_TIME_MACRO = "{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}" + "-{}".format(AIRFLOW_RETRY_MACRO)
+AIRFLOW_TIME_MACRO_LEN = 22
+AIRFLOW_TIME_MACRO_SHORT = "{{ execution_date.strftime('%y%m%d-%H%M') }}" + "-{}".format(AIRFLOW_RETRY_MACRO)
+AIRFLOW_TIME_MACRO_SHORT_LEN = 14
 
 
 # Use the base name of the image as the job name if the user doesn't give us one


### PR DESCRIPTION
… in retry

*Issue #, if available:*

*Description of changes:*
Now during Airflow operator retry, the job names (training/model/tuning/transform/endpoint-config/endpoint) are same as before. So there will be naming collision and all retries will fail for job already existed. This PR appends a retry id to the default job names. Then different attempt of operator will have different job_name which avoids failure due to naming collisions.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have updated the [changelog](https://github.com/aws/sagemaker-python-sdk/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
