### PR TITLE
move sagemaker_s3_output to model class

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ CHANGELOG
 
 * bug-fix: Append retry id to default Airflow job name to avoid name collisions in retry
 * bug-fix: Local Mode: No longer requires s3 permissions to run local entry point file
+* bug-fix: Local Mode: Move dependency on sagemaker_s3_output from rl.estimator to model
 
 1.16.2
 ======

--- a/src/sagemaker/local/image.py
+++ b/src/sagemaker/local/image.py
@@ -317,8 +317,7 @@ class _SageMakerContainer(object):
                 volumes.append(_Volume(shared_dir, '/opt/ml/shared'))
 
         parsed_uri = urlparse(output_data_config['S3OutputPath'])
-        if parsed_uri.scheme == 'file' \
-                and sagemaker.rl.estimator.SAGEMAKER_OUTPUT_LOCATION in hyperparameters:
+        if parsed_uri.scheme == 'file' and sagemaker.model.SAGEMAKER_OUTPUT_LOCATION in hyperparameters:
             intermediate_dir = os.path.join(parsed_uri.path, 'output', 'intermediate')
             if not os.path.exists(intermediate_dir):
                 os.makedirs(intermediate_dir)

--- a/src/sagemaker/model.py
+++ b/src/sagemaker/model.py
@@ -257,6 +257,7 @@ CONTAINER_LOG_LEVEL_PARAM_NAME = 'sagemaker_container_log_level'
 JOB_NAME_PARAM_NAME = 'sagemaker_job_name'
 MODEL_SERVER_WORKERS_PARAM_NAME = 'sagemaker_model_server_workers'
 SAGEMAKER_REGION_PARAM_NAME = 'sagemaker_region'
+SAGEMAKER_OUTPUT_LOCATION = 'sagemaker_s3_output'
 
 
 class FrameworkModel(Model):

--- a/src/sagemaker/rl/estimator.py
+++ b/src/sagemaker/rl/estimator.py
@@ -18,7 +18,7 @@ import re
 
 from sagemaker.estimator import Framework
 import sagemaker.fw_utils as fw_utils
-from sagemaker.model import FrameworkModel
+from sagemaker.model import FrameworkModel, SAGEMAKER_OUTPUT_LOCATION
 from sagemaker.mxnet.model import MXNetModel
 from sagemaker.vpc_utils import VPC_CONFIG_DEFAULT
 
@@ -27,7 +27,6 @@ logger = logging.getLogger('sagemaker')
 
 SAGEMAKER_ESTIMATOR = 'sagemaker_estimator'
 SAGEMAKER_ESTIMATOR_VALUE = 'RLEstimator'
-SAGEMAKER_OUTPUT_LOCATION = 'sagemaker_s3_output'
 PYTHON_VERSION = 'py3'
 TOOLKIT_FRAMEWORK_VERSION_MAP = {
     'coach': {


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/sagemaker-python-sdk/issues/554

*Description of changes:*
Moved sagemaker_s3_output to model class.

There was a dependency error, in that a file in the local directory was taking dependency on a file in the rl directory.

I could have also allowed the rl directory to be properly scoped so that all directories have access, however that doesn't seem like the right call, as parameters and what not should be generic and not specific.

Reproduced customer error on a notebook instance and installed changes and tested properly.

It is difficult to write a test that catches this, as there seems to be weird interaction with tox and how our tests import classes. For now this is a quick fix.

Refactoring these parameters to a common class in the sagemaker directory might make things a little easier to manage.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have updated the [changelog](https://github.com/aws/sagemaker-python-sdk/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
