### PR TITLE
Remove retry_id in Airflow job name, needs more design on this

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,8 +5,7 @@ CHANGELOG
 1.16.3
 ======
 
-* bug-fix: Local Mode: Allow support for SSH in local mode 
-* bug-fix: Append retry id to default Airflow job name to avoid name collisions in retry
+* bug-fix: Local Mode: Allow support for SSH in local mode
 * bug-fix: Local Mode: No longer requires s3 permissions to run local entry point file
 * feature: Estimators: add support for PyTorch 1.0.0
 * bug-fix: Local Mode: Move dependency on sagemaker_s3_output from rl.estimator to model

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,10 +2,16 @@
 CHANGELOG
 =========
 
+1.17.0
+======
+
+* bug-fix: Revert appending Airflow retry id to default job name
+
 1.16.3
 ======
 
 * bug-fix: Local Mode: Allow support for SSH in local mode
+* bug-fix: Append retry id to default Airflow job name to avoid name collisions in retry
 * bug-fix: Local Mode: No longer requires s3 permissions to run local entry point file
 * feature: Estimators: add support for PyTorch 1.0.0
 * bug-fix: Local Mode: Move dependency on sagemaker_s3_output from rl.estimator to model

--- a/src/sagemaker/utils.py
+++ b/src/sagemaker/utils.py
@@ -27,11 +27,10 @@ from functools import wraps
 import six
 
 
-AIRFLOW_RETRY_MACRO = "{{ task_instance.try_number }}"
-AIRFLOW_TIME_MACRO = "{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}" + "-{}".format(AIRFLOW_RETRY_MACRO)
-AIRFLOW_TIME_MACRO_LEN = 22
-AIRFLOW_TIME_MACRO_SHORT = "{{ execution_date.strftime('%y%m%d-%H%M') }}" + "-{}".format(AIRFLOW_RETRY_MACRO)
-AIRFLOW_TIME_MACRO_SHORT_LEN = 14
+AIRFLOW_TIME_MACRO = "{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}"
+AIRFLOW_TIME_MACRO_LEN = 19
+AIRFLOW_TIME_MACRO_SHORT = "{{ execution_date.strftime('%y%m%d-%H%M') }}"
+AIRFLOW_TIME_MACRO_SHORT_LEN = 11
 
 
 # Use the base name of the image as the job name if the user doesn't give us one

--- a/tests/unit/test_airflow.py
+++ b/tests/unit/test_airflow.py
@@ -26,16 +26,6 @@ REGION = 'us-west-2'
 BUCKET_NAME = 'output'
 
 
-def get_job_name(job_name_prefix, short=False):
-    if not short:
-        job_name_postfix = "{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}" \
-                           "-{{ task_instance.try_number }}"
-    else:
-        job_name_postfix = "{{ execution_date.strftime('%y%m%d-%H%M') }}" \
-                           "-{{ task_instance.try_number }}"
-    return "{}-{}".format(job_name_prefix, job_name_postfix)
-
-
 @pytest.fixture()
 def sagemaker_session():
     boto_mock = mock.Mock(name='boto_session', region_name=REGION)
@@ -47,7 +37,6 @@ def sagemaker_session():
 
 
 def test_byo_training_config_required_args(sagemaker_session):
-    job_name = get_job_name('byo')
     byo = estimator.Estimator(
         image_name="byo",
         role="{{ role }}",
@@ -70,7 +59,7 @@ def test_byo_training_config_required_args(sagemaker_session):
         'OutputDataConfig': {
             'S3OutputPath': 's3://output/'
         },
-        'TrainingJobName': job_name,
+        'TrainingJobName': "byo-{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}",
         'StoppingCondition': {
             'MaxRuntimeInSeconds': 86400
         },
@@ -98,7 +87,6 @@ def test_byo_training_config_required_args(sagemaker_session):
 
 
 def test_byo_training_config_all_args(sagemaker_session):
-    job_name = get_job_name("{{ base_job_name }}")
     byo = estimator.Estimator(
         image_name="byo",
         role="{{ role }}",
@@ -134,7 +122,7 @@ def test_byo_training_config_all_args(sagemaker_session):
             'S3OutputPath': '{{ output_path }}',
             'KmsKeyId': '{{ output_volume_kms_key }}'
         },
-        'TrainingJobName': job_name,
+        'TrainingJobName': "{{ base_job_name }}-{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}",
         'StoppingCondition': {
             'MaxRuntimeInSeconds': '{{ train_max_run }}'
         },
@@ -183,7 +171,6 @@ def test_byo_training_config_all_args(sagemaker_session):
 
 
 def test_framework_training_config_required_args(sagemaker_session):
-    job_name = get_job_name('sagemaker-tensorflow')
     tf = tensorflow.TensorFlow(
         entry_point="{{ entry_point }}",
         framework_version='1.10.0',
@@ -205,7 +192,7 @@ def test_framework_training_config_required_args(sagemaker_session):
         'OutputDataConfig': {
             'S3OutputPath': 's3://output/'
         },
-        'TrainingJobName': job_name,
+        'TrainingJobName': "sagemaker-tensorflow-{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}",
         'StoppingCondition': {
             'MaxRuntimeInSeconds': 86400
         },
@@ -226,13 +213,16 @@ def test_framework_training_config_required_args(sagemaker_session):
             'ChannelName': 'training'
         }],
         'HyperParameters': {
-            'sagemaker_submit_directory': '"s3://output/{}/source/sourcedir.tar.gz"'.format(job_name),
+            'sagemaker_submit_directory': '"s3://output/sagemaker-tensorflow-'
+                                          '{{ execution_date.strftime(\'%Y-%m-%d-%H-%M-%S\') }}'
+                                          '/source/sourcedir.tar.gz"',
             'sagemaker_program': '"{{ entry_point }}"',
             'sagemaker_enable_cloudwatch_metrics': 'false',
             'sagemaker_container_log_level': '20',
-            'sagemaker_job_name': '"{}"'.format(job_name),
+            'sagemaker_job_name': '"sagemaker-tensorflow-{{ execution_date.strftime(\'%Y-%m-%d-%H-%M-%S\') }}"',
             'sagemaker_region': '"us-west-2"',
-            'checkpoint_path': '"s3://output/{}/checkpoints"'.format(job_name),
+            'checkpoint_path': '"s3://output/sagemaker-tensorflow-{{ execution_date.strftime(\'%Y-%m-%d-%H-%M-%S\') }}'
+                               '/checkpoints"',
             'training_steps': '1000',
             'evaluation_steps': '100',
             'sagemaker_requirements': '""'},
@@ -240,7 +230,8 @@ def test_framework_training_config_required_args(sagemaker_session):
             'S3Upload': [{
                 'Path': '{{ entry_point }}',
                 'Bucket': 'output',
-                'Key': "{}/source/sourcedir.tar.gz".format(job_name),
+                'Key': "sagemaker-tensorflow-{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}"
+                       "/source/sourcedir.tar.gz",
                 'Tar': True}]
         }
     }
@@ -248,7 +239,6 @@ def test_framework_training_config_required_args(sagemaker_session):
 
 
 def test_framework_training_config_all_args(sagemaker_session):
-    job_name = get_job_name("{{ base_job_name }}")
     tf = tensorflow.TensorFlow(
         entry_point="{{ entry_point }}",
         source_dir="{{ source_dir }}",
@@ -288,7 +278,7 @@ def test_framework_training_config_all_args(sagemaker_session):
             'S3OutputPath': '{{ output_path }}',
             'KmsKeyId': '{{ output_volume_kms_key }}'
         },
-        'TrainingJobName': job_name,
+        'TrainingJobName': "{{ base_job_name }}-{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}",
         'StoppingCondition': {
             'MaxRuntimeInSeconds': '{{ train_max_run }}'
         },
@@ -318,7 +308,7 @@ def test_framework_training_config_all_args(sagemaker_session):
             'sagemaker_program': '"{{ entry_point }}"',
             'sagemaker_enable_cloudwatch_metrics': 'false',
             'sagemaker_container_log_level': '"{{ log_level }}"',
-            'sagemaker_job_name': '"{}"'.format(job_name),
+            'sagemaker_job_name': '"{{ base_job_name }}-{{ execution_date.strftime(\'%Y-%m-%d-%H-%M-%S\') }}"',
             'sagemaker_region': '"us-west-2"',
             'checkpoint_path': '"{{ checkpoint_path }}"',
             'training_steps': '1000',
@@ -338,7 +328,6 @@ def test_framework_training_config_all_args(sagemaker_session):
 
 
 def test_amazon_alg_training_config_required_args(sagemaker_session):
-    job_name = get_job_name('ntm')
     ntm_estimator = ntm.NTM(
         role="{{ role }}",
         num_topics=10,
@@ -359,7 +348,7 @@ def test_amazon_alg_training_config_required_args(sagemaker_session):
         'OutputDataConfig': {
             'S3OutputPath': 's3://output/'
         },
-        'TrainingJobName': job_name,
+        'TrainingJobName': "ntm-{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}",
         'StoppingCondition': {'MaxRuntimeInSeconds': 86400},
         'ResourceConfig': {
             'InstanceCount': '{{ instance_count }}',
@@ -388,7 +377,6 @@ def test_amazon_alg_training_config_required_args(sagemaker_session):
 
 
 def test_amazon_alg_training_config_all_args(sagemaker_session):
-    job_name = get_job_name("{{ base_job_name }}")
     ntm_estimator = ntm.NTM(
         role="{{ role }}",
         num_topics=10,
@@ -420,7 +408,7 @@ def test_amazon_alg_training_config_all_args(sagemaker_session):
             'S3OutputPath': '{{ output_path }}',
             'KmsKeyId': '{{ output_volume_kms_key }}'
         },
-        'TrainingJobName': job_name,
+        'TrainingJobName': "{{ base_job_name }}-{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}",
         'StoppingCondition': {
             'MaxRuntimeInSeconds': '{{ train_max_run }}'
         },
@@ -458,8 +446,6 @@ def test_amazon_alg_training_config_all_args(sagemaker_session):
 
 
 def test_framework_tuning_config(sagemaker_session):
-    training_job_name = get_job_name("{{ base_job_name }}")
-    tuning_job_name = get_job_name("tuning", short=True)
     mxnet_estimator = mxnet.MXNet(
         entry_point="{{ entry_point }}",
         source_dir="{{ source_dir }}",
@@ -489,13 +475,13 @@ def test_framework_tuning_config(sagemaker_session):
         max_jobs="{{ max_job }}",
         max_parallel_jobs="{{ max_parallel_job }}",
         tags=[{'{{ key }}': '{{ value }}'}],
-        base_tuning_job_name="tuning")
+        base_tuning_job_name="{{ base_job_name }}")
 
     data = "{{ training_data }}"
 
     config = airflow.tuning_config(mxnet_tuner, data)
     expected_config = {
-        'HyperParameterTuningJobName': tuning_job_name,
+        'HyperParameterTuningJobName': "{{ base_job_name }}-{{ execution_date.strftime('%y%m%d-%H%M') }}",
         'HyperParameterTuningJobConfig': {
             'Strategy': 'Bayesian',
             'HyperParameterTuningJobObjective': {
@@ -554,18 +540,22 @@ def test_framework_tuning_config(sagemaker_session):
             }],
             'StaticHyperParameters': {
                 'batch_size': '100',
-                'sagemaker_submit_directory': '"s3://output/{}/source/sourcedir.tar.gz"'.format(training_job_name),
+                'sagemaker_submit_directory': '"s3://output/{{ base_job_name }}'
+                                              '-{{ execution_date.strftime(\'%Y-%m-%d-%H-%M-%S\') }}'
+                                              '/source/sourcedir.tar.gz"',
                 'sagemaker_program': '"{{ entry_point }}"',
                 'sagemaker_enable_cloudwatch_metrics': 'false',
                 'sagemaker_container_log_level': '20',
-                'sagemaker_job_name': '"{}"'.format(training_job_name),
+                'sagemaker_job_name': '"{{ base_job_name }}-'
+                                      '{{ execution_date.strftime(\'%Y-%m-%d-%H-%M-%S\') }}"',
                 'sagemaker_region': '"us-west-2"'}},
         'Tags': [{'{{ key }}': '{{ value }}'}],
         'S3Operations': {
             'S3Upload': [{
                 'Path': '{{ source_dir }}',
                 'Bucket': 'output',
-                'Key': "{}/source/sourcedir.tar.gz".format(training_job_name),
+                'Key': "{{ base_job_name }}-"
+                       "{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}/source/sourcedir.tar.gz",
                 'Tar': True
             }]
         }
@@ -637,7 +627,6 @@ def test_byo_framework_model_config(sagemaker_session):
 
 
 def test_framework_model_config(sagemaker_session):
-    job_name = get_job_name('sagemaker-chainer')
     chainer_model = chainer.ChainerModel(
         model_data="{{ model_data }}",
         role="{{ role }}",
@@ -651,12 +640,14 @@ def test_framework_model_config(sagemaker_session):
 
     config = airflow.model_config(instance_type='ml.c4.xlarge', model=chainer_model)
     expected_config = {
-        'ModelName': job_name,
+        'ModelName': "sagemaker-chainer-{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}",
         'PrimaryContainer': {
             'Image': '520713654638.dkr.ecr.us-west-2.amazonaws.com/sagemaker-chainer:5.0.0-cpu-py3',
             'Environment': {
                 'SAGEMAKER_PROGRAM': '{{ entry_point }}',
-                'SAGEMAKER_SUBMIT_DIRECTORY': "s3://output/{}/source/sourcedir.tar.gz".format(job_name),
+                'SAGEMAKER_SUBMIT_DIRECTORY': "s3://output/sagemaker-chainer-"
+                                              "{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}"
+                                              "/source/sourcedir.tar.gz",
                 'SAGEMAKER_ENABLE_CLOUDWATCH_METRICS': 'false',
                 'SAGEMAKER_CONTAINER_LOG_LEVEL': '20',
                 'SAGEMAKER_REGION': 'us-west-2',
@@ -669,7 +660,7 @@ def test_framework_model_config(sagemaker_session):
             'S3Upload': [{
                 'Path': '{{ source_dir }}',
                 'Bucket': 'output',
-                'Key': "{}/source/sourcedir.tar.gz".format(job_name),
+                'Key': "sagemaker-chainer-{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}/source/sourcedir.tar.gz",
                 'Tar': True}]
         }
     }
@@ -678,7 +669,6 @@ def test_framework_model_config(sagemaker_session):
 
 
 def test_amazon_alg_model_config(sagemaker_session):
-    job_name = get_job_name('pca')
     pca_model = pca.PCAModel(
         model_data="{{ model_data }}",
         role="{{ role }}",
@@ -686,7 +676,7 @@ def test_amazon_alg_model_config(sagemaker_session):
 
     config = airflow.model_config(instance_type='ml.c4.xlarge', model=pca_model)
     expected_config = {
-        'ModelName': job_name,
+        'ModelName': "pca-{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}",
         'PrimaryContainer': {
             'Image': '174872318107.dkr.ecr.us-west-2.amazonaws.com/pca:1',
             'Environment': {},
@@ -699,7 +689,6 @@ def test_amazon_alg_model_config(sagemaker_session):
 
 
 def test_model_config_from_framework_estimator(sagemaker_session):
-    job_name = get_job_name("{{ base_job_name }}")
     mxnet_estimator = mxnet.MXNet(
         entry_point="{{ entry_point }}",
         source_dir="{{ source_dir }}",
@@ -719,18 +708,20 @@ def test_model_config_from_framework_estimator(sagemaker_session):
 
     config = airflow.model_config_from_estimator(instance_type='ml.c4.xlarge', estimator=mxnet_estimator)
     expected_config = {
-        'ModelName': job_name,
+        'ModelName': "{{ base_job_name }}-{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}",
         'PrimaryContainer': {
             'Image': '520713654638.dkr.ecr.us-west-2.amazonaws.com/sagemaker-mxnet:1.3.0-cpu-py3',
             'Environment': {
                 'SAGEMAKER_PROGRAM': '{{ entry_point }}',
-                'SAGEMAKER_SUBMIT_DIRECTORY': "s3://output/{}/source/sourcedir.tar.gz".format(job_name),
+                'SAGEMAKER_SUBMIT_DIRECTORY': "s3://output/{{ base_job_name }}-"
+                                              "{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}"
+                                              "/source/sourcedir.tar.gz",
                 'SAGEMAKER_ENABLE_CLOUDWATCH_METRICS': 'false',
                 'SAGEMAKER_CONTAINER_LOG_LEVEL': '20',
                 'SAGEMAKER_REGION': 'us-west-2'
             },
-            'ModelDataUrl': "s3://output/{}/output/model.tar.gz".format(job_name)
-        },
+            'ModelDataUrl': "s3://output/{{ base_job_name }}-"
+                            "{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}/output/model.tar.gz"},
         'ExecutionRoleArn': '{{ role }}'
     }
 
@@ -738,7 +729,6 @@ def test_model_config_from_framework_estimator(sagemaker_session):
 
 
 def test_model_config_from_amazon_alg_estimator(sagemaker_session):
-    job_name = get_job_name('knn')
     knn_estimator = knn.KNN(
         role="{{ role }}",
         train_instance_count="{{ instance_count }}",
@@ -755,11 +745,11 @@ def test_model_config_from_amazon_alg_estimator(sagemaker_session):
 
     config = airflow.model_config_from_estimator(instance_type='ml.c4.xlarge', estimator=knn_estimator)
     expected_config = {
-        'ModelName': job_name,
+        'ModelName': "knn-{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}",
         'PrimaryContainer': {
             'Image': '174872318107.dkr.ecr.us-west-2.amazonaws.com/knn:1',
             'Environment': {},
-            'ModelDataUrl': "s3://output/{}/output/model.tar.gz".format(job_name)},
+            'ModelDataUrl': "s3://output/knn-{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}/output/model.tar.gz"},
         'ExecutionRoleArn': '{{ role }}'
     }
 
@@ -767,7 +757,6 @@ def test_model_config_from_amazon_alg_estimator(sagemaker_session):
 
 
 def test_transformer_config(sagemaker_session):
-    job_name = get_job_name('tensorflow-transform')
     tf_transformer = transformer.Transformer(
         model_name="tensorflow-model",
         instance_count="{{ instance_count }}",
@@ -790,7 +779,7 @@ def test_transformer_config(sagemaker_session):
     config = airflow.transform_config(tf_transformer, data, data_type='S3Prefix', content_type="{{ content_type }}",
                                       compression_type="{{ compression_type }}", split_type="{{ split_type }}")
     expected_config = {
-        'TransformJobName': job_name,
+        'TransformJobName': "tensorflow-transform-{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}",
         'ModelName': 'tensorflow-model',
         'TransformInput': {
             'DataSource': {
@@ -824,7 +813,6 @@ def test_transformer_config(sagemaker_session):
 
 
 def test_transform_config_from_framework_estimator(sagemaker_session):
-    job_name = get_job_name("{{ base_job_name }}")
     mxnet_estimator = mxnet.MXNet(
         entry_point="{{ entry_point }}",
         source_dir="{{ source_dir }}",
@@ -850,22 +838,24 @@ def test_transform_config_from_framework_estimator(sagemaker_session):
         data=transform_data)
     expected_config = {
         'Model': {
-            'ModelName': job_name,
+            'ModelName': "{{ base_job_name }}-{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}",
             'PrimaryContainer': {
                 'Image': '520713654638.dkr.ecr.us-west-2.amazonaws.com/sagemaker-mxnet:1.3.0-gpu-py3',
                 'Environment': {'SAGEMAKER_PROGRAM': '{{ entry_point }}',
-                                'SAGEMAKER_SUBMIT_DIRECTORY': "s3://output/{}/source/sourcedir.tar.gz".format(job_name),
+                                'SAGEMAKER_SUBMIT_DIRECTORY': "s3://output/{{ base_job_name }}-"
+                                                              "{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}/"
+                                                              "source/sourcedir.tar.gz",
                                 'SAGEMAKER_ENABLE_CLOUDWATCH_METRICS': 'false',
                                 'SAGEMAKER_CONTAINER_LOG_LEVEL': '20',
                                 'SAGEMAKER_REGION': 'us-west-2'
                                 },
-                'ModelDataUrl': "s3://output/{}/output/model.tar.gz".format(job_name)
-            },
+                'ModelDataUrl': "s3://output/{{ base_job_name }}-"
+                                "{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}/output/model.tar.gz"},
             'ExecutionRoleArn': '{{ role }}'
         },
         'Transform': {
-            'TransformJobName': job_name,
-            'ModelName': job_name,
+            'TransformJobName': "{{ base_job_name }}-{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}",
+            'ModelName': "{{ base_job_name }}-{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}",
             'TransformInput': {
                 'DataSource': {
                     'S3DataSource': {
@@ -875,7 +865,7 @@ def test_transform_config_from_framework_estimator(sagemaker_session):
                 }
             },
             'TransformOutput': {
-                'S3OutputPath': "s3://output/{}".format(job_name)
+                'S3OutputPath': "s3://output/{{ base_job_name }}-{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}"
             },
             'TransformResources': {
                 'InstanceCount': '{{ instance_count }}',
@@ -889,7 +879,6 @@ def test_transform_config_from_framework_estimator(sagemaker_session):
 
 
 def test_transform_config_from_amazon_alg_estimator(sagemaker_session):
-    job_name = get_job_name('knn')
     knn_estimator = knn.KNN(
         role="{{ role }}",
         train_instance_count="{{ instance_count }}",
@@ -912,39 +901,35 @@ def test_transform_config_from_amazon_alg_estimator(sagemaker_session):
         data=transform_data)
     expected_config = {
         'Model': {
-            'ModelName': job_name,
+            'ModelName': "knn-{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}",
             'PrimaryContainer': {
                 'Image': '174872318107.dkr.ecr.us-west-2.amazonaws.com/knn:1',
                 'Environment': {},
-                'ModelDataUrl': "s3://output/{}/output/model.tar.gz".format(job_name)
-            },
+                'ModelDataUrl': "s3://output/knn-{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}"
+                                "/output/model.tar.gz"},
             'ExecutionRoleArn': '{{ role }}'},
-        'Transform': {
-            'TransformJobName': job_name,
-            'ModelName': job_name,
-            'TransformInput': {
-                'DataSource': {
-                    'S3DataSource': {
-                        'S3DataType': 'S3Prefix',
-                        'S3Uri': '{{ transform_data }}'
-                    }
-                }
-            },
-            'TransformOutput': {
-                'S3OutputPath': "s3://output/{}".format(job_name)
-            },
-            'TransformResources': {
-                'InstanceCount': '{{ instance_count }}',
-                'InstanceType': 'ml.p2.xlarge'
-            }
-        }
+        'Transform': {'TransformJobName': "knn-{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}",
+                      'ModelName': "knn-{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}",
+                      'TransformInput': {
+                          'DataSource': {
+                              'S3DataSource': {
+                                  'S3DataType': 'S3Prefix',
+                                  'S3Uri': '{{ transform_data }}'}
+                          }
+                      },
+                      'TransformOutput': {
+                          'S3OutputPath': "s3://output/knn-{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}"
+                      },
+                      'TransformResources': {
+                          'InstanceCount': '{{ instance_count }}',
+                          'InstanceType': 'ml.p2.xlarge'}
+                      }
     }
 
     assert config == expected_config
 
 
 def test_deploy_framework_model_config(sagemaker_session):
-    job_name = get_job_name('sagemaker-chainer')
     chainer_model = chainer.ChainerModel(
         model_data="{{ model_data }}",
         role="{{ role }}",
@@ -961,12 +946,14 @@ def test_deploy_framework_model_config(sagemaker_session):
                                    instance_type="ml.m4.xlarge")
     expected_config = {
         'Model': {
-            'ModelName': job_name,
+            'ModelName': "sagemaker-chainer-{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}",
             'PrimaryContainer': {
                 'Image': '520713654638.dkr.ecr.us-west-2.amazonaws.com/sagemaker-chainer:5.0.0-cpu-py3',
                 'Environment': {
                     'SAGEMAKER_PROGRAM': '{{ entry_point }}',
-                    'SAGEMAKER_SUBMIT_DIRECTORY': "s3://output/{}/source/sourcedir.tar.gz".format(job_name),
+                    'SAGEMAKER_SUBMIT_DIRECTORY': "s3://output/sagemaker-chainer-"
+                                                  "{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}"
+                                                  "/source/sourcedir.tar.gz",
                     'SAGEMAKER_ENABLE_CLOUDWATCH_METRICS': 'false',
                     'SAGEMAKER_CONTAINER_LOG_LEVEL': '20',
                     'SAGEMAKER_REGION': 'us-west-2',
@@ -976,24 +963,24 @@ def test_deploy_framework_model_config(sagemaker_session):
             'ExecutionRoleArn': '{{ role }}'
         },
         'EndpointConfig': {
-            'EndpointConfigName': job_name,
+            'EndpointConfigName': "sagemaker-chainer-{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}",
             'ProductionVariants': [{
                 'InstanceType': 'ml.m4.xlarge',
                 'InitialInstanceCount': '{{ instance_count }}',
-                'ModelName': job_name,
+                'ModelName': "sagemaker-chainer-{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}",
                 'VariantName': 'AllTraffic',
                 'InitialVariantWeight': 1
             }]
         },
         'Endpoint': {
-            'EndpointName': job_name,
-            'EndpointConfigName': job_name
+            'EndpointName': "sagemaker-chainer-{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}",
+            'EndpointConfigName': "sagemaker-chainer-{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}"
         },
         'S3Operations': {
             'S3Upload': [{
                 'Path': '{{ source_dir }}',
                 'Bucket': 'output',
-                'Key': "{}/source/sourcedir.tar.gz".format(job_name),
+                'Key': "sagemaker-chainer-{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}/source/sourcedir.tar.gz",
                 'Tar': True
             }]
         }
@@ -1003,7 +990,6 @@ def test_deploy_framework_model_config(sagemaker_session):
 
 
 def test_deploy_amazon_alg_model_config(sagemaker_session):
-    job_name = get_job_name('pca')
     pca_model = pca.PCAModel(
         model_data="{{ model_data }}",
         role="{{ role }}",
@@ -1014,25 +1000,25 @@ def test_deploy_amazon_alg_model_config(sagemaker_session):
                                    instance_type='ml.c4.xlarge')
     expected_config = {
         'Model': {
-            'ModelName': job_name,
+            'ModelName': "pca-{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}",
             'PrimaryContainer': {
                 'Image': '174872318107.dkr.ecr.us-west-2.amazonaws.com/pca:1',
                 'Environment': {},
                 'ModelDataUrl': '{{ model_data }}'},
             'ExecutionRoleArn': '{{ role }}'},
         'EndpointConfig': {
-            'EndpointConfigName': job_name,
+            'EndpointConfigName': "pca-{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}",
             'ProductionVariants': [{
                 'InstanceType': 'ml.c4.xlarge',
                 'InitialInstanceCount': '{{ instance_count }}',
-                'ModelName': job_name,
+                'ModelName': "pca-{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}",
                 'VariantName': 'AllTraffic',
                 'InitialVariantWeight': 1
             }]
         },
         'Endpoint': {
-            'EndpointName': job_name,
-            'EndpointConfigName': job_name
+            'EndpointName': "pca-{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}",
+            'EndpointConfigName': "pca-{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}"
         }
     }
 
@@ -1040,7 +1026,6 @@ def test_deploy_amazon_alg_model_config(sagemaker_session):
 
 
 def test_deploy_config_from_framework_estimator(sagemaker_session):
-    job_name = get_job_name("{{ base_job_name }}")
     mxnet_estimator = mxnet.MXNet(
         entry_point="{{ entry_point }}",
         source_dir="{{ source_dir }}",
@@ -1064,32 +1049,34 @@ def test_deploy_config_from_framework_estimator(sagemaker_session):
                                                   endpoint_name="mxnet-endpoint")
     expected_config = {
         'Model': {
-            'ModelName': job_name,
+            'ModelName': "{{ base_job_name }}-{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}",
             'PrimaryContainer': {
                 'Image': '520713654638.dkr.ecr.us-west-2.amazonaws.com/sagemaker-mxnet:1.3.0-cpu-py3',
                 'Environment': {
                     'SAGEMAKER_PROGRAM': '{{ entry_point }}',
-                    'SAGEMAKER_SUBMIT_DIRECTORY': "s3://output/{}/source/sourcedir.tar.gz".format(job_name),
+                    'SAGEMAKER_SUBMIT_DIRECTORY': "s3://output/{{ base_job_name }}-"
+                                                  "{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}/"
+                                                  "source/sourcedir.tar.gz",
                     'SAGEMAKER_ENABLE_CLOUDWATCH_METRICS': 'false',
                     'SAGEMAKER_CONTAINER_LOG_LEVEL': '20',
                     'SAGEMAKER_REGION': 'us-west-2'},
-                'ModelDataUrl': "s3://output/{}/output/model.tar.gz".format(job_name)
-            },
+                'ModelDataUrl': "s3://output/{{ base_job_name }}-"
+                                "{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}/output/model.tar.gz"},
             'ExecutionRoleArn': '{{ role }}'
         },
         'EndpointConfig': {
-            'EndpointConfigName': job_name,
+            'EndpointConfigName': "{{ base_job_name }}-{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}",
             'ProductionVariants': [{
                 'InstanceType': 'ml.c4.large',
                 'InitialInstanceCount': '{{ instance_count}}',
-                'ModelName': job_name,
+                'ModelName': "{{ base_job_name }}-{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}",
                 'VariantName': 'AllTraffic',
                 'InitialVariantWeight': 1
             }]
         },
         'Endpoint': {
             'EndpointName': 'mxnet-endpoint',
-            'EndpointConfigName': job_name
+            'EndpointConfigName': "{{ base_job_name }}-{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}"
         }
     }
 
@@ -1097,7 +1084,6 @@ def test_deploy_config_from_framework_estimator(sagemaker_session):
 
 
 def test_deploy_config_from_amazon_alg_estimator(sagemaker_session):
-    job_name = get_job_name('knn')
     knn_estimator = knn.KNN(
         role="{{ role }}",
         train_instance_count="{{ instance_count }}",
@@ -1117,26 +1103,24 @@ def test_deploy_config_from_amazon_alg_estimator(sagemaker_session):
                                                   instance_type="ml.p2.xlarge")
     expected_config = {
         'Model': {
-            'ModelName': job_name,
+            'ModelName': "knn-{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}",
             'PrimaryContainer': {
                 'Image': '174872318107.dkr.ecr.us-west-2.amazonaws.com/knn:1',
                 'Environment': {},
-                'ModelDataUrl': "s3://output/{}/output/model.tar.gz".format(job_name)
-            },
-            'ExecutionRoleArn': '{{ role }}'
-        },
+                'ModelDataUrl': "s3://output/knn-{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}"
+                                "/output/model.tar.gz"}, 'ExecutionRoleArn': '{{ role }}'},
         'EndpointConfig': {
-            'EndpointConfigName': job_name,
+            'EndpointConfigName': "knn-{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}",
             'ProductionVariants': [{
                 'InstanceType': 'ml.p2.xlarge',
                 'InitialInstanceCount': '{{ instance_count }}',
-                'ModelName': job_name,
+                'ModelName': "knn-{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}",
                 'VariantName': 'AllTraffic', 'InitialVariantWeight': 1
             }]
         },
         'Endpoint': {
-            'EndpointName': job_name,
-            'EndpointConfigName': job_name
+            'EndpointName': "knn-{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}",
+            'EndpointConfigName': "knn-{{ execution_date.strftime('%Y-%m-%d-%H-%M-%S') }}"
         }
     }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Just appending retry id after a job name is not a good solution for solving naming collisions in Airflow operators. It may add more risk for users to manage jobs across operators. So revert the changes in:

https://github.com/aws/sagemaker-python-sdk/commit/2ad6c1da29eba210a1fcd51156d9b5e7ab0627f5

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated the [changelog](https://github.com/aws/sagemaker-python-sdk/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
