### PR TITLE
Make include_cls_metadata default to False for everything except Frameworks

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,10 +2,15 @@
 CHANGELOG
 =========
 
+1.16.4.dev
+==========
+
+* bug-fix: HyperparameterTuner: make ``include_cls_metadata`` default to ``False`` for everything except Frameworks
+
 1.16.3
 ======
 
-* bug-fix: Local Mode: Allow support for SSH in local mode 
+* bug-fix: Local Mode: Allow support for SSH in local mode
 * bug-fix: Append retry id to default Airflow job name to avoid name collisions in retry
 * bug-fix: Local Mode: No longer requires s3 permissions to run local entry point file
 * feature: Estimators: add support for PyTorch 1.0.0

--- a/README.rst
+++ b/README.rst
@@ -640,15 +640,9 @@ In addition, the ``fit()`` call uses a list of ``RecordSet`` objects instead of 
     my_tuner.fit([train_records, test_records])
 
 To help attach a previously-started hyperparameter tuning job to a ``HyperparameterTuner`` instance,
-``fit()`` adds the module path of the class used to create the tuner to the list of static hyperparameters by default.
-If the algorithm you are using cannot handle unknown hyperparameters
-(for example, an Amazon SageMaker built-in algorithm that does not have a custom estimator in the Python SDK),
-set ``include_cls_metadata`` to ``False`` when you call ``fit``, so that it does not add the module path as a static hyperparameter:
-
-.. code:: python
-
-    my_tuner.fit({'train': 's3://my_bucket/my_training_data', 'test': 's3://my_bucket_my_testing_data'},
-                 include_cls_metadata=False)
+``fit()`` adds the module path of the class used to create the hyperparameter tuner to the list of static hyperparameters by default.
+If you are using your own custom estimator class (i.e. not one provided in this SDK) and want that class to be used when attaching a hyperparamter tuning job,
+set ``include_cls_metadata`` to ``True`` when you call ``fit`` to add the module path as static hyperparameters.
 
 There is also an analytics object associated with each ``HyperparameterTuner`` instance that contains useful information about the hyperparameter tuning job.
 For example, the ``dataframe`` method gets a pandas dataframe summarizing the associated training jobs:

--- a/tests/unit/test_tuner.py
+++ b/tests/unit/test_tuner.py
@@ -13,22 +13,21 @@
 from __future__ import absolute_import
 
 import copy
-import json
-
 import os
+
 import pytest
 from mock import Mock
 
 from sagemaker import RealTimePredictor
-from sagemaker.amazon.pca import PCA
 from sagemaker.amazon.amazon_estimator import RecordSet
+from sagemaker.amazon.pca import PCA
 from sagemaker.estimator import Estimator
-from sagemaker.parameter import (ParameterRange, ContinuousParameter,
-                                 IntegerParameter, CategoricalParameter)
-from sagemaker.tuner import (HyperparameterTuner, _TuningJob, WarmStartConfig, WarmStartTypes,
-                             create_identical_dataset_and_algorithm_tuner,
-                             create_transfer_learning_tuner)
 from sagemaker.mxnet import MXNet
+from sagemaker.parameter import (CategoricalParameter, ContinuousParameter,
+                                 IntegerParameter, ParameterRange)
+from sagemaker.tuner import (_TuningJob, create_identical_dataset_and_algorithm_tuner,
+                             create_transfer_learning_tuner, HyperparameterTuner, WarmStartConfig,
+                             WarmStartTypes)
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), '..', 'data')
 MODEL_DATA = "s3://bucket/model.tar.gz"

--- a/tests/unit/test_tuner.py
+++ b/tests/unit/test_tuner.py
@@ -157,13 +157,8 @@ def test_prepare_for_training(tuner):
 
     assert tuner._current_job_name.startswith(IMAGE_NAME)
 
-    assert len(tuner.static_hyperparameters) == 3
+    assert len(tuner.static_hyperparameters) == 1
     assert tuner.static_hyperparameters['another_one'] == '0'
-
-    class_name = json.dumps(tuner.estimator.__class__.__name__)
-    assert tuner.static_hyperparameters['sagemaker_estimator_class_name'] == class_name
-    module = json.dumps(tuner.estimator.__module__)
-    assert tuner.static_hyperparameters['sagemaker_estimator_module'] == module
 
 
 def test_prepare_for_training_with_amazon_estimator(tuner, sagemaker_session):
@@ -175,10 +170,10 @@ def test_prepare_for_training_with_amazon_estimator(tuner, sagemaker_session):
     assert 'sagemaker_estimator_module' not in tuner.static_hyperparameters
 
 
-def test_prepare_for_training_dont_include_estimator_cls(tuner):
-    tuner._prepare_for_training(include_cls_metadata=False)
-    assert 'sagemaker_estimator_class_name' not in tuner.static_hyperparameters
-    assert 'sagemaker_estimator_module' not in tuner.static_hyperparameters
+def test_prepare_for_training_include_estimator_cls(tuner):
+    tuner._prepare_for_training(include_cls_metadata=True)
+    assert 'sagemaker_estimator_class_name' in tuner.static_hyperparameters
+    assert 'sagemaker_estimator_module' in tuner.static_hyperparameters
 
 
 def test_prepare_for_training_with_job_name(tuner):


### PR DESCRIPTION
*Description of changes:*
When a `HyperparameterTuner` is created using `attach()`, the tuner needs to pick an Estimator class to use. It looks for the following things (in this order):
1. if the hyperparameters have class metadata (e.g. a path like sagemaker.tensorflow.estimator.TensorFlow)
1. if the image being used corresponds to one of our 1P estimators
1. if nothing is present, in which case it just uses the generic Estimator class

These are the following scenarios I see currently:
1. Framework (e.g. TensorFlow): defaults to including the class, and our framework images can handle arbitrary hyperparameters. No problem.
1. 1P with a dedicated Python SDK estimator (e.g. kNN, NTM): defaults to not including the class and determines the estimator class based on the image name. No problem.
1. 1P without a dedicated estimator (e.g. XGBoost, DeepAR): defaults to including the class while requiring the generic Estimator. Requires customers to read the documentation and set `include_cls_metadata` to `False`.
1. BYO + generic Estimator: defaults to including the class while using the generic Estimator. Requires customers to read the documentation and set `include_cls_metadata` to `False` if their Docker image doesn’t accept arbitrary hyperparameters.
1. BYO + custom estimator: not actually sure how popular this use case is, but theoretically a customer could subclass one of the Python SDK estimators for their own use. Currently the class/module path will be included by default, but we don’t know if the customer’s Docker image can handle arbitrary hyperparameters.

Situations 3 and 4 are the buggy situations that cause many customer questions. Both require use of the generic Estimator class, which is the default class used by `attach()` if there is no other information available. Therefore, defaulting `include_cls_metadata` to `False` in these situations will result in only one change in behavior: that the customer no longer needs to know about this.

Situation 5 is the only case that is broken by flipping the `include_cls_metadata` default. I'm open to ideas on how best to communicate this if it's a cause for concern.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have updated the [changelog](https://github.com/aws/sagemaker-python-sdk/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [x] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
