### PR TITLE
enable canary for EI supported regions

### DIFF
--- a/tests/integ/__init__.py
+++ b/tests/integ/__init__.py
@@ -28,6 +28,8 @@ PYTHON_VERSION = 'py' + str(sys.version_info.major)
 HOSTING_NO_P2_REGIONS = ['ca-central-1', 'eu-west-2', 'us-west-1', 'eu-central-1']
 HOSTING_NO_P3_REGIONS = ['ap-southeast-1', 'ap-southeast-2', 'ap-south-1', 'ca-central-1',
                          'eu-west-2', 'us-west-1']
+# EI is currently only supported in the following regions
+EI_SUPPORTED_REGIONS = ['us-east-1', 'us-east-2', 'us-west-2', 'eu-west-1', 'ap-northeast-1', 'ap-northeast-2']
 
 logging.getLogger('boto3').setLevel(logging.INFO)
 logging.getLogger('botocore').setLevel(logging.INFO)

--- a/tests/integ/__init__.py
+++ b/tests/integ/__init__.py
@@ -29,6 +29,7 @@ HOSTING_NO_P2_REGIONS = ['ca-central-1', 'eu-west-2', 'us-west-1', 'eu-central-1
 HOSTING_NO_P3_REGIONS = ['ap-southeast-1', 'ap-southeast-2', 'ap-south-1', 'ca-central-1',
                          'eu-west-2', 'us-west-1']
 # EI is currently only supported in the following regions
+# regions were derived from https://aws.amazon.com/machine-learning/elastic-inference/pricing/
 EI_SUPPORTED_REGIONS = ['us-east-1', 'us-east-2', 'us-west-2', 'eu-west-1', 'ap-northeast-1', 'ap-northeast-2']
 
 logging.getLogger('boto3').setLevel(logging.INFO)

--- a/tests/integ/test_mxnet_train.py
+++ b/tests/integ/test_mxnet_train.py
@@ -72,8 +72,8 @@ def test_deploy_model(mxnet_training_job, sagemaker_session):
         predictor.predict(data)
 
 
-@pytest.continous_testing
-@pytest.regional_testing
+@pytest.mark.continous_testing
+@pytest.mark.regional_testing
 @pytest.mark.skipif(tests.integ.test_region() not in tests.integ.EI_SUPPORTED_REGIONS,
                     reason="EI isn't supported in that specific region.")
 def test_deploy_model_with_accelerator(mxnet_training_job, sagemaker_session, ei_mxnet_version):

--- a/tests/integ/test_mxnet_train.py
+++ b/tests/integ/test_mxnet_train.py
@@ -72,7 +72,7 @@ def test_deploy_model(mxnet_training_job, sagemaker_session):
         predictor.predict(data)
 
 
-@pytest.mark.continous_testing
+@pytest.mark.continuous_testing
 @pytest.mark.regional_testing
 @pytest.mark.skipif(tests.integ.test_region() not in tests.integ.EI_SUPPORTED_REGIONS,
                     reason="EI isn't supported in that specific region.")

--- a/tests/integ/test_mxnet_train.py
+++ b/tests/integ/test_mxnet_train.py
@@ -18,6 +18,7 @@ import time
 import numpy
 import pytest
 
+import tests.integ
 from sagemaker.mxnet.estimator import MXNet
 from sagemaker.mxnet.model import MXNetModel
 from sagemaker.utils import sagemaker_timestamp
@@ -71,6 +72,10 @@ def test_deploy_model(mxnet_training_job, sagemaker_session):
         predictor.predict(data)
 
 
+@pytest.continous_testing
+@pytest.regional_testing
+@pytest.mark.skipif(tests.integ.test_region() in tests.integ.EI_SUPPORTED_REGIONS,
+                    reason="EI isn't supported in that specific region.")
 def test_deploy_model_with_accelerator(mxnet_training_job, sagemaker_session, ei_mxnet_version):
     endpoint_name = 'test-mxnet-deploy-model-ei-{}'.format(sagemaker_timestamp())
 

--- a/tests/integ/test_mxnet_train.py
+++ b/tests/integ/test_mxnet_train.py
@@ -74,7 +74,7 @@ def test_deploy_model(mxnet_training_job, sagemaker_session):
 
 @pytest.continous_testing
 @pytest.regional_testing
-@pytest.mark.skipif(tests.integ.test_region() in tests.integ.EI_SUPPORTED_REGIONS,
+@pytest.mark.skipif(tests.integ.test_region() not in tests.integ.EI_SUPPORTED_REGIONS,
                     reason="EI isn't supported in that specific region.")
 def test_deploy_model_with_accelerator(mxnet_training_job, sagemaker_session, ei_mxnet_version):
     endpoint_name = 'test-mxnet-deploy-model-ei-{}'.format(sagemaker_timestamp())

--- a/tests/integ/test_tf.py
+++ b/tests/integ/test_tf.py
@@ -79,7 +79,7 @@ def test_deploy_model(sagemaker_session, tf_training_job):
 
 @pytest.continous_testing
 @pytest.regional_testing
-@pytest.mark.skipif(tests.integ.test_region() in tests.integ.EI_SUPPORTED_REGIONS,
+@pytest.mark.skipif(tests.integ.test_region() not in tests.integ.EI_SUPPORTED_REGIONS,
                     reason="EI isn't supported in that specific region.")
 @pytest.mark.skipif(PYTHON_VERSION != 'py2', reason="TensorFlow image supports only python 2.")
 def test_deploy_model_with_accelerator(sagemaker_session, tf_training_job, ei_tf_version):

--- a/tests/integ/test_tf.py
+++ b/tests/integ/test_tf.py
@@ -17,6 +17,7 @@ import time
 
 import pytest
 
+import tests.integ
 from sagemaker.tensorflow import TensorFlow, TensorFlowModel
 from sagemaker.utils import sagemaker_timestamp
 from tests.integ import DATA_DIR, TRAINING_DEFAULT_TIMEOUT_MINUTES, PYTHON_VERSION
@@ -76,6 +77,10 @@ def test_deploy_model(sagemaker_session, tf_training_job):
         assert dict_result == list_result
 
 
+@pytest.continous_testing
+@pytest.regional_testing
+@pytest.mark.skipif(tests.integ.test_region() in tests.integ.EI_SUPPORTED_REGIONS,
+                    reason="EI isn't supported in that specific region.")
 @pytest.mark.skipif(PYTHON_VERSION != 'py2', reason="TensorFlow image supports only python 2.")
 def test_deploy_model_with_accelerator(sagemaker_session, tf_training_job, ei_tf_version):
     endpoint_name = 'test-tf-deploy-model-ei-{}'.format(sagemaker_timestamp())

--- a/tests/integ/test_tf.py
+++ b/tests/integ/test_tf.py
@@ -77,7 +77,7 @@ def test_deploy_model(sagemaker_session, tf_training_job):
         assert dict_result == list_result
 
 
-@pytest.mark.continous_testing
+@pytest.mark.continuous_testing
 @pytest.mark.regional_testing
 @pytest.mark.skipif(tests.integ.test_region() not in tests.integ.EI_SUPPORTED_REGIONS,
                     reason="EI isn't supported in that specific region.")

--- a/tests/integ/test_tf.py
+++ b/tests/integ/test_tf.py
@@ -77,8 +77,8 @@ def test_deploy_model(sagemaker_session, tf_training_job):
         assert dict_result == list_result
 
 
-@pytest.continous_testing
-@pytest.regional_testing
+@pytest.mark.continous_testing
+@pytest.mark.regional_testing
 @pytest.mark.skipif(tests.integ.test_region() not in tests.integ.EI_SUPPORTED_REGIONS,
                     reason="EI isn't supported in that specific region.")
 @pytest.mark.skipif(PYTHON_VERSION != 'py2', reason="TensorFlow image supports only python 2.")


### PR DESCRIPTION
*Description of changes:*
Enabling the tests specified here as canaries: https://github.com/aws/sagemaker-python-sdk/pull/527

The regions were determined based on: https://aws.amazon.com/machine-learning/elastic-inference/pricing/

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have updated the [changelog](https://github.com/aws/sagemaker-python-sdk/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [x] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
