### PR TITLE
Prepend SageMaker Notebook Instance version ID to boto3 User Agent

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,10 @@ CHANGELOG
 =========
 
 
+1.18.2.dev
+======
+* enhancement: Include SageMaker Notebook Instance version number in boto3 user agent, if available.
+
 1.18.1
 ======
 


### PR DESCRIPTION
SageMaker Notebook Instances provide the version ID as a file on a
Notebook Instance.  In order to enhance version adoption from within
SageMaker, provide an extra segment to the user_agent supplied to the
boto3 ClientConfig.

*Issue #, if available:*

*Description of changes:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [X] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated the [changelog](https://github.com/aws/sagemaker-python-sdk/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
