### PR TITLE
Add Airflow example DAGs of tensorflow and kmeans

### DIFF
--- a/src/sagemaker/workflow/README.rst
+++ b/src/sagemaker/workflow/README.rst
@@ -164,3 +164,6 @@ Then build your workflow by using the PythonOperator with the Python callables d
 
 A workflow that runs a SageMaker training job and a batch transform job is finished. You can customize your Python
 callables with the SageMaker Python SDK according to your needs, and build more flexible and powerful workflows.
+
+For more examples, you can refer to our
+`example DAGs <https://github.com/aws/sagemaker-python-sdk/tree/master/src/sagemaker/workflow/examples>`_

--- a/src/sagemaker/workflow/examples/kmeans_training_lowlevel.py
+++ b/src/sagemaker/workflow/examples/kmeans_training_lowlevel.py
@@ -1,0 +1,121 @@
+from __future__ import absolute_import
+
+import io
+import gzip
+import pickle
+from datetime import timedelta
+from time import gmtime, strftime
+from urllib import request
+
+import airflow
+from airflow import DAG
+from airflow.operators.python_operator import PythonOperator
+from airflow.contrib.operators.sagemaker_training_operator import SageMakerTrainingOperator
+import boto3
+from sagemaker.session import Session
+from sagemaker.amazon.common import write_numpy_to_dense_tensor
+from sagemaker.amazon.amazon_estimator import get_image_uri
+
+
+default_args = {
+    'owner': 'airflow',
+    'start_date': airflow.utils.dates.days_ago(2),
+    'provide_context': True,
+    'retry_delay': timedelta(minutes=1)
+}
+
+dag = DAG('kmeans_training_lowlevel', default_args=default_args,
+          schedule_interval='@once')
+
+# Constants
+role = 'my_sagemaker_role'
+job_name = 'kmeans-lowlevel-' + strftime("%Y-%m-%d-%H-%M-%S", gmtime())
+
+
+def prepare_resources(**context):
+    bucket = Session().default_bucket()
+
+    # Load the input dataset
+    request.urlretrieve("http://deeplearning.net/data/mnist/mnist.pkl.gz", "mnist.pkl.gz")
+    with gzip.open('mnist.pkl.gz', 'rb') as f:
+        train_set, valid_set, test_set = pickle.load(f, encoding='latin1')
+
+    data_key = 'kmeans_lowlevel_example/data'
+    data_location = 's3://{}/{}'.format(bucket, data_key)
+
+    # Convert the training data into the format required by the SageMaker KMeans algorithm
+    buf = io.BytesIO()
+    write_numpy_to_dense_tensor(buf, train_set[0], train_set[1])
+    buf.seek(0)
+
+    # upload the input data
+    boto3.resource('s3').Bucket(bucket).Object(data_key).upload_fileobj(buf)
+    print('training data uploaded to: {}'.format(data_location))
+
+    # get image and model output location
+    image = get_image_uri(boto3.Session().region_name, 'kmeans')
+    output_location = 's3://{}/kmeans_example/output'.format(bucket)
+
+    # store necessary training resources in XCOM
+    return {
+        'data_location': data_location,
+        'image': image,
+        'output_location': output_location
+    }
+
+
+resources = PythonOperator(
+    task_id='prepare_resources',
+    python_callable=prepare_resources,
+    provide_context=True,
+    dag=dag
+)
+
+# build the training config
+# See: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sagemaker.html#SageMaker.Client.create_training_job # noqa: E501
+kmeans_training_config = {
+    "AlgorithmSpecification": {
+        "TrainingImage": "{{ task_instance.xcom_pull(task_ids='prepare_resources')['image'] }}",
+        "TrainingInputMode": "File"
+    },
+    "RoleArn": role,
+    "OutputDataConfig": {
+        "S3OutputPath": "{{ task_instance.xcom_pull(task_ids='prepare_resources')['output_location'] }}"
+    },
+    "ResourceConfig": {
+        "InstanceCount": 2,
+        "InstanceType": "ml.c4.8xlarge",
+        "VolumeSizeInGB": 50
+    },
+    "TrainingJobName": job_name,
+    "HyperParameters": {
+        "k": "10",
+        "feature_dim": "784",
+        "mini_batch_size": "500",
+        "force_dense": "True"
+    },
+    "StoppingCondition": {
+        "MaxRuntimeInSeconds": 60 * 60
+    },
+    "InputDataConfig": [
+        {
+            "ChannelName": "train",
+            "DataSource": {
+                "S3DataSource": {
+                    "S3DataType": "S3Prefix",
+                    "S3Uri": "{{ task_instance.xcom_pull(task_ids='prepare_resources')['data_location'] }}",
+                    "S3DataDistributionType": "FullyReplicated"
+                }
+            },
+            "CompressionType": "None",
+            "RecordWrapperType": "None"
+        }
+    ]
+}
+
+training = SageMakerTrainingOperator(
+    task_id='kmeans_training',
+    config=kmeans_training_config,
+    retries=3,
+    dag=dag)
+training.set_upstream(resources)

--- a/src/sagemaker/workflow/examples/scripts/tf_mnist.py
+++ b/src/sagemaker/workflow/examples/scripts/tf_mnist.py
@@ -1,0 +1,121 @@
+import os
+import tensorflow as tf
+from tensorflow.python.estimator.model_fn import ModeKeys as Modes
+
+INPUT_TENSOR_NAME = 'inputs'
+SIGNATURE_NAME = 'predictions'
+
+LEARNING_RATE = 0.001
+
+
+def model_fn(features, labels, mode, params):
+    # Input Layer
+    input_layer = tf.reshape(features[INPUT_TENSOR_NAME], [-1, 28, 28, 1])
+
+    # Convolutional Layer #1
+    conv1 = tf.layers.conv2d(
+        inputs=input_layer,
+        filters=32,
+        kernel_size=[5, 5],
+        padding='same',
+        activation=tf.nn.relu)
+
+    # Pooling Layer #1
+    pool1 = tf.layers.max_pooling2d(inputs=conv1, pool_size=[2, 2], strides=2)
+
+    # Convolutional Layer #2 and Pooling Layer #2
+    conv2 = tf.layers.conv2d(
+        inputs=pool1,
+        filters=64,
+        kernel_size=[5, 5],
+        padding='same',
+        activation=tf.nn.relu)
+    pool2 = tf.layers.max_pooling2d(inputs=conv2, pool_size=[2, 2], strides=2)
+
+    # Dense Layer
+    pool2_flat = tf.reshape(pool2, [-1, 7 * 7 * 64])
+    dense = tf.layers.dense(inputs=pool2_flat, units=1024, activation=tf.nn.relu)
+    dropout = tf.layers.dropout(
+        inputs=dense, rate=0.4, training=(mode == Modes.TRAIN))
+
+    # Logits Layer
+    logits = tf.layers.dense(inputs=dropout, units=10)
+
+    # Define operations
+    if mode in (Modes.PREDICT, Modes.EVAL):
+        predicted_indices = tf.argmax(input=logits, axis=1)
+        probabilities = tf.nn.softmax(logits, name='softmax_tensor')
+
+    if mode in (Modes.TRAIN, Modes.EVAL):
+        global_step = tf.train.get_or_create_global_step()
+        label_indices = tf.cast(labels, tf.int32)
+        loss = tf.losses.softmax_cross_entropy(
+            onehot_labels=tf.one_hot(label_indices, depth=10), logits=logits)
+        tf.summary.scalar('OptimizeLoss', loss)
+
+    if mode == Modes.PREDICT:
+        predictions = {
+            'classes': predicted_indices,
+            'probabilities': probabilities
+        }
+        export_outputs = {
+            SIGNATURE_NAME: tf.estimator.export.PredictOutput(predictions)
+        }
+        return tf.estimator.EstimatorSpec(
+            mode, predictions=predictions, export_outputs=export_outputs)
+
+    if mode == Modes.TRAIN:
+        optimizer = tf.train.AdamOptimizer(learning_rate=0.001)
+        train_op = optimizer.minimize(loss, global_step=global_step)
+        return tf.estimator.EstimatorSpec(mode, loss=loss, train_op=train_op)
+
+    if mode == Modes.EVAL:
+        eval_metric_ops = {
+            'accuracy': tf.metrics.accuracy(label_indices, predicted_indices)
+        }
+        return tf.estimator.EstimatorSpec(
+            mode, loss=loss, eval_metric_ops=eval_metric_ops)
+
+
+def serving_input_fn(params):
+    inputs = {INPUT_TENSOR_NAME: tf.placeholder(tf.float32, [None, 784])}
+    return tf.estimator.export.ServingInputReceiver(inputs, inputs)
+
+
+def read_and_decode(filename_queue):
+    reader = tf.TFRecordReader()
+    _, serialized_example = reader.read(filename_queue)
+
+    features = tf.parse_single_example(
+        serialized_example,
+        features={
+            'image_raw': tf.FixedLenFeature([], tf.string),
+            'label': tf.FixedLenFeature([], tf.int64),
+        })
+
+    image = tf.decode_raw(features['image_raw'], tf.uint8)
+    image.set_shape([784])
+    image = tf.cast(image, tf.float32) * (1. / 255)
+    label = tf.cast(features['label'], tf.int32)
+
+    return image, label
+
+
+def train_input_fn(training_dir, params):
+    return _input_fn(training_dir, 'train.tfrecords', batch_size=100)
+
+
+def eval_input_fn(training_dir, params):
+    return _input_fn(training_dir, 'test.tfrecords', batch_size=100)
+
+
+def _input_fn(training_dir, training_filename, batch_size=100):
+    test_file = os.path.join(training_dir, training_filename)
+    filename_queue = tf.train.string_input_producer([test_file])
+
+    image, label = read_and_decode(filename_queue)
+    images, labels = tf.train.batch(
+        [image, label], batch_size=batch_size,
+        capacity=1000 + 3 * batch_size)
+
+    return {INPUT_TENSOR_NAME: images}, labels

--- a/src/sagemaker/workflow/examples/tensorflow_training_transform.py
+++ b/src/sagemaker/workflow/examples/tensorflow_training_transform.py
@@ -1,0 +1,139 @@
+from __future__ import absolute_import
+
+import os
+from datetime import timedelta
+
+import airflow
+from airflow import DAG
+from airflow.operators.python_operator import PythonOperator
+from airflow.contrib.operators.sagemaker_training_operator import SageMakerTrainingOperator
+from airflow.contrib.operators.sagemaker_transform_operator import SageMakerTransformOperator
+import sagemaker
+from sagemaker import Session
+from sagemaker.tensorflow import TensorFlow
+from sagemaker.workflow.airflow import training_config, transform_config_from_estimator
+import tensorflow as tf
+from tensorflow.contrib.learn.python.learn.datasets import mnist
+
+default_args = {
+    'owner': 'airflow',
+    'start_date': airflow.utils.dates.days_ago(2),
+    'provide_context': True,
+    'retry_delay': timedelta(minutes=1)
+}
+
+dag = DAG('tensorflow_training_transform', default_args=default_args,
+          schedule_interval='@once')
+
+# Constants
+role = 'SageMakerRole'
+
+
+def _int64_feature(value):
+    return tf.train.Feature(int64_list=tf.train.Int64List(value=[value]))
+
+
+def _bytes_feature(value):
+    return tf.train.Feature(bytes_list=tf.train.BytesList(value=[value]))
+
+
+# Convert MNIST data to TFRecords file format with Example protos
+def convert_to(data_set, name, directory):
+    """Converts a dataset to tfrecords."""
+    images = data_set.images
+    labels = data_set.labels
+    num_examples = data_set.num_examples
+
+    if images.shape[0] != num_examples:
+        raise ValueError('Images size %d does not match label size %d.' %
+                         (images.shape[0], num_examples))
+    rows = images.shape[1]
+    cols = images.shape[2]
+    depth = images.shape[3]
+
+    filename = os.path.join(directory, name + '.tfrecords')
+    print('Writing', filename)
+    writer = tf.python_io.TFRecordWriter(filename)
+    for index in range(num_examples):
+        image_raw = images[index].tostring()
+        example = tf.train.Example(features=tf.train.Features(feature={
+            'height': _int64_feature(rows),
+            'width': _int64_feature(cols),
+            'depth': _int64_feature(depth),
+            'label': _int64_feature(int(labels[index])),
+            'image_raw': _bytes_feature(image_raw)}))
+        writer.write(example.SerializeToString())
+    writer.close()
+
+
+def prepare_data(**context):
+    sagemaker_session = Session()
+
+    # Download the training data
+    data_sets = mnist.read_data_sets('data', dtype=tf.uint8, reshape=False, validation_size=5000)
+
+    # Convert data format
+    convert_to(data_sets.train, 'train', 'data')
+    convert_to(data_sets.validation, 'validation', 'data')
+    convert_to(data_sets.test, 'test', 'data')
+
+    # Upload the training data
+    training_data = sagemaker_session.upload_data(path='data', key_prefix='data/DEMO-mnist')
+
+    # Use data that contains 1000 MNIST images in public SageMaker sample data bucket
+    region = sagemaker_session.boto_region_name
+    transform_data = "s3://sagemaker-sample-data-{}/batch-transform/mnist-1000-samples".format(region)
+
+    # Store data URIs in XCOM
+    return {
+        'training_data': training_data,
+        'transform_data': transform_data
+    }
+
+
+prepare = PythonOperator(
+    task_id='prepare_data',
+    python_callable=prepare_data,
+    provide_context=True,
+    retries=3,
+    dag=dag)
+
+training_data = "{{ ti.xcom_pull(task_ids='prepare_data')['training_data'] }}"
+
+# You need to put the training script at ./scripts/tf_mnist.py in AIRFLOW_HOME.
+mnist_estimator = TensorFlow(entry_point='tf_mnist.py',
+                             role=role,
+                             framework_version='1.11.0',
+                             training_steps=1000,
+                             evaluation_steps=100,
+                             train_instance_count=2,
+                             train_instance_type='ml.c4.xlarge')
+
+train_config = training_config(estimator=mnist_estimator,
+                               inputs=training_data)
+
+tf_training = SageMakerTrainingOperator(
+    task_id='tf_training',
+    config=train_config,
+    retries=3,
+    dag=dag)
+
+tf_training.set_upstream(prepare)
+
+transform_data = "{{ ti.xcom_pull(task_ids='prepare_data')['transform_data'] }}"
+
+trans_config = transform_config_from_estimator(estimator=mnist_estimator,
+                                               task_id='tf_training',
+                                               task_type='training',
+                                               instance_count=1,
+                                               instance_type='ml.m4.xlarge',
+                                               data=transform_data,
+                                               content_type='text/csv')
+
+tf_transform = SageMakerTransformOperator(
+    task_id='tf_transform',
+    config=trans_config,
+    retries=3,
+    dag=dag)
+
+tf_transform.set_upstream(tf_training)

--- a/src/sagemaker/workflow/examples/tensorflow_training_transform_pythonoperator.py
+++ b/src/sagemaker/workflow/examples/tensorflow_training_transform_pythonoperator.py
@@ -1,0 +1,135 @@
+from __future__ import absolute_import
+
+import os
+from datetime import timedelta
+
+import airflow
+from airflow import DAG
+from airflow.operators.python_operator import PythonOperator
+from sagemaker import Session
+from sagemaker.tensorflow import TensorFlow
+import tensorflow as tf
+from tensorflow.contrib.learn.python.learn.datasets import mnist
+
+default_args = {
+    'owner': 'airflow',
+    'start_date': airflow.utils.dates.days_ago(2),
+    'provide_context': True,
+    'retry_delay': timedelta(minutes=1)
+}
+
+dag = DAG('tensorflow_training_transform_pyop', default_args=default_args,
+          schedule_interval='@once')
+
+# Constants
+role = 'my_sagemaker_role'
+
+
+def _int64_feature(value):
+    return tf.train.Feature(int64_list=tf.train.Int64List(value=[value]))
+
+
+def _bytes_feature(value):
+    return tf.train.Feature(bytes_list=tf.train.BytesList(value=[value]))
+
+
+# Convert MNIST data to TFRecords file format with Example protos
+def convert_to(data_set, name, directory):
+    """Converts a dataset to tfrecords."""
+    images = data_set.images
+    labels = data_set.labels
+    num_examples = data_set.num_examples
+
+    if images.shape[0] != num_examples:
+        raise ValueError('Images size %d does not match label size %d.' %
+                         (images.shape[0], num_examples))
+    rows = images.shape[1]
+    cols = images.shape[2]
+    depth = images.shape[3]
+
+    filename = os.path.join(directory, name + '.tfrecords')
+    print('Writing', filename)
+    writer = tf.python_io.TFRecordWriter(filename)
+    for index in range(num_examples):
+        image_raw = images[index].tostring()
+        example = tf.train.Example(features=tf.train.Features(feature={
+            'height': _int64_feature(rows),
+            'width': _int64_feature(cols),
+            'depth': _int64_feature(depth),
+            'label': _int64_feature(int(labels[index])),
+            'image_raw': _bytes_feature(image_raw)}))
+        writer.write(example.SerializeToString())
+    writer.close()
+
+
+def prepare_data(**context):
+    sagemaker_session = Session()
+
+    # Download the training data
+    data_sets = mnist.read_data_sets('data', dtype=tf.uint8, reshape=False, validation_size=5000)
+
+    # Convert data format
+    convert_to(data_sets.train, 'train', 'data')
+    convert_to(data_sets.validation, 'validation', 'data')
+    convert_to(data_sets.test, 'test', 'data')
+
+    # Upload the training data
+    training_data = sagemaker_session.upload_data(path='data', key_prefix='data/DEMO-mnist')
+
+    # Use data that contains 1000 MNIST images in public SageMaker sample data bucket
+    region = sagemaker_session.boto_region_name
+    transform_data = "s3://sagemaker-sample-data-{}/batch-transform/mnist-1000-samples".format(region)
+
+    # Store data URIs in XCOM
+    return {
+        'training_data': training_data,
+        'transform_data': transform_data
+    }
+
+
+prepare = PythonOperator(
+    task_id='prepare_data',
+    python_callable=prepare_data,
+    retries=3,
+    dag=dag)
+
+
+# You need to put the training script at ./scripts/tf_mnist.py in AIRFLOW_HOME.
+def train(**context):
+    mnist_estimator = TensorFlow(entry_point='tf_mnist.py',
+                                 role=role,
+                                 framework_version='1.11.0',
+                                 training_steps=1000,
+                                 evaluation_steps=100,
+                                 train_instance_count=2,
+                                 train_instance_type='ml.c4.xlarge')
+    data = context['ti'].xcom_pull(task_ids='prepare_data')['training_data']
+    mnist_estimator.fit(data)
+    return mnist_estimator.latest_training_job.job_name
+
+
+tf_train = PythonOperator(
+    task_id='tf_training',
+    python_callable=train,
+    retries=3,
+    dag=dag)
+
+tf_train.set_upstream(prepare)
+
+
+def transform(**context):
+    training_job = context['ti'].xcom_pull(task_ids='tf_training')
+    mnist_estimator = TensorFlow.attach(training_job)
+    transformer = mnist_estimator.transformer(instance_count=1, instance_type='ml.m4.xlarge')
+    data = context['ti'].xcom_pull(task_ids='prepare_data')['transform_data']
+    transformer.transform(data, content_type='text/csv')
+    transformer.wait()
+
+
+tf_transform = PythonOperator(
+    task_id='tf_transform',
+    python_callable=transform,
+    retries=3,
+    dag=dag)
+
+tf_transform.set_upstream(tf_train)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add 3 DAG examples of using SageMaker in Airflow:
1. KMeans low level training example
2. TF training and transform in Python Operator
3. TF training and transform in SageMaker Operator

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated the [changelog](https://github.com/aws/sagemaker-python-sdk/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
