### PR TITLE
Fix SKLearnModel default account in image uri.

### DIFF
--- a/src/sagemaker/sklearn/defaults.py
+++ b/src/sagemaker/sklearn/defaults.py
@@ -12,4 +12,6 @@
 # language governing permissions and limitations under the License.
 from __future__ import absolute_import
 
+SKLEARN_NAME = "scikit-learn"
+
 SKLEARN_VERSION = '0.20.0'

--- a/src/sagemaker/sklearn/defaults.py
+++ b/src/sagemaker/sklearn/defaults.py
@@ -12,6 +12,6 @@
 # language governing permissions and limitations under the License.
 from __future__ import absolute_import
 
-SKLEARN_NAME = "scikit-learn"
+SKLEARN_NAME = 'scikit-learn'
 
 SKLEARN_VERSION = '0.20.0'

--- a/src/sagemaker/sklearn/estimator.py
+++ b/src/sagemaker/sklearn/estimator.py
@@ -17,7 +17,7 @@ import logging
 from sagemaker.estimator import Framework
 from sagemaker.fw_registry import default_framework_uri
 from sagemaker.fw_utils import framework_name_from_image, empty_framework_version_warning
-from sagemaker.sklearn.defaults import SKLEARN_VERSION
+from sagemaker.sklearn.defaults import SKLEARN_VERSION, SKLEARN_NAME
 from sagemaker.sklearn.model import SKLearnModel
 from sagemaker.vpc_utils import VPC_CONFIG_DEFAULT
 
@@ -28,7 +28,7 @@ logger = logging.getLogger('sagemaker')
 class SKLearn(Framework):
     """Handle end-to-end training and deployment of custom Scikit-learn code."""
 
-    __framework_name__ = "scikit-learn"
+    __framework_name__ = SKLEARN_NAME
 
     def __init__(self, entry_point, framework_version=SKLEARN_VERSION, source_dir=None, hyperparameters=None,
                  py_version='py3', image_name=None, **kwargs):
@@ -74,7 +74,7 @@ class SKLearn(Framework):
         train_instance_count = kwargs.get('train_instance_count')
         if train_instance_count:
             if train_instance_count != 1:
-                raise AttributeError("SciKit-Learn does not support distributed training. "
+                raise AttributeError("Scikit-Learn does not support distributed training. "
                                      "Please remove the 'train_instance_count' argument or set "
                                      "'train_instance_count=1' when initializing SKLearn.")
         super(SKLearn, self).__init__(entry_point, source_dir, hyperparameters, image_name=image_name,
@@ -154,6 +154,6 @@ def _validate_not_gpu_instance_type(training_instance_type):
                           'ml.p3.xlarge', 'ml.p3.8xlarge', 'ml.p3.16xlarge']
 
     if training_instance_type in gpu_instance_types:
-        raise ValueError("GPU training in not supported for SciKit-Learn. "
+        raise ValueError("GPU training in not supported for Scikit-Learn. "
                          "Please pick a different instance type from here: "
                          "https://aws.amazon.com/ec2/instance-types/")

--- a/tests/unit/test_sklearn.py
+++ b/tests/unit/test_sklearn.py
@@ -128,7 +128,17 @@ def test_train_image(sagemaker_session, sklearn_version):
     assert train_image == '246618743249.dkr.ecr.us-west-2.amazonaws.com/sagemaker-scikit-learn:0.20.0-cpu-py3'
 
 
-def test_create_model(sagemaker_session, sklearn_version):
+def test_create_model(sagemaker_session):
+    source_dir = 's3://mybucket/source'
+
+    sklearn_model = SKLearnModel(model_data=source_dir, role=ROLE, sagemaker_session=sagemaker_session,
+                                 entry_point=SCRIPT_PATH)
+    default_image_uri = _get_full_cpu_image_uri('0.20.0')
+    model_values = sklearn_model.prepare_container_def(CPU)
+    assert model_values['Image'] == default_image_uri
+
+
+def test_create_model_from_estimator(sagemaker_session, sklearn_version):
     container_log_level = '"logging.INFO"'
     source_dir = 's3://mybucket/source'
     sklearn = SKLearn(entry_point=SCRIPT_PATH, role=ROLE, sagemaker_session=sagemaker_session,
@@ -231,7 +241,7 @@ def test_fail_distributed_training(sagemaker_session, sklearn_version):
         SKLearn(entry_point=SCRIPT_PATH, role=ROLE, sagemaker_session=sagemaker_session,
                 train_instance_count=DIST_INSTANCE_COUNT, train_instance_type=INSTANCE_TYPE,
                 py_version=PYTHON_VERSION, framework_version=sklearn_version)
-    assert "SciKit-Learn does not support distributed training." in str(error)
+    assert "Scikit-Learn does not support distributed training." in str(error)
 
 
 def test_fail_GPU_training(sagemaker_session, sklearn_version):
@@ -239,7 +249,7 @@ def test_fail_GPU_training(sagemaker_session, sklearn_version):
         SKLearn(entry_point=SCRIPT_PATH, role=ROLE, sagemaker_session=sagemaker_session,
                 train_instance_type=GPU_INSTANCE_TYPE, py_version=PYTHON_VERSION,
                 framework_version=sklearn_version)
-    assert "GPU training in not supported for SciKit-Learn." in str(error)
+    assert "GPU training in not supported for Scikit-Learn." in str(error)
 
 
 def test_model(sagemaker_session):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The SKLearnModel was defaulting to the wrong account because it was still using the fw_utils.py file methods. MLeaps and SKLearn use its own framework registry (since they use different accounts).

Also fixed exception messages.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated the [changelog](https://github.com/aws/sagemaker-python-sdk/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [x] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
