### PR TITLE
Add new APIs to clean up resources from predictor and transformer.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,8 @@ CHANGELOG
 
 * doc-fix: update information about saving models in the MXNet README
 * doc-fix: change ReadTheDocs links from latest to stable
+* feature: Support for predictor to delete endpoint and endpoint configuration
+* feature: Support for transformer to delete model
 
 1.18.2
 ======

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,7 @@ CHANGELOG
 
 * doc-fix: update information about saving models in the MXNet README
 * doc-fix: change ReadTheDocs links from latest to stable
-* feature: Support for predictor to delete endpoint, and delete endpoint configuration with ``delete_endpoint()`` by default
+* feature: Make predictor to delete endpoint configuration by default when calling ``delete_endpoint()``
 * feature: Support for model class to delete SageMaker model
 * feature: Support for transformer to delete Sagemaker model
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,8 +7,9 @@ CHANGELOG
 
 * doc-fix: update information about saving models in the MXNet README
 * doc-fix: change ReadTheDocs links from latest to stable
-* feature: Support for predictor to delete endpoint and endpoint configuration
-* feature: Support for transformer to delete model
+* feature: Support for predictor to delete endpoint, and delete endpoint configuration with ``delete_endpoint()`` by default
+* feature: Support for model class to delete SageMaker model
+* feature: Support for transformer to delete Sagemaker model
 
 1.18.2
 ======

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,7 @@ CHANGELOG
 
 * doc-fix: update information about saving models in the MXNet README
 * doc-fix: change ReadTheDocs links from latest to stable
-* feature: Make predictor to delete endpoint configuration by default when calling ``delete_endpoint()``
+* feature: Support for predictor class to delete endpoint configuration by default when calling ``delete_endpoint()``
 * feature: Support for model class to delete SageMaker model
 * feature: Support for transformer to delete Sagemaker model
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,9 +8,9 @@ CHANGELOG
 * doc-fix: update information about saving models in the MXNet README
 * doc-fix: change ReadTheDocs links from latest to stable
 * doc-fix: add ``transform_fn`` information and fix ``input_fn`` signature in the MXNet README
-* feature: Support for predictor class to delete endpoint configuration by default when calling ``delete_endpoint()``
-* feature: Support for model class to delete SageMaker model
-* feature: Support for transformer to delete Sagemaker model
+* feature: Support for ``Predictor`` to delete endpoint configuration by default when calling ``delete_endpoint()``
+* feature: Support for ``model`` to delete SageMaker model
+* feature: Support for ``Transformer`` to delete SageMaker model
 
 1.18.2
 ======

--- a/README.rst
+++ b/README.rst
@@ -189,13 +189,14 @@ Here is an end to end example of how to use a SageMaker Estimator:
     # Serializes data and makes a prediction request to the SageMaker endpoint
     response = mxnet_predictor.predict(data)
 
-    # Tears down the SageMaker endpoint
+    # Tears down the SageMaker endpoint and endpoint configuration
     mxnet_predictor.delete_endpoint()
 
 
-The above example will delete endpoint and endpoint configuration at the same time. If you want to keep endpoint configuration, you can do the following:
+The example above will eventually delete both the SageMaker endpoint and endpoint configuration through `delete_endpoint()`. If you want to keep your SageMaker endpoint configuration, use the value False for the `delete_endpoint_config` parameter, as shown below.
 
 .. code:: python
+    # Only delete the endpoint and keep the endpoint endpoint configuration
     mxnet_predictor.delete_endpoint(delete_endpoint_config=False)
 
 Additionally, it is possible to deploy a different endpoint configuration, which links to your model, to an already existing SageMaker endpoint.
@@ -225,7 +226,7 @@ For more `information <https://boto3.amazonaws.com/v1/documentation/api/latest/r
     # Serializes data and makes a prediction request to the SageMaker endpoint
     response = mxnet_predictor.predict(data)
 
-    # Tears down the SageMaker endpoint
+    # Tears down the SageMaker endpoint and endpoint configuration
     mxnet_predictor.delete_endpoint()
 
 Training Metrics
@@ -279,7 +280,7 @@ We can take the example in  `Using Estimators <#using-estimators>`__ , and use e
     # Serializes data and makes a prediction request to the local endpoint
     response = mxnet_predictor.predict(data)
 
-    # Tears down the endpoint container
+    # Tears down the endpoint and endpoint configuration
     mxnet_predictor.delete_endpoint()
 
 
@@ -302,7 +303,7 @@ Here is an end-to-end example:
     data = numpy.zeros(shape=(1, 1, 28, 28))
     predictor.predict(data)
 
-    # Tear down the endpoint container
+    # Tear down the endpoint and endpoint configuration
     predictor.delete_endpoint()
 
 
@@ -326,6 +327,8 @@ Here is an end-to-end example:
     transformer = mxnet_estimator.transformer(1, 'local', assemble_with='Line', max_payload=1)
     transformer.transform('s3://my/transform/data, content_type='text/csv', split_type='Line')
     transformer.wait()
+
+    # Deletes the SageMaker model
     transformer.delete_model()
 
 

--- a/README.rst
+++ b/README.rst
@@ -190,8 +190,13 @@ Here is an end to end example of how to use a SageMaker Estimator:
     response = mxnet_predictor.predict(data)
 
     # Tears down the SageMaker endpoint
-    mxnet_estimator.delete_endpoint()
+    mxnet_predictor.delete_endpoint()
 
+
+The above example will delete endpoint and endpoint configuration at the same time. If you want to keep endpoint configuration, you can do the following:
+
+.. code:: python
+    mxnet_predictor.delete_endpoint(delete_endpoint_config=False)
 
 Additionally, it is possible to deploy a different endpoint configuration, which links to your model, to an already existing SageMaker endpoint.
 This can be done by specifying the existing endpoint name for the ``endpoint_name`` parameter along with the ``update_endpoint`` parameter as ``True`` within your ``deploy()`` call.
@@ -221,7 +226,7 @@ For more `information <https://boto3.amazonaws.com/v1/documentation/api/latest/r
     response = mxnet_predictor.predict(data)
 
     # Tears down the SageMaker endpoint
-    mxnet_estimator.delete_endpoint()
+    mxnet_predictor.delete_endpoint()
 
 Training Metrics
 ~~~~~~~~~~~~~~~~
@@ -275,7 +280,7 @@ We can take the example in  `Using Estimators <#using-estimators>`__ , and use e
     response = mxnet_predictor.predict(data)
 
     # Tears down the endpoint container
-    mxnet_estimator.delete_endpoint()
+    mxnet_predictor.delete_endpoint()
 
 
 If you have an existing model and want to deploy it locally, don't specify a sagemaker_session argument to the ``MXNetModel`` constructor.
@@ -321,6 +326,7 @@ Here is an end-to-end example:
     transformer = mxnet_estimator.transformer(1, 'local', assemble_with='Line', max_payload=1)
     transformer.transform('s3://my/transform/data, content_type='text/csv', split_type='Line')
     transformer.wait()
+    transformer.delete_model()
 
 
 For detailed examples of running Docker in local mode, see:

--- a/README.rst
+++ b/README.rst
@@ -196,7 +196,7 @@ Here is an end to end example of how to use a SageMaker Estimator:
 The example above will eventually delete both the SageMaker endpoint and endpoint configuration through `delete_endpoint()`. If you want to keep your SageMaker endpoint configuration, use the value False for the `delete_endpoint_config` parameter, as shown below.
 
 .. code:: python
-    # Only delete the endpoint and keep the endpoint endpoint configuration
+    # Only delete the SageMaker endpoint, while keeping the corresponding endpoint configuration.
     mxnet_predictor.delete_endpoint(delete_endpoint_config=False)
 
 Additionally, it is possible to deploy a different endpoint configuration, which links to your model, to an already existing SageMaker endpoint.

--- a/README.rst
+++ b/README.rst
@@ -280,7 +280,7 @@ We can take the example in  `Using Estimators <#using-estimators>`__ , and use e
     # Serializes data and makes a prediction request to the local endpoint
     response = mxnet_predictor.predict(data)
 
-    # Tears down the endpoint and endpoint configuration
+    # Tears down the endpoint container and deletes the corresponding endpoint configuration
     mxnet_predictor.delete_endpoint()
 
 
@@ -303,7 +303,7 @@ Here is an end-to-end example:
     data = numpy.zeros(shape=(1, 1, 28, 28))
     predictor.predict(data)
 
-    # Tear down the endpoint and endpoint configuration
+    # Tear down the endpoint container and delete the corresponding endpoint configuration
     predictor.delete_endpoint()
 
 

--- a/src/sagemaker/local/local_session.py
+++ b/src/sagemaker/local/local_session.py
@@ -150,6 +150,14 @@ class LocalSagemakerClient(object):
         if EndpointName in LocalSagemakerClient._endpoints:
             LocalSagemakerClient._endpoints[EndpointName].stop()
 
+    def delete_endpoint_config(self, EndpointConfigName):
+        if EndpointConfigName in LocalSagemakerClient._endpoint_configs:
+            del LocalSagemakerClient._endpoint_configs[EndpointConfigName]
+
+    def delete_model(self, ModelName):
+        if ModelName in LocalSagemakerClient._models:
+            del LocalSagemakerClient._models[ModelName]
+
 
 class LocalSagemakerRuntimeClient(object):
     """A SageMaker Runtime client that calls a local endpoint only.

--- a/src/sagemaker/model.py
+++ b/src/sagemaker/model.py
@@ -302,6 +302,16 @@ class Model(object):
                            env=env, tags=tags, base_transform_job_name=self.name,
                            volume_kms_key=volume_kms_key, sagemaker_session=self.sagemaker_session)
 
+    def delete_model(self):
+        """Delete an Amazon SageMaker ``Model``.
+
+        Raises: ValueError if model is not deployed yet.
+
+        """
+        if self.name is None:
+            raise ValueError('The SageMaker model is not deployed yet.')
+        self.sagemaker_session.delete_model(self.name)
+
 
 SCRIPT_PARAM_NAME = 'sagemaker_program'
 DIR_PARAM_NAME = 'sagemaker_submit_directory'

--- a/src/sagemaker/model.py
+++ b/src/sagemaker/model.py
@@ -303,13 +303,14 @@ class Model(object):
                            volume_kms_key=volume_kms_key, sagemaker_session=self.sagemaker_session)
 
     def delete_model(self):
-        """Delete an Amazon SageMaker ``Model``.
+        """Delete an Amazon SageMaker Model.
 
-        Raises: ValueError if model is not deployed yet.
+        Raises:
+            ValueError: if the model is not created yet.
 
         """
         if self.name is None:
-            raise ValueError('The SageMaker model must be deployed first before attempting to delete.')
+            raise ValueError('The SageMaker model must be created first before attempting to delete.')
         self.sagemaker_session.delete_model(self.name)
 
 

--- a/src/sagemaker/model.py
+++ b/src/sagemaker/model.py
@@ -309,7 +309,7 @@ class Model(object):
 
         """
         if self.name is None:
-            raise ValueError('The SageMaker model is not deployed yet.')
+            raise ValueError('The SageMaker model must be deployed first before attempting to delete.')
         self.sagemaker_session.delete_model(self.name)
 
 

--- a/src/sagemaker/predictor.py
+++ b/src/sagemaker/predictor.py
@@ -107,6 +107,22 @@ class RealTimePredictor(object):
 
     def _delete_endpoint_config(self):
         """Delete the Amazon SageMaker endpoint configuration
+<<<<<<< HEAD
+=======
+        """
+        endpoint_description = self.sagemaker_session.sagemaker_client.describe_endpoint(EndpointName=self.endpoint)
+        endpoint_config_name = endpoint_description['EndpointConfigName']
+        self.sagemaker_session.delete_endpoint_config(endpoint_config_name)
+
+    def delete_endpoint(self, delete_endpoint_config=True):
+        """Delete the Amazon SageMaker endpoint backing this predictor. Also delete the endpoint configuration attached
+           to it if delete_endpoint_config is True.
+
+        Args:
+            delete_endpoint_config (bool): Flag to indicate whether to delete endpoint configuration together with
+                endpoint. If False, only endpoint will be deleted. Default: True.
+
+>>>>>>> 45e5c07... Add new APIs to predictor to delete endpoint and endpoint config, and transformer to delete model.
         """
         endpoint_description = self.sagemaker_session.sagemaker_client.describe_endpoint(EndpointName=self.endpoint)
         endpoint_config_name = endpoint_description['EndpointConfigName']
@@ -124,6 +140,9 @@ class RealTimePredictor(object):
             self._delete_endpoint_config()
 
         self.sagemaker_session.delete_endpoint(self.endpoint)
+
+        if delete_endpoint_config:
+            self._delete_endpoint_config()
 
 
 class _CsvSerializer(object):

--- a/src/sagemaker/predictor.py
+++ b/src/sagemaker/predictor.py
@@ -108,9 +108,12 @@ class RealTimePredictor(object):
     def _delete_endpoint_config(self):
         """Delete the Amazon SageMaker endpoint configuration
         """
-        endpoint_description = self.sagemaker_session.sagemaker_client.describe_endpoint(EndpointName=self.endpoint)
-        endpoint_config_name = endpoint_description['EndpointConfigName']
-        self.sagemaker_session.delete_endpoint_config(endpoint_config_name)
+        try:
+            endpoint_description = self.sagemaker_session.sagemaker_client.describe_endpoint(EndpointName=self.endpoint)
+            endpoint_config_name = endpoint_description['EndpointConfigName']
+            self.sagemaker_session.delete_endpoint_config(endpoint_config_name)
+        except Exception:
+            raise ValueError('The endpoint this config attached to does not exist.')
 
     def delete_endpoint(self, delete_endpoint_config=True):
         """Delete the Amazon SageMaker endpoint backing this predictor. Also delete the endpoint configuration attached
@@ -121,10 +124,10 @@ class RealTimePredictor(object):
                 endpoint. If False, only endpoint will be deleted. Default: True.
 
         """
-        self.sagemaker_session.delete_endpoint(self.endpoint)
-
         if delete_endpoint_config:
             self._delete_endpoint_config()
+
+        self.sagemaker_session.delete_endpoint(self.endpoint)
 
 
 class _CsvSerializer(object):

--- a/src/sagemaker/predictor.py
+++ b/src/sagemaker/predictor.py
@@ -105,10 +105,26 @@ class RealTimePredictor(object):
         args['Body'] = data
         return args
 
-    def delete_endpoint(self):
-        """Delete the Amazon SageMaker endpoint backing this predictor.
+    def _delete_endpoint_config(self):
+        """Delete the Amazon SageMaker endpoint configuration
+        """
+        endpoint_description = self.sagemaker_session.sagemaker_client.describe_endpoint(EndpointName=self.endpoint)
+        endpoint_config_name = endpoint_description['EndpointConfigName']
+        self.sagemaker_session.delete_endpoint_config(endpoint_config_name)
+
+    def delete_endpoint(self, delete_endpoint_config=True):
+        """Delete the Amazon SageMaker endpoint backing this predictor. Also delete the endpoint configuration attached
+           to it if delete_endpoint_config is True.
+
+        Args:
+            delete_endpoint_config (bool): Flag to indicate whether to delete endpoint configuration together with
+                endpoint. If False, only endpoint will be deleted. Default: True.
+
         """
         self.sagemaker_session.delete_endpoint(self.endpoint)
+
+        if delete_endpoint_config:
+            self._delete_endpoint_config()
 
 
 class _CsvSerializer(object):

--- a/src/sagemaker/predictor.py
+++ b/src/sagemaker/predictor.py
@@ -108,12 +108,9 @@ class RealTimePredictor(object):
     def _delete_endpoint_config(self):
         """Delete the Amazon SageMaker endpoint configuration
         """
-        try:
-            endpoint_description = self.sagemaker_session.sagemaker_client.describe_endpoint(EndpointName=self.endpoint)
-            endpoint_config_name = endpoint_description['EndpointConfigName']
-            self.sagemaker_session.delete_endpoint_config(endpoint_config_name)
-        except Exception:
-            raise ValueError('The endpoint this config attached to does not exist.')
+        endpoint_description = self.sagemaker_session.sagemaker_client.describe_endpoint(EndpointName=self.endpoint)
+        endpoint_config_name = endpoint_description['EndpointConfigName']
+        self.sagemaker_session.delete_endpoint_config(endpoint_config_name)
 
     def delete_endpoint(self, delete_endpoint_config=True):
         """Delete the Amazon SageMaker endpoint backing this predictor. Also delete the endpoint configuration attached

--- a/src/sagemaker/predictor.py
+++ b/src/sagemaker/predictor.py
@@ -107,22 +107,7 @@ class RealTimePredictor(object):
 
     def _delete_endpoint_config(self):
         """Delete the Amazon SageMaker endpoint configuration
-<<<<<<< HEAD
-=======
-        """
-        endpoint_description = self.sagemaker_session.sagemaker_client.describe_endpoint(EndpointName=self.endpoint)
-        endpoint_config_name = endpoint_description['EndpointConfigName']
-        self.sagemaker_session.delete_endpoint_config(endpoint_config_name)
 
-    def delete_endpoint(self, delete_endpoint_config=True):
-        """Delete the Amazon SageMaker endpoint backing this predictor. Also delete the endpoint configuration attached
-           to it if delete_endpoint_config is True.
-
-        Args:
-            delete_endpoint_config (bool): Flag to indicate whether to delete endpoint configuration together with
-                endpoint. If False, only endpoint will be deleted. Default: True.
-
->>>>>>> 45e5c07... Add new APIs to predictor to delete endpoint and endpoint config, and transformer to delete model.
         """
         endpoint_description = self.sagemaker_session.sagemaker_client.describe_endpoint(EndpointName=self.endpoint)
         endpoint_config_name = endpoint_description['EndpointConfigName']
@@ -140,9 +125,6 @@ class RealTimePredictor(object):
             self._delete_endpoint_config()
 
         self.sagemaker_session.delete_endpoint(self.endpoint)
-
-        if delete_endpoint_config:
-            self._delete_endpoint_config()
 
 
 class _CsvSerializer(object):

--- a/src/sagemaker/predictor.py
+++ b/src/sagemaker/predictor.py
@@ -113,12 +113,11 @@ class RealTimePredictor(object):
         self.sagemaker_session.delete_endpoint_config(endpoint_config_name)
 
     def delete_endpoint(self, delete_endpoint_config=True):
-        """Delete the Amazon SageMaker endpoint backing this predictor. Also delete the endpoint configuration attached
-           to it if delete_endpoint_config is True.
+        """Delete the Amazon SageMaker endpoint and endpoint configuration backing this predictor.
 
         Args:
-            delete_endpoint_config (bool): Flag to indicate whether to delete endpoint configuration together with
-                endpoint. If False, only endpoint will be deleted. Default: True.
+            delete_endpoint_config (bool): Flag to indicate whether to delete the corresponding SageMaker endpoint
+                configuration tied to the endpoint. If False, only the endpoint will be deleted. (default: True)
 
         """
         if delete_endpoint_config:

--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -780,6 +780,24 @@ class Session(object):
         LOGGER.info('Deleting endpoint with name: {}'.format(endpoint_name))
         self.sagemaker_client.delete_endpoint(EndpointName=endpoint_name)
 
+    def delete_endpoint_config(self, endpoint_config_name):
+        """Delete an Amazon SageMaker endpoint configuration.
+
+        Args:
+            endpoint_config_name (str): Name of the Amazon SageMaker endpoint configuration to delete.
+        """
+        LOGGER.info('Deleting endpoint configuration with name: {}'.format(endpoint_config_name))
+        self.sagemaker_client.delete_endpoint_config(EndpointConfigName=endpoint_config_name)
+
+    def delete_model(self, model_name):
+        """Delete an Amazon SageMaker ``Model``.
+
+        Args:
+            model_name (str): Name of the Amazon SageMaker model to delete.
+        """
+        LOGGER.info('Deleting model with name: {}'.format(model_name))
+        self.sagemaker_client.delete_model(ModelName=model_name)
+
     def wait_for_job(self, job, poll=5):
         """Wait for an Amazon SageMaker training job to complete.
 

--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -795,15 +795,9 @@ class Session(object):
         Args:
             model_name (str): Name of the Amazon SageMaker model to delete.
 
-        Raises: ValueError if model is not deployed yet.
-
         """
-        try:
-            self.sagemaker_client.describe_model(ModelName=model_name)
-            LOGGER.info('Deleting model with name: {}'.format(model_name))
-            self.sagemaker_client.delete_model(ModelName=model_name)
-        except Exception:
-            raise ValueError('The Sagemaker model must be deployed first before attempting to delete.')
+        LOGGER.info('Deleting model with name: {}'.format(model_name))
+        self.sagemaker_client.delete_model(ModelName=model_name)
 
     def wait_for_job(self, job, poll=5):
         """Wait for an Amazon SageMaker training job to complete.

--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -796,8 +796,12 @@ class Session(object):
             model_name (str): Name of the Amazon SageMaker model to delete.
 
         """
-        LOGGER.info('Deleting model with name: {}'.format(model_name))
-        self.sagemaker_client.delete_model(ModelName=model_name)
+        try:
+            self.sagemaker_client.describe_model(ModelName=model_name)
+            LOGGER.info('Deleting model with name: {}'.format(model_name))
+            self.sagemaker_client.delete_model(ModelName=model_name)
+        except Exception:
+            raise ValueError('The Sagemaker model must be deployed first before attempting to delete.')
 
     def wait_for_job(self, job, poll=5):
         """Wait for an Amazon SageMaker training job to complete.

--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -790,7 +790,7 @@ class Session(object):
         self.sagemaker_client.delete_endpoint_config(EndpointConfigName=endpoint_config_name)
 
     def delete_model(self, model_name):
-        """Delete an Amazon SageMaker ``Model``.
+        """Delete an Amazon SageMaker Model.
 
         Args:
             model_name (str): Name of the Amazon SageMaker model to delete.

--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -794,9 +794,16 @@ class Session(object):
 
         Args:
             model_name (str): Name of the Amazon SageMaker model to delete.
+
+        Raises: ValueError if model is not deployed yet.
+
         """
-        LOGGER.info('Deleting model with name: {}'.format(model_name))
-        self.sagemaker_client.delete_model(ModelName=model_name)
+        try:
+            self.sagemaker_client.describe_model(ModelName=model_name)
+            LOGGER.info('Deleting model with name: {}'.format(model_name))
+            self.sagemaker_client.delete_model(ModelName=model_name)
+        except Exception:
+            raise ValueError('The Sagemaker model must be deployed first before attempting to delete.')
 
     def wait_for_job(self, job, poll=5):
         """Wait for an Amazon SageMaker training job to complete.

--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -796,12 +796,8 @@ class Session(object):
             model_name (str): Name of the Amazon SageMaker model to delete.
 
         """
-        try:
-            self.sagemaker_client.describe_model(ModelName=model_name)
-            LOGGER.info('Deleting model with name: {}'.format(model_name))
-            self.sagemaker_client.delete_model(ModelName=model_name)
-        except Exception:
-            raise ValueError('The Sagemaker model must be deployed first before attempting to delete.')
+        LOGGER.info('Deleting model with name: {}'.format(model_name))
+        self.sagemaker_client.delete_model(ModelName=model_name)
 
     def wait_for_job(self, job, poll=5):
         """Wait for an Amazon SageMaker training job to complete.

--- a/src/sagemaker/transformer.py
+++ b/src/sagemaker/transformer.py
@@ -52,8 +52,6 @@ class Transformer(object):
                 using the default AWS configuration chain.
             volume_kms_key (str): Optional. KMS key ID for encrypting the volume attached to the ML
                 compute instance (default: None).
-            model (sagemaker.model.Model): A SageMaker Model object, used for SageMaker Model interactions
-                (default: None). If not specified, model object related activities will fail.
         """
         self.model_name = model_name
         self.strategy = strategy

--- a/src/sagemaker/transformer.py
+++ b/src/sagemaker/transformer.py
@@ -52,8 +52,6 @@ class Transformer(object):
                 using the default AWS configuration chain.
             volume_kms_key (str): Optional. KMS key ID for encrypting the volume attached to the ML
                 compute instance (default: None).
-            model (sagemaker.model.Model): A SageMaker Model object, used for SageMaker Model interactions
-                (default: None). If not specified, model object related activities will fail.
         """
         self.model_name = model_name
         self.strategy = strategy
@@ -115,7 +113,7 @@ class Transformer(object):
                                                             split_type)
 
     def delete_model(self):
-        """Delete a SageMaker Model.
+        """Delete the corresponding SageMaker model for this Transformer.
 
         """
         self.sagemaker_session.delete_model(self.model_name)

--- a/src/sagemaker/transformer.py
+++ b/src/sagemaker/transformer.py
@@ -52,6 +52,8 @@ class Transformer(object):
                 using the default AWS configuration chain.
             volume_kms_key (str): Optional. KMS key ID for encrypting the volume attached to the ML
                 compute instance (default: None).
+            model (sagemaker.model.Model): A SageMaker Model object, used for SageMaker Model interactions
+                (default: None). If not specified, model object related activities will fail.
         """
         self.model_name = model_name
         self.strategy = strategy
@@ -111,6 +113,12 @@ class Transformer(object):
 
         self.latest_transform_job = _TransformJob.start_new(self, data, data_type, content_type, compression_type,
                                                             split_type)
+
+    def delete_model(self):
+        """Delete a SageMaker Model.
+
+        """
+        self.sagemaker_session.delete_model(self.model_name)
 
     def _retrieve_image_name(self):
         model_desc = self.sagemaker_session.sagemaker_client.describe_model(ModelName=self.model_name)

--- a/src/sagemaker/transformer.py
+++ b/src/sagemaker/transformer.py
@@ -52,6 +52,8 @@ class Transformer(object):
                 using the default AWS configuration chain.
             volume_kms_key (str): Optional. KMS key ID for encrypting the volume attached to the ML
                 compute instance (default: None).
+            model (sagemaker.model.Model): A SageMaker Model object, used for SageMaker Model interactions
+                (default: None). If not specified, model object related activities will fail.
         """
         self.model_name = model_name
         self.strategy = strategy

--- a/tests/integ/test_transformer.py
+++ b/tests/integ/test_transformer.py
@@ -106,46 +106,6 @@ def test_attach_transform_kmeans(sagemaker_session):
         attached_transformer.wait()
 
 
-# def test_transformer_delete_model(sagemaker_session):
-#     data_path = os.path.join(DATA_DIR, 'one_p_mnist')
-#     pickle_args = {} if sys.version_info.major == 2 else {'encoding': 'latin1'}
-#
-#     train_set_path = os.path.join(data_path, 'mnist.pkl.gz')
-#     with gzip.open(train_set_path, 'rb') as f:
-#         train_set, _, _ = pickle.load(f, **pickle_args)
-#
-#     kmeans = KMeans(role='SageMakerRole', train_instance_count=1,
-#                     train_instance_type='ml.c4.xlarge', k=10, sagemaker_session=sagemaker_session,
-#                     output_path='s3://{}/'.format(sagemaker_session.default_bucket()))
-#
-#     kmeans.init_method = 'random'
-#     kmeans.max_iterations = 1
-#     kmeans.tol = 1
-#     kmeans.num_trials = 1
-#     kmeans.local_init_method = 'kmeans++'
-#     kmeans.half_life_time_size = 1
-#     kmeans.epochs = 1
-#
-#     records = kmeans.record_set(train_set[0][:100])
-#     with timeout(minutes=TRAINING_DEFAULT_TIMEOUT_MINUTES):
-#         kmeans.fit(records)
-#
-#     transform_input_path = os.path.join(data_path, 'transform_input.csv')
-#     transform_input_key_prefix = 'integ-test-data/one_p_mnist/transform'
-#     transform_input = kmeans.sagemaker_session.upload_data(path=transform_input_path,
-#                                                            key_prefix=transform_input_key_prefix)
-#
-#     transformer = _create_transformer_and_transform_job(kmeans, transform_input)
-#     with timeout(minutes=TRANSFORM_DEFAULT_TIMEOUT_MINUTES):
-#         transformer.wait()
-#
-#     transformer.delete_model()
-#
-#     with pytest.raises(Exception) as exception:
-#         sagemaker_session.sagemaker_client.describe_model(ModelName=transformer.model_name)
-#         assert 'Could not find model' in exception.value.message
-
-
 def test_transform_mxnet_vpc(sagemaker_session, mxnet_full_version):
     data_path = os.path.join(DATA_DIR, 'mxnet_mnist')
     script_path = os.path.join(data_path, 'mnist.py')

--- a/tests/integ/test_transformer.py
+++ b/tests/integ/test_transformer.py
@@ -106,44 +106,44 @@ def test_attach_transform_kmeans(sagemaker_session):
         attached_transformer.wait()
 
 
-def test_transformer_delete_model(sagemaker_session):
-    data_path = os.path.join(DATA_DIR, 'one_p_mnist')
-    pickle_args = {} if sys.version_info.major == 2 else {'encoding': 'latin1'}
-
-    train_set_path = os.path.join(data_path, 'mnist.pkl.gz')
-    with gzip.open(train_set_path, 'rb') as f:
-        train_set, _, _ = pickle.load(f, **pickle_args)
-
-    kmeans = KMeans(role='SageMakerRole', train_instance_count=1,
-                    train_instance_type='ml.c4.xlarge', k=10, sagemaker_session=sagemaker_session,
-                    output_path='s3://{}/'.format(sagemaker_session.default_bucket()))
-
-    kmeans.init_method = 'random'
-    kmeans.max_iterations = 1
-    kmeans.tol = 1
-    kmeans.num_trials = 1
-    kmeans.local_init_method = 'kmeans++'
-    kmeans.half_life_time_size = 1
-    kmeans.epochs = 1
-
-    records = kmeans.record_set(train_set[0][:100])
-    with timeout(minutes=TRAINING_DEFAULT_TIMEOUT_MINUTES):
-        kmeans.fit(records)
-
-    transform_input_path = os.path.join(data_path, 'transform_input.csv')
-    transform_input_key_prefix = 'integ-test-data/one_p_mnist/transform'
-    transform_input = kmeans.sagemaker_session.upload_data(path=transform_input_path,
-                                                           key_prefix=transform_input_key_prefix)
-
-    transformer = _create_transformer_and_transform_job(kmeans, transform_input)
-    with timeout(minutes=TRANSFORM_DEFAULT_TIMEOUT_MINUTES):
-        transformer.wait()
-
-    transformer.delete_model()
-
-    with pytest.raises(Exception) as exception:
-        sagemaker_session.sagemaker_client.describe_model(ModelName=transformer.model_name)
-        assert 'Could not find model' in exception.value.message
+# def test_transformer_delete_model(sagemaker_session):
+#     data_path = os.path.join(DATA_DIR, 'one_p_mnist')
+#     pickle_args = {} if sys.version_info.major == 2 else {'encoding': 'latin1'}
+#
+#     train_set_path = os.path.join(data_path, 'mnist.pkl.gz')
+#     with gzip.open(train_set_path, 'rb') as f:
+#         train_set, _, _ = pickle.load(f, **pickle_args)
+#
+#     kmeans = KMeans(role='SageMakerRole', train_instance_count=1,
+#                     train_instance_type='ml.c4.xlarge', k=10, sagemaker_session=sagemaker_session,
+#                     output_path='s3://{}/'.format(sagemaker_session.default_bucket()))
+#
+#     kmeans.init_method = 'random'
+#     kmeans.max_iterations = 1
+#     kmeans.tol = 1
+#     kmeans.num_trials = 1
+#     kmeans.local_init_method = 'kmeans++'
+#     kmeans.half_life_time_size = 1
+#     kmeans.epochs = 1
+#
+#     records = kmeans.record_set(train_set[0][:100])
+#     with timeout(minutes=TRAINING_DEFAULT_TIMEOUT_MINUTES):
+#         kmeans.fit(records)
+#
+#     transform_input_path = os.path.join(data_path, 'transform_input.csv')
+#     transform_input_key_prefix = 'integ-test-data/one_p_mnist/transform'
+#     transform_input = kmeans.sagemaker_session.upload_data(path=transform_input_path,
+#                                                            key_prefix=transform_input_key_prefix)
+#
+#     transformer = _create_transformer_and_transform_job(kmeans, transform_input)
+#     with timeout(minutes=TRANSFORM_DEFAULT_TIMEOUT_MINUTES):
+#         transformer.wait()
+#
+#     transformer.delete_model()
+#
+#     with pytest.raises(Exception) as exception:
+#         sagemaker_session.sagemaker_client.describe_model(ModelName=transformer.model_name)
+#         assert 'Could not find model' in exception.value.message
 
 
 def test_transform_mxnet_vpc(sagemaker_session, mxnet_full_version):

--- a/tests/integ/test_transformer.py
+++ b/tests/integ/test_transformer.py
@@ -106,6 +106,46 @@ def test_attach_transform_kmeans(sagemaker_session):
         attached_transformer.wait()
 
 
+def test_transformer_delete_model(sagemaker_session):
+    data_path = os.path.join(DATA_DIR, 'one_p_mnist')
+    pickle_args = {} if sys.version_info.major == 2 else {'encoding': 'latin1'}
+
+    train_set_path = os.path.join(data_path, 'mnist.pkl.gz')
+    with gzip.open(train_set_path, 'rb') as f:
+        train_set, _, _ = pickle.load(f, **pickle_args)
+
+    kmeans = KMeans(role='SageMakerRole', train_instance_count=1,
+                    train_instance_type='ml.c4.xlarge', k=10, sagemaker_session=sagemaker_session,
+                    output_path='s3://{}/'.format(sagemaker_session.default_bucket()))
+
+    kmeans.init_method = 'random'
+    kmeans.max_iterations = 1
+    kmeans.tol = 1
+    kmeans.num_trials = 1
+    kmeans.local_init_method = 'kmeans++'
+    kmeans.half_life_time_size = 1
+    kmeans.epochs = 1
+
+    records = kmeans.record_set(train_set[0][:100])
+    with timeout(minutes=TRAINING_DEFAULT_TIMEOUT_MINUTES):
+        kmeans.fit(records)
+
+    transform_input_path = os.path.join(data_path, 'transform_input.csv')
+    transform_input_key_prefix = 'integ-test-data/one_p_mnist/transform'
+    transform_input = kmeans.sagemaker_session.upload_data(path=transform_input_path,
+                                                           key_prefix=transform_input_key_prefix)
+
+    transformer = _create_transformer_and_transform_job(kmeans, transform_input)
+    with timeout(minutes=TRANSFORM_DEFAULT_TIMEOUT_MINUTES):
+        transformer.wait()
+
+    transformer.delete_model()
+
+    with pytest.raises(Exception) as exception:
+        sagemaker_session.sagemaker_client.describe_model(ModelName=transformer.model_name)
+        assert 'Could not find model' in exception.value.message
+
+
 def test_transform_mxnet_vpc(sagemaker_session, mxnet_full_version):
     data_path = os.path.join(DATA_DIR, 'mxnet_mnist')
     script_path = os.path.join(data_path, 'mnist.py')

--- a/tests/integ/test_transformer.py
+++ b/tests/integ/test_transformer.py
@@ -24,7 +24,7 @@ from sagemaker.mxnet import MXNet
 from sagemaker.transformer import Transformer
 from tests.integ import DATA_DIR, TRAINING_DEFAULT_TIMEOUT_MINUTES, TRANSFORM_DEFAULT_TIMEOUT_MINUTES
 from tests.integ.kms_utils import get_or_create_kms_key
-from tests.integ.timeout import timeout
+from tests.integ.timeout import timeout, timeout_and_delete_model_with_transformer
 from tests.integ.vpc_test_utils import get_or_create_vpc_resources
 
 
@@ -56,7 +56,8 @@ def test_transform_mxnet(sagemaker_session, mxnet_full_version):
     kms_key_arn = get_or_create_kms_key(kms_client, account_id)
 
     transformer = _create_transformer_and_transform_job(mx, transform_input, kms_key_arn)
-    with timeout(minutes=TRANSFORM_DEFAULT_TIMEOUT_MINUTES):
+    with timeout_and_delete_model_with_transformer(transformer, sagemaker_session,
+                                                   minutes=TRANSFORM_DEFAULT_TIMEOUT_MINUTES):
         transformer.wait()
 
     job_desc = transformer.sagemaker_session.sagemaker_client.describe_transform_job(
@@ -100,48 +101,49 @@ def test_attach_transform_kmeans(sagemaker_session):
 
     attached_transformer = Transformer.attach(transformer.latest_transform_job.name,
                                               sagemaker_session=sagemaker_session)
-    with timeout(minutes=TRANSFORM_DEFAULT_TIMEOUT_MINUTES):
+    with timeout_and_delete_model_with_transformer(transformer, sagemaker_session,
+                                                   minutes=TRANSFORM_DEFAULT_TIMEOUT_MINUTES):
         attached_transformer.wait()
 
 
-def test_transformer_delete_model(sagemaker_session):
-    data_path = os.path.join(DATA_DIR, 'one_p_mnist')
-    pickle_args = {} if sys.version_info.major == 2 else {'encoding': 'latin1'}
-
-    train_set_path = os.path.join(data_path, 'mnist.pkl.gz')
-    with gzip.open(train_set_path, 'rb') as f:
-        train_set, _, _ = pickle.load(f, **pickle_args)
-
-    kmeans = KMeans(role='SageMakerRole', train_instance_count=1,
-                    train_instance_type='ml.c4.xlarge', k=10, sagemaker_session=sagemaker_session,
-                    output_path='s3://{}/'.format(sagemaker_session.default_bucket()))
-
-    kmeans.init_method = 'random'
-    kmeans.max_iterations = 1
-    kmeans.tol = 1
-    kmeans.num_trials = 1
-    kmeans.local_init_method = 'kmeans++'
-    kmeans.half_life_time_size = 1
-    kmeans.epochs = 1
-
-    records = kmeans.record_set(train_set[0][:100])
-    with timeout(minutes=TRAINING_DEFAULT_TIMEOUT_MINUTES):
-        kmeans.fit(records)
-
-    transform_input_path = os.path.join(data_path, 'transform_input.csv')
-    transform_input_key_prefix = 'integ-test-data/one_p_mnist/transform'
-    transform_input = kmeans.sagemaker_session.upload_data(path=transform_input_path,
-                                                           key_prefix=transform_input_key_prefix)
-
-    transformer = _create_transformer_and_transform_job(kmeans, transform_input)
-    with timeout(minutes=TRANSFORM_DEFAULT_TIMEOUT_MINUTES):
-        transformer.wait()
-
-    transformer.delete_model()
-
-    with pytest.raises(Exception) as exception:
-        sagemaker_session.sagemaker_client.describe_model(ModelName=transformer.model_name)
-        assert 'Could not find model' in exception.value.message
+# def test_transformer_delete_model(sagemaker_session):
+#     data_path = os.path.join(DATA_DIR, 'one_p_mnist')
+#     pickle_args = {} if sys.version_info.major == 2 else {'encoding': 'latin1'}
+#
+#     train_set_path = os.path.join(data_path, 'mnist.pkl.gz')
+#     with gzip.open(train_set_path, 'rb') as f:
+#         train_set, _, _ = pickle.load(f, **pickle_args)
+#
+#     kmeans = KMeans(role='SageMakerRole', train_instance_count=1,
+#                     train_instance_type='ml.c4.xlarge', k=10, sagemaker_session=sagemaker_session,
+#                     output_path='s3://{}/'.format(sagemaker_session.default_bucket()))
+#
+#     kmeans.init_method = 'random'
+#     kmeans.max_iterations = 1
+#     kmeans.tol = 1
+#     kmeans.num_trials = 1
+#     kmeans.local_init_method = 'kmeans++'
+#     kmeans.half_life_time_size = 1
+#     kmeans.epochs = 1
+#
+#     records = kmeans.record_set(train_set[0][:100])
+#     with timeout(minutes=TRAINING_DEFAULT_TIMEOUT_MINUTES):
+#         kmeans.fit(records)
+#
+#     transform_input_path = os.path.join(data_path, 'transform_input.csv')
+#     transform_input_key_prefix = 'integ-test-data/one_p_mnist/transform'
+#     transform_input = kmeans.sagemaker_session.upload_data(path=transform_input_path,
+#                                                            key_prefix=transform_input_key_prefix)
+#
+#     transformer = _create_transformer_and_transform_job(kmeans, transform_input)
+#     with timeout(minutes=TRANSFORM_DEFAULT_TIMEOUT_MINUTES):
+#         transformer.wait()
+#
+#     transformer.delete_model()
+#
+#     with pytest.raises(Exception) as exception:
+#         sagemaker_session.sagemaker_client.describe_model(ModelName=transformer.model_name)
+#         assert 'Could not find model' in exception.value.message
 
 
 def test_transform_mxnet_vpc(sagemaker_session, mxnet_full_version):

--- a/tests/integ/test_transformer.py
+++ b/tests/integ/test_transformer.py
@@ -137,12 +137,12 @@ def test_transform_mxnet_vpc(sagemaker_session, mxnet_full_version):
                                                        key_prefix=transform_input_key_prefix)
 
     transformer = _create_transformer_and_transform_job(mx, transform_input)
-    with timeout(minutes=TRANSFORM_DEFAULT_TIMEOUT_MINUTES):
+    with timeout_and_delete_model_with_transformer(transformer, sagemaker_session,
+                                                   minutes=TRANSFORM_DEFAULT_TIMEOUT_MINUTES):
         transformer.wait()
-
-    model_desc = sagemaker_session.sagemaker_client.describe_model(ModelName=transformer.model_name)
-    assert set(subnet_ids) == set(model_desc['VpcConfig']['Subnets'])
-    assert [security_group_id] == model_desc['VpcConfig']['SecurityGroupIds']
+        model_desc = sagemaker_session.sagemaker_client.describe_model(ModelName=transformer.model_name)
+        assert set(subnet_ids) == set(model_desc['VpcConfig']['Subnets'])
+        assert [security_group_id] == model_desc['VpcConfig']['SecurityGroupIds']
 
 
 def _create_transformer_and_transform_job(estimator, transform_input, volume_kms_key=None):

--- a/tests/integ/timeout.py
+++ b/tests/integ/timeout.py
@@ -75,9 +75,9 @@ def timeout_and_delete_endpoint_by_name(endpoint_name, sagemaker_session, second
                     sagemaker_session.delete_endpoint(endpoint_name)
                     LOGGER.info('deleted endpoint {}'.format(endpoint_name))
 
-                    _show_endpoint_logs(endpoint_name, sagemaker_session)
+                    _show_logs(endpoint_name, 'Endpoints', sagemaker_session)
                     if no_errors:
-                        _cleanup_endpoint_logs(endpoint_name, sagemaker_session)
+                        _cleanup_logs(endpoint_name, 'Endpoints', sagemaker_session)
                     return
                 except ClientError as ce:
                     if ce.response['Error']['Code'] == 'ValidationException':
@@ -102,8 +102,10 @@ def timeout_and_delete_model_with_transformer(transformer, sagemaker_session, se
                 try:
                     transformer.delete_model()
                     LOGGER.info('deleted SageMaker model {}'.format(transformer.model_name))
+
+                    _show_logs(transformer.model_name, 'Models', sagemaker_session)
                     if no_errors:
-                        _cleanup_model_logs(transformer.model_name, sagemaker_session)
+                        _cleanup_logs(transformer.model_name, 'Models', sagemaker_session)
                         return
                 except ClientError as ce:
                     if ce.response['Error']['Code'] == 'ValidationException':
@@ -111,32 +113,8 @@ def timeout_and_delete_model_with_transformer(transformer, sagemaker_session, se
                 sleep(10)
 
 
-def _show_model_logs(model_name, sagemaker_session):
-    log_group = '/aws/sagemaker/Models/{}'.format(model_name)
-    try:
-        LOGGER.info('cloudwatch logs for log group {}'.format(log_group))
-        logs = AWSLogs(log_group_name=log_group, log_stream_name='ALL', start='1d',
-                       aws_region=sagemaker_session.boto_session.region_name)
-        logs.list_logs()
-    except Exception:
-        LOGGER.exception('Failure occurred while listing cloudwatch log group %s. Swallowing exception but printing '
-                         'stacktrace for debugging.', log_group)
-
-
-def _cleanup_model_logs(model_name, sagemaker_session):
-    log_group = '/aws/sagemaker/Models/{}'.format(model_name)
-    try:
-        LOGGER.info('deleting cloudwatch log group {}:'.format(log_group))
-        cwl_client = sagemaker_session.boto_session.client('logs')
-        cwl_client.delete_log_group(logGroupName=log_group)
-        LOGGER.info('deleted cloudwatch log group: {}'.format(log_group))
-    except Exception:
-        LOGGER.exception('Failure occurred while cleaning up cloudwatch log group %s. '
-                         'Swallowing exception but printing stacktrace for debugging.', log_group)
-
-
-def _show_endpoint_logs(endpoint_name, sagemaker_session):
-    log_group = '/aws/sagemaker/Endpoints/{}'.format(endpoint_name)
+def _show_logs(resource_name, resource_type, sagemaker_session):
+    log_group = '/aws/sagemaker/{}/{}'.format(resource_type, resource_name)
     try:
         # print out logs before deletion for debuggability
         LOGGER.info('cloudwatch logs for log group {}:'.format(log_group))
@@ -148,8 +126,8 @@ def _show_endpoint_logs(endpoint_name, sagemaker_session):
                          'stacktrace for debugging.', log_group)
 
 
-def _cleanup_endpoint_logs(endpoint_name, sagemaker_session):
-    log_group = '/aws/sagemaker/Endpoints/{}'.format(endpoint_name)
+def _cleanup_logs(resource_name, resource_type, sagemaker_session):
+    log_group = '/aws/sagemaker/{}/{}'.format(resource_type, resource_name)
     try:
         # print out logs before deletion for debuggability
         LOGGER.info('deleting cloudwatch log group {}:'.format(log_group))

--- a/tests/integ/timeout.py
+++ b/tests/integ/timeout.py
@@ -102,10 +102,15 @@ def timeout_and_delete_model_with_transformer(transformer, sagemaker_session, se
                 try:
                     transformer.delete_model()
                     LOGGER.info('deleted SageMaker model {}'.format(transformer.model_name))
+<<<<<<< HEAD
 
                     _show_logs(transformer.model_name, 'Models', sagemaker_session)
                     if no_errors:
                         _cleanup_logs(transformer.model_name, 'Models', sagemaker_session)
+=======
+                    if no_errors:
+                        _cleanup_model_logs(transformer.model_name, sagemaker_session)
+>>>>>>> 334a0d6... Modify some functions, tests and update docs.
                         return
                 except ClientError as ce:
                     if ce.response['Error']['Code'] == 'ValidationException':
@@ -113,8 +118,37 @@ def timeout_and_delete_model_with_transformer(transformer, sagemaker_session, se
                 sleep(10)
 
 
+<<<<<<< HEAD
 def _show_logs(resource_name, resource_type, sagemaker_session):
     log_group = '/aws/sagemaker/{}/{}'.format(resource_type, resource_name)
+=======
+def _show_model_logs(model_name, sagemaker_session):
+    log_group = '/aws/sagemaker/Models/{}'.format(model_name)
+    try:
+        LOGGER.info('cloudwatch logs for log group {}'.format(log_group))
+        logs = AWSLogs(log_group_name=log_group, log_stream_name='ALL', start='1d',
+                       aws_region=sagemaker_session.boto_session.region_name)
+        logs.list_logs()
+    except Exception:
+        LOGGER.exception('Failure occurred while listing cloudwatch log group %s. Swallowing exception but printing '
+                         'stacktrace for debugging.', log_group)
+
+
+def _cleanup_model_logs(model_name, sagemaker_session):
+    log_group = '/aws/sagemaker/Models/{}'.format(model_name)
+    try:
+        LOGGER.info('deleting cloudwatch log group {}:'.format(log_group))
+        cwl_client = sagemaker_session.boto_session.client('logs')
+        cwl_client.delete_log_group(logGroupName=log_group)
+        LOGGER.info('deleted cloudwatch log group: {}'.format(log_group))
+    except Exception:
+        LOGGER.exception('Failure occurred while cleaning up cloudwatch log group %s. '
+                         'Swallowing exception but printing stacktrace for debugging.', log_group)
+
+
+def _show_endpoint_logs(endpoint_name, sagemaker_session):
+    log_group = '/aws/sagemaker/Endpoints/{}'.format(endpoint_name)
+>>>>>>> 334a0d6... Modify some functions, tests and update docs.
     try:
         # print out logs before deletion for debuggability
         LOGGER.info('cloudwatch logs for log group {}:'.format(log_group))

--- a/tests/integ/timeout.py
+++ b/tests/integ/timeout.py
@@ -32,13 +32,9 @@ def timeout(seconds=0, minutes=0, hours=0):
     """
     Add a signal-based timeout to any block of code.
     If multiple time units are specified, they will be added together to determine time limit.
-
     Usage:
-
     with timeout(seconds=5):
         my_slow_function(...)
-
-
     Args:
         - seconds: The time limit, in seconds.
         - minutes: The time limit, in minutes.
@@ -102,15 +98,10 @@ def timeout_and_delete_model_with_transformer(transformer, sagemaker_session, se
                 try:
                     transformer.delete_model()
                     LOGGER.info('deleted SageMaker model {}'.format(transformer.model_name))
-<<<<<<< HEAD
 
                     _show_logs(transformer.model_name, 'Models', sagemaker_session)
                     if no_errors:
                         _cleanup_logs(transformer.model_name, 'Models', sagemaker_session)
-=======
-                    if no_errors:
-                        _cleanup_model_logs(transformer.model_name, sagemaker_session)
->>>>>>> 334a0d6... Modify some functions, tests and update docs.
                         return
                 except ClientError as ce:
                     if ce.response['Error']['Code'] == 'ValidationException':
@@ -118,37 +109,8 @@ def timeout_and_delete_model_with_transformer(transformer, sagemaker_session, se
                 sleep(10)
 
 
-<<<<<<< HEAD
 def _show_logs(resource_name, resource_type, sagemaker_session):
     log_group = '/aws/sagemaker/{}/{}'.format(resource_type, resource_name)
-=======
-def _show_model_logs(model_name, sagemaker_session):
-    log_group = '/aws/sagemaker/Models/{}'.format(model_name)
-    try:
-        LOGGER.info('cloudwatch logs for log group {}'.format(log_group))
-        logs = AWSLogs(log_group_name=log_group, log_stream_name='ALL', start='1d',
-                       aws_region=sagemaker_session.boto_session.region_name)
-        logs.list_logs()
-    except Exception:
-        LOGGER.exception('Failure occurred while listing cloudwatch log group %s. Swallowing exception but printing '
-                         'stacktrace for debugging.', log_group)
-
-
-def _cleanup_model_logs(model_name, sagemaker_session):
-    log_group = '/aws/sagemaker/Models/{}'.format(model_name)
-    try:
-        LOGGER.info('deleting cloudwatch log group {}:'.format(log_group))
-        cwl_client = sagemaker_session.boto_session.client('logs')
-        cwl_client.delete_log_group(logGroupName=log_group)
-        LOGGER.info('deleted cloudwatch log group: {}'.format(log_group))
-    except Exception:
-        LOGGER.exception('Failure occurred while cleaning up cloudwatch log group %s. '
-                         'Swallowing exception but printing stacktrace for debugging.', log_group)
-
-
-def _show_endpoint_logs(endpoint_name, sagemaker_session):
-    log_group = '/aws/sagemaker/Endpoints/{}'.format(endpoint_name)
->>>>>>> 334a0d6... Modify some functions, tests and update docs.
     try:
         # print out logs before deletion for debuggability
         LOGGER.info('cloudwatch logs for log group {}:'.format(log_group))

--- a/tests/unit/test_local_session.py
+++ b/tests/unit/test_local_session.py
@@ -172,6 +172,19 @@ def test_delete_model(LocalSession):
 
 
 @patch('sagemaker.local.local_session.LocalSession')
+def test_delete_model(LocalSession):
+    local_sagemaker_client = sagemaker.local.local_session.LocalSagemakerClient()
+    model_name = 'my-model'
+    primary_container = {'ModelDataUrl': '/some/model/path', 'Environment': {'env1': 1, 'env2': 'b'}}
+
+    local_sagemaker_client.create_model(model_name, primary_container)
+    assert model_name in sagemaker.local.local_session.LocalSagemakerClient._models
+
+    local_sagemaker_client.delete_model(model_name)
+    assert model_name not in sagemaker.local.local_session.LocalSagemakerClient._models
+
+
+@patch('sagemaker.local.local_session.LocalSession')
 def test_describe_model(LocalSession):
     local_sagemaker_client = sagemaker.local.local_session.LocalSagemakerClient()
 
@@ -239,6 +252,19 @@ def test_delete_endpoint_config(LocalSession):
 
     local_sagemaker_client.delete_endpoint_config(ENDPOINT_CONFIG_NAME)
     assert ENDPOINT_CONFIG_NAME not in sagemaker.local.local_session.LocalSagemakerClient._endpoint_configs
+
+
+@patch('sagemaker.local.local_session.LocalSession')
+def test_delete_endpoint_config(LocalSession):
+    local_sagemaker_client = sagemaker.local.local_session.LocalSagemakerClient()
+    production_variants = [{'InstanceType': 'ml.c4.99xlarge', 'InitialInstanceCount': 10}]
+    endpoint_config_name = 'my-endpoint-config'
+
+    local_sagemaker_client.create_endpoint_config(endpoint_config_name, production_variants)
+    assert endpoint_config_name in sagemaker.local.local_session.LocalSagemakerClient._endpoint_configs
+
+    local_sagemaker_client.delete_endpoint_config(endpoint_config_name)
+    assert endpoint_config_name not in sagemaker.local.local_session.LocalSagemakerClient._endpoint_configs
 
 
 @patch('sagemaker.local.image._SageMakerContainer.serve')

--- a/tests/unit/test_local_session.py
+++ b/tests/unit/test_local_session.py
@@ -156,6 +156,7 @@ def test_create_model(LocalSession):
     local_sagemaker_client = sagemaker.local.local_session.LocalSagemakerClient()
 
     local_sagemaker_client.create_model(MODEL_NAME, PRIMARY_CONTAINER)
+<<<<<<< HEAD
 
     assert MODEL_NAME in sagemaker.local.local_session.LocalSagemakerClient._models
 
@@ -169,19 +170,21 @@ def test_delete_model(LocalSession):
 
     local_sagemaker_client.delete_model(MODEL_NAME)
     assert MODEL_NAME not in sagemaker.local.local_session.LocalSagemakerClient._models
+=======
+
+    assert MODEL_NAME in sagemaker.local.local_session.LocalSagemakerClient._models
+>>>>>>> 334a0d6... Modify some functions, tests and update docs.
 
 
 @patch('sagemaker.local.local_session.LocalSession')
 def test_delete_model(LocalSession):
     local_sagemaker_client = sagemaker.local.local_session.LocalSagemakerClient()
-    model_name = 'my-model'
-    primary_container = {'ModelDataUrl': '/some/model/path', 'Environment': {'env1': 1, 'env2': 'b'}}
 
-    local_sagemaker_client.create_model(model_name, primary_container)
-    assert model_name in sagemaker.local.local_session.LocalSagemakerClient._models
+    local_sagemaker_client.create_model(MODEL_NAME, PRIMARY_CONTAINER)
+    assert MODEL_NAME in sagemaker.local.local_session.LocalSagemakerClient._models
 
-    local_sagemaker_client.delete_model(model_name)
-    assert model_name not in sagemaker.local.local_session.LocalSagemakerClient._models
+    local_sagemaker_client.delete_model(MODEL_NAME)
+    assert MODEL_NAME not in sagemaker.local.local_session.LocalSagemakerClient._models
 
 
 @patch('sagemaker.local.local_session.LocalSession')
@@ -239,6 +242,7 @@ def test_describe_endpoint_config(LocalSession):
 def test_create_endpoint_config(LocalSession):
     local_sagemaker_client = sagemaker.local.local_session.LocalSagemakerClient()
     local_sagemaker_client.create_endpoint_config(ENDPOINT_CONFIG_NAME, PRODUCTION_VARIANTS)
+<<<<<<< HEAD
 
     assert ENDPOINT_CONFIG_NAME in sagemaker.local.local_session.LocalSagemakerClient._endpoint_configs
 
@@ -252,19 +256,21 @@ def test_delete_endpoint_config(LocalSession):
 
     local_sagemaker_client.delete_endpoint_config(ENDPOINT_CONFIG_NAME)
     assert ENDPOINT_CONFIG_NAME not in sagemaker.local.local_session.LocalSagemakerClient._endpoint_configs
+=======
+
+    assert ENDPOINT_CONFIG_NAME in sagemaker.local.local_session.LocalSagemakerClient._endpoint_configs
+>>>>>>> 334a0d6... Modify some functions, tests and update docs.
 
 
 @patch('sagemaker.local.local_session.LocalSession')
 def test_delete_endpoint_config(LocalSession):
     local_sagemaker_client = sagemaker.local.local_session.LocalSagemakerClient()
-    production_variants = [{'InstanceType': 'ml.c4.99xlarge', 'InitialInstanceCount': 10}]
-    endpoint_config_name = 'my-endpoint-config'
 
-    local_sagemaker_client.create_endpoint_config(endpoint_config_name, production_variants)
-    assert endpoint_config_name in sagemaker.local.local_session.LocalSagemakerClient._endpoint_configs
+    local_sagemaker_client.create_endpoint_config(ENDPOINT_CONFIG_NAME, PRODUCTION_VARIANTS)
+    assert ENDPOINT_CONFIG_NAME in sagemaker.local.local_session.LocalSagemakerClient._endpoint_configs
 
-    local_sagemaker_client.delete_endpoint_config(endpoint_config_name)
-    assert endpoint_config_name not in sagemaker.local.local_session.LocalSagemakerClient._endpoint_configs
+    local_sagemaker_client.delete_endpoint_config(ENDPOINT_CONFIG_NAME)
+    assert ENDPOINT_CONFIG_NAME not in sagemaker.local.local_session.LocalSagemakerClient._endpoint_configs
 
 
 @patch('sagemaker.local.image._SageMakerContainer.serve')

--- a/tests/unit/test_local_session.py
+++ b/tests/unit/test_local_session.py
@@ -156,7 +156,6 @@ def test_create_model(LocalSession):
     local_sagemaker_client = sagemaker.local.local_session.LocalSagemakerClient()
 
     local_sagemaker_client.create_model(MODEL_NAME, PRIMARY_CONTAINER)
-<<<<<<< HEAD
 
     assert MODEL_NAME in sagemaker.local.local_session.LocalSagemakerClient._models
 
@@ -170,10 +169,6 @@ def test_delete_model(LocalSession):
 
     local_sagemaker_client.delete_model(MODEL_NAME)
     assert MODEL_NAME not in sagemaker.local.local_session.LocalSagemakerClient._models
-=======
-
-    assert MODEL_NAME in sagemaker.local.local_session.LocalSagemakerClient._models
->>>>>>> 334a0d6... Modify some functions, tests and update docs.
 
 
 @patch('sagemaker.local.local_session.LocalSession')
@@ -242,7 +237,6 @@ def test_describe_endpoint_config(LocalSession):
 def test_create_endpoint_config(LocalSession):
     local_sagemaker_client = sagemaker.local.local_session.LocalSagemakerClient()
     local_sagemaker_client.create_endpoint_config(ENDPOINT_CONFIG_NAME, PRODUCTION_VARIANTS)
-<<<<<<< HEAD
 
     assert ENDPOINT_CONFIG_NAME in sagemaker.local.local_session.LocalSagemakerClient._endpoint_configs
 
@@ -256,10 +250,6 @@ def test_delete_endpoint_config(LocalSession):
 
     local_sagemaker_client.delete_endpoint_config(ENDPOINT_CONFIG_NAME)
     assert ENDPOINT_CONFIG_NAME not in sagemaker.local.local_session.LocalSagemakerClient._endpoint_configs
-=======
-
-    assert ENDPOINT_CONFIG_NAME in sagemaker.local.local_session.LocalSagemakerClient._endpoint_configs
->>>>>>> 334a0d6... Modify some functions, tests and update docs.
 
 
 @patch('sagemaker.local.local_session.LocalSession')

--- a/tests/unit/test_local_session.py
+++ b/tests/unit/test_local_session.py
@@ -27,6 +27,12 @@ OK_RESPONSE.status = 200
 BAD_RESPONSE = urllib3.HTTPResponse()
 BAD_RESPONSE.status = 502
 
+ENDPOINT_CONFIG_NAME = 'test-endpoint-config'
+PRODUCTION_VARIANTS = [{'InstanceType': 'ml.c4.99xlarge', 'InitialInstanceCount': 10}]
+
+MODEL_NAME = 'test-model'
+PRIMARY_CONTAINER = {'ModelDataUrl': '/some/model/path', 'Environment': {'env1': 1, 'env2': 'b'}}
+
 
 @patch('sagemaker.local.image._SageMakerContainer.train', return_value="/some/path/to/model")
 @patch('sagemaker.local.local_session.LocalSession')
@@ -148,38 +154,32 @@ def test_create_training_job_not_fully_replicated(train, LocalSession):
 @patch('sagemaker.local.local_session.LocalSession')
 def test_create_model(LocalSession):
     local_sagemaker_client = sagemaker.local.local_session.LocalSagemakerClient()
-    model_name = 'my-model'
-    primary_container = {'ModelDataUrl': '/some/model/path', 'Environment': {'env1': 1, 'env2': 'b'}}
 
-    local_sagemaker_client.create_model(model_name, primary_container)
+    local_sagemaker_client.create_model(MODEL_NAME, PRIMARY_CONTAINER)
 
-    assert 'my-model' in sagemaker.local.local_session.LocalSagemakerClient._models
+    assert MODEL_NAME in sagemaker.local.local_session.LocalSagemakerClient._models
 
 
 @patch('sagemaker.local.local_session.LocalSession')
 def test_delete_model(LocalSession):
     local_sagemaker_client = sagemaker.local.local_session.LocalSagemakerClient()
-    model_name = 'my-model'
-    primary_container = {'ModelDataUrl': '/some/model/path', 'Environment': {'env1': 1, 'env2': 'b'}}
 
-    local_sagemaker_client.create_model(model_name, primary_container)
-    assert model_name in sagemaker.local.local_session.LocalSagemakerClient._models
+    local_sagemaker_client.create_model(MODEL_NAME, PRIMARY_CONTAINER)
+    assert MODEL_NAME in sagemaker.local.local_session.LocalSagemakerClient._models
 
-    local_sagemaker_client.delete_model(model_name)
-    assert model_name not in sagemaker.local.local_session.LocalSagemakerClient._models
+    local_sagemaker_client.delete_model(MODEL_NAME)
+    assert MODEL_NAME not in sagemaker.local.local_session.LocalSagemakerClient._models
 
 
 @patch('sagemaker.local.local_session.LocalSession')
 def test_describe_model(LocalSession):
     local_sagemaker_client = sagemaker.local.local_session.LocalSagemakerClient()
-    model_name = 'test-model'
-    primary_container = {'ModelDataUrl': '/some/model/path', 'Environment': {'env1': 1, 'env2': 'b'}}
 
     with pytest.raises(ClientError):
         local_sagemaker_client.describe_model('model-does-not-exist')
 
-    local_sagemaker_client.create_model(model_name, primary_container)
-    response = local_sagemaker_client.describe_model('test-model')
+    local_sagemaker_client.create_model(MODEL_NAME, PRIMARY_CONTAINER)
+    response = local_sagemaker_client.describe_model(MODEL_NAME)
 
     assert response['ModelName'] == 'test-model'
     assert response['PrimaryContainer']['ModelDataUrl'] == '/some/model/path'
@@ -225,23 +225,20 @@ def test_describe_endpoint_config(LocalSession):
 @patch('sagemaker.local.local_session.LocalSession')
 def test_create_endpoint_config(LocalSession):
     local_sagemaker_client = sagemaker.local.local_session.LocalSagemakerClient()
-    production_variants = [{'InstanceType': 'ml.c4.99xlarge', 'InitialInstanceCount': 10}]
-    local_sagemaker_client.create_endpoint_config('my-endpoint-config', production_variants)
+    local_sagemaker_client.create_endpoint_config(ENDPOINT_CONFIG_NAME, PRODUCTION_VARIANTS)
 
-    assert 'my-endpoint-config' in sagemaker.local.local_session.LocalSagemakerClient._endpoint_configs
+    assert ENDPOINT_CONFIG_NAME in sagemaker.local.local_session.LocalSagemakerClient._endpoint_configs
 
 
 @patch('sagemaker.local.local_session.LocalSession')
 def test_delete_endpoint_config(LocalSession):
     local_sagemaker_client = sagemaker.local.local_session.LocalSagemakerClient()
-    production_variants = [{'InstanceType': 'ml.c4.99xlarge', 'InitialInstanceCount': 10}]
-    endpoint_config_name = 'my-endpoint-config'
 
-    local_sagemaker_client.create_endpoint_config(endpoint_config_name, production_variants)
-    assert endpoint_config_name in sagemaker.local.local_session.LocalSagemakerClient._endpoint_configs
+    local_sagemaker_client.create_endpoint_config(ENDPOINT_CONFIG_NAME, PRODUCTION_VARIANTS)
+    assert ENDPOINT_CONFIG_NAME in sagemaker.local.local_session.LocalSagemakerClient._endpoint_configs
 
-    local_sagemaker_client.delete_endpoint_config(endpoint_config_name)
-    assert endpoint_config_name not in sagemaker.local.local_session.LocalSagemakerClient._endpoint_configs
+    local_sagemaker_client.delete_endpoint_config(ENDPOINT_CONFIG_NAME)
+    assert ENDPOINT_CONFIG_NAME not in sagemaker.local.local_session.LocalSagemakerClient._endpoint_configs
 
 
 @patch('sagemaker.local.image._SageMakerContainer.serve')

--- a/tests/unit/test_local_session.py
+++ b/tests/unit/test_local_session.py
@@ -157,6 +157,19 @@ def test_create_model(LocalSession):
 
 
 @patch('sagemaker.local.local_session.LocalSession')
+def test_delete_model(LocalSession):
+    local_sagemaker_client = sagemaker.local.local_session.LocalSagemakerClient()
+    model_name = 'my-model'
+    primary_container = {'ModelDataUrl': '/some/model/path', 'Environment': {'env1': 1, 'env2': 'b'}}
+
+    local_sagemaker_client.create_model(model_name, primary_container)
+    assert model_name in sagemaker.local.local_session.LocalSagemakerClient._models
+
+    local_sagemaker_client.delete_model(model_name)
+    assert model_name not in sagemaker.local.local_session.LocalSagemakerClient._models
+
+
+@patch('sagemaker.local.local_session.LocalSession')
 def test_describe_model(LocalSession):
     local_sagemaker_client = sagemaker.local.local_session.LocalSagemakerClient()
     model_name = 'test-model'
@@ -216,6 +229,19 @@ def test_create_endpoint_config(LocalSession):
     local_sagemaker_client.create_endpoint_config('my-endpoint-config', production_variants)
 
     assert 'my-endpoint-config' in sagemaker.local.local_session.LocalSagemakerClient._endpoint_configs
+
+
+@patch('sagemaker.local.local_session.LocalSession')
+def test_delete_endpoint_config(LocalSession):
+    local_sagemaker_client = sagemaker.local.local_session.LocalSagemakerClient()
+    production_variants = [{'InstanceType': 'ml.c4.99xlarge', 'InitialInstanceCount': 10}]
+    endpoint_config_name = 'my-endpoint-config'
+
+    local_sagemaker_client.create_endpoint_config(endpoint_config_name, production_variants)
+    assert endpoint_config_name in sagemaker.local.local_session.LocalSagemakerClient._endpoint_configs
+
+    local_sagemaker_client.delete_endpoint_config(endpoint_config_name)
+    assert endpoint_config_name not in sagemaker.local.local_session.LocalSagemakerClient._endpoint_configs
 
 
 @patch('sagemaker.local.image._SageMakerContainer.serve')
@@ -316,7 +342,7 @@ def test_update_endpoint(LocalSession):
     endpoint_name = 'my-endpoint'
     endpoint_config = 'my-endpoint-config'
     expected_error_message = 'Update endpoint name is not supported in local session.'
-    with pytest.raises(NotImplementedError, message=expected_error_message):
+    with pytest.raises(NotImplementedError, match=expected_error_message):
         local_sagemaker_client.update_endpoint(endpoint_name, endpoint_config)
 
 

--- a/tests/unit/test_local_session.py
+++ b/tests/unit/test_local_session.py
@@ -172,17 +172,6 @@ def test_delete_model(LocalSession):
 
 
 @patch('sagemaker.local.local_session.LocalSession')
-def test_delete_model(LocalSession):
-    local_sagemaker_client = sagemaker.local.local_session.LocalSagemakerClient()
-
-    local_sagemaker_client.create_model(MODEL_NAME, PRIMARY_CONTAINER)
-    assert MODEL_NAME in sagemaker.local.local_session.LocalSagemakerClient._models
-
-    local_sagemaker_client.delete_model(MODEL_NAME)
-    assert MODEL_NAME not in sagemaker.local.local_session.LocalSagemakerClient._models
-
-
-@patch('sagemaker.local.local_session.LocalSession')
 def test_describe_model(LocalSession):
     local_sagemaker_client = sagemaker.local.local_session.LocalSagemakerClient()
 
@@ -239,17 +228,6 @@ def test_create_endpoint_config(LocalSession):
     local_sagemaker_client.create_endpoint_config(ENDPOINT_CONFIG_NAME, PRODUCTION_VARIANTS)
 
     assert ENDPOINT_CONFIG_NAME in sagemaker.local.local_session.LocalSagemakerClient._endpoint_configs
-
-
-@patch('sagemaker.local.local_session.LocalSession')
-def test_delete_endpoint_config(LocalSession):
-    local_sagemaker_client = sagemaker.local.local_session.LocalSagemakerClient()
-
-    local_sagemaker_client.create_endpoint_config(ENDPOINT_CONFIG_NAME, PRODUCTION_VARIANTS)
-    assert ENDPOINT_CONFIG_NAME in sagemaker.local.local_session.LocalSagemakerClient._endpoint_configs
-
-    local_sagemaker_client.delete_endpoint_config(ENDPOINT_CONFIG_NAME)
-    assert ENDPOINT_CONFIG_NAME not in sagemaker.local.local_session.LocalSagemakerClient._endpoint_configs
 
 
 @patch('sagemaker.local.local_session.LocalSession')

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -345,3 +345,11 @@ def test_model_delete_model(sagemaker_session, tmpdir):
     model.delete_model()
 
     sagemaker_session.delete_model.assert_called_with(model.name)
+
+
+@patch('sagemaker.fw_utils.tar_and_upload_dir', MagicMock())
+@patch('time.strftime', MagicMock(return_value=TIMESTAMP))
+def test_delete_non_deployed_model(sagemaker_session, tmpdir):
+    model = DummyFrameworkModel(sagemaker_session, source_dir=str(tmpdir))
+    with pytest.raises(ValueError, match='The SageMaker model must be deployed first before attempting to delete.'):
+        model.delete_model()

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -346,6 +346,7 @@ def test_model_delete_model(sagemaker_session, tmpdir):
 
     sagemaker_session.delete_model.assert_called_with(model.name)
 <<<<<<< HEAD
+<<<<<<< HEAD
 
 
 def test_delete_non_deployed_model(sagemaker_session):
@@ -354,3 +355,13 @@ def test_delete_non_deployed_model(sagemaker_session):
         model.delete_model()
 =======
 >>>>>>> 45e5c07... Add new APIs to predictor to delete endpoint and endpoint config, and transformer to delete model.
+=======
+
+
+@patch('sagemaker.fw_utils.tar_and_upload_dir', MagicMock())
+@patch('time.strftime', MagicMock(return_value=TIMESTAMP))
+def test_delete_non_deployed_model(sagemaker_session, tmpdir):
+    model = DummyFrameworkModel(sagemaker_session, source_dir=str(tmpdir))
+    with pytest.raises(ValueError, match='The SageMaker model must be deployed first before attempting to delete.'):
+        model.delete_model()
+>>>>>>> 334a0d6... Modify some functions, tests and update docs.

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -347,9 +347,7 @@ def test_model_delete_model(sagemaker_session, tmpdir):
     sagemaker_session.delete_model.assert_called_with(model.name)
 
 
-@patch('sagemaker.fw_utils.tar_and_upload_dir', MagicMock())
-@patch('time.strftime', MagicMock(return_value=TIMESTAMP))
-def test_delete_non_deployed_model(sagemaker_session, tmpdir):
-    model = DummyFrameworkModel(sagemaker_session, source_dir=str(tmpdir))
+def test_delete_non_deployed_model(sagemaker_session):
+    model = DummyFrameworkModel(sagemaker_session)
     with pytest.raises(ValueError, match='The SageMaker model must be deployed first before attempting to delete.'):
         model.delete_model()

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -345,9 +345,12 @@ def test_model_delete_model(sagemaker_session, tmpdir):
     model.delete_model()
 
     sagemaker_session.delete_model.assert_called_with(model.name)
+<<<<<<< HEAD
 
 
 def test_delete_non_deployed_model(sagemaker_session):
     model = DummyFrameworkModel(sagemaker_session)
     with pytest.raises(ValueError, match='The SageMaker model must be deployed first before attempting to delete.'):
         model.delete_model()
+=======
+>>>>>>> 45e5c07... Add new APIs to predictor to delete endpoint and endpoint config, and transformer to delete model.

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -345,23 +345,9 @@ def test_model_delete_model(sagemaker_session, tmpdir):
     model.delete_model()
 
     sagemaker_session.delete_model.assert_called_with(model.name)
-<<<<<<< HEAD
-<<<<<<< HEAD
 
 
 def test_delete_non_deployed_model(sagemaker_session):
     model = DummyFrameworkModel(sagemaker_session)
     with pytest.raises(ValueError, match='The SageMaker model must be deployed first before attempting to delete.'):
         model.delete_model()
-=======
->>>>>>> 45e5c07... Add new APIs to predictor to delete endpoint and endpoint config, and transformer to delete model.
-=======
-
-
-@patch('sagemaker.fw_utils.tar_and_upload_dir', MagicMock())
-@patch('time.strftime', MagicMock(return_value=TIMESTAMP))
-def test_delete_non_deployed_model(sagemaker_session, tmpdir):
-    model = DummyFrameworkModel(sagemaker_session, source_dir=str(tmpdir))
-    with pytest.raises(ValueError, match='The SageMaker model must be deployed first before attempting to delete.'):
-        model.delete_model()
->>>>>>> 334a0d6... Modify some functions, tests and update docs.

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -349,5 +349,5 @@ def test_model_delete_model(sagemaker_session, tmpdir):
 
 def test_delete_non_deployed_model(sagemaker_session):
     model = DummyFrameworkModel(sagemaker_session)
-    with pytest.raises(ValueError, match='The SageMaker model must be deployed first before attempting to delete.'):
+    with pytest.raises(ValueError, match='The SageMaker model must be created first before attempting to delete.'):
         model.delete_model()

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -96,7 +96,7 @@ class DummyFrameworkModel(FrameworkModel):
                                                   sagemaker_session=sagemaker_session, **kwargs)
 
     def create_predictor(self, endpoint_name):
-        return RealTimePredictor(endpoint_name, self.sagemaker_session)
+        return RealTimePredictor(endpoint_name, sagemaker_session=self.sagemaker_session)
 
 
 @pytest.fixture()
@@ -335,3 +335,13 @@ def test_model_package_create_transformer_with_product_id(sagemaker_session):
     assert transformer.model_name == 'auto-generated-model'
     assert transformer.instance_type == 'ml.m4.xlarge'
     assert transformer.env is None
+
+
+@patch('sagemaker.fw_utils.tar_and_upload_dir', MagicMock())
+@patch('time.strftime', MagicMock(return_value=TIMESTAMP))
+def test_model_delete_model(sagemaker_session, tmpdir):
+    model = DummyFrameworkModel(sagemaker_session, source_dir=str(tmpdir))
+    model.deploy(instance_type=INSTANCE_TYPE, initial_instance_count=1)
+    model.delete_model()
+
+    sagemaker_session.delete_model.assert_called_with(model.name)

--- a/tests/unit/test_predictor.py
+++ b/tests/unit/test_predictor.py
@@ -447,3 +447,22 @@ def test_predict_call_with_headers_and_csv():
     assert kwargs == expected_request_args
 
     assert result == CSV_RETURN_VALUE
+
+
+def test_delete_endpoint_with_config():
+    sagemaker_session = empty_sagemaker_session()
+    sagemaker_session.sagemaker_client.describe_endpoint = Mock(return_value={'EndpointConfigName': 'endpoint-config'})
+    predictor = RealTimePredictor(ENDPOINT, sagemaker_session=sagemaker_session)
+    predictor.delete_endpoint()
+
+    sagemaker_session.delete_endpoint.assert_called_with(ENDPOINT)
+    sagemaker_session.delete_endpoint_config.assert_called_with('endpoint-config')
+
+
+def test_delete_endpoint_only():
+    sagemaker_session = empty_sagemaker_session()
+    predictor = RealTimePredictor(ENDPOINT, sagemaker_session=sagemaker_session)
+    predictor.delete_endpoint(delete_endpoint_config=False)
+
+    sagemaker_session.delete_endpoint.assert_called_with(ENDPOINT)
+    sagemaker_session.delete_endpoint_config.assert_not_called()

--- a/tests/unit/test_predictor.py
+++ b/tests/unit/test_predictor.py
@@ -459,6 +459,16 @@ def test_delete_endpoint_with_config():
     sagemaker_session.delete_endpoint_config.assert_called_with('endpoint-config')
 
 
+def test_delete_non_existing_endpoint():
+    sagemaker_session = empty_sagemaker_session()
+    expected_error_message = 'The endpoint this config attached to does not exist.'
+    sagemaker_session.sagemaker_client.describe_endpoint = Mock(side_effect=ValueError(expected_error_message))
+    predictor = RealTimePredictor(ENDPOINT, sagemaker_session=sagemaker_session)
+
+    with pytest.raises(ValueError, match=expected_error_message):
+        predictor.delete_endpoint()
+
+
 def test_delete_endpoint_only():
     sagemaker_session = empty_sagemaker_session()
     predictor = RealTimePredictor(ENDPOINT, sagemaker_session=sagemaker_session)

--- a/tests/unit/test_predictor.py
+++ b/tests/unit/test_predictor.py
@@ -459,16 +459,6 @@ def test_delete_endpoint_with_config():
     sagemaker_session.delete_endpoint_config.assert_called_with('endpoint-config')
 
 
-def test_delete_non_existing_endpoint():
-    sagemaker_session = empty_sagemaker_session()
-    expected_error_message = 'The endpoint this config attached to does not exist.'
-    sagemaker_session.sagemaker_client.describe_endpoint = Mock(side_effect=ValueError(expected_error_message))
-    predictor = RealTimePredictor(ENDPOINT, sagemaker_session=sagemaker_session)
-
-    with pytest.raises(ValueError, match=expected_error_message):
-        predictor.delete_endpoint()
-
-
 def test_delete_endpoint_only():
     sagemaker_session = empty_sagemaker_session()
     predictor = RealTimePredictor(ENDPOINT, sagemaker_session=sagemaker_session)

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -154,9 +154,22 @@ def test_delete_endpoint_config(boto_session):
 
 def test_delete_model(boto_session):
     sess = Session(boto_session)
-    sess.delete_model('my_model')
 
-    boto_session.client().delete_model.assert_called_with(ModelName='my_model')
+    model_name = 'my_model'
+    boto_session.client().describe_model = Mock(return_value={'ModelName': model_name})
+    sess.delete_model(model_name)
+
+    boto_session.client().delete_model.assert_called_with(ModelName=model_name)
+
+
+def test_delete_non_existing_model(boto_session):
+    sess = Session(boto_session)
+
+    expected_error_message = 'The Sagemaker model must be deployed first before attempting to delete.'
+    boto_session.client().describe_model = Mock(side_effect=ValueError(expected_error_message))
+
+    with pytest.raises(ValueError, match=expected_error_message):
+        sess.delete_model('non_existing_model')
 
 
 def test_user_agent_injected(boto_session):

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -145,6 +145,20 @@ def test_delete_endpoint(boto_session):
     boto_session.client().delete_endpoint.assert_called_with(EndpointName='my_endpoint')
 
 
+def test_delete_endpoint_config(boto_session):
+    sess = Session(boto_session)
+    sess.delete_endpoint_config('my_endpoint_config')
+
+    boto_session.client().delete_endpoint_config.assert_called_with(EndpointConfigName='my_endpoint_config')
+
+
+def test_delete_model(boto_session):
+    sess = Session(boto_session)
+    sess.delete_model('my_model')
+
+    boto_session.client().delete_model.assert_called_with(ModelName='my_model')
+
+
 def test_user_agent_injected(boto_session):
     assert 'AWS-SageMaker-Python-SDK' not in boto_session.client('sagemaker')._client_config.user_agent
 
@@ -933,7 +947,7 @@ def test_update_endpoint_non_existing_endpoint(sagemaker_session):
     expected_error_message = 'Endpoint with name "non-existing-endpoint" does not exist; ' \
                              'please use an existing endpoint name'
     sagemaker_session.sagemaker_client.describe_endpoint = Mock(side_effect=error)
-    with pytest.raises(ValueError, message=expected_error_message):
+    with pytest.raises(ValueError, match=expected_error_message):
         sagemaker_session.update_endpoint("non-existing-endpoint", "non-existing-config")
 
 

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -156,20 +156,9 @@ def test_delete_model(boto_session):
     sess = Session(boto_session)
 
     model_name = 'my_model'
-    boto_session.client().describe_model = Mock(return_value={'ModelName': model_name})
     sess.delete_model(model_name)
 
     boto_session.client().delete_model.assert_called_with(ModelName=model_name)
-
-
-def test_delete_non_existing_model(boto_session):
-    sess = Session(boto_session)
-
-    expected_error_message = 'The Sagemaker model must be deployed first before attempting to delete.'
-    boto_session.client().describe_model = Mock(side_effect=ValueError(expected_error_message))
-
-    with pytest.raises(ValueError, match=expected_error_message):
-        sess.delete_model('non_existing_model')
 
 
 def test_user_agent_injected(boto_session):

--- a/tests/unit/test_transformer.py
+++ b/tests/unit/test_transformer.py
@@ -60,8 +60,7 @@ def transformer(sagemaker_session):
 
 
 def test_delete_model(sagemaker_session):
-    transformer = Transformer(MODEL_NAME, INSTANCE_COUNT, INSTANCE_TYPE, output_path=OUTPUT_PATH,
-                              sagemaker_session=sagemaker_session, volume_kms_key=KMS_KEY_ID)
+    transformer = Transformer(MODEL_NAME, INSTANCE_COUNT, INSTANCE_TYPE, sagemaker_session=sagemaker_session)
     transformer.delete_model()
     sagemaker_session.delete_model.assert_called_with(MODEL_NAME)
 

--- a/tests/unit/test_transformer.py
+++ b/tests/unit/test_transformer.py
@@ -59,6 +59,13 @@ def transformer(sagemaker_session):
                        volume_kms_key=KMS_KEY_ID)
 
 
+def test_delete_model(sagemaker_session):
+    transformer = Transformer(MODEL_NAME, INSTANCE_COUNT, INSTANCE_TYPE, output_path=OUTPUT_PATH,
+                              sagemaker_session=sagemaker_session, volume_kms_key=KMS_KEY_ID)
+    transformer.delete_model()
+    sagemaker_session.delete_model.assert_called_with(MODEL_NAME)
+
+
 @patch('sagemaker.transformer._TransformJob.start_new')
 def test_transform_with_all_params(start_new_job, transformer):
     content_type = 'text/csv'


### PR DESCRIPTION
… transformer to delete model.

*Issue #, if available:*
#447 

*Description of changes:*
- Add support to delete endpoint configuration by default within delete_endpoint() to predictor class.
- Add delete_model() to transformer class. Instead of linking a model class to it, the transformer class directly calls session's delete_model() method because it already has access to the model_name. We don't want to pass in a model object on top of that. We don't want to construct a model object here either because that requires extra parameters, such as the s3 path to the model artifacts, while we can just utilize the model_name variable.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have updated the [changelog](https://github.com/aws/sagemaker-python-sdk/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [x] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
