### PR TITLE
allow ei versions to be configurable in integ test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -111,11 +111,6 @@ def mxnet_version(request):
     return request.param
 
 
-@pytest.fixture(scope='module', params=['1.3', '1.3.0'])
-def ei_mxnet_version(request):
-    return request.param
-
-
 @pytest.fixture(scope='module', params=['0.4', '0.4.0', '1.0', '1.0.0'])
 def pytorch_version(request):
     return request.param
@@ -130,11 +125,6 @@ def sklearn_version(request):
                                         '1.7', '1.7.0', '1.8', '1.8.0', '1.9', '1.9.0',
                                         '1.10', '1.10.0', '1.11', '1.11.0', '1.12', '1.12.0'])
 def tf_version(request):
-    return request.param
-
-
-@pytest.fixture(scope='module', params=['1.11', '1.11.0', '1.12', '1.12.0'])
-def ei_tf_version(request):
     return request.param
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,6 +37,7 @@ def pytest_addoption(parser):
     parser.addoption('--boto-config', action='store', default=None)
     parser.addoption('--chainer-full-version', action='store', default=Chainer.LATEST_VERSION)
     parser.addoption('--mxnet-full-version', action='store', default=MXNet.LATEST_VERSION)
+    parser.addoption('--ei-mxnet-full-version', action='store', default=MXNet.LATEST_VERSION)
     parser.addoption('--pytorch-full-version', action='store', default=PyTorch.LATEST_VERSION)
     parser.addoption('--rl-coach-full-version', action='store',
                      default=RLEstimator.COACH_LATEST_VERSION)
@@ -44,6 +45,7 @@ def pytest_addoption(parser):
                      default=RLEstimator.RAY_LATEST_VERSION)
     parser.addoption('--sklearn-full-version', action='store', default=SKLEARN_VERSION)
     parser.addoption('--tf-full-version', action='store', default=TensorFlow.LATEST_VERSION)
+    parser.addoption('--ei-tf-full-version', action='store', default=TensorFlow.LATEST_VERSION)
 
 
 def pytest_configure(config):
@@ -131,7 +133,7 @@ def tf_version(request):
     return request.param
 
 
-@pytest.fixture(scope='module', params=['1.12', '1.12.0'])
+@pytest.fixture(scope='module', params=['1.11', '1.11.0', '1.12', '1.12.0'])
 def ei_tf_version(request):
     return request.param
 
@@ -162,6 +164,11 @@ def mxnet_full_version(request):
 
 
 @pytest.fixture(scope='module')
+def ei_mxnet_full_version(request):
+    return request.config.getoption('--ei-mxnet-full-version')
+
+
+@pytest.fixture(scope='module')
 def pytorch_full_version(request):
     return request.config.getoption('--pytorch-full-version')
 
@@ -184,3 +191,8 @@ def sklearn_full_version(request):
 @pytest.fixture(scope='module')
 def tf_full_version(request):
     return request.config.getoption('--tf-full-version')
+
+
+@pytest.fixture(scope='module')
+def ei_tf_full_version(request):
+    return request.config.getoption('--ei-tf-full-version')

--- a/tests/integ/test_mxnet_train.py
+++ b/tests/integ/test_mxnet_train.py
@@ -121,7 +121,7 @@ def test_deploy_model_with_update_non_existing_endpoint(mxnet_training_job, sage
 @pytest.mark.regional_testing
 @pytest.mark.skipif(tests.integ.test_region() not in tests.integ.EI_SUPPORTED_REGIONS,
                     reason="EI isn't supported in that specific region.")
-def test_deploy_model_with_accelerator(mxnet_training_job, sagemaker_session, ei_mxnet_version):
+def test_deploy_model_with_accelerator(mxnet_training_job, sagemaker_session, ei_mxnet_full_version):
     endpoint_name = 'test-mxnet-deploy-model-ei-{}'.format(sagemaker_timestamp())
 
     with timeout_and_delete_endpoint_by_name(endpoint_name, sagemaker_session):
@@ -129,7 +129,7 @@ def test_deploy_model_with_accelerator(mxnet_training_job, sagemaker_session, ei
         model_data = desc['ModelArtifacts']['S3ModelArtifacts']
         script_path = os.path.join(DATA_DIR, 'mxnet_mnist', 'mnist.py')
         model = MXNetModel(model_data, 'SageMakerRole', entry_point=script_path,
-                           framework_version=ei_mxnet_version, py_version=PYTHON_VERSION,
+                           framework_version=ei_mxnet_full_version, py_version=PYTHON_VERSION,
                            sagemaker_session=sagemaker_session)
         predictor = model.deploy(1, 'ml.m4.xlarge', endpoint_name=endpoint_name, accelerator_type='ml.eia1.medium')
 

--- a/tests/integ/test_tf.py
+++ b/tests/integ/test_tf.py
@@ -83,7 +83,7 @@ def test_deploy_model(sagemaker_session, tf_training_job):
 @pytest.mark.skipif(tests.integ.test_region() not in tests.integ.EI_SUPPORTED_REGIONS,
                     reason="EI isn't supported in that specific region.")
 @pytest.mark.skipif(PYTHON_VERSION != 'py2', reason="TensorFlow image supports only python 2.")
-def test_deploy_model_with_accelerator(sagemaker_session, tf_training_job, ei_tf_version):
+def test_deploy_model_with_accelerator(sagemaker_session, tf_training_job, ei_tf_full_version):
     endpoint_name = 'test-tf-deploy-model-ei-{}'.format(sagemaker_timestamp())
 
     with timeout_and_delete_endpoint_by_name(endpoint_name, sagemaker_session):
@@ -92,7 +92,7 @@ def test_deploy_model_with_accelerator(sagemaker_session, tf_training_job, ei_tf
 
         script_path = os.path.join(DATA_DIR, 'iris', 'iris-dnn-classifier.py')
         model = TensorFlowModel(model_data, 'SageMakerRole', entry_point=script_path,
-                                framework_version=ei_tf_version, sagemaker_session=sagemaker_session)
+                                framework_version=ei_tf_full_version, sagemaker_session=sagemaker_session)
 
         json_predictor = model.deploy(initial_instance_count=1, instance_type='ml.c4.xlarge',
                                       endpoint_name=endpoint_name, accelerator_type='ml.eia1.medium')


### PR DESCRIPTION
*Description of changes:*
Allow the ei versions for TF and MXNet to be configurable in the integration tests.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have updated the [changelog](https://github.com/aws/sagemaker-python-sdk/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [x] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
