### PR TITLE
fix README for PyPI

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 CHANGELOG
 =========
 
+1.18.3.post1
+============
+
+* doc-fix: fix README for PyPI
+
 1.18.3
 ======
 

--- a/README.rst
+++ b/README.rst
@@ -196,6 +196,7 @@ Here is an end to end example of how to use a SageMaker Estimator:
 The example above will eventually delete both the SageMaker endpoint and endpoint configuration through `delete_endpoint()`. If you want to keep your SageMaker endpoint configuration, use the value False for the `delete_endpoint_config` parameter, as shown below.
 
 .. code:: python
+
     # Only delete the SageMaker endpoint, while keeping the corresponding endpoint configuration.
     mxnet_predictor.delete_endpoint(delete_endpoint_config=False)
 

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ if sys.version_info < (3, 4):
     required_packages.append('enum34>=1.1.6')
 
 setup(name="sagemaker",
-      version='1.18.3',
+      version='1.18.3.post1',
       description="Open source library for training and deploying models on Amazon SageMaker.",
       packages=find_packages('src'),
       package_dir={'': 'src'},


### PR DESCRIPTION
*Issue #, if available:*
The README doc is broken in PyPI: https://pypi.org/project/sagemaker/1.18.3/

The code snippet below was missing a newline.

Twine provides the ability to check if your readme will render properly on PyPI.
https://packaging.python.org/guides/making-a-pypi-friendly-readme/#validating-restructuredtext-markup

https://github.com/aws/sagemaker-tensorflow-extensions/pull/32

*Description of changes:*
Added newline in code snippet portion in README.
Bumped to 1.18.3.post1

Going to add the step in our CI.

=== TEST ===
twine check dist/*
/anaconda3/lib/python3.6/site-packages/readme_renderer/markdown.py:38: UserWarning: Markdown renderers are not available. Install 'readme_render[md]' to enable Markdown rendering.
  warnings.warn(_EXTRA_WARNING)
Checking distribution dist/sagemaker-1.18.3.post1.tar.gz: Passed

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have updated the [changelog](https://github.com/aws/sagemaker-python-sdk/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [x] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
