### PR TITLE
add sphinx-build in tox

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,6 @@ CHANGELOG
 ==========
 
 * doc-fix: Remove incorrect parameter for EI TFS Python README
-* enhancement: tox.ini: Add sphinx-build check for readthedocs
 
 1.18.3.post1
 ============

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ CHANGELOG
 ==========
 
 * doc-fix: Remove incorrect parameter for EI TFS Python README
+* enhancement: tox.ini: Add sphinx-build check for readthedocs
 
 1.18.3.post1
 ============

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27,py35,flake8,pylint
+envlist = py27,py35,flake8,pylint,sphinx
 skip_missing_interpreters = False
 
 [travis]
@@ -72,3 +72,29 @@ deps =
     pylint==2.1.1
 commands =
     python -m pylint --rcfile=.pylintrc -j 0 src/sagemaker
+
+[testenv:sphinx]
+basepython = python
+changedir = doc
+# Based on: https://github.com/rtfd/readthedocs.org/blob/8f0c78dde5edcc85acf90462a8518735a25482d3/readthedocs/doc_builder/python_environments.py#L263
+install_command = python -m pip install --upgrade -I {packages}
+# Based on: https://github.com/rtfd/readthedocs.org/blob/8f0c78dde5edcc85acf90462a8518735a25482d3/readthedocs/doc_builder/python_environments.py#L280
+deps =
+    Pygments==2.2.0
+    setuptools<40
+    docutils==0.13.1
+    mock==1.0.1
+    pillow==2.6.1
+    alabaster>=0.7,<0.8,!=0.7.5
+    commonmark==0.5.4
+    recommonmark==0.4.0
+    sphinx<1.8
+    sphinx-rtd-theme<0.5
+    readthedocs-sphinx-ext<0.6
+# pip install requirements.txt is separate as RTD does it in separate steps
+# having the requirements.txt installed in deps above results in Double Requirement exception
+# https://github.com/pypa/pip/issues/988
+commands_pre =
+    pip install --exists-action=w -r requirements.txt
+commands =
+    sphinx-build -T -W -b html -d _build/doctrees-readthedocs -D language=en . _build/html

--- a/tox.ini
+++ b/tox.ini
@@ -94,7 +94,6 @@ deps =
 # pip install requirements.txt is separate as RTD does it in separate steps
 # having the requirements.txt installed in deps above results in Double Requirement exception
 # https://github.com/pypa/pip/issues/988
-commands_pre =
-    pip install --exists-action=w -r requirements.txt
 commands =
+    pip install --exists-action=w -r requirements.txt
     sphinx-build -T -W -b html -d _build/doctrees-readthedocs -D language=en . _build/html

--- a/tox.ini
+++ b/tox.ini
@@ -74,7 +74,7 @@ commands =
     python -m pylint --rcfile=.pylintrc -j 0 src/sagemaker
 
 [testenv:sphinx]
-basepython = python
+basepython = python3
 changedir = doc
 # Based on: https://github.com/rtfd/readthedocs.org/blob/8f0c78dde5edcc85acf90462a8518735a25482d3/readthedocs/doc_builder/python_environments.py#L263
 install_command = python -m pip install --upgrade -I {packages}


### PR DESCRIPTION
*Issue #, if available:*
Build the sphinx docs similar to RTD build process: https://readthedocs.org/projects/sagemaker/builds/8577862/

*Description of changes:*
Added new env within tox which handles building the sphinx-docs similar to that of RTD.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have updated the [changelog](https://github.com/aws/sagemaker-python-sdk/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [x] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
