### PR TITLE
Estimator.attach should work with a job without hps

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ CHANGELOG
 * doc-fix: Remove incorrect parameter for EI TFS Python README
 * feature: ``Predictor``: delete SageMaker model
 * feature: ``Pipeline``: delete SageMaker model
+* bug-fix: Estimator.attach works with training jobs without hyperparameters
 
 1.18.3.post1
 ============

--- a/src/sagemaker/estimator.py
+++ b/src/sagemaker/estimator.py
@@ -425,7 +425,9 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):
         init_params['output_path'] = job_details['OutputDataConfig']['S3OutputPath']
         init_params['output_kms_key'] = job_details['OutputDataConfig']['KmsKeyId']
 
-        init_params['hyperparameters'] = job_details['HyperParameters']
+        has_hps = 'HyperParameters' in job_details
+        init_params['hyperparameters'] = job_details['HyperParameters'] if has_hps else {}
+
         if 'TrainingImage' in job_details['AlgorithmSpecification']:
             init_params['image'] = job_details['AlgorithmSpecification']['TrainingImage']
         elif 'AlgorithmName' in job_details['AlgorithmSpecification']:

--- a/tests/unit/test_estimator.py
+++ b/tests/unit/test_estimator.py
@@ -451,6 +451,20 @@ def test_attach_framework(sagemaker_session):
     assert framework_estimator.encrypt_inter_container_traffic is False
 
 
+def test_attach_without_hyperparameters(sagemaker_session):
+    returned_job_description = RETURNED_JOB_DESCRIPTION.copy()
+    del returned_job_description['HyperParameters']
+
+    mock_describe_training_job = Mock(name='describe_training_job',
+                                      return_value=returned_job_description)
+    sagemaker_session.sagemaker_client.describe_training_job = mock_describe_training_job
+
+    estimator = Estimator.attach(training_job_name='job',
+                                 sagemaker_session=sagemaker_session)
+
+    assert estimator.hyperparameters() == {}
+
+
 def test_attach_framework_with_tuning(sagemaker_session):
     returned_job_description = RETURNED_JOB_DESCRIPTION.copy()
     returned_job_description['HyperParameters']['_tuning_objective_metric'] = 'Validation-accuracy'


### PR DESCRIPTION
*Issue #, if available:*
- https://github.com/aws/sagemaker-python-sdk/issues/657

*Description of changes:*
- Estimator.attach should work with a job without hps

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [X] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have updated the [changelog](https://github.com/aws/sagemaker-python-sdk/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [x] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
