### PR TITLE
pass accelerator_type for tfs model

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ CHANGELOG
 * doc-fix: Remove incorrect parameter for EI TFS Python README
 * feature: ``Predictor``: delete SageMaker model
 * feature: ``Pipeline``: delete SageMaker model
+* bug-fix: pass accelerator_type in ``deploy`` for REST API TFS ``Model``
 
 1.18.3.post1
 ============

--- a/src/sagemaker/fw_utils.py
+++ b/src/sagemaker/fw_utils.py
@@ -106,7 +106,7 @@ def _accelerator_type_valid_for_framework(framework, accelerator_type=None, opti
 
     if framework not in VALID_EIA_FRAMEWORKS:
         raise ValueError('{} is not supported with Amazon Elastic Inference. Currently only '
-                         'TensorFlow and MXNet are supported for SageMaker.'.format(framework))
+                         'Python-based TensorFlow and MXNet are supported for SageMaker.'.format(framework))
 
     if optimized_families:
         raise ValueError('Neo does not support Amazon Elastic Inference.')

--- a/src/sagemaker/fw_utils.py
+++ b/src/sagemaker/fw_utils.py
@@ -106,7 +106,7 @@ def _accelerator_type_valid_for_framework(framework, accelerator_type=None, opti
 
     if framework not in VALID_EIA_FRAMEWORKS:
         raise ValueError('{} is not supported with Amazon Elastic Inference. Currently only '
-                         'Python-based TensorFlow and MXNet are supported for SageMaker.'.format(framework))
+                         'Python-based TensorFlow and MXNet are supported.'.format(framework))
 
     if optimized_families:
         raise ValueError('Neo does not support Amazon Elastic Inference.')

--- a/src/sagemaker/tensorflow/deploying_python.rst
+++ b/src/sagemaker/tensorflow/deploying_python.rst
@@ -25,7 +25,7 @@ like this:
 
 The code block above deploys a SageMaker Endpoint with one instance of the type 'ml.c4.xlarge'.
 
-TensorFlow serving on SageMaker has support for `Elastic Inference <https://docs.aws.amazon.com/sagemaker/latest/dg/ei.html>`_, which allows for inference acceleration to a hosted endpoint for a fraction of the cost of using a full GPU instance. In order to attach an Elastic Inference accelerator to your endpoint provide the accelerator type to ``accelerator_type`` to your ``deploy`` call.
+Python-based TensorFlow serving on SageMaker has support for `Elastic Inference <https://docs.aws.amazon.com/sagemaker/latest/dg/ei.html>`_, which allows for inference acceleration to a hosted endpoint for a fraction of the cost of using a full GPU instance. In order to attach an Elastic Inference accelerator to your endpoint provide the accelerator type to ``accelerator_type`` to your ``deploy`` call.
 
 .. code:: python
 

--- a/src/sagemaker/tensorflow/deploying_tensorflow_serving.rst
+++ b/src/sagemaker/tensorflow/deploying_tensorflow_serving.rst
@@ -34,6 +34,8 @@ estimator object to create a SageMaker Endpoint:
 
 The code block above deploys a SageMaker Endpoint with one instance of the type 'ml.c5.xlarge'.
 
+As of now, only the Python based TensorFlow serving endpoints support Elastic Inference. For more information, see `Deploying to Python-based Endpoints <https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/tensorflow/deploying_python.rst#deploying-to-python-based-endpoints>`_.
+
 What happens when deploy is called
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/sagemaker/tensorflow/deploying_tensorflow_serving.rst
+++ b/src/sagemaker/tensorflow/deploying_tensorflow_serving.rst
@@ -34,7 +34,7 @@ estimator object to create a SageMaker Endpoint:
 
 The code block above deploys a SageMaker Endpoint with one instance of the type 'ml.c5.xlarge'.
 
-As of now, only the Python based TensorFlow serving endpoints support Elastic Inference. For more information, see `Deploying to Python-based Endpoints <https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/tensorflow/deploying_python.rst#deploying-to-python-based-endpoints>`_.
+As of now, only the Python-based TensorFlow serving endpoints support Elastic Inference. For more information, see `Deploying to Python-based Endpoints <https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/tensorflow/deploying_python.rst#deploying-to-python-based-endpoints>`_.
 
 What happens when deploy is called
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/sagemaker/tensorflow/serving.py
+++ b/src/sagemaker/tensorflow/serving.py
@@ -123,7 +123,7 @@ class Model(sagemaker.Model):
         self._container_log_level = container_log_level
 
     def prepare_container_def(self, instance_type, accelerator_type=None):
-        image = self._get_image_uri(instance_type)
+        image = self._get_image_uri(instance_type, accelerator_type)
         env = self._get_container_env()
         return sagemaker.container_def(image, self.model_data, env)
 
@@ -139,10 +139,10 @@ class Model(sagemaker.Model):
         env[Model.LOG_LEVEL_PARAM_NAME] = Model.LOG_LEVEL_MAP[self._container_log_level]
         return env
 
-    def _get_image_uri(self, instance_type):
+    def _get_image_uri(self, instance_type, accelerator_type=None):
         if self.image:
             return self.image
 
         region_name = self.sagemaker_session.boto_region_name
         return create_image_uri(region_name, Model.FRAMEWORK_NAME, instance_type,
-                                self._framework_version)
+                                self._framework_version, accelerator_type=accelerator_type)

--- a/tests/unit/test_tfs.py
+++ b/tests/unit/test_tfs.py
@@ -25,6 +25,7 @@ JSON_CONTENT_TYPE = 'application/json'
 CSV_CONTENT_TYPE = 'text/csv'
 INSTANCE_COUNT = 1
 INSTANCE_TYPE = 'ml.c4.4xlarge'
+ACCELERATOR_TYPE = 'ml.eia.medium'
 ROLE = 'Dummy'
 REGION = 'us-west-2'
 PREDICT_INPUT = {'instances': [1.0, 2.0, 5.0]}
@@ -73,6 +74,13 @@ def test_tfs_model(sagemaker_session, tf_version):
 
     predictor = model.deploy(INSTANCE_COUNT, INSTANCE_TYPE)
     assert isinstance(predictor, Predictor)
+
+
+def test_tfs_model_image_accelerator(sagemaker_session, tf_version):
+    model = Model("s3://some/data.tar.gz", role=ROLE, framework_version=tf_version,
+                  sagemaker_session=sagemaker_session)
+    with pytest.raises(ValueError):
+        model.prepare_container_def(INSTANCE_TYPE, accelerator_type=ACCELERATOR_TYPE)
 
 
 def test_tfs_model_with_log_level(sagemaker_session, tf_version):


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/amazon-sagemaker-examples/issues/613#issuecomment-463937167
https://github.com/aws/sagemaker-python-sdk/commit/4732545bd9d1880390b3951c9b941f2bb62d6e5a#r32336726

*Description of changes:*
Pass in accelerator_type into the deploy() for the REST API TFS Model object, which should result in an exception, as EI for the TFS container isn't supported.

I can also change it so that the failure happens on SageMaker side instead of client side as the image doesn't exist and is currently in the works, however this is to mitigate users from pulling down CPU or GPU only images when expecting EI images.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have updated the [changelog](https://github.com/aws/sagemaker-python-sdk/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [x] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
