### PR TITLE
Remove condition for kms resource policy

### DIFF
--- a/tests/integ/kms_utils.py
+++ b/tests/integ/kms_utils.py
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 from __future__ import absolute_import
 
-KEY_ALIAS = "SageMakerTestKmsKey"
+KEY_ALIAS = "SageMakerIntegTestKmsKey"
 KEY_POLICY = '''
 {{
   "Version": "2012-10-17",
@@ -25,34 +25,6 @@ KEY_POLICY = '''
         "AWS": "{account_id}"
       }},
       "Action": "kms:*",
-      "Resource": "*"
-    }},
-    {{
-      "Sid": "Allow use of the key",
-      "Effect": "Allow",
-      "Principal": {{
-        "AWS": "{account_id}"
-      }},
-      "Action": [
-        "kms:Encrypt",
-        "kms:Decrypt",
-        "kms:ReEncrypt*",
-        "kms:GenerateDataKey*",
-        "kms:DescribeKey"
-      ],
-      "Resource": "*"
-    }},
-    {{
-      "Sid": "Allow attachment of persistent resources",
-      "Effect": "Allow",
-      "Principal": {{
-        "AWS": "{account_id}"
-      }},
-      "Action": [
-        "kms:CreateGrant",
-        "kms:ListGrants",
-        "kms:RevokeGrant"
-      ],
       "Resource": "*"
     }}
   ]

--- a/tests/integ/kms_utils.py
+++ b/tests/integ/kms_utils.py
@@ -53,12 +53,7 @@ KEY_POLICY = '''
         "kms:ListGrants",
         "kms:RevokeGrant"
       ],
-      "Resource": "*",
-      "Condition": {{
-        "Bool": {{
-          "kms:GrantIsForAWSResource": "true"
-        }}
-      }}
+      "Resource": "*"
     }}
   ]
 }}

--- a/tests/integ/kms_utils.py
+++ b/tests/integ/kms_utils.py
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 from __future__ import absolute_import
 
-KEY_ALIAS = "SageMakerKmsKey"
+KEY_ALIAS = "SageMakerTestKmsKey"
 KEY_POLICY = '''
 {{
   "Version": "2012-10-17",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
https://docs.aws.amazon.com/kms/latest/developerguide/policy-conditions.html#conditions-kms-grant-is-for-aws-resource

This page shows the kms:GrantIsForAWSResource is only set to True in specific AWS services where SageMaker is not one of it. We should remove it in the policy.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated the [changelog](https://github.com/aws/sagemaker-python-sdk/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
