### PR TITLE
Fix local image unit tests

### DIFF
--- a/tests/unit/test_image.py
+++ b/tests/unit/test_image.py
@@ -304,9 +304,13 @@ def test_check_output():
 @patch('sagemaker.local.local_session.LocalSession', Mock())
 @patch('sagemaker.local.image._stream_output', Mock())
 @patch('sagemaker.local.image._SageMakerContainer._cleanup', Mock())
-@patch('sagemaker.local.data.get_data_source_instance', Mock())
+@patch('sagemaker.local.data.get_data_source_instance')
 @patch('subprocess.Popen')
-def test_train(popen, tmpdir, sagemaker_session):
+def test_train(popen, get_data_source_instance, tmpdir, sagemaker_session):
+    data_source = Mock()
+    data_source.get_root_dir.return_value = 'foo'
+    get_data_source_instance.return_value = data_source
+
     directories = [str(tmpdir.mkdir('container-root')), str(tmpdir.mkdir('data'))]
     with patch('sagemaker.local.image._SageMakerContainer._create_tmp_folder',
                side_effect=directories):
@@ -342,8 +346,12 @@ def test_train(popen, tmpdir, sagemaker_session):
 @patch('sagemaker.local.local_session.LocalSession', Mock())
 @patch('sagemaker.local.image._stream_output', Mock())
 @patch('sagemaker.local.image._SageMakerContainer._cleanup', Mock())
-@patch('sagemaker.local.data.get_data_source_instance', Mock())
-def test_train_with_hyperparameters_without_job_name(tmpdir, sagemaker_session):
+@patch('sagemaker.local.data.get_data_source_instance')
+def test_train_with_hyperparameters_without_job_name(get_data_source_instance, tmpdir, sagemaker_session):
+    data_source = Mock()
+    data_source.get_root_dir.return_value = 'foo'
+    get_data_source_instance.return_value = data_source
+
     directories = [str(tmpdir.mkdir('container-root')), str(tmpdir.mkdir('data'))]
     with patch('sagemaker.local.image._SageMakerContainer._create_tmp_folder',
                side_effect=directories):
@@ -364,11 +372,14 @@ def test_train_with_hyperparameters_without_job_name(tmpdir, sagemaker_session):
 @patch('sagemaker.local.local_session.LocalSession', Mock())
 @patch('sagemaker.local.image._stream_output', side_effect=RuntimeError('this is expected'))
 @patch('sagemaker.local.image._SageMakerContainer._cleanup', Mock())
-@patch('sagemaker.local.data.get_data_source_instance', Mock())
+@patch('sagemaker.local.data.get_data_source_instance')
 @patch('subprocess.Popen', Mock())
-def test_train_error(_stream_output, tmpdir, sagemaker_session):
-    directories = [str(tmpdir.mkdir('container-root')), str(tmpdir.mkdir('data'))]
+def test_train_error(get_data_source_instance, _stream_output, tmpdir, sagemaker_session):
+    data_source = Mock()
+    data_source.get_root_dir.return_value = 'foo'
+    get_data_source_instance.return_value = data_source
 
+    directories = [str(tmpdir.mkdir('container-root')), str(tmpdir.mkdir('data'))]
     with patch('sagemaker.local.image._SageMakerContainer._create_tmp_folder', side_effect=directories):
         instance_count = 2
         image = 'my-image'
@@ -384,9 +395,13 @@ def test_train_error(_stream_output, tmpdir, sagemaker_session):
 @patch('sagemaker.local.local_session.LocalSession', Mock())
 @patch('sagemaker.local.image._stream_output', Mock())
 @patch('sagemaker.local.image._SageMakerContainer._cleanup', Mock())
-@patch('sagemaker.local.data.get_data_source_instance', Mock())
+@patch('sagemaker.local.data.get_data_source_instance')
 @patch('subprocess.Popen', Mock())
-def test_train_local_code(tmpdir, sagemaker_session):
+def test_train_local_code(get_data_source_instance, tmpdir, sagemaker_session):
+    data_source = Mock()
+    data_source.get_root_dir.return_value = 'foo'
+    get_data_source_instance.return_value = data_source
+
     directories = [str(tmpdir.mkdir('container-root')), str(tmpdir.mkdir('data'))]
     with patch('sagemaker.local.image._SageMakerContainer._create_tmp_folder',
                side_effect=directories):
@@ -422,9 +437,13 @@ def test_train_local_code(tmpdir, sagemaker_session):
 @patch('sagemaker.local.local_session.LocalSession', Mock())
 @patch('sagemaker.local.image._stream_output', Mock())
 @patch('sagemaker.local.image._SageMakerContainer._cleanup', Mock())
-@patch('sagemaker.local.data.get_data_source_instance', Mock())
+@patch('sagemaker.local.data.get_data_source_instance')
 @patch('subprocess.Popen', Mock())
-def test_train_local_intermediate_output(tmpdir, sagemaker_session):
+def test_train_local_intermediate_output(get_data_source_instance, tmpdir, sagemaker_session):
+    data_source = Mock()
+    data_source.get_root_dir.return_value = 'foo'
+    get_data_source_instance.return_value = data_source
+
     directories = [str(tmpdir.mkdir('container-root')), str(tmpdir.mkdir('data'))]
     with patch('sagemaker.local.image._SageMakerContainer._create_tmp_folder',
                side_effect=directories):


### PR DESCRIPTION
*Description of changes:*
the unit tests were failing with Python 3.6 with:

```
E               TypeError: join() argument must be str or bytes, not 'Mock'
```

not entirely sure what changed, but the changes in this PR made them pass on my laptop

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated the [changelog](https://github.com/aws/sagemaker-python-sdk/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
