### PR TITLE
change: add pytest marks for integ tests using local mode

### DIFF
--- a/tests/integ/test_horovod.py
+++ b/tests/integ/test_horovod.py
@@ -52,6 +52,7 @@ def test_horovod(sagemaker_session, instance_type, tmpdir):
             assert read_json('rank-%s' % rank, tmp)['rank'] == rank
 
 
+@pytest.mark.local_mode
 @pytest.mark.parametrize('instances, processes', [
     [1, 2],
     (2, 1),

--- a/tests/integ/test_local_mode.py
+++ b/tests/integ/test_local_mode.py
@@ -77,6 +77,7 @@ def mxnet_model(sagemaker_local_session, mxnet_full_version):
     return _create_model
 
 
+@pytest.mark.local_mode
 @pytest.mark.skipif(PYTHON_VERSION != 'py2', reason="TensorFlow image supports only python 2.")
 def test_tf_local_mode(tf_full_version, sagemaker_local_session):
     with timeout(minutes=5):
@@ -116,6 +117,7 @@ def test_tf_local_mode(tf_full_version, sagemaker_local_session):
             estimator.delete_endpoint()
 
 
+@pytest.mark.local_mode
 @pytest.mark.skipif(PYTHON_VERSION != 'py2', reason="TensorFlow image supports only python 2.")
 def test_tf_distributed_local_mode(sagemaker_local_session):
     with timeout(minutes=5):
@@ -154,6 +156,7 @@ def test_tf_distributed_local_mode(sagemaker_local_session):
             estimator.delete_endpoint()
 
 
+@pytest.mark.local_mode
 @pytest.mark.skipif(PYTHON_VERSION != 'py2', reason="TensorFlow image supports only python 2.")
 def test_tf_local_data(sagemaker_local_session):
     with timeout(minutes=5):
@@ -191,6 +194,7 @@ def test_tf_local_data(sagemaker_local_session):
             estimator.delete_endpoint()
 
 
+@pytest.mark.local_mode
 @pytest.mark.skipif(PYTHON_VERSION != 'py2', reason="TensorFlow image supports only python 2.")
 def test_tf_local_data_local_script():
     with timeout(minutes=5):
@@ -229,6 +233,7 @@ def test_tf_local_data_local_script():
             estimator.delete_endpoint()
 
 
+@pytest.mark.local_mode
 def test_local_mode_serving_from_s3_model(sagemaker_local_session, mxnet_model, mxnet_full_version):
     path = 's3://%s' % sagemaker_local_session.default_bucket()
     s3_model = mxnet_model(path)
@@ -245,6 +250,7 @@ def test_local_mode_serving_from_s3_model(sagemaker_local_session, mxnet_model, 
                 predictor.delete_endpoint()
 
 
+@pytest.mark.local_mode
 def test_local_mode_serving_from_local_model(tmpdir, sagemaker_local_session, mxnet_model):
     predictor = None
 
@@ -261,6 +267,7 @@ def test_local_mode_serving_from_local_model(tmpdir, sagemaker_local_session, mx
                 predictor.delete_endpoint()
 
 
+@pytest.mark.local_mode
 def test_mxnet_local_mode(sagemaker_local_session, mxnet_full_version):
     script_path = os.path.join(DATA_DIR, 'mxnet_mnist', 'mnist.py')
     data_path = os.path.join(DATA_DIR, 'mxnet_mnist')
@@ -286,6 +293,7 @@ def test_mxnet_local_mode(sagemaker_local_session, mxnet_full_version):
             mx.delete_endpoint()
 
 
+@pytest.mark.local_mode
 def test_mxnet_local_data_local_script(mxnet_full_version):
     data_path = os.path.join(DATA_DIR, 'mxnet_mnist')
     script_path = os.path.join(data_path, 'mnist.py')
@@ -310,6 +318,7 @@ def test_mxnet_local_data_local_script(mxnet_full_version):
             mx.delete_endpoint()
 
 
+@pytest.mark.local_mode
 def test_local_transform_mxnet(sagemaker_local_session, tmpdir, mxnet_full_version):
     data_path = os.path.join(DATA_DIR, 'mxnet_mnist')
     script_path = os.path.join(data_path, 'mnist.py')

--- a/tests/integ/test_source_dirs.py
+++ b/tests/integ/test_source_dirs.py
@@ -14,6 +14,8 @@ from __future__ import absolute_import
 
 import os
 
+import pytest
+
 import tests.integ.local_mode_utils as local_mode_utils
 from tests.integ import DATA_DIR, PYTHON_VERSION
 

--- a/tests/integ/test_source_dirs.py
+++ b/tests/integ/test_source_dirs.py
@@ -20,6 +20,7 @@ from tests.integ import DATA_DIR, PYTHON_VERSION
 from sagemaker.pytorch.estimator import PyTorch
 
 
+@pytest.mark.local_mode
 def test_source_dirs(tmpdir, sagemaker_local_session):
     source_dir = os.path.join(DATA_DIR, 'pytorch_source_dirs')
     lib = os.path.join(str(tmpdir), 'alexa.py')


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Local mode tests are special in the integration tests since there are many restrictions for them to run in parallel. For example, there's at most one local endpoint on a single instance. So to better manage them in canary tests, this PR adds pytest mark of 'local_mode' to all integ tests using local mode.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#commit-message-guidlines)
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
