### PR TITLE
documentation: fix formatting for HyperparameterTuner.attach()

### DIFF
--- a/src/sagemaker/tuner.py
+++ b/src/sagemaker/tuner.py
@@ -282,7 +282,7 @@ class HyperparameterTuner(object):
         """Attach to an existing hyperparameter tuning job.
 
         Create a HyperparameterTuner bound to an existing hyperparameter tuning job. After attaching, if there exists a
-        best training job (or any other completed training job), that can be ``deploy()``ed to create
+        best training job (or any other completed training job), that can be ``deploy()``\ ed to create
         an Amazon SageMaker Endpoint and return a ``Predictor``.
 
         Args:

--- a/src/sagemaker/tuner.py
+++ b/src/sagemaker/tuner.py
@@ -282,7 +282,7 @@ class HyperparameterTuner(object):
         """Attach to an existing hyperparameter tuning job.
 
         Create a HyperparameterTuner bound to an existing hyperparameter tuning job. After attaching, if there exists a
-        best training job (or any other completed training job), that can be ``deploy()``\ ed to create
+        best training job (or any other completed training job), that can be deployed to create
         an Amazon SageMaker Endpoint and return a ``Predictor``.
 
         Args:


### PR DESCRIPTION

*Issue #, if available:*

The documentation at for `attach()` looks like this:

![image](https://user-images.githubusercontent.com/2398765/54869954-d8fa4380-4dda-11e9-87f9-24fbb2a4adf8.png)

I believe the intention was to only have `deploy()` highlighted.

*Description of changes:*
According to [spinx documentation](http://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html):

`it (markups) must be separated from surrounding text by non-word characters. Use a backslash escaped space to work around that: thisis\ *one*\ word.`

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#commit-message-guidlines)
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
