### PR TITLE
doc: fix typo of argument spelling in linear learner docstrings

### DIFF
--- a/src/sagemaker/amazon/linear_learner.py
+++ b/src/sagemaker/amazon/linear_learner.py
@@ -171,7 +171,7 @@ class LinearLearner(AmazonAlgorithmEstimatorBase):
             normalize_label (bool): Normalizes the regression label to have a standard deviation of 1.0.
                 If set for classification, it will be ignored.
             unbias_data (bool): If true, features are modified to have mean 0.0.
-            ubias_label (bool): If true, labels are modified to have mean 0.0.
+            unbias_label (bool): If true, labels are modified to have mean 0.0.
             num_point_for_scaler (int): The number of data points to use for calculating the normalizing  and
                 unbiasing terms.
             margin (float):  the margin for hinge_loss.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix the mis-spelling of argument unbias_label in linear learner docstrings.


## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#commit-message-guidlines)
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
