### PR TITLE
restore notebook test

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -21,12 +21,10 @@ phases:
 
       # run notebook test
       - |
-        # Temporarily disable notebook tests until we know what is wrong
-        if false; then
-        #if has-matching-changes "src/*.py" "setup.py" "setup.cfg"; then
+        if has-matching-changes "src/*.py" "setup.py" "setup.cfg"; then
           echo "running notebook test"
           python setup.py sdist
-          aws s3 --region us-west-2 cp ./dist/sagemaker-*.tar.gz s3://sagemaker-python-sdk-pr/
+          aws s3 --region us-west-2 cp ./dist/sagemaker-*.tar.gz s3://sagemaker-python-sdk-pr/sagemaker.tar.gz
           aws s3 cp s3://sagemaker-mead-cli/mead-nb-test.tar.gz mead-nb-test.tar.gz
           tar -xzf mead-nb-test.tar.gz
           git clone --depth 1 https://github.com/awslabs/amazon-sagemaker-examples.git
@@ -47,7 +45,8 @@ phases:
       # run integration tests
       - |
         if has-matching-changes "tests/" "src/*.py" "setup.py" "setup.cfg"; then
-          IGNORE_COVERAGE=- tox -e py27,py36 -- tests/integ -n 24 --boxed --reruns 2
+          IGNORE_COVERAGE=- tox -e py36 -- tests/integ -n 24 --boxed --reruns 2
+          IGNORE_COVERAGE=- tox -e py27 -- tests/integ -n 24 --boxed --reruns 2
         else
           echo "skipping integration tests"
         fi


### PR DESCRIPTION
*Description of changes:*

- restore notebook test in PR builds
- also separate py27,py36 integ tests so build can fail faster

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#commit-message-guidlines)
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
