### PR TITLE
fix: use unique names for test training jobs

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -21,12 +21,10 @@ phases:
 
       # run notebook test
       - |
-        # Temporarily disable notebook tests until we know what is wrong
-        if false; then
-        #if has-matching-changes "src/*.py" "setup.py" "setup.cfg"; then
+        if has-matching-changes "src/*.py" "setup.py" "setup.cfg"; then
           echo "running notebook test"
           python setup.py sdist
-          aws s3 --region us-west-2 cp ./dist/sagemaker-*.tar.gz s3://sagemaker-python-sdk-pr/
+          aws s3 --region us-west-2 cp ./dist/sagemaker-*.tar.gz s3://sagemaker-python-sdk-pr/sagemaker.tar.gz
           aws s3 cp s3://sagemaker-mead-cli/mead-nb-test.tar.gz mead-nb-test.tar.gz
           tar -xzf mead-nb-test.tar.gz
           git clone --depth 1 https://github.com/awslabs/amazon-sagemaker-examples.git
@@ -47,7 +45,8 @@ phases:
       # run integration tests
       - |
         if has-matching-changes "tests/" "src/*.py" "setup.py" "setup.cfg"; then
-          IGNORE_COVERAGE=- tox -e py27,py36 -- tests/integ -n 24 --boxed --reruns 2
+          IGNORE_COVERAGE=- tox -e py36 -- tests/integ -n 24 --boxed --reruns 2
+          IGNORE_COVERAGE=- tox -e py27 -- tests/integ -n 24 --boxed --reruns 2
         else
           echo "skipping integration tests"
         fi

--- a/tests/integ/test_factorization_machines.py
+++ b/tests/integ/test_factorization_machines.py
@@ -25,6 +25,8 @@ from tests.integ.timeout import timeout, timeout_and_delete_endpoint_by_name
 
 
 def test_factorization_machines(sagemaker_session):
+    job_name = unique_name_from_base('fm')
+
     with timeout(minutes=TRAINING_DEFAULT_TIMEOUT_MINUTES):
         data_path = os.path.join(DATA_DIR, 'one_p_mnist', 'mnist.pkl.gz')
         pickle_args = {} if sys.version_info.major == 2 else {'encoding': 'latin1'}
@@ -37,15 +39,16 @@ def test_factorization_machines(sagemaker_session):
                                    train_instance_type='ml.c4.xlarge',
                                    num_factors=10, predictor_type='regressor',
                                    epochs=2, clip_gradient=1e2, eps=0.001, rescale_grad=1.0 / 100,
-                                   sagemaker_session=sagemaker_session, base_job_name='test-fm')
+                                   sagemaker_session=sagemaker_session)
 
         # training labels must be 'float32'
-        fm.fit(fm.record_set(train_set[0][:200], train_set[1][:200].astype('float32')))
+        fm.fit(fm.record_set(train_set[0][:200], train_set[1][:200].astype('float32')),
+               job_name=job_name)
 
-    endpoint_name = unique_name_from_base('fm')
-    with timeout_and_delete_endpoint_by_name(endpoint_name, sagemaker_session):
-        model = FactorizationMachinesModel(fm.model_data, role='SageMakerRole', sagemaker_session=sagemaker_session)
-        predictor = model.deploy(1, 'ml.c4.xlarge', endpoint_name=endpoint_name)
+    with timeout_and_delete_endpoint_by_name(job_name, sagemaker_session):
+        model = FactorizationMachinesModel(fm.model_data, role='SageMakerRole',
+                                           sagemaker_session=sagemaker_session)
+        predictor = model.deploy(1, 'ml.c4.xlarge', endpoint_name=job_name)
         result = predictor.predict(train_set[0][:10])
 
         assert len(result) == 10
@@ -54,8 +57,7 @@ def test_factorization_machines(sagemaker_session):
 
 
 def test_async_factorization_machines(sagemaker_session):
-    training_job_name = ""
-    endpoint_name = unique_name_from_base('factorizationMachines')
+    job_name = unique_name_from_base('fm')
 
     with timeout(minutes=5):
         data_path = os.path.join(DATA_DIR, 'one_p_mnist', 'mnist.pkl.gz')
@@ -69,22 +71,23 @@ def test_async_factorization_machines(sagemaker_session):
                                    train_instance_type='ml.c4.xlarge',
                                    num_factors=10, predictor_type='regressor',
                                    epochs=2, clip_gradient=1e2, eps=0.001, rescale_grad=1.0 / 100,
-                                   sagemaker_session=sagemaker_session, base_job_name='test-fm')
+                                   sagemaker_session=sagemaker_session)
 
         # training labels must be 'float32'
-        fm.fit(fm.record_set(train_set[0][:200], train_set[1][:200].astype('float32')), wait=False)
-        training_job_name = fm.latest_training_job.name
+        fm.fit(fm.record_set(train_set[0][:200], train_set[1][:200].astype('float32')),
+               job_name=job_name,
+               wait=False)
 
         print("Detached from training job. Will re-attach in 20 seconds")
         time.sleep(20)
         print("attaching now...")
 
-    with timeout_and_delete_endpoint_by_name(endpoint_name, sagemaker_session):
-        estimator = FactorizationMachines.attach(training_job_name=training_job_name,
+    with timeout_and_delete_endpoint_by_name(job_name, sagemaker_session):
+        estimator = FactorizationMachines.attach(training_job_name=job_name,
                                                  sagemaker_session=sagemaker_session)
         model = FactorizationMachinesModel(estimator.model_data, role='SageMakerRole',
                                            sagemaker_session=sagemaker_session)
-        predictor = model.deploy(1, 'ml.c4.xlarge', endpoint_name=endpoint_name)
+        predictor = model.deploy(1, 'ml.c4.xlarge', endpoint_name=job_name)
         result = predictor.predict(train_set[0][:10])
 
         assert len(result) == 10

--- a/tests/integ/test_knn.py
+++ b/tests/integ/test_knn.py
@@ -25,6 +25,8 @@ from tests.integ.timeout import timeout, timeout_and_delete_endpoint_by_name
 
 
 def test_knn_regressor(sagemaker_session):
+    job_name = unique_name_from_base('knn')
+
     with timeout(minutes=TRAINING_DEFAULT_TIMEOUT_MINUTES):
         data_path = os.path.join(DATA_DIR, 'one_p_mnist', 'mnist.pkl.gz')
         pickle_args = {} if sys.version_info.major == 2 else {'encoding': 'latin1'}
@@ -36,15 +38,15 @@ def test_knn_regressor(sagemaker_session):
         knn = KNN(role='SageMakerRole', train_instance_count=1,
                   train_instance_type='ml.c4.xlarge',
                   k=10, predictor_type='regressor', sample_size=500,
-                  sagemaker_session=sagemaker_session, base_job_name='test-knn-rr')
+                  sagemaker_session=sagemaker_session)
 
         # training labels must be 'float32'
-        knn.fit(knn.record_set(train_set[0][:200], train_set[1][:200].astype('float32')))
+        knn.fit(knn.record_set(train_set[0][:200], train_set[1][:200].astype('float32')),
+                job_name=job_name)
 
-    endpoint_name = unique_name_from_base('knn')
-    with timeout_and_delete_endpoint_by_name(endpoint_name, sagemaker_session):
+    with timeout_and_delete_endpoint_by_name(job_name, sagemaker_session):
         model = KNNModel(knn.model_data, role='SageMakerRole', sagemaker_session=sagemaker_session)
-        predictor = model.deploy(1, 'ml.c4.xlarge', endpoint_name=endpoint_name)
+        predictor = model.deploy(1, 'ml.c4.xlarge', endpoint_name=job_name)
         result = predictor.predict(train_set[0][:10])
 
         assert len(result) == 10
@@ -53,8 +55,7 @@ def test_knn_regressor(sagemaker_session):
 
 
 def test_async_knn_classifier(sagemaker_session):
-    training_job_name = ""
-    endpoint_name = unique_name_from_base('knn')
+    job_name = unique_name_from_base('knn')
 
     with timeout(minutes=5):
         data_path = os.path.join(DATA_DIR, 'one_p_mnist', 'mnist.pkl.gz')
@@ -68,22 +69,22 @@ def test_async_knn_classifier(sagemaker_session):
                   train_instance_count=1, train_instance_type='ml.c4.xlarge',
                   k=10, predictor_type='classifier', sample_size=500,
                   index_type='faiss.IVFFlat', index_metric='L2',
-                  sagemaker_session=sagemaker_session, base_job_name='test-knn-cl')
+                  sagemaker_session=sagemaker_session)
 
         # training labels must be 'float32'
-        knn.fit(knn.record_set(train_set[0][:200], train_set[1][:200].astype('float32')), wait=False)
-        training_job_name = knn.latest_training_job.name
+        knn.fit(knn.record_set(train_set[0][:200], train_set[1][:200].astype('float32')),
+                wait=False, job_name=job_name)
 
         print("Detached from training job. Will re-attach in 20 seconds")
         time.sleep(20)
         print("attaching now...")
 
-    with timeout_and_delete_endpoint_by_name(endpoint_name, sagemaker_session):
-        estimator = KNN.attach(training_job_name=training_job_name,
+    with timeout_and_delete_endpoint_by_name(job_name, sagemaker_session):
+        estimator = KNN.attach(training_job_name=job_name,
                                sagemaker_session=sagemaker_session)
         model = KNNModel(estimator.model_data, role='SageMakerRole',
                          sagemaker_session=sagemaker_session)
-        predictor = model.deploy(1, 'ml.c4.xlarge', endpoint_name=endpoint_name)
+        predictor = model.deploy(1, 'ml.c4.xlarge', endpoint_name=job_name)
         result = predictor.predict(train_set[0][:10])
 
         assert len(result) == 10

--- a/tests/integ/test_linear_learner.py
+++ b/tests/integ/test_linear_learner.py
@@ -22,7 +22,7 @@ import numpy as np
 import pytest
 
 from sagemaker.amazon.linear_learner import LinearLearner, LinearLearnerModel
-from sagemaker.utils import unique_name_from_base, sagemaker_timestamp
+from sagemaker.utils import unique_name_from_base
 from tests.integ import DATA_DIR, TRAINING_DEFAULT_TIMEOUT_MINUTES
 from tests.integ.timeout import timeout, timeout_and_delete_endpoint_by_name
 

--- a/tests/integ/test_linear_learner.py
+++ b/tests/integ/test_linear_learner.py
@@ -123,8 +123,7 @@ def test_linear_learner_multiclass(sagemaker_session):
 
 
 def test_async_linear_learner(sagemaker_session):
-    training_job_name = ""
-    endpoint_name = 'test-linear-learner-async-{}'.format(sagemaker_timestamp())
+    job_name = unique_name_from_base('linear-learner')
 
     with timeout(minutes=TRAINING_DEFAULT_TIMEOUT_MINUTES):
         data_path = os.path.join(DATA_DIR, 'one_p_mnist', 'mnist.pkl.gz')
@@ -138,7 +137,7 @@ def test_async_linear_learner(sagemaker_session):
         train_set[1][100:200] = 0
         train_set = train_set[0], train_set[1].astype(np.dtype('float32'))
 
-        ll = LinearLearner('SageMakerRole', 1, 'ml.c4.2xlarge', base_job_name='test-linear-learner',
+        ll = LinearLearner('SageMakerRole', 1, 'ml.c4.2xlarge',
                            predictor_type='binary_classifier', sagemaker_session=sagemaker_session)
         ll.binary_classifier_model_selection_criteria = 'accuracy'
         ll.target_recall = 0.5
@@ -175,17 +174,17 @@ def test_async_linear_learner(sagemaker_session):
         ll.huber_delta = 0.1
         ll.early_stopping_tolerance = 0.0001
         ll.early_stopping_patience = 3
-        ll.fit(ll.record_set(train_set[0][:200], train_set[1][:200]), wait=False)
+        ll.fit(ll.record_set(train_set[0][:200], train_set[1][:200]), wait=False, job_name=job_name)
 
-        print("Waiting to re-attach to the training job: %s" % training_job_name)
+        print("Waiting to re-attach to the training job: %s" % job_name)
         time.sleep(20)
 
-    with timeout_and_delete_endpoint_by_name(endpoint_name, sagemaker_session):
-        estimator = LinearLearner.attach(training_job_name=training_job_name,
+    with timeout_and_delete_endpoint_by_name(job_name, sagemaker_session):
+        estimator = LinearLearner.attach(training_job_name=job_name,
                                          sagemaker_session=sagemaker_session)
         model = LinearLearnerModel(estimator.model_data, role='SageMakerRole',
                                    sagemaker_session=sagemaker_session)
-        predictor = model.deploy(1, 'ml.c4.xlarge', endpoint_name=endpoint_name)
+        predictor = model.deploy(1, 'ml.c4.xlarge', endpoint_name=job_name)
 
         result = predictor.predict(train_set[0][0:100])
         assert len(result) == 100

--- a/tests/integ/test_ntm.py
+++ b/tests/integ/test_ntm.py
@@ -27,6 +27,8 @@ from tests.integ.record_set import prepare_record_set_from_local_files
 
 @pytest.mark.canary_quick
 def test_ntm(sagemaker_session):
+    job_name = unique_name_from_base('ntm')
+
     with timeout(minutes=TRAINING_DEFAULT_TIMEOUT_MINUTES):
         data_path = os.path.join(DATA_DIR, 'ntm')
         data_filename = 'nips-train_1.pbr'
@@ -37,17 +39,18 @@ def test_ntm(sagemaker_session):
         # all records must be same
         feature_num = int(all_records[0].features['values'].float32_tensor.shape[0])
 
-        ntm = NTM(role='SageMakerRole', train_instance_count=1, train_instance_type='ml.c4.xlarge', num_topics=10,
-                  sagemaker_session=sagemaker_session, base_job_name='test-ntm')
+        ntm = NTM(role='SageMakerRole', train_instance_count=1, train_instance_type='ml.c4.xlarge',
+                  num_topics=10,
+                  sagemaker_session=sagemaker_session)
 
         record_set = prepare_record_set_from_local_files(data_path, ntm.data_location,
-                                                         len(all_records), feature_num, sagemaker_session)
-        ntm.fit(record_set, None)
+                                                         len(all_records), feature_num,
+                                                         sagemaker_session)
+        ntm.fit(records=record_set, job_name=job_name)
 
-    endpoint_name = unique_name_from_base('ntm')
-    with timeout_and_delete_endpoint_by_name(endpoint_name, sagemaker_session):
+    with timeout_and_delete_endpoint_by_name(job_name, sagemaker_session):
         model = NTMModel(ntm.model_data, role='SageMakerRole', sagemaker_session=sagemaker_session)
-        predictor = model.deploy(1, 'ml.c4.xlarge', endpoint_name=endpoint_name)
+        predictor = model.deploy(1, 'ml.c4.xlarge', endpoint_name=job_name)
 
         predict_input = np.random.rand(1, feature_num)
         result = predictor.predict(predict_input)

--- a/tests/integ/test_randomcutforest.py
+++ b/tests/integ/test_randomcutforest.py
@@ -21,21 +21,24 @@ from tests.integ.timeout import timeout, timeout_and_delete_endpoint_by_name
 
 
 def test_randomcutforest(sagemaker_session):
+    job_name = unique_name_from_base('randomcutforest')
+
     with timeout(minutes=TRAINING_DEFAULT_TIMEOUT_MINUTES):
         # Generate a thousand 14-dimensional datapoints.
         feature_num = 14
         train_input = np.random.rand(1000, feature_num)
 
-        rcf = RandomCutForest(role='SageMakerRole', train_instance_count=1, train_instance_type='ml.c4.xlarge',
-                              num_trees=50, num_samples_per_tree=20, sagemaker_session=sagemaker_session,
-                              base_job_name='test-randomcutforest')
+        rcf = RandomCutForest(role='SageMakerRole', train_instance_count=1,
+                              train_instance_type='ml.c4.xlarge',
+                              num_trees=50, num_samples_per_tree=20,
+                              sagemaker_session=sagemaker_session)
 
-        rcf.fit(rcf.record_set(train_input))
+        rcf.fit(records=rcf.record_set(train_input), job_name=job_name)
 
-    endpoint_name = unique_name_from_base('randomcutforest')
-    with timeout_and_delete_endpoint_by_name(endpoint_name, sagemaker_session):
-        model = RandomCutForestModel(rcf.model_data, role='SageMakerRole', sagemaker_session=sagemaker_session)
-        predictor = model.deploy(1, 'ml.c4.xlarge', endpoint_name=endpoint_name)
+    with timeout_and_delete_endpoint_by_name(job_name, sagemaker_session):
+        model = RandomCutForestModel(rcf.model_data, role='SageMakerRole',
+                                     sagemaker_session=sagemaker_session)
+        predictor = model.deploy(1, 'ml.c4.xlarge', endpoint_name=job_name)
 
         predict_input = np.random.rand(1, feature_num)
         result = predictor.predict(predict_input)


### PR DESCRIPTION
*Description of changes:*

- use unique names for training jobs created by integ tests. 
- fixes some transient ResourceInUse errors

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#commit-message-guidlines)
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
