### PR TITLE
change: make Local Mode export artifacts even after failure

### DIFF
--- a/src/sagemaker/local/image.py
+++ b/src/sagemaker/local/image.py
@@ -137,14 +137,15 @@ class _SageMakerContainer(object):
             # which contains the exit code and append the command line to it.
             msg = "Failed to run: %s, %s" % (compose_command, str(e))
             raise RuntimeError(msg)
+        finally:
+            artifacts = self.retrieve_artifacts(compose_data, output_data_config, job_name)
 
-        artifacts = self.retrieve_artifacts(compose_data, output_data_config, job_name)
+            # free up the training data directory as it may contain
+            # lots of data downloaded from S3. This doesn't delete any local
+            # data that was just mounted to the container.
+            dirs_to_delete = [data_dir, shared_dir]
+            self._cleanup(dirs_to_delete)
 
-        # free up the training data directory as it may contain
-        # lots of data downloaded from S3. This doesn't delete any local
-        # data that was just mounted to the container.
-        dirs_to_delete = [data_dir, shared_dir]
-        self._cleanup(dirs_to_delete)
         # Print our Job Complete line to have a similar experience to training on SageMaker where you
         # see this line at the end.
         print('===== Job Complete =====')

--- a/tests/unit/test_image.py
+++ b/tests/unit/test_image.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2017-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You
 # may not use this file except in compliance with the License. A copy of
@@ -303,10 +303,11 @@ def test_check_output():
 
 @patch('sagemaker.local.local_session.LocalSession', Mock())
 @patch('sagemaker.local.image._stream_output', Mock())
-@patch('sagemaker.local.image._SageMakerContainer._cleanup', Mock())
+@patch('sagemaker.local.image._SageMakerContainer._cleanup')
+@patch('sagemaker.local.image._SageMakerContainer.retrieve_artifacts')
 @patch('sagemaker.local.data.get_data_source_instance')
 @patch('subprocess.Popen')
-def test_train(popen, get_data_source_instance, tmpdir, sagemaker_session):
+def test_train(popen, get_data_source_instance, retrieve_artifacts, cleanup, tmpdir, sagemaker_session):
     data_source = Mock()
     data_source.get_root_dir.return_value = 'foo'
     get_data_source_instance.return_value = data_source
@@ -342,6 +343,9 @@ def test_train(popen, get_data_source_instance, tmpdir, sagemaker_session):
         assert os.path.exists(os.path.join(sagemaker_container.container_root, 'output'))
         assert os.path.exists(os.path.join(sagemaker_container.container_root, 'output/data'))
 
+    retrieve_artifacts.assert_called_once()
+    cleanup.assert_called_once()
+
 
 @patch('sagemaker.local.local_session.LocalSession', Mock())
 @patch('sagemaker.local.image._stream_output', Mock())
@@ -371,10 +375,11 @@ def test_train_with_hyperparameters_without_job_name(get_data_source_instance, t
 
 @patch('sagemaker.local.local_session.LocalSession', Mock())
 @patch('sagemaker.local.image._stream_output', side_effect=RuntimeError('this is expected'))
-@patch('sagemaker.local.image._SageMakerContainer._cleanup', Mock())
+@patch('sagemaker.local.image._SageMakerContainer._cleanup')
+@patch('sagemaker.local.image._SageMakerContainer.retrieve_artifacts')
 @patch('sagemaker.local.data.get_data_source_instance')
 @patch('subprocess.Popen', Mock())
-def test_train_error(get_data_source_instance, _stream_output, tmpdir, sagemaker_session):
+def test_train_error(get_data_source_instance, retrieve_artifacts, cleanup, _stream_output, tmpdir, sagemaker_session):
     data_source = Mock()
     data_source.get_root_dir.return_value = 'foo'
     get_data_source_instance.return_value = data_source
@@ -390,6 +395,9 @@ def test_train_error(get_data_source_instance, _stream_output, tmpdir, sagemaker
                 INPUT_DATA_CONFIG, OUTPUT_DATA_CONFIG, HYPERPARAMETERS, TRAINING_JOB_NAME)
 
         assert 'this is expected' in str(e)
+
+    retrieve_artifacts.assert_called_once()
+    cleanup.assert_called_once()
 
 
 @patch('sagemaker.local.local_session.LocalSession', Mock())


### PR DESCRIPTION
*Issue #, if available:*
see code comments in https://github.com/aws/sagemaker-chainer-container/pull/76 and https://github.com/aws/sagemaker-pytorch-container/pull/88

*Description of changes:*
SageMaker Training exports model/output artifacts even when the training job fails (though it didn't when Local Mode was initially released). This change makes Local Mode emulate that behavior.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#commit-message-guidlines)
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
