### PR TITLE
fix: skip p2 test of tf script mode in regions without p2 instances

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,8 +29,8 @@ def read_version():
 
 # Declare minimal set for installation
 required_packages = ['boto3>=1.9.64', 'numpy>=1.9.0', 'protobuf>=3.1', 'scipy>=0.19.0',
-                     'urllib3>=1.21', 'protobuf3-to-dict>=0.1.5', 'docker-compose>=1.23.0',
-                     'requests>=2.20.0, <2.21', 'urllib3<1.25']
+                     'urllib3>=1.21, <1.25', 'protobuf3-to-dict>=0.1.5', 'docker-compose>=1.23.0',
+                     'requests>=2.20.0, <2.21']
 
 # enum is introduced in Python 3.4. Installing enum back port
 if sys.version_info < (3, 4):

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ def read_version():
 # Declare minimal set for installation
 required_packages = ['boto3>=1.9.64', 'numpy>=1.9.0', 'protobuf>=3.1', 'scipy>=0.19.0',
                      'urllib3>=1.21', 'protobuf3-to-dict>=0.1.5', 'docker-compose>=1.23.0',
-                     'requests>=2.20.0, <2.21']
+                     'requests>=2.20.0, <2.21', 'urllib3<1.25']
 
 # enum is introduced in Python 3.4. Installing enum back port
 if sys.version_info < (3, 4):

--- a/tests/integ/test_tf_script_mode.py
+++ b/tests/integ/test_tf_script_mode.py
@@ -40,6 +40,8 @@ def instance_type(request):
     return request.param
 
 
+@pytest.mark.skipif(integ.test_region() in integ.HOSTING_NO_P2_REGIONS,
+                    reason='no ml.p2 instances in these regions')
 @pytest.mark.skipif(integ.PYTHON_VERSION != 'py3', reason="Script Mode tests are only configured to run with Python 3")
 def test_mnist(sagemaker_session, instance_type):
     estimator = TensorFlow(entry_point=SCRIPT,

--- a/tests/unit/test_predictor.py
+++ b/tests/unit/test_predictor.py
@@ -249,7 +249,7 @@ def test_npy_serializer_object():
 
     result = npy_serializer(object)
 
-    assert np.array_equal(np.array(object), np.load(io.BytesIO(result)))
+    assert np.array_equal(np.array(object), np.load(io.BytesIO(result), allow_pickle=True))
 
 
 def test_npy_serializer_list_of_empty():


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#commit-message-guidlines)
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
