### PR TITLE
change: add KMS key option for Endpoint Configs

### DIFF
--- a/src/sagemaker/model.py
+++ b/src/sagemaker/model.py
@@ -235,8 +235,8 @@ class Model(object):
                 If True, this will deploy a new EndpointConfig to an already existing endpoint and delete resources
                 corresponding to the previous EndpointConfig. If False, a new endpoint will be created. Default: False
             tags(List[dict[str, str]]): The list of tags to attach to this specific endpoint.
-            kms_key (str): The KMS key that is used to encrypt the data on the storage volume attached
-                to the instance hosting the endpoint.
+            kms_key (str): The ARN of the KMS key that is used to encrypt the data on the
+                storage volume attached to the instance hosting the endpoint.
 
         Returns:
             callable[string, sagemaker.session.Session] or None: Invocation of ``self.predictor_cls`` on

--- a/src/sagemaker/model.py
+++ b/src/sagemaker/model.py
@@ -209,7 +209,7 @@ class Model(object):
         return self
 
     def deploy(self, initial_instance_count, instance_type, accelerator_type=None, endpoint_name=None,
-               update_endpoint=False, tags=None):
+               update_endpoint=False, tags=None, kms_key=None):
         """Deploy this ``Model`` to an ``Endpoint`` and optionally return a ``Predictor``.
 
         Create a SageMaker ``Model`` and ``EndpointConfig``, and deploy an ``Endpoint`` from this ``Model``.
@@ -235,6 +235,8 @@ class Model(object):
                 If True, this will deploy a new EndpointConfig to an already existing endpoint and delete resources
                 corresponding to the previous EndpointConfig. If False, a new endpoint will be created. Default: False
             tags(List[dict[str, str]]): The list of tags to attach to this specific endpoint.
+            kms_key (str): The KMS key that is used to encrypt the data on the storage volume attached
+                to the instance hosting the endpoint.
 
         Returns:
             callable[string, sagemaker.session.Session] or None: Invocation of ``self.predictor_cls`` on
@@ -270,10 +272,12 @@ class Model(object):
                 initial_instance_count=initial_instance_count,
                 instance_type=instance_type,
                 accelerator_type=accelerator_type,
-                tags=tags)
+                tags=tags,
+                kms_key=kms_key)
             self.sagemaker_session.update_endpoint(self.endpoint_name, endpoint_config_name)
         else:
-            self.sagemaker_session.endpoint_from_production_variants(self.endpoint_name, [production_variant], tags)
+            self.sagemaker_session.endpoint_from_production_variants(self.endpoint_name, [production_variant],
+                                                                     tags, kms_key)
 
         if self.predictor_cls:
             return self.predictor_cls(self.endpoint_name, self.sagemaker_session)

--- a/tests/integ/kms_utils.py
+++ b/tests/integ/kms_utils.py
@@ -101,12 +101,15 @@ def _add_role_to_policy(kms_client,
                                   Policy=KEY_POLICY.format(id=POLICY_NAME, principal=principal))
 
 
-def get_or_create_kms_key(kms_client,
-                          account_id,
+def get_or_create_kms_key(sagemaker_session,
                           role_arn=None,
                           alias=KEY_ALIAS,
                           sagemaker_role='SageMakerRole'):
+    kms_client = sagemaker_session.boto_session.client('kms')
     kms_key_arn = _get_kms_key_arn(kms_client, alias)
+
+    sts_client = sagemaker_session.boto_session.client('sts')
+    account_id = sts_client.get_caller_identity()['Account']
 
     if kms_key_arn is None:
         return _create_kms_key(kms_client, account_id, role_arn, sagemaker_role, alias)

--- a/tests/integ/test_mxnet_train.py
+++ b/tests/integ/test_mxnet_train.py
@@ -79,7 +79,7 @@ def test_deploy_model(mxnet_training_job, sagemaker_session, mxnet_full_version)
         assert 'Could not find model' in str(exception.value)
 
 
-def test_deploy_model_with_tags(mxnet_training_job, sagemaker_session, mxnet_full_version):
+def test_deploy_model_with_tags_and_kms(mxnet_training_job, sagemaker_session, mxnet_full_version):
     endpoint_name = 'test-mxnet-deploy-model-{}'.format(sagemaker_timestamp())
 
     with timeout_and_delete_endpoint_by_name(endpoint_name, sagemaker_session):
@@ -89,8 +89,11 @@ def test_deploy_model_with_tags(mxnet_training_job, sagemaker_session, mxnet_ful
         model = MXNetModel(model_data, 'SageMakerRole', entry_point=script_path,
                            py_version=PYTHON_VERSION, sagemaker_session=sagemaker_session,
                            framework_version=mxnet_full_version)
+
         tags = [{'Key': 'TagtestKey', 'Value': 'TagtestValue'}]
-        model.deploy(1, 'ml.m4.xlarge', endpoint_name=endpoint_name, tags=tags)
+        kms_key_arn = get_or_create_kms_key(sagemaker_session)
+
+        model.deploy(1, 'ml.m4.xlarge', endpoint_name=endpoint_name, tags=tags, kms_key=kms_key_arn)
 
         returned_model = sagemaker_session.describe_model(EndpointName=model.name)
         returned_model_tags = sagemaker_session.list_tags(ResourceArn=returned_model['ModelArn'])['Tags']
@@ -108,29 +111,6 @@ def test_deploy_model_with_tags(mxnet_training_job, sagemaker_session, mxnet_ful
         assert endpoint_tags == tags
         assert production_variants[0]['InstanceType'] == 'ml.m4.xlarge'
         assert production_variants[0]['InitialInstanceCount'] == 1
-
-
-def test_deploy_model_with_kms_key(mxnet_training_job, sagemaker_session, mxnet_full_version):
-    endpoint_name = 'test-mxnet-deploy-model-{}'.format(sagemaker_timestamp())
-
-    with timeout_and_delete_endpoint_by_name(endpoint_name, sagemaker_session):
-        desc = sagemaker_session.sagemaker_client.describe_training_job(TrainingJobName=mxnet_training_job)
-        model_data = desc['ModelArtifacts']['S3ModelArtifacts']
-        script_path = os.path.join(DATA_DIR, 'mxnet_mnist', 'mnist.py')
-        model = MXNetModel(model_data, 'SageMakerRole', entry_point=script_path,
-                           py_version=PYTHON_VERSION, sagemaker_session=sagemaker_session,
-                           framework_version=mxnet_full_version)
-
-        sts_client = sagemaker_session.boto_session.client('sts')
-        account_id = sts_client.get_caller_identity()['Account']
-        kms_client = sagemaker_session.boto_session.client('kms')
-        kms_key_arn = get_or_create_kms_key(kms_client, account_id)
-
-        model.deploy(1, 'ml.m4.xlarge', endpoint_name=endpoint_name, kms_key=kms_key_arn)
-
-        endpoint = sagemaker_session.describe_endpoint(EndpointName=endpoint_name)
-        endpoint_config = sagemaker_session.describe_endpoint_config(EndpointConfigName=endpoint['EndpointConfigName'])
-
         assert endpoint_config['KmsKeyId'] == kms_key_arn
 
 

--- a/tests/integ/test_transformer.py
+++ b/tests/integ/test_transformer.py
@@ -50,10 +50,7 @@ def test_transform_mxnet(sagemaker_session, mxnet_full_version):
     transform_input = mx.sagemaker_session.upload_data(path=transform_input_path,
                                                        key_prefix=transform_input_key_prefix)
 
-    sts_client = sagemaker_session.boto_session.client('sts')
-    account_id = sts_client.get_caller_identity()['Account']
-    kms_client = sagemaker_session.boto_session.client('kms')
-    kms_key_arn = get_or_create_kms_key(kms_client, account_id)
+    kms_key_arn = get_or_create_kms_key(sagemaker_session)
 
     transformer = _create_transformer_and_transform_job(mx, transform_input, kms_key_arn)
     with timeout_and_delete_model_with_transformer(transformer, sagemaker_session,

--- a/tests/unit/test_estimator.py
+++ b/tests/unit/test_estimator.py
@@ -902,7 +902,8 @@ def test_fit_deploy_keep_tags(sagemaker_session):
     job_name = estimator._current_job_name
     sagemaker_session.endpoint_from_production_variants.assert_called_with(job_name,
                                                                            variant,
-                                                                           tags)
+                                                                           tags,
+                                                                           None)
 
     sagemaker_session.create_model.assert_called_with(
         ANY,


### PR DESCRIPTION
*Description of changes:*
This change exposes the option of using a KMS key to encrypt the instance hosting a SageMaker Endpoint.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#commit-message-guidlines)
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
