### PR TITLE
fix airflow.py HyperParameterTuningJobConfig

### DIFF
--- a/src/sagemaker/workflow/airflow.py
+++ b/src/sagemaker/workflow/airflow.py
@@ -263,6 +263,7 @@ def tuning_config(tuner, inputs, job_name=None):
                 'MaxParallelTrainingJobs': tuner.max_parallel_jobs,
             },
             'ParameterRanges': tuner.hyperparameter_ranges(),
+            'TrainingJobEarlyStoppingType': tuner.early_stopping_type
         },
         'TrainingJobDefinition': train_config
     }

--- a/tests/unit/test_airflow.py
+++ b/tests/unit/test_airflow.py
@@ -513,7 +513,8 @@ def test_framework_tuning_config(sagemaker_session):
                     'MinValue': '10',
                     'MaxValue': '50',
                     'ScalingType': 'Auto'
-                }]
+                }],
+            'TrainingJobEarlyStoppingType': 'Off' 
             }},
         'TrainingJobDefinition': {
             'AlgorithmSpecification': {


### PR DESCRIPTION
*Description of changes:*
Include the `TrainingJobEarlyStoppingType` as another key from `HyperParameterTuningJobConfig`. This seems to be missing.
## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#commit-message-guidlines)
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
