### PR TITLE
feature: sts endpoint support

### DIFF
--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -173,7 +173,7 @@ class Session(object):
 
         Args:
             sts_endpoint_url (str): Optional. URL of STS endpoint to send requests to. If not specified,
-                the global endpoint will be used (sts.amazonaws.com). Should be in the format of 
+                the global endpoint will be used (sts.amazonaws.com). Should be in the format of
                 sts.<region>.amazonaws.com
 
         Returns:

--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -171,6 +171,10 @@ class Session(object):
     def default_bucket(self, sts_endpoint_url=None):
         """Return the name of the default bucket to use in relevant Amazon SageMaker interactions.
 
+        Args:
+            sts_endpoint_url (str): Optional. URL of STS endpoint to send requests to. If not specified, 
+            the global endpoint will be used (sts.amazonaws.com).
+
         Returns:
             str: The name of the default bucket, which is of the form: ``sagemaker-{region}-{AWS account ID}``.
         """
@@ -1086,6 +1090,11 @@ class Session(object):
 
     def get_caller_identity_arn(self, sts_endpoint_url=None):
         """Returns the ARN user or role whose credentials are used to call the API.
+
+        Args:
+            sts_endpoint_url (str): Optional. URL of STS endpoint to send requests to. If not specified, 
+            the global endpoint will be used (sts.amazonaws.com).
+            
         Returns:
             (str): The ARN user or role
         """
@@ -1303,6 +1312,9 @@ def get_execution_role(sagemaker_session=None, sts_endpoint_url=None):
     Throws an exception if
     Args:
         sagemaker_session(Session): Current sagemaker session
+        sts_endpoint_url (str): Optional. URL of STS endpoint to send requests to. If not specified, 
+            the global endpoint will be used (sts.amazonaws.com).
+
     Returns:
         (str): The role ARN
     """

--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -172,7 +172,7 @@ class Session(object):
         """Return the name of the default bucket to use in relevant Amazon SageMaker interactions.
 
         Args:
-            sts_endpoint_url (str): Optional. URL of STS endpoint to send requests to. If not specified, 
+            sts_endpoint_url (str): Optional. URL of STS endpoint to send requests to. If not specified,
             the global endpoint will be used (sts.amazonaws.com).
 
         Returns:
@@ -1092,9 +1092,9 @@ class Session(object):
         """Returns the ARN user or role whose credentials are used to call the API.
 
         Args:
-            sts_endpoint_url (str): Optional. URL of STS endpoint to send requests to. If not specified, 
+            sts_endpoint_url (str): Optional. URL of STS endpoint to send requests to. If not specified,
             the global endpoint will be used (sts.amazonaws.com).
-            
+
         Returns:
             (str): The ARN user or role
         """
@@ -1312,7 +1312,7 @@ def get_execution_role(sagemaker_session=None, sts_endpoint_url=None):
     Throws an exception if
     Args:
         sagemaker_session(Session): Current sagemaker session
-        sts_endpoint_url (str): Optional. URL of STS endpoint to send requests to. If not specified, 
+        sts_endpoint_url (str): Optional. URL of STS endpoint to send requests to. If not specified,
             the global endpoint will be used (sts.amazonaws.com).
 
     Returns:

--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -1312,8 +1312,8 @@ def get_execution_role(sagemaker_session=None, sts_endpoint_url=None):
     Throws an exception if
     Args:
         sagemaker_session(Session): Current sagemaker session
-        sts_endpoint_url (str): Optional. URL of STS endpoint to send requests to. If not specified,
-            the global endpoint will be used (sts.amazonaws.com).
+        sts_endpoint_url (str): Optional. URL of STS endpoint to send requests to. If not specified, 
+        the global endpoint will be used (sts.amazonaws.com).
 
     Returns:
         (str): The role ARN

--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -173,7 +173,7 @@ class Session(object):
 
         Args:
             sts_endpoint_url (str): Optional. URL of STS endpoint to send requests to. If not specified,
-            the global endpoint will be used (sts.amazonaws.com).
+                the global endpoint will be used (sts.amazonaws.com).
 
         Returns:
             str: The name of the default bucket, which is of the form: ``sagemaker-{region}-{AWS account ID}``.
@@ -1093,7 +1093,7 @@ class Session(object):
 
         Args:
             sts_endpoint_url (str): Optional. URL of STS endpoint to send requests to. If not specified,
-            the global endpoint will be used (sts.amazonaws.com).
+                the global endpoint will be used (sts.amazonaws.com).
 
         Returns:
             (str): The ARN user or role

--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -173,7 +173,7 @@ class Session(object):
 
         Args:
             sts_endpoint_url (str): Optional. URL of STS endpoint to send requests to. If not specified,
-                the global endpoint will be used (sts.amazonaws.com).
+                the global endpoint will be used (sts.amazonaws.com). Should be in the format of sts.<region>.amazonaws.com
 
         Returns:
             str: The name of the default bucket, which is of the form: ``sagemaker-{region}-{AWS account ID}``.

--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -1312,7 +1312,7 @@ def get_execution_role(sagemaker_session=None, sts_endpoint_url=None):
     Throws an exception if
     Args:
         sagemaker_session(Session): Current sagemaker session
-        sts_endpoint_url (str): Optional. URL of STS endpoint to send requests to. If not specified, 
+        sts_endpoint_url (str): Optional. URL of STS endpoint to send requests to. If not specified,
         the global endpoint will be used (sts.amazonaws.com).
 
     Returns:

--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -180,8 +180,10 @@ class Session(object):
         """
         if self._default_bucket:
             return self._default_bucket
-
-        account = self.boto_session.client('sts', endpoint_url=sts_endpoint_url).get_caller_identity()['Account']
+        if not sts_endpoint_url:
+            account = self.boto_session.client('sts').get_caller_identity()['Account']
+        else:
+            account = self.boto_session.client('sts', endpoint_url=sts_endpoint_url).get_caller_identity()['Account']
         region = self.boto_session.region_name
         default_bucket = 'sagemaker-{}-{}'.format(region, account)
 

--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -173,7 +173,8 @@ class Session(object):
 
         Args:
             sts_endpoint_url (str): Optional. URL of STS endpoint to send requests to. If not specified,
-                the global endpoint will be used (sts.amazonaws.com). Should be in the format of sts.<region>.amazonaws.com
+                the global endpoint will be used (sts.amazonaws.com). Should be in the format of 
+                sts.<region>.amazonaws.com
 
         Returns:
             str: The name of the default bucket, which is of the form: ``sagemaker-{region}-{AWS account ID}``.

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -53,6 +53,14 @@ def test_get_execution_role():
     assert actual == 'arn:aws:iam::369233609183:role/SageMakerRole'
 
 
+def test_get_execution_role_with_sts_endpoint():
+    session = Mock()
+    session.get_caller_identity_arn.return_value = 'arn:aws:iam::369233609183:role/SageMakerRole'
+
+    actual = get_execution_role(session, sts_endpoint_url='https://sts.us-west-2.amazonaws.com')
+    assert actual == 'arn:aws:iam::369233609183:role/SageMakerRole'
+
+    
 def test_get_execution_role_works_with_service_role():
     session = Mock()
     session.get_caller_identity_arn.return_value = \

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -60,7 +60,7 @@ def test_get_execution_role_with_sts_endpoint():
     actual = get_execution_role(session, sts_endpoint_url='https://sts.us-west-2.amazonaws.com')
     assert actual == 'arn:aws:iam::369233609183:role/SageMakerRole'
 
-    
+
 def test_get_execution_role_works_with_service_role():
     session = Mock()
     session.get_caller_identity_arn.return_value = \


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Added the ability to pass an optional STS endpoint URL. This optional STS url allows the override of the global endpoint for regional ones.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#commit-message-guidlines)
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
