### PR TITLE
fix: TF estimator s3 requirements file validation

### DIFF
--- a/src/sagemaker/tensorflow/estimator.py
+++ b/src/sagemaker/tensorflow/estimator.py
@@ -283,6 +283,9 @@ class TensorFlow(Framework):
         if not self.source_dir:
             raise ValueError('Must specify source_dir along with a requirements file.')
 
+        if self.source_dir.lower().startswith('s3://'):
+            return
+
         if os.path.isabs(requirements_file):
             raise ValueError('Requirements file {} is not a path relative to source_dir.'.format(
                 requirements_file))


### PR DESCRIPTION
*Issue #, if available:* #669 

*Description of changes:* skip the local path validation if source_dir is an S3 location

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#commit-message-guidlines)
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
