### PR TITLE
Add ability to serve py3 model

### DIFF
--- a/src/sagemaker/tensorflow/serving.py
+++ b/src/sagemaker/tensorflow/serving.py
@@ -102,7 +102,7 @@ class Model(sagemaker.model.FrameworkModel):
     }
 
     def __init__(self, model_data, role, entry_point=None, image=None, framework_version=TF_VERSION,
-                 container_log_level=None, predictor_cls=Predictor, **kwargs):
+                 container_log_level=None, predictor_cls=Predictor, py_version='py2', **kwargs):
         """Initialize a Model.
 
        Args:
@@ -117,12 +117,15 @@ class Model(sagemaker.model.FrameworkModel):
            predictor_cls (callable[str, sagemaker.session.Session]): A function to call to create a
                 predictor with an endpoint name and SageMaker ``Session``. If specified, ``deploy()``
                 returns the result of invoking this function on the created endpoint name.
+           entry_point (str): Optional. Python script for pre/post-processing.
+           py_version (str): The string 'py2' or 'py3' (default: 'py2')
            **kwargs: Keyword arguments passed to the ``Model`` initializer.
        """
         super(Model, self).__init__(model_data=model_data, role=role, image=image,
                                     predictor_cls=predictor_cls, entry_point=entry_point, **kwargs)
         self._framework_version = framework_version
         self._container_log_level = container_log_level
+        self._py_version = py_version
 
     def prepare_container_def(self, instance_type, accelerator_type=None):
         image = self._get_image_uri(instance_type, accelerator_type)
@@ -163,4 +166,4 @@ class Model(sagemaker.model.FrameworkModel):
 
         region_name = self.sagemaker_session.boto_region_name
         return create_image_uri(region_name, Model.FRAMEWORK_NAME, instance_type,
-                                self._framework_version, accelerator_type=accelerator_type)
+                                self._framework_version, accelerator_type=accelerator_type, py_version=self._py_version)

--- a/tests/unit/test_tfs.py
+++ b/tests/unit/test_tfs.py
@@ -71,7 +71,7 @@ def test_tfs_model(sagemaker_session, tf_version):
     model = Model("s3://some/data.tar.gz", role=ROLE, framework_version=tf_version,
                   sagemaker_session=sagemaker_session)
     cdef = model.prepare_container_def(INSTANCE_TYPE)
-    assert cdef['Image'].endswith('sagemaker-tensorflow-serving:{}-cpu'.format(tf_version))
+    assert cdef['Image'].endswith('sagemaker-tensorflow-serving:{}-cpu-py2'.format(tf_version))
     assert cdef['Environment'] == {}
 
     predictor = model.deploy(INSTANCE_COUNT, INSTANCE_TYPE)
@@ -82,7 +82,7 @@ def test_tfs_model_image_accelerator(sagemaker_session, tf_version):
     model = Model("s3://some/data.tar.gz", role=ROLE, framework_version=tf_version,
                   sagemaker_session=sagemaker_session)
     cdef = model.prepare_container_def(INSTANCE_TYPE, accelerator_type=ACCELERATOR_TYPE)
-    assert cdef['Image'].endswith('sagemaker-tensorflow-serving-eia:{}-cpu'.format(tf_version))
+    assert cdef['Image'].endswith('sagemaker-tensorflow-serving-eia:{}-cpu-py2'.format(tf_version))
 
     predictor = model.deploy(INSTANCE_COUNT, INSTANCE_TYPE)
     assert isinstance(predictor, Predictor)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Added documentation for `entry_point` and added class variable `_py_version` corresponding to kwarg `py_version` to feed into `create_image_uri`

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#commit-message-guidlines)
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
