### PR TITLE
change: downgrade c5 in integ tests and test all TF Script Mode images

### DIFF
--- a/tests/integ/test_horovod.py
+++ b/tests/integ/test_horovod.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2017-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You
 # may not use this file except in compliance with the License. A copy of
@@ -29,7 +29,7 @@ horovod_dir = os.path.join(os.path.dirname(__file__), '..', 'data', 'horovod')
 
 
 @pytest.fixture(scope='session', params=[
-    'ml.c5.xlarge',
+    'ml.c4.xlarge',
     pytest.param('ml.p3.2xlarge',
                  marks=pytest.mark.skipif(
                      test_region() in HOSTING_NO_P3_REGIONS,

--- a/tests/integ/test_tf_script_mode.py
+++ b/tests/integ/test_tf_script_mode.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2017-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You
 # may not use this file except in compliance with the License. A copy of
@@ -39,7 +39,7 @@ TAGS = [{'Key': 'some-key', 'Value': 'some-value'}]
 
 
 @pytest.fixture(scope='session', params=[
-    'ml.c5.xlarge',
+    'ml.c4.xlarge',
     pytest.param('ml.p2.xlarge',
                  marks=pytest.mark.skipif(
                      tests.integ.test_region() in tests.integ.HOSTING_NO_P2_REGIONS
@@ -49,15 +49,13 @@ def instance_type(request):
     return request.param
 
 
-@pytest.mark.skipif(tests.integ.PYTHON_VERSION != 'py3',
-                    reason="Script Mode tests are only configured to run with Python 3")
 def test_mnist(sagemaker_session, instance_type):
     estimator = TensorFlow(entry_point=SCRIPT,
                            role='SageMakerRole',
                            train_instance_count=1,
                            train_instance_type=instance_type,
                            sagemaker_session=sagemaker_session,
-                           py_version='py3',
+                           script_mode=True,
                            framework_version=TensorFlow.LATEST_VERSION,
                            metric_definitions=[
                                {'Name': 'train:global_steps', 'Regex': r'global_step\/sec:\s(.*)'}])
@@ -85,7 +83,7 @@ def test_server_side_encryption(sagemaker_session):
                                train_instance_count=1,
                                train_instance_type='ml.c5.xlarge',
                                sagemaker_session=sagemaker_session,
-                               py_version='py3',
+                               script_mode=True,
                                framework_version=TensorFlow.LATEST_VERSION,
                                code_location=output_path,
                                output_path=output_path,
@@ -102,8 +100,6 @@ def test_server_side_encryption(sagemaker_session):
 
 
 @pytest.mark.canary_quick
-@pytest.mark.skipif(tests.integ.PYTHON_VERSION != 'py3',
-                    reason="Script Mode tests are only configured to run with Python 3")
 def test_mnist_distributed(sagemaker_session, instance_type):
     estimator = TensorFlow(entry_point=SCRIPT,
                            role=ROLE,
@@ -130,7 +126,7 @@ def test_mnist_async(sagemaker_session):
                            train_instance_count=1,
                            train_instance_type='ml.c5.4xlarge',
                            sagemaker_session=sagemaker_session,
-                           py_version='py3',
+                           script_mode=True,
                            framework_version=TensorFlow.LATEST_VERSION,
                            tags=TAGS)
     inputs = estimator.sagemaker_session.upload_data(
@@ -155,8 +151,6 @@ def test_mnist_async(sagemaker_session):
                                  estimator.latest_training_job.name, TAGS)
 
 
-@pytest.mark.skipif(tests.integ.PYTHON_VERSION != 'py3',
-                    reason="Script Mode tests are only configured to run with Python 3")
 def test_deploy_with_input_handlers(sagemaker_session, instance_type):
     estimator = TensorFlow(entry_point='inference.py',
                            source_dir=TFS_RESOURCE_PATH,
@@ -164,7 +158,7 @@ def test_deploy_with_input_handlers(sagemaker_session, instance_type):
                            train_instance_count=1,
                            train_instance_type=instance_type,
                            sagemaker_session=sagemaker_session,
-                           py_version='py3',
+                           script_mode=True,
                            framework_version=TensorFlow.LATEST_VERSION,
                            tags=TAGS)
 


### PR DESCRIPTION
*Description of changes:*
* our continuous testing has seen some issues with insufficient capacity errors for c5s in certain regions. Hoping that downgrading to c4 will help. I ran the Horovod test to make sure that changing the instance type wouldn't negatively impact the test duration, and with the c4, `pytest tests/integ/test_horovod.py::test_horovod` went from 517.67 seconds _down_ to 464.24 seconds.
* the TF Script Mode tests have been restricted to testing only the Python 3 images even though we have images for both Python 2 and Python 3. There's no reason to not test half the images we support with the tests in this suite when other tests are set up to test both Python versions.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#commit-message-guidlines)
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
