### PR TITLE
change: correct code per len-as-condition Pylint check

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -82,7 +82,7 @@ disable=
     invalid-name,
     too-many-instance-attributes,
     line-too-long, # We let Flake8 take care of this # TODO: Fix these and stop relying on flake8
-    len-as-condition, # TODO: Use if seq: and if not seq: instead
+    len-as-condition, # TODO: Enable this check once pylint 2.4.0 is released and consumed due to the fix in https://github.com/PyCQA/pylint/issues/2684
     logging-format-interpolation, # TODO: Fix logging so as to remove this.
     import-error, # TODO: Fix import errors
     logging-not-lazy, # TODO: Fix logging

--- a/src/sagemaker/predictor.py
+++ b/src/sagemaker/predictor.py
@@ -195,7 +195,7 @@ class _CsvSerializer(object):
         if isinstance(data, np.ndarray):
             data = np.ndarray.flatten(data)
         if hasattr(data, "__len__"):
-            if len(data):
+            if len(data) > 0:
                 return _csv_serialize_python_array(data)
             else:
                 raise ValueError("Cannot serialize empty array")


### PR DESCRIPTION
The Pylint check is not actually enabled in this commit as it conflicts
directly with NumPy. Pylint has corrected this, and it will be included
in their next release (2.4.0):
https://github.com/PyCQA/pylint/issues/2684

Once Pylint 2.4.0 is released, we can consume it and remove this check.
A summary of this information is included in a TODO near the relevant
Pylint disable rule (len-as-condition).

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [X] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [X] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#commit-message-guidlines)
- [X] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [X] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
