### PR TITLE
change: enable signature-differs pylint check

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -88,7 +88,6 @@ disable=
     attribute-defined-outside-init, # TODO: Fix scope
     protected-access, # TODO: Fix access
     abstract-method, # TODO: Fix abstract methods
-    signature-differs, # TODO: Fix signature overrides
     unidiomatic-typecheck, # TODO: Fix typechecks
     wrong-import-order, # TODO: Fix import order
     no-else-return, # TODO: Remove unnecessary elses

--- a/src/sagemaker/amazon/lda.py
+++ b/src/sagemaker/amazon/lda.py
@@ -120,7 +120,9 @@ class LDA(AmazonAlgorithmEstimatorBase):
             vpc_config=self.get_vpc_config(vpc_config_override),
         )
 
-    def _prepare_for_training(self, records, mini_batch_size, job_name=None):
+    def _prepare_for_training(  # pylint: disable=signature-differs
+        self, records, mini_batch_size, job_name=None
+    ):
         # mini_batch_size is required, prevent explicit calls with None
         if mini_batch_size is None:
             raise ValueError("mini_batch_size must be set")

--- a/src/sagemaker/amazon/ntm.py
+++ b/src/sagemaker/amazon/ntm.py
@@ -151,7 +151,9 @@ class NTM(AmazonAlgorithmEstimatorBase):
             vpc_config=self.get_vpc_config(vpc_config_override),
         )
 
-    def _prepare_for_training(self, records, mini_batch_size, job_name=None):
+    def _prepare_for_training(  # pylint: disable=signature-differs
+        self, records, mini_batch_size, job_name=None
+    ):
         if mini_batch_size is not None and (mini_batch_size < 1 or mini_batch_size > 10000):
             raise ValueError("mini_batch_size must be in [1, 10000]")
         super(NTM, self)._prepare_for_training(


### PR DESCRIPTION
I think the design choice to keep the additional parameter out of the top-most superclass makes sense, and that this pylint check should be overridden for this particular use-case.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [X] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [X] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#commit-message-guidlines)
- [X] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [X] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
