### PR TITLE
change: remove TODO comment on import-error Pylint check

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -83,7 +83,7 @@ disable=
     too-many-instance-attributes,
     line-too-long, # We let Flake8 take care of this # TODO: Fix these and stop relying on flake8
     len-as-condition, # TODO: Enable this check once pylint 2.4.0 is released and consumed due to the fix in https://github.com/PyCQA/pylint/issues/2684
-    import-error, # TODO: Fix import errors
+    import-error, # Since we run Pylint before any of our builds in tox, this will always fail
     attribute-defined-outside-init, # TODO: Fix scope
     protected-access, # TODO: Fix access
     abstract-method, # TODO: Fix abstract methods


### PR DESCRIPTION
By running Pylint before any of the unit tests (and dependency
installs), the import-error check will always fail since the
dependencies are not yet installed.

We could move Pylint to a later stage to resolve this, but there's
value in this quick check occurring before the unit tests.

As a result, this Pylint check is being disabled.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [X] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [X] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#commit-message-guidlines)
- [X] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [X] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
