### PR TITLE
change: set num_processes_per_host only if provided by user

### DIFF
--- a/src/sagemaker/tensorflow/estimator.py
+++ b/src/sagemaker/tensorflow/estimator.py
@@ -545,9 +545,12 @@ class TensorFlow(Framework):
                 mpi_dict = self.distributions["mpi"]
                 mpi_enabled = mpi_dict.get("enabled", False)
                 additional_hyperparameters[self.LAUNCH_MPI_ENV_NAME] = mpi_enabled
-                additional_hyperparameters[self.MPI_NUM_PROCESSES_PER_HOST] = mpi_dict.get(
-                    "processes_per_host", 1
-                )
+
+                if mpi_dict.get("processes_per_host"):
+                    additional_hyperparameters[self.MPI_NUM_PROCESSES_PER_HOST] = mpi_dict.get(
+                        "processes_per_host"
+                    )
+
                 additional_hyperparameters[self.MPI_CUSTOM_MPI_OPTIONS] = mpi_dict.get(
                     "custom_mpi_options", ""
                 )


### PR DESCRIPTION
Waiting on the TF container with the corresponding container change to be released first.

*Issue #, if available:*
https://github.com/aws/sagemaker-containers/issues/203

*Description of changes:*
The Github issue above suggests using a smarter default for processes_per_host when using GPU instances.

The change on the container side can be seen here: https://github.com/aws/sagemaker-containers/pull/204

This change is to remove the default and only set processes_per_host variable if provided by the user. Before this change the default was always handled on both the client and container side, however the default on the container side will never kick in, as the default on the client side is interpreted as the user input, which will always take precedence over any defaults on the container side.

To get around this, we remove setting the variable, as changing the default to None requires container side changes to deal with NoneTypes, as we are normally expecting an int.

## Testing

I tested against a TF notebook with a custom container and custom Python SDK and was able to get the right number of processes_per_host as shown in the flag -np here:

`mpirun --host algo-1:4,algo-2:4 -np 8 --allow-run-as-root --display-map --tag-output -mca btl_tcp_if_include eth0 -mca oob_tcp_if_include eth0 -mca plm_rsh_no_tree_spawn 1 -bind-to socket -map-by slot -mca pml ob1 -mca btl ^openib -mca orte_abort_on_non_zero_status 1 -x NCCL_MIN_NRINGS=4 -x NCCL_SOCKET_IFNAME=eth0 -x NCCL_DEBUG=INFO -x LD_LIBRARY_PATH -x PATH -x LD_PRELOAD=/usr/local/lib/python3.6/dist-packages/gethostname.cpython-36m-x86_64-linux-gnu.so -verbose -x SM_HOSTS -x SM_NETWORK_INTERFACE_NAME -x SM_HPS -x SM_USER_ENTRY_POINT -x SM_FRAMEWORK_PARAMS -x SM_RESOURCE_CONFIG -x SM_INPUT_DATA_CONFIG -x SM_OUTPUT_DATA_DIR -x SM_CHANNELS -x SM_CURRENT_HOST -x SM_MODULE_NAME -x SM_LOG_LEVEL -x SM_FRAMEWORK_MODULE -x SM_INPUT_DIR -x SM_INPUT_CONFIG_DIR -x SM_OUTPUT_DIR -x SM_NUM_CPUS -x SM_NUM_GPUS -x SM_MODEL_DIR -x SM_MODULE_DIR -x SM_TRAINING_ENV -x SM_USER_ARGS -x SM_OUTPUT_INTERMEDIATE_DIR -x SM_CHANNEL_TEST -x SM_CHANNEL_TRAIN -x SM_HP_MODEL_DIR -x PYTHONPATH /usr/bin/python -m mpi4py mnist_hvd.py --model_dir /opt/ml/model`

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#commit-message-guidlines)
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
