### PR TITLE
change: enable inconsistent-return-statements Pylint check

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -91,7 +91,6 @@ disable=
     useless-object-inheritance, # TODO: Remove unnecessary imports
     cyclic-import, # TODO: Resolve cyclic imports
     no-self-use, # TODO: Convert methods to functions where appropriate
-    inconsistent-return-statements, # TODO: Make returns consistent
     consider-merging-isinstance, # TODO: Merge isinstance where appropriate
     consider-using-in, # TODO: Consider merging comparisons with "in"
     simplifiable-if-expression, # TODO: Simplify expressions

--- a/src/sagemaker/job.py
+++ b/src/sagemaker/job.py
@@ -169,7 +169,7 @@ class _Job(object):
         input_mode=None,
     ):
         if not channel_uri:
-            return
+            return None
         if not channel_name:
             raise ValueError(
                 "Expected a channel name if a channel URI {} is specified".format(channel_uri)

--- a/src/sagemaker/local/data.py
+++ b/src/sagemaker/local/data.py
@@ -38,8 +38,11 @@ def get_data_source_instance(data_source, sagemaker_session):
         sagemaker_session (:class:`sagemaker.session.Session`): a SageMaker Session to interact with
             S3 if required.
 
-    Returns
+    Returns:
         :class:`sagemaker.local.data.DataSource`: an Instance of a Data Source
+
+    Raises:
+        ValueError: If parsed_uri scheme is neither `file` nor `s3`, raise an error.
 
     """
     parsed_uri = urlparse(data_source)
@@ -47,6 +50,9 @@ def get_data_source_instance(data_source, sagemaker_session):
         return LocalFileDataSource(parsed_uri.netloc + parsed_uri.path)
     if parsed_uri.scheme == "s3":
         return S3DataSource(parsed_uri.netloc, parsed_uri.path, sagemaker_session)
+    raise ValueError(
+        "data_source must be either file or s3. parsed_uri.scheme: {}".format(parsed_uri.scheme)
+    )
 
 
 def get_splitter_instance(split_type):

--- a/src/sagemaker/model.py
+++ b/src/sagemaker/model.py
@@ -389,6 +389,7 @@ class Model(object):
 
         if self.predictor_cls:
             return self.predictor_cls(self.endpoint_name, self.sagemaker_session)
+        return None
 
     def transformer(
         self,

--- a/src/sagemaker/pipeline.py
+++ b/src/sagemaker/pipeline.py
@@ -115,6 +115,7 @@ class PipelineModel(object):
         )
         if self.predictor_cls:
             return self.predictor_cls(self.endpoint_name, self.sagemaker_session)
+        return None
 
     def _create_sagemaker_pipeline_model(self, instance_type):
         """Create a SageMaker Model Entity

--- a/src/sagemaker/predictor.py
+++ b/src/sagemaker/predictor.py
@@ -392,6 +392,11 @@ class _NumpyDeserializer(object):
                 return np.load(BytesIO(stream.read()))
         finally:
             stream.close()
+        raise ValueError(
+            "content_type must be one of the following: CSV, JSON, NPY. content_type: {}".format(
+                content_type
+            )
+        )
 
 
 numpy_deserializer = _NumpyDeserializer()

--- a/src/sagemaker/rl/estimator.py
+++ b/src/sagemaker/rl/estimator.py
@@ -184,7 +184,8 @@ class RLEstimator(Framework):
                     MXNet was used as RL backend;
                 * sagemaker.tensorflow.serving.Model - if image_name wasn't specified and
                     TensorFlow was used as RL backend.
-
+        Raises:
+            ValueError: If image_name was not specified and framework enum is not valid.
         """
         base_args = dict(
             model_data=self.model_data,
@@ -230,6 +231,9 @@ class RLEstimator(Framework):
             return MXNetModel(
                 framework_version=self.framework_version, py_version=PYTHON_VERSION, **extended_args
             )
+        raise ValueError(
+            "An unknown RLFramework enum was passed in. framework: {}".format(self.framework)
+        )
 
     def train_image(self):
         """Return the Docker image to use for training.
@@ -399,6 +403,9 @@ class RLEstimator(Framework):
 
         Returns:
             list: metric definitions
+
+        Raises:
+            ValueError: If toolkit enum is not valid.
         """
         if toolkit is RLToolkit.COACH:
             return [
@@ -412,3 +419,4 @@ class RLEstimator(Framework):
                 {"Name": "episode_reward_mean", "Regex": "episode_reward_mean: (%s)" % float_regex},
                 {"Name": "episode_reward_max", "Regex": "episode_reward_max: (%s)" % float_regex},
             ]
+        raise ValueError("An unknown RLToolkit enum was passed in. toolkit: {}".format(toolkit))


### PR DESCRIPTION
> # Note that this commit also raises ValueErrors in situations that would previously have returned None.

Per PEP8: Be consistent in return statements. Either all return
statements in a function should return an expression, or none of them
should. If any return statement returns an expression, any return
statements where no value is returned should explicitly state this as
return None, and an explicit return statement should be present at the
end of the function (if reachable).

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [X] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [X] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#commit-message-guidlines)
- [X] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [X] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
