### PR TITLE
change: fix attach for 1P algorithm estimators

### DIFF
--- a/src/sagemaker/tuner.py
+++ b/src/sagemaker/tuner.py
@@ -497,9 +497,7 @@ class HyperparameterTuner(object):
         )
 
     @classmethod
-    def _prepare_estimator_from_job_description(
-        cls, estimator_cls, job_details, sagemaker_session
-    ):
+    def _prepare_estimator_from_job_description(cls, estimator_cls, job_details, sagemaker_session):
         training_details = job_details["TrainingJobDefinition"]
 
         # Swap name for static hyperparameters to what an estimator would expect
@@ -511,9 +509,11 @@ class HyperparameterTuner(object):
 
         # Add missing hyperparameters defined in the hyperparameter ranges,
         # as potentially required in the Amazon algorithm estimator's constructor
-        if isinstance(estimator_cls, AmazonAlgorithmEstimatorBase):
+        if issubclass(estimator_cls, AmazonAlgorithmEstimatorBase):
             parameter_ranges = job_details["HyperParameterTuningJobConfig"]["ParameterRanges"]
-            additional_hyperparameters = cls._extract_hyperparmeters_from_parameter_ranges(parameter_ranges)
+            additional_hyperparameters = cls._extract_hyperparmeters_from_parameter_ranges(
+                parameter_ranges
+            )
             training_details["HyperParameters"].update(additional_hyperparameters)
 
         # Add items expected by the estimator (but aren't needed otherwise)

--- a/src/sagemaker/tuner.py
+++ b/src/sagemaker/tuner.py
@@ -511,7 +511,7 @@ class HyperparameterTuner(object):
         # as potentially required in the Amazon algorithm estimator's constructor
         if issubclass(estimator_cls, AmazonAlgorithmEstimatorBase):
             parameter_ranges = job_details["HyperParameterTuningJobConfig"]["ParameterRanges"]
-            additional_hyperparameters = cls._extract_hyperparmeters_from_parameter_ranges(
+            additional_hyperparameters = cls._extract_hyperparameters_from_parameter_ranges(
                 parameter_ranges
             )
             training_details["HyperParameters"].update(additional_hyperparameters)
@@ -569,7 +569,7 @@ class HyperparameterTuner(object):
         return ranges
 
     @classmethod
-    def _extract_hyperparmeters_from_parameter_ranges(cls, parameter_ranges):
+    def _extract_hyperparameters_from_parameter_ranges(cls, parameter_ranges):
         hyperparameters = {}
 
         for parameter in parameter_ranges["CategoricalParameterRanges"]:

--- a/src/sagemaker/tuner.py
+++ b/src/sagemaker/tuner.py
@@ -19,7 +19,7 @@ import logging
 from enum import Enum
 
 import sagemaker
-from sagemaker.amazon.amazon_estimator import RecordSet
+from sagemaker.amazon.amazon_estimator import RecordSet, AmazonAlgorithmEstimatorBase
 from sagemaker.amazon.hyperparameter import Hyperparameter as hp  # noqa
 from sagemaker.analytics import HyperparameterTuningJobAnalytics
 from sagemaker.estimator import Framework
@@ -357,7 +357,7 @@ class HyperparameterTuner(object):
             estimator_cls, job_details["TrainingJobDefinition"]
         )
         estimator = cls._prepare_estimator_from_job_description(
-            estimator_cls, job_details["TrainingJobDefinition"], sagemaker_session
+            estimator_cls, job_details, sagemaker_session
         )
         init_params = cls._prepare_init_params_from_job_description(job_details)
 
@@ -497,14 +497,23 @@ class HyperparameterTuner(object):
 
     @classmethod
     def _prepare_estimator_from_job_description(
-        cls, estimator_cls, training_details, sagemaker_session
+        cls, estimator_cls, job_details, sagemaker_session
     ):
+        training_details = job_details["TrainingJobDefinition"]
+
         # Swap name for static hyperparameters to what an estimator would expect
         training_details["HyperParameters"] = training_details["StaticHyperParameters"]
         del training_details["StaticHyperParameters"]
 
         # Remove hyperparameter reserved by SageMaker for tuning jobs
         del training_details["HyperParameters"]["_tuning_objective_metric"]
+
+        # Add missing hyperparameters defined in the hyperparameter ranges,
+        # as potentially required in the Amazon algorithm estimator's constructor
+        if isinstance(estimator_cls, AmazonAlgorithmEstimatorBase):
+            parameter_ranges = job_details["HyperParameterTuningJobConfig"]["ParameterRanges"]
+            additional_hyperparameters = cls._extract_hyperparmeters_from_parameter_ranges(parameter_ranges)
+            training_details["HyperParameters"].update(additional_hyperparameters)
 
         # Add items expected by the estimator (but aren't needed otherwise)
         training_details["TrainingJobName"] = ""
@@ -557,6 +566,21 @@ class HyperparameterTuner(object):
             )
 
         return ranges
+
+    @classmethod
+    def _extract_hyperparmeters_from_parameter_ranges(cls, parameter_ranges):
+        hyperparameters = {}
+
+        for parameter in parameter_ranges["CategoricalParameterRanges"]:
+            hyperparameters[parameter["Name"]] = parameter["Values"][0]
+
+        for parameter in parameter_ranges["ContinuousParameterRanges"]:
+            hyperparameters[parameter["Name"]] = float(parameter["MinValue"])
+
+        for parameter in parameter_ranges["IntegerParameterRanges"]:
+            hyperparameters[parameter["Name"]] = int(parameter["MinValue"])
+
+        return hyperparameters
 
     def hyperparameter_ranges(self):
         """Return the hyperparameter ranges in a dictionary to be used as part of a request for creating a

--- a/tests/unit/test_tuner.py
+++ b/tests/unit/test_tuner.py
@@ -78,7 +78,7 @@ TUNING_JOB_DETAILS = {
             "IntegerParameterRanges": [
                 {
                     "MaxValue": "100",
-                    "Name": "mini_batch_size",
+                    "Name": "num_components",
                     "MinValue": "10",
                     "ScalingType": "Auto",
                 }
@@ -416,7 +416,7 @@ def test_attach_tuning_job_with_estimator_from_hyperparameters(sagemaker_session
     assert tuner.estimator.output_kms_key == ""
 
     assert "_tuning_objective_metric" not in tuner.estimator.hyperparameters()
-    assert tuner.estimator.hyperparameters()["num_components"] == "1"
+    assert tuner.estimator.hyperparameters()["num_components"] == "10"
 
 
 def test_attach_tuning_job_with_estimator_from_hyperparameters_with_early_stopping(


### PR DESCRIPTION
*Description of changes:*
Add in hyperparameter values based on any hyperparameter ranges defined in the Tuning job detail for 1P algorithms.

When creating in a tuning job for a 1P algorithm, the constructor parameters and the parameter ranges overlap and will get removed in the hyperparameters if they are present as a range, shown here: https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/tuner.py#L262-L266

When attaching to a hyperparameter job for a 1P algorithm, the 1p Estimator created will have required constructor parameters that never get fulfilled as they have been removed from the static_hyperparameter map and needs to be added back in.

The value that is taken doesn't matter as a tuner is being created and when the user calls fit, those constructor values will get popped, thus taking the first and min values defined in the ranges.

This only applies to 1P algorithms as the other Estimators most likely don't define hyperparameters within its constructor and usually has defaults.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#commit-message-guidlines)
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
