### PR TITLE
change: enable wrong-import-order Pylint check

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -86,7 +86,6 @@ disable=
     import-error, # Since we run Pylint before any of our builds in tox, this will always fail
     protected-access, # TODO: Fix access
     abstract-method, # TODO: Fix abstract methods
-    wrong-import-order, # TODO: Fix import order
     useless-object-inheritance, # TODO: Remove unnecessary imports
     cyclic-import, # TODO: Resolve cyclic imports
     no-self-use, # TODO: Convert methods to functions where appropriate

--- a/src/sagemaker/fw_utils.py
+++ b/src/sagemaker/fw_utils.py
@@ -16,11 +16,11 @@ from collections import namedtuple
 
 import os
 import re
-import sagemaker.utils
 import shutil
 import tempfile
 from six.moves.urllib.parse import urlparse
 
+import sagemaker.utils
 from sagemaker.utils import get_ecr_image_uri_prefix, ECR_URI_PATTERN
 
 _TAR_SOURCE_FILENAME = "source.tar.gz"

--- a/src/sagemaker/git_utils.py
+++ b/src/sagemaker/git_utils.py
@@ -13,10 +13,10 @@
 from __future__ import absolute_import
 
 import os
-import six
 import subprocess
 import tempfile
 import warnings
+import six
 from six.moves import urllib
 
 

--- a/src/sagemaker/local/image.py
+++ b/src/sagemaker/local/image.py
@@ -28,8 +28,8 @@ import sys
 import tarfile
 import tempfile
 
-from six.moves.urllib.parse import urlparse
 from threading import Thread
+from six.moves.urllib.parse import urlparse
 
 import yaml
 

--- a/src/sagemaker/predictor.py
+++ b/src/sagemaker/predictor.py
@@ -15,9 +15,9 @@ from __future__ import print_function, absolute_import
 import codecs
 import csv
 import json
-import numpy as np
 import six
 from six import StringIO, BytesIO
+import numpy as np
 
 from sagemaker.content_types import CONTENT_TYPE_JSON, CONTENT_TYPE_CSV, CONTENT_TYPE_NPY
 from sagemaker.session import Session

--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -20,9 +20,9 @@ import sys
 import time
 import warnings
 
+import six
 import boto3
 import botocore.config
-import six
 import yaml
 from botocore.exceptions import ClientError
 

--- a/src/sagemaker/user_agent.py
+++ b/src/sagemaker/user_agent.py
@@ -12,9 +12,9 @@
 # language governing permissions and limitations under the License.
 from __future__ import absolute_import
 
-import pkg_resources
 import platform
 import sys
+import pkg_resources
 
 import boto3
 import botocore


### PR DESCRIPTION
change: enable wrong-import-order Pylint check

Per PEP8:
Imports should be grouped in the following order:
1- Standard library imports.
2- Related third party imports.
3- Local application/library specific imports.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [X] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [X] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#commit-message-guidlines)
- [X] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [X] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
