### PR TITLE
change: allow serving script to be defined for deploy() and transformer() with frameworks

### DIFF
--- a/src/sagemaker/chainer/estimator.py
+++ b/src/sagemaker/chainer/estimator.py
@@ -134,7 +134,13 @@ class Chainer(Framework):
         return hyperparameters
 
     def create_model(
-        self, model_server_workers=None, role=None, vpc_config_override=VPC_CONFIG_DEFAULT
+        self,
+        model_server_workers=None,
+        role=None,
+        vpc_config_override=VPC_CONFIG_DEFAULT,
+        entry_point=None,
+        source_dir=None,
+        dependencies=None,
     ):
         """Create a SageMaker ``ChainerModel`` object that can be deployed to an ``Endpoint``.
 
@@ -147,17 +153,24 @@ class Chainer(Framework):
                 Default: use subnets and security groups from this Estimator.
                 * 'Subnets' (list[str]): List of subnet ids.
                 * 'SecurityGroupIds' (list[str]): List of security group ids.
+            entry_point (str): Path (absolute or relative) to the local Python source file which should be executed
+                as the entry point to training. If not specified, the training entry point is used.
+            source_dir (str): Path (absolute or relative) to a directory with any other serving
+                source code dependencies aside from the entry point file.
+                If not specified, the model source directory from training is used.
+            dependencies (list[str]): A list of paths to directories (absolute or relative) with
+                any additional libraries that will be exported to the container.
+                If not specified, the dependencies from training are used.
 
         Returns:
             sagemaker.chainer.model.ChainerModel: A SageMaker ``ChainerModel`` object.
                 See :func:`~sagemaker.chainer.model.ChainerModel` for full details.
         """
-        role = role or self.role
         return ChainerModel(
             self.model_data,
-            role,
-            self.entry_point,
-            source_dir=self._model_source_dir(),
+            role or self.role,
+            entry_point or self.entry_point,
+            source_dir=(source_dir or self._model_source_dir()),
             enable_cloudwatch_metrics=self.enable_cloudwatch_metrics,
             name=self._current_job_name,
             container_log_level=self.container_log_level,
@@ -168,7 +181,7 @@ class Chainer(Framework):
             image=self.image_name,
             sagemaker_session=self.sagemaker_session,
             vpc_config=self.get_vpc_config(vpc_config_override),
-            dependencies=self.dependencies,
+            dependencies=(dependencies or self.dependencies),
         )
 
     @classmethod

--- a/src/sagemaker/estimator.py
+++ b/src/sagemaker/estimator.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2017-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You
 # may not use this file except in compliance with the License. A copy of

--- a/src/sagemaker/estimator.py
+++ b/src/sagemaker/estimator.py
@@ -1336,6 +1336,7 @@ class Framework(EstimatorBase):
         role=None,
         model_server_workers=None,
         volume_kms_key=None,
+        entry_point=None,
     ):
         """Return a ``Transformer`` that uses a SageMaker Model based on the training job. It reuses the
         SageMaker Session and base job name used by the Estimator.
@@ -1362,11 +1363,19 @@ class Framework(EstimatorBase):
                 If None, server will use one worker per vCPU.
             volume_kms_key (str): Optional. KMS key ID for encrypting the volume attached to the ML
                 compute instance (default: None).
+            entry_point (str): Path (absolute or relative) to the local Python source file which should be executed
+                as the entry point to training. If not specified, the training entry point is used.
+
+        Returns:
+            sagemaker.transformer.Transformer: a ``Transformer`` object that can be used to start a
+                SageMaker Batch Transform job.
         """
         role = role or self.role
 
         if self.latest_training_job is not None:
-            model = self.create_model(role=role, model_server_workers=model_server_workers)
+            model = self.create_model(
+                role=role, model_server_workers=model_server_workers, entry_point=entry_point
+            )
 
             container_def = model.prepare_container_def(instance_type)
             model_name = model.name or name_from_image(container_def["Image"])

--- a/src/sagemaker/model.py
+++ b/src/sagemaker/model.py
@@ -552,7 +552,7 @@ class FrameworkModel(Model):
                 the same as GitHub-like repos. When 'repo' is an HTTPS URL, username+password will be used for
                 authentication if they are provided; otherwise, python SDK will try to use either CodeCommit credential
                 helper or local credential storage for authentication.
-            source_dir (str): Path (absolute or relative) to a directory with any other training
+            source_dir (str): Path (absolute or relative) to a directory with any other serving
                 source code dependencies aside from the entry point file (default: None). Structure within this
                 directory will be preserved when training on SageMaker. If 'git_config' is provided,
                 'source_dir' should be a relative location to a directory in the Git repo. If the directory points

--- a/src/sagemaker/mxnet/estimator.py
+++ b/src/sagemaker/mxnet/estimator.py
@@ -117,7 +117,13 @@ class MXNet(Framework):
             self._hyperparameters[self.LAUNCH_PS_ENV_NAME] = enabled
 
     def create_model(
-        self, model_server_workers=None, role=None, vpc_config_override=VPC_CONFIG_DEFAULT
+        self,
+        model_server_workers=None,
+        role=None,
+        vpc_config_override=VPC_CONFIG_DEFAULT,
+        entry_point=None,
+        source_dir=None,
+        dependencies=None,
     ):
         """Create a SageMaker ``MXNetModel`` object that can be deployed to an ``Endpoint``.
 
@@ -130,17 +136,24 @@ class MXNet(Framework):
                 Default: use subnets and security groups from this Estimator.
                 * 'Subnets' (list[str]): List of subnet ids.
                 * 'SecurityGroupIds' (list[str]): List of security group ids.
+            entry_point (str): Path (absolute or relative) to the local Python source file which should be executed
+                as the entry point to training. If not specified, the training entry point is used.
+            source_dir (str): Path (absolute or relative) to a directory with any other serving
+                source code dependencies aside from the entry point file.
+                If not specified, the model source directory from training is used.
+            dependencies (list[str]): A list of paths to directories (absolute or relative) with
+                any additional libraries that will be exported to the container.
+                If not specified, the dependencies from training are used.
 
         Returns:
             sagemaker.mxnet.model.MXNetModel: A SageMaker ``MXNetModel`` object.
                 See :func:`~sagemaker.mxnet.model.MXNetModel` for full details.
         """
-        role = role or self.role
         return MXNetModel(
             self.model_data,
-            role,
-            self.entry_point,
-            source_dir=self._model_source_dir(),
+            role or self.role,
+            entry_point or self.entry_point,
+            source_dir=(source_dir or self._model_source_dir()),
             enable_cloudwatch_metrics=self.enable_cloudwatch_metrics,
             name=self._current_job_name,
             container_log_level=self.container_log_level,
@@ -151,7 +164,7 @@ class MXNet(Framework):
             model_server_workers=model_server_workers,
             sagemaker_session=self.sagemaker_session,
             vpc_config=self.get_vpc_config(vpc_config_override),
-            dependencies=self.dependencies,
+            dependencies=(dependencies or self.dependencies),
         )
 
     @classmethod

--- a/src/sagemaker/pytorch/estimator.py
+++ b/src/sagemaker/pytorch/estimator.py
@@ -96,7 +96,13 @@ class PyTorch(Framework):
         self.py_version = py_version
 
     def create_model(
-        self, model_server_workers=None, role=None, vpc_config_override=VPC_CONFIG_DEFAULT
+        self,
+        model_server_workers=None,
+        role=None,
+        vpc_config_override=VPC_CONFIG_DEFAULT,
+        entry_point=None,
+        source_dir=None,
+        dependencies=None,
     ):
         """Create a SageMaker ``PyTorchModel`` object that can be deployed to an ``Endpoint``.
 
@@ -109,17 +115,24 @@ class PyTorch(Framework):
                 Default: use subnets and security groups from this Estimator.
                 * 'Subnets' (list[str]): List of subnet ids.
                 * 'SecurityGroupIds' (list[str]): List of security group ids.
+            entry_point (str): Path (absolute or relative) to the local Python source file which should be executed
+                as the entry point to training. If not specified, the training entry point is used.
+            source_dir (str): Path (absolute or relative) to a directory with any other serving
+                source code dependencies aside from the entry point file.
+                If not specified, the model source directory from training is used.
+            dependencies (list[str]): A list of paths to directories (absolute or relative) with
+                any additional libraries that will be exported to the container.
+                If not specified, the dependencies from training are used.
 
         Returns:
             sagemaker.pytorch.model.PyTorchModel: A SageMaker ``PyTorchModel`` object.
                 See :func:`~sagemaker.pytorch.model.PyTorchModel` for full details.
         """
-        role = role or self.role
         return PyTorchModel(
             self.model_data,
-            role,
-            self.entry_point,
-            source_dir=self._model_source_dir(),
+            role or self.role,
+            entry_point or self.entry_point,
+            source_dir=(source_dir or self._model_source_dir()),
             enable_cloudwatch_metrics=self.enable_cloudwatch_metrics,
             name=self._current_job_name,
             container_log_level=self.container_log_level,
@@ -130,7 +143,7 @@ class PyTorch(Framework):
             model_server_workers=model_server_workers,
             sagemaker_session=self.sagemaker_session,
             vpc_config=self.get_vpc_config(vpc_config_override),
-            dependencies=self.dependencies,
+            dependencies=(dependencies or self.dependencies),
         )
 
     @classmethod

--- a/src/sagemaker/tensorflow/estimator.py
+++ b/src/sagemaker/tensorflow/estimator.py
@@ -487,11 +487,13 @@ class TensorFlow(Framework):
                 as the entry point to training. If not specified and ``endpoint_type`` is 'tensorflow-serving',
                 no entry point is used. If ``endpoint_type`` is also ``None``, then the training entry point is used.
             source_dir (str): Path (absolute or relative) to a directory with any other serving
-                source code dependencies aside from the entry point file.
-                If not specified, the model source directory from training is used.
+                source code dependencies aside from the entry point file. If not specified and
+                ``endpoint_type`` is 'tensorflow-serving', no source_dir is used. If ``endpoint_type`` is also ``None``,
+                then the model source directory from training is used.
             dependencies (list[str]): A list of paths to directories (absolute or relative) with
                 any additional libraries that will be exported to the container.
-                If not specified, the dependencies from training are used.
+                If not specified and ``endpoint_type`` is 'tensorflow-serving', ``dependencies`` is set to ``None``.
+                If ``endpoint_type`` is also ``None``, then the dependencies from training are used.
 
         Returns:
             sagemaker.tensorflow.model.TensorFlowModel or sagemaker.tensorflow.serving.Model: A ``Model`` object.
@@ -536,6 +538,8 @@ class TensorFlow(Framework):
             sagemaker_session=self.sagemaker_session,
             vpc_config=self.get_vpc_config(vpc_config_override),
             entry_point=entry_point,
+            source_dir=source_dir,
+            dependencies=dependencies,
         )
 
     def _create_default_model(
@@ -551,7 +555,7 @@ class TensorFlow(Framework):
             self.model_data,
             role,
             entry_point or self.entry_point,
-            source_dir=self._model_source_dir(),
+            source_dir=source_dir or self._model_source_dir(),
             enable_cloudwatch_metrics=self.enable_cloudwatch_metrics,
             env={"SAGEMAKER_REQUIREMENTS": self.requirements_file},
             image=self.image_name,
@@ -563,7 +567,7 @@ class TensorFlow(Framework):
             model_server_workers=model_server_workers,
             sagemaker_session=self.sagemaker_session,
             vpc_config=self.get_vpc_config(vpc_config_override),
-            dependencies=self.dependencies,
+            dependencies=dependencies or self.dependencies,
         )
 
     def hyperparameters(self):

--- a/src/sagemaker/tensorflow/estimator.py
+++ b/src/sagemaker/tensorflow/estimator.py
@@ -463,8 +463,12 @@ class TensorFlow(Framework):
         role=None,
         vpc_config_override=VPC_CONFIG_DEFAULT,
         endpoint_type=None,
+        entry_point=None,
+        source_dir=None,
+        dependencies=None,
     ):
-        """Create a SageMaker ``TensorFlowModel`` object that can be deployed to an ``Endpoint``.
+        """Create a ``Model`` object that can be used for creating SageMaker model entities,
+        deploying to a SageMaker endpoint, or starting SageMaker Batch Transform jobs.
 
         Args:
             role (str): The ``ExecutionRoleArn`` IAM Role ARN for the ``Model``, which is also used during
@@ -475,27 +479,53 @@ class TensorFlow(Framework):
                 Default: use subnets and security groups from this Estimator.
                 * 'Subnets' (list[str]): List of subnet ids.
                 * 'SecurityGroupIds' (list[str]): List of security group ids.
-            endpoint_type: Optional. Selects the software stack used by the inference server.
+            endpoint_type (str): Optional. Selects the software stack used by the inference server.
                 If  not specified, the model will be configured to use the default
                 SageMaker model server. If 'tensorflow-serving', the model will be configured to
                 use the SageMaker Tensorflow Serving container.
+            entry_point (str): Path (absolute or relative) to the local Python source file which should be executed
+                as the entry point to training. If not specified and ``endpoint_type`` is 'tensorflow-serving',
+                no entry point is used. If ``endpoint_type`` is also ``None``, then the training entry point is used.
+            source_dir (str): Path (absolute or relative) to a directory with any other serving
+                source code dependencies aside from the entry point file.
+                If not specified, the model source directory from training is used.
+            dependencies (list[str]): A list of paths to directories (absolute or relative) with
+                any additional libraries that will be exported to the container.
+                If not specified, the dependencies from training are used.
 
         Returns:
-            sagemaker.tensorflow.model.TensorFlowModel: A SageMaker ``TensorFlowModel`` object.
-                See :func:`~sagemaker.tensorflow.model.TensorFlowModel` for full details.
+            sagemaker.tensorflow.model.TensorFlowModel or sagemaker.tensorflow.serving.Model: A ``Model`` object.
+                See :class:`~sagemaker.tensorflow.serving.Model` or :class:`~sagemaker.tensorflow.model.TensorFlowModel`
+                for full details.
         """
-
         role = role or self.role
+
         if endpoint_type == "tensorflow-serving" or self._script_mode_enabled():
-            return self._create_tfs_model(role=role, vpc_config_override=vpc_config_override)
+            return self._create_tfs_model(
+                role=role,
+                vpc_config_override=vpc_config_override,
+                entry_point=entry_point,
+                source_dir=source_dir,
+                dependencies=dependencies,
+            )
 
         return self._create_default_model(
             model_server_workers=model_server_workers,
             role=role,
             vpc_config_override=vpc_config_override,
+            entry_point=entry_point,
+            source_dir=source_dir,
+            dependencies=dependencies,
         )
 
-    def _create_tfs_model(self, role=None, vpc_config_override=VPC_CONFIG_DEFAULT):
+    def _create_tfs_model(
+        self,
+        role=None,
+        vpc_config_override=VPC_CONFIG_DEFAULT,
+        entry_point=None,
+        source_dir=None,
+        dependencies=None,
+    ):
         return Model(
             model_data=self.model_data,
             role=role,
@@ -505,13 +535,22 @@ class TensorFlow(Framework):
             framework_version=utils.get_short_version(self.framework_version),
             sagemaker_session=self.sagemaker_session,
             vpc_config=self.get_vpc_config(vpc_config_override),
+            entry_point=entry_point,
         )
 
-    def _create_default_model(self, model_server_workers, role, vpc_config_override):
+    def _create_default_model(
+        self,
+        model_server_workers,
+        role,
+        vpc_config_override,
+        entry_point=None,
+        source_dir=None,
+        dependencies=None,
+    ):
         return TensorFlowModel(
             self.model_data,
             role,
-            self.entry_point,
+            entry_point or self.entry_point,
             source_dir=self._model_source_dir(),
             enable_cloudwatch_metrics=self.enable_cloudwatch_metrics,
             env={"SAGEMAKER_REQUIREMENTS": self.requirements_file},
@@ -613,6 +652,7 @@ class TensorFlow(Framework):
         model_server_workers=None,
         volume_kms_key=None,
         endpoint_type=None,
+        entry_point=None,
     ):
         """Return a ``Transformer`` that uses a SageMaker Model based on the training job. It reuses the
         SageMaker Session and base job name used by the Estimator.
@@ -644,6 +684,9 @@ class TensorFlow(Framework):
                 SageMaker model server.
                 If 'tensorflow-serving', the model will be configured to
                 use the SageMaker Tensorflow Serving container.
+            entry_point (str): Path (absolute or relative) to the local Python source file which should be executed
+                as the entry point to training. If not specified and ``endpoint_type`` is 'tensorflow-serving',
+                no entry point is used. If ``endpoint_type`` is also ``None``, then the training entry point is used.
         """
 
         role = role or self.role
@@ -652,6 +695,7 @@ class TensorFlow(Framework):
             role=role,
             vpc_config_override=VPC_CONFIG_DEFAULT,
             endpoint_type=endpoint_type,
+            entry_point=entry_point,
         )
         return model.transformer(
             instance_count,

--- a/tests/data/tfs/tfs-test-entrypoint-with-handler/training.py
+++ b/tests/data/tfs/tfs-test-entrypoint-with-handler/training.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You
 # may not use this file except in compliance with the License. A copy of
@@ -10,17 +10,19 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import json
+
+"""Exports a toy TensorFlow model.
+Exports a TensorFlow model to /opt/ml/model/
+This graph calculates,
+  y = a*x + b
+where a and b are variables with a=0.5 and b=2.
+"""
+import shutil
 
 
-def input_handler(data, context):
-    data = json.loads(data.read().decode("utf-8"))
-    new_values = [x + 1 for x in data["instances"]]
-    dumps = json.dumps({"instances": new_values})
-    return dumps
+def save_model():
+    shutil.copytree("/opt/ml/code/123", "/opt/ml/model/123")
 
 
-def output_handler(data, context):
-    response_content_type = context.accept_header
-    prediction = data.content
-    return prediction, response_content_type
+if __name__ == "__main__":
+    save_model()

--- a/tests/integ/test_tf_script_mode.py
+++ b/tests/integ/test_tf_script_mode.py
@@ -185,7 +185,7 @@ def test_mnist_async(sagemaker_session):
 
 def test_deploy_with_input_handlers(sagemaker_session, instance_type):
     estimator = TensorFlow(
-        entry_point="inference.py",
+        entry_point="training.py",
         source_dir=TFS_RESOURCE_PATH,
         role=ROLE,
         train_instance_count=1,
@@ -202,9 +202,11 @@ def test_deploy_with_input_handlers(sagemaker_session, instance_type):
     endpoint_name = estimator.latest_training_job.name
 
     with timeout.timeout_and_delete_endpoint_by_name(endpoint_name, sagemaker_session):
-
         predictor = estimator.deploy(
-            initial_instance_count=1, instance_type=instance_type, endpoint_name=endpoint_name
+            initial_instance_count=1,
+            instance_type=instance_type,
+            endpoint_name=endpoint_name,
+            entry_point=os.path.join(TFS_RESOURCE_PATH, "inference.py"),
         )
 
         input_data = {"instances": [1.0, 2.0, 5.0]}

--- a/tests/unit/test_chainer.py
+++ b/tests/unit/test_chainer.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2017-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You
 # may not use this file except in compliance with the License. A copy of

--- a/tests/unit/test_chainer.py
+++ b/tests/unit/test_chainer.py
@@ -29,6 +29,7 @@ from sagemaker.chainer import ChainerPredictor, ChainerModel
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), "..", "data")
 SCRIPT_PATH = os.path.join(DATA_DIR, "dummy_script.py")
+SERVING_SCRIPT_FILE = "another_dummy_script.py"
 MODEL_DATA = "s3://some/data.tar.gz"
 TIMESTAMP = "2017-11-06-14:14:15.672"
 TIME = 1507167947
@@ -314,12 +315,16 @@ def test_create_model_with_optional_params(sagemaker_session):
     model_server_workers = 2
     vpc_config = {"Subnets": ["foo"], "SecurityGroupIds": ["bar"]}
     model = chainer.create_model(
-        role=new_role, model_server_workers=model_server_workers, vpc_config_override=vpc_config
+        role=new_role,
+        model_server_workers=model_server_workers,
+        vpc_config_override=vpc_config,
+        entry_point=SERVING_SCRIPT_FILE,
     )
 
     assert model.role == new_role
     assert model.model_server_workers == model_server_workers
     assert model.vpc_config == vpc_config
+    assert model.entry_point == SERVING_SCRIPT_FILE
 
 
 def test_create_model_with_custom_image(sagemaker_session):

--- a/tests/unit/test_estimator.py
+++ b/tests/unit/test_estimator.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2017-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You
 # may not use this file except in compliance with the License. A copy of

--- a/tests/unit/test_estimator.py
+++ b/tests/unit/test_estimator.py
@@ -112,8 +112,10 @@ class DummyFramework(Framework):
     def train_image(self):
         return IMAGE_NAME
 
-    def create_model(self, role=None, model_server_workers=None):
-        return DummyFrameworkModel(self.sagemaker_session, vpc_config=self.get_vpc_config())
+    def create_model(self, role=None, model_server_workers=None, entry_point=None):
+        return DummyFrameworkModel(
+            self.sagemaker_session, vpc_config=self.get_vpc_config(), entry_point=entry_point
+        )
 
     @classmethod
     def _prepare_init_params_from_job_description(cls, job_details, model_channel_name=None):
@@ -125,13 +127,13 @@ class DummyFramework(Framework):
 
 
 class DummyFrameworkModel(FrameworkModel):
-    def __init__(self, sagemaker_session, **kwargs):
+    def __init__(self, sagemaker_session, entry_point=None, **kwargs):
         super(DummyFrameworkModel, self).__init__(
             MODEL_DATA,
             MODEL_IMAGE,
             INSTANCE_TYPE,
             ROLE,
-            ENTRY_POINT,
+            entry_point or ENTRY_POINT,
             sagemaker_session=sagemaker_session,
             **kwargs
         )

--- a/tests/unit/test_mxnet.py
+++ b/tests/unit/test_mxnet.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2017-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You
 # may not use this file except in compliance with the License. A copy of

--- a/tests/unit/test_mxnet.py
+++ b/tests/unit/test_mxnet.py
@@ -28,6 +28,7 @@ from sagemaker.mxnet import MXNetPredictor, MXNetModel
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), "..", "data")
 SCRIPT_PATH = os.path.join(DATA_DIR, "dummy_script.py")
+SERVING_SCRIPT_FILE = "another_dummy_script.py"
 MODEL_DATA = "s3://mybucket/model"
 TIMESTAMP = "2017-11-06-14:14:15.672"
 TIME = 1507167947
@@ -213,12 +214,16 @@ def test_create_model_with_optional_params(sagemaker_session):
     model_server_workers = 2
     vpc_config = {"Subnets": ["foo"], "SecurityGroupIds": ["bar"]}
     model = mx.create_model(
-        role=new_role, model_server_workers=model_server_workers, vpc_config_override=vpc_config
+        role=new_role,
+        model_server_workers=model_server_workers,
+        vpc_config_override=vpc_config,
+        entry_point=SERVING_SCRIPT_FILE,
     )
 
     assert model.role == new_role
     assert model.model_server_workers == model_server_workers
     assert model.vpc_config == vpc_config
+    assert model.entry_point == SERVING_SCRIPT_FILE
 
 
 def test_create_model_with_custom_image(sagemaker_session):

--- a/tests/unit/test_pytorch.py
+++ b/tests/unit/test_pytorch.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2017-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You
 # may not use this file except in compliance with the License. A copy of

--- a/tests/unit/test_pytorch.py
+++ b/tests/unit/test_pytorch.py
@@ -27,6 +27,7 @@ from sagemaker.pytorch import PyTorchPredictor, PyTorchModel
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), "..", "data")
 SCRIPT_PATH = os.path.join(DATA_DIR, "dummy_script.py")
+SERVING_SCRIPT_FILE = "another_dummy_script.py"
 MODEL_DATA = "s3://some/data.tar.gz"
 TIMESTAMP = "2017-11-06-14:14:15.672"
 TIME = 1507167947
@@ -195,12 +196,16 @@ def test_create_model_with_optional_params(sagemaker_session):
     model_server_workers = 2
     vpc_config = {"Subnets": ["foo"], "SecurityGroupIds": ["bar"]}
     model = pytorch.create_model(
-        role=new_role, model_server_workers=model_server_workers, vpc_config_override=vpc_config
+        role=new_role,
+        model_server_workers=model_server_workers,
+        vpc_config_override=vpc_config,
+        entry_point=SERVING_SCRIPT_FILE,
     )
 
     assert model.role == new_role
     assert model.model_server_workers == model_server_workers
     assert model.vpc_config == vpc_config
+    assert model.entry_point == SERVING_SCRIPT_FILE
 
 
 def test_create_model_with_custom_image(sagemaker_session):

--- a/tests/unit/test_tf_estimator.py
+++ b/tests/unit/test_tf_estimator.py
@@ -29,6 +29,7 @@ import sagemaker.tensorflow.estimator as tfe
 DATA_DIR = os.path.join(os.path.dirname(__file__), "..", "data")
 SCRIPT_FILE = "dummy_script.py"
 SCRIPT_PATH = os.path.join(DATA_DIR, SCRIPT_FILE)
+SERVING_SCRIPT_FILE = "another_dummy_script.py"
 MODEL_DATA = "s3://some/data.tar.gz"
 REQUIREMENTS_FILE = "dummy_requirements.txt"
 TIMESTAMP = "2017-11-06-14:14:15.673"
@@ -298,12 +299,16 @@ def test_create_model_with_optional_params(sagemaker_session):
     model_server_workers = 2
     vpc_config = {"Subnets": ["foo"], "SecurityGroupIds": ["bar"]}
     model = tf.create_model(
-        role=new_role, model_server_workers=model_server_workers, vpc_config_override=vpc_config
+        role=new_role,
+        model_server_workers=model_server_workers,
+        vpc_config_override=vpc_config,
+        entry_point=SERVING_SCRIPT_FILE,
     )
 
     assert model.role == new_role
     assert model.model_server_workers == model_server_workers
     assert model.vpc_config == vpc_config
+    assert model.entry_point == SERVING_SCRIPT_FILE
 
 
 @patch("sagemaker.tensorflow.estimator.TensorFlow.create_model")
@@ -319,13 +324,19 @@ def test_transformer_creation_with_endpoint_type(create_model, sagemaker_session
         train_instance_type=INSTANCE_TYPE,
     )
 
-    tf.transformer(INSTANCE_COUNT, INSTANCE_TYPE, endpoint_type="tensorflow-serving")
+    tf.transformer(
+        INSTANCE_COUNT,
+        INSTANCE_TYPE,
+        endpoint_type="tensorflow-serving",
+        entry_point=SERVING_SCRIPT_FILE,
+    )
 
     create_model.assert_called_with(
         endpoint_type="tensorflow-serving",
         model_server_workers=None,
         role=ROLE,
         vpc_config_override="VPC_CONFIG_DEFAULT",
+        entry_point=SERVING_SCRIPT_FILE,
     )
     model.transformer.assert_called_with(
         INSTANCE_COUNT,
@@ -362,6 +373,7 @@ def test_transformer_creation_without_endpoint_type(create_model, sagemaker_sess
         model_server_workers=None,
         role=ROLE,
         vpc_config_override="VPC_CONFIG_DEFAULT",
+        entry_point=None,
     )
     model.transformer.assert_called_with(
         INSTANCE_COUNT,

--- a/tests/unit/test_tf_estimator.py
+++ b/tests/unit/test_tf_estimator.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2017-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You
 # may not use this file except in compliance with the License. A copy of


### PR DESCRIPTION
*Issue #, if available:*
Related: #690. This was initially motivated, however, by the TFS with pre/post-processing use case.

*Description of changes:*
With TFS, there is a code path where the inference.py file is not correctly packed with the model. It was a similar enough change to just allowing the entry point script to be specified to deploy/transformer that I went ahead and made the general change.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#commit-message-guidlines)
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
