### PR TITLE
change: Format and add missing docstring placeholders

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -92,7 +92,6 @@ disable=
     cyclic-import, # TODO: Resolve cyclic imports
     no-self-use, # TODO: Convert methods to functions where appropriate
     too-many-branches, # TODO: Simplify or ignore as appropriate
-    missing-docstring, # TODO: Fix missing docstring
 
 [REPORTS]
 # Set the output format. Available formats are text, parseable, colorized, msvs

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import absolute_import
 
 import os
@@ -22,6 +23,10 @@ from unittest.mock import MagicMock
 class Mock(MagicMock):
     @classmethod
     def __getattr__(cls, name):
+        """
+        Args:
+            name:
+        """
         if name == "__version__":
             return "1.4.0"
         else:

--- a/examples/cli/host/script.py
+++ b/examples/cli/host/script.py
@@ -6,11 +6,13 @@ from mxnet import gluon
 
 
 def model_fn(model_dir):
-    """
-    Load the gluon model. Called once when hosting service starts.
+    """Load the gluon model. Called once when hosting service starts.
 
-    :param: model_dir The directory where model files are stored.
-    :return: a model (in this case a Gluon network)
+    Args:
+        model_dir: The directory where model files are stored.
+
+    Returns:
+        a model (in this case a Gluon network)
     """
     symbol = mx.sym.load("%s/model.json" % model_dir)
     outputs = mx.symbol.softmax(data=symbol, name="softmax_label")
@@ -22,14 +24,16 @@ def model_fn(model_dir):
 
 
 def transform_fn(net, data, input_content_type, output_content_type):
-    """
-    Transform a request using the Gluon model. Called once per request.
+    """Transform a request using the Gluon model. Called once per request.
 
-    :param net: The Gluon model.
-    :param data: The request payload.
-    :param input_content_type: The request content type.
-    :param output_content_type: The (desired) response content type.
-    :return: response payload and content type.
+    Args:
+        net: The Gluon model.
+        data: The request payload.
+        input_content_type: The request content type.
+        output_content_type: The (desired) response content type.
+
+    Returns:
+        response payload and content type.
     """
     # we can use content types to vary input/output handling, but
     # here we just assume json for both

--- a/examples/cli/train/script.py
+++ b/examples/cli/train/script.py
@@ -12,6 +12,12 @@ logger = logging.getLogger(__name__)
 def train(channel_input_dirs, hyperparameters, **kwargs):
     # SageMaker passes num_cpus, num_gpus and other args we can use to tailor training to
     # the current container environment, but here we just use simple cpu context.
+    """
+    Args:
+        channel_input_dirs:
+        hyperparameters:
+        **kwargs:
+    """
     ctx = mx.cpu()
 
     # retrieve the hyperparameters we set in notebook (with some defaults)
@@ -80,6 +86,11 @@ def train(channel_input_dirs, hyperparameters, **kwargs):
 
 def save(net, model_dir):
     # save the model
+    """
+    Args:
+        net:
+        model_dir:
+    """
     y = net(mx.sym.var("data"))
     y.save("%s/model.json" % model_dir)
     net.collect_params().save("%s/model.params" % model_dir)
@@ -95,11 +106,21 @@ def define_network():
 
 
 def input_transformer(data, label):
+    """
+    Args:
+        data:
+        label:
+    """
     data = data.reshape((-1,)).astype(np.float32) / 255
     return data, label
 
 
 def get_train_data(data_dir, batch_size):
+    """
+    Args:
+        data_dir:
+        batch_size:
+    """
     return gluon.data.DataLoader(
         gluon.data.vision.MNIST(data_dir, train=True, transform=input_transformer),
         batch_size=batch_size,
@@ -109,6 +130,11 @@ def get_train_data(data_dir, batch_size):
 
 
 def get_val_data(data_dir, batch_size):
+    """
+    Args:
+        data_dir:
+        batch_size:
+    """
     return gluon.data.DataLoader(
         gluon.data.vision.MNIST(data_dir, train=False, transform=input_transformer),
         batch_size=batch_size,
@@ -117,6 +143,12 @@ def get_val_data(data_dir, batch_size):
 
 
 def test(ctx, net, val_data):
+    """
+    Args:
+        ctx:
+        net:
+        val_data:
+    """
     metric = mx.metric.Accuracy()
     for data, label in val_data:
         data = data.as_in_context(ctx)

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import absolute_import
 
 import os
@@ -20,6 +21,10 @@ from setuptools import setup, find_packages
 
 
 def read(fname):
+    """
+    Args:
+        fname:
+    """
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 

--- a/src/sagemaker/__init__.py
+++ b/src/sagemaker/__init__.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import absolute_import
 
 import pkg_resources

--- a/src/sagemaker/algorithm.py
+++ b/src/sagemaker/algorithm.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Test docstring"""
 from __future__ import absolute_import
 
 import sagemaker
@@ -21,9 +22,10 @@ from sagemaker.predictor import RealTimePredictor
 
 
 class AlgorithmEstimator(EstimatorBase):
-    """A generic Estimator to train using any algorithm object (with an ``algorithm_arn``).
-    The Algorithm can be your own, or any Algorithm from AWS Marketplace that you have a valid
-    subscription for. This class will perform client-side validation on all the inputs.
+    """A generic Estimator to train using any algorithm object (with an
+    ``algorithm_arn``). The Algorithm can be your own, or any Algorithm from AWS
+    Marketplace that you have a valid subscription for. This class will perform
+    client-side validation on all the inputs.
     """
 
     # These Hyperparameter Types have a range definition.
@@ -55,54 +57,111 @@ class AlgorithmEstimator(EstimatorBase):
         """Initialize an ``AlgorithmEstimator`` instance.
 
         Args:
-           algorithm_arn (str): algorithm arn used for training. Can be just the name if your
-                account owns the algorithm.
-            role (str): An AWS IAM role (either name or full ARN). The Amazon SageMaker training jobs and APIs
-                that create Amazon SageMaker endpoints use this role to access training data and model artifacts.
-                After the endpoint is created, the inference code might use the IAM role,
-                if it needs to access an AWS resource.
-            train_instance_count (int): Number of Amazon EC2 instances to use for training.
-            train_instance_type (str): Type of EC2 instance to use for training, for example, 'ml.c4.xlarge'.
-            train_volume_size (int): Size in GB of the EBS volume to use for storing input data
-                during training (default: 30). Must be large enough to store training data if File Mode is used
-                (which is the default).
-            train_volume_kms_key (str): Optional. KMS key ID for encrypting EBS volume attached to the
-                training instance (default: None).
-            train_max_run (int): Timeout in seconds for training (default: 24 * 60 * 60).
-                After this amount of time Amazon SageMaker terminates the job regardless of its current status.
-            input_mode (str): The input mode that the algorithm supports (default: 'File'). Valid modes:
+            algorithm_arn (str): algorithm arn used for training. Can be just the name if your
+                    account owns the algorithm.
 
-                * 'File' - Amazon SageMaker copies the training dataset from the S3 location to a local directory.
-                * 'Pipe' - Amazon SageMaker streams data directly from S3 to the container via a Unix-named pipe.
+                role (str): An AWS IAM role (either name or full ARN). The Amazon SageMaker
+                    training jobs and APIsthat create Amazon SageMaker endpoints use this role to
+                    access training data and model artifacts. After the endpoint
+                    is created, the inference code might use the IAM role, if it
+                    needs to access an AWS resource.
 
-                This argument can be overriden on a per-channel basis using ``sagemaker.session.s3_input.input_mode``.
-            output_path (str): S3 location for saving the training result (model artifacts and output files).
-                If not specified, results are stored to a default bucket. If the bucket with the specific name
-                does not exist, the estimator creates the bucket during the
-                :meth:`~sagemaker.estimator.EstimatorBase.fit` method execution.
-            output_kms_key (str): Optional. KMS key ID for encrypting the training output (default: None).
-            base_job_name (str): Prefix for training job name when the :meth:`~sagemaker.estimator.EstimatorBase.fit`
-                method launches. If not specified, the estimator generates a default job name, based on
-                the training image name and current timestamp.
-            sagemaker_session (sagemaker.session.Session): Session object which manages interactions with
-                Amazon SageMaker APIs and any other AWS services needed. If not specified, the estimator creates one
-                using the default AWS configuration chain.
-            tags (list[dict]): List of tags for labeling a training job. For more, see
-                https://docs.aws.amazon.com/sagemaker/latest/dg/API_Tag.html.
-            subnets (list[str]): List of subnet ids. If not specified training job will be created without VPC config.
-            security_group_ids (list[str]): List of security group ids. If not specified training job will be created
-                without VPC config.
-            model_uri (str): URI where a pre-trained model is stored, either locally or in S3 (default: None). If
-                specified, the estimator will create a channel pointing to the model so the training job can download
-                it. This model can be a 'model.tar.gz' from a previous training job, or other artifacts coming from a
-                different source.
-                More information: https://docs.aws.amazon.com/sagemaker/latest/dg/cdf-training.html#td-deserialization
-            model_channel_name (str): Name of the channel where 'model_uri' will be downloaded (default: 'model').
-            metric_definitions (list[dict]): A list of dictionaries that defines the metric(s) used to evaluate the
-                training jobs. Each dictionary contains two keys: 'Name' for the name of the metric, and 'Regex' for
-                the regular expression used to extract the metric from the logs.
-            encrypt_inter_container_traffic (bool): Specifies whether traffic between training containers is encrypted
-                for the training job (default: ``False``).
+                train_instance_count (int): Number of Amazon EC2 instances to
+                use for training. train_instance_type (str): Type of EC2
+                instance to use for training, for example, 'ml.c4.xlarge'.
+                train_volume_size (int): Size in GB of the EBS volume to use for
+                storing input data
+
+                    during training (default: 30). Must be large enough to store
+                    training data if File Mode is used (which is the default).
+
+                train_volume_kms_key (str): Optional. KMS key ID for encrypting EBS volume attached
+                    to the training instance (default: None).
+
+                train_max_run (int): Timeout in seconds for training (default: 24 * 60 * 60).
+                    After this amount of time Amazon SageMaker terminates the
+                    job regardless of its current status.
+
+                input_mode (str): The input mode that the algorithm supports
+                (default: 'File'). Valid modes:
+
+                    * 'File' - Amazon SageMaker copies the training dataset from
+                      the S3 location to a local directory.
+                    * 'Pipe' - Amazon SageMaker streams data directly from S3 to
+                      the container via a Unix-named pipe.
+
+                    This argument can be overriden on a per-channel basis using
+                    ``sagemaker.session.s3_input.input_mode``.
+
+                output_path (str): S3 location for saving the training result (model artifacts and
+                    output files). If not specified, results are stored to a default bucket. If
+                    the bucket with the specific name does not exist, the
+                    estimator creates the bucket during the
+                    :meth:`~sagemaker.estimator.EstimatorBase.fit` method
+                    execution.
+
+                output_kms_key (str): Optional. KMS key ID for encrypting the
+                training output (default: None). base_job_name (str): Prefix for
+                training job name when the
+                :meth:`~sagemaker.estimator.EstimatorBase.fit`
+
+                    method launches. If not specified, the estimator generates a
+                    default job name, based on the training image name and
+                    current timestamp.
+
+                sagemaker_session (sagemaker.session.Session): Session object which manages
+                    interactions with Amazon SageMaker APIs and any other AWS services needed. If
+                    not specified, the estimator creates one using the default
+                    AWS configuration chain.
+
+                tags (list[dict]): List of tags for labeling a training job. For more, see
+                    https://docs.aws.amazon.com/sagemaker/latest/dg/API_Tag.html.
+
+                subnets (list[str]): List of subnet ids. If not specified
+                training job will be created without VPC config.
+                security_group_ids (list[str]): List of security group ids. If
+                not specified training job will be created
+
+                    without VPC config.
+
+                model_uri (str): URI where a pre-trained model is stored, either locally or in S3
+                    (default: None). If specified, the estimator will create a channel pointing to
+                    the model so the training job can download it. This model
+                    can be a 'model.tar.gz' from a previous training job, or
+                    other artifacts coming from a different source. More
+                    More information:
+                    https://docs.aws.amazon.com/sagemaker/latest/dg/cdf-training.html#td-deserialization
+
+                model_channel_name (str): Name of the channel where 'model_uri'
+                will be downloaded (default: 'model'). metric_definitions
+                (list[dict]): A list of dictionaries that defines the metric(s)
+                used to evaluate the
+
+                    training jobs. Each dictionary contains two keys: 'Name' for
+                    the name of the metric, and 'Regex' for the regular
+                    expression used to extract the metric from the logs.
+
+                encrypt_inter_container_traffic (bool): Specifies whether traffic between training
+                    containers is encrypted for the training job (default: ``False``).
+            role:
+            train_instance_count:
+            train_instance_type:
+            train_volume_size:
+            train_volume_kms_key:
+            train_max_run:
+            input_mode:
+            output_path:
+            output_kms_key:
+            base_job_name:
+            sagemaker_session:
+            hyperparameters:
+            tags:
+            subnets:
+            security_group_ids:
+            model_uri:
+            model_channel_name:
+            metric_definitions:
+            encrypt_inter_container_traffic:
         """
         self.algorithm_arn = algorithm_arn
         super(AlgorithmEstimator, self).__init__(
@@ -137,6 +196,7 @@ class AlgorithmEstimator(EstimatorBase):
             self.set_hyperparameters(**hyperparameters)
 
     def validate_train_spec(self):
+        """Placeholder docstring"""
         train_spec = self.algorithm_spec["TrainingSpecification"]
         algorithm_name = self.algorithm_spec["AlgorithmName"]
 
@@ -169,6 +229,10 @@ class AlgorithmEstimator(EstimatorBase):
             )
 
     def set_hyperparameters(self, **kwargs):
+        """
+        Args:
+            **kwargs:
+        """
         for k, v in kwargs.items():
             value = self._validate_and_cast_hyperparameter(k, v)
             self.hyperparam_dict[k] = value
@@ -178,23 +242,25 @@ class AlgorithmEstimator(EstimatorBase):
     def hyperparameters(self):
         """Returns the hyperparameters as a dictionary to use for training.
 
-        The fit() method, that does the model training, calls this method to find the hyperparameters you specified.
+        The fit() method, that does the model training, calls this method to
+        find the hyperparameters you specified.
         """
         return self.hyperparam_dict
 
     def train_image(self):
         """Returns the docker image to use for training.
 
-        The fit() method, that does the model training, calls this method to find the image to use for model training.
+        The fit() method, that does the model training, calls this method to
+        find the image to use for model training.
         """
         raise RuntimeError("train_image is never meant to be called on Algorithm Estimators")
 
     def enable_network_isolation(self):
         """Return True if this Estimator will need network isolation to run.
 
-        On Algorithm Estimators this depends on the algorithm being used. If this is algorithm
-        owned by your account it will be False. If this is an an algorithm consumed from Marketplace
-        it will be True.
+        On Algorithm Estimators this depends on the algorithm being used. If
+        this is algorithm owned by your account it will be False. If this is an
+        an algorithm consumed from Marketplace it will be True.
 
         Returns:
             bool: Whether this Estimator needs network isolation or not.
@@ -214,25 +280,33 @@ class AlgorithmEstimator(EstimatorBase):
     ):
         """Create a model to deploy.
 
-        The serializer, deserializer, content_type, and accept arguments are only used to define a default
-        RealTimePredictor. They are ignored if an explicit predictor class is passed in. Other arguments
-        are passed through to the Model class.
+        The serializer, deserializer, content_type, and accept arguments are
+        only used to define a default RealTimePredictor. They are ignored if an
+        explicit predictor class is passed in. Other arguments are passed
+        through to the Model class.
 
         Args:
-            role (str): The ``ExecutionRoleArn`` IAM Role ARN for the ``Model``, which is also used during
-                transform jobs. If not specified, the role from the Estimator will be used.
-            predictor_cls (RealTimePredictor): The predictor class to use when deploying the model.
-            serializer (callable): Should accept a single argument, the input data, and return a sequence
-                of bytes. May provide a content_type attribute that defines the endpoint request content type
-            deserializer (callable): Should accept two arguments, the result data and the response content type,
-                and return a sequence of bytes. May provide a content_type attribute that defines th endpoint
-                response Accept content type.
-            content_type (str): The invocation ContentType, overriding any content_type from the serializer
-            accept (str): The invocation Accept, overriding any accept from the deserializer.
-            vpc_config_override (dict[str, list[str]]): Optional override for VpcConfig set on the model.
-                Default: use subnets and security groups from this Estimator.
+            role (str): The ``ExecutionRoleArn`` IAM Role ARN for the ``Model``,
+                which is also used during transform jobs. If not specified, the
+                role from the Estimator will be used.
+            predictor_cls (RealTimePredictor): The predictor class to use when
+                deploying the model.
+            serializer (callable): Should accept a single argument, the input
+                data, and return a sequence of bytes. May provide a content_type
+                attribute that defines the endpoint request content type
+            deserializer (callable): Should accept two arguments, the result
+                data and the response content type, and return a sequence of
+                bytes. May provide a content_type attribute that defines the
+                endpoint response Accept content type.
+            content_type (str): The invocation ContentType, overriding any
+                content_type from the serializer
+            accept (str): The invocation Accept, overriding any accept from the
+                deserializer.
+            vpc_config_override (dict[str, list[str]]): Optional override for VpcConfig set on
+                the model. Default: use subnets and security groups from this Estimator.
                 * 'Subnets' (list[str]): List of subnet ids.
                 * 'SecurityGroupIds' (list[str]): List of security group ids.
+            **kwargs:
 
         Returns:
             a Model ready for deployment.
@@ -274,29 +348,39 @@ class AlgorithmEstimator(EstimatorBase):
         role=None,
         volume_kms_key=None,
     ):
-        """Return a ``Transformer`` that uses a SageMaker Model based on the training job. It reuses the
-        SageMaker Session and base job name used by the Estimator.
+        """Return a ``Transformer`` that uses a SageMaker Model based on the
+        training job. It reuses the SageMaker Session and base job name used by
+        the Estimator.
 
         Args:
             instance_count (int): Number of EC2 instances to use.
-            instance_type (str): Type of EC2 instance to use, for example, 'ml.c4.xlarge'.
-            strategy (str): The strategy used to decide how to batch records in a single request (default: None).
-                Valid values: 'MULTI_RECORD' and 'SINGLE_RECORD'.
-            assemble_with (str): How the output is assembled (default: None). Valid values: 'Line' or 'None'.
-            output_path (str): S3 location for saving the transform result. If not specified, results are stored to
-                a default bucket.
-            output_kms_key (str): Optional. KMS key ID for encrypting the transform output (default: None).
-            accept (str): The content type accepted by the endpoint deployed during the transform job.
-            env (dict): Environment variables to be set for use during the transform job (default: None).
-            max_concurrent_transforms (int): The maximum number of HTTP requests to be made to
-                each individual transform container at one time.
-            max_payload (int): Maximum size of the payload in a single HTTP request to the container in MB.
-            tags (list[dict]): List of tags for labeling a transform job. If none specified, then the tags used for
-                the training job are used for the transform job.
-            role (str): The ``ExecutionRoleArn`` IAM Role ARN for the ``Model``, which is also used during
-                transform jobs. If not specified, the role from the Estimator will be used.
-            volume_kms_key (str): Optional. KMS key ID for encrypting the volume attached to the ML
-                compute instance (default: None).
+            instance_type (str): Type of EC2 instance to use, for example,
+                'ml.c4.xlarge'.
+            strategy (str): The strategy used to decide how to batch records in
+                a single request (default: None). Valid values: 'MULTI_RECORD'
+                and 'SINGLE_RECORD'.
+            assemble_with (str): How the output is assembled (default: None).
+                Valid values: 'Line' or 'None'.
+            output_path (str): S3 location for saving the transform result. If
+                not specified, results are stored to a default bucket.
+            output_kms_key (str): Optional. KMS key ID for encrypting the
+                transform output (default: None).
+            accept (str): The content type accepted by the endpoint deployed
+                during the transform job.
+            env (dict): Environment variables to be set for use during the
+                transform job (default: None).
+            max_concurrent_transforms (int): The maximum number of HTTP requests
+                to be made to each individual transform container at one time.
+            max_payload (int): Maximum size of the payload in a single HTTP
+                request to the container in MB.
+            tags (list[dict]): List of tags for labeling a transform job. If
+                none specified, then the tags used for the training job are used
+                for the transform job.
+            role (str): The ``ExecutionRoleArn`` IAM Role ARN for the ``Model``,
+                which is also used during transform jobs. If not specified, the
+                role from the Estimator will be used.
+            volume_kms_key (str): Optional. KMS key ID for encrypting the volume
+                attached to the ML compute instance (default: None).
         """
         role = role or self.role
 
@@ -334,23 +418,39 @@ class AlgorithmEstimator(EstimatorBase):
         )
 
     def _is_marketplace(self):
+        """Placeholder docstring"""
         return "ProductId" in self.algorithm_spec
 
     def _prepare_for_training(self, job_name=None):
         # Validate hyperparameters
         # an explicit call to set_hyperparameters() will also validate the hyperparameters
         # but it is possible that the user never called it.
+        """
+        Args:
+            job_name:
+        """
         self._validate_and_set_default_hyperparameters()
 
         super(AlgorithmEstimator, self)._prepare_for_training(job_name)
 
     def fit(self, inputs=None, wait=True, logs=True, job_name=None):
+        """
+        Args:
+            inputs:
+            wait:
+            logs:
+            job_name:
+        """
         if inputs:
             self._validate_input_channels(inputs)
 
         super(AlgorithmEstimator, self).fit(inputs, wait, logs, job_name)
 
     def _validate_input_channels(self, channels):
+        """
+        Args:
+            channels:
+        """
         train_spec = self.algorithm_spec["TrainingSpecification"]
         algorithm_name = self.algorithm_spec["AlgorithmName"]
         training_channels = {c["Name"]: c for c in train_spec["TrainingChannels"]}
@@ -368,6 +468,11 @@ class AlgorithmEstimator(EstimatorBase):
                 raise ValueError("Required input channel: %s Was not provided." % (name))
 
     def _validate_and_cast_hyperparameter(self, name, v):
+        """
+        Args:
+            name:
+            v:
+        """
         algorithm_name = self.algorithm_spec["AlgorithmName"]
 
         if name not in self.hyperparameter_definitions:
@@ -387,6 +492,7 @@ class AlgorithmEstimator(EstimatorBase):
         return value
 
     def _validate_and_set_default_hyperparameters(self):
+        """Placeholder docstring"""
         # Check if all the required hyperparameters are set. If there is a default value
         # for one, set it.
         for name, definition in self.hyperparameter_definitions.items():
@@ -398,6 +504,7 @@ class AlgorithmEstimator(EstimatorBase):
                     raise ValueError("Required hyperparameter: %s is not set" % name)
 
     def _parse_hyperparameters(self):
+        """Placeholder docstring"""
         definitions = {}
 
         training_spec = self.algorithm_spec["TrainingSpecification"]
@@ -419,6 +526,11 @@ class AlgorithmEstimator(EstimatorBase):
         return definitions
 
     def _hyperparameter_range_and_class(self, parameter_type, hyperparameter):
+        """
+        Args:
+            parameter_type:
+            hyperparameter:
+        """
         if parameter_type in self._hyperpameters_with_range:
             range_name = parameter_type + "ParameterRangeSpecification"
 
@@ -459,6 +571,10 @@ class AlgorithmEstimator(EstimatorBase):
         return parameter_class, parameter_range
 
     def _algorithm_training_input_modes(self, training_channels):
+        """
+        Args:
+            training_channels:
+        """
         current_input_modes = {"File", "Pipe"}
         for channel in training_channels:
             supported_input_modes = set(channel["SupportedInputModes"])

--- a/src/sagemaker/amazon/amazon_estimator.py
+++ b/src/sagemaker/amazon/amazon_estimator.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import absolute_import
 
 import json
@@ -30,8 +31,9 @@ logger = logging.getLogger(__name__)
 
 
 class AmazonAlgorithmEstimatorBase(EstimatorBase):
-    """Base class for Amazon first-party Estimator implementations. This class isn't intended
-    to be instantiated directly."""
+    """Base class for Amazon first-party Estimator implementations. This class
+    isn't intended to be instantiated directly.
+    """
 
     feature_dim = hp("feature_dim", validation.gt(0), data_type=int)
     mini_batch_size = hp("mini_batch_size", validation.gt(0), data_type=int)
@@ -44,10 +46,16 @@ class AmazonAlgorithmEstimatorBase(EstimatorBase):
         """Initialize an AmazonAlgorithmEstimatorBase.
 
         Args:
-            data_location (str or None): The s3 prefix to upload RecordSet objects to, expressed as an
-                S3 url. For example "s3://example-bucket/some-key-prefix/". Objects will be
-                saved in a unique sub-directory of the specified location. If None, a default
-                data location will be used."""
+            role:
+            train_instance_count:
+            train_instance_type:
+            data_location (str or None): The s3 prefix to upload RecordSet
+                objects to, expressed as an S3 url. For example
+                "s3://example-bucket/some-key-prefix/". Objects will be saved in
+                a unique sub-directory of the specified location. If None, a
+                default data location will be used.
+            **kwargs:
+        """
         super(AmazonAlgorithmEstimatorBase, self).__init__(
             role, train_instance_count, train_instance_type, **kwargs
         )
@@ -58,19 +66,26 @@ class AmazonAlgorithmEstimatorBase(EstimatorBase):
         self._data_location = data_location
 
     def train_image(self):
+        """Placeholder docstring"""
         return get_image_uri(
             self.sagemaker_session.boto_region_name, type(self).repo_name, type(self).repo_version
         )
 
     def hyperparameters(self):
+        """Placeholder docstring"""
         return hp.serialize_all(self)
 
     @property
     def data_location(self):
+        """Placeholder docstring"""
         return self._data_location
 
     @data_location.setter
     def data_location(self, data_location):
+        """
+        Args:
+            data_location:
+        """
         if not data_location.startswith("s3://"):
             raise ValueError(
                 'Expecting an S3 URL beginning with "s3://". Got "{}"'.format(data_location)
@@ -81,15 +96,17 @@ class AmazonAlgorithmEstimatorBase(EstimatorBase):
 
     @classmethod
     def _prepare_init_params_from_job_description(cls, job_details, model_channel_name=None):
-        """Convert the job description to init params that can be handled by the class constructor
+        """Convert the job description to init params that can be handled by the
+        class constructor
 
         Args:
-            job_details: the returned job details from a describe_training_job API call.
-            model_channel_name (str): Name of the channel where pre-trained model data will be downloaded.
+            job_details: the returned job details from a describe_training_job
+                API call.
+            model_channel_name (str): Name of the channel where pre-trained
+                model data will be downloaded.
 
         Returns:
-             dictionary: The transformed init_params
-
+            dictionary: The transformed init_params
         """
         init_params = super(
             AmazonAlgorithmEstimatorBase, cls
@@ -111,11 +128,12 @@ class AmazonAlgorithmEstimatorBase(EstimatorBase):
         """Set hyperparameters needed for training.
 
         Args:
-            * records (:class:`~RecordSet`): The records to train this ``Estimator`` on.
-            * mini_batch_size (int or None): The size of each mini-batch to use when training. If ``None``, a
-                default value will be used.
-            * job_name (str): Name of the training job to be created. If not specified, one is generated,
-                using the base name given to the constructor if applicable.
+            records (:class:`~RecordSet`): The records to train this ``Estimator`` on.
+            mini_batch_size (int or None): The size of each mini-batch to use when
+                training. If ``None``, a default value will be used.
+            job_name (str): Name of the training job to be created. If not
+                specified, one is generated, using the base name given to the
+                constructor if applicable.
         """
         super(AmazonAlgorithmEstimatorBase, self)._prepare_for_training(job_name=job_name)
 
@@ -137,28 +155,31 @@ class AmazonAlgorithmEstimatorBase(EstimatorBase):
     def fit(self, records, mini_batch_size=None, wait=True, logs=True, job_name=None):
         """Fit this Estimator on serialized Record objects, stored in S3.
 
-        ``records`` should be an instance of :class:`~RecordSet`. This defines a collection of
-        S3 data files to train this ``Estimator`` on.
+        ``records`` should be an instance of :class:`~RecordSet`. This
+        defines a collection of S3 data files to train this ``Estimator`` on.
 
-        Training data is expected to be encoded as dense or sparse vectors in the "values" feature
-        on each Record. If the data is labeled, the label is expected to be encoded as a list of
-        scalas in the "values" feature of the Record label.
+        Training data is expected to be encoded as dense or sparse vectors in
+        the "values" feature on each Record. If the data is labeled, the label
+        is expected to be encoded as a list of scalas in the "values" feature of
+        the Record label.
 
         More information on the Amazon Record format is available at:
         https://docs.aws.amazon.com/sagemaker/latest/dg/cdf-training.html
 
-        See :meth:`~AmazonAlgorithmEstimatorBase.record_set` to construct a ``RecordSet`` object
-        from :class:`~numpy.ndarray` arrays.
+        See :meth:`~AmazonAlgorithmEstimatorBase.record_set` to construct a
+        ``RecordSet`` object from :class:`~numpy.ndarray` arrays.
 
         Args:
             records (:class:`~RecordSet`): The records to train this ``Estimator`` on
-            mini_batch_size (int or None): The size of each mini-batch to use when training. If ``None``, a
-                default value will be used.
-            wait (bool): Whether the call should wait until the job completes (default: True).
-            logs (bool): Whether to show the logs produced by the job.
-                Only meaningful when wait is True (default: True).
-            job_name (str): Training job name. If not specified, the estimator generates a default job name,
-                based on the training image name and current timestamp.
+            mini_batch_size (int or None): The size of each mini-batch to use
+                when training. If ``None``, a default value will be used.
+            wait (bool): Whether the call should wait until the job completes
+                (default: True).
+            logs (bool): Whether to show the logs produced by the job. Only
+                meaningful when wait is True (default: True).
+            job_name (str): Training job name. If not specified, the estimator
+                generates a default job name, based on the training image name
+                and current timestamp.
         """
         self._prepare_for_training(records, job_name=job_name, mini_batch_size=mini_batch_size)
 
@@ -167,29 +188,35 @@ class AmazonAlgorithmEstimatorBase(EstimatorBase):
             self.latest_training_job.wait(logs=logs)
 
     def record_set(self, train, labels=None, channel="train", encrypt=False):
-        """Build a :class:`~RecordSet` from a numpy :class:`~ndarray` matrix and label vector.
+        """Build a :class:`~RecordSet` from a numpy :class:`~ndarray` matrix and
+        label vector.
 
-        For the 2D ``ndarray`` ``train``, each row is converted to a :class:`~Record` object.
-        The vector is stored in the "values" entry of the ``features`` property of each Record.
-        If ``labels`` is not None, each corresponding label is assigned to the "values" entry
-        of the ``labels`` property of each Record.
+        For the 2D ``ndarray`` ``train``, each row is converted to a
+        :class:`~Record` object. The vector is stored in the "values" entry of
+        the ``features`` property of each Record. If ``labels`` is not None,
+        each corresponding label is assigned to the "values" entry of the
+        ``labels`` property of each Record.
 
-        The collection of ``Record`` objects are protobuf serialized and uploaded to new
-        S3 locations. A manifest file is generated containing the list of objects created and
-        also stored in S3.
+        The collection of ``Record`` objects are protobuf serialized and
+        uploaded to new S3 locations. A manifest file is generated containing
+        the list of objects created and also stored in S3.
 
-        The number of S3 objects created is controlled by the ``train_instance_count`` property
-        on this Estimator. One S3 object is created per training instance.
+        The number of S3 objects created is controlled by the
+        ``train_instance_count`` property on this Estimator. One S3 object is
+        created per training instance.
 
         Args:
             train (numpy.ndarray): A 2D numpy array of training data.
-            labels (numpy.ndarray): A 1D numpy array of labels. Its length must be equal to the
-                number of rows in ``train``.
-            channel (str): The SageMaker TrainingJob channel this RecordSet should be assigned to.
-            encrypt (bool): Specifies whether the objects uploaded to S3 are encrypted on the
-                server side using AES-256 (default: ``False``).
+            labels (numpy.ndarray): A 1D numpy array of labels. Its length must
+                be equal to the number of rows in ``train``.
+            channel (str): The SageMaker TrainingJob channel this RecordSet
+                should be assigned to.
+            encrypt (bool): Specifies whether the objects uploaded to S3 are
+                encrypted on the server side using AES-256 (default: ``False``).
+
         Returns:
-            RecordSet: A RecordSet referencing the encoded, uploading training and label data.
+            RecordSet: A RecordSet referencing the encoded, uploading training
+            and label data.
         """
         s3 = self.sagemaker_session.boto_session.resource("s3")
         parsed_s3_url = urlparse(self.data_location)
@@ -210,21 +237,26 @@ class AmazonAlgorithmEstimatorBase(EstimatorBase):
 
 
 class RecordSet(object):
+    """Placeholder docstring"""
+
     def __init__(
         self, s3_data, num_records, feature_dim, s3_data_type="ManifestFile", channel="train"
     ):
-        """A collection of Amazon :class:~`Record` objects serialized and stored in S3.
+        """A collection of Amazon :class:~`Record` objects serialized and stored
+        in S3.
 
         Args:
             s3_data (str): The S3 location of the training data
             num_records (int): The number of records in the set.
-            feature_dim (int): The dimensionality of "values" arrays in the Record features,
-                and label (if each Record is labeled).
-            s3_data_type (str): Valid values: 'S3Prefix', 'ManifestFile'. If 'S3Prefix', ``s3_data`` defines
-                a prefix of s3 objects to train on. All objects with s3 keys beginning with ``s3_data`` will
-                be used to train. If 'ManifestFile', then ``s3_data`` defines a single s3 manifest file, listing
-                each s3 object to train on.
-            channel (str): The SageMaker Training Job channel this RecordSet should be bound to
+            feature_dim (int): The dimensionality of "values" arrays in the
+                Record features, and label (if each Record is labeled).
+            s3_data_type (str): Valid values: 'S3Prefix', 'ManifestFile'. If
+                'S3Prefix', ``s3_data`` defines a prefix of s3 objects to train
+                on. All objects with s3 keys beginning with ``s3_data`` will be
+                used to train. If 'ManifestFile', then ``s3_data`` defines a
+                single s3 manifest file, listing each s3 object to train on.
+            channel (str): The SageMaker Training Job channel this RecordSet
+                should be bound to
         """
         self.s3_data = s3_data
         self.feature_dim = feature_dim
@@ -237,7 +269,9 @@ class RecordSet(object):
         return str((RecordSet, self.__dict__))
 
     def data_channel(self):
-        """Return a dictionary to represent the training data in a channel for use with ``fit()``"""
+        """Return a dictionary to represent the training data in a channel for
+        use with ``fit()``
+        """
         return {self.channel: self.records_s3_input()}
 
     def records_s3_input(self):
@@ -246,6 +280,11 @@ class RecordSet(object):
 
 
 def _build_shards(num_shards, array):
+    """
+    Args:
+        num_shards:
+        array:
+    """
     if num_shards < 1:
         raise ValueError("num_shards must be >= 1")
     shard_size = int(array.shape[0] / num_shards)
@@ -259,9 +298,19 @@ def _build_shards(num_shards, array):
 def upload_numpy_to_s3_shards(
     num_shards, s3, bucket, key_prefix, array, labels=None, encrypt=False
 ):
-    """Upload the training ``array`` and ``labels`` arrays to ``num_shards`` S3 objects,
-    stored in "s3://``bucket``/``key_prefix``/". Optionally ``encrypt`` the S3 objects using
-    AES-256."""
+    """Upload the training ``array`` and ``labels`` arrays to ``num_shards`` S3
+    objects, stored in "s3:// ``bucket`` / ``key_prefix`` /". Optionally
+    ``encrypt`` the S3 objects using AES-256.
+
+    Args:
+        num_shards:
+        s3:
+        bucket:
+        key_prefix:
+        array:
+        labels:
+        encrypt:
+    """
     shards = _build_shards(num_shards, array)
     if labels is not None:
         label_shards = _build_shards(num_shards, labels)
@@ -300,10 +349,14 @@ def upload_numpy_to_s3_shards(
 def registry(region_name, algorithm=None):
     """Return docker registry for the given AWS region
 
-    Note: Not all the algorithms listed below have an Amazon Estimator implemented. For full list of
-    pre-implemented Estimators, look at:
+    Note: Not all the algorithms listed below have an Amazon Estimator
+    implemented. For full list of pre-implemented Estimators, look at:
 
     https://github.com/aws/sagemaker-python-sdk/tree/master/src/sagemaker/amazon
+
+    Args:
+        region_name:
+        algorithm:
     """
     if algorithm in [
         None,
@@ -406,6 +459,13 @@ def registry(region_name, algorithm=None):
 
 
 def get_image_uri(region_name, repo_name, repo_version=1):
-    """Return algorithm image URI for the given AWS region, repository name, and repository version"""
+    """Return algorithm image URI for the given AWS region, repository name, and
+    repository version
+
+    Args:
+        region_name:
+        repo_name:
+        repo_version:
+    """
     repo = "{}:{}".format(repo_name, repo_version)
     return "{}/{}".format(registry(region_name, repo_name), repo)

--- a/src/sagemaker/amazon/common.py
+++ b/src/sagemaker/amazon/common.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import absolute_import
 
 import io
@@ -23,10 +24,20 @@ from sagemaker.amazon.record_pb2 import Record
 
 
 class numpy_to_record_serializer(object):
+    """Placeholder docstring"""
+
     def __init__(self, content_type="application/x-recordio-protobuf"):
+        """
+        Args:
+            content_type:
+        """
         self.content_type = content_type
 
     def __call__(self, array):
+        """
+        Args:
+            array:
+        """
         if len(array.shape) == 1:
             array = array.reshape(1, array.shape[0])
         assert len(array.shape) == 2, "Expecting a 1 or 2 dimensional array"
@@ -37,10 +48,21 @@ class numpy_to_record_serializer(object):
 
 
 class record_deserializer(object):
+    """Placeholder docstring"""
+
     def __init__(self, accept="application/x-recordio-protobuf"):
+        """
+        Args:
+            accept:
+        """
         self.accept = accept
 
     def __call__(self, stream, content_type):
+        """
+        Args:
+            stream:
+            content_type:
+        """
         try:
             return read_records(stream)
         finally:
@@ -48,6 +70,12 @@ class record_deserializer(object):
 
 
 def _write_feature_tensor(resolved_type, record, vector):
+    """
+    Args:
+        resolved_type:
+        record:
+        vector:
+    """
     if resolved_type == "Int32":
         record.features["values"].int32_tensor.values.extend(vector)
     elif resolved_type == "Float64":
@@ -57,6 +85,12 @@ def _write_feature_tensor(resolved_type, record, vector):
 
 
 def _write_label_tensor(resolved_type, record, scalar):
+    """
+    Args:
+        resolved_type:
+        record:
+        scalar:
+    """
     if resolved_type == "Int32":
         record.label["values"].int32_tensor.values.extend([scalar])
     elif resolved_type == "Float64":
@@ -66,6 +100,12 @@ def _write_label_tensor(resolved_type, record, scalar):
 
 
 def _write_keys_tensor(resolved_type, record, vector):
+    """
+    Args:
+        resolved_type:
+        record:
+        vector:
+    """
     if resolved_type == "Int32":
         record.features["values"].int32_tensor.keys.extend(vector)
     elif resolved_type == "Float64":
@@ -75,6 +115,12 @@ def _write_keys_tensor(resolved_type, record, vector):
 
 
 def _write_shape(resolved_type, record, scalar):
+    """
+    Args:
+        resolved_type:
+        record:
+        scalar:
+    """
     if resolved_type == "Int32":
         record.features["values"].int32_tensor.shape.extend([scalar])
     elif resolved_type == "Float64":
@@ -84,7 +130,13 @@ def _write_shape(resolved_type, record, scalar):
 
 
 def write_numpy_to_dense_tensor(file, array, labels=None):
-    """Writes a numpy array to a dense tensor"""
+    """Writes a numpy array to a dense tensor
+
+    Args:
+        file:
+        array:
+        labels:
+    """
 
     # Validate shape of array and labels, resolve array and label types
     if not len(array.shape) == 2:
@@ -112,7 +164,13 @@ def write_numpy_to_dense_tensor(file, array, labels=None):
 
 
 def write_spmatrix_to_sparse_tensor(file, array, labels=None):
-    """Writes a scipy sparse matrix to a sparse tensor"""
+    """Writes a scipy sparse matrix to a sparse tensor
+
+    Args:
+        file:
+        array:
+        labels:
+    """
 
     if not issparse(array):
         raise TypeError("Array must be sparse")
@@ -155,7 +213,11 @@ def write_spmatrix_to_sparse_tensor(file, array, labels=None):
 
 
 def read_records(file):
-    """Eagerly read a collection of amazon Record protobuf objects from file."""
+    """Eagerly read a collection of amazon Record protobuf objects from file.
+
+    Args:
+        file:
+    """
     records = []
     for record_data in read_recordio(file):
         record = Record()
@@ -178,7 +240,12 @@ _kmagic = 0xCED7230A
 
 
 def _write_recordio(f, data):
-    """Writes a single data point as a RecordIO record to the given file."""
+    """Writes a single data point as a RecordIO record to the given file.
+
+    Args:
+        f:
+        data:
+    """
     length = len(data)
     f.write(struct.pack("I", _kmagic))
     f.write(struct.pack("I", length))
@@ -188,6 +255,10 @@ def _write_recordio(f, data):
 
 
 def read_recordio(f):
+    """
+    Args:
+        f:
+    """
     while True:
         try:
             read_kmagic, = struct.unpack("I", f.read(4))
@@ -202,6 +273,10 @@ def read_recordio(f):
 
 
 def _resolve_type(dtype):
+    """
+    Args:
+        dtype:
+    """
     if dtype == np.dtype(int):
         return "Int32"
     if dtype == np.dtype(float):

--- a/src/sagemaker/amazon/factorization_machines.py
+++ b/src/sagemaker/amazon/factorization_machines.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import absolute_import
 
 from sagemaker.amazon.amazon_estimator import AmazonAlgorithmEstimatorBase, registry
@@ -23,6 +24,7 @@ from sagemaker.vpc_utils import VPC_CONFIG_DEFAULT
 
 
 class FactorizationMachines(AmazonAlgorithmEstimatorBase):
+    """Placeholder docstring"""
 
     repo_name = "factorization-machines"
     repo_version = 1
@@ -103,76 +105,105 @@ class FactorizationMachines(AmazonAlgorithmEstimatorBase):
         factors_init_value=None,
         **kwargs
     ):
-        """Factorization Machines is :class:`Estimator` for general-purpose supervised learning.
+        """Factorization Machines is :class:`Estimator` for general-purpose
+        supervised learning.
 
-        Amazon SageMaker Factorization Machines is a general-purpose supervised learning algorithm that you can use
-        for both classification and regression tasks. It is an extension of a linear model that is designed
-        to parsimoniously capture interactions between features within high dimensional sparse datasets.
+        Amazon SageMaker Factorization Machines is a general-purpose
+        supervised learning algorithm that you can use for both classification
+        and regression tasks. It is an extension of a linear model that is
+        designed to parsimoniously capture interactions between features within
+        high dimensional sparse datasets.
 
         This Estimator may be fit via calls to
-        :meth:`~sagemaker.amazon.amazon_estimator.AmazonAlgorithmEstimatorBase.fit`. It requires Amazon
-        :class:`~sagemaker.amazon.record_pb2.Record` protobuf serialized data to be stored in S3.
-        There is an utility :meth:`~sagemaker.amazon.amazon_estimator.AmazonAlgorithmEstimatorBase.record_set` that
-        can be used to upload data to S3 and creates :class:`~sagemaker.amazon.amazon_estimator.RecordSet` to be passed
-        to the `fit` call.
+        :meth:`~sagemaker.amazon.amazon_estimator.AmazonAlgorithmEstimatorBase.fit`.
+        It requires Amazon :class:`~sagemaker.amazon.record_pb2.Record` protobuf
+        serialized data to be stored in S3. There is an utility
+        :meth:`~sagemaker.amazon.amazon_estimator.AmazonAlgorithmEstimatorBase.record_set`
+        that can be used to upload data to S3 and creates
+        :class:`~sagemaker.amazon.amazon_estimator.RecordSet` to be passed to
+        the `fit` call.
 
-        To learn more about the Amazon protobuf Record class and how to prepare bulk data in this format, please
-        consult AWS technical documentation: https://docs.aws.amazon.com/sagemaker/latest/dg/cdf-training.html
+        To learn more about the Amazon protobuf Record class and how to
+        prepare bulk data in this format, please consult AWS technical
+        documentation:
+        https://docs.aws.amazon.com/sagemaker/latest/dg/cdf-training.html
 
-        After this Estimator is fit, model data is stored in S3. The model may be deployed to an Amazon SageMaker
-        Endpoint by invoking :meth:`~sagemaker.amazon.estimator.EstimatorBase.deploy`. As well as deploying an Endpoint,
-        deploy returns a :class:`~sagemaker.amazon.pca.FactorizationMachinesPredictor` object that can be used
-        for inference calls using the trained model hosted in the SageMaker Endpoint.
+        After this Estimator is fit, model data is stored in S3. The model
+        may be deployed to an Amazon SageMaker Endpoint by invoking
+        :meth:`~sagemaker.amazon.estimator.EstimatorBase.deploy`. As well as
+        deploying an Endpoint, deploy returns a
+        :class:`~sagemaker.amazon.pca.FactorizationMachinesPredictor` object
+        that can be used for inference calls using the trained model hosted in
+        the SageMaker Endpoint.
 
-        FactorizationMachines Estimators can be configured by setting hyperparameters. The available hyperparameters for
-        FactorizationMachines are documented below.
+        FactorizationMachines Estimators can be configured by setting
+        hyperparameters. The available hyperparameters for FactorizationMachines
+        are documented below.
 
         For further information on the AWS FactorizationMachines algorithm,
-        please consult AWS technical documentation: https://docs.aws.amazon.com/sagemaker/latest/dg/fact-machines.html
+        please consult AWS technical documentation:
+        https://docs.aws.amazon.com/sagemaker/latest/dg/fact-machines.html
 
         Args:
-            role (str): An AWS IAM role (either name or full ARN). The Amazon SageMaker training jobs and
-                APIs that create Amazon SageMaker endpoints use this role to access
-                training data and model artifacts. After the endpoint is created,
-                the inference code might use the IAM role, if accessing AWS resource.
-            train_instance_count (int): Number of Amazon EC2 instances to use for training.
-            train_instance_type (str): Type of EC2 instance to use for training, for example, 'ml.c4.xlarge'.
+            role (str): An AWS IAM role (either name or full ARN). The Amazon
+                SageMaker training jobs and APIs that create Amazon SageMaker
+                endpoints use this role to access training data and model
+                artifacts. After the endpoint is created, the inference code
+                might use the IAM role, if accessing AWS resource.
+            train_instance_count (int): Number of Amazon EC2 instances to use
+                for training.
+            train_instance_type (str): Type of EC2 instance to use for training,
+                for example, 'ml.c4.xlarge'.
             num_factors (int): Dimensionality of factorization.
-            predictor_type (str): Type of predictor 'binary_classifier' or 'regressor'.
+            predictor_type (str): Type of predictor 'binary_classifier' or
+                'regressor'.
             epochs (int): Number of training epochs to run.
-            clip_gradient (float): Optimizer parameter. Clip the gradient by projecting onto
-                the box [-clip_gradient, +clip_gradient]
-            eps (float): Optimizer parameter. Small value to avoid division by 0.
-            rescale_grad (float): Optimizer parameter. If set, multiplies the gradient with rescale_grad
-                before updating. Often choose to be 1.0/batch_size.
+            clip_gradient (float): Optimizer parameter. Clip the gradient by
+                projecting onto the box [-clip_gradient, +clip_gradient]
+            eps (float): Optimizer parameter. Small value to avoid division by
+                0.
+            rescale_grad (float): Optimizer parameter. If set, multiplies the
+                gradient with rescale_grad before updating. Often choose to be
+                1.0/batch_size.
             bias_lr (float): Non-negative learning rate for the bias term.
             linear_lr (float): Non-negative learning rate for linear terms.
-            factors_lr (float): Noon-negative learning rate for factorization terms.
+            factors_lr (float): Noon-negative learning rate for factorization
+                terms.
             bias_wd (float): Non-negative weight decay for the bias term.
             linear_wd (float): Non-negative weight decay for linear terms.
-            factors_wd (float): Non-negative weight decay for factorization terms.
-            bias_init_method (string): Initialization method for the bias term: 'normal', 'uniform' or 'constant'.
-            bias_init_scale (float): Non-negative range for initialization of the bias term that takes
-                effect when bias_init_method parameter is 'uniform'
-            bias_init_sigma (float): Non-negative standard deviation for initialization of the bias term that takes
-                effect when bias_init_method parameter is 'normal'.
-            bias_init_value (float): Initial value of the bias term  that takes effect
-                when bias_init_method parameter is 'constant'.
-            linear_init_method (string): Initialization method for linear term: 'normal', 'uniform' or 'constant'.
-            linear_init_scale (float): Non-negative range for initialization of linear terms that takes
-                effect when linear_init_method parameter is 'uniform'.
-            linear_init_sigma (float): Non-negative standard deviation for initialization of linear terms that takes
-                effect when linear_init_method parameter is 'normal'.
-            linear_init_value (float): Initial value of linear terms that takes effect
-                when linear_init_method parameter is 'constant'.
-            factors_init_method (string): Initialization method for factorization term: 'normal',
-                'uniform' or 'constant'.
-            factors_init_scale (float): Non-negative range for initialization of factorization terms that takes
-                effect when factors_init_method parameter is 'uniform'.
-            factors_init_sigma (float): Non-negative standard deviation for initialization of factorization terms that
-                takes effect when factors_init_method parameter is 'normal'.
-            factors_init_value (float): Initial value of factorization terms that takes
-                effect when factors_init_method parameter is 'constant'.
+            factors_wd (float): Non-negative weight decay for factorization
+                terms.
+            bias_init_method (string): Initialization method for the bias term:
+                'normal', 'uniform' or 'constant'.
+            bias_init_scale (float): Non-negative range for initialization of
+                the bias term that takes effect when bias_init_method parameter
+                is 'uniform'
+            bias_init_sigma (float): Non-negative standard deviation for
+                initialization of the bias term that takes effect when
+                bias_init_method parameter is 'normal'.
+            bias_init_value (float): Initial value of the bias term that takes
+                effect when bias_init_method parameter is 'constant'.
+            linear_init_method (string): Initialization method for linear term:
+                'normal', 'uniform' or 'constant'.
+            linear_init_scale (float): Non-negative range for initialization of
+                linear terms that takes effect when linear_init_method parameter
+                is 'uniform'.
+            linear_init_sigma (float): Non-negative standard deviation for
+                initialization of linear terms that takes effect when
+                linear_init_method parameter is 'normal'.
+            linear_init_value (float): Initial value of linear terms that takes
+                effect when linear_init_method parameter is 'constant'.
+            factors_init_method (string): Initialization method for
+                factorization term: 'normal', 'uniform' or 'constant'.
+            factors_init_scale (float): Non-negative range for initialization of
+                factorization terms that takes effect when factors_init_method
+                parameter is 'uniform'.
+            factors_init_sigma (float): Non-negative standard deviation for
+                initialization of factorization terms that takes effect when
+                factors_init_method parameter is 'normal'.
+            factors_init_value (float): Initial value of factorization terms
+                that takes effect when factors_init_method parameter is
+                'constant'.
             **kwargs: base class keyword argument values.
         """
         super(FactorizationMachines, self).__init__(
@@ -205,15 +236,14 @@ class FactorizationMachines(AmazonAlgorithmEstimatorBase):
         self.factors_init_value = factors_init_value
 
     def create_model(self, vpc_config_override=VPC_CONFIG_DEFAULT):
-        """Return a :class:`~sagemaker.amazon.FactorizationMachinesModel` referencing the latest
-        s3 model data produced by this Estimator.
+        """Return a :class:`~sagemaker.amazon.FactorizationMachinesModel`
+        referencing the latest s3 model data produced by this Estimator.
 
         Args:
-            vpc_config_override (dict[str, list[str]]): Optional override for VpcConfig set on the model.
-                Default: use subnets and security groups from this Estimator.
+            vpc_config_override (dict[str, list[str]]): Optional override for VpcConfig set on
+                the model. Default: use subnets and security groups from this Estimator.
                 * 'Subnets' (list[str]): List of subnet ids.
                 * 'SecurityGroupIds' (list[str]): List of security group ids.
-
         """
         return FactorizationMachinesModel(
             self.model_data,
@@ -224,20 +254,28 @@ class FactorizationMachines(AmazonAlgorithmEstimatorBase):
 
 
 class FactorizationMachinesPredictor(RealTimePredictor):
-    """Performs binary-classification or regression prediction from input vectors.
+    """Performs binary-classification or regression prediction from input
+    vectors.
 
-    The implementation of :meth:`~sagemaker.predictor.RealTimePredictor.predict` in this
-    `RealTimePredictor` requires a numpy ``ndarray`` as input. The array should contain the
-    same number of columns as the feature-dimension of the data used to fit the model this
-    Predictor performs inference on.
+    The implementation of
+    :meth:`~sagemaker.predictor.RealTimePredictor.predict` in this
+    `RealTimePredictor` requires a numpy ``ndarray`` as input. The array should
+    contain the same number of columns as the feature-dimension of the data used
+    to fit the model this Predictor performs inference on.
 
-    :meth:`predict()` returns a list of :class:`~sagemaker.amazon.record_pb2.Record` objects, one
-    for each row in the input ``ndarray``. The prediction is stored in the ``"score"``
-    key of the ``Record.label`` field.
-    Please refer to the formats details described: https://docs.aws.amazon.com/sagemaker/latest/dg/fm-in-formats.html
+    :meth:`predict()` returns a list of
+    :class:`~sagemaker.amazon.record_pb2.Record` objects, one for each row in
+    the input ``ndarray``. The prediction is stored in the ``"score"`` key of
+    the ``Record.label`` field. Please refer to the formats details described:
+    https://docs.aws.amazon.com/sagemaker/latest/dg/fm-in-formats.html
     """
 
     def __init__(self, endpoint, sagemaker_session=None):
+        """
+        Args:
+            endpoint:
+            sagemaker_session:
+        """
         super(FactorizationMachinesPredictor, self).__init__(
             endpoint,
             sagemaker_session,
@@ -247,10 +285,19 @@ class FactorizationMachinesPredictor(RealTimePredictor):
 
 
 class FactorizationMachinesModel(Model):
-    """Reference S3 model data created by FactorizationMachines estimator. Calling :meth:`~sagemaker.model.Model.deploy`
-    creates an Endpoint and returns :class:`FactorizationMachinesPredictor`."""
+    """Reference S3 model data created by FactorizationMachines estimator.
+    Calling :meth:`~sagemaker.model.Model.deploy` creates an Endpoint and
+    returns :class:`FactorizationMachinesPredictor`.
+    """
 
     def __init__(self, model_data, role, sagemaker_session=None, **kwargs):
+        """
+        Args:
+            model_data:
+            role:
+            sagemaker_session:
+            **kwargs:
+        """
         sagemaker_session = sagemaker_session or Session()
         repo = "{}:{}".format(FactorizationMachines.repo_name, FactorizationMachines.repo_version)
         image = "{}/{}".format(registry(sagemaker_session.boto_session.region_name), repo)

--- a/src/sagemaker/amazon/hyperparameter.py
+++ b/src/sagemaker/amazon/hyperparameter.py
@@ -10,22 +10,33 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import absolute_import
 
 import json
 
 
 class Hyperparameter(object):
-    """An algorithm hyperparameter with optional validation. Implemented as a python
-    descriptor object."""
+    """An algorithm hyperparameter with optional validation. Implemented as a
+    python descriptor object.
+    """
 
     def __init__(self, name, validate=lambda _: True, validation_message="", data_type=str):
-        """Args:
-            name (str): The name of this hyperparameter
-            validate (callable[object]->[bool]): A validation function or list of validation functions.
-                Each function validates an object and returns False if the object value is invalid for
-                this hyperparameter.
-            validation_message (str): A usage guide to display on validation failure.
+        """Args: name (str): The name of this hyperparameter validate
+        (callable[object]->[bool]): A validation function or list of validation
+        functions.
+
+            Each function validates an object and returns False if the object
+            value is invalid for this hyperparameter.
+
+        validation_message (str): A usage guide to display on validation
+        failure.
+
+        Args:
+            name:
+            validate:
+            validation_message:
+            data_type:
         """
         self.validation = validate
         self.validation_message = validation_message
@@ -37,6 +48,10 @@ class Hyperparameter(object):
             self.validation = [self.validation]
 
     def validate(self, value):
+        """
+        Args:
+            value:
+        """
         if value is None:  # We allow assignment from None, but Nones are not sent to training.
             return
 
@@ -48,12 +63,22 @@ class Hyperparameter(object):
                 raise ValueError(error_message)
 
     def __get__(self, obj, objtype):
+        """
+        Args:
+            obj:
+            objtype:
+        """
         if "_hyperparameters" not in dir(obj) or self.name not in obj._hyperparameters:
             raise AttributeError()
         return obj._hyperparameters[self.name]
 
     def __set__(self, obj, value):
-        """Validate the supplied value and set this hyperparameter to value"""
+        """Validate the supplied value and set this hyperparameter to value
+
+        Args:
+            obj:
+            value:
+        """
         value = None if value is None else self.data_type(value)
         self.validate(value)
         if "_hyperparameters" not in dir(obj):
@@ -61,12 +86,21 @@ class Hyperparameter(object):
         obj._hyperparameters[self.name] = value
 
     def __delete__(self, obj):
-        """Delete this hyperparameter"""
+        """Delete this hyperparameter
+
+        Args:
+            obj:
+        """
         del obj._hyperparameters[self.name]
 
     @staticmethod
     def serialize_all(obj):
-        """Return all non-None ``hyperparameter`` values on ``obj`` as a ``dict[str,str].``"""
+        """Return all non-None ``hyperparameter`` values on ``obj`` as a
+        ``dict[str,str].``
+
+        Args:
+            obj:
+        """
         if "_hyperparameters" not in dir(obj):
             return {}
         return {

--- a/src/sagemaker/amazon/ipinsights.py
+++ b/src/sagemaker/amazon/ipinsights.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import absolute_import
 
 from sagemaker.amazon.amazon_estimator import AmazonAlgorithmEstimatorBase, registry
@@ -22,6 +23,8 @@ from sagemaker.vpc_utils import VPC_CONFIG_DEFAULT
 
 
 class IPInsights(AmazonAlgorithmEstimatorBase):
+    """Placeholder docstring"""
+
     repo_name = "ipinsights"
     repo_version = 1
     MINI_BATCH_SIZE = 10000
@@ -63,42 +66,58 @@ class IPInsights(AmazonAlgorithmEstimatorBase):
         weight_decay=None,
         **kwargs
     ):
-        """This estimator is for IP Insights, an unsupervised algorithm that learns usage patterns of IP addresses.
+        """This estimator is for IP Insights, an unsupervised algorithm that
+        learns usage patterns of IP addresses.
 
         This Estimator may be fit via calls to
-        :meth:`~sagemaker.amazon.amazon_estimator.AmazonAlgorithmEstimatorBase.fit`. It requires
-        CSV data to be stored in S3.
+        :meth:`~sagemaker.amazon.amazon_estimator.AmazonAlgorithmEstimatorBase.fit`.
+        It requires CSV data to be stored in S3.
 
-        After this Estimator is fit, model data is stored in S3. The model may be deployed to an Amazon SageMaker
-        Endpoint by invoking :meth:`~sagemaker.amazon.estimator.EstimatorBase.deploy`. As well as deploying an Endpoint,
-        deploy returns a :class:`~sagemaker.amazon.IPInsightPredictor` object that can be used
-        for inference calls using the trained model hosted in the SageMaker Endpoint.
+        After this Estimator is fit, model data is stored in S3. The model
+        may be deployed to an Amazon SageMaker Endpoint by invoking
+        :meth:`~sagemaker.amazon.estimator.EstimatorBase.deploy`. As well as
+        deploying an Endpoint, deploy returns a
+        :class:`~sagemaker.amazon.IPInsightPredictor` object that can be used
+        for inference calls using the trained model hosted in the SageMaker
+        Endpoint.
 
         IPInsights Estimators can be configured by setting hyperparamters.
         The available hyperparamters are documented below.
 
-        For further information on the AWS IPInsights algorithm, please consult AWS technical documentation:
+        For further information on the AWS IPInsights algorithm, please
+        consult AWS technical documentation:
         https://docs.aws.amazon.com/sagemaker/latest/dg/ip-insights-hyperparameters.html
 
         Args:
-            role (str): An AWS IAM role (either name or full ARN). The Amazon SageMaker training jobs and
-                APIs that create Amazon SageMaker endpoints use this role to access
-                training data and model artifacts. After the endpoint is created,
-                the inference code might use the IAM role, if accessing AWS resource.
-            train_instance_count (int): Number of Amazon EC2 instances to use for training.
-            train_instance_type (str): Type of EC2 instance to use for training, for example, 'ml.m5.xlarge'.
-            num_entity_vectors (int): Required. The number of embeddings to train for entities accessing online
-                resources. We recommend 2x the total number of unique entity IDs.
-            vector_dim (int): Required. The size of the embedding vectors for both entity and IP addresses.
-            batch_metrics_publish_interval (int): Optional. The period at which to publish metrics (batches).
-            epochs (int): Optional. Maximum number of passes over the training data.
+            role (str): An AWS IAM role (either name or full ARN). The Amazon
+                SageMaker training jobs and APIs that create Amazon SageMaker
+                endpoints use this role to access training data and model
+                artifacts. After the endpoint is created, the inference code
+                might use the IAM role, if accessing AWS resource.
+            train_instance_count (int): Number of Amazon EC2 instances to use
+                for training.
+            train_instance_type (str): Type of EC2 instance to use for training,
+                for example, 'ml.m5.xlarge'.
+            num_entity_vectors (int): Required. The number of embeddings to
+                train for entities accessing online resources. We recommend 2x
+                the total number of unique entity IDs.
+            vector_dim (int): Required. The size of the embedding vectors for
+                both entity and IP addresses.
+            batch_metrics_publish_interval (int): Optional. The period at which
+                to publish metrics (batches).
+            epochs (int): Optional. Maximum number of passes over the training
+                data.
             learning_rate (float): Optional. Learning rate for the optimizer.
-            num_ip_encoder_layers (int): Optional. The number of fully-connected layers to encode IP address embedding.
-            random_negative_sampling_rate (int): Optional. The ratio of random negative samples to draw during training.
-                Random negative samples are randomly drawn IPv4 addresses.
-            shuffled_negative_sampling_rate (int): Optional. The ratio of shuffled negative samples to draw during
-                training. Shuffled negative samples are IP addresses picked from within a batch.
-            weight_decay (float): Optional. Weight decay coefficient. Adds L2 regularization.
+            num_ip_encoder_layers (int): Optional. The number of fully-connected
+                layers to encode IP address embedding.
+            random_negative_sampling_rate (int): Optional. The ratio of random
+                negative samples to draw during training. Random negative
+                samples are randomly drawn IPv4 addresses.
+            shuffled_negative_sampling_rate (int): Optional. The ratio of
+                shuffled negative samples to draw during training. Shuffled
+                negative samples are IP addresses picked from within a batch.
+            weight_decay (float): Optional. Weight decay coefficient. Adds L2
+                regularization.
             **kwargs: base class keyword argument values.
         """
         super(IPInsights, self).__init__(role, train_instance_count, train_instance_type, **kwargs)
@@ -116,12 +135,14 @@ class IPInsights(AmazonAlgorithmEstimatorBase):
         """Create a model for the latest s3 model produced by this estimator.
 
         Args:
-            vpc_config_override (dict[str, list[str]]): Optional override for VpcConfig set on the model.
+            vpc_config_override (dict[str, list[str]]): Optional override for VpcConfig set on
+                the model.
                 Default: use subnets and security groups from this Estimator.
                 * 'Subnets' (list[str]): List of subnet ids.
                 * 'SecurityGroupIds' (list[str]): List of security group ids.
         Returns:
-            :class:`~sagemaker.amazon.IPInsightsModel`: references the latest s3 model data produced by this estimator.
+            :class:`~sagemaker.amazon.IPInsightsModel`: references the latest s3 model
+            data produced by this estimator.
         """
         return IPInsightsModel(
             self.model_data,
@@ -131,6 +152,12 @@ class IPInsights(AmazonAlgorithmEstimatorBase):
         )
 
     def _prepare_for_training(self, records, mini_batch_size=None, job_name=None):
+        """
+        Args:
+            records:
+            mini_batch_size:
+            job_name:
+        """
         if mini_batch_size is not None and (mini_batch_size < 1 or mini_batch_size > 500000):
             raise ValueError("mini_batch_size must be in [1, 500000]")
         super(IPInsights, self)._prepare_for_training(
@@ -139,25 +166,41 @@ class IPInsights(AmazonAlgorithmEstimatorBase):
 
 
 class IPInsightsPredictor(RealTimePredictor):
-    """Returns dot product of entity and IP address embeddings as a score for compatibility.
+    """Returns dot product of entity and IP address embeddings as a score for
+    compatibility.
 
-    The implementation of :meth:`~sagemaker.predictor.RealTimePredictor.predict` in this
-    `RealTimePredictor` requires a numpy ``ndarray`` as input. The array should contain
-    two columns. The first column should contain the entity ID. The second column should
-    contain the IPv4 address in dot notation.
+    The implementation of
+    :meth:`~sagemaker.predictor.RealTimePredictor.predict` in this
+    `RealTimePredictor` requires a numpy ``ndarray`` as input. The array should
+    contain two columns. The first column should contain the entity ID. The
+    second column should contain the IPv4 address in dot notation.
     """
 
     def __init__(self, endpoint, sagemaker_session=None):
+        """
+        Args:
+            endpoint:
+            sagemaker_session:
+        """
         super(IPInsightsPredictor, self).__init__(
             endpoint, sagemaker_session, serializer=csv_serializer, deserializer=json_deserializer
         )
 
 
 class IPInsightsModel(Model):
-    """Reference IPInsights s3 model data. Calling :meth:`~sagemaker.model.Model.deploy` creates an
-    Endpoint and returns a Predictor that calculates anomaly scores for data points."""
+    """Reference IPInsights s3 model data. Calling
+    :meth:`~sagemaker.model.Model.deploy` creates an Endpoint and returns a
+    Predictor that calculates anomaly scores for data points.
+    """
 
     def __init__(self, model_data, role, sagemaker_session=None, **kwargs):
+        """
+        Args:
+            model_data:
+            role:
+            sagemaker_session:
+            **kwargs:
+        """
         sagemaker_session = sagemaker_session or Session()
         repo = "{}:{}".format(IPInsights.repo_name, IPInsights.repo_version)
         image = "{}/{}".format(

--- a/src/sagemaker/amazon/kmeans.py
+++ b/src/sagemaker/amazon/kmeans.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import absolute_import
 
 from sagemaker.amazon.amazon_estimator import AmazonAlgorithmEstimatorBase, registry
@@ -23,6 +24,7 @@ from sagemaker.vpc_utils import VPC_CONFIG_DEFAULT
 
 
 class KMeans(AmazonAlgorithmEstimatorBase):
+    """Placeholder docstring"""
 
     repo_name = "kmeans"
     repo_version = 1
@@ -63,53 +65,75 @@ class KMeans(AmazonAlgorithmEstimatorBase):
         eval_metrics=None,
         **kwargs
     ):
-        """
-        A k-means clustering :class:`~sagemaker.amazon.AmazonAlgorithmEstimatorBase`. Finds k clusters of data in an
-        unlabeled dataset.
+        """A k-means clustering
+        :class:`~sagemaker.amazon.AmazonAlgorithmEstimatorBase`. Finds k
+        clusters of data in an unlabeled dataset.
 
         This Estimator may be fit via calls to
         :meth:`~sagemaker.amazon.amazon_estimator.AmazonAlgorithmEstimatorBase.fit_ndarray`
-        or :meth:`~sagemaker.amazon.amazon_estimator.AmazonAlgorithmEstimatorBase.fit`. The former allows a KMeans model
-        to be fit on a 2-dimensional numpy array. The latter requires Amazon
-        :class:`~sagemaker.amazon.record_pb2.Record` protobuf serialized data to be stored in S3.
+        or
+        :meth:`~sagemaker.amazon.amazon_estimator.AmazonAlgorithmEstimatorBase.fit`.
+        The former allows a KMeans model to be fit on a 2-dimensional numpy
+        array. The latter requires Amazon
+        :class:`~sagemaker.amazon.record_pb2.Record` protobuf serialized data to
+        be stored in S3.
 
-        To learn more about the Amazon protobuf Record class and how to prepare bulk data in this format, please
-        consult AWS technical documentation: https://docs.aws.amazon.com/sagemaker/latest/dg/cdf-training.html.
+        To learn more about the Amazon protobuf Record class and how to
+        prepare bulk data in this format, please consult AWS technical
+        documentation:
+        https://docs.aws.amazon.com/sagemaker/latest/dg/cdf-training.html.
 
-        After this Estimator is fit, model data is stored in S3. The model may be deployed to an Amazon SageMaker
-        Endpoint by invoking :meth:`~sagemaker.amazon.estimator.EstimatorBase.deploy`. As well as deploying an Endpoint,
-        ``deploy`` returns a :class:`~sagemaker.amazon.kmeans.KMeansPredictor` object that can be used to k-means
-        cluster assignments, using the trained k-means model hosted in the SageMaker Endpoint.
+        After this Estimator is fit, model data is stored in S3. The model
+        may be deployed to an Amazon SageMaker Endpoint by invoking
+        :meth:`~sagemaker.amazon.estimator.EstimatorBase.deploy`. As well as
+        deploying an Endpoint, ``deploy`` returns a
+        :class:`~sagemaker.amazon.kmeans.KMeansPredictor` object that can be
+        used to k-means cluster assignments, using the trained k-means model
+        hosted in the SageMaker Endpoint.
 
-        KMeans Estimators can be configured by setting hyperparameters. The available hyperparameters for KMeans
-        are documented below. For further information on the AWS KMeans algorithm, please consult AWS technical
-        documentation: https://docs.aws.amazon.com/sagemaker/latest/dg/k-means.html.
+        KMeans Estimators can be configured by setting hyperparameters. The
+        available hyperparameters for KMeans are documented below. For further
+        information on the AWS KMeans algorithm, please consult AWS technical
+        documentation:
+        https://docs.aws.amazon.com/sagemaker/latest/dg/k-means.html.
 
         Args:
-            role (str): An AWS IAM role (either name or full ARN). The Amazon SageMaker training jobs and
-                APIs that create Amazon SageMaker endpoints use this role to access
-                training data and model artifacts. After the endpoint is created,
-                the inference code might use the IAM role, if accessing AWS resource.
-            train_instance_count (int): Number of Amazon EC2 instances to use for training.
-            train_instance_type (str): Type of EC2 instance to use for training, for example, 'ml.c4.xlarge'.
+            role (str): An AWS IAM role (either name or full ARN). The Amazon
+                SageMaker training jobs and APIs that create Amazon SageMaker
+                endpoints use this role to access training data and model
+                artifacts. After the endpoint is created, the inference code
+                might use the IAM role, if accessing AWS resource.
+            train_instance_count (int): Number of Amazon EC2 instances to use
+                for training.
+            train_instance_type (str): Type of EC2 instance to use for training,
+                for example, 'ml.c4.xlarge'.
             k (int): The number of clusters to produce.
-            init_method (str): How to initialize cluster locations. One of 'random' or 'kmeans++'.
-            max_iterations (int): Maximum iterations for Lloyds EM procedure in the local kmeans used in finalize stage.
-            tol (float): Tolerance for change in ssd for early stopping in local kmeans.
-            num_trials (int): Local version is run multiple times and the one with the best loss is chosen. This
-                              determines how many times.
-            local_init_method (str): Initialization method for local version. One of 'random', 'kmeans++'
-            half_life_time_size (int): The points can have a decayed weight. When a point is observed its weight,
-                with regard to the computation of the cluster mean is 1. This weight will decay exponentially as we
-                observe more points. The exponent coefficient is chosen such that after observing
-                ``half_life_time_size`` points after the mentioned point, its weight will become 1/2. If set to 0,
-                there will be no decay.
+            init_method (str): How to initialize cluster locations. One of
+                'random' or 'kmeans++'.
+            max_iterations (int): Maximum iterations for Lloyds EM procedure in
+                the local kmeans used in finalize stage.
+            tol (float): Tolerance for change in ssd for early stopping in local
+                kmeans.
+            num_trials (int): Local version is run multiple times and the one
+                with the best loss is chosen. This determines how many times.
+            local_init_method (str): Initialization method for local version.
+                One of 'random', 'kmeans++'
+            half_life_time_size (int): The points can have a decayed weight.
+                When a point is observed its weight, with regard to the
+                computation of the cluster mean is 1. This weight will decay
+                exponentially as we observe more points. The exponent
+                coefficient is chosen such that after observing
+                ``half_life_time_size`` points after the mentioned point, its
+                weight will become 1/2. If set to 0, there will be no decay.
             epochs (int): Number of passes done over the training data.
-            center_factor(int): The algorithm will create ``num_clusters * extra_center_factor`` as it runs and
-                reduce the number of centers to ``k`` when finalizing
-            eval_metrics(list): JSON list of metrics types to be used for reporting the score for the model.
-                Allowed values are "msd" Means Square Error, "ssd": Sum of square distance. If test data is provided,
-                the score shall be reported in terms of all requested metrics.
+            center_factor (int): The algorithm will create
+                ``num_clusters * extra_center_factor`` as it runs and reduce the
+                number of centers to ``k`` when finalizing
+            eval_metrics (list): JSON list of metrics types to be used for
+                reporting the score for the model. Allowed values are "msd"
+                Means Square Error, "ssd": Sum of square distance. If test data
+                is provided, the score shall be reported in terms of all
+                requested metrics.
             **kwargs: base class keyword argument values.
         """
         super(KMeans, self).__init__(role, train_instance_count, train_instance_type, **kwargs)
@@ -125,11 +149,12 @@ class KMeans(AmazonAlgorithmEstimatorBase):
         self.eval_metrics = eval_metrics
 
     def create_model(self, vpc_config_override=VPC_CONFIG_DEFAULT):
-        """Return a :class:`~sagemaker.amazon.kmeans.KMeansModel` referencing the latest
-        s3 model data produced by this Estimator.
+        """Return a :class:`~sagemaker.amazon.kmeans.KMeansModel` referencing
+        the latest s3 model data produced by this Estimator.
 
         Args:
-            vpc_config_override (dict[str, list[str]]): Optional override for VpcConfig set on the model.
+            vpc_config_override (dict[str, list[str]]): Optional override for
+                VpcConfig set on the model.
                 Default: use subnets and security groups from this Estimator.
                 * 'Subnets' (list[str]): List of subnet ids.
                 * 'SecurityGroupIds' (list[str]): List of security group ids.
@@ -142,12 +167,20 @@ class KMeans(AmazonAlgorithmEstimatorBase):
         )
 
     def _prepare_for_training(self, records, mini_batch_size=5000, job_name=None):
+        """
+        Args:
+            records:
+            mini_batch_size:
+            job_name:
+        """
         super(KMeans, self)._prepare_for_training(
             records, mini_batch_size=mini_batch_size, job_name=job_name
         )
 
     def hyperparameters(self):
-        """Return the SageMaker hyperparameters for training this KMeans Estimator"""
+        """Return the SageMaker hyperparameters for training this KMeans
+        Estimator
+        """
         hp_dict = dict(force_dense="True")  # KMeans requires this hp to fit on Record objects
         hp_dict.update(super(KMeans, self).hyperparameters())
         return hp_dict
@@ -156,16 +189,24 @@ class KMeans(AmazonAlgorithmEstimatorBase):
 class KMeansPredictor(RealTimePredictor):
     """Assigns input vectors to their closest cluster in a KMeans model.
 
-    The implementation of :meth:`~sagemaker.predictor.RealTimePredictor.predict` in this
-    `RealTimePredictor` requires a numpy ``ndarray`` as input. The array should contain the
-    same number of columns as the feature-dimension of the data used to fit the model this
-    Predictor performs inference on.
+    The implementation of
+    :meth:`~sagemaker.predictor.RealTimePredictor.predict` in this
+    `RealTimePredictor` requires a numpy ``ndarray`` as input. The array should
+    contain the same number of columns as the feature-dimension of the data used
+    to fit the model this Predictor performs inference on.
 
-    ``predict()`` returns a list of :class:`~sagemaker.amazon.record_pb2.Record` objects, one
-    for each row in the input ``ndarray``. The nearest cluster is stored in the ``closest_cluster``
-    key of the ``Record.label`` field."""
+    ``predict()`` returns a list of
+    :class:`~sagemaker.amazon.record_pb2.Record` objects, one for each row in
+    the input ``ndarray``. The nearest cluster is stored in the
+    ``closest_cluster`` key of the ``Record.label`` field.
+    """
 
     def __init__(self, endpoint, sagemaker_session=None):
+        """
+        Args:
+            endpoint:
+            sagemaker_session:
+        """
         super(KMeansPredictor, self).__init__(
             endpoint,
             sagemaker_session,
@@ -175,10 +216,19 @@ class KMeansPredictor(RealTimePredictor):
 
 
 class KMeansModel(Model):
-    """Reference KMeans s3 model data. Calling :meth:`~sagemaker.model.Model.deploy` creates an Endpoint and return
-    a Predictor to performs k-means cluster assignment."""
+    """Reference KMeans s3 model data. Calling
+    :meth:`~sagemaker.model.Model.deploy` creates an Endpoint and return a
+    Predictor to performs k-means cluster assignment.
+    """
 
     def __init__(self, model_data, role, sagemaker_session=None, **kwargs):
+        """
+        Args:
+            model_data:
+            role:
+            sagemaker_session:
+            **kwargs:
+        """
         sagemaker_session = sagemaker_session or Session()
         repo = "{}:{}".format(KMeans.repo_name, KMeans.repo_version)
         image = "{}/{}".format(registry(sagemaker_session.boto_session.region_name), repo)

--- a/src/sagemaker/amazon/knn.py
+++ b/src/sagemaker/amazon/knn.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import absolute_import
 
 from sagemaker.amazon.amazon_estimator import AmazonAlgorithmEstimatorBase, registry
@@ -23,6 +24,8 @@ from sagemaker.vpc_utils import VPC_CONFIG_DEFAULT
 
 
 class KNN(AmazonAlgorithmEstimatorBase):
+    """Placeholder docstring"""
+
     repo_name = "knn"
     repo_version = 1
 
@@ -73,46 +76,57 @@ class KNN(AmazonAlgorithmEstimatorBase):
         faiss_index_pq_m=None,
         **kwargs
     ):
-        """k-nearest neighbors (KNN) is :class:`Estimator` used for classification and regression.
-        This Estimator may be fit via calls to
-        :meth:`~sagemaker.amazon.amazon_estimator.AmazonAlgorithmEstimatorBase.fit`. It requires Amazon
-        :class:`~sagemaker.amazon.record_pb2.Record` protobuf serialized data to be stored in S3.
-        There is an utility :meth:`~sagemaker.amazon.amazon_estimator.AmazonAlgorithmEstimatorBase.record_set` that
-        can be used to upload data to S3 and creates :class:`~sagemaker.amazon.amazon_estimator.RecordSet` to be passed
-        to the `fit` call.
-        To learn more about the Amazon protobuf Record class and how to prepare bulk data in this format, please
-        consult AWS technical documentation: https://docs.aws.amazon.com/sagemaker/latest/dg/cdf-training.html
-        After this Estimator is fit, model data is stored in S3. The model may be deployed to an Amazon SageMaker
-        Endpoint by invoking :meth:`~sagemaker.amazon.estimator.EstimatorBase.deploy`. As well as deploying an Endpoint,
-        deploy returns a :class:`~sagemaker.amazon.knn.KNNPredictor` object that can be used
-        for inference calls using the trained model hosted in the SageMaker Endpoint.
-        KNN Estimators can be configured by setting hyperparameters. The available hyperparameters for
-        KNN are documented below.
-        For further information on the AWS KNN algorithm,
-        please consult AWS technical documentation: https://docs.aws.amazon.com/sagemaker/latest/dg/knn.html
+        """k-nearest neighbors (KNN) is :class:`Estimator` used for
+        classification and regression. This Estimator may be fit via calls to
+        :meth:`~sagemaker.amazon.amazon_estimator.AmazonAlgorithmEstimatorBase.fit`.
+        It requires Amazon :class:`~sagemaker.amazon.record_pb2.Record` protobuf
+        serialized data to be stored in S3. There is an utility
+        :meth:`~sagemaker.amazon.amazon_estimator.AmazonAlgorithmEstimatorBase.record_set`
+        that can be used to upload data to S3 and creates
+        :class:`~sagemaker.amazon.amazon_estimator.RecordSet` to be passed to
+        the `fit` call. To learn more about the Amazon protobuf Record class and
+        how to prepare bulk data in this format, please consult AWS technical
+        documentation:
+        https://docs.aws.amazon.com/sagemaker/latest/dg/cdf-training.html After
+        this Estimator is fit, model data is stored in S3. The model may be
+        deployed to an Amazon SageMaker Endpoint by invoking
+        :meth:`~sagemaker.amazon.estimator.EstimatorBase.deploy`. As well as
+        deploying an Endpoint, deploy returns a
+        :class:`~sagemaker.amazon.knn.KNNPredictor` object that can be used for
+        inference calls using the trained model hosted in the SageMaker
+        Endpoint. KNN Estimators can be configured by setting hyperparameters.
+        The available hyperparameters for KNN are documented below. For further
+        information on the AWS KNN algorithm, please consult AWS technical
+        documentation: https://docs.aws.amazon.com/sagemaker/latest/dg/knn.html
 
         Args:
-            role (str): An AWS IAM role (either name or full ARN). The Amazon SageMaker training jobs and
-                APIs that create Amazon SageMaker endpoints use this role to access
-                training data and model artifacts. After the endpoint is created,
-                the inference code might use the IAM role, if accessing AWS resource.
-            train_instance_type (str): Type of EC2 instance to use for training, for example, 'ml.c4.xlarge'.
+            role (str): An AWS IAM role (either name or full ARN). The Amazon
+                SageMaker training jobs and APIs that create Amazon SageMaker
+                endpoints use this role to access training data and model
+                artifacts. After the endpoint is created, the inference code
+                might use the IAM role, if accessing AWS resource.
+            train_instance_count:
+            train_instance_type (str): Type of EC2 instance to use for training,
+                for example, 'ml.c4.xlarge'.
             k (int): Required. Number of nearest neighbors.
-            sample_size(int): Required. Number of data points to be sampled from the training data set.
-            predictor_type (str): Required. Type of inference to use on the data's labels,
-                allowed values are 'classifier' and 'regressor'.
-            dimension_reduction_type (str): Optional. Type of dimension reduction technique to use.
-                Valid values: "sign", "fjlt"
-            dimension_reduction_target (int): Optional. Target dimension to reduce to. Required when
-                dimension_reduction_type is specified.
+            sample_size (int): Required. Number of data points to be sampled
+                from the training data set.
+            predictor_type (str): Required. Type of inference to use on the
+                data's labels, allowed values are 'classifier' and 'regressor'.
+            dimension_reduction_type (str): Optional. Type of dimension
+                reduction technique to use. Valid values: "sign", "fjlt"
+            dimension_reduction_target (int): Optional. Target dimension to
+                reduce to. Required when dimension_reduction_type is specified.
             index_type (str): Optional. Type of index to use. Valid values are
                 "faiss.Flat", "faiss.IVFFlat", "faiss.IVFPQ".
-            index_metric(str): Optional. Distance metric to measure between points when finding nearest neighbors.
-                Valid values are "COSINE", "INNER_PRODUCT", "L2"
-            faiss_index_ivf_nlists(str): Optional. Number of centroids to construct in the index if
-                index_type is "faiss.IVFFlat" or "faiss.IVFPQ".
-            faiss_index_pq_m(int): Optional. Number of vector sub-components to construct in the index,
-                if index_type is "faiss.IVFPQ".
+            index_metric (str): Optional. Distance metric to measure between
+                points when finding nearest neighbors. Valid values are
+                "COSINE", "INNER_PRODUCT", "L2"
+            faiss_index_ivf_nlists (str): Optional. Number of centroids to
+                construct in the index if index_type is "faiss.IVFFlat" or
+                "faiss.IVFPQ".
+            faiss_index_pq_m (int): Optional. Number of vector sub-components to
+                construct in the index, if index_type is "faiss.IVFPQ".
             **kwargs: base class keyword argument values.
         """
 
@@ -136,8 +150,8 @@ class KNN(AmazonAlgorithmEstimatorBase):
         s3 model data produced by this Estimator.
 
         Args:
-            vpc_config_override (dict[str, list[str]]): Optional override for VpcConfig set on the model.
-                Default: use subnets and security groups from this Estimator.
+            vpc_config_override (dict[str, list[str]]): Optional override for VpcConfig set on
+                the model. Default: use subnets and security groups from this Estimator.
                 * 'Subnets' (list[str]): List of subnet ids.
                 * 'SecurityGroupIds' (list[str]): List of security group ids.
         """
@@ -149,6 +163,12 @@ class KNN(AmazonAlgorithmEstimatorBase):
         )
 
     def _prepare_for_training(self, records, mini_batch_size=None, job_name=None):
+        """
+        Args:
+            records:
+            mini_batch_size:
+            job_name:
+        """
         super(KNN, self)._prepare_for_training(
             records, mini_batch_size=mini_batch_size, job_name=job_name
         )
@@ -157,16 +177,24 @@ class KNN(AmazonAlgorithmEstimatorBase):
 class KNNPredictor(RealTimePredictor):
     """Performs classification or regression prediction from input vectors.
 
-    The implementation of :meth:`~sagemaker.predictor.RealTimePredictor.predict` in this
-    `RealTimePredictor` requires a numpy ``ndarray`` as input. The array should contain the
-    same number of columns as the feature-dimension of the data used to fit the model this
-    Predictor performs inference on.
+    The implementation of
+    :meth:`~sagemaker.predictor.RealTimePredictor.predict` in this
+    `RealTimePredictor` requires a numpy ``ndarray`` as input. The array should
+    contain the same number of columns as the feature-dimension of the data used
+    to fit the model this Predictor performs inference on.
 
-    :func:`predict` returns a list of :class:`~sagemaker.amazon.record_pb2.Record` objects, one
-    for each row in the input ``ndarray``. The prediction is stored in the ``"predicted_label"``
-    key of the ``Record.label`` field."""
+    :func:`predict` returns a list of
+    :class:`~sagemaker.amazon.record_pb2.Record` objects, one for each row in
+    the input ``ndarray``. The prediction is stored in the ``"predicted_label"``
+    key of the ``Record.label`` field.
+    """
 
     def __init__(self, endpoint, sagemaker_session=None):
+        """
+        Args:
+            endpoint:
+            sagemaker_session:
+        """
         super(KNNPredictor, self).__init__(
             endpoint,
             sagemaker_session,
@@ -176,10 +204,19 @@ class KNNPredictor(RealTimePredictor):
 
 
 class KNNModel(Model):
-    """Reference S3 model data created by KNN estimator. Calling :meth:`~sagemaker.model.Model.deploy`
-    creates an Endpoint and returns :class:`KNNPredictor`."""
+    """Reference S3 model data created by KNN estimator. Calling
+    :meth:`~sagemaker.model.Model.deploy` creates an Endpoint and returns
+    :class:`KNNPredictor`.
+    """
 
     def __init__(self, model_data, role, sagemaker_session=None, **kwargs):
+        """
+        Args:
+            model_data:
+            role:
+            sagemaker_session:
+            **kwargs:
+        """
         sagemaker_session = sagemaker_session or Session()
         repo = "{}:{}".format(KNN.repo_name, KNN.repo_version)
         image = "{}/{}".format(

--- a/src/sagemaker/amazon/lda.py
+++ b/src/sagemaker/amazon/lda.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import absolute_import
 
 from sagemaker.amazon.amazon_estimator import AmazonAlgorithmEstimatorBase, registry
@@ -23,6 +24,7 @@ from sagemaker.vpc_utils import VPC_CONFIG_DEFAULT
 
 
 class LDA(AmazonAlgorithmEstimatorBase):
+    """Placeholder docstring"""
 
     repo_name = "lda"
     repo_version = 1
@@ -44,48 +46,65 @@ class LDA(AmazonAlgorithmEstimatorBase):
         tol=None,
         **kwargs
     ):
-        """Latent Dirichlet Allocation (LDA) is :class:`Estimator` used for unsupervised learning.
+        """Latent Dirichlet Allocation (LDA) is :class:`Estimator` used for
+        unsupervised learning.
 
-        Amazon SageMaker Latent Dirichlet Allocation is an unsupervised learning algorithm that attempts to describe
-        a set of observations as a mixture of distinct categories. LDA is most commonly used to discover
-        a user-specified number of topics shared by documents within a text corpus.
-        Here each observation is a document, the features are the presence (or occurrence count) of each word, and
-        the categories are the topics.
+        Amazon SageMaker Latent Dirichlet Allocation is an unsupervised
+        learning algorithm that attempts to describe a set of observations as a
+        mixture of distinct categories. LDA is most commonly used to discover a
+        user-specified number of topics shared by documents within a text
+        corpus. Here each observation is a document, the features are the
+        presence (or occurrence count) of each word, and the categories are the
+        topics.
 
         This Estimator may be fit via calls to
-        :meth:`~sagemaker.amazon.amazon_estimator.AmazonAlgorithmEstimatorBase.fit`. It requires Amazon
-        :class:`~sagemaker.amazon.record_pb2.Record` protobuf serialized data to be stored in S3.
-        There is an utility :meth:`~sagemaker.amazon.amazon_estimator.AmazonAlgorithmEstimatorBase.record_set` that
-        can be used to upload data to S3 and creates :class:`~sagemaker.amazon.amazon_estimator.RecordSet` to be passed
-        to the `fit` call.
+        :meth:`~sagemaker.amazon.amazon_estimator.AmazonAlgorithmEstimatorBase.fit`.
+        It requires Amazon :class:`~sagemaker.amazon.record_pb2.Record` protobuf
+        serialized data to be stored in S3. There is an utility
+        :meth:`~sagemaker.amazon.amazon_estimator.AmazonAlgorithmEstimatorBase.record_set`
+        that can be used to upload data to S3 and creates
+        :class:`~sagemaker.amazon.amazon_estimator.RecordSet` to be passed to
+        the `fit` call.
 
-        To learn more about the Amazon protobuf Record class and how to prepare bulk data in this format, please
-        consult AWS technical documentation: https://docs.aws.amazon.com/sagemaker/latest/dg/cdf-training.html
+        To learn more about the Amazon protobuf Record class and how to
+        prepare bulk data in this format, please consult AWS technical
+        documentation:
+        https://docs.aws.amazon.com/sagemaker/latest/dg/cdf-training.html
 
-        After this Estimator is fit, model data is stored in S3. The model may be deployed to an Amazon SageMaker
-        Endpoint by invoking :meth:`~sagemaker.amazon.estimator.EstimatorBase.deploy`. As well as deploying an Endpoint,
-        deploy returns a :class:`~sagemaker.amazon.lda.LDAPredictor` object that can be used
-        for inference calls using the trained model hosted in the SageMaker Endpoint.
+        After this Estimator is fit, model data is stored in S3. The model
+        may be deployed to an Amazon SageMaker Endpoint by invoking
+        :meth:`~sagemaker.amazon.estimator.EstimatorBase.deploy`. As well as
+        deploying an Endpoint, deploy returns a
+        :class:`~sagemaker.amazon.lda.LDAPredictor` object that can be used for
+        inference calls using the trained model hosted in the SageMaker
+        Endpoint.
 
-        LDA Estimators can be configured by setting hyperparameters. The available hyperparameters for
-        LDA are documented below.
+        LDA Estimators can be configured by setting hyperparameters. The
+        available hyperparameters for LDA are documented below.
 
-        For further information on the AWS LDA algorithm,
-        please consult AWS technical documentation: https://docs.aws.amazon.com/sagemaker/latest/dg/lda.html
+        For further information on the AWS LDA algorithm, please consult AWS
+        technical documentation:
+        https://docs.aws.amazon.com/sagemaker/latest/dg/lda.html
 
         Args:
-            role (str): An AWS IAM role (either name or full ARN). The Amazon SageMaker training jobs and
-                APIs that create Amazon SageMaker endpoints use this role to access
-                training data and model artifacts. After the endpoint is created,
-                the inference code might use the IAM role, if accessing AWS resource.
-            train_instance_type (str): Type of EC2 instance to use for training, for example, 'ml.c4.xlarge'.
-            num_topics (int): The number of topics for LDA to find within the data.
-            alpha0 (float): Optional. Initial guess for the concentration parameter
-            max_restarts (int): Optional. The number of restarts to perform during the Alternating Least Squares (ALS)
-                spectral decomposition phase of the algorithm.
-            max_iterations (int): Optional. The maximum number of iterations to perform during the
-                ALS phase of the algorithm.
-            tol (float): Optional. Target error tolerance for the ALS phase of the algorithm.
+            role (str): An AWS IAM role (either name or full ARN). The Amazon
+                SageMaker training jobs and APIs that create Amazon SageMaker
+                endpoints use this role to access training data and model
+                artifacts. After the endpoint is created, the inference code
+                might use the IAM role, if accessing AWS resource.
+            train_instance_type (str): Type of EC2 instance to use for training,
+                for example, 'ml.c4.xlarge'.
+            num_topics (int): The number of topics for LDA to find within the
+                data.
+            alpha0 (float): Optional. Initial guess for the concentration
+                parameter
+            max_restarts (int): Optional. The number of restarts to perform
+                during the Alternating Least Squares (ALS) spectral
+                decomposition phase of the algorithm.
+            max_iterations (int): Optional. The maximum number of iterations to
+                perform during the ALS phase of the algorithm.
+            tol (float): Optional. Target error tolerance for the ALS phase of
+                the algorithm.
             **kwargs: base class keyword argument values.
         """
         # this algorithm only supports single instance training
@@ -108,7 +127,8 @@ class LDA(AmazonAlgorithmEstimatorBase):
         s3 model data produced by this Estimator.
 
         Args:
-            vpc_config_override (dict[str, list[str]]): Optional override for VpcConfig set on the model.
+            vpc_config_override (dict[str, list[str]]): Optional override for
+                VpcConfig set on the model.
                 Default: use subnets and security groups from this Estimator.
                 * 'Subnets' (list[str]): List of subnet ids.
                 * 'SecurityGroupIds' (list[str]): List of security group ids.
@@ -124,6 +144,12 @@ class LDA(AmazonAlgorithmEstimatorBase):
         self, records, mini_batch_size, job_name=None
     ):
         # mini_batch_size is required, prevent explicit calls with None
+        """
+        Args:
+            records:
+            mini_batch_size:
+            job_name:
+        """
         if mini_batch_size is None:
             raise ValueError("mini_batch_size must be set")
 
@@ -135,16 +161,24 @@ class LDA(AmazonAlgorithmEstimatorBase):
 class LDAPredictor(RealTimePredictor):
     """Transforms input vectors to lower-dimesional representations.
 
-    The implementation of :meth:`~sagemaker.predictor.RealTimePredictor.predict` in this
-    `RealTimePredictor` requires a numpy ``ndarray`` as input. The array should contain the
-    same number of columns as the feature-dimension of the data used to fit the model this
-    Predictor performs inference on.
+    The implementation of
+    :meth:`~sagemaker.predictor.RealTimePredictor.predict` in this
+    `RealTimePredictor` requires a numpy ``ndarray`` as input. The array should
+    contain the same number of columns as the feature-dimension of the data used
+    to fit the model this Predictor performs inference on.
 
-    :meth:`predict()` returns a list of :class:`~sagemaker.amazon.record_pb2.Record` objects, one
-    for each row in the input ``ndarray``. The lower dimension vector result is stored in the ``projection``
-    key of the ``Record.label`` field."""
+    :meth:`predict()` returns a list of
+    :class:`~sagemaker.amazon.record_pb2.Record` objects, one for each row in
+    the input ``ndarray``. The lower dimension vector result is stored in the
+    ``projection`` key of the ``Record.label`` field.
+    """
 
     def __init__(self, endpoint, sagemaker_session=None):
+        """
+        Args:
+            endpoint:
+            sagemaker_session:
+        """
         super(LDAPredictor, self).__init__(
             endpoint,
             sagemaker_session,
@@ -154,10 +188,19 @@ class LDAPredictor(RealTimePredictor):
 
 
 class LDAModel(Model):
-    """Reference LDA s3 model data. Calling :meth:`~sagemaker.model.Model.deploy` creates an Endpoint and return
-    a Predictor that transforms vectors to a lower-dimensional representation."""
+    """Reference LDA s3 model data. Calling
+    :meth:`~sagemaker.model.Model.deploy` creates an Endpoint and return a
+    Predictor that transforms vectors to a lower-dimensional representation.
+    """
 
     def __init__(self, model_data, role, sagemaker_session=None, **kwargs):
+        """
+        Args:
+            model_data:
+            role:
+            sagemaker_session:
+            **kwargs:
+        """
         sagemaker_session = sagemaker_session or Session()
         repo = "{}:{}".format(LDA.repo_name, LDA.repo_version)
         image = "{}/{}".format(

--- a/src/sagemaker/amazon/linear_learner.py
+++ b/src/sagemaker/amazon/linear_learner.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import absolute_import
 
 from sagemaker.amazon.amazon_estimator import AmazonAlgorithmEstimatorBase, registry
@@ -23,6 +24,8 @@ from sagemaker.vpc_utils import VPC_CONFIG_DEFAULT
 
 
 class LinearLearner(AmazonAlgorithmEstimatorBase):
+    """Placeholder docstring"""
+
     repo_name = "linear-learner"
     repo_version = 1
 
@@ -165,111 +168,155 @@ class LinearLearner(AmazonAlgorithmEstimatorBase):
     ):
         """An :class:`Estimator` for binary classification and regression.
 
-        Amazon SageMaker Linear Learner provides a solution for both classification and regression problems, allowing
-        for exploring different training objectives simultaneously and choosing the best solution from a validation set.
-        It allows the user to explore a large number of models and choose the best, which optimizes either continuous
-        objectives such as mean square error, cross entropy loss, absolute error, etc., or discrete objectives suited
-        for classification such as F1 measure, precision@recall, accuracy. The implementation provides a significant
-        speedup over naive hyperparameter optimization techniques and an added convenience, when compared with
-        solutions providing a solution only to continuous objectives.
+        Amazon SageMaker Linear Learner provides a solution for both
+        classification and regression problems, allowing for exploring different
+        training objectives simultaneously and choosing the best solution from a
+        validation set. It allows the user to explore a large number of models
+        and choose the best, which optimizes either continuous objectives such
+        as mean square error, cross entropy loss, absolute error, etc., or
+        discrete objectives suited for classification such as F1 measure,
+        precision@recall, accuracy. The implementation provides a significant
+        speedup over naive hyperparameter optimization techniques and an added
+        convenience, when compared with solutions providing a solution only to
+        continuous objectives.
 
         This Estimator may be fit via calls to
         :meth:`~sagemaker.amazon.amazon_estimator.AmazonAlgorithmEstimatorBase.fit_ndarray`
-        or :meth:`~sagemaker.amazon.amazon_estimator.AmazonAlgorithmEstimatorBase.fit`. The former allows a
-        LinearLearner model to be fit on a 2-dimensional numpy array. The latter requires Amazon
-        :class:`~sagemaker.amazon.record_pb2.Record` protobuf serialized data to be stored in S3.
+        or
+        :meth:`~sagemaker.amazon.amazon_estimator.AmazonAlgorithmEstimatorBase.fit`.
+        The former allows a LinearLearner model to be fit on a 2-dimensional
+        numpy array. The latter requires Amazon
+        :class:`~sagemaker.amazon.record_pb2.Record` protobuf serialized data to
+        be stored in S3.
 
-        To learn more about the Amazon protobuf Record class and how to prepare bulk data in this format, please
-        consult AWS technical documentation: https://docs.aws.amazon.com/sagemaker/latest/dg/cdf-training.html
+        To learn more about the Amazon protobuf Record class and how to
+        prepare bulk data in this format, please consult AWS technical
+        documentation:
+        https://docs.aws.amazon.com/sagemaker/latest/dg/cdf-training.html
 
-        After this Estimator is fit, model data is stored in S3. The model may be deployed to an Amazon SageMaker
-        Endpoint by invoking :meth:`~sagemaker.amazon.estimator.EstimatorBase.deploy`. As well as deploying an Endpoint,
-        ``deploy`` returns a :class:`~sagemaker.amazon.linear_learner.LinearLearnerPredictor` object that can be used
-        to make class or regression predictions, using the trained model.
+        After this Estimator is fit, model data is stored in S3. The model
+        may be deployed to an Amazon SageMaker Endpoint by invoking
+        :meth:`~sagemaker.amazon.estimator.EstimatorBase.deploy`. As well as
+        deploying an Endpoint, ``deploy`` returns a
+        :class:`~sagemaker.amazon.linear_learner.LinearLearnerPredictor` object
+        that can be used to make class or regression predictions, using the
+        trained model.
 
-        LinearLearner Estimators can be configured by setting hyperparameters. The available hyperparameters for
-        LinearLearner are documented below. For further information on the AWS LinearLearner algorithm, please consult
-        AWS technical documentation: https://docs.aws.amazon.com/sagemaker/latest/dg/linear-learner.html
+        LinearLearner Estimators can be configured by setting
+        hyperparameters. The available hyperparameters for LinearLearner are
+        documented below. For further information on the AWS LinearLearner
+        algorithm, please consult AWS technical documentation:
+        https://docs.aws.amazon.com/sagemaker/latest/dg/linear-learner.html
 
         Args:
-            role (str): An AWS IAM role (either name or full ARN). The Amazon SageMaker training jobs and
-                APIs that create Amazon SageMaker endpoints use this role to access
-                training data and model artifacts. After the endpoint is created,
-                the inference code might use the IAM role, if accessing AWS resource.
-            train_instance_count (int): Number of Amazon EC2 instances to use for training.
-            train_instance_type (str): Type of EC2 instance to use for training, for example, 'ml.c4.xlarge'.
-            predictor_type (str): The type of predictor to learn. Either "binary_classifier" or
-            "multiclass_classifier" or "regressor".
-            binary_classifier_model_selection_criteria (str): One of 'accuracy', 'f1', 'f_beta',
-            'precision_at_target_recall', 'recall_at_target_precision', 'cross_entropy_loss', 'loss_function'
-            target_recall (float): Target recall. Only applicable if binary_classifier_model_selection_criteria is
+            role (str): An AWS IAM role (either name or full ARN). The Amazon
+                SageMaker training jobs and APIs that create Amazon SageMaker
+                endpoints use this role to access training data and model
+                artifacts. After the endpoint is created, the inference code
+                might use the IAM role, if accessing AWS resource.
+            train_instance_count (int): Number of Amazon EC2 instances to use
+                for training.
+            train_instance_type (str): Type of EC2 instance to use for training,
+                for example, 'ml.c4.xlarge'.
+            predictor_type (str): The type of predictor to learn. Either
+                "binary_classifier" or "multiclass_classifier" or "regressor".
+            binary_classifier_model_selection_criteria (str): One of 'accuracy',
+                'f1', 'f_beta', 'precision_at_target_recall', 'recall_at_target_precision',
+                'cross_entropy_loss', 'loss_function'
+            target_recall (float): Target recall. Only applicable if
+                binary_classifier_model_selection_criteria is
                 precision_at_target_recall.
-            target_precision (float): Target precision. Only applicable if binary_classifier_model_selection_criteria
-                is recall_at_target_precision.
-            positive_example_weight_mult (float): The importance weight of positive examples is multiplied by this
-               constant. Useful for skewed datasets. Only applies for classification tasks.
-            epochs (int): The maximum number of passes to make over the training data.
+            target_precision (float): Target precision. Only applicable if
+                binary_classifier_model_selection_criteria is
+                recall_at_target_precision.
+            positive_example_weight_mult (float): The importance weight of
+                positive examples is multiplied by this constant. Useful for
+                skewed datasets. Only applies for classification tasks.
+            epochs (int): The maximum number of passes to make over the training
+                data.
             use_bias (bool): Whether to include a bias field
-            num_models (int): Number of models to train in parallel. If not set, the number of parallel models to
-                train will be decided by the algorithm itself. One model will be trained according to the given training
-            parameter (regularization, optimizer, loss) and the rest by close by parameters.
-            num_calibration_samples (int): Number of observations to use from validation dataset for doing model
-            calibration (finding the best threshold).
-            init_method (str): Function to use to set the initial model weights. One of "uniform" or "normal"
+            num_models (int): Number of models to train in parallel. If not set,
+                the number of parallel models to train will be decided by the
+                algorithm itself. One model will be trained according to the
+                given training parameter (regularization, optimizer, loss) and
+                the rest by close by parameters.
+            num_calibration_samples (int): Number of observations to use from
+                validation dataset for doing model calibration (finding the best threshold).
+            init_method (str): Function to use to set the initial model weights.
+                One of "uniform" or "normal"
             init_scale (float): For "uniform" init, the range of values.
             init_sigma (float): For "normal" init, the standard-deviation.
-            init_bias (float):  Initial weight for bias term
+            init_bias (float): Initial weight for bias term
             optimizer (str): One of 'sgd', 'adam', 'rmsprop' or 'auto'
-            loss (str): One of  'logistic', 'squared_loss', 'absolute_loss', 'hinge_loss',
-            'eps_insensitive_squared_loss', 'eps_insensitive_absolute_loss', 'quantile_loss', 'huber_loss' or
+            loss (str): One of 'logistic', 'squared_loss', 'absolute_loss',
+                'hinge_loss', 'eps_insensitive_squared_loss', 'eps_insensitive_absolute_loss',
+                'quantile_loss', 'huber_loss' or
             'softmax_loss' or 'auto'.
-            wd (float): L2 regularization parameter i.e. the weight decay parameter. Use 0 for no L2 regularization.
-            l1 (float): L1 regularization parameter. Use 0 for no L1 regularization.
+            wd (float): L2 regularization parameter i.e. the weight decay
+                parameter. Use 0 for no L2 regularization.
+            l1 (float): L1 regularization parameter. Use 0 for no L1
+                regularization.
             momentum (float): Momentum parameter of sgd optimizer.
             learning_rate (float): The SGD learning rate
-            beta_1 (float): Exponential decay rate for first moment estimates. Only applies for adam optimizer.
-            beta_2 (float): Exponential decay rate for second moment estimates. Only applies for adam optimizer.
-            bias_lr_mult (float): Allows different learning rate for the bias term. The actual learning rate for the
-            bias is learning rate times bias_lr_mult.
-            bias_wd_mult (float): Allows different regularization for the bias term. The actual L2 regularization weight
-            for the bias is wd times bias_wd_mult. By default there is no regularization on the bias term.
-            use_lr_scheduler (bool): If true, we use a scheduler for the learning rate.
-            lr_scheduler_step (int): The number of steps between decreases of the learning rate. Only applies to
-                learning rate scheduler.
-            lr_scheduler_factor (float): Every lr_scheduler_step the learning rate will decrease by this quantity.
-                Only applies for learning rate scheduler.
-            lr_scheduler_minimum_lr (float): The learning rate will never decrease to a value lower than this.
-            lr_scheduler_minimum_lr (float): Only applies for learning rate scheduler.
-            normalize_data (bool): Normalizes the features before training to have standard deviation of 1.0.
-            normalize_label (bool): Normalizes the regression label to have a standard deviation of 1.0.
-                If set for classification, it will be ignored.
+            beta_1 (float): Exponential decay rate for first moment estimates.
+                Only applies for adam optimizer.
+            beta_2 (float): Exponential decay rate for second moment estimates.
+                Only applies for adam optimizer.
+            bias_lr_mult (float): Allows different learning rate for the bias
+                term. The actual learning rate for the bias is learning rate times bias_lr_mult.
+            bias_wd_mult (float): Allows different regularization for the bias
+                term. The actual L2 regularization weight for the bias is wd times bias_wd_mult.
+                By default there is no regularization on the bias term.
+            use_lr_scheduler (bool): If true, we use a scheduler for the
+                learning rate.
+            lr_scheduler_step (int): The number of steps between decreases of
+                the learning rate. Only applies to learning rate scheduler.
+            lr_scheduler_factor (float): Every lr_scheduler_step the learning
+                rate will decrease by this quantity. Only applies for learning
+                rate scheduler.
+            lr_scheduler_minimum_lr (float): The learning rate will never
+                decrease to a value lower than this. Only applies for learning rate scheduler.
+            normalize_data (bool): Normalizes the features before training to
+                have standard deviation of 1.0.
+            normalize_label (bool): Normalizes the regression label to have a
+                standard deviation of 1.0. If set for classification, it will be
+                ignored.
             unbias_data (bool): If true, features are modified to have mean 0.0.
             unbias_label (bool): If true, labels are modified to have mean 0.0.
-            num_point_for_scaler (int): The number of data points to use for calculating the normalizing  and
-                unbiasing terms.
-            margin (float):  the margin for hinge_loss.
-            quantile (float): Quantile for quantile loss. For quantile q, the model will attempt to produce
-            predictions such that true_label < prediction with probability q.
-            loss_insensitivity (float): Parameter for epsilon insensitive loss type. During training and metric
-            evaluation, any error smaller than this is considered to be zero.
-            huber_delta (float): Parameter for Huber loss. During training and metric evaluation, compute L2 loss for
-            errors smaller than delta and L1 loss for errors larger than delta.
-            early_stopping_patience (int): the number of epochs to wait before ending training if no improvement is
-            made. The improvement is training loss if validation data is not provided, or else it is the validation
-            loss or the binary classification model selection criteria like accuracy, f1-score etc. To disable early
-            stopping, set early_stopping_patience to a value larger than epochs.
-            early_stopping_tolerance (float):  Relative tolerance to measure an improvement in loss. If the ratio of
-            the improvement in loss divided by the previous best loss is smaller than this value, early stopping will
+            num_point_for_scaler (int): The number of data points to use for
+                calculating the normalizing and unbiasing terms.
+            margin (float): the margin for hinge_loss.
+            quantile (float): Quantile for quantile loss. For quantile q, the
+                model will attempt to produce predictions such that true_label < prediction with
+                probability q.
+            loss_insensitivity (float): Parameter for epsilon insensitive loss
+                type. During training and metric evaluation, any error smaller than this is
+                considered to be zero.
+            huber_delta (float): Parameter for Huber loss. During training and
+                metric evaluation, compute L2 loss for errors smaller than delta and L1 loss for
+                errors larger than delta.
+            early_stopping_patience (int): the number of epochs to wait before ending training
+            if no improvement is made. The improvement is training loss if validation data is
+            not provided, or else it is the validation loss or the binary classification model
+            selection criteria like accuracy, f1-score etc. To disable early stopping,
+            set early_stopping_patience to a value larger than epochs.
+            early_stopping_tolerance (float): Relative tolerance to measure an
+                improvement in loss. If the ratio of the improvement in loss divided by the
+                previous best loss is smaller than this value, early stopping will
             consider the improvement to be zero.
-            num_classes (int): The number of classes for the response variable. Required when predictor_type is
-            multiclass_classifier and ignored otherwise. The classes are assumed to be labeled 0, ..., num_classes - 1.
-            accuracy_top_k (int): The value of k when computing the Top K Accuracy metric for multiclass
-            classification. An example is scored as correct if the model assigns one of the top k scores to the true
+            num_classes (int): The number of classes for the response variable.
+                Required when predictor_type is multiclass_classifier and ignored otherwise. The
+                classes are assumed to be labeled 0, ..., num_classes - 1.
+            accuracy_top_k (int): The value of k when computing the Top K
+                Accuracy metric for multiclass classification. An example is scored as correct
+                if the model assigns one of the top k scores to the true
             label.
-            f_beta (float): The value of beta to use when calculating F score metrics for binary or multiclass
-            classification. Also used if binary_classifier_model_selection_criteria is f_beta.
-            balance_multiclass_weights (bool): Whether to use class weights which give each class equal importance in
-            the loss function. Only used when predictor_type is multiclass_classifier.
+            f_beta (float): The value of beta to use when calculating F score
+                metrics for binary or multiclass classification. Also used if
+                binary_classifier_model_selection_criteria is f_beta.
+            balance_multiclass_weights (bool): Whether to use class weights
+                which give each class equal importance in the loss function. Only used when
+                predictor_type is multiclass_classifier.
             **kwargs: base class keyword argument values.
         """
         super(LinearLearner, self).__init__(
@@ -326,12 +373,12 @@ class LinearLearner(AmazonAlgorithmEstimatorBase):
             )
 
     def create_model(self, vpc_config_override=VPC_CONFIG_DEFAULT):
-        """Return a :class:`~sagemaker.amazon.LinearLearnerModel` referencing the latest
-        s3 model data produced by this Estimator.
+        """Return a :class:`~sagemaker.amazon.LinearLearnerModel` referencing
+        the latest s3 model data produced by this Estimator.
 
         Args:
-            vpc_config_override (dict[str, list[str]]): Optional override for VpcConfig set on the model.
-                Default: use subnets and security groups from this Estimator.
+            vpc_config_override (dict[str, list[str]]): Optional override for VpcConfig set on
+                the model. Default: use subnets and security groups from this Estimator.
                 * 'Subnets' (list[str]): List of subnet ids.
                 * 'SecurityGroupIds' (list[str]): List of security group ids.
         """
@@ -343,6 +390,12 @@ class LinearLearner(AmazonAlgorithmEstimatorBase):
         )
 
     def _prepare_for_training(self, records, mini_batch_size=None, job_name=None):
+        """
+        Args:
+            records:
+            mini_batch_size:
+            job_name:
+        """
         num_records = None
         if isinstance(records, list):
             for record in records:
@@ -365,18 +418,27 @@ class LinearLearner(AmazonAlgorithmEstimatorBase):
 
 
 class LinearLearnerPredictor(RealTimePredictor):
-    """Performs binary-classification or regression prediction from input vectors.
+    """Performs binary-classification or regression prediction from input
+    vectors.
 
-    The implementation of :meth:`~sagemaker.predictor.RealTimePredictor.predict` in this
-    `RealTimePredictor` requires a numpy ``ndarray`` as input. The array should contain the
-    same number of columns as the feature-dimension of the data used to fit the model this
-    Predictor performs inference on.
+    The implementation of
+    :meth:`~sagemaker.predictor.RealTimePredictor.predict` in this
+    `RealTimePredictor` requires a numpy ``ndarray`` as input. The array should
+    contain the same number of columns as the feature-dimension of the data used
+    to fit the model this Predictor performs inference on.
 
-    :func:`predict` returns a list of :class:`~sagemaker.amazon.record_pb2.Record` objects, one
-    for each row in the input ``ndarray``. The prediction is stored in the ``"predicted_label"``
-    key of the ``Record.label`` field."""
+    :func:`predict` returns a list of
+    :class:`~sagemaker.amazon.record_pb2.Record` objects, one for each row in
+    the input ``ndarray``. The prediction is stored in the ``"predicted_label"``
+    key of the ``Record.label`` field.
+    """
 
     def __init__(self, endpoint, sagemaker_session=None):
+        """
+        Args:
+            endpoint:
+            sagemaker_session:
+        """
         super(LinearLearnerPredictor, self).__init__(
             endpoint,
             sagemaker_session,
@@ -386,10 +448,19 @@ class LinearLearnerPredictor(RealTimePredictor):
 
 
 class LinearLearnerModel(Model):
-    """Reference LinearLearner s3 model data. Calling :meth:`~sagemaker.model.Model.deploy` creates an Endpoint
-    and returns a :class:`LinearLearnerPredictor`"""
+    """Reference LinearLearner s3 model data. Calling
+    :meth:`~sagemaker.model.Model.deploy` creates an Endpoint and returns a
+    :class:`LinearLearnerPredictor`
+    """
 
     def __init__(self, model_data, role, sagemaker_session=None, **kwargs):
+        """
+        Args:
+            model_data:
+            role:
+            sagemaker_session:
+            **kwargs:
+        """
         sagemaker_session = sagemaker_session or Session()
         repo = "{}:{}".format(LinearLearner.repo_name, LinearLearner.repo_version)
         image = "{}/{}".format(registry(sagemaker_session.boto_session.region_name), repo)

--- a/src/sagemaker/amazon/ntm.py
+++ b/src/sagemaker/amazon/ntm.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import absolute_import
 
 from sagemaker.amazon.amazon_estimator import AmazonAlgorithmEstimatorBase, registry
@@ -23,6 +24,7 @@ from sagemaker.vpc_utils import VPC_CONFIG_DEFAULT
 
 
 class NTM(AmazonAlgorithmEstimatorBase):
+    """Placeholder docstring"""
 
     repo_name = "ntm"
     repo_version = 1
@@ -73,49 +75,68 @@ class NTM(AmazonAlgorithmEstimatorBase):
         learning_rate=None,
         **kwargs
     ):
-        """Neural Topic Model (NTM) is :class:`Estimator` used for unsupervised learning.
+        """Neural Topic Model (NTM) is :class:`Estimator` used for unsupervised
+        learning.
 
         This Estimator may be fit via calls to
-        :meth:`~sagemaker.amazon.amazon_estimator.AmazonAlgorithmEstimatorBase.fit`. It requires Amazon
-        :class:`~sagemaker.amazon.record_pb2.Record` protobuf serialized data to be stored in S3.
-        There is an utility :meth:`~sagemaker.amazon.amazon_estimator.AmazonAlgorithmEstimatorBase.record_set` that
-        can be used to upload data to S3 and creates :class:`~sagemaker.amazon.amazon_estimator.RecordSet` to be passed
-        to the `fit` call.
+        :meth:`~sagemaker.amazon.amazon_estimator.AmazonAlgorithmEstimatorBase.fit`.
+        It requires Amazon :class:`~sagemaker.amazon.record_pb2.Record` protobuf
+        serialized data to be stored in S3. There is an utility
+        :meth:`~sagemaker.amazon.amazon_estimator.AmazonAlgorithmEstimatorBase.record_set`
+        that can be used to upload data to S3 and creates
+        :class:`~sagemaker.amazon.amazon_estimator.RecordSet` to be passed to
+        the `fit` call.
 
-        To learn more about the Amazon protobuf Record class and how to prepare bulk data in this format, please
-        consult AWS technical documentation: https://docs.aws.amazon.com/sagemaker/latest/dg/cdf-training.html
+        To learn more about the Amazon protobuf Record class and how to
+        prepare bulk data in this format, please consult AWS technical
+        documentation:
+        https://docs.aws.amazon.com/sagemaker/latest/dg/cdf-training.html
 
-        After this Estimator is fit, model data is stored in S3. The model may be deployed to an Amazon SageMaker
-        Endpoint by invoking :meth:`~sagemaker.amazon.estimator.EstimatorBase.deploy`. As well as deploying an Endpoint,
-        deploy returns a :class:`~sagemaker.amazon.ntm.NTMPredictor` object that can be used
-        for inference calls using the trained model hosted in the SageMaker Endpoint.
+        After this Estimator is fit, model data is stored in S3. The model
+        may be deployed to an Amazon SageMaker Endpoint by invoking
+        :meth:`~sagemaker.amazon.estimator.EstimatorBase.deploy`. As well as
+        deploying an Endpoint, deploy returns a
+        :class:`~sagemaker.amazon.ntm.NTMPredictor` object that can be used for
+        inference calls using the trained model hosted in the SageMaker
+        Endpoint.
 
-        NTM Estimators can be configured by setting hyperparameters. The available hyperparameters for
-        NTM are documented below.
+        NTM Estimators can be configured by setting hyperparameters. The
+        available hyperparameters for NTM are documented below.
 
-        For further information on the AWS NTM algorithm,
-        please consult AWS technical documentation: https://docs.aws.amazon.com/sagemaker/latest/dg/ntm.html
+        For further information on the AWS NTM algorithm, please consult AWS
+        technical documentation:
+        https://docs.aws.amazon.com/sagemaker/latest/dg/ntm.html
 
         Args:
-            role (str): An AWS IAM role (either name or full ARN). The Amazon SageMaker training jobs and
-                APIs that create Amazon SageMaker endpoints use this role to access
-                training data and model artifacts. After the endpoint is created,
-                the inference code might use the IAM role, if accessing AWS resource.
-            train_instance_type (str): Type of EC2 instance to use for training, for example, 'ml.c4.xlarge'.
-            num_topics (int): Required. The number of topics for NTM to find within the data.
-            encoder_layers (list): Optional. Represents number of layers in the encoder and the output size of
-                each layer.
-            epochs (int): Optional. Maximum number of passes over the training data.
-            encoder_layers_activation (str): Optional. Activation function to use in the encoder layers.
+            role (str): An AWS IAM role (either name or full ARN). The Amazon
+                SageMaker training jobs and APIs that create Amazon SageMaker
+                endpoints use this role to access training data and model
+                artifacts. After the endpoint is created, the inference code
+                might use the IAM role, if accessing AWS resource.
+            train_instance_count:
+            train_instance_type (str): Type of EC2 instance to use for training,
+                for example, 'ml.c4.xlarge'.
+            num_topics (int): Required. The number of topics for NTM to find
+                within the data.
+            encoder_layers (list): Optional. Represents number of layers in the
+                encoder and the output size of each layer.
+            epochs (int): Optional. Maximum number of passes over the training
+                data.
+            encoder_layers_activation (str): Optional. Activation function to
+                use in the encoder layers.
             optimizer (str): Optional. Optimizer to use for training.
-            tolerance (float): Optional. Maximum relative change in the loss function within the last
-                num_patience_epochs number of epochs below which early stopping is triggered.
-            num_patience_epochs (int): Optional. Number of successive epochs over which early stopping criterion
-                is evaluated.
-            batch_norm (bool): Optional. Whether to use batch normalization during training.
+            tolerance (float): Optional. Maximum relative change in the loss
+                function within the last num_patience_epochs number of epochs
+                below which early stopping is triggered.
+            num_patience_epochs (int): Optional. Number of successive epochs
+                over which early stopping criterion is evaluated.
+            batch_norm (bool): Optional. Whether to use batch normalization
+                during training.
             rescale_gradient (float): Optional. Rescale factor for gradient.
-            clip_gradient (float): Optional. Maximum magnitude for each gradient component.
-            weight_decay (float): Optional. Weight decay coefficient. Adds L2 regularization.
+            clip_gradient (float): Optional. Maximum magnitude for each gradient
+                component.
+            weight_decay (float): Optional. Weight decay coefficient. Adds L2
+                regularization.
             learning_rate (float): Optional. Learning rate for the optimizer.
             **kwargs: base class keyword argument values.
         """
@@ -139,8 +160,8 @@ class NTM(AmazonAlgorithmEstimatorBase):
         s3 model data produced by this Estimator.
 
         Args:
-            vpc_config_override (dict[str, list[str]]): Optional override for VpcConfig set on the model.
-                Default: use subnets and security groups from this Estimator.
+            vpc_config_override (dict[str, list[str]]): Optional override for VpcConfig set on
+                the model. Default: use subnets and security groups from this Estimator.
                 * 'Subnets' (list[str]): List of subnet ids.
                 * 'SecurityGroupIds' (list[str]): List of security group ids.
         """
@@ -154,6 +175,12 @@ class NTM(AmazonAlgorithmEstimatorBase):
     def _prepare_for_training(  # pylint: disable=signature-differs
         self, records, mini_batch_size, job_name=None
     ):
+        """
+        Args:
+            records:
+            mini_batch_size:
+            job_name:
+        """
         if mini_batch_size is not None and (mini_batch_size < 1 or mini_batch_size > 10000):
             raise ValueError("mini_batch_size must be in [1, 10000]")
         super(NTM, self)._prepare_for_training(
@@ -164,16 +191,24 @@ class NTM(AmazonAlgorithmEstimatorBase):
 class NTMPredictor(RealTimePredictor):
     """Transforms input vectors to lower-dimesional representations.
 
-    The implementation of :meth:`~sagemaker.predictor.RealTimePredictor.predict` in this
-    `RealTimePredictor` requires a numpy ``ndarray`` as input. The array should contain the
-    same number of columns as the feature-dimension of the data used to fit the model this
-    Predictor performs inference on.
+    The implementation of
+    :meth:`~sagemaker.predictor.RealTimePredictor.predict` in this
+    `RealTimePredictor` requires a numpy ``ndarray`` as input. The array should
+    contain the same number of columns as the feature-dimension of the data used
+    to fit the model this Predictor performs inference on.
 
-    :meth:`predict()` returns a list of :class:`~sagemaker.amazon.record_pb2.Record` objects, one
-    for each row in the input ``ndarray``. The lower dimension vector result is stored in the ``projection``
-    key of the ``Record.label`` field."""
+    :meth:`predict()` returns a list of
+    :class:`~sagemaker.amazon.record_pb2.Record` objects, one for each row in
+    the input ``ndarray``. The lower dimension vector result is stored in the
+    ``projection`` key of the ``Record.label`` field.
+    """
 
     def __init__(self, endpoint, sagemaker_session=None):
+        """
+        Args:
+            endpoint:
+            sagemaker_session:
+        """
         super(NTMPredictor, self).__init__(
             endpoint,
             sagemaker_session,
@@ -183,10 +218,19 @@ class NTMPredictor(RealTimePredictor):
 
 
 class NTMModel(Model):
-    """Reference NTM s3 model data. Calling :meth:`~sagemaker.model.Model.deploy` creates an Endpoint and return
-    a Predictor that transforms vectors to a lower-dimensional representation."""
+    """Reference NTM s3 model data. Calling
+    :meth:`~sagemaker.model.Model.deploy` creates an Endpoint and return a
+    Predictor that transforms vectors to a lower-dimensional representation.
+    """
 
     def __init__(self, model_data, role, sagemaker_session=None, **kwargs):
+        """
+        Args:
+            model_data:
+            role:
+            sagemaker_session:
+            **kwargs:
+        """
         sagemaker_session = sagemaker_session or Session()
         repo = "{}:{}".format(NTM.repo_name, NTM.repo_version)
         image = "{}/{}".format(

--- a/src/sagemaker/amazon/object2vec.py
+++ b/src/sagemaker/amazon/object2vec.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import absolute_import
 
 from sagemaker.amazon.amazon_estimator import AmazonAlgorithmEstimatorBase, registry
@@ -22,6 +23,10 @@ from sagemaker.vpc_utils import VPC_CONFIG_DEFAULT
 
 
 def _list_check_subset(valid_super_list):
+    """
+    Args:
+        valid_super_list:
+    """
     valid_superset = set(valid_super_list)
 
     def validate(value):
@@ -35,6 +40,7 @@ def _list_check_subset(valid_super_list):
 
 
 class Object2Vec(AmazonAlgorithmEstimatorBase):
+    """Placeholder docstring"""
 
     repo_name = "object2vec"
     repo_version = 1
@@ -168,66 +174,86 @@ class Object2Vec(AmazonAlgorithmEstimatorBase):
 
         This Estimator may be fit via calls to
         :meth:`~sagemaker.amazon.amazon_estimator.AmazonAlgorithmEstimatorBase.fit`.
-        There is an utility :meth:`~sagemaker.amazon.amazon_estimator.AmazonAlgorithmEstimatorBase.record_set` that
-        can be used to upload data to S3 and creates :class:`~sagemaker.amazon.amazon_estimator.RecordSet` to be passed
-        to the `fit` call.
+        There is an utility
+        :meth:`~sagemaker.amazon.amazon_estimator.AmazonAlgorithmEstimatorBase.record_set`
+        that can be used to upload data to S3 and creates
+        :class:`~sagemaker.amazon.amazon_estimator.RecordSet` to be passed to
+        the `fit` call.
 
-        After this Estimator is fit, model data is stored in S3. The model may be deployed to an Amazon SageMaker
-        Endpoint by invoking :meth:`~sagemaker.amazon.estimator.EstimatorBase.deploy`. As well as deploying an
-        Endpoint, deploy returns a :class:`~sagemaker.amazon.RealTimePredictor` object that can be used
-        for inference calls using the trained model hosted in the SageMaker Endpoint.
+        After this Estimator is fit, model data is stored in S3. The model
+        may be deployed to an Amazon SageMaker Endpoint by invoking
+        :meth:`~sagemaker.amazon.estimator.EstimatorBase.deploy`. As well as
+        deploying an Endpoint, deploy returns a
+        :class:`~sagemaker.amazon.RealTimePredictor` object that can be used for
+        inference calls using the trained model hosted in the SageMaker
+        Endpoint.
 
-        Object2Vec Estimators can be configured by setting hyperparameters. The available hyperparameters for
-        Object2Vec are documented below.
+        Object2Vec Estimators can be configured by setting hyperparameters.
+        The available hyperparameters for Object2Vec are documented below.
 
-        For further information on the AWS Object2Vec algorithm,
-        please consult AWS technical documentation: https://docs.aws.amazon.com/sagemaker/latest/dg/object2vec.html
+        For further information on the AWS Object2Vec algorithm, please
+        consult AWS technical documentation:
+        https://docs.aws.amazon.com/sagemaker/latest/dg/object2vec.html
 
         Args:
-            role (str): An AWS IAM role (either name or full ARN). The Amazon SageMaker training jobs and
-                APIs that create Amazon SageMaker endpoints use this role to access
-                training data and model artifacts. After the endpoint is created,
-                the inference code might use the IAM role, if accessing AWS resource.
-            train_instance_count (int): Number of Amazon EC2 instances to use for training.
-            train_instance_type (str): Type of EC2 instance to use for training, for example, 'ml.c4.xlarge'.
-
-            epochs(int): Total number of epochs for SGD training
-            enc0_max_seq_len(int): Maximum sequence length
-            enc0_vocab_size(int): Vocabulary size of tokens
-
-            enc_dim(int): Optional. Dimension of the output of the embedding layer
-            mini_batch_size(int): Optional. mini batch size for SGD training
-            early_stopping_patience(int): Optional. The allowed number of consecutive epochs without improvement
-                before early stopping is applied
-            early_stopping_tolerance(float): Optional. The value used to determine whether the algorithm has made
-                improvement between two consecutive epochs for early stopping
-            dropout(float): Optional. Dropout probability on network layers
-            weight_decay(float): Optional. Weight decay parameter during optimization
-            bucket_width(int): Optional. The allowed difference between data sequence length when bucketing is enabled
-            num_classes(int): Optional. Number of classes for classification training (ignored for regression problems)
-            mlp_layers(int): Optional. Number of MLP layers in the network
-            mlp_dim(int): Optional. Dimension of the output of MLP layer
-            mlp_activation(str): Optional. Type of activation function for the MLP layer
-            output_layer(str): Optional. Type of output layer
-            optimizer(str): Optional. Type of optimizer for training
-            learning_rate(float): Optional. Learning rate for SGD training
-            negative_sampling_rate(int): Optional. Negative sampling rate
-            comparator_list(str): Optional. Customization of comparator operator
-            tied_token_embedding_weight(bool): Optional. Tying of token embedding layer weight
-            token_embedding_storage_type(str): Optional. Type of token embedding storage
-            enc0_network(str): Optional. Network model of encoder "enc0"
-            enc1_network(str): Optional. Network model of encoder "enc1"
-            enc0_cnn_filter_width(int): Optional. CNN filter width
-            enc1_cnn_filter_width(int): Optional. CNN filter width
-            enc1_max_seq_len(int): Optional. Maximum sequence length
-            enc0_token_embedding_dim(int): Optional. Output dimension of token embedding layer
-            enc1_token_embedding_dim(int): Optional. Output dimension of token embedding layer
-            enc1_vocab_size(int): Optional. Vocabulary size of tokens
-            enc0_layers(int): Optional. Number of layers in encoder
-            enc1_layers(int): Optional. Number of layers in encoder
-            enc0_freeze_pretrained_embedding(bool): Optional. Freeze pretrained embedding weights
-            enc1_freeze_pretrained_embedding(bool): Optional. Freeze pretrained embedding weights
-
+            role (str): An AWS IAM role (either name or full ARN). The Amazon
+                SageMaker training jobs and APIs that create Amazon SageMaker
+                endpoints use this role to access training data and model
+                artifacts. After the endpoint is created, the inference code
+                might use the IAM role, if accessing AWS resource.
+            train_instance_count (int): Number of Amazon EC2 instances to use
+                for training.
+            train_instance_type (str): Type of EC2 instance to use for training,
+                for example, 'ml.c4.xlarge'.
+            epochs (int): Total number of epochs for SGD training
+            enc0_max_seq_len (int): Maximum sequence length
+            enc0_vocab_size (int): Vocabulary size of tokens
+            enc_dim (int): Optional. Dimension of the output of the embedding
+                layer
+            mini_batch_size (int): Optional. mini batch size for SGD training
+            early_stopping_patience (int): Optional. The allowed number of
+                consecutive epochs without improvement before early stopping is
+                applied
+            early_stopping_tolerance (float): Optional. The value used to
+                determine whether the algorithm has made improvement between two
+                consecutive epochs for early stopping
+            dropout (float): Optional. Dropout probability on network layers
+            weight_decay (float): Optional. Weight decay parameter during
+                optimization
+            bucket_width (int): Optional. The allowed difference between data
+                sequence length when bucketing is enabled
+            num_classes (int): Optional. Number of classes for classification
+                training (ignored for regression problems)
+            mlp_layers (int): Optional. Number of MLP layers in the network
+            mlp_dim (int): Optional. Dimension of the output of MLP layer
+            mlp_activation (str): Optional. Type of activation function for the
+                MLP layer
+            output_layer (str): Optional. Type of output layer
+            optimizer (str): Optional. Type of optimizer for training
+            learning_rate (float): Optional. Learning rate for SGD training
+            negative_sampling_rate (int): Optional. Negative sampling rate
+            comparator_list (str): Optional. Customization of comparator
+                operator
+            tied_token_embedding_weight (bool): Optional. Tying of token
+                embedding layer weight
+            token_embedding_storage_type (str): Optional. Type of token
+                embedding storage
+            enc0_network (str): Optional. Network model of encoder "enc0"
+            enc1_network (str): Optional. Network model of encoder "enc1"
+            enc0_cnn_filter_width (int): Optional. CNN filter width
+            enc1_cnn_filter_width (int): Optional. CNN filter width
+            enc1_max_seq_len (int): Optional. Maximum sequence length
+            enc0_token_embedding_dim (int): Optional. Output dimension of token
+                embedding layer
+            enc1_token_embedding_dim (int): Optional. Output dimension of token
+                embedding layer
+            enc1_vocab_size (int): Optional. Vocabulary size of tokens
+            enc0_layers (int): Optional. Number of layers in encoder
+            enc1_layers (int): Optional. Number of layers in encoder
+            enc0_freeze_pretrained_embedding (bool): Optional. Freeze pretrained
+                embedding weights
+            enc1_freeze_pretrained_embedding (bool): Optional. Freeze pretrained
+                embedding weights
             **kwargs: base class keyword argument values.
         """
 
@@ -270,12 +296,12 @@ class Object2Vec(AmazonAlgorithmEstimatorBase):
         self.enc1_freeze_pretrained_embedding = enc1_freeze_pretrained_embedding
 
     def create_model(self, vpc_config_override=VPC_CONFIG_DEFAULT):
-        """Return a :class:`~sagemaker.amazon.Object2VecModel` referencing the latest
-        s3 model data produced by this Estimator.
+        """Return a :class:`~sagemaker.amazon.Object2VecModel` referencing the
+        latest s3 model data produced by this Estimator.
 
         Args:
-            vpc_config_override (dict[str, list[str]]): Optional override for VpcConfig set on the model.
-                Default: use subnets and security groups from this Estimator.
+            vpc_config_override (dict[str, list[str]]): Optional override for VpcConfig set on
+                the model. Default: use subnets and security groups from this Estimator.
                 * 'Subnets' (list[str]): List of subnet ids.
                 * 'SecurityGroupIds' (list[str]): List of security group ids.
         """
@@ -287,6 +313,12 @@ class Object2Vec(AmazonAlgorithmEstimatorBase):
         )
 
     def _prepare_for_training(self, records, mini_batch_size=None, job_name=None):
+        """
+        Args:
+            records:
+            mini_batch_size:
+            job_name:
+        """
         if mini_batch_size is None:
             mini_batch_size = self.MINI_BATCH_SIZE
 
@@ -296,10 +328,19 @@ class Object2Vec(AmazonAlgorithmEstimatorBase):
 
 
 class Object2VecModel(Model):
-    """Reference Object2Vec s3 model data. Calling :meth:`~sagemaker.model.Model.deploy` creates an
-    Endpoint and returns a Predictor that calculates anomaly scores for datapoints."""
+    """Reference Object2Vec s3 model data. Calling
+    :meth:`~sagemaker.model.Model.deploy` creates an Endpoint and returns a
+    Predictor that calculates anomaly scores for datapoints.
+    """
 
     def __init__(self, model_data, role, sagemaker_session=None, **kwargs):
+        """
+        Args:
+            model_data:
+            role:
+            sagemaker_session:
+            **kwargs:
+        """
         sagemaker_session = sagemaker_session or Session()
         repo = "{}:{}".format(Object2Vec.repo_name, Object2Vec.repo_version)
         image = "{}/{}".format(

--- a/src/sagemaker/amazon/pca.py
+++ b/src/sagemaker/amazon/pca.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import absolute_import
 
 from sagemaker.amazon.amazon_estimator import AmazonAlgorithmEstimatorBase, registry
@@ -23,6 +24,7 @@ from sagemaker.vpc_utils import VPC_CONFIG_DEFAULT
 
 
 class PCA(AmazonAlgorithmEstimatorBase):
+    """Placeholder docstring"""
 
     repo_name = "pca"
     repo_version = 1
@@ -56,46 +58,60 @@ class PCA(AmazonAlgorithmEstimatorBase):
         extra_components=None,
         **kwargs
     ):
-        """A Principal Components Analysis (PCA) :class:`~sagemaker.amazon.amazon_estimator.AmazonAlgorithmEstimatorBase`.
+        """A Principal Components Analysis (PCA)
+        :class:`~sagemaker.amazon.amazon_estimator.AmazonAlgorithmEstimatorBase`.
 
         This Estimator may be fit via calls to
         :meth:`~sagemaker.amazon.amazon_estimator.AmazonAlgorithmEstimatorBase.fit_ndarray`
-        or :meth:`~sagemaker.amazon.amazon_estimator.AmazonAlgorithmEstimatorBase.fit`. The former allows a PCA model
-        to be fit on a 2-dimensional numpy array. The latter requires Amazon
-        :class:`~sagemaker.amazon.record_pb2.Record` protobuf serialized data to be stored in S3.
+        or
+        :meth:`~sagemaker.amazon.amazon_estimator.AmazonAlgorithmEstimatorBase.fit`.
+        The former allows a PCA model to be fit on a 2-dimensional numpy array.
+        The latter requires Amazon :class:`~sagemaker.amazon.record_pb2.Record`
+        protobuf serialized data to be stored in S3.
 
-        To learn more about the Amazon protobuf Record class and how to prepare bulk data in this format, please
-        consult AWS technical documentation: https://docs.aws.amazon.com/sagemaker/latest/dg/cdf-training.html
+        To learn more about the Amazon protobuf Record class and how to
+        prepare bulk data in this format, please consult AWS technical
+        documentation:
+        https://docs.aws.amazon.com/sagemaker/latest/dg/cdf-training.html
 
-        After this Estimator is fit, model data is stored in S3. The model may be deployed to an Amazon SageMaker
-        Endpoint by invoking :meth:`~sagemaker.amazon.estimator.EstimatorBase.deploy`. As well as deploying an Endpoint,
-        deploy returns a :class:`~sagemaker.amazon.pca.PCAPredictor` object that can be used to project
-        input vectors to the learned lower-dimensional representation, using the trained PCA model hosted in the
-        SageMaker Endpoint.
+        After this Estimator is fit, model data is stored in S3. The model
+        may be deployed to an Amazon SageMaker Endpoint by invoking
+        :meth:`~sagemaker.amazon.estimator.EstimatorBase.deploy`. As well as
+        deploying an Endpoint, deploy returns a
+        :class:`~sagemaker.amazon.pca.PCAPredictor` object that can be used to
+        project input vectors to the learned lower-dimensional representation,
+        using the trained PCA model hosted in the SageMaker Endpoint.
 
-        PCA Estimators can be configured by setting hyperparameters. The available hyperparameters for PCA
-        are documented below. For further information on the AWS PCA algorithm, please consult AWS technical
+        PCA Estimators can be configured by setting hyperparameters. The
+        available hyperparameters for PCA are documented below. For further
+        information on the AWS PCA algorithm, please consult AWS technical
         documentation: https://docs.aws.amazon.com/sagemaker/latest/dg/pca.html
 
-        This Estimator uses Amazon SageMaker PCA to perform training and host deployed models. To
-        learn more about Amazon SageMaker PCA, please read:
+        This Estimator uses Amazon SageMaker PCA to perform training and host
+        deployed models. To learn more about Amazon SageMaker PCA, please read:
         https://docs.aws.amazon.com/sagemaker/latest/dg/how-pca-works.html
 
         Args:
-            role (str): An AWS IAM role (either name or full ARN). The Amazon SageMaker training jobs and
-                APIs that create Amazon SageMaker endpoints use this role to access
-                training data and model artifacts. After the endpoint is created,
-                the inference code might use the IAM role, if accessing AWS resource.
-            train_instance_count (int): Number of Amazon EC2 instances to use for training.
-            train_instance_type (str): Type of EC2 instance to use for training, for example, 'ml.c4.xlarge'.
-            num_components(int): The number of principal components. Must be greater than zero.
-            algorithm_mode (str): Mode for computing the principal components. One of 'regular' or
-                'randomized'.
-            subtract_mean (bool): Whether the data should be unbiased both during train and at inference.
-            extra_components (int): As the value grows larger, the solution becomes more accurate but the
-                runtime and memory consumption increase linearly. If this value is unset or set to -1,
-                then a default value equal to the maximum of 10 and num_components will be used.
-                Valid for randomized mode only.
+            role (str): An AWS IAM role (either name or full ARN). The Amazon
+                SageMaker training jobs and APIs that create Amazon SageMaker
+                endpoints use this role to access training data and model
+                artifacts. After the endpoint is created, the inference code
+                might use the IAM role, if accessing AWS resource.
+            train_instance_count (int): Number of Amazon EC2 instances to use
+                for training.
+            train_instance_type (str): Type of EC2 instance to use for training,
+                for example, 'ml.c4.xlarge'.
+            num_components (int): The number of principal components. Must be
+                greater than zero.
+            algorithm_mode (str): Mode for computing the principal components.
+                One of 'regular' or 'randomized'.
+            subtract_mean (bool): Whether the data should be unbiased both
+                during train and at inference.
+            extra_components (int): As the value grows larger, the solution
+                becomes more accurate but the runtime and memory consumption
+                increase linearly. If this value is unset or set to -1, then a
+                default value equal to the maximum of 10 and num_components will
+                be used. Valid for randomized mode only.
             **kwargs: base class keyword argument values.
         """
         super(PCA, self).__init__(role, train_instance_count, train_instance_type, **kwargs)
@@ -105,12 +121,12 @@ class PCA(AmazonAlgorithmEstimatorBase):
         self.extra_components = extra_components
 
     def create_model(self, vpc_config_override=VPC_CONFIG_DEFAULT):
-        """Return a :class:`~sagemaker.amazon.pca.PCAModel` referencing the latest
-        s3 model data produced by this Estimator.
+        """Return a :class:`~sagemaker.amazon.pca.PCAModel` referencing the
+        latest s3 model data produced by this Estimator.
 
         Args:
-            vpc_config_override (dict[str, list[str]]): Optional override for VpcConfig set on the model.
-                Default: use subnets and security groups from this Estimator.
+            vpc_config_override (dict[str, list[str]]): Optional override for VpcConfig set on
+                the model. Default: use subnets and security groups from this Estimator.
                 * 'Subnets' (list[str]): List of subnet ids.
                 * 'SecurityGroupIds' (list[str]): List of security group ids.
         """
@@ -125,11 +141,12 @@ class PCA(AmazonAlgorithmEstimatorBase):
         """Set hyperparameters needed for training.
 
         Args:
-            * records (:class:`~RecordSet`): The records to train this ``Estimator`` on.
-            * mini_batch_size (int or None): The size of each mini-batch to use when training. If ``None``, a
-                default value will be used.
-            * job_name (str): Name of the training job to be created. If not specified, one is generated,
-                using the base name given to the constructor if applicable.
+            records (:class:`~RecordSet`): The records to train this ``Estimator`` on.
+            mini_batch_size (int or None): The size of each mini-batch to use when
+                training. If ``None``, a default value will be used.
+            job_name (str): Name of the training job to be created. If not
+                specified, one is generated, using the base name given to the
+                constructor if applicable.
         """
         num_records = None
         if isinstance(records, list):
@@ -156,16 +173,24 @@ class PCA(AmazonAlgorithmEstimatorBase):
 class PCAPredictor(RealTimePredictor):
     """Transforms input vectors to lower-dimesional representations.
 
-    The implementation of :meth:`~sagemaker.predictor.RealTimePredictor.predict` in this
-    `RealTimePredictor` requires a numpy ``ndarray`` as input. The array should contain the
-    same number of columns as the feature-dimension of the data used to fit the model this
-    Predictor performs inference on.
+    The implementation of
+    :meth:`~sagemaker.predictor.RealTimePredictor.predict` in this
+    `RealTimePredictor` requires a numpy ``ndarray`` as input. The array should
+    contain the same number of columns as the feature-dimension of the data used
+    to fit the model this Predictor performs inference on.
 
-    :meth:`predict()` returns a list of :class:`~sagemaker.amazon.record_pb2.Record` objects, one
-    for each row in the input ``ndarray``. The lower dimension vector result is stored in the ``projection``
-    key of the ``Record.label`` field."""
+    :meth:`predict()` returns a list of
+    :class:`~sagemaker.amazon.record_pb2.Record` objects, one for each row in
+    the input ``ndarray``. The lower dimension vector result is stored in the
+    ``projection`` key of the ``Record.label`` field.
+    """
 
     def __init__(self, endpoint, sagemaker_session=None):
+        """
+        Args:
+            endpoint:
+            sagemaker_session:
+        """
         super(PCAPredictor, self).__init__(
             endpoint,
             sagemaker_session,
@@ -175,10 +200,19 @@ class PCAPredictor(RealTimePredictor):
 
 
 class PCAModel(Model):
-    """Reference PCA s3 model data. Calling :meth:`~sagemaker.model.Model.deploy` creates an Endpoint and return
-    a Predictor that transforms vectors to a lower-dimensional representation."""
+    """Reference PCA s3 model data. Calling
+    :meth:`~sagemaker.model.Model.deploy` creates an Endpoint and return a
+    Predictor that transforms vectors to a lower-dimensional representation.
+    """
 
     def __init__(self, model_data, role, sagemaker_session=None, **kwargs):
+        """
+        Args:
+            model_data:
+            role:
+            sagemaker_session:
+            **kwargs:
+        """
         sagemaker_session = sagemaker_session or Session()
         repo = "{}:{}".format(PCA.repo_name, PCA.repo_version)
         image = "{}/{}".format(registry(sagemaker_session.boto_session.region_name), repo)

--- a/src/sagemaker/amazon/randomcutforest.py
+++ b/src/sagemaker/amazon/randomcutforest.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import absolute_import
 
 from sagemaker.amazon.amazon_estimator import AmazonAlgorithmEstimatorBase, registry
@@ -23,6 +24,7 @@ from sagemaker.vpc_utils import VPC_CONFIG_DEFAULT
 
 
 class RandomCutForest(AmazonAlgorithmEstimatorBase):
+    """Placeholder docstring"""
 
     repo_name = "randomcutforest"
     repo_version = 1
@@ -53,39 +55,54 @@ class RandomCutForest(AmazonAlgorithmEstimatorBase):
         """RandomCutForest is :class:`Estimator` used for anomaly detection.
 
         This Estimator may be fit via calls to
-        :meth:`~sagemaker.amazon.amazon_estimator.AmazonAlgorithmEstimatorBase.fit`. It requires Amazon
-        :class:`~sagemaker.amazon.record_pb2.Record` protobuf serialized data to be stored in S3.
-        There is an utility :meth:`~sagemaker.amazon.amazon_estimator.AmazonAlgorithmEstimatorBase.record_set` that
-        can be used to upload data to S3 and creates :class:`~sagemaker.amazon.amazon_estimator.RecordSet` to be passed
-        to the `fit` call.
+        :meth:`~sagemaker.amazon.amazon_estimator.AmazonAlgorithmEstimatorBase.fit`.
+        It requires Amazon :class:`~sagemaker.amazon.record_pb2.Record` protobuf
+        serialized data to be stored in S3. There is an utility
+        :meth:`~sagemaker.amazon.amazon_estimator.AmazonAlgorithmEstimatorBase.record_set`
+        that can be used to upload data to S3 and creates
+        :class:`~sagemaker.amazon.amazon_estimator.RecordSet` to be passed to
+        the `fit` call.
 
-        To learn more about the Amazon protobuf Record class and how to prepare bulk data in this format, please
-        consult AWS technical documentation: https://docs.aws.amazon.com/sagemaker/latest/dg/cdf-training.html
+        To learn more about the Amazon protobuf Record class and how to
+        prepare bulk data in this format, please consult AWS technical
+        documentation:
+        https://docs.aws.amazon.com/sagemaker/latest/dg/cdf-training.html
 
-        After this Estimator is fit, model data is stored in S3. The model may be deployed to an Amazon SageMaker
-        Endpoint by invoking :meth:`~sagemaker.amazon.estimator.EstimatorBase.deploy`. As well as deploying an
-        Endpoint, deploy returns a :class:`~sagemaker.amazon.ntm.RandomCutForestPredictor` object that can be used
-        for inference calls using the trained model hosted in the SageMaker Endpoint.
+        After this Estimator is fit, model data is stored in S3. The model
+        may be deployed to an Amazon SageMaker Endpoint by invoking
+        :meth:`~sagemaker.amazon.estimator.EstimatorBase.deploy`. As well as
+        deploying an Endpoint, deploy returns a
+        :class:`~sagemaker.amazon.ntm.RandomCutForestPredictor` object that can
+        be used for inference calls using the trained model hosted in the
+        SageMaker Endpoint.
 
-        RandomCutForest Estimators can be configured by setting hyperparameters. The available hyperparameters for
-        RandomCutForest are documented below.
+        RandomCutForest Estimators can be configured by setting
+        hyperparameters. The available hyperparameters for RandomCutForest are
+        documented below.
 
         For further information on the AWS Random Cut Forest algorithm,
-        please consult AWS technical documentation: https://docs.aws.amazon.com/sagemaker/latest/dg/randomcutforest.html
+        please consult AWS technical documentation:
+        https://docs.aws.amazon.com/sagemaker/latest/dg/randomcutforest.html
 
         Args:
-            role (str): An AWS IAM role (either name or full ARN). The Amazon SageMaker training jobs and
-                APIs that create Amazon SageMaker endpoints use this role to access
-                training data and model artifacts. After the endpoint is created,
-                the inference code might use the IAM role, if accessing AWS resource.
-            train_instance_count (int): Number of Amazon EC2 instances to use for training.
-            train_instance_type (str): Type of EC2 instance to use for training, for example, 'ml.c4.xlarge'.
-            num_samples_per_tree (int): Optional. The number of samples used to build each tree in the forest.
-                The total number of samples drawn from the train dataset is num_trees * num_samples_per_tree.
+            role (str): An AWS IAM role (either name or full ARN). The Amazon
+                SageMaker training jobs and APIs that create Amazon SageMaker
+                endpoints use this role to access training data and model
+                artifacts. After the endpoint is created, the inference code
+                might use the IAM role, if accessing AWS resource.
+            train_instance_count (int): Number of Amazon EC2 instances to use
+                for training.
+            train_instance_type (str): Type of EC2 instance to use for training,
+                for example, 'ml.c4.xlarge'.
+            num_samples_per_tree (int): Optional. The number of samples used to
+                build each tree in the forest. The total number of samples drawn
+                from the train dataset is num_trees * num_samples_per_tree.
             num_trees (int): Optional. The number of trees used in the forest.
-            eval_metrics(list): Optional. JSON list of metrics types to be used for reporting the score for the model.
-                Allowed values are "accuracy", "precision_recall_fscore": positive and negative precision, recall,
-                and f1 scores. If test data is provided, the score shall be reported in terms of all requested metrics.
+            eval_metrics (list): Optional. JSON list of metrics types to be used
+                for reporting the score for the model. Allowed values are
+                "accuracy", "precision_recall_fscore": positive and negative
+                precision, recall, and f1 scores. If test data is provided, the
+                score shall be reported in terms of all requested metrics.
             **kwargs: base class keyword argument values.
         """
 
@@ -97,12 +114,12 @@ class RandomCutForest(AmazonAlgorithmEstimatorBase):
         self.eval_metrics = eval_metrics
 
     def create_model(self, vpc_config_override=VPC_CONFIG_DEFAULT):
-        """Return a :class:`~sagemaker.amazon.RandomCutForestModel` referencing the latest
-        s3 model data produced by this Estimator.
+        """Return a :class:`~sagemaker.amazon.RandomCutForestModel` referencing
+        the latest s3 model data produced by this Estimator.
 
         Args:
-            vpc_config_override (dict[str, list[str]]): Optional override for VpcConfig set on the model.
-                Default: use subnets and security groups from this Estimator.
+            vpc_config_override (dict[str, list[str]]): Optional override for VpcConfig set on
+                the model. Default: use subnets and security groups from this Estimator.
                 * 'Subnets' (list[str]): List of subnet ids.
                 * 'SecurityGroupIds' (list[str]): List of security group ids.
         """
@@ -114,6 +131,12 @@ class RandomCutForest(AmazonAlgorithmEstimatorBase):
         )
 
     def _prepare_for_training(self, records, mini_batch_size=None, job_name=None):
+        """
+        Args:
+            records:
+            mini_batch_size:
+            job_name:
+        """
         if mini_batch_size is None:
             mini_batch_size = self.MINI_BATCH_SIZE
         elif mini_batch_size != self.MINI_BATCH_SIZE:
@@ -129,16 +152,24 @@ class RandomCutForest(AmazonAlgorithmEstimatorBase):
 class RandomCutForestPredictor(RealTimePredictor):
     """Assigns an anomaly score to each of the datapoints provided.
 
-    The implementation of :meth:`~sagemaker.predictor.RealTimePredictor.predict` in this
-    `RealTimePredictor` requires a numpy ``ndarray`` as input. The array should contain the
-    same number of columns as the feature-dimension of the data used to fit the model this
-    Predictor performs inference on.
+    The implementation of
+    :meth:`~sagemaker.predictor.RealTimePredictor.predict` in this
+    `RealTimePredictor` requires a numpy ``ndarray`` as input. The array should
+    contain the same number of columns as the feature-dimension of the data used
+    to fit the model this Predictor performs inference on.
 
-    :meth:`predict()` returns a list of :class:`~sagemaker.amazon.record_pb2.Record` objects,
-    one for each row in the input. Each row's score is stored in the key ``score`` of the
-    ``Record.label`` field."""
+    :meth:`predict()` returns a list of
+    :class:`~sagemaker.amazon.record_pb2.Record` objects, one for each row in
+    the input. Each row's score is stored in the key ``score`` of the
+    ``Record.label`` field.
+    """
 
     def __init__(self, endpoint, sagemaker_session=None):
+        """
+        Args:
+            endpoint:
+            sagemaker_session:
+        """
         super(RandomCutForestPredictor, self).__init__(
             endpoint,
             sagemaker_session,
@@ -148,10 +179,19 @@ class RandomCutForestPredictor(RealTimePredictor):
 
 
 class RandomCutForestModel(Model):
-    """Reference RandomCutForest s3 model data. Calling :meth:`~sagemaker.model.Model.deploy` creates an
-    Endpoint and returns a Predictor that calculates anomaly scores for datapoints."""
+    """Reference RandomCutForest s3 model data. Calling
+    :meth:`~sagemaker.model.Model.deploy` creates an Endpoint and returns a
+    Predictor that calculates anomaly scores for datapoints.
+    """
 
     def __init__(self, model_data, role, sagemaker_session=None, **kwargs):
+        """
+        Args:
+            model_data:
+            role:
+            sagemaker_session:
+            **kwargs:
+        """
         sagemaker_session = sagemaker_session or Session()
         repo = "{}:{}".format(RandomCutForest.repo_name, RandomCutForest.repo_version)
         image = "{}/{}".format(

--- a/src/sagemaker/amazon/validation.py
+++ b/src/sagemaker/amazon/validation.py
@@ -10,10 +10,16 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import absolute_import
 
 
 def gt(minimum):
+    """
+    Args:
+        minimum:
+    """
+
     def validate(value):
         return value > minimum
 
@@ -21,6 +27,11 @@ def gt(minimum):
 
 
 def ge(minimum):
+    """
+    Args:
+        minimum:
+    """
+
     def validate(value):
         return value >= minimum
 
@@ -28,6 +39,11 @@ def ge(minimum):
 
 
 def lt(maximum):
+    """
+    Args:
+        maximum:
+    """
+
     def validate(value):
         return value < maximum
 
@@ -35,6 +51,11 @@ def lt(maximum):
 
 
 def le(maximum):
+    """
+    Args:
+        maximum:
+    """
+
     def validate(value):
         return value <= maximum
 
@@ -42,6 +63,11 @@ def le(maximum):
 
 
 def isin(*expected):
+    """
+    Args:
+        *expected:
+    """
+
     def validate(value):
         return value in expected
 
@@ -49,6 +75,11 @@ def isin(*expected):
 
 
 def istype(expected):
+    """
+    Args:
+        expected:
+    """
+
     def validate(value):
         return isinstance(value, expected)
 

--- a/src/sagemaker/analytics.py
+++ b/src/sagemaker/analytics.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import print_function, absolute_import
 
 from abc import ABCMeta, abstractmethod
@@ -33,8 +34,8 @@ METRICS_PERIOD_DEFAULT = 60  # seconds
 
 
 class AnalyticsMetricsBase(with_metaclass(ABCMeta, object)):
-    """Base class for tuning job or training job analytics classes.
-    Understands common functionality like persistence and caching.
+    """Base class for tuning job or training job analytics classes. Understands
+    common functionality like persistence and caching.
     """
 
     def __init__(self):
@@ -49,12 +50,13 @@ class AnalyticsMetricsBase(with_metaclass(ABCMeta, object)):
         self.dataframe().to_csv(filename)
 
     def dataframe(self, force_refresh=False):
-        """A pandas dataframe with lots of interesting results about this object.
-        Created by calling SageMaker List and Describe APIs and converting them into
-        a convenient tabular summary.
+        """A pandas dataframe with lots of interesting results about this
+        object. Created by calling SageMaker List and Describe APIs and
+        converting them into a convenient tabular summary.
 
         Args:
-            force_refresh (bool): Set to True to fetch the latest data from SageMaker API.
+            force_refresh (bool): Set to True to fetch the latest data from
+                SageMaker API.
         """
         if force_refresh:
             self.clear_cache()
@@ -64,29 +66,31 @@ class AnalyticsMetricsBase(with_metaclass(ABCMeta, object)):
 
     @abstractmethod
     def _fetch_dataframe(self):
-        """Sub-class must calculate the dataframe and return it.
-        """
+        """Sub-class must calculate the dataframe and return it."""
 
     def clear_cache(self):
-        """Clear the object of all local caches of API methods, so
-        that the next time any properties are accessed they will be refreshed from
-        the service.
+        """Clear the object of all local caches of API methods, so that the next
+        time any properties are accessed they will be refreshed from the
+        service.
         """
         self._dataframe = None
 
 
 class HyperparameterTuningJobAnalytics(AnalyticsMetricsBase):
-    """Fetch results about a hyperparameter tuning job and make them accessible for analytics.
+    """Fetch results about a hyperparameter tuning job and make them accessible
+    for analytics.
     """
 
     def __init__(self, hyperparameter_tuning_job_name, sagemaker_session=None):
         """Initialize a ``HyperparameterTuningJobAnalytics`` instance.
 
         Args:
-            hyperparameter_tuning_job_name (str): name of the HyperparameterTuningJob to analyze.
-            sagemaker_session (sagemaker.session.Session): Session object which manages interactions with
-                Amazon SageMaker APIs and any other AWS services needed. If not specified, one is created
-                using the default AWS configuration chain.
+            hyperparameter_tuning_job_name (str): name of the
+                HyperparameterTuningJob to analyze.
+            sagemaker_session (sagemaker.session.Session): Session object which
+                manages interactions with Amazon SageMaker APIs and any other
+                AWS services needed. If not specified, one is created using the
+                default AWS configuration chain.
         """
         sagemaker_session = sagemaker_session or Session()
         self._sage_client = sagemaker_session.sagemaker_client
@@ -98,24 +102,22 @@ class HyperparameterTuningJobAnalytics(AnalyticsMetricsBase):
 
     @property
     def name(self):
-        """Name of the HyperparameterTuningJob being analyzed
-        """
+        """Name of the HyperparameterTuningJob being analyzed"""
         return self._tuning_job_name
 
     def __repr__(self):
         return "<sagemaker.HyperparameterTuningJobAnalytics for %s>" % self.name
 
     def clear_cache(self):
-        """Clear the object of all local caches of API methods.
-        """
+        """Clear the object of all local caches of API methods."""
         super(HyperparameterTuningJobAnalytics, self).clear_cache()
         self._tuning_job_describe_result = None
         self._training_job_summaries = None
 
     def _fetch_dataframe(self):
-        """Return a pandas dataframe with all the training jobs, along with their
-        hyperparameters, results, and metadata. This also includes a column to indicate
-        if a training job was the best seen so far.
+        """Return a pandas dataframe with all the training jobs, along with
+        their hyperparameters, results, and metadata. This also includes a
+        column to indicate if a training job was the best seen so far.
         """
 
         def reshape(training_summary):
@@ -148,8 +150,8 @@ class HyperparameterTuningJobAnalytics(AnalyticsMetricsBase):
 
     @property
     def tuning_ranges(self):
-        """A dictionary describing the ranges of all tuned hyperparameters.
-        The keys are the names of the hyperparameter, and the values are the ranges.
+        """A dictionary describing the ranges of all tuned hyperparameters. The
+        keys are the names of the hyperparameter, and the values are the ranges.
         """
         out = {}
         for _, ranges in self.description()["HyperParameterTuningJobConfig"][
@@ -160,13 +162,16 @@ class HyperparameterTuningJobAnalytics(AnalyticsMetricsBase):
         return out
 
     def description(self, force_refresh=False):
-        """Call ``DescribeHyperParameterTuningJob`` for the hyperparameter tuning job.
+        """Call ``DescribeHyperParameterTuningJob`` for the hyperparameter
+        tuning job.
 
         Args:
-            force_refresh (bool): Set to True to fetch the latest data from SageMaker API.
+            force_refresh (bool): Set to True to fetch the latest data from
+                SageMaker API.
 
         Returns:
-            dict: The Amazon SageMaker response for ``DescribeHyperParameterTuningJob``.
+            dict: The Amazon SageMaker response for
+            ``DescribeHyperParameterTuningJob``.
         """
         if force_refresh:
             self.clear_cache()
@@ -177,13 +182,16 @@ class HyperparameterTuningJobAnalytics(AnalyticsMetricsBase):
         return self._tuning_job_describe_result
 
     def training_job_summaries(self, force_refresh=False):
-        """A (paginated) list of everything from ``ListTrainingJobsForTuningJob``.
+        """A (paginated) list of everything from
+        ``ListTrainingJobsForTuningJob``.
 
         Args:
-            force_refresh (bool): Set to True to fetch the latest data from SageMaker API.
+            force_refresh (bool): Set to True to fetch the latest data from
+                SageMaker API.
 
         Returns:
-            dict: The Amazon SageMaker response for ``ListTrainingJobsForTuningJob``.
+            dict: The Amazon SageMaker response for
+            ``ListTrainingJobsForTuningJob``.
         """
         if force_refresh:
             self.clear_cache()
@@ -210,7 +218,8 @@ class HyperparameterTuningJobAnalytics(AnalyticsMetricsBase):
 
 
 class TrainingJobAnalytics(AnalyticsMetricsBase):
-    """Fetch training curve data from CloudWatch Metrics for a specific training job.
+    """Fetch training curve data from CloudWatch Metrics for a specific training
+    job.
     """
 
     CLOUDWATCH_NAMESPACE = "/aws/sagemaker/TrainingJobs"
@@ -228,11 +237,16 @@ class TrainingJobAnalytics(AnalyticsMetricsBase):
 
         Args:
             training_job_name (str): name of the TrainingJob to analyze.
-            metric_names (list, optional): string names of all the metrics to collect for this training job.
-                If not specified, then it will use all metric names configured for this job.
-            sagemaker_session (sagemaker.session.Session): Session object which manages interactions with
-                Amazon SageMaker APIs and any other AWS services needed. If not specified, one is specified
-                using the default AWS configuration chain.
+            metric_names (list, optional): string names of all the metrics to
+                collect for this training job. If not specified, then it will
+                use all metric names configured for this job.
+            sagemaker_session (sagemaker.session.Session): Session object which
+                manages interactions with Amazon SageMaker APIs and any other
+                AWS services needed. If not specified, one is specified using
+                the default AWS configuration chain.
+            start_time:
+            end_time:
+            period:
         """
         sagemaker_session = sagemaker_session or Session()
         self._sage_client = sagemaker_session.sagemaker_client
@@ -252,25 +266,24 @@ class TrainingJobAnalytics(AnalyticsMetricsBase):
 
     @property
     def name(self):
-        """Name of the TrainingJob being analyzed
-        """
+        """Name of the TrainingJob being analyzed"""
         return self._training_job_name
 
     def __repr__(self):
         return "<sagemaker.TrainingJobAnalytics for %s>" % self.name
 
     def clear_cache(self):
-        """Clear the object of all local caches of API methods, so
-        that the next time any properties are accessed they will be refreshed from
-        the service.
+        """Clear the object of all local caches of API methods, so that the next
+        time any properties are accessed they will be refreshed from the
+        service.
         """
         super(TrainingJobAnalytics, self).clear_cache()
         self._data = defaultdict(list)
         self._time_interval = self._determine_timeinterval()
 
     def _determine_timeinterval(self):
-        """Return a dictionary with two datetime objects, start_time and end_time,
-        covering the interval of the training job
+        """Return a dictionary with two datetime objects, start_time and
+        end_time, covering the interval of the training job
         """
         description = self._sage_client.describe_training_job(TrainingJobName=self.name)
         start_time = self._start_time or description[u"TrainingStartTime"]  # datetime object
@@ -292,6 +305,9 @@ class TrainingJobAnalytics(AnalyticsMetricsBase):
 
     def _fetch_metric(self, metric_name):
         """Fetch all the values of a named metric, and add them to _data
+
+        Args:
+            metric_name:
         """
         request = {
             "Namespace": self.CLOUDWATCH_NAMESPACE,
@@ -321,8 +337,13 @@ class TrainingJobAnalytics(AnalyticsMetricsBase):
             self._add_single_metric(elapsed_seconds, metric_name, value)
 
     def _add_single_metric(self, timestamp, metric_name, value):
-        """Store a single metric in the _data dict which can be
-        converted to a dataframe.
+        """Store a single metric in the _data dict which can be converted to a
+        dataframe.
+
+        Args:
+            timestamp:
+            metric_name:
+            value:
         """
         # note that this method is built this way to make it possible to
         # support live-refreshing charts in Bokeh at some point in the future.
@@ -331,8 +352,7 @@ class TrainingJobAnalytics(AnalyticsMetricsBase):
         self._data["value"].append(value)
 
     def _metric_names_for_training_job(self):
-        """Helper method to discover the metrics defined for a training job.
-        """
+        """Helper method to discover the metrics defined for a training job."""
         training_description = self._sage_client.describe_training_job(
             TrainingJobName=self._training_job_name
         )

--- a/src/sagemaker/chainer/__init__.py
+++ b/src/sagemaker/chainer/__init__.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import absolute_import
 
 from sagemaker.chainer.estimator import Chainer  # noqa: F401

--- a/src/sagemaker/chainer/defaults.py
+++ b/src/sagemaker/chainer/defaults.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import absolute_import
 
 CHAINER_VERSION = "4.1.0"

--- a/src/sagemaker/chainer/estimator.py
+++ b/src/sagemaker/chainer/estimator.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import absolute_import
 
 import logging
@@ -56,49 +57,67 @@ class Chainer(Framework):
         image_name=None,
         **kwargs
     ):
-        """
-        This ``Estimator`` executes an Chainer script in a managed Chainer execution environment, within a SageMaker
-        Training Job. The managed Chainer environment is an Amazon-built Docker container that executes functions
-        defined in the supplied ``entry_point`` Python script.
+        """This ``Estimator`` executes an Chainer script in a managed Chainer
+        execution environment, within a SageMaker Training Job. The managed
+        Chainer environment is an Amazon-built Docker container that executes
+        functions defined in the supplied ``entry_point`` Python script.
 
-        Training is started by calling :meth:`~sagemaker.amazon.estimator.Framework.fit` on this Estimator.
-        After training is complete, calling :meth:`~sagemaker.amazon.estimator.Framework.deploy` creates a
-        hosted SageMaker endpoint and returns an :class:`~sagemaker.amazon.chainer.model.ChainerPredictor` instance
-        that can be used to perform inference against the hosted model.
+        Training is started by calling
+        :meth:`~sagemaker.amazon.estimator.Framework.fit` on this Estimator.
+        After training is complete, calling
+        :meth:`~sagemaker.amazon.estimator.Framework.deploy` creates a hosted
+        SageMaker endpoint and returns an
+        :class:`~sagemaker.amazon.chainer.model.ChainerPredictor` instance that
+        can be used to perform inference against the hosted model.
 
-        Technical documentation on preparing Chainer scripts for SageMaker training and using the Chainer Estimator is
-        available on the project home-page: https://github.com/aws/sagemaker-python-sdk
+        Technical documentation on preparing Chainer scripts for SageMaker
+        training and using the Chainer Estimator is available on the project
+        home-page: https://github.com/aws/sagemaker-python-sdk
 
         Args:
-            entry_point (str): Path (absolute or relative) to the Python source file which should be executed
-                as the entry point to training. This should be compatible with either Python 2.7 or Python 3.5.
-            use_mpi (bool): If true, entry point is run as an MPI script. By default, the Chainer Framework runs
-                the entry point with 'mpirun' if more than one instance is used.
-            num_processes (int): Total number of processes to run the entry point with. By default, the Chainer
-                Framework runs one process per GPU (on GPU instances), or one process per host (on CPU instances).
-            process_slots_per_host (int): The number of processes that can run on each instance. By default, this is
-                set to the number of GPUs on the instance (on GPU instances), or one (on CPU instances).
-            additional_mpi_options (str): String of options to the 'mpirun' command used to run the entry point.
-                For example, '-X NCCL_DEBUG=WARN' will pass that option string to the mpirun command.
-            source_dir (str): Path (absolute or relative) to a directory with any other training
-                source code dependencies aside from tne entry point file (default: None). Structure within this
-                directory are preserved when training on Amazon SageMaker.
-            hyperparameters (dict): Hyperparameters that will be used for training (default: None).
-                The hyperparameters are made accessible as a dict[str, str] to the training code on SageMaker.
-                For convenience, this accepts other types for keys and values, but ``str()`` will be called
-                to convert them before training.
-            py_version (str): Python version you want to use for executing your model training code (default: 'py2').
-                              One of 'py2' or 'py3'.
-            framework_version (str): Chainer version you want to use for executing your model training code.
-                List of supported versions https://github.com/aws/sagemaker-python-sdk#chainer-sagemaker-estimators.
+            entry_point (str): Path (absolute or relative) to the Python source
+                file which should be executed as the entry point to training.
+                This should be compatible with either Python 2.7 or Python 3.5.
+            use_mpi (bool): If true, entry point is run as an MPI script. By
+                default, the Chainer Framework runs the entry point with
+                'mpirun' if more than one instance is used.
+            num_processes (int): Total number of processes to run the entry
+                point with. By default, the Chainer Framework runs one process
+                per GPU (on GPU instances), or one process per host (on CPU
+                instances).
+            process_slots_per_host (int): The number of processes that can run
+                on each instance. By default, this is set to the number of GPUs
+                on the instance (on GPU instances), or one (on CPU instances).
+            additional_mpi_options (str): String of options to the 'mpirun'
+                command used to run the entry point. For example, '-X
+                NCCL_DEBUG=WARN' will pass that option string to the mpirun
+                command.
+            source_dir (str): Path (absolute or relative) to a directory with
+                any other training source code dependencies aside from tne entry
+                point file (default: None). Structure within this directory are
+                preserved when training on Amazon SageMaker.
+            hyperparameters (dict): Hyperparameters that will be used for
+                training (default: None). The hyperparameters are made
+                accessible as a dict[str, str] to the training code on
+                SageMaker. For convenience, this accepts other types for keys
+                and values, but ``str()`` will be called to convert them before
+                training.
+            py_version (str): Python version you want to use for executing your
+                model training code (default: 'py2'). One of 'py2' or 'py3'.
+            framework_version (str): Chainer version you want to use for
+                executing your model training code. List of supported versions
+                https://github.com/aws/sagemaker-python-sdk#chainer-sagemaker-estimators.
                 If not specified, this will default to 4.1.
-            image_name (str): If specified, the estimator will use this image for training and hosting, instead of
-                selecting the appropriate SageMaker official image based on framework_version and py_version. It can
-                be an ECR url or dockerhub image and tag.
-                Examples:
+            image_name (str): If specified, the estimator will use this image
+                for training and hosting, instead of selecting the appropriate
+                SageMaker official image based on framework_version and
+                py_version. It can be an ECR url or dockerhub image and tag. ..
+                admonition:: Examples
+
                     123.dkr.ecr.us-west-2.amazonaws.com/my-custom-image:1.0
                     custom-image:latest.
-            **kwargs: Additional kwargs passed to the :class:`~sagemaker.estimator.Framework` constructor.
+            **kwargs: Additional kwargs passed to the
+                :class:`~sagemaker.estimator.Framework` constructor.
         """
         if framework_version is None:
             logger.warning(empty_framework_version_warning(CHAINER_VERSION, self.LATEST_VERSION))
@@ -118,7 +137,9 @@ class Chainer(Framework):
         self.additional_mpi_options = additional_mpi_options
 
     def hyperparameters(self):
-        """Return hyperparameters used by your custom Chainer code during training."""
+        """Return hyperparameters used by your custom Chainer code during
+        training.
+        """
         hyperparameters = super(Chainer, self).hyperparameters()
 
         additional_hyperparameters = {
@@ -136,21 +157,24 @@ class Chainer(Framework):
     def create_model(
         self, model_server_workers=None, role=None, vpc_config_override=VPC_CONFIG_DEFAULT
     ):
-        """Create a SageMaker ``ChainerModel`` object that can be deployed to an ``Endpoint``.
+        """Create a SageMaker ``ChainerModel`` object that can be deployed to an
+        ``Endpoint``.
 
         Args:
-            role (str): The ``ExecutionRoleArn`` IAM Role ARN for the ``Model``, which is also used during
-                transform jobs. If not specified, the role from the Estimator will be used.
-            model_server_workers (int): Optional. The number of worker processes used by the inference server.
-                If None, server will use one worker per vCPU.
-            vpc_config_override (dict[str, list[str]]): Optional override for VpcConfig set on the model.
-                Default: use subnets and security groups from this Estimator.
+            model_server_workers (int): Optional. The number of worker processes
+                used by the inference server. If None, server will use one
+                worker per vCPU.
+            role (str): The ``ExecutionRoleArn`` IAM Role ARN for the ``Model``,
+                which is also used during transform jobs. If not specified, the
+                role from the Estimator will be used.
+            vpc_config_override (dict[str, list[str]]): Optional override for VpcConfig set on
+                the model. Default: use subnets and security groups from this Estimator.
                 * 'Subnets' (list[str]): List of subnet ids.
                 * 'SecurityGroupIds' (list[str]): List of security group ids.
 
         Returns:
-            sagemaker.chainer.model.ChainerModel: A SageMaker ``ChainerModel`` object.
-                See :func:`~sagemaker.chainer.model.ChainerModel` for full details.
+            sagemaker.chainer.model.ChainerModel: A SageMaker ``ChainerModel``
+            object. See :func:`~sagemaker.chainer.model.ChainerModel` for full details.
         """
         role = role or self.role
         return ChainerModel(
@@ -173,15 +197,17 @@ class Chainer(Framework):
 
     @classmethod
     def _prepare_init_params_from_job_description(cls, job_details, model_channel_name=None):
-        """Convert the job description to init params that can be handled by the class constructor
+        """Convert the job description to init params that can be handled by the
+        class constructor
 
         Args:
-            job_details: the returned job details from a describe_training_job API call.
-            model_channel_name (str): Name of the channel where pre-trained model data will be downloaded.
+            job_details: the returned job details from a describe_training_job
+                API call.
+            model_channel_name (str): Name of the channel where pre-trained
+                model data will be downloaded.
 
         Returns:
-             dictionary: The transformed init_params
-
+            dictionary: The transformed init_params
         """
         init_params = super(Chainer, cls)._prepare_init_params_from_job_description(
             job_details, model_channel_name

--- a/src/sagemaker/chainer/model.py
+++ b/src/sagemaker/chainer/model.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import absolute_import
 
 import logging
@@ -26,16 +27,19 @@ logger = logging.getLogger("sagemaker")
 class ChainerPredictor(RealTimePredictor):
     """A RealTimePredictor for inference against Chainer Endpoints.
 
-    This is able to serialize Python lists, dictionaries, and numpy arrays to multidimensional tensors for Chainer
-    inference."""
+    This is able to serialize Python lists, dictionaries, and numpy arrays to
+    multidimensional tensors for Chainer inference.
+    """
 
     def __init__(self, endpoint_name, sagemaker_session=None):
         """Initialize an ``ChainerPredictor``.
 
         Args:
-            endpoint_name (str): The name of the endpoint to perform inference on.
-            sagemaker_session (sagemaker.session.Session): Session object which manages interactions with
-                Amazon SageMaker APIs and any other AWS services needed. If not specified, the estimator creates one
+            endpoint_name (str): The name of the endpoint to perform inference
+                on.
+            sagemaker_session (sagemaker.session.Session): Session object which
+                manages interactions with Amazon SageMaker APIs and any other
+                AWS services needed. If not specified, the estimator creates one
                 using the default AWS configuration chain.
         """
         super(ChainerPredictor, self).__init__(
@@ -44,7 +48,9 @@ class ChainerPredictor(RealTimePredictor):
 
 
 class ChainerModel(FrameworkModel):
-    """An Chainer SageMaker ``Model`` that can be deployed to a SageMaker ``Endpoint``."""
+    """An Chainer SageMaker ``Model`` that can be deployed to a SageMaker
+    ``Endpoint``.
+    """
 
     __framework_name__ = "chainer"
 
@@ -63,22 +69,32 @@ class ChainerModel(FrameworkModel):
         """Initialize an ChainerModel.
 
         Args:
-            model_data (str): The S3 location of a SageMaker model data ``.tar.gz`` file.
-            role (str): An AWS IAM role (either name or full ARN). The Amazon SageMaker training jobs and APIs
-                that create Amazon SageMaker endpoints use this role to access training data and model artifacts.
-                After the endpoint is created, the inference code might use the IAM role,
-                if it needs to access an AWS resource.
-            entry_point (str): Path (absolute or relative) to the Python source file which should be executed
-                as the entry point to model hosting. This should be compatible with either Python 2.7 or Python 3.5.
-            image (str): A Docker image URI (default: None). If not specified, a default image for Chainer will be used.
-            py_version (str): Python version you want to use for executing your model training code (default: 'py2').
-            framework_version (str): Chainer version you want to use for executing your model training code.
-            predictor_cls (callable[str, sagemaker.session.Session]): A function to call to create a predictor
-                with an endpoint name and SageMaker ``Session``. If specified, ``deploy()`` returns the result of
-                invoking this function on the created endpoint name.
-            model_server_workers (int): Optional. The number of worker processes used by the inference server.
-                If None, server will use one worker per vCPU.
-            **kwargs: Keyword arguments passed to the ``FrameworkModel`` initializer.
+            model_data (str): The S3 location of a SageMaker model data
+                ``.tar.gz`` file.
+            role (str): An AWS IAM role (either name or full ARN). The Amazon
+                SageMaker training jobs and APIs that create Amazon SageMaker
+                endpoints use this role to access training data and model
+                artifacts. After the endpoint is created, the inference code
+                might use the IAM role, if it needs to access an AWS resource.
+            entry_point (str): Path (absolute or relative) to the Python source
+                file which should be executed as the entry point to model
+                hosting. This should be compatible with either Python 2.7 or
+                Python 3.5.
+            image (str): A Docker image URI (default: None). If not specified, a
+                default image for Chainer will be used.
+            py_version (str): Python version you want to use for executing your
+                model training code (default: 'py2').
+            framework_version (str): Chainer version you want to use for
+                executing your model training code.
+            predictor_cls (callable[str, sagemaker.session.Session]): A function
+                to call to create a predictor with an endpoint name and
+                SageMaker ``Session``. If specified, ``deploy()`` returns the
+                result of invoking this function on the created endpoint name.
+            model_server_workers (int): Optional. The number of worker processes
+                used by the inference server. If None, server will use one
+                worker per vCPU.
+            **kwargs: Keyword arguments passed to the ``FrameworkModel``
+                initializer.
         """
         super(ChainerModel, self).__init__(
             model_data, image, role, entry_point, predictor_cls=predictor_cls, **kwargs
@@ -91,15 +107,19 @@ class ChainerModel(FrameworkModel):
         self.model_server_workers = model_server_workers
 
     def prepare_container_def(self, instance_type, accelerator_type=None):
-        """Return a container definition with framework configuration set in model environment variables.
+        """Return a container definition with framework configuration set in
+        model environment variables.
 
         Args:
-            instance_type (str): The EC2 instance type to deploy this Model to. For example, 'ml.p2.xlarge'.
-            accelerator_type (str): The Elastic Inference accelerator type to deploy to the instance for loading and
-                making inferences to the model. For example, 'ml.eia1.medium'.
+            instance_type (str): The EC2 instance type to deploy this Model to.
+                For example, 'ml.p2.xlarge'.
+            accelerator_type (str): The Elastic Inference accelerator type to
+                deploy to the instance for loading and making inferences to the
+                model. For example, 'ml.eia1.medium'.
 
         Returns:
-            dict[str, str]: A container definition object usable with the CreateModel API.
+            dict[str, str]: A container definition object usable with the
+            CreateModel API.
         """
         deploy_image = self.image
         if not deploy_image:

--- a/src/sagemaker/cli/common.py
+++ b/src/sagemaker/cli/common.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import absolute_import
 
 import json
@@ -25,7 +26,13 @@ logger = logging.getLogger(__name__)
 
 
 class HostCommand(object):
+    """Placeholder docstring"""
+
     def __init__(self, args):
+        """
+        Args:
+            args:
+        """
         self.endpoint_name = args.job_name
         self.bucket = args.bucket_name  # may be None
         self.role_name = args.role_name
@@ -39,6 +46,7 @@ class HostCommand(object):
         self.session = sagemaker.Session()
 
     def upload_model(self):
+        """Placeholder docstring"""
         prefix = "{}/model".format(self.endpoint_name)
 
         archive = self.create_model_archive(self.data)
@@ -49,6 +57,10 @@ class HostCommand(object):
 
     @staticmethod
     def create_model_archive(src):
+        """
+        Args:
+            src:
+        """
         if os.path.isdir(src):
             arcname = "."
         else:
@@ -62,9 +74,14 @@ class HostCommand(object):
         return archive
 
     def create_model(self, model_url):
+        """
+        Args:
+            model_url:
+        """
         raise NotImplementedError  # subclasses must override
 
     def start(self):
+        """Placeholder docstring"""
         model_url = self.upload_model()
         model = self.create_model(model_url)
         predictor = model.deploy(
@@ -75,7 +92,13 @@ class HostCommand(object):
 
 
 class TrainCommand(object):
+    """Placeholder docstring"""
+
     def __init__(self, args):
+        """
+        Args:
+            args:
+        """
         self.job_name = args.job_name
         self.bucket = args.bucket_name  # may be None
         self.role_name = args.role_name
@@ -90,6 +113,10 @@ class TrainCommand(object):
 
     @staticmethod
     def load_hyperparameters(src):
+        """
+        Args:
+            src:
+        """
         hp = {}
         if src and os.path.exists(src):
             with open(src, "r") as f:
@@ -97,14 +124,17 @@ class TrainCommand(object):
         return hp
 
     def upload_training_data(self):
+        """Placeholder docstring"""
         prefix = "{}/data".format(self.job_name)
         data_url = self.session.upload_data(path=self.data, bucket=self.bucket, key_prefix=prefix)
         return data_url
 
     def create_estimator(self):
+        """Placeholder docstring"""
         raise NotImplementedError  # subclasses must override
 
     def start(self):
+        """Placeholder docstring"""
         data_url = self.upload_training_data()
         estimator = self.create_estimator()
         estimator.fit(data_url)

--- a/src/sagemaker/cli/main.py
+++ b/src/sagemaker/cli/main.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import absolute_import
 
 import argparse
@@ -27,6 +28,10 @@ DEFAULT_BOTOCORE_LOG_LEVEL = "warning"
 
 
 def parse_arguments(args):
+    """
+    Args:
+        args:
+    """
     parser = argparse.ArgumentParser(
         description="Launch SageMaker training jobs or hosting endpoints"
     )
@@ -125,6 +130,10 @@ def parse_arguments(args):
 
 
 def configure_logging(args):
+    """
+    Args:
+        args:
+    """
     log_format = "%(asctime)s %(levelname)s %(name)s: %(message)s"
     log_level = logging.getLevelName(args.log_level.upper())
     logging.basicConfig(format=log_format, level=log_level)
@@ -132,6 +141,7 @@ def configure_logging(args):
 
 
 def main():
+    """Placeholder docstring"""
     args = parse_arguments(sys.argv[1:])
     configure_logging(args)
     logger.debug("args: %s", args)

--- a/src/sagemaker/cli/mxnet.py
+++ b/src/sagemaker/cli/mxnet.py
@@ -10,21 +10,33 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import absolute_import
 
 from sagemaker.cli.common import HostCommand, TrainCommand
 
 
 def train(args):
+    """
+    Args:
+        args:
+    """
     MXNetTrainCommand(args).start()
 
 
 def host(args):
+    """
+    Args:
+        args:
+    """
     MXNetHostCommand(args).start()
 
 
 class MXNetTrainCommand(TrainCommand):
+    """Placeholder docstring"""
+
     def create_estimator(self):
+        """Placeholder docstring"""
         from sagemaker.mxnet.estimator import MXNet
 
         return MXNet(
@@ -39,7 +51,13 @@ class MXNetTrainCommand(TrainCommand):
 
 
 class MXNetHostCommand(HostCommand):
+    """Placeholder docstring"""
+
     def create_model(self, model_url):
+        """
+        Args:
+            model_url:
+        """
         from sagemaker.mxnet.model import MXNetModel
 
         return MXNetModel(

--- a/src/sagemaker/cli/tensorflow.py
+++ b/src/sagemaker/cli/tensorflow.py
@@ -10,21 +10,36 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import absolute_import
 
 from sagemaker.cli.common import HostCommand, TrainCommand
 
 
 def train(args):
+    """
+    Args:
+        args:
+    """
     TensorFlowTrainCommand(args).start()
 
 
 def host(args):
+    """
+    Args:
+        args:
+    """
     TensorFlowHostCommand(args).start()
 
 
 class TensorFlowTrainCommand(TrainCommand):
+    """Placeholder docstring"""
+
     def __init__(self, args):
+        """
+        Args:
+            args:
+        """
         super(TensorFlowTrainCommand, self).__init__(args)
         self.training_steps = args.training_steps
         self.evaluation_steps = args.evaluation_steps
@@ -46,7 +61,13 @@ class TensorFlowTrainCommand(TrainCommand):
 
 
 class TensorFlowHostCommand(HostCommand):
+    """Placeholder docstring"""
+
     def create_model(self, model_url):
+        """
+        Args:
+            model_url:
+        """
         from sagemaker.tensorflow.model import TensorFlowModel
 
         return TensorFlowModel(

--- a/src/sagemaker/content_types.py
+++ b/src/sagemaker/content_types.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Contains content types strings"""
 from __future__ import absolute_import
 
 CONTENT_TYPE_JSON = "application/json"

--- a/src/sagemaker/estimator.py
+++ b/src/sagemaker/estimator.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import print_function, absolute_import
 
 import json
@@ -57,7 +58,8 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):
     http://docs.aws.amazon.com/sagemaker/latest/dg/how-it-works-training.html
 
     Subclasses must define a way to determine what image to use for training,
-    what hyperparameters to use, and how to create an appropriate predictor instance.
+    what hyperparameters to use, and how to create an appropriate predictor
+    instance.
     """
 
     def __init__(
@@ -84,55 +86,77 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):
         """Initialize an ``EstimatorBase`` instance.
 
         Args:
-            role (str): An AWS IAM role (either name or full ARN). The Amazon SageMaker training jobs and APIs
-                that create Amazon SageMaker endpoints use this role to access training data and model artifacts.
-                After the endpoint is created, the inference code might use the IAM role,
-                if it needs to access an AWS resource.
-            train_instance_count (int): Number of Amazon EC2 instances to use for training.
-            train_instance_type (str): Type of EC2 instance to use for training, for example, 'ml.c4.xlarge'.
-            train_volume_size (int): Size in GB of the EBS volume to use for storing input data
-                during training (default: 30). Must be large enough to store training data if File Mode is used
-                (which is the default).
-            train_volume_kms_key (str): Optional. KMS key ID for encrypting EBS volume attached to the
-                training instance (default: None).
-            train_max_run (int): Timeout in seconds for training (default: 24 * 60 * 60).
-                After this amount of time Amazon SageMaker terminates the job regardless of its current status.
-            input_mode (str): The input mode that the algorithm supports (default: 'File'). Valid modes:
-                'File' - Amazon SageMaker copies the training dataset from the S3 location to a local directory.
-                'Pipe' - Amazon SageMaker streams data directly from S3 to the container via a Unix-named pipe.
-                This argument can be overriden on a per-channel basis using ``sagemaker.session.s3_input.input_mode``.
-            output_path (str): S3 location for saving the training result (model artifacts and output files).
-                If not specified, results are stored to a default bucket. If the bucket with the specific name
+            role (str): An AWS IAM role (either name or full ARN). The Amazon
+                SageMaker training jobs and APIs that create Amazon SageMaker
+                endpoints use this role to access training data and model
+                artifacts. After the endpoint is created, the inference code
+                might use the IAM role, if it needs to access an AWS resource.
+            train_instance_count (int): Number of Amazon EC2 instances to use
+                for training.
+            train_instance_type (str): Type of EC2 instance to use for training,
+                for example, 'ml.c4.xlarge'.
+            train_volume_size (int): Size in GB of the EBS volume to use for
+                storing input data during training (default: 30). Must be large
+                enough to store training data if File Mode is used (which is the
+                default).
+            train_volume_kms_key (str): Optional. KMS key ID for encrypting EBS
+                volume attached to the training instance (default: None).
+            train_max_run (int): Timeout in seconds for training (default: 24 *
+                60 * 60). After this amount of time Amazon SageMaker terminates
+                the job regardless of its current status.
+            input_mode (str): The input mode that the algorithm supports
+                (default: 'File'). Valid modes: 'File' - Amazon SageMaker copies
+                the training dataset from the S3 location to a local directory.
+                'Pipe' - Amazon SageMaker streams data directly from S3 to the
+                container via a Unix-named pipe. This argument can be overriden
+                on a per-channel basis using
+                ``sagemaker.session.s3_input.input_mode``.
+            output_path (str): S3 location for saving the training result (model
+                artifacts and output files). If not specified, results are
+                stored to a default bucket. If the bucket with the specific name
                 does not exist, the estimator creates the bucket during the
                 :meth:`~sagemaker.estimator.EstimatorBase.fit` method execution.
-            output_kms_key (str): Optional. KMS key ID for encrypting the training output (default: None).
-            base_job_name (str): Prefix for training job name when the :meth:`~sagemaker.estimator.EstimatorBase.fit`
-                method launches. If not specified, the estimator generates a default job name, based on
-                the training image name and current timestamp.
-            sagemaker_session (sagemaker.session.Session): Session object which manages interactions with
-                Amazon SageMaker APIs and any other AWS services needed. If not specified, the estimator creates one
+            output_kms_key (str): Optional. KMS key ID for encrypting the
+                training output (default: None).
+            base_job_name (str): Prefix for training job name when the
+                :meth:`~sagemaker.estimator.EstimatorBase.fit` method launches.
+                If not specified, the estimator generates a default job name,
+                based on the training image name and current timestamp.
+            sagemaker_session (sagemaker.session.Session): Session object which
+                manages interactions with Amazon SageMaker APIs and any other
+                AWS services needed. If not specified, the estimator creates one
                 using the default AWS configuration chain.
-            tags (list[dict]): List of tags for labeling a training job. For more, see
+            tags (list[dict]): List of tags for labeling a training job. For
+                more, see
                 https://docs.aws.amazon.com/sagemaker/latest/dg/API_Tag.html.
-            subnets (list[str]): List of subnet ids. If not specified training job will be created without VPC config.
-            security_group_ids (list[str]): List of security group ids. If not specified training job will be created
-                without VPC config.
-            model_uri (str): URI where a pre-trained model is stored, either locally or in S3 (default: None). If
-                specified, the estimator will create a channel pointing to the model so the training job can download
-                it. This model can be a 'model.tar.gz' from a previous training job, or other artifacts coming from a
+            subnets (list[str]): List of subnet ids. If not specified training
+                job will be created without VPC config.
+            security_group_ids (list[str]): List of security group ids. If not
+                specified training job will be created without VPC config.
+            model_uri (str): URI where a pre-trained model is stored, either
+                locally or in S3 (default: None). If specified, the estimator
+                will create a channel pointing to the model so the training job
+                can download it. This model can be a 'model.tar.gz' from a
+                previous training job, or other artifacts coming from a
                 different source.
 
-                In local mode, this should point to the path in which the model is located and not the file itself, as
-                local Docker containers will try to mount the URI as a volume.
+                In local mode, this should point to the path in which the model
+                is located and not the file itself, as local Docker containers
+                will try to mount the URI as a volume.
 
-                More information: https://docs.aws.amazon.com/sagemaker/latest/dg/cdf-training.html#td-deserialization
-            model_channel_name (str): Name of the channel where 'model_uri' will be downloaded (default: 'model').
-            metric_definitions (list[dict]): A list of dictionaries that defines the metric(s) used to evaluate the
-                training jobs. Each dictionary contains two keys: 'Name' for the name of the metric, and 'Regex' for
-                the regular expression used to extract the metric from the logs. This should be defined only
-                for jobs that don't use an Amazon algorithm.
-            encrypt_inter_container_traffic (bool): Specifies whether traffic between training containers is encrypted
-                for the training job (default: ``False``).
+                More information:
+                https://docs.aws.amazon.com/sagemaker/latest/dg/cdf-training.html#td-deserialization
+            model_channel_name (str): Name of the channel where 'model_uri' will
+                be downloaded (default: 'model').
+            metric_definitions (list[dict]): A list of dictionaries that defines
+                the metric(s) used to evaluate the training jobs. Each
+                dictionary contains two keys: 'Name' for the name of the metric,
+                and 'Regex' for the regular expression used to extract the
+                metric from the logs. This should be defined only for jobs that
+                don't use an Amazon algorithm.
+            encrypt_inter_container_traffic (bool): Specifies whether traffic
+                between training containers is encrypted for the training job
+                (default: ``False``).
         """
         self.role = role
         self.train_instance_count = train_instance_count
@@ -180,8 +204,9 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):
     def train_image(self):
         """Return the Docker image to use for training.
 
-        The  :meth:`~sagemaker.estimator.EstimatorBase.fit` method, which does the model training, calls this method to
-        find the image to use for model training.
+        The :meth:`~sagemaker.estimator.EstimatorBase.fit` method, which does
+        the model training, calls this method to find the image to use for model
+        training.
 
         Returns:
             str: The URI of the Docker image.
@@ -191,8 +216,8 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):
     def hyperparameters(self):
         """Return the hyperparameters as a dictionary to use for training.
 
-        The  :meth:`~sagemaker.estimator.EstimatorBase.fit` method, which trains the model, calls this method to
-        find the hyperparameters.
+        The :meth:`~sagemaker.estimator.EstimatorBase.fit` method, which
+        trains the model, calls this method to find the hyperparameters.
 
         Returns:
             dict[str, str]: The hyperparameters.
@@ -210,8 +235,9 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):
         """Set any values in the estimator that need to be set before training.
 
         Args:
-            * job_name (str): Name of the training job to be created. If not specified, one is generated,
-                using the base name given to the constructor if applicable.
+            job_name (str): Name of the training job to be created. If not
+                specified, one is generated, using the base name given to the
+                constructor if applicable.
         """
         if job_name is not None:
             self._current_job_name = job_name
@@ -238,30 +264,37 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):
     def fit(self, inputs=None, wait=True, logs=True, job_name=None):
         """Train a model using the input training dataset.
 
-        The API calls the Amazon SageMaker CreateTrainingJob API to start model training.
-        The API uses configuration you provided to create the estimator and the
-        specified input training data to send the CreatingTrainingJob request to Amazon SageMaker.
+        The API calls the Amazon SageMaker CreateTrainingJob API to start
+        model training. The API uses configuration you provided to create the
+        estimator and the specified input training data to send the
+        CreatingTrainingJob request to Amazon SageMaker.
 
-        This is a synchronous operation. After the model training successfully completes,
-        you can call the ``deploy()`` method to host the model using the Amazon SageMaker hosting services.
+        This is a synchronous operation. After the model training
+        successfully completes, you can call the ``deploy()`` method to host the
+        model using the Amazon SageMaker hosting services.
 
         Args:
-            inputs (str or dict or sagemaker.session.s3_input): Information about the training data.
-                This can be one of three types:
+            inputs (str or dict or sagemaker.session.s3_input): Information
+                about the training data. This can be one of three types:
 
                 * (str) the S3 location where training data is saved.
 
                 * (dict[str, str] or dict[str, sagemaker.session.s3_input]) If using multiple channels for
-                    training data, you can specify a dict mapping channel names
-                    to strings or :func:`~sagemaker.session.s3_input` objects.
+                      training data, you can specify a dict mapping channel
+                      names to strings or :func:`~sagemaker.session.s3_input`
+                      objects.
+
                 * (sagemaker.session.s3_input) - channel configuration for S3 data sources that can provide
-                    additional information as well as the path to the training dataset.
-                    See :func:`sagemaker.session.s3_input` for full details.
-            wait (bool): Whether the call should wait until the job completes (default: True).
-            logs (bool): Whether to show the logs produced by the job.
-                Only meaningful when wait is True (default: True).
-            job_name (str): Training job name. If not specified, the estimator generates a default job name,
-                based on the training image name and current timestamp.
+                      additional information as well as the path to the training
+                      dataset. See :func:`sagemaker.session.s3_input` for full
+                      details.
+            wait (bool): Whether the call should wait until the job completes
+                (default: True).
+            logs (bool): Whether to show the logs produced by the job. Only
+                meaningful when wait is True (default: True).
+            job_name (str): Training job name. If not specified, the estimator
+                generates a default job name, based on the training image name
+                and current timestamp.
         """
         self._prepare_for_training(job_name=job_name)
 
@@ -270,6 +303,7 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):
             self.latest_training_job.wait(logs=logs)
 
     def _compilation_job_name(self):
+        """Placeholder docstring"""
         base_name = self.base_job_name or base_name_from_image(self.train_image())
         return name_from_base("compilation-" + base_name)
 
@@ -287,25 +321,33 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):
         """Compile a Neo model using the input model.
 
         Args:
-            target_instance_family (str): Identifies the device that you want to run your model after compilation, for
-                example: ml_c5. Allowed strings are: ml_c5, ml_m5, ml_c4, ml_m4, jetsontx1, jetsontx2, ml_p2, ml_p3,
-                deeplens, rasp3b
-            input_shape (dict): Specifies the name and shape of the expected inputs for your trained model in json
-                dictionary form, for example: {'data':[1,3,1024,1024]}, or {'var1': [1,1,28,28], 'var2':[1,1,28,28]}
+            target_instance_family (str): Identifies the device that you want to
+                run your model after compilation, for example: ml_c5. Allowed
+                strings are: ml_c5, ml_m5, ml_c4, ml_m4, jetsontx1, jetsontx2,
+                ml_p2, ml_p3, deeplens, rasp3b
+            input_shape (dict): Specifies the name and shape of the expected
+                inputs for your trained model in json dictionary form, for
+                example: {'data':[1,3,1024,1024]}, or {'var1': [1,1,28,28],
+                'var2':[1,1,28,28]}
             output_path (str): Specifies where to store the compiled model
-            framework (str): The framework that is used to train the original model. Allowed values: 'mxnet',
-                'tensorflow', 'pytorch', 'onnx', 'xgboost'
+            framework (str): The framework that is used to train the original
+                model. Allowed values: 'mxnet', 'tensorflow', 'pytorch', 'onnx',
+                'xgboost'
             framework_version (str): The version of the framework
-            compile_max_run (int): Timeout in seconds for compilation (default: 3 * 60).
-                After this amount of time Amazon SageMaker Neo terminates the compilation job regardless of its
-                current status.
-            tags (list[dict]): List of tags for labeling a compilation job. For more, see
+            compile_max_run (int): Timeout in seconds for compilation (default:
+                3 * 60). After this amount of time Amazon SageMaker Neo
+                terminates the compilation job regardless of its current status.
+            tags (list[dict]): List of tags for labeling a compilation job. For
+                more, see
                 https://docs.aws.amazon.com/sagemaker/latest/dg/API_Tag.html.
-            **kwargs: Passed to invocation of ``create_model()``. Implementations may customize
-                ``create_model()`` to accept ``**kwargs`` to customize model creation during deploy.
-                For more, see the implementation docs.
+            **kwargs: Passed to invocation of ``create_model()``.
+                Implementations may customize ``create_model()`` to accept
+                ``**kwargs`` to customize model creation during deploy. For
+                more, see the implementation docs.
+
         Returns:
-            sagemaker.model.Model: A SageMaker ``Model`` object. See :func:`~sagemaker.model.Model` for full details.
+            sagemaker.model.Model: A SageMaker ``Model`` object. See
+            :func:`~sagemaker.model.Model` for full details.
         """
         if target_instance_family not in NEO_ALLOWED_TARGET_INSTANCE_FAMILY:
             raise ValueError(
@@ -339,21 +381,16 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):
     def attach(cls, training_job_name, sagemaker_session=None, model_channel_name="model"):
         """Attach to an existing training job.
 
-        Create an Estimator bound to an existing training job, each subclass is responsible to implement
-        ``_prepare_init_params_from_job_description()`` as this method delegates the actual conversion of a training
-        job description to the arguments that the class constructor expects. After attaching, if the training job has a
-        Complete status, it can be ``deploy()`` ed to create a SageMaker Endpoint and return a ``Predictor``.
+        Create an Estimator bound to an existing training job, each subclass
+        is responsible to implement
+        ``_prepare_init_params_from_job_description()`` as this method delegates
+        the actual conversion of a training job description to the arguments
+        that the class constructor expects. After attaching, if the training job
+        has a Complete status, it can be ``deploy()`` ed to create a SageMaker
+        Endpoint and return a ``Predictor``.
 
-        If the training job is in progress, attach will block and display log messages
-        from the training job, until the training job completes.
-
-        Args:
-            training_job_name (str): The name of the training job to attach to.
-            sagemaker_session (sagemaker.session.Session): Session object which manages interactions with
-                Amazon SageMaker APIs and any other AWS services needed. If not specified, the estimator creates one
-                using the default AWS configuration chain.
-            model_channel_name (str): Name of the channel where pre-trained model data will be downloaded (default:
-                'model'). If no channel with the same name exists in the training job, this option will be ignored.
+        If the training job is in progress, attach will block and display log
+        messages from the training job, until the training job completes.
 
         Examples:
             >>> my_estimator.fit(wait=False)
@@ -362,8 +399,20 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):
             >>> attached_estimator = Estimator.attach(training_job_name)
             >>> attached_estimator.deploy()
 
+        Args:
+            training_job_name (str): The name of the training job to attach to.
+            sagemaker_session (sagemaker.session.Session): Session object which
+                manages interactions with Amazon SageMaker APIs and any other
+                AWS services needed. If not specified, the estimator creates one
+                using the default AWS configuration chain.
+            model_channel_name (str): Name of the channel where pre-trained
+                model data will be downloaded (default: 'model'). If no channel
+                with the same name exists in the training job, this option will
+                be ignored.
+
         Returns:
-            Instance of the calling ``Estimator`` Class with the attached training job.
+            Instance of the calling ``Estimator`` Class with the attached
+            training job.
         """
         sagemaker_session = sagemaker_session or Session()
 
@@ -396,40 +445,52 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):
         model_name=None,
         **kwargs
     ):
-        """Deploy the trained model to an Amazon SageMaker endpoint and return a ``sagemaker.RealTimePredictor`` object.
+        """Deploy the trained model to an Amazon SageMaker endpoint and return a
+        ``sagemaker.RealTimePredictor`` object.
 
         More information:
         http://docs.aws.amazon.com/sagemaker/latest/dg/how-it-works-training.html
 
         Args:
-            initial_instance_count (int): Minimum number of EC2 instances to deploy to an endpoint for prediction.
-            instance_type (str): Type of EC2 instance to deploy to an endpoint for prediction,
-                for example, 'ml.c4.xlarge'.
-            accelerator_type (str): Type of Elastic Inference accelerator to attach to an endpoint for model loading
-                and inference, for example, 'ml.eia1.medium'. If not specified, no Elastic Inference accelerator
-                will be attached to the endpoint.
-                For more information: https://docs.aws.amazon.com/sagemaker/latest/dg/ei.html
-            endpoint_name (str): Name to use for creating an Amazon SageMaker endpoint. If not specified, the name of
-                the training job is used.
-            use_compiled_model (bool): Flag to select whether to use compiled (optimized) model. Default: False.
-            update_endpoint (bool): Flag to update the model in an existing Amazon SageMaker endpoint.
-                If True, this will deploy a new EndpointConfig to an already existing endpoint and delete resources
-                corresponding to the previous EndpointConfig. Default: False
-            wait (bool): Whether the call should wait until the deployment of model completes (default: True).
-            model_name (str): Name to use for creating an Amazon SageMaker model. If not specified, the name of
-                the training job is used.
-            tags(List[dict[str, str]]): Optional. The list of tags to attach to this specific endpoint. Example:
-                    >>> tags = [{'Key': 'tagname', 'Value': 'tagvalue'}]
-                    For more information about tags, see https://boto3.amazonaws.com/v1/documentation\
-                    /api/latest/reference/services/sagemaker.html#SageMaker.Client.add_tags
-
-            **kwargs: Passed to invocation of ``create_model()``. Implementations may customize
-                ``create_model()`` to accept ``**kwargs`` to customize model creation during deploy.
+            initial_instance_count (int): Minimum number of EC2 instances to
+                deploy to an endpoint for prediction.
+            instance_type (str): Type of EC2 instance to deploy to an endpoint
+                for prediction, for example, 'ml.c4.xlarge'.
+            accelerator_type (str): Type of Elastic Inference accelerator to
+                attach to an endpoint for model loading and inference, for
+                example, 'ml.eia1.medium'. If not specified, no Elastic
+                Inference accelerator will be attached to the endpoint. For more
+                information:
+                https://docs.aws.amazon.com/sagemaker/latest/dg/ei.html
+            endpoint_name (str): Name to use for creating an Amazon SageMaker
+                endpoint. If not specified, the name of the training job is
+                used.
+            use_compiled_model (bool): Flag to select whether to use compiled
+                (optimized) model. Default: False.
+            update_endpoint (bool): Flag to update the model in an existing
+                Amazon SageMaker endpoint. If True, this will deploy a new
+                EndpointConfig to an already existing endpoint and delete
+                resources corresponding to the previous EndpointConfig. Default:
+                False
+            wait (bool): Whether the call should wait until the deployment of
+                model completes (default: True).
+            model_name (str): Name to use for creating an Amazon SageMaker
+                model. If not specified, the name of the training job is used.
+            tags(List[dict[str, str]]): Optional. The list of tags to attach to this specific
+                endpoint. Example:
+                >>> tags = [{'Key': 'tagname', 'Value': 'tagvalue'}]
+                For more information about tags, see
+                https://boto3.amazonaws.com/v1/documentation\
+                /api/latest/reference/services/sagemaker.html#SageMaker.Client.add_tags
+            **kwargs: Passed to invocation of ``create_model()``.
+                Implementations may customize ``create_model()`` to accept
+                ``**kwargs`` to customize model creation during deploy.
                 For more, see the implementation docs.
 
         Returns:
             sagemaker.predictor.RealTimePredictor: A predictor that provides a ``predict()`` method,
-                which can be used to send requests to the Amazon SageMaker endpoint and obtain inferences.
+                which can be used to send requests to the Amazon SageMaker
+                endpoint and obtain inferences.
         """
         self._ensure_latest_training_job()
         endpoint_name = endpoint_name or self.latest_training_job.name
@@ -458,7 +519,9 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):
 
     @property
     def model_data(self):
-        """str: The model location in S3. Only set if Estimator has been ``fit()``."""
+        """str: The model location in S3. Only set if Estimator has been
+        ``fit()``.
+        """
         if self.latest_training_job is not None:
             model_uri = self.sagemaker_session.sagemaker_client.describe_training_job(
                 TrainingJobName=self.latest_training_job.name
@@ -476,26 +539,31 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):
 
     @abstractmethod
     def create_model(self, **kwargs):
-        """Create a SageMaker ``Model`` object that can be deployed to an ``Endpoint``.
+        """Create a SageMaker ``Model`` object that can be deployed to an
+        ``Endpoint``.
 
         Args:
-            **kwargs: Keyword arguments used by the implemented method for creating the ``Model``.
+            **kwargs: Keyword arguments used by the implemented method for
+                creating the ``Model``.
 
         Returns:
-            sagemaker.model.Model: A SageMaker ``Model`` object. See :func:`~sagemaker.model.Model` for full details.
+            sagemaker.model.Model: A SageMaker ``Model`` object. See
+            :func:`~sagemaker.model.Model` for full details.
         """
 
     @classmethod
     def _prepare_init_params_from_job_description(cls, job_details, model_channel_name=None):
-        """Convert the job description to init params that can be handled by the class constructor
+        """Convert the job description to init params that can be handled by the
+        class constructor
 
         Args:
-            job_details: the returned job details from a describe_training_job API call.
-            model_channel_name (str): Name of the channel where pre-trained model data will be downloaded.
+            job_details: the returned job details from a describe_training_job
+                API call.
+            model_channel_name (str): Name of the channel where pre-trained
+                model data will be downloaded.
 
         Returns:
-             dictionary: The transformed init_params
-
+            dictionary: The transformed init_params
         """
         init_params = dict()
 
@@ -572,29 +640,39 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):
         role=None,
         volume_kms_key=None,
     ):
-        """Return a ``Transformer`` that uses a SageMaker Model based on the training job. It reuses the
-        SageMaker Session and base job name used by the Estimator.
+        """Return a ``Transformer`` that uses a SageMaker Model based on the
+        training job. It reuses the SageMaker Session and base job name used by
+        the Estimator.
 
         Args:
             instance_count (int): Number of EC2 instances to use.
-            instance_type (str): Type of EC2 instance to use, for example, 'ml.c4.xlarge'.
-            strategy (str): The strategy used to decide how to batch records in a single request (default: None).
-                Valid values: 'MULTI_RECORD' and 'SINGLE_RECORD'.
-            assemble_with (str): How the output is assembled (default: None). Valid values: 'Line' or 'None'.
-            output_path (str): S3 location for saving the transform result. If not specified, results are stored to
-                a default bucket.
-            output_kms_key (str): Optional. KMS key ID for encrypting the transform output (default: None).
-            accept (str): The content type accepted by the endpoint deployed during the transform job.
-            env (dict): Environment variables to be set for use during the transform job (default: None).
-            max_concurrent_transforms (int): The maximum number of HTTP requests to be made to
-                each individual transform container at one time.
-            max_payload (int): Maximum size of the payload in a single HTTP request to the container in MB.
-            tags (list[dict]): List of tags for labeling a transform job. If none specified, then the tags used for
-                the training job are used for the transform job.
-            role (str): The ``ExecutionRoleArn`` IAM Role ARN for the ``Model``, which is also used during
-                transform jobs. If not specified, the role from the Estimator will be used.
-            volume_kms_key (str): Optional. KMS key ID for encrypting the volume attached to the ML
-                compute instance (default: None).
+            instance_type (str): Type of EC2 instance to use, for example,
+                'ml.c4.xlarge'.
+            strategy (str): The strategy used to decide how to batch records in
+                a single request (default: None). Valid values: 'MULTI_RECORD'
+                and 'SINGLE_RECORD'.
+            assemble_with (str): How the output is assembled (default: None).
+                Valid values: 'Line' or 'None'.
+            output_path (str): S3 location for saving the transform result. If
+                not specified, results are stored to a default bucket.
+            output_kms_key (str): Optional. KMS key ID for encrypting the
+                transform output (default: None).
+            accept (str): The content type accepted by the endpoint deployed
+                during the transform job.
+            env (dict): Environment variables to be set for use during the
+                transform job (default: None).
+            max_concurrent_transforms (int): The maximum number of HTTP requests
+                to be made to each individual transform container at one time.
+            max_payload (int): Maximum size of the payload in a single HTTP
+                request to the container in MB.
+            tags (list[dict]): List of tags for labeling a transform job. If
+                none specified, then the tags used for the training job are used
+                for the transform job.
+            role (str): The ``ExecutionRoleArn`` IAM Role ARN for the ``Model``,
+                which is also used during transform jobs. If not specified, the
+                role from the Estimator will be used.
+            volume_kms_key (str): Optional. KMS key ID for encrypting the volume
+                attached to the ML compute instance (default: None).
         """
         tags = tags or self.tags
 
@@ -629,7 +707,8 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):
 
     @property
     def training_job_analytics(self):
-        """Return a ``TrainingJobAnalytics`` object for the current training job.
+        """Return a ``TrainingJobAnalytics`` object for the current training
+        job.
         """
         if self._current_job_name is None:
             raise ValueError("Estimator is not associated with a TrainingJob")
@@ -638,9 +717,11 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):
         )
 
     def get_vpc_config(self, vpc_config_override=vpc_utils.VPC_CONFIG_DEFAULT):
-        """
-        Returns VpcConfig dict either from this Estimator's subnets and security groups,
-        or else validate and return an optional override value.
+        """Returns VpcConfig dict either from this Estimator's subnets and
+        security groups, or else validate and return an optional override value.
+
+        Args:
+            vpc_config_override:
         """
         if vpc_config_override is vpc_utils.VPC_CONFIG_DEFAULT:
             return vpc_utils.to_dict(self.subnets, self.security_group_ids)
@@ -649,22 +730,30 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):
     def _ensure_latest_training_job(
         self, error_message="Estimator is not associated with a training job"
     ):
+        """
+        Args:
+            error_message:
+        """
         if self.latest_training_job is None:
             raise ValueError(error_message)
 
 
 class _TrainingJob(_Job):
+    """Placeholder docstring"""
+
     @classmethod
     def start_new(cls, estimator, inputs):
         """Create a new Amazon SageMaker training job from the estimator.
 
         Args:
-            estimator (sagemaker.estimator.EstimatorBase): Estimator object created by the user.
-            inputs (str): Parameters used when called  :meth:`~sagemaker.estimator.EstimatorBase.fit`.
+            estimator (sagemaker.estimator.EstimatorBase): Estimator object
+                created by the user.
+            inputs (str): Parameters used when called
+                :meth:`~sagemaker.estimator.EstimatorBase.fit`.
 
         Returns:
-            sagemaker.estimator._TrainingJob: Constructed object that captures all information about the started
-            training job.
+            sagemaker.estimator._TrainingJob: Constructed object that captures
+            all information about the started training job.
         """
 
         local_mode = estimator.sagemaker_session.local_mode
@@ -714,9 +803,17 @@ class _TrainingJob(_Job):
 
     @classmethod
     def _is_local_channel(cls, input_uri):
+        """
+        Args:
+            input_uri:
+        """
         return isinstance(input_uri, string_types) and input_uri.startswith("file://")
 
     def wait(self, logs=True):
+        """
+        Args:
+            logs:
+        """
         if logs:
             self.sagemaker_session.logs_for_job(self.job_name, wait=True)
         else:
@@ -724,9 +821,8 @@ class _TrainingJob(_Job):
 
 
 class Estimator(EstimatorBase):
-    """
-    A generic Estimator to train using any supplied algorithm. This class is designed for use with
-    algorithms that don't have their own, custom class.
+    """A generic Estimator to train using any supplied algorithm. This class is
+    designed for use with algorithms that don't have their own, custom class.
     """
 
     def __init__(
@@ -756,58 +852,82 @@ class Estimator(EstimatorBase):
 
         Args:
             image_name (str): The container image to use for training.
-            role (str): An AWS IAM role (either name or full ARN). The Amazon SageMaker training jobs and APIs
-                that create Amazon SageMaker endpoints use this role to access training data and model artifacts.
-                After the endpoint is created, the inference code might use the IAM role,
-                if it needs to access an AWS resource.
-            train_instance_count (int): Number of Amazon EC2 instances to use for training.
-            train_instance_type (str): Type of EC2 instance to use for training, for example, 'ml.c4.xlarge'.
-            train_volume_size (int): Size in GB of the EBS volume to use for storing input data
-                during training (default: 30). Must be large enough to store training data if File Mode is used
-                (which is the default).
-            train_volume_kms_key (str): Optional. KMS key ID for encrypting EBS volume attached to the
-                training instance (default: None).
-            train_max_run (int): Timeout in seconds for training (default: 24 * 60 * 60).
-                After this amount of time Amazon SageMaker terminates the job regardless of its current status.
-            input_mode (str): The input mode that the algorithm supports (default: 'File'). Valid modes:
+            role (str): An AWS IAM role (either name or full ARN). The Amazon
+                SageMaker training jobs and APIs that create Amazon SageMaker
+                endpoints use this role to access training data and model
+                artifacts. After the endpoint is created, the inference code
+                might use the IAM role, if it needs to access an AWS resource.
+            train_instance_count (int): Number of Amazon EC2 instances to use
+                for training.
+            train_instance_type (str): Type of EC2 instance to use for training,
+                for example, 'ml.c4.xlarge'.
+            train_volume_size (int): Size in GB of the EBS volume to use for
+                storing input data during training (default: 30). Must be large
+                enough to store training data if File Mode is used (which is the
+                default).
+            train_volume_kms_key (str): Optional. KMS key ID for encrypting EBS
+                volume attached to the training instance (default: None).
+            train_max_run (int): Timeout in seconds for training (default: 24 *
+                60 * 60). After this amount of time Amazon SageMaker terminates
+                the job regardless of its current status.
+            input_mode (str): The input mode that the algorithm supports
+                (default: 'File'). Valid modes:
 
-                * 'File' - Amazon SageMaker copies the training dataset from the S3 location to a local directory.
-                * 'Pipe' - Amazon SageMaker streams data directly from S3 to the container via a Unix-named pipe.
+                * 'File' - Amazon SageMaker copies the training dataset from the
+                  S3 location to a local directory.
+                * 'Pipe' - Amazon SageMaker streams data directly from S3 to the
+                  container via a Unix-named pipe.
 
-                This argument can be overriden on a per-channel basis using ``sagemaker.session.s3_input.input_mode``.
-            output_path (str): S3 location for saving the training result (model artifacts and output files).
-                If not specified, results are stored to a default bucket. If the bucket with the specific name
+                This argument can be overriden on a per-channel basis using
+                ``sagemaker.session.s3_input.input_mode``.
+            output_path (str): S3 location for saving the training result (model
+                artifacts and output files). If not specified, results are
+                stored to a default bucket. If the bucket with the specific name
                 does not exist, the estimator creates the bucket during the
                 :meth:`~sagemaker.estimator.EstimatorBase.fit` method execution.
-            output_kms_key (str): Optional. KMS key ID for encrypting the training output (default: None).
-            base_job_name (str): Prefix for training job name when the :meth:`~sagemaker.estimator.EstimatorBase.fit`
-                method launches. If not specified, the estimator generates a default job name, based on
-                the training image name and current timestamp.
-            sagemaker_session (sagemaker.session.Session): Session object which manages interactions with
-                Amazon SageMaker APIs and any other AWS services needed. If not specified, the estimator creates one
+            output_kms_key (str): Optional. KMS key ID for encrypting the
+                training output (default: None).
+            base_job_name (str): Prefix for training job name when the
+                :meth:`~sagemaker.estimator.EstimatorBase.fit` method launches.
+                If not specified, the estimator generates a default job name,
+                based on the training image name and current timestamp.
+            sagemaker_session (sagemaker.session.Session): Session object which
+                manages interactions with Amazon SageMaker APIs and any other
+                AWS services needed. If not specified, the estimator creates one
                 using the default AWS configuration chain.
-            hyperparameters (dict): Dictionary containing the hyperparameters to initialize this estimator with.
-            tags (list[dict]): List of tags for labeling a training job. For more, see
+            hyperparameters (dict): Dictionary containing the hyperparameters to
+                initialize this estimator with.
+            tags (list[dict]): List of tags for labeling a training job. For
+                more, see
                 https://docs.aws.amazon.com/sagemaker/latest/dg/API_Tag.html.
-            subnets (list[str]): List of subnet ids. If not specified training job will be created without VPC config.
-            security_group_ids (list[str]): List of security group ids. If not specified training job will be created
-                without VPC config.
-            model_uri (str): URI where a pre-trained model is stored, either locally or in S3 (default: None). If
-                specified, the estimator will create a channel pointing to the model so the training job can download
-                it. This model can be a 'model.tar.gz' from a previous training job, or other artifacts coming from a
+            subnets (list[str]): List of subnet ids. If not specified training
+                job will be created without VPC config.
+            security_group_ids (list[str]): List of security group ids. If not
+                specified training job will be created without VPC config.
+            model_uri (str): URI where a pre-trained model is stored, either
+                locally or in S3 (default: None). If specified, the estimator
+                will create a channel pointing to the model so the training job
+                can download it. This model can be a 'model.tar.gz' from a
+                previous training job, or other artifacts coming from a
                 different source.
 
-                In local mode, this should point to the path in which the model is located and not the file itself,
-                as local Docker containers will try to mount the URI as a volume.
+                In local mode, this should point to the path in which the model
+                is located and not the file itself, as local Docker containers
+                will try to mount the URI as a volume.
 
-                More information: https://docs.aws.amazon.com/sagemaker/latest/dg/cdf-training.html#td-deserialization
-            model_channel_name (str): Name of the channel where 'model_uri' will be downloaded (default: 'model').
-            metric_definitions (list[dict]): A list of dictionaries that defines the metric(s) used to evaluate the
-                training jobs. Each dictionary contains two keys: 'Name' for the name of the metric, and 'Regex' for
-                the regular expression used to extract the metric from the logs. This should be defined only
-                for jobs that don't use an Amazon algorithm.
-            encrypt_inter_container_traffic (bool): Specifies whether traffic between training containers is encrypted
-                for the training job (default: ``False``).
+                More information:
+                https://docs.aws.amazon.com/sagemaker/latest/dg/cdf-training.html#td-deserialization
+            model_channel_name (str): Name of the channel where 'model_uri' will
+                be downloaded (default: 'model').
+            metric_definitions (list[dict]): A list of dictionaries that defines
+                the metric(s) used to evaluate the training jobs. Each
+                dictionary contains two keys: 'Name' for the name of the metric,
+                and 'Regex' for the regular expression used to extract the
+                metric from the logs. This should be defined only for jobs that
+                don't use an Amazon algorithm.
+            encrypt_inter_container_traffic (bool): Specifies whether traffic
+                between training containers is encrypted for the training job
+                (default: ``False``).
         """
         self.image_name = image_name
         self.hyperparam_dict = hyperparameters.copy() if hyperparameters else {}
@@ -833,21 +953,26 @@ class Estimator(EstimatorBase):
         )
 
     def train_image(self):
-        """
-        Returns the docker image to use for training.
+        """Returns the docker image to use for training.
 
-        The fit() method, that does the model training, calls this method to find the image to use for model training.
+        The fit() method, that does the model training, calls this method to
+        find the image to use for model training.
         """
         return self.image_name
 
     def set_hyperparameters(self, **kwargs):
+        """
+        Args:
+            **kwargs:
+        """
         for k, v in kwargs.items():
             self.hyperparam_dict[k] = v
 
     def hyperparameters(self):
         """Returns the hyperparameters as a dictionary to use for training.
 
-       The fit() method, that does the model training, calls this method to find the hyperparameters you specified.
+        The fit() method, that does the model training, calls this method to
+        find the hyperparameters you specified.
         """
         return self.hyperparam_dict
 
@@ -863,29 +988,37 @@ class Estimator(EstimatorBase):
         vpc_config_override=vpc_utils.VPC_CONFIG_DEFAULT,
         **kwargs
     ):
-        """
-        Create a model to deploy.
+        """Create a model to deploy.
+
+        The serializer, deserializer, content_type, and accept arguments are only used to define a default
+        RealTimePredictor. They are ignored if an explicit predictor class is passed in. Other arguments
+        are passed through to the Model class.
 
         Args:
-            role (str): The ``ExecutionRoleArn`` IAM Role ARN for the ``Model``, which is also used during
-                transform jobs. If not specified, the role from the Estimator will be used.
-            image (str): An container image to use for deploying the model. Defaults to the image used for training.
-            predictor_cls (RealTimePredictor): The predictor class to use when deploying the model.
-            serializer (callable): Should accept a single argument, the input data, and return a sequence
-                of bytes. May provide a content_type attribute that defines the endpoint request content type
-            deserializer (callable): Should accept two arguments, the result data and the response content type,
-                and return a sequence of bytes. May provide a content_type attribute that defines th endpoint
-                response Accept content type.
-            content_type (str): The invocation ContentType, overriding any content_type from the serializer
-            accept (str): The invocation Accept, overriding any accept from the deserializer.
-            vpc_config_override (dict[str, list[str]]): Optional override for VpcConfig set on the model.
+            role (str): The ``ExecutionRoleArn`` IAM Role ARN for the ``Model``,
+                which is also used during transform jobs. If not specified, the
+                role from the Estimator will be used.
+            image (str): An container image to use for deploying the model.
+                Defaults to the image used for training.
+            predictor_cls (RealTimePredictor): The predictor class to use when
+                deploying the model.
+            serializer (callable): Should accept a single argument, the input
+                data, and return a sequence of bytes. May provide a content_type
+                attribute that defines the endpoint request content type
+            deserializer (callable): Should accept two arguments, the result
+                data and the response content type, and return a sequence of
+                bytes. May provide a content_type attribute that defines th
+                endpoint response Accept content type.
+            content_type (str): The invocation ContentType, overriding any
+                content_type from the serializer
+            accept (str): The invocation Accept, overriding any accept from the
+                deserializer.
+            vpc_config_override (dict[str, list[str]]): Optional override for VpcConfig set on
+                the model.
                 Default: use subnets and security groups from this Estimator.
                 * 'Subnets' (list[str]): List of subnet ids.
                 * 'SecurityGroupIds' (list[str]): List of security group ids.
-
-            The serializer, deserializer, content_type, and accept arguments are only used to define a default
-            RealTimePredictor. They are ignored if an explicit predictor class is passed in. Other arguments
-            are passed through to the Model class.
+            **kwargs:
 
         Returns: a Model ready for deployment.
         """
@@ -912,15 +1045,17 @@ class Estimator(EstimatorBase):
 
     @classmethod
     def _prepare_init_params_from_job_description(cls, job_details, model_channel_name=None):
-        """Convert the job description to init params that can be handled by the class constructor
+        """Convert the job description to init params that can be handled by the
+        class constructor
 
         Args:
-            job_details: the returned job details from a describe_training_job API call.
-            model_channel_name (str): Name of the channel where pre-trained model data will be downloaded
+            job_details: the returned job details from a describe_training_job
+                API call.
+            model_channel_name (str): Name of the channel where pre-trained
+                model data will be downloaded
 
         Returns:
-             dictionary: The transformed init_params
-
+            dictionary: The transformed init_params
         """
         init_params = super(Estimator, cls)._prepare_init_params_from_job_description(
             job_details, model_channel_name
@@ -959,14 +1094,16 @@ class Framework(EstimatorBase):
         git_config=None,
         **kwargs
     ):
-        """Base class initializer. Subclasses which override ``__init__`` should invoke ``super()``
+        """Base class initializer. Subclasses which override ``__init__`` should
+        invoke ``super()``
 
         Args:
-            entry_point (str): Path (absolute or relative) to the local Python source file which should be executed
-                as the entry point to training. This should be compatible with either Python 2.7 or Python 3.5.
-                If 'git_config' is provided, 'entry_point' should be a relative location to the Python source file in
-                the Git repo.
-                Example:
+            entry_point (str): Path (absolute or relative) to the local Python
+                source file which should be executed as the entry point to
+                training. This should be compatible with either Python 2.7 or
+                Python 3.5. If 'git_config' is provided, 'entry_point' should be
+                a relative location to the Python source file in the Git repo.
+                Example
 
                     With the following GitHub repo directory structure:
 
@@ -976,45 +1113,12 @@ class Framework(EstimatorBase):
                     >>>         |----- test.py
 
                     You can assign entry_point='src/train.py'.
-            git_config (dict[str, str]): Git configurations used for cloning files, including ``repo``, ``branch``,
-                ``commit``, ``2FA_enabled``, ``username``, ``password`` and ``token``. The ``repo`` field is required.
-                All other fields are optional. ``repo`` specifies the Git repository where your training script is
-                stored. If you don't provide ``branch``, the default value  'master' is used. If you don't provide
-                ``commit``, the latest commit in the specified branch is used.
-                Example:
-
-                    The following config:
-
-                    >>> git_config = {'repo': 'https://github.com/aws/sagemaker-python-sdk.git',
-                    >>>               'branch': 'test-branch-git-config',
-                    >>>               'commit': '329bfcf884482002c05ff7f44f62599ebc9f445a'}
-
-                    results in cloning the repo specified in 'repo', then checkout the 'master' branch, and checkout
-                    the specified commit.
-                ``2FA_enabled``, ``username``, ``password`` and ``token`` are used for authentication. For GitHub
-                (or other Git) accounts, set ``2FA_enabled`` to 'True' if two-factor authentication is enabled for the
-                account, otherwise set it to 'False'. If you do not provide a value for ``2FA_enabled``, a default
-                value of 'False' is used. CodeCommit does not support two-factor authentication, so do not provide
-                "2FA_enabled" with CodeCommit repositories.
-
-                For GitHub and other Git repos, when SSH URLs are provided, it doesn't matter whether 2FA is
-                enabled or disabled; you should either have no passphrase for the SSH key pairs, or have the ssh-agent
-                configured so that you will not be prompted for SSH passphrase when you do 'git clone' command with SSH
-                URLs. When HTTPS URLs are provided: if 2FA is disabled, then either token or username+password will be
-                used for authentication if provided (token prioritized); if 2FA is enabled, only token will be used for
-                authentication if provided. If required authentication info is not provided, python SDK will try to use
-                local credentials storage to authenticate. If that fails either, an error message will be thrown.
-
-                For CodeCommit repos, 2FA is not supported, so '2FA_enabled' should not be provided. There is no token
-                in CodeCommit, so 'token' should not be provided too. When 'repo' is an SSH URL, the requirements are
-                the same as GitHub-like repos. When 'repo' is an HTTPS URL, username+password will be used for
-                authentication if they are provided; otherwise, python SDK will try to use either CodeCommit credential
-                helper or local credential storage for authentication.
-            source_dir (str): Path (absolute or relative) to a directory with any other training
-                source code dependencies aside from the entry point file (default: None). Structure within this
-                directory are preserved when training on Amazon SageMaker. If 'git_config' is provided,
-                'source_dir' should be a relative location to a directory in the Git repo.
-                Example:
+            source_dir (str): Path (absolute or relative) to a directory with
+                any other training source code dependencies aside from the entry
+                point file (default: None). Structure within this directory are
+                preserved when training on Amazon SageMaker. If 'git_config' is
+                provided, 'source_dir' should be a relative location to a
+                directory in the Git repo. .. admonition:: Example
 
                     With the following GitHub repo directory structure:
 
@@ -1023,33 +1127,42 @@ class Framework(EstimatorBase):
                     >>>         |----- train.py
                     >>>         |----- test.py
 
-                    and you need 'train.py' as entry point and 'test.py' as training source code as well, you can
-                    assign entry_point='train.py', source_dir='src'.
-            hyperparameters (dict): Hyperparameters that will be used for training (default: None).
-                The hyperparameters are made accessible as a dict[str, str] to the training code on SageMaker.
-                For convenience, this accepts other types for keys and values, but ``str()`` will be called
-                to convert them before training.
-            enable_cloudwatch_metrics (bool): [DEPRECATED] Now there are cloudwatch metrics emitted by all SageMaker
-                training jobs. This will be ignored for now and removed in a further release.
-            container_log_level (int): Log level to use within the container (default: logging.INFO).
-                Valid values are defined in the Python logging module.
-            code_location (str): The S3 prefix URI where custom code will be uploaded (default: None).
-                The code file uploaded in S3 is 'code_location/source/sourcedir.tar.gz'.
-                If not specified, the default code location is s3://default_bucket/job-name/. And code file
-                uploaded to S3 is s3://default_bucket/job-name/source/sourcedir.tar.gz
-            image_name (str): An alternate image name to use instead of the official Sagemaker image
-                for the framework. This is useful to run one of the Sagemaker supported frameworks
-                with an image containing custom dependencies.
-            dependencies (list[str]): A list of paths to directories (absolute or relative) with
-                any additional libraries that will be exported to the container (default: []).
-                The library folders will be copied to SageMaker in the same folder where the entrypoint is copied.
-                If 'git_config' is provided, 'dependencies' should be a list of relative locations to directories
-                with any additional libraries needed in the Git repo.
-                Example:
+                    and you need 'train.py' as entry point and 'test.py' as
+                    training source code as well, you can assign
+                    entry_point='train.py', source_dir='src'.
+            hyperparameters (dict): Hyperparameters that will be used for
+                training (default: None). The hyperparameters are made
+                accessible as a dict[str, str] to the training code on
+                SageMaker. For convenience, this accepts other types for keys
+                and values, but ``str()`` will be called to convert them before
+                training.
+            enable_cloudwatch_metrics (bool): [DEPRECATED] Now there are
+                cloudwatch metrics emitted by all SageMaker training jobs. This
+                will be ignored for now and removed in a further release.
+            container_log_level (int): Log level to use within the container
+                (default: logging.INFO). Valid values are defined in the Python
+                logging module.
+            code_location (str): The S3 prefix URI where custom code will be
+                uploaded (default: None). The code file uploaded in S3 is
+                'code_location/source/sourcedir.tar.gz'. If not specified, the
+                default code location is s3://default_bucket/job-name/. And code
+                file uploaded to S3 is
+                s3://default_bucket/job-name/source/sourcedir.tar.gz
+            image_name (str): An alternate image name to use instead of the
+                official Sagemaker image for the framework. This is useful to
+                run one of the Sagemaker supported frameworks with an image
+                containing custom dependencies.
+            dependencies (list[str]): A list of paths to directories (absolute
+                or relative) with any additional libraries that will be exported
+                to the container (default: []). The library folders will be
+                copied to SageMaker in the same folder where the entrypoint is
+                copied. If 'git_config' is provided, 'dependencies' should be a
+                list of relative locations to directories with any additional
+                libraries needed in the Git repo. .. admonition:: Example
 
-                    The following call
-                    >>> Estimator(entry_point='train.py', dependencies=['my/libs/common', 'virtual-env'])
-                    results in the following inside the container:
+                    The following call >>> Estimator(entry_point='train.py',
+                    dependencies=['my/libs/common', 'virtual-env']) results in
+                    the following inside the container:
 
                     >>> $ ls
 
@@ -1057,13 +1170,66 @@ class Framework(EstimatorBase):
                     >>>     |------ train.py
                     >>>     |------ common
                     >>>     |------ virtual-env
+            enable_network_isolation (bool): Specifies whether container will
+                run in network isolation mode. Network isolation mode restricts
+                the container access to outside networks (such as the internet).
+                The container does not make any inbound or outbound network
+                calls. If True, a channel named "code" will be created for any
+                user entry script for training. The user entry script, files in
+                source_dir (if specified), and dependencies will be uploaded in
+                a tar to S3. Also known as internet-free mode (default: `False`
+                ).
+            git_config (dict[str, str]): Git configurations used for cloning
+                files, including ``repo``, ``branch``, ``commit``,
+                ``2FA_enabled``, ``username``, ``password`` and ``token``. The
+                ``repo`` field is required. All other fields are optional.
+                ``repo`` specifies the Git repository where your training script
+                is stored. If you don't provide ``branch``, the default value
+                'master' is used. If you don't provide ``commit``, the latest
+                commit in the specified branch is used. .. admonition:: Example
 
-            enable_network_isolation (bool): Specifies whether container will run in network isolation mode. Network
-                isolation mode restricts the container access to outside networks (such as the internet). The container
-                does not make any inbound or outbound network calls. If True, a channel named "code" will be created
-                for any user entry script for training. The user entry script, files in source_dir (if specified), and
-                dependencies will be uploaded in a tar to S3. Also known as internet-free mode (default: `False`).
-            **kwargs: Additional kwargs passed to the ``EstimatorBase`` constructor.
+                    The following config:
+
+                    >>> git_config = {'repo': 'https://github.com/aws/sagemaker-python-sdk.git',
+                    >>>               'branch': 'test-branch-git-config',
+                    >>>               'commit': '329bfcf884482002c05ff7f44f62599ebc9f445a'}
+
+                    results in cloning the repo specified in 'repo', then
+                    checkout the 'master' branch, and checkout the specified
+                    commit.
+
+                ``2FA_enabled``, ``username``, ``password`` and ``token`` are
+                used for authentication. For GitHub (or other Git) accounts, set
+                ``2FA_enabled`` to 'True' if two-factor authentication is
+                enabled for the account, otherwise set it to 'False'. If you do
+                not provide a value for ``2FA_enabled``, a default value of
+                'False' is used. CodeCommit does not support two-factor
+                authentication, so do not provide "2FA_enabled" with CodeCommit
+                repositories.
+
+                For GitHub and other Git repos, when SSH URLs are provided, it
+                doesn't matter whether 2FA is enabled or disabled; you should
+                either have no passphrase for the SSH key pairs, or have the
+                ssh-agent configured so that you will not be prompted for SSH
+                passphrase when you do 'git clone' command with SSH URLs. When
+                HTTPS URLs are provided: if 2FA is disabled, then either token
+                or username+password will be used for authentication if provided
+                (token prioritized); if 2FA is enabled, only token will be used
+                for authentication if provided. If required authentication info
+                is not provided, python SDK will try to use local credentials
+                storage to authenticate. If that fails either, an error message
+                will be thrown.
+
+                For CodeCommit repos, 2FA is not supported, so '2FA_enabled'
+                should not be provided. There is no token in CodeCommit, so
+                'token' should not be provided too. When 'repo' is an SSH URL,
+                the requirements are the same as GitHub-like repos. When 'repo'
+                is an HTTPS URL, username+password will be used for
+                authentication if they are provided; otherwise, python SDK will
+                try to use either CodeCommit credential helper or local
+                credential storage for authentication.
+            **kwargs: Additional kwargs passed to the ``EstimatorBase``
+                constructor.
         """
         super(Framework, self).__init__(**kwargs)
         if entry_point.startswith("s3://"):
@@ -1100,11 +1266,13 @@ class Framework(EstimatorBase):
         return self._enable_network_isolation
 
     def _prepare_for_training(self, job_name=None):
-        """Set hyperparameters needed for training. This method will also validate ``source_dir``.
+        """Set hyperparameters needed for training. This method will also
+        validate ``source_dir``.
 
         Args:
-            * job_name (str): Name of the training job to be created. If not specified, one is generated,
-                using the base name given to the constructor if applicable.
+           * job_name (str): Name of the training job to be created. If not
+                specified, one is generated, using the base name given to the
+                constructor if applicable.
         """
         super(Framework, self)._prepare_for_training(job_name=job_name)
 
@@ -1154,7 +1322,6 @@ class Framework(EstimatorBase):
         """Upload the user training script to s3 and return the location.
 
         Returns: s3 uri
-
         """
         local_mode = self.output_path.startswith("file://")
 
@@ -1185,10 +1352,12 @@ class Framework(EstimatorBase):
         )
 
     def _model_source_dir(self):
-        """Get the appropriate value to pass as source_dir to model constructor on deploying
+        """Get the appropriate value to pass as source_dir to model constructor
+        on deploying
 
         Returns:
-            str: Either a local or an S3 path pointing to the source_dir to be used for code by the model to be deployed
+            str: Either a local or an S3 path pointing to the source_dir to be
+            used for code by the model to be deployed
         """
         return (
             self.source_dir if self.sagemaker_session.local_mode else self.uploaded_code.s3_prefix
@@ -1197,8 +1366,8 @@ class Framework(EstimatorBase):
     def hyperparameters(self):
         """Return the hyperparameters as a dictionary to use for training.
 
-        The  :meth:`~sagemaker.estimator.EstimatorBase.fit` method, which trains the model, calls this method
-        to find the hyperparameters.
+        The :meth:`~sagemaker.estimator.EstimatorBase.fit` method, which
+        trains the model, calls this method to find the hyperparameters.
 
         Returns:
             dict[str, str]: The hyperparameters.
@@ -1207,15 +1376,17 @@ class Framework(EstimatorBase):
 
     @classmethod
     def _prepare_init_params_from_job_description(cls, job_details, model_channel_name=None):
-        """Convert the job description to init params that can be handled by the class constructor
+        """Convert the job description to init params that can be handled by the
+        class constructor
 
         Args:
-            job_details: the returned job details from a describe_training_job API call.
-            model_channel_name (str): Name of the channel where pre-trained model data will be downloaded
+            job_details: the returned job details from a describe_training_job
+                API call.
+            model_channel_name (str): Name of the channel where pre-trained
+                model data will be downloaded
 
         Returns:
-             dictionary: The transformed init_params
-
+            dictionary: The transformed init_params
         """
         init_params = super(Framework, cls)._prepare_init_params_from_job_description(
             job_details, model_channel_name
@@ -1249,8 +1420,9 @@ class Framework(EstimatorBase):
     def train_image(self):
         """Return the Docker image to use for training.
 
-        The  :meth:`~sagemaker.estimator.EstimatorBase.fit` method, which does the model training,
-        calls this method to find the image to use for model training.
+        The :meth:`~sagemaker.estimator.EstimatorBase.fit` method, which does
+        the model training, calls this method to find the image to use for model
+        training.
 
         Returns:
             str: The URI of the Docker image.
@@ -1269,21 +1441,16 @@ class Framework(EstimatorBase):
     def attach(cls, training_job_name, sagemaker_session=None, model_channel_name="model"):
         """Attach to an existing training job.
 
-        Create an Estimator bound to an existing training job, each subclass is responsible to implement
-        ``_prepare_init_params_from_job_description()`` as this method delegates the actual conversion of a training
-        job description to the arguments that the class constructor expects. After attaching, if the training job has a
-        Complete status, it can be ``deploy()`` ed to create a SageMaker Endpoint and return a ``Predictor``.
+        Create an Estimator bound to an existing training job, each subclass
+        is responsible to implement
+        ``_prepare_init_params_from_job_description()`` as this method delegates
+        the actual conversion of a training job description to the arguments
+        that the class constructor expects. After attaching, if the training job
+        has a Complete status, it can be ``deploy()`` ed to create a SageMaker
+        Endpoint and return a ``Predictor``.
 
-        If the training job is in progress, attach will block and display log messages
-        from the training job, until the training job completes.
-
-        Args:
-            training_job_name (str): The name of the training job to attach to.
-            sagemaker_session (sagemaker.session.Session): Session object which manages interactions with
-                Amazon SageMaker APIs and any other AWS services needed. If not specified, the estimator creates one
-                using the default AWS configuration chain.
-            model_channel_name (str): Name of the channel where pre-trained model data will be downloaded (default:
-                'model'). If no channel with the same name exists in the training job, this option will be ignored.
+        If the training job is in progress, attach will block and display log
+        messages from the training job, until the training job completes.
 
         Examples:
             >>> my_estimator.fit(wait=False)
@@ -1292,8 +1459,20 @@ class Framework(EstimatorBase):
             >>> attached_estimator = Estimator.attach(training_job_name)
             >>> attached_estimator.deploy()
 
+        Args:
+            training_job_name (str): The name of the training job to attach to.
+            sagemaker_session (sagemaker.session.Session): Session object which
+                manages interactions with Amazon SageMaker APIs and any other
+                AWS services needed. If not specified, the estimator creates one
+                using the default AWS configuration chain.
+            model_channel_name (str): Name of the channel where pre-trained
+                model data will be downloaded (default: 'model'). If no channel
+                with the same name exists in the training job, this option will
+                be ignored.
+
         Returns:
-            Instance of the calling ``Estimator`` Class with the attached training job.
+            Instance of the calling ``Estimator`` Class with the attached
+            training job.
         """
         estimator = super(Framework, cls).attach(
             training_job_name, sagemaker_session, model_channel_name
@@ -1308,10 +1487,19 @@ class Framework(EstimatorBase):
 
     @staticmethod
     def _json_encode_hyperparameters(hyperparameters):
+        """
+        Args:
+            hyperparameters:
+        """
         return {str(k): json.dumps(v) for (k, v) in hyperparameters.items()}
 
     @classmethod
     def _update_init_params(cls, hp, tf_arguments):
+        """
+        Args:
+            hp:
+            tf_arguments:
+        """
         updated_params = {}
         for argument in tf_arguments:
             value = hp.pop(argument, None)
@@ -1337,31 +1525,42 @@ class Framework(EstimatorBase):
         model_server_workers=None,
         volume_kms_key=None,
     ):
-        """Return a ``Transformer`` that uses a SageMaker Model based on the training job. It reuses the
-        SageMaker Session and base job name used by the Estimator.
+        """Return a ``Transformer`` that uses a SageMaker Model based on the
+        training job. It reuses the SageMaker Session and base job name used by
+        the Estimator.
 
         Args:
             instance_count (int): Number of EC2 instances to use.
-            instance_type (str): Type of EC2 instance to use, for example, 'ml.c4.xlarge'.
-            strategy (str): The strategy used to decide how to batch records in a single request (default: None).
-                Valid values: 'MULTI_RECORD' and 'SINGLE_RECORD'.
-            assemble_with (str): How the output is assembled (default: None). Valid values: 'Line' or 'None'.
-            output_path (str): S3 location for saving the transform result. If not specified, results are stored to
-                a default bucket.
-            output_kms_key (str): Optional. KMS key ID for encrypting the transform output (default: None).
-            accept (str): The content type accepted by the endpoint deployed during the transform job.
-            env (dict): Environment variables to be set for use during the transform job (default: None).
-            max_concurrent_transforms (int): The maximum number of HTTP requests to be made to
-                each individual transform container at one time.
-            max_payload (int): Maximum size of the payload in a single HTTP request to the container in MB.
-            tags (list[dict]): List of tags for labeling a transform job. If none specified, then the tags used for
-                the training job are used for the transform job.
-            role (str): The ``ExecutionRoleArn`` IAM Role ARN for the ``Model``, which is also used during
-                transform jobs. If not specified, the role from the Estimator will be used.
-            model_server_workers (int): Optional. The number of worker processes used by the inference server.
-                If None, server will use one worker per vCPU.
-            volume_kms_key (str): Optional. KMS key ID for encrypting the volume attached to the ML
-                compute instance (default: None).
+            instance_type (str): Type of EC2 instance to use, for example,
+                'ml.c4.xlarge'.
+            strategy (str): The strategy used to decide how to batch records in
+                a single request (default: None). Valid values: 'MULTI_RECORD'
+                and 'SINGLE_RECORD'.
+            assemble_with (str): How the output is assembled (default: None).
+                Valid values: 'Line' or 'None'.
+            output_path (str): S3 location for saving the transform result. If
+                not specified, results are stored to a default bucket.
+            output_kms_key (str): Optional. KMS key ID for encrypting the
+                transform output (default: None).
+            accept (str): The content type accepted by the endpoint deployed
+                during the transform job.
+            env (dict): Environment variables to be set for use during the
+                transform job (default: None).
+            max_concurrent_transforms (int): The maximum number of HTTP requests
+                to be made to each individual transform container at one time.
+            max_payload (int): Maximum size of the payload in a single HTTP
+                request to the container in MB.
+            tags (list[dict]): List of tags for labeling a transform job. If
+                none specified, then the tags used for the training job are used
+                for the transform job.
+            role (str): The ``ExecutionRoleArn`` IAM Role ARN for the ``Model``,
+                which is also used during transform jobs. If not specified, the
+                role from the Estimator will be used.
+            model_server_workers (int): Optional. The number of worker processes
+                used by the inference server. If None, server will use one
+                worker per vCPU.
+            volume_kms_key (str): Optional. KMS key ID for encrypting the volume
+                attached to the ML compute instance (default: None).
         """
         role = role or self.role
 
@@ -1407,6 +1606,11 @@ class Framework(EstimatorBase):
 
 
 def _s3_uri_prefix(channel_name, s3_data):
+    """
+    Args:
+        channel_name:
+        s3_data:
+    """
     if isinstance(s3_data, s3_input):
         s3_uri = s3_data.config["DataSource"]["S3DataSource"]["S3Uri"]
     else:
@@ -1420,6 +1624,10 @@ def _s3_uri_prefix(channel_name, s3_data):
 # Also accepts other valid input types, e.g. dict and s3_input.
 def _s3_uri_without_prefix_from_input(input_data):
     # Unpack an input_config object from a dict if a dict was passed in.
+    """
+    Args:
+        input_data:
+    """
     if isinstance(input_data, dict):
         response = {}
         for channel_name, channel_s3_uri in input_data.items():

--- a/src/sagemaker/fw_registry.py
+++ b/src/sagemaker/fw_registry.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import absolute_import
 import logging
 
@@ -35,9 +36,12 @@ image_registry_map = {
 
 
 def registry(region_name, framework=None):
-    """
-    Return docker registry for the given AWS region for the given framework.
+    """Return docker registry for the given AWS region for the given framework.
     This is only used for SparkML and Scikit-learn for now.
+
+    Args:
+        region_name:
+        framework:
     """
     try:
         account_id = image_registry_map[region_name][framework]
@@ -48,6 +52,12 @@ def registry(region_name, framework=None):
 
 
 def default_framework_uri(framework, region_name, image_tag):
+    """
+    Args:
+        framework:
+        region_name:
+        image_tag:
+    """
     repository_name = "sagemaker-{}".format(framework)
     account_name = registry(region_name, framework)
     return "{}/{}:{}".format(account_name, repository_name, image_tag)

--- a/src/sagemaker/fw_utils.py
+++ b/src/sagemaker/fw_utils.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import absolute_import
 
 from collections import namedtuple
@@ -70,20 +71,28 @@ MERGED_FRAMEWORKS_LOWEST_VERSIONS = {
 
 
 def is_version_equal_or_higher(lowest_version, framework_version):
-    """Determine whether the ``framework_version`` is equal to or higher than ``lowest_version``
+    """Determine whether the ``framework_version`` is equal to or higher than
+    ``lowest_version``
 
     Args:
-        lowest_version (List[int]): lowest version represented in an integer list
+        lowest_version (List[int]): lowest version represented in an integer
+            list
         framework_version (str): framework version string
 
     Returns:
-        bool: Whether or not framework_version is equal to or higher than lowest_version
+        bool: Whether or not framework_version is equal to or higher than
+        lowest_version
     """
     version_list = [int(s) for s in framework_version.split(".")]
     return version_list >= lowest_version[0 : len(version_list)]
 
 
 def _is_merged_versions(framework, framework_version):
+    """
+    Args:
+        framework:
+        framework_version:
+    """
     lowest_version_list = MERGED_FRAMEWORKS_LOWEST_VERSIONS.get(framework)
     if lowest_version_list:
         return is_version_equal_or_higher(lowest_version_list, framework_version)
@@ -91,6 +100,14 @@ def _is_merged_versions(framework, framework_version):
 
 
 def _using_merged_images(region, framework, py_version, accelerator_type, framework_version):
+    """
+    Args:
+        region:
+        framework:
+        py_version:
+        accelerator_type:
+        framework_version:
+    """
     is_gov_region = region in VALID_ACCOUNTS_BY_REGION
     is_py3 = py_version == "py3" or py_version is None
     is_merged_versions = _is_merged_versions(framework, framework_version)
@@ -98,6 +115,15 @@ def _using_merged_images(region, framework, py_version, accelerator_type, framew
 
 
 def _registry_id(region, framework, py_version, account, accelerator_type, framework_version):
+    """
+    Args:
+        region:
+        framework:
+        py_version:
+        account:
+        accelerator_type:
+        framework_version:
+    """
     if _using_merged_images(region, framework, py_version, accelerator_type, framework_version):
         return "763104351884"
     return VALID_ACCOUNTS_BY_REGION.get(region, account)
@@ -118,13 +144,17 @@ def create_image_uri(
     Args:
         region (str): AWS region where the image is uploaded.
         framework (str): framework used by the image.
-        instance_type (str): SageMaker instance type. Used to determine device type (cpu/gpu/family-specific optimized).
+        instance_type (str): SageMaker instance type. Used to determine device
+            type (cpu/gpu/family-specific optimized).
         framework_version (str): The version of the framework.
-        py_version (str): Optional. Python version. If specified, should be one of 'py2' or 'py3'.
-            If not specified, image uri will not include a python component.
-        account (str): AWS account that contains the image. (default: '520713654638')
+        py_version (str): Optional. Python version. If specified, should be one
+            of 'py2' or 'py3'. If not specified, image uri will not include a
+            python component.
+        account (str): AWS account that contains the image. (default:
+            '520713654638')
         accelerator_type (str): SageMaker Elastic Inference accelerator type.
-        optimized_families (str): Instance families for which there exist specific optimized images.
+        optimized_families (str): Instance families for which there exist
+            specific optimized images.
 
     Returns:
         str: The appropriate image URI based on the given parameters.
@@ -186,6 +216,12 @@ def create_image_uri(
 def _accelerator_type_valid_for_framework(
     framework, accelerator_type=None, optimized_families=None
 ):
+    """
+    Args:
+        framework:
+        accelerator_type:
+        optimized_families:
+    """
     if accelerator_type is None:
         return False
 
@@ -214,11 +250,12 @@ def validate_source_dir(script, directory):
     """Validate that the source directory exists and it contains the user script
 
     Args:
-        script (str):  Script filename.
+        script (str): Script filename.
         directory (str): Directory containing the source file.
 
     Raises:
-        ValueError: If ``directory`` does not exist, is not a directory, or does not contain ``script``.
+        ValueError: If ``directory`` does not exist, is not a directory, or does
+            not contain ``script``.
     """
     if directory:
         if not os.path.isfile(os.path.join(directory, script)):
@@ -232,29 +269,32 @@ def validate_source_dir(script, directory):
 def tar_and_upload_dir(
     session, bucket, s3_key_prefix, script, directory=None, dependencies=None, kms_key=None
 ):
-    """Package source files and upload a compress tar file to S3. The S3 location will be
-    ``s3://<bucket>/s3_key_prefix/sourcedir.tar.gz``.
+    """Package source files and upload a compress tar file to S3. The S3
+    location will be ``s3://<bucket>/s3_key_prefix/sourcedir.tar.gz``.
 
-    If directory is an S3 URI, an UploadedCode object will be returned, but nothing will be
-    uploaded to S3 (this allow reuse of code already in S3).
+    If directory is an S3 URI, an UploadedCode object will be returned, but
+    nothing will be uploaded to S3 (this allow reuse of code already in S3).
 
-    If directory is None, the script will be added to the archive at ``./<basename of script>``.
+    If directory is None, the script will be added to the archive at
+    ``./<basename of script>``.
 
-    If directory is not None, the (recursive) contents of the directory will be added to
-    the archive. directory is treated as the base path of the archive, and the script name is
-    assumed to be a filename or relative path inside the directory.
+    If directory is not None, the (recursive) contents of the directory will
+    be added to the archive. directory is treated as the base path of the
+    archive, and the script name is assumed to be a filename or relative path
+    inside the directory.
 
     Args:
         session (boto3.Session): Boto session used to access S3.
         bucket (str): S3 bucket to which the compressed file is uploaded.
         s3_key_prefix (str): Prefix for the S3 key.
         script (str): Script filename or path.
-        directory (str): Optional. Directory containing the source file. If it starts with "s3://",
-            no action is taken.
-        dependencies (List[str]): Optional. A list of paths to directories (absolute or relative)
-                                containing additional libraries that will be copied into
-                                /opt/ml/lib
-        kms_key (str):  Optional. KMS key ID used to upload objects to the bucket (default: None).
+        directory (str): Optional. Directory containing the source file. If it
+            starts with "s3://", no action is taken.
+        dependencies (List[str]): Optional. A list of paths to directories
+            (absolute or relative) containing additional libraries that will be
+            copied into /opt/ml/lib
+        kms_key (str): Optional. KMS key ID used to upload objects to the bucket
+            (default: None).
 
     Returns:
         sagemaker.fw_utils.UserCode: An object with the S3 bucket and key (S3 prefix) and
@@ -287,6 +327,11 @@ def tar_and_upload_dir(
 
 
 def _list_files_to_compress(script, directory):
+    """
+    Args:
+        script:
+        directory:
+    """
     if directory is None:
         return [script]
 
@@ -310,9 +355,7 @@ def framework_name_from_image(image_name):
 
     Returns:
         tuple: A tuple containing:
-            str: The framework name
-            str: The Python version
-            str: The image tag
+            str: The framework name str: The Python version str: The image tag
             str: If the image is script mode
     """
     sagemaker_pattern = re.compile(ECR_URI_PATTERN)
@@ -347,7 +390,8 @@ def framework_version_from_tag(image_tag):
     """Extract the framework version from the image tag.
 
     Args:
-        image_tag (str): Image tag, which should take the form '<framework_version>-<device>-<py_version>'
+        image_tag (str): Image tag, which should take the form
+            '<framework_version>-<device>-<py_version>'
 
     Returns:
         str: The framework version.
@@ -358,15 +402,15 @@ def framework_version_from_tag(image_tag):
 
 
 def parse_s3_url(url):
-    """Returns an (s3 bucket, key name/prefix) tuple from a url with an s3 scheme
+    """Returns an (s3 bucket, key name/prefix) tuple from a url with an s3
+    scheme
 
     Args:
         url (str):
 
     Returns:
         tuple: A tuple containing:
-            str: S3 bucket name
-            str: S3 key
+            str: S3 bucket name str: S3 key
     """
     parsed_url = urlparse(url)
     if parsed_url.scheme != "s3":
@@ -394,6 +438,11 @@ def model_code_key_prefix(code_location_key_prefix, model_name, image):
 
 
 def empty_framework_version_warning(default_version, latest_version):
+    """
+    Args:
+        default_version:
+        latest_version:
+    """
     msgs = [EMPTY_FRAMEWORK_VERSION_WARNING.format(default_version)]
     if default_version != latest_version:
         msgs.append(LATER_FRAMEWORK_VERSION_WARNING.format(latest=latest_version))
@@ -401,4 +450,8 @@ def empty_framework_version_warning(default_version, latest_version):
 
 
 def python_deprecation_warning(framework):
+    """
+    Args:
+        framework:
+    """
     return PYTHON_2_DEPRECATION_WARNING.format(framework=framework)

--- a/src/sagemaker/git_utils.py
+++ b/src/sagemaker/git_utils.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import absolute_import
 
 import os
@@ -21,37 +22,55 @@ from six.moves import urllib
 
 
 def git_clone_repo(git_config, entry_point, source_dir=None, dependencies=None):
-    """Git clone repo containing the training code and serving code. This method also validate ``git_config``,
-    and set ``entry_point``, ``source_dir`` and ``dependencies`` to the right file or directory in the repo cloned.
+    """Git clone repo containing the training code and serving code. This method
+    also validate ``git_config``, and set ``entry_point``, ``source_dir`` and
+    ``dependencies`` to the right file or directory in the repo cloned.
 
     Args:
-        git_config (dict[str, str]): Git configurations used for cloning files, including ``repo``, ``branch``,
-            ``commit``, ``2FA_enabled``, ``username``, ``password`` and ``token``. The ``repo`` field is required.
-            All other fields are optional. ``repo`` specifies the Git repository where your training script is stored.
-            If you don't provide ``branch``, the default value  'master' is used. If you don't provide ``commit``,
-            the latest commit in the specified branch is used. ``2FA_enabled``, ``username``, ``password`` and
-            ``token`` are for authentication purpose. If ``2FA_enabled`` is not provided, we consider 2FA as disabled.
+        git_config (dict[str, str]): Git configurations used for cloning files,
+            including ``repo``, ``branch``, ``commit``, ``2FA_enabled``,
+            ``username``, ``password`` and ``token``. The ``repo`` field is
+            required. All other fields are optional. ``repo`` specifies the Git
+            repository where your training script is stored. If you don't
+            provide ``branch``, the default value 'master' is used. If you don't
+            provide ``commit``, the latest commit in the specified branch is
+            used. ``2FA_enabled``, ``username``, ``password`` and ``token`` are
+            for authentication purpose. If ``2FA_enabled`` is not provided, we
+            consider 2FA as disabled.
 
-            For GitHub and GitHub-like repos, when SSH URLs are provided, it doesn't matter whether 2FA is
-            enabled or disabled; you should either have no passphrase for the SSH key pairs, or have the ssh-agent
-            configured so that you will not be prompted for SSH passphrase when you do 'git clone' command with SSH
-            URLs. When https URLs are provided: if 2FA is disabled, then either token or username+password will be
-            used for authentication if provided (token prioritized); if 2FA is enabled, only token will be used for
-            authentication if provided. If required authentication info is not provided, python SDK will try to use
-            local credentials storage to authenticate. If that fails either, an error message will be thrown.
+            For GitHub and GitHub-like repos, when SSH URLs are provided, it
+            doesn't matter whether 2FA is enabled or disabled; you should either
+            have no passphrase for the SSH key pairs, or have the ssh-agent
+            configured so that you will not be prompted for SSH passphrase when
+            you do 'git clone' command with SSH URLs. When https URLs are
+            provided: if 2FA is disabled, then either token or username+password
+            will be used for authentication if provided (token prioritized); if
+            2FA is enabled, only token will be used for authentication if
+            provided. If required authentication info is not provided, python
+            SDK will try to use local credentials storage to authenticate. If
+            that fails either, an error message will be thrown.
 
-            For CodeCommit repos, 2FA is not supported, so '2FA_enabled' should not be provided. There is no token in
-            CodeCommit, so 'token' should not be provided too. When 'repo' is an SSH URL, the requirements are the
-            same as GitHub-like repos. When 'repo' is an https URL, username+password will be used for
-            authentication if they are provided; otherwise, python SDK will try to use either CodeCommit credential
-            helper or local credential storage for authentication.
-        entry_point (str): A relative location to the Python source file which should be executed as the entry point
-            to training or model hosting in the Git repo.
-        source_dir (str): A relative location to a directory with other training or model hosting source code
-            dependencies aside from the entry point file in the Git repo (default: None). Structure within this
+            For CodeCommit repos, 2FA is not supported, so '2FA_enabled' should
+            not be provided. There is no token in CodeCommit, so 'token' should
+            not be provided too. When 'repo' is an SSH URL, the requirements are
+            the same as GitHub-like repos. When 'repo' is an https URL,
+            username+password will be used for authentication if they are
+            provided; otherwise, python SDK will try to use either CodeCommit
+            credential helper or local credential storage for authentication.
+        entry_point (str): A relative location to the Python source file which
+            should be executed as the entry point to training or model hosting
+            in the Git repo.
+        source_dir (str): A relative location to a directory with other training
+            or model hosting source code dependencies aside from the entry point
+            file in the Git repo (default: None). Structure within this
             directory are preserved when training on Amazon SageMaker.
-        dependencies (list[str]): A list of relative locations to directories with any additional libraries that will
-            be exported to the container in the Git repo (default: []).
+        dependencies (list[str]): A list of relative locations to directories
+            with any additional libraries that will be exported to the container
+            in the Git repo (default: []).
+
+    Returns:
+        dict: A dict that contains the updated values of entry_point, source_dir
+        and dependencies.
 
     Raises:
         CalledProcessError: If 1. failed to clone git repo
@@ -61,9 +80,6 @@ def git_clone_repo(git_config, entry_point, source_dir=None, dependencies=None):
                        2. source dir specified does not exist in the repo
                        3. dependencies specified do not exist in the repo
                        4. wrong format is provided for git_config
-
-    Returns:
-        dict: A dict that contains the updated values of entry_point, source_dir and dependencies.
     """
     if entry_point is None:
         raise ValueError("Please provide an entry point.")
@@ -102,6 +118,10 @@ def git_clone_repo(git_config, entry_point, source_dir=None, dependencies=None):
 
 
 def _validate_git_config(git_config):
+    """
+    Args:
+        git_config:
+    """
     if "repo" not in git_config:
         raise ValueError("Please provide a repo for git_config.")
     for key in git_config:
@@ -113,11 +133,12 @@ def _validate_git_config(git_config):
 
 
 def _generate_and_run_clone_command(git_config, dest_dir):
-    """check if a git_config param is valid, if it is, create the command to git clone the repo, and run it.
+    """check if a git_config param is valid, if it is, create the command to git
+    clone the repo, and run it.
 
     Args:
-        git_config ((dict[str, str]): Git configurations used for cloning files, including ``repo``, ``branch``
-            and ``commit``.
+        git_config ((dict[str, str]): Git configurations used for cloning files,
+            including ``repo``, ``branch`` and ``commit``.
         dest_dir (str): The local directory to clone the Git repo into.
 
     Raises:
@@ -132,12 +153,12 @@ def _generate_and_run_clone_command(git_config, dest_dir):
 
 
 def _clone_command_for_github_like(git_config, dest_dir):
-    """check if a git_config param representing a GitHub (or like) repo is valid, if it is, create the command to
-    git clone the repo, and run it.
+    """check if a git_config param representing a GitHub (or like) repo is
+    valid, if it is, create the command to git clone the repo, and run it.
 
     Args:
-        git_config ((dict[str, str]): Git configurations used for cloning files, including ``repo``, ``branch``
-            and ``commit``.
+        git_config ((dict[str, str]): Git configurations used for cloning files,
+            including ``repo``, ``branch`` and ``commit``.
         dest_dir (str): The local directory to clone the Git repo into.
 
     Raises:
@@ -157,12 +178,22 @@ def _clone_command_for_github_like(git_config, dest_dir):
 
 
 def _clone_command_for_ssh(git_config, dest_dir):
+    """
+    Args:
+        git_config:
+        dest_dir:
+    """
     if "username" in git_config or "password" in git_config or "token" in git_config:
         warnings.warn("SSH cloning, authentication information in git config will be ignored.")
     _run_clone_command(git_config["repo"], dest_dir)
 
 
 def _clone_command_for_github_like_https_2fa_disabled(git_config, dest_dir):
+    """
+    Args:
+        git_config:
+        dest_dir:
+    """
     updated_url = git_config["repo"]
     if "token" in git_config:
         if "username" in git_config or "password" in git_config:
@@ -178,6 +209,11 @@ def _clone_command_for_github_like_https_2fa_disabled(git_config, dest_dir):
 
 
 def _clone_command_for_github_like_https_2fa_enabled(git_config, dest_dir):
+    """
+    Args:
+        git_config:
+        dest_dir:
+    """
     updated_url = git_config["repo"]
     if "token" in git_config:
         if "username" in git_config or "password" in git_config:
@@ -187,17 +223,17 @@ def _clone_command_for_github_like_https_2fa_enabled(git_config, dest_dir):
 
 
 def _clone_command_for_codecommit(git_config, dest_dir):
-    """check if a git_config param representing a CodeCommit repo is valid, if it is, create the command to
-        git clone the repo, and run it.
+    """check if a git_config param representing a CodeCommit repo is valid, if
+    it is, create the command to git clone the repo, and run it.
 
-        Args:
-            git_config ((dict[str, str]): Git configurations used for cloning files, including ``repo``, ``branch``
-                and ``commit``.
-            dest_dir (str): The local directory to clone the Git repo into.
+    Args:
+        git_config ((dict[str, str]): Git configurations used for cloning files,
+            including ``repo``, ``branch`` and ``commit``.
+        dest_dir (str): The local directory to clone the Git repo into.
 
-        Raises:
-            ValueError: If git_config['repo'] is in the wrong format.
-            CalledProcessError: If failed to clone git repo.
+    Raises:
+        ValueError: If git_config['repo'] is in the wrong format.
+        CalledProcessError: If failed to clone git repo.
     """
     is_https = git_config["repo"].startswith("https://git-codecommit")
     is_ssh = git_config["repo"].startswith("ssh://git-codecommit")
@@ -214,6 +250,11 @@ def _clone_command_for_codecommit(git_config, dest_dir):
 
 
 def _clone_command_for_codecommit_https(git_config, dest_dir):
+    """
+    Args:
+        git_config:
+        dest_dir:
+    """
     updated_url = git_config["repo"]
     if "username" in git_config and "password" in git_config:
         updated_url = _insert_username_and_password_to_repo_url(
@@ -225,7 +266,8 @@ def _clone_command_for_codecommit_https(git_config, dest_dir):
 
 
 def _run_clone_command(repo_url, dest_dir):
-    """Run the 'git clone' command with the repo url and the directory to clone the repo into.
+    """Run the 'git clone' command with the repo url and the directory to clone
+    the repo into.
 
     Args:
         repo_url (str): Git repo url to be cloned.
@@ -250,8 +292,8 @@ def _run_clone_command(repo_url, dest_dir):
 
 
 def _insert_token_to_repo_url(url, token):
-    """Insert the token to the Git repo url, to make a component of the git clone command. This method can
-    only be called when repo_url is an https url.
+    """Insert the token to the Git repo url, to make a component of the git
+    clone command. This method can only be called when repo_url is an https url.
 
     Args:
         url (str): Git repo url where the token should be inserted into.
@@ -267,8 +309,9 @@ def _insert_token_to_repo_url(url, token):
 
 
 def _insert_username_and_password_to_repo_url(url, username, password):
-    """Insert the username and the password to the Git repo url, to make a component of the git clone command.
-    This method can only be called when repo_url is an https url.
+    """Insert the username and the password to the Git repo url, to make a
+    component of the git clone command. This method can only be called when
+    repo_url is an https url.
 
     Args:
         url (str): Git repo url where the token should be inserted into.
@@ -289,13 +332,13 @@ def _checkout_branch_and_commit(git_config, dest_dir):
     """Checkout the required branch and commit.
 
     Args:
-        git_config (dict[str, str]): Git configurations used for cloning files, including ``repo``, ``branch``
-            and ``commit``.
+        git_config (dict[str, str]): Git configurations used for cloning files,
+            including ``repo``, ``branch`` and ``commit``.
         dest_dir (str): the directory where the repo is cloned
 
     Raises:
-        CalledProcessError: If 1. failed to checkout the required branch
-                               2. failed to checkout the required commit
+        CalledProcessError: If 1. failed to checkout the required branch 2.
+            failed to checkout the required commit
     """
     if "branch" in git_config:
         subprocess.check_call(args=["git", "checkout", git_config["branch"]], cwd=str(dest_dir))

--- a/src/sagemaker/job.py
+++ b/src/sagemaker/job.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import absolute_import
 
 from abc import abstractmethod
@@ -20,14 +21,21 @@ from sagemaker.session import s3_input
 
 
 class _Job(object):
-    """Handle creating, starting and waiting for Amazon SageMaker jobs to finish.
+    """Handle creating, starting and waiting for Amazon SageMaker jobs to
+    finish.
 
     This class shouldn't be directly instantiated.
 
-    Subclasses must define a way to create, start and wait for an Amazon SageMaker job.
+    Subclasses must define a way to create, start and wait for an Amazon
+    SageMaker job.
     """
 
     def __init__(self, sagemaker_session, job_name):
+        """
+        Args:
+            sagemaker_session:
+            job_name:
+        """
         self.sagemaker_session = sagemaker_session
         self.job_name = job_name
 
@@ -36,20 +44,29 @@ class _Job(object):
         """Create a new Amazon SageMaker job from the estimator.
 
         Args:
-            estimator (sagemaker.estimator.EstimatorBase): Estimator object created by the user.
-            inputs (str): Parameters used when called  :meth:`~sagemaker.estimator.EstimatorBase.fit`.
+            estimator (sagemaker.estimator.EstimatorBase): Estimator object
+                created by the user.
+            inputs (str): Parameters used when called
+                :meth:`~sagemaker.estimator.EstimatorBase.fit`.
 
         Returns:
-            sagemaker.job: Constructed object that captures all information about the started job.
+            sagemaker.job: Constructed object that captures all information
+            about the started job.
         """
 
     @abstractmethod
     def wait(self):
-        """Wait for the Amazon SageMaker job to finish.
-        """
+        """Wait for the Amazon SageMaker job to finish."""
 
     @staticmethod
     def _load_config(inputs, estimator, expand_role=True, validate_uri=True):
+        """
+        Args:
+            inputs:
+            estimator:
+            expand_role:
+            validate_uri:
+        """
         input_config = _Job._format_inputs_to_input_config(inputs, validate_uri)
         role = (
             estimator.sagemaker_session.expand_role(estimator.role)
@@ -98,6 +115,11 @@ class _Job(object):
 
     @staticmethod
     def _format_inputs_to_input_config(inputs, validate_uri=True):
+        """
+        Args:
+            inputs:
+            validate_uri:
+        """
         if inputs is None:
             return None
 
@@ -132,12 +154,24 @@ class _Job(object):
 
     @staticmethod
     def _convert_input_to_channel(channel_name, channel_s3_input):
+        """
+        Args:
+            channel_name:
+            channel_s3_input:
+        """
         channel_config = channel_s3_input.config.copy()
         channel_config["ChannelName"] = channel_name
         return channel_config
 
     @staticmethod
     def _format_string_uri_input(uri_input, validate_uri=True, content_type=None, input_mode=None):
+        """
+        Args:
+            uri_input:
+            validate_uri:
+            content_type:
+            input_mode:
+        """
         if isinstance(uri_input, str) and validate_uri and uri_input.startswith("s3://"):
             return s3_input(uri_input, content_type=content_type, input_mode=input_mode)
         if isinstance(uri_input, str) and validate_uri and uri_input.startswith("file://"):
@@ -168,6 +202,15 @@ class _Job(object):
         content_type=None,
         input_mode=None,
     ):
+        """
+        Args:
+            input_config:
+            channel_uri:
+            channel_name:
+            validate_uri:
+            content_type:
+            input_mode:
+        """
         if not channel_uri:
             return None
         if not channel_name:
@@ -189,6 +232,11 @@ class _Job(object):
 
     @staticmethod
     def _format_model_uri_input(model_uri, validate_uri=True):
+        """
+        Args:
+            model_uri:
+            validate_uri:
+        """
         if isinstance(model_uri, string_types) and validate_uri and model_uri.startswith("s3://"):
             return s3_input(
                 model_uri,
@@ -214,6 +262,10 @@ class _Job(object):
     @staticmethod
     def _format_record_set_list_input(inputs):
         # Deferred import due to circular dependency
+        """
+        Args:
+            inputs:
+        """
         from sagemaker.amazon.amazon_estimator import RecordSet
 
         input_dict = {}
@@ -230,6 +282,11 @@ class _Job(object):
 
     @staticmethod
     def _prepare_output_config(s3_path, kms_key_id):
+        """
+        Args:
+            s3_path:
+            kms_key_id:
+        """
         config = {"S3OutputPath": s3_path}
         if kms_key_id is not None:
             config["KmsKeyId"] = kms_key_id
@@ -237,6 +294,13 @@ class _Job(object):
 
     @staticmethod
     def _prepare_resource_config(instance_count, instance_type, volume_size, train_volume_kms_key):
+        """
+        Args:
+            instance_count:
+            instance_type:
+            volume_size:
+            train_volume_kms_key:
+        """
         resource_config = {
             "InstanceCount": instance_count,
             "InstanceType": instance_type,
@@ -249,8 +313,13 @@ class _Job(object):
 
     @staticmethod
     def _prepare_stop_condition(max_run):
+        """
+        Args:
+            max_run:
+        """
         return {"MaxRuntimeInSeconds": max_run}
 
     @property
     def name(self):
+        """Placeholder docstring"""
         return self.job_name

--- a/src/sagemaker/local/__init__.py
+++ b/src/sagemaker/local/__init__.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import absolute_import
 
 from .local_session import (  # noqa: F401

--- a/src/sagemaker/local/data.py
+++ b/src/sagemaker/local/data.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import absolute_import
 
 import os
@@ -28,22 +29,22 @@ import sagemaker.utils
 
 
 def get_data_source_instance(data_source, sagemaker_session):
-    """Return an Instance of :class:`sagemaker.local.data.DataSource` that can handle
-    the provided data_source URI.
+    """Return an Instance of :class:`sagemaker.local.data.DataSource` that can
+    handle the provided data_source URI.
 
     data_source can be either file:// or s3://
 
     Args:
         data_source (str): a valid URI that points to a data source.
-        sagemaker_session (:class:`sagemaker.session.Session`): a SageMaker Session to interact with
-            S3 if required.
+        sagemaker_session (:class:`sagemaker.session.Session`): a SageMaker Session to
+            interact with S3 if required.
 
     Returns:
-        :class:`sagemaker.local.data.DataSource`: an Instance of a Data Source
+        sagemaker.local.data.DataSource: an Instance of a Data Source
 
     Raises:
-        ValueError: If parsed_uri scheme is neither `file` nor `s3`, raise an error.
-
+        ValueError: If parsed_uri scheme is neither `file` nor `s3` , raise an
+            error.
     """
     parsed_uri = urlparse(data_source)
     if parsed_uri.scheme == "file":
@@ -57,11 +58,11 @@ def get_data_source_instance(data_source, sagemaker_session):
 
 def get_splitter_instance(split_type):
     """Return an Instance of :class:`sagemaker.local.data.Splitter` according to
-    the specified `split_type`.
+    the specified `split_type` .
 
     Args:
-        split_type (str): either 'Line' or 'RecordIO'. Can be left as None to signal no data split
-            will happen.
+        split_type (str): either 'Line' or 'RecordIO'. Can be left as None to
+            signal no data split will happen.
 
     Returns
         :class:`sagemaker.local.data.Splitter`: an Instance of a Splitter
@@ -93,12 +94,15 @@ def get_batch_strategy_instance(strategy, splitter):
 
 
 class DataSource(with_metaclass(ABCMeta, object)):
+    """Placeholder docstring"""
+
     @abstractmethod
     def get_file_list(self):
-        """Retrieve the list of absolute paths to all the files in this data source.
+        """Retrieve the list of absolute paths to all the files in this data
+        source.
 
         Returns:
-             List[str]: List of absolute paths.
+            List[str]: List of absolute paths.
         """
 
     @abstractmethod
@@ -111,19 +115,23 @@ class DataSource(with_metaclass(ABCMeta, object)):
 
 
 class LocalFileDataSource(DataSource):
-    """Represents a data source within the local filesystem.
-    """
+    """Represents a data source within the local filesystem."""
 
     def __init__(self, root_path):
+        """
+        Args:
+            root_path:
+        """
         self.root_path = os.path.abspath(root_path)
         if not os.path.exists(self.root_path):
             raise RuntimeError("Invalid data source: %s does not exist." % self.root_path)
 
     def get_file_list(self):
-        """Retrieve the list of absolute paths to all the files in this data source.
+        """Retrieve the list of absolute paths to all the files in this data
+        source.
 
         Returns:
-             List[str] List of absolute paths.
+            List[str] List of absolute paths.
         """
         if os.path.isdir(self.root_path):
             return [
@@ -145,8 +153,8 @@ class LocalFileDataSource(DataSource):
 
 
 class S3DataSource(DataSource):
-    """Defines a data source given by a bucket and S3 prefix. The contents will be downloaded
-    and then processed as local data.
+    """Defines a data source given by a bucket and S3 prefix. The contents will
+    be downloaded and then processed as local data.
     """
 
     def __init__(self, bucket, prefix, sagemaker_session):
@@ -155,7 +163,8 @@ class S3DataSource(DataSource):
         Args:
             bucket (str): S3 bucket name
             prefix (str): S3 prefix path to the data
-            sagemaker_session (:class:`sagemaker.session.Session`): a sagemaker_session with the desired settings
+            sagemaker_session (:class:`sagemaker.session.Session`): a sagemaker_session with the
+            desired settings
                 to talk to S3
         """
 
@@ -177,10 +186,11 @@ class S3DataSource(DataSource):
         self.files = LocalFileDataSource(working_dir)
 
     def get_file_list(self):
-        """Retrieve the list of absolute paths to all the files in this data source.
+        """Retrieve the list of absolute paths to all the files in this data
+        source.
 
         Returns:
-             List[str]: List of absolute paths.
+            List[str]: List of absolute paths.
         """
         return self.files.get_file_list()
 
@@ -194,6 +204,8 @@ class S3DataSource(DataSource):
 
 
 class Splitter(with_metaclass(ABCMeta, object)):
+    """Placeholder docstring"""
+
     @abstractmethod
     def split(self, file):
         """Split a file into records using a specific strategy
@@ -207,27 +219,26 @@ class Splitter(with_metaclass(ABCMeta, object)):
 
 
 class NoneSplitter(Splitter):
-    """Does not split records, essentially reads the whole file.
-    """
+    """Does not split records, essentially reads the whole file."""
 
     def split(self, file):
         """Split a file into records using a specific strategy.
 
-        For this NoneSplitter there is no actual split happening and the file is returned
-        as a whole.
+        For this NoneSplitter there is no actual split happening and the file
+        is returned as a whole.
 
         Args:
             file (str): path to the file to split
 
-        Returns: generator for the individual records that were split from the file
+        Returns: generator for the individual records that were split from
+        the file
         """
         with open(file, "r") as f:
             yield f.read()
 
 
 class LineSplitter(Splitter):
-    """Split records by new line.
-    """
+    """Split records by new line."""
 
     def split(self, file):
         """Split a file into records using a specific strategy
@@ -237,7 +248,8 @@ class LineSplitter(Splitter):
         Args:
             file (str): path to the file to split
 
-        Returns: generator for the individual records that were split from the file
+        Returns: generator for the individual records that were split from
+        the file
         """
         with open(file, "r") as f:
             for line in f:
@@ -248,18 +260,19 @@ class RecordIOSplitter(Splitter):
     """Split using Amazon Recordio.
 
     Not useful for string content.
-
     """
 
     def split(self, file):
         """Split a file into records using a specific strategy
 
-        This RecordIOSplitter splits the data into individual RecordIO records.
+        This RecordIOSplitter splits the data into individual RecordIO
+        records.
 
         Args:
             file (str): path to the file to split
 
-        Returns: generator for the individual records that were split from the file
+        Returns: generator for the individual records that were split from
+        the file
         """
         with open(file, "rb") as f:
             for record in sagemaker.amazon.common.read_recordio(f):
@@ -267,23 +280,26 @@ class RecordIOSplitter(Splitter):
 
 
 class BatchStrategy(with_metaclass(ABCMeta, object)):
+    """Placeholder docstring"""
+
     def __init__(self, splitter):
         """Create a Batch Strategy Instance
 
         Args:
-            splitter (:class:`sagemaker.local.data.Splitter`): A Splitter to pre-process the data
-                before batching.
+            splitter (sagemaker.local.data.Splitter): A Splitter to pre-process
+                the data before batching.
         """
         self.splitter = splitter
 
     @abstractmethod
     def pad(self, file, size):
-        """Group together as many records as possible to fit in the specified size
+        """Group together as many records as possible to fit in the specified
+        size
 
         Args:
             file (str): file path to read the records from.
-            size (int): maximum size in MB that each group of records will be fitted to.
-                passing 0 means unlimited size.
+            size (int): maximum size in MB that each group of records will be
+                fitted to. passing 0 means unlimited size.
 
         Returns:
             generator of records
@@ -297,12 +313,13 @@ class MultiRecordStrategy(BatchStrategy):
     """
 
     def pad(self, file, size=6):
-        """Group together as many records as possible to fit in the specified size
+        """Group together as many records as possible to fit in the specified
+        size
 
         Args:
             file (str): file path to read the records from.
-            size (int): maximum size in MB that each group of records will be fitted to.
-                passing 0 means unlimited size.
+            size (int): maximum size in MB that each group of records will be
+                fitted to. passing 0 means unlimited size.
 
         Returns:
             generator of records
@@ -322,22 +339,24 @@ class MultiRecordStrategy(BatchStrategy):
 class SingleRecordStrategy(BatchStrategy):
     """Feed a single record at a time for batch inference.
 
-    If a single record does not fit within the payload specified it will throw a RuntimeError.
+    If a single record does not fit within the payload specified it will
+    throw a RuntimeError.
     """
 
     def pad(self, file, size=6):
-        """Group together as many records as possible to fit in the specified size
+        """Group together as many records as possible to fit in the specified
+        size
 
-        This SingleRecordStrategy will not group any record and will return them one by one as
-        long as they are within the maximum size.
+        This SingleRecordStrategy will not group any record and will return
+        them one by one as long as they are within the maximum size.
 
         Args:
             file (str): file path to read the records from.
-            size (int): maximum size in MB that each group of records will be fitted to.
-                passing 0 means unlimited size.
+            size (int): maximum size in MB that each group of records will be
+                fitted to. passing 0 means unlimited size.
 
         Returns:
-             generator of records
+            generator of records
         """
         for element in self.splitter.split(file):
             if _validate_payload_size(element, size):
@@ -345,6 +364,11 @@ class SingleRecordStrategy(BatchStrategy):
 
 
 def _payload_size_within_limit(payload, size):
+    """
+    Args:
+        payload:
+        size:
+    """
     size_in_bytes = size * 1024 * 1024
     if size == 0:
         return True
@@ -352,14 +376,15 @@ def _payload_size_within_limit(payload, size):
 
 
 def _validate_payload_size(payload, size):
-    """Check if a payload is within the size in MB threshold. Raise an exception otherwise.
+    """Check if a payload is within the size in MB threshold. Raise an exception
+    otherwise.
 
     Args:
         payload: data that will be checked
         size (int): max size in MB
 
     Returns:
-         bool: True if within bounds. if size=0 it will always return True
+        bool: True if within bounds. if size=0 it will always return True
 
     Raises:
         RuntimeError: If the payload is larger a runtime error is thrown.

--- a/src/sagemaker/local/entities.py
+++ b/src/sagemaker/local/entities.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import absolute_import
 
 import datetime
@@ -32,6 +33,7 @@ HEALTH_CHECK_TIMEOUT_LIMIT = 120
 
 
 class _LocalTrainingJob(object):
+    """Placeholder docstring"""
 
     _STARTING = "Starting"
     _TRAINING = "Training"
@@ -39,6 +41,10 @@ class _LocalTrainingJob(object):
     _states = ["Starting", "Training", "Completed"]
 
     def __init__(self, container):
+        """
+        Args:
+            container:
+        """
         self.container = container
         self.model_artifacts = None
         self.state = "created"
@@ -46,6 +52,13 @@ class _LocalTrainingJob(object):
         self.end_time = None
 
     def start(self, input_data_config, output_data_config, hyperparameters, job_name):
+        """
+        Args:
+            input_data_config:
+            output_data_config:
+            hyperparameters:
+            job_name:
+        """
         for channel in input_data_config:
             if channel["DataSource"] and "S3DataSource" in channel["DataSource"]:
                 data_distribution = channel["DataSource"]["S3DataSource"]["S3DataDistributionType"]
@@ -79,6 +92,7 @@ class _LocalTrainingJob(object):
         self.state = self._COMPLETED
 
     def describe(self):
+        """Placeholder docstring"""
         response = {
             "ResourceConfig": {"InstanceCount": self.container.instance_count},
             "TrainingJobStatus": self.state,
@@ -90,11 +104,18 @@ class _LocalTrainingJob(object):
 
 
 class _LocalTransformJob(object):
+    """Placeholder docstring"""
 
     _CREATING = "Creating"
     _COMPLETED = "Completed"
 
     def __init__(self, transform_job_name, model_name, local_session=None):
+        """
+        Args:
+            transform_job_name:
+            model_name:
+            local_session:
+        """
         from sagemaker.local import LocalSession
 
         self.local_session = local_session or LocalSession()
@@ -120,10 +141,12 @@ class _LocalTransformJob(object):
         """Start the Local Transform Job
 
         Args:
-            input_data (dict): Describes the dataset to be transformed and the location where it is stored.
-            output_data (dict): Identifies the location where to save the results from the transform job
-            transform_resources (dict): compute instances for the transform job. Currently only supports local or
-                local_gpu
+            input_data (dict): Describes the dataset to be transformed and the
+                location where it is stored.
+            output_data (dict): Identifies the location where to save the
+                results from the transform job
+            transform_resources (dict): compute instances for the transform job.
+                Currently only supports local or local_gpu
             **kwargs: additional arguments coming from the boto request object
         """
         self.transform_resources = transform_resources
@@ -171,8 +194,8 @@ class _LocalTransformJob(object):
     def describe(self):
         """Describe this _LocalTransformJob
 
-        The response is a JSON-like dictionary that follows the response of the
-        boto describe_transform_job() API.
+        The response is a JSON-like dictionary that follows the response of
+        the boto describe_transform_job() API.
 
         Returns:
             dict: description of this _LocalTransformJob
@@ -201,17 +224,19 @@ class _LocalTransformJob(object):
         return response
 
     def _get_container_environment(self, **kwargs):
-        """Get all the Environment variables that will be passed to the container
+        """Get all the Environment variables that will be passed to the
+        container
 
-        Certain input fields such as BatchStrategy have different values for the API vs the Environment
-        variables, such as SingleRecord vs SINGLE_RECORD. This method also handles this conversion.
+        Certain input fields such as BatchStrategy have different values for
+        the API vs the Environment variables, such as SingleRecord vs
+        SINGLE_RECORD. This method also handles this conversion.
 
         Args:
             **kwargs: existing transform arguments
 
         Returns:
-            dict: All the environment variables that should be set in the container
-
+            dict: All the environment variables that should be set in the
+            container
         """
         environment = {}
         environment.update(self.primary_container["Environment"])
@@ -242,7 +267,8 @@ class _LocalTransformJob(object):
         return environment
 
     def _get_required_defaults(self, **kwargs):
-        """Return the default values for anything that was not provided by either the user or the container
+        """Return the default values for anything that was not provided by
+        either the user or the container
 
         Args:
             **kwargs: current transform arguments
@@ -260,6 +286,7 @@ class _LocalTransformJob(object):
         return defaults
 
     def _get_working_directory(self):
+        """Placeholder docstring"""
         # Root dir to use for intermediate data location. To make things simple we will write here regardless
         # of the final destination. At the end the files will either be moved or uploaded to S3 and deleted.
         root_dir = get_config_value("local.container_root", self.local_session.config)
@@ -270,6 +297,11 @@ class _LocalTransformJob(object):
         return working_dir
 
     def _prepare_data_transformation(self, input_data, batch_strategy):
+        """
+        Args:
+            input_data:
+            batch_strategy:
+        """
         input_path = input_data["DataSource"]["S3DataSource"]["S3Uri"]
         data_source = sagemaker.local.data.get_data_source_instance(input_path, self.local_session)
 
@@ -284,6 +316,12 @@ class _LocalTransformJob(object):
         # from S3 or Local FileSystem. Split them as required (Line, RecordIO, None) and finally batch them
         # according to the batch strategy and limit the request size.
 
+        """
+        Args:
+            input_data:
+            output_data:
+            **kwargs:
+        """
         batch_strategy = kwargs["BatchStrategy"]
         max_payload = int(kwargs["MaxPayloadInMB"])
         data_source, batch_provider = self._prepare_data_transformation(input_data, batch_strategy)
@@ -320,12 +358,20 @@ class _LocalTransformJob(object):
 
 
 class _LocalModel(object):
+    """Placeholder docstring"""
+
     def __init__(self, model_name, primary_container):
+        """
+        Args:
+            model_name:
+            primary_container:
+        """
         self.model_name = model_name
         self.primary_container = primary_container
         self.creation_time = datetime.datetime.now()
 
     def describe(self):
+        """Placeholder docstring"""
         response = {
             "ModelName": self.model_name,
             "CreationTime": self.creation_time,
@@ -337,13 +383,22 @@ class _LocalModel(object):
 
 
 class _LocalEndpointConfig(object):
+    """Placeholder docstring"""
+
     def __init__(self, config_name, production_variants, tags=None):
+        """
+        Args:
+            config_name:
+            production_variants:
+            tags:
+        """
         self.name = config_name
         self.production_variants = production_variants
         self.tags = tags
         self.creation_time = datetime.datetime.now()
 
     def describe(self):
+        """Placeholder docstring"""
         response = {
             "EndpointConfigName": self.name,
             "EndpointConfigArn": _UNUSED_ARN,
@@ -355,6 +410,7 @@ class _LocalEndpointConfig(object):
 
 
 class _LocalEndpoint(object):
+    """Placeholder docstring"""
 
     _CREATING = "Creating"
     _IN_SERVICE = "InService"
@@ -362,6 +418,13 @@ class _LocalEndpoint(object):
 
     def __init__(self, endpoint_name, endpoint_config_name, tags=None, local_session=None):
         # runtime import since there is a cyclic dependency between entities and local_session
+        """
+        Args:
+            endpoint_name:
+            endpoint_config_name:
+            tags:
+            local_session:
+        """
         from sagemaker.local import LocalSession
 
         self.local_session = local_session or LocalSession()
@@ -380,6 +443,7 @@ class _LocalEndpoint(object):
         self.state = _LocalEndpoint._CREATING
 
     def serve(self):
+        """Placeholder docstring"""
         image = self.primary_container["Image"]
         instance_type = self.production_variant["InstanceType"]
         instance_count = self.production_variant["InitialInstanceCount"]
@@ -404,10 +468,12 @@ class _LocalEndpoint(object):
         self.state = _LocalEndpoint._IN_SERVICE
 
     def stop(self):
+        """Placeholder docstring"""
         if self.container:
             self.container.stop_serving()
 
     def describe(self):
+        """Placeholder docstring"""
         response = {
             "EndpointConfigName": self.endpoint_config["EndpointConfigName"],
             "CreationTime": self.create_time,
@@ -421,6 +487,10 @@ class _LocalEndpoint(object):
 
 
 def _wait_for_serving_container(serving_port):
+    """
+    Args:
+        serving_port:
+    """
     i = 0
     http = urllib3.PoolManager()
 
@@ -441,6 +511,11 @@ def _wait_for_serving_container(serving_port):
 
 
 def _perform_request(endpoint_url, pool_manager=None):
+    """
+    Args:
+        endpoint_url:
+        pool_manager:
+    """
     http = pool_manager or urllib3.PoolManager()
     try:
         r = http.request("GET", endpoint_url)

--- a/src/sagemaker/local/image.py
+++ b/src/sagemaker/local/image.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import absolute_import
 
 import base64
@@ -52,25 +53,27 @@ logger = logging.getLogger(__name__)
 
 
 class _SageMakerContainer(object):
-    """Handle the lifecycle and configuration of a local docker container execution.
+    """Handle the lifecycle and configuration of a local docker container
+    execution.
 
-    This class is responsible for creating the directories and configuration files that
-    the docker containers will use for either training or serving.
+    This class is responsible for creating the directories and configuration
+    files that the docker containers will use for either training or serving.
     """
 
     def __init__(self, instance_type, instance_count, image, sagemaker_session=None):
         """Initialize a SageMakerContainer instance
 
-        It uses a :class:`sagemaker.session.Session` for general interaction with user configuration
-        such as getting the default sagemaker S3 bucket. However this class does not call any of the
-        SageMaker APIs.
+        It uses a :class:`sagemaker.session.Session` for general interaction
+        with user configuration such as getting the default sagemaker S3 bucket.
+        However this class does not call any of the SageMaker APIs.
 
         Args:
-            instance_type (str): The instance type to use. Either 'local' or 'local_gpu'
+            instance_type (str): The instance type to use. Either 'local' or
+                'local_gpu'
             instance_count (int): The number of instances to create.
             image (str): docker image to use.
-            sagemaker_session (sagemaker.session.Session): a sagemaker session to use when interacting
-                with SageMaker.
+            sagemaker_session (sagemaker.session.Session): a sagemaker session
+                to use when interacting with SageMaker.
         """
         from sagemaker.local.local_session import LocalSession
 
@@ -90,9 +93,11 @@ class _SageMakerContainer(object):
 
     def train(self, input_data_config, output_data_config, hyperparameters, job_name):
         """Run a training job locally using docker-compose.
+
         Args:
             input_data_config (dict): The Input Data Configuration, this contains data such as the
                 channels to be used for training.
+            output_data_config:
             hyperparameters (dict): The HyperParameters for the training job.
             job_name (str): Name of the local training job being run.
 
@@ -166,7 +171,8 @@ class _SageMakerContainer(object):
             primary_container (dict): dictionary containing the container runtime settings
                 for serving. Expected keys:
                 - 'ModelDataUrl' pointing to a file or s3:// location.
-                - 'Environment' a dictionary of environment variables to be passed to the hosting container.
+                - 'Environment' a dictionary of environment variables to be passed to the
+                    hosting container.
 
         """
         logger.info("serving")
@@ -199,7 +205,8 @@ class _SageMakerContainer(object):
     def stop_serving(self):
         """Stop the serving container.
 
-        The serving container runs in async mode to allow the SDK to do other tasks.
+        The serving container runs in async mode to allow the SDK to do other
+        tasks.
         """
         if self.container:
             self.container.down()
@@ -211,15 +218,18 @@ class _SageMakerContainer(object):
     def retrieve_artifacts(self, compose_data, output_data_config, job_name):
         """Get the model artifacts from all the container nodes.
 
-        Used after training completes to gather the data from all the individual containers. As the
-        official SageMaker Training Service, it will override duplicate files if multiple containers have
-        the same file names.
+        Used after training completes to gather the data from all the
+        individual containers. As the official SageMaker Training Service, it
+        will override duplicate files if multiple containers have the same file
+        names.
 
         Args:
-            compose_data(dict): Docker-Compose configuration in dictionary format.
+            compose_data (dict): Docker-Compose configuration in dictionary
+                format.
+            output_data_config:
+            job_name:
 
         Returns: Local path to the collected model artifacts.
-
         """
         # We need a directory to store the artfiacts from all the nodes
         # and another one to contained the compressed final artifacts
@@ -275,15 +285,16 @@ class _SageMakerContainer(object):
     def write_config_files(self, host, hyperparameters, input_data_config):
         """Write the config files for the training containers.
 
-        This method writes the hyperparameters, resources and input data configuration files.
+        This method writes the hyperparameters, resources and input data
+        configuration files.
+
+        Returns: None
 
         Args:
             host (str): Host to write the configuration for
             hyperparameters (dict): Hyperparameters for training.
-            input_data_config (dict): Training input channels to be used for training.
-
-        Returns: None
-
+            input_data_config (dict): Training input channels to be used for
+                training.
         """
         config_path = os.path.join(self.container_root, host, "input", "config")
 
@@ -303,6 +314,13 @@ class _SageMakerContainer(object):
     def _prepare_training_volumes(
         self, data_dir, input_data_config, output_data_config, hyperparameters
     ):
+        """
+        Args:
+            data_dir:
+            input_data_config:
+            output_data_config:
+            hyperparameters:
+        """
         shared_dir = os.path.join(self.container_root, "shared")
         model_dir = os.path.join(self.container_root, "model")
         volumes = []
@@ -343,6 +361,11 @@ class _SageMakerContainer(object):
         return volumes
 
     def _update_local_src_path(self, params, key):
+        """
+        Args:
+            params:
+            key:
+        """
         if key in params:
             src_dir = json.loads(params[key])
             parsed_uri = urlparse(src_dir)
@@ -353,6 +376,10 @@ class _SageMakerContainer(object):
         return params
 
     def _prepare_serving_volumes(self, model_location):
+        """
+        Args:
+            model_location:
+        """
         volumes = []
         host = self.hosts[0]
         # Make the model available to the container. If this is a local file just mount it to
@@ -375,21 +402,22 @@ class _SageMakerContainer(object):
         return volumes
 
     def _generate_compose_file(self, command, additional_volumes=None, additional_env_vars=None):
-        """Writes a config file describing a training/hosting  environment.
+        """Writes a config file describing a training/hosting environment.
 
-        This method generates a docker compose configuration file, it has an entry for each container
-        that will be created (based on self.hosts). it calls
-        :meth:~sagemaker.local_session.SageMakerContainer._create_docker_host to generate the config
-        for each individual container.
+        This method generates a docker compose configuration file, it has an
+        entry for each container that will be created (based on self.hosts). it
+        calls
+        :meth:~sagemaker.local_session.SageMakerContainer._create_docker_host to
+        generate the config for each individual container.
 
         Args:
             command (str): either 'train' or 'serve'
-            additional_volumes (list): a list of volumes that will be mapped to the containers
-            additional_env_vars (dict): a dictionary with additional environment variables to be
-                passed on to the containers.
+            additional_volumes (list): a list of volumes that will be mapped to
+                the containers
+            additional_env_vars (dict): a dictionary with additional environment
+                variables to be passed on to the containers.
 
         Returns: (dict) A dictionary representation of the configuration that was written.
-
         """
         boto_session = self.sagemaker_session.boto_session
         additional_volumes = additional_volumes or []
@@ -431,6 +459,10 @@ class _SageMakerContainer(object):
         return content
 
     def _compose(self, detached=False):
+        """
+        Args:
+            detached:
+        """
         compose_cmd = "docker-compose"
 
         command = [
@@ -449,6 +481,14 @@ class _SageMakerContainer(object):
         return command
 
     def _create_docker_host(self, host, environment, optml_subdirs, command, volumes):
+        """
+        Args:
+            host:
+            environment:
+            optml_subdirs:
+            command:
+            volumes:
+        """
         optml_volumes = self._build_optml_volumes(host, optml_subdirs)
         optml_volumes.extend(volumes)
 
@@ -479,6 +519,7 @@ class _SageMakerContainer(object):
         return host_config
 
     def _create_tmp_folder(self):
+        """Placeholder docstring"""
         root_dir = sagemaker.utils.get_config_value(
             "local.container_root", self.sagemaker_session.config
         )
@@ -496,14 +537,16 @@ class _SageMakerContainer(object):
         return os.path.abspath(working_dir)
 
     def _build_optml_volumes(self, host, subdirs):
-        """Generate a list of :class:`~sagemaker.local_session.Volume` required for the container to start.
+        """Generate a list of :class:`~sagemaker.local_session.Volume` required
+        for the container to start.
 
-        It takes a folder with the necessary files for training and creates a list of opt volumes that
-        the Container needs to start.
+        It takes a folder with the necessary files for training and creates a
+        list of opt volumes that the Container needs to start.
 
         Args:
             host (str): container for which the volumes will be generated.
-            subdirs (list): list of subdirectories that will be mapped. For example: ['input', 'output', 'model']
+            subdirs (list): list of subdirectories that will be mapped. For
+                example: ['input', 'output', 'model']
 
         Returns: (list) List of :class:`~sagemaker.local_session.Volume`
         """
@@ -518,6 +561,10 @@ class _SageMakerContainer(object):
         return volumes
 
     def _cleanup(self, dirs_to_delete=None):
+        """
+        Args:
+            dirs_to_delete:
+        """
         if dirs_to_delete:
             for d in dirs_to_delete:
                 _delete_tree(d)
@@ -529,12 +576,19 @@ class _SageMakerContainer(object):
 
 
 class _HostingContainer(Thread):
+    """Placeholder docstring"""
+
     def __init__(self, command):
+        """
+        Args:
+            command:
+        """
         Thread.__init__(self)
         self.command = command
         self.process = None
 
     def run(self):
+        """Placeholder docstring"""
         self.process = subprocess.Popen(
             self.command, stdout=subprocess.PIPE, stderr=subprocess.PIPE
         )
@@ -547,13 +601,12 @@ class _HostingContainer(Thread):
             raise RuntimeError(msg)
 
     def down(self):
+        """Placeholder docstring"""
         self.process.terminate()
 
 
 class _Volume(object):
-    """Represent a Volume that will be mapped to a container.
-
-    """
+    """Represent a Volume that will be mapped to a container."""
 
     def __init__(self, host_dir, container_dir=None, channel=None):
         """Create a Volume instance
@@ -584,11 +637,11 @@ class _Volume(object):
 def _stream_output(process):
     """Stream the output of a process to stdout
 
-    This function takes an existing process that will be polled for output. Only stdout
-    will be polled and sent to sys.stdout.
+    This function takes an existing process that will be polled for output.
+    Only stdout will be polled and sent to sys.stdout.
 
     Args:
-        process(subprocess.Popen): a process that has been started with
+        process (subprocess.Popen): a process that has been started with
             stdout=PIPE and stderr=STDOUT
 
     Returns (int): process exit code
@@ -607,6 +660,12 @@ def _stream_output(process):
 
 
 def _check_output(cmd, *popenargs, **kwargs):
+    """
+    Args:
+        cmd:
+        *popenargs:
+        **kwargs:
+    """
     if isinstance(cmd, str):
         cmd = shlex.split(cmd)
 
@@ -626,11 +685,20 @@ def _check_output(cmd, *popenargs, **kwargs):
 
 
 def _create_config_file_directories(root, host):
+    """
+    Args:
+        root:
+        host:
+    """
     for d in ["input", "input/config", "output", "model"]:
         os.makedirs(os.path.join(root, host, d))
 
 
 def _delete_tree(path):
+    """
+    Args:
+        path:
+    """
     try:
         shutil.rmtree(path)
     except OSError as exc:
@@ -646,6 +714,10 @@ def _delete_tree(path):
 
 
 def _aws_credentials(session):
+    """
+    Args:
+        session:
+    """
     try:
         creds = session.get_credentials()
         access_key = creds.access_key
@@ -685,6 +757,7 @@ def _aws_credentials(session):
 
 
 def _aws_credentials_available_in_metadata_service():
+    """Placeholder docstring"""
     import botocore
     from botocore.credentials import InstanceMetadataProvider
     from botocore.utils import InstanceMetadataFetcher
@@ -701,12 +774,22 @@ def _aws_credentials_available_in_metadata_service():
 
 
 def _write_json_file(filename, content):
+    """
+    Args:
+        filename:
+        content:
+    """
     with open(filename, "w") as f:
         json.dump(content, f)
 
 
 def _ecr_login_if_needed(boto_session, image):
     # Only ECR images need login
+    """
+    Args:
+        boto_session:
+        image:
+    """
     sagemaker_pattern = re.compile(sagemaker.utils.ECR_URI_PATTERN)
     sagemaker_match = sagemaker_pattern.match(image)
     if not sagemaker_match:
@@ -737,6 +820,10 @@ def _ecr_login_if_needed(boto_session, image):
 
 
 def _pull_image(image):
+    """
+    Args:
+        image:
+    """
     pull_image_command = ("docker pull %s" % image).strip()
     logger.info("docker command: %s", pull_image_command)
 

--- a/src/sagemaker/local/local_session.py
+++ b/src/sagemaker/local/local_session.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import absolute_import
 
 import logging
@@ -40,6 +41,11 @@ class LocalSagemakerClient(object):
     a boto client to interact with S3 but it won't perform any SageMaker call.
 
     Implements the methods with the same signature as the boto SageMakerClient.
+
+    Args:
+
+    Returns:
+
     """
 
     _training_jobs = {}
@@ -66,16 +72,23 @@ class LocalSagemakerClient(object):
         InputDataConfig=None,
         **kwargs
     ):
-        """
-        Create a training job in Local Mode
+        """Create a training job in Local Mode
+
         Args:
-            TrainingJobName (str): local training job name.
-            AlgorithmSpecification (dict): Identifies the training algorithm to use.
-            InputDataConfig (dict): Describes the training dataset and the location where it is stored.
-            OutputDataConfig (dict): Identifies the location where you want to save the results of model training.
-            ResourceConfig (dict): Identifies the resources to use for local model traininig.
-            HyperParameters (dict) [optional]: Specifies these algorithm-specific parameters to influence the quality of
-                the final model.
+          TrainingJobName(str): local training job name.
+          AlgorithmSpecification(dict): Identifies the training algorithm to use.
+          InputDataConfig(dict, optional): Describes the training dataset and the location where
+            it is stored. (Default value = None)
+          OutputDataConfig(dict): Identifies the location where you want to save the results of
+            model training.
+          ResourceConfig(dict): Identifies the resources to use for local model training.
+          HyperParameters(dict) [optional]: Specifies these algorithm-specific parameters to influence the
+            quality of
+        the final model.
+          **kwargs:
+
+        Returns:
+
         """
         InputDataConfig = InputDataConfig or {}
         container = _SageMakerContainer(
@@ -94,9 +107,10 @@ class LocalSagemakerClient(object):
         """Describe a local training job.
 
         Args:
-            TrainingJobName (str): Training job name to describe.
-
+          TrainingJobName(str): Training job name to describe.
         Returns: (dict) DescribeTrainingJob Response.
+
+        Returns:
 
         """
         if TrainingJobName not in LocalSagemakerClient._training_jobs:
@@ -118,11 +132,32 @@ class LocalSagemakerClient(object):
         TransformResources,
         **kwargs
     ):
+        """
+
+        Args:
+          TransformJobName:
+          ModelName:
+          TransformInput:
+          TransformOutput:
+          TransformResources:
+          **kwargs:
+
+        Returns:
+
+        """
         transform_job = _LocalTransformJob(TransformJobName, ModelName, self.sagemaker_session)
         LocalSagemakerClient._transform_jobs[TransformJobName] = transform_job
         transform_job.start(TransformInput, TransformOutput, TransformResources, **kwargs)
 
     def describe_transform_job(self, TransformJobName):
+        """
+
+        Args:
+          TransformJobName:
+
+        Returns:
+
+        """
         if TransformJobName not in LocalSagemakerClient._transform_jobs:
             error_response = {
                 "Error": {
@@ -138,13 +173,26 @@ class LocalSagemakerClient(object):
     ):  # pylint: disable=unused-argument
         """Create a Local Model Object
 
+
         Args:
-            ModelName (str): the Model Name
-            PrimaryContainer (dict): a SageMaker primary container definition
+          ModelName (str): the Model Name
+          PrimaryContainer (dict): a SageMaker primary container definition
+          *args:
+          **kwargs:
+
+        Returns:
         """
         LocalSagemakerClient._models[ModelName] = _LocalModel(ModelName, PrimaryContainer)
 
     def describe_model(self, ModelName):
+        """
+
+        Args:
+          ModelName:
+
+        Returns:
+
+        """
         if ModelName not in LocalSagemakerClient._models:
             error_response = {
                 "Error": {"Code": "ValidationException", "Message": "Could not find local model"}
@@ -153,6 +201,14 @@ class LocalSagemakerClient(object):
         return LocalSagemakerClient._models[ModelName].describe()
 
     def describe_endpoint_config(self, EndpointConfigName):
+        """
+
+        Args:
+          EndpointConfigName:
+
+        Returns:
+
+        """
         if EndpointConfigName not in LocalSagemakerClient._endpoint_configs:
             error_response = {
                 "Error": {
@@ -164,11 +220,29 @@ class LocalSagemakerClient(object):
         return LocalSagemakerClient._endpoint_configs[EndpointConfigName].describe()
 
     def create_endpoint_config(self, EndpointConfigName, ProductionVariants, Tags=None):
+        """
+
+        Args:
+          EndpointConfigName:
+          ProductionVariants:
+          Tags:  (Default value = None)
+
+        Returns:
+
+        """
         LocalSagemakerClient._endpoint_configs[EndpointConfigName] = _LocalEndpointConfig(
             EndpointConfigName, ProductionVariants, Tags
         )
 
     def describe_endpoint(self, EndpointName):
+        """
+
+        Args:
+          EndpointName:
+
+        Returns:
+
+        """
         if EndpointName not in LocalSagemakerClient._endpoints:
             error_response = {
                 "Error": {"Code": "ValidationException", "Message": "Could not find local endpoint"}
@@ -177,30 +251,71 @@ class LocalSagemakerClient(object):
         return LocalSagemakerClient._endpoints[EndpointName].describe()
 
     def create_endpoint(self, EndpointName, EndpointConfigName, Tags=None):
+        """
+
+        Args:
+          EndpointName:
+          EndpointConfigName:
+          Tags:  (Default value = None)
+
+        Returns:
+
+        """
         endpoint = _LocalEndpoint(EndpointName, EndpointConfigName, Tags, self.sagemaker_session)
         LocalSagemakerClient._endpoints[EndpointName] = endpoint
         endpoint.serve()
 
     def update_endpoint(self, EndpointName, EndpointConfigName):  # pylint: disable=unused-argument
+        """
+
+        Args:
+          EndpointName:
+          EndpointConfigName:
+
+        Returns:
+
+        """
         raise NotImplementedError("Update endpoint name is not supported in local session.")
 
     def delete_endpoint(self, EndpointName):
+        """
+
+        Args:
+          EndpointName:
+
+        Returns:
+
+        """
         if EndpointName in LocalSagemakerClient._endpoints:
             LocalSagemakerClient._endpoints[EndpointName].stop()
 
     def delete_endpoint_config(self, EndpointConfigName):
+        """
+
+        Args:
+          EndpointConfigName:
+
+        Returns:
+
+        """
         if EndpointConfigName in LocalSagemakerClient._endpoint_configs:
             del LocalSagemakerClient._endpoint_configs[EndpointConfigName]
 
     def delete_model(self, ModelName):
+        """
+
+        Args:
+          ModelName:
+
+        Returns:
+
+        """
         if ModelName in LocalSagemakerClient._models:
             del LocalSagemakerClient._models[ModelName]
 
 
 class LocalSagemakerRuntimeClient(object):
-    """A SageMaker Runtime client that calls a local endpoint only.
-
-    """
+    """A SageMaker Runtime client that calls a local endpoint only."""
 
     def __init__(self, config=None):
         """Initializes a LocalSageMakerRuntimeClient
@@ -222,6 +337,17 @@ class LocalSagemakerRuntimeClient(object):
         Accept=None,
         CustomAttributes=None,
     ):
+        """
+
+        Args:
+          Body:
+          EndpointName:
+          Accept:  (Default value = None)
+          CustomAttributes:  (Default value = None)
+
+        Returns:
+
+        """
         url = "http://localhost:%s/invocations" % self.serving_port
         headers = {}
 
@@ -240,6 +366,8 @@ class LocalSagemakerRuntimeClient(object):
 
 
 class LocalSession(Session):
+    """Placeholder docstring"""
+
     def __init__(self, boto_session=None):
         super(LocalSession, self).__init__(boto_session)
 
@@ -247,7 +375,16 @@ class LocalSession(Session):
             logger.warning("Windows Support for Local Mode is Experimental")
 
     def _initialize(self, boto_session, sagemaker_client, sagemaker_runtime_client):
-        """Initialize this Local SageMaker Session."""
+        """Initialize this Local SageMaker Session.
+
+        Args:
+          boto_session:
+          sagemaker_client:
+          sagemaker_runtime_client:
+
+        Returns:
+
+        """
 
         self.boto_session = boto_session or boto3.Session()
         self._region_name = self.boto_session.region_name
@@ -262,17 +399,23 @@ class LocalSession(Session):
         self.local_mode = True
 
     def logs_for_job(self, job_name, wait=False, poll=5):
+        """
+
+        Args:
+          job_name:
+          wait:  (Default value = False)
+          poll:  (Default value = 5)
+
+        Returns:
+
+        """
         # override logs_for_job() as it doesn't need to perform any action
         # on local mode.
-        pass
+        pass  # pylint: disable=unnecessary-pass
 
 
 class file_input(object):
-    """Amazon SageMaker channel configuration for FILE data sources, used in local mode.
-
-    Attributes:
-        config (dict[str, dict]): A SageMaker ``DataSource`` referencing a SageMaker ``FileDataSource``.
-    """
+    """Amazon SageMaker channel configuration for FILE data sources, used in local mode."""
 
     def __init__(self, fileUri, content_type=None):
         """Create a definition for input data used by an SageMaker training job in local mode.

--- a/src/sagemaker/local/utils.py
+++ b/src/sagemaker/local/utils.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import absolute_import
 
 import os
@@ -20,18 +21,20 @@ from six.moves.urllib.parse import urlparse
 
 
 def copy_directory_structure(destination_directory, relative_path):
-    """Create all the intermediate directories required for relative_path to exist within destination_directory.
-    This assumes that relative_path is a directory located within root_dir.
+    """Create all the intermediate directories required for relative_path to
+    exist within destination_directory. This assumes that relative_path is a
+    directory located within root_dir.
 
     Examples:
-        destination_directory: /tmp/destination
-        relative_path: test/unit/
+        destination_directory: /tmp/destination relative_path: test/unit/
 
-        will create:  /tmp/destination/test/unit
+        will create: /tmp/destination/test/unit
 
     Args:
-        destination_directory (str): root of the destination directory where the directory structure will be created.
-        relative_path (str): relative path that will be created within destination_directory
+        destination_directory (str): root of the destination directory where the
+            directory structure will be created.
+        relative_path (str): relative path that will be created within
+            destination_directory
     """
     full_path = os.path.join(destination_directory, relative_path)
     if os.path.exists(full_path):
@@ -47,7 +50,8 @@ def move_to_destination(source, destination, job_name, sagemaker_session):
         source (str): root directory to move
         destination (str): file:// or s3:// URI that source will be moved to.
         job_name (str): SageMaker job name.
-        sagemaker_session (sagemaker.Session): a sagemaker_session to interact with S3 if needed
+        sagemaker_session (sagemaker.Session): a sagemaker_session to interact
+            with S3 if needed
 
     Returns:
         (str): destination URI
@@ -69,8 +73,8 @@ def move_to_destination(source, destination, job_name, sagemaker_session):
 
 
 def recursive_copy(source, destination):
-    """A wrapper around distutils.dir_util.copy_tree but won't throw any exception when the source
-    directory does not exist.
+    """A wrapper around distutils.dir_util.copy_tree but won't throw any
+    exception when the source directory does not exist.
 
     Args:
         source (str): source path

--- a/src/sagemaker/logs.py
+++ b/src/sagemaker/logs.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import absolute_import
 
 import collections
@@ -25,8 +26,9 @@ import sys
 
 
 class ColorWrap(object):
-    """A callable that will print text in a different color depending on the instance (up
-    to 6 if standard output is a terminal or a Jupyter notebook cell).
+    """A callable that will print text in a different color depending on the
+    instance (up to 6 if standard output is a terminal or a Jupyter notebook
+    cell).
     """
 
     _stream_colors = [31, 32, 33, 34, 35, 36]
@@ -35,16 +37,17 @@ class ColorWrap(object):
         """Initialize the class.
 
         Args:
-            force (bool): If True, render colorizes output no matter where the output is (default: False).
+            force (bool): If True, render colorizes output no matter where the
+                output is (default: False).
         """
         self.colorize = force or sys.stdout.isatty() or os.environ.get("JPY_PARENT_PID", None)
 
     def __call__(self, index, s):
         """Print the output, colorized or not, depending on the environment.
 
-           Args:
-               index (int): The instance number.
-               s (str): The string to print.
+        Args:
+            index (int): The instance number.
+            s (str): The string to print.
         """
         if self.colorize:
             self._color_wrap(index, s)
@@ -52,11 +55,21 @@ class ColorWrap(object):
             print(s)
 
     def _color_wrap(self, index, s):
+        """
+        Args:
+            index:
+            s:
+        """
         print("\x1b[{}m{}\x1b[0m".format(self._stream_colors[index % len(self._stream_colors)], s))
 
 
 def argmin(arr, f):
-    """Return the index, i, in arr that minimizes f(arr[i])"""
+    """Return the index, i, in arr that minimizes f(arr[i])
+
+    Args:
+        arr:
+        f:
+    """
     m = None
     i = None
     for idx, item in enumerate(arr):
@@ -68,7 +81,11 @@ def argmin(arr, f):
 
 
 def some(arr):
-    """Return True iff there is an element, a, of arr such that a is not None"""
+    """Return True iff there is an element, a, of arr such that a is not None
+
+    Args:
+        arr:
+    """
     return functools.reduce(lambda x, y: x or (y is not None), arr, False)
 
 
@@ -84,10 +101,10 @@ def multi_stream_iter(client, log_group, streams, positions=None):
     Args:
         client (boto3 client): The boto client for logs.
         log_group (str): The name of the log group.
-        streams (list of str): A list of the log stream names. The position of the stream in this list is
-                               the stream number.
-        positions: (list of Positions): A list of pairs of (timestamp, skip) which represents the last record
-                                     read from each stream.
+        streams (list of str): A list of the log stream names. The position of the stream in
+        this list is the stream number.
+        positions: (list of Positions): A list of pairs of (timestamp, skip) which represents
+        the last record read from each stream.
 
     Yields:
         A tuple of (stream number, cloudwatch log event).
@@ -124,8 +141,8 @@ def log_stream(client, log_group, stream_name, start_time=0, skip=0):
         log_group (str): The name of the log group.
         stream_name (str): The name of the specific stream.
         start_time (int): The time stamp value to start reading the logs from (default: 0).
-        skip (int): The number of log entries to skip at the start (default: 0). This is for when there are
-                    multiple entries at the same timestamp.
+        skip (int): The number of log entries to skip at the start (default: 0). This is for
+        when there are multiple entries at the same timestamp.
 
     Yields:
        dict: A CloudWatch log event with the following key-value pairs:

--- a/src/sagemaker/model.py
+++ b/src/sagemaker/model.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import absolute_import
 
 import json
@@ -70,26 +71,37 @@ class Model(object):
         """Initialize an SageMaker ``Model``.
 
         Args:
-            model_data (str): The S3 location of a SageMaker model data ``.tar.gz`` file.
+            model_data (str): The S3 location of a SageMaker model data
+                ``.tar.gz`` file.
             image (str): A Docker image URI.
-            role (str): An AWS IAM role (either name or full ARN). The Amazon SageMaker training jobs and APIs
-                that create Amazon SageMaker endpoints use this role to access training data and model artifacts.
-                After the endpoint is created, the inference code might use the IAM role if it needs to access some AWS
-                resources. It can be null if this is being used to create a Model to pass to a ``PipelineModel`` which
-                has its own Role field. (default: None)
-            predictor_cls (callable[string, sagemaker.session.Session]): A function to call to create
-               a predictor (default: None). If not None, ``deploy`` will return the result of invoking
-               this function on the created endpoint name.
-            env (dict[str, str]): Environment variables to run with ``image`` when hosted in SageMaker (default: None).
-            name (str): The model name. If None, a default model name will be selected on each ``deploy``.
-            vpc_config (dict[str, list[str]]): The VpcConfig set on the model (default: None)
+            role (str): An AWS IAM role (either name or full ARN). The Amazon
+                SageMaker training jobs and APIs that create Amazon SageMaker
+                endpoints use this role to access training data and model
+                artifacts. After the endpoint is created, the inference code
+                might use the IAM role if it needs to access some AWS resources.
+                It can be null if this is being used to create a Model to pass
+                to a ``PipelineModel`` which has its own Role field. (default:
+                None)
+            predictor_cls (callable[string, sagemaker.session.Session]): A
+                function to call to create a predictor (default: None). If not
+                None, ``deploy`` will return the result of invoking this
+                function on the created endpoint name.
+            env (dict[str, str]): Environment variables to run with ``image``
+                when hosted in SageMaker (default: None).
+            name (str): The model name. If None, a default model name will be
+                selected on each ``deploy``.
+            vpc_config (dict[str, list[str]]): The VpcConfig set on the model
+                (default: None)
                 * 'Subnets' (list[str]): List of subnet ids.
                 * 'SecurityGroupIds' (list[str]): List of security group ids.
-            sagemaker_session (sagemaker.session.Session): A SageMaker Session object, used for SageMaker
-               interactions (default: None). If not specified, one is created using the default AWS configuration chain.
-            enable_network_isolation (Boolean): Default False. if True, enables network isolation in the endpoint,
-                isolating the model container. No inbound or outbound network calls can be made to or from the
-                model container.
+            sagemaker_session (sagemaker.session.Session): A SageMaker Session
+                object, used for SageMaker interactions (default: None). If not
+                specified, one is created using the default AWS configuration
+                chain.
+            enable_network_isolation (Boolean): Default False. if True, enables
+                network isolation in the endpoint, isolating the model
+                container. No inbound or outbound network calls can be made to
+                or from the model container.
         """
         self.model_data = model_data
         self.image = image
@@ -107,15 +119,18 @@ class Model(object):
     def prepare_container_def(
         self, instance_type, accelerator_type=None
     ):  # pylint: disable=unused-argument
-        """Return a dict created by ``sagemaker.container_def()`` for deploying this model to a specified instance type.
+        """Return a dict created by ``sagemaker.container_def()`` for deploying
+        this model to a specified instance type.
 
-        Subclasses can override this to provide custom container definitions for
-        deployment to a specific instance type. Called by ``deploy()``.
+        Subclasses can override this to provide custom container definitions
+        for deployment to a specific instance type. Called by ``deploy()``.
 
         Args:
-            instance_type (str): The EC2 instance type to deploy this Model to. For example, 'ml.p2.xlarge'.
-            accelerator_type (str): The Elastic Inference accelerator type to deploy to the instance for loading and
-                making inferences to the model. For example, 'ml.eia1.medium'.
+            instance_type (str): The EC2 instance type to deploy this Model to.
+                For example, 'ml.p2.xlarge'.
+            accelerator_type (str): The Elastic Inference accelerator type to
+                deploy to the instance for loading and making inferences to the
+                model. For example, 'ml.eia1.medium'.
 
         Returns:
             dict: A container definition object usable with the CreateModel API.
@@ -134,16 +149,18 @@ class Model(object):
         """Create a SageMaker Model Entity
 
         Args:
-            instance_type (str): The EC2 instance type that this Model will be used for, this is only
-                used to determine if the image needs GPU support or not.
-            accelerator_type (str): Type of Elastic Inference accelerator to attach to an endpoint for model loading
-                and inference, for example, 'ml.eia1.medium'. If not specified, no Elastic Inference accelerator
-                will be attached to the endpoint.
-            tags(List[dict[str, str]]): Optional. The list of tags to add to the model. Example:
-                    >>> tags = [{'Key': 'tagname', 'Value': 'tagvalue'}]
-                    For more information about tags, see https://boto3.amazonaws.com/v1/documentation\
-                    /api/latest/reference/services/sagemaker.html#SageMaker.Client.add_tags
-
+            instance_type (str): The EC2 instance type that this Model will be
+                used for, this is only used to determine if the image needs GPU
+                support or not.
+            accelerator_type (str): Type of Elastic Inference accelerator to
+                attach to an endpoint for model loading and inference, for
+                example, 'ml.eia1.medium'. If not specified, no Elastic
+                Inference accelerator will be attached to the endpoint.
+            tags (List[dict[str, str]]): Optional. The list of tags to add to
+                the model. Example: >>> tags = [{'Key': 'tagname', 'Value':
+                'tagvalue'}] For more information about tags, see
+                https://boto3.amazonaws.com/v1/documentation
+                /api/latest/reference/services/sagemaker.html#SageMaker.Client.add_tags
         """
         container_def = self.prepare_container_def(instance_type, accelerator_type=accelerator_type)
         self.name = self.name or utils.name_from_image(container_def["Image"])
@@ -158,9 +175,11 @@ class Model(object):
         )
 
     def _framework(self):
+        """Placeholder docstring"""
         return getattr(self, "__framework_name__", None)
 
     def _get_framework_version(self):
+        """Placeholder docstring"""
         return getattr(self, "framework_version", None)
 
     def _compilation_job_config(
@@ -174,6 +193,17 @@ class Model(object):
         framework,
         tags,
     ):
+        """
+        Args:
+            target_instance_type:
+            input_shape:
+            output_path:
+            role:
+            compile_max_run:
+            job_name:
+            framework:
+            tags:
+        """
         input_model_config = {
             "S3Uri": self.model_data,
             "DataInputConfig": input_shape
@@ -201,14 +231,20 @@ class Model(object):
 
         Args:
             region (str): Specifies the region where want to execute compilation
+
         Returns:
-            bool: boolean value whether if neo is available in the specified region
+            bool: boolean value whether if neo is available in the specified
+            region
         """
         if region in NEO_IMAGE_ACCOUNT:
             return True
         return False
 
     def _neo_image_account(self, region):
+        """
+        Args:
+            region:
+        """
         if region not in NEO_IMAGE_ACCOUNT:
             raise ValueError(
                 "Neo is not currently supported in {}, "
@@ -217,6 +253,13 @@ class Model(object):
         return NEO_IMAGE_ACCOUNT[region]
 
     def _neo_image(self, region, target_instance_type, framework, framework_version):
+        """
+        Args:
+            region:
+            target_instance_type:
+            framework:
+            framework_version:
+        """
         return fw_utils.create_image_uri(
             region,
             "neo-" + framework.lower(),
@@ -241,24 +284,31 @@ class Model(object):
         """Compile this ``Model`` with SageMaker Neo.
 
         Args:
-            target_instance_family (str): Identifies the device that you want to run your model after compilation, for
-                example: ml_c5. Allowed strings are: ml_c5, ml_m5, ml_c4, ml_m4, jetsontx1, jetsontx2, ml_p2, ml_p3,
-                deeplens, rasp3b
-            input_shape (dict): Specifies the name and shape of the expected inputs for your trained model in json
-                dictionary form, for example: {'data':[1,3,1024,1024]}, or {'var1': [1,1,28,28], 'var2':[1,1,28,28]}
+            target_instance_family (str): Identifies the device that you want to
+                run your model after compilation, for example: ml_c5. Allowed
+                strings are: ml_c5, ml_m5, ml_c4, ml_m4, jetsontx1, jetsontx2,
+                ml_p2, ml_p3, deeplens, rasp3b
+            input_shape (dict): Specifies the name and shape of the expected
+                inputs for your trained model in json dictionary form, for
+                example: {'data':[1,3,1024,1024]}, or {'var1': [1,1,28,28],
+                'var2':[1,1,28,28]}
             output_path (str): Specifies where to store the compiled model
             role (str): Execution role
-            tags (list[dict]): List of tags for labeling a compilation job. For more, see
+            tags (list[dict]): List of tags for labeling a compilation job. For
+                more, see
                 https://docs.aws.amazon.com/sagemaker/latest/dg/API_Tag.html.
             job_name (str): The name of the compilation job
-            compile_max_run (int): Timeout in seconds for compilation (default: 3 * 60).
-                After this amount of time Amazon SageMaker Neo terminates the compilation job regardless of its
-                current status.
-            framework (str): The framework that is used to train the original model. Allowed values: 'mxnet',
-                'tensorflow', 'pytorch', 'onnx', 'xgboost'
-            framework_version (str)
+            compile_max_run (int): Timeout in seconds for compilation (default:
+                3 * 60). After this amount of time Amazon SageMaker Neo
+                terminates the compilation job regardless of its current status.
+            framework (str): The framework that is used to train the original
+                model. Allowed values: 'mxnet', 'tensorflow', 'pytorch', 'onnx',
+                'xgboost'
+            framework_version (str):
+
         Returns:
-            sagemaker.model.Model: A SageMaker ``Model`` object. See :func:`~sagemaker.model.Model` for full details.
+            sagemaker.model.Model: A SageMaker ``Model`` object. See
+            :func:`~sagemaker.model.Model` for full details.
         """
         framework = self._framework() or framework
         if framework is None:
@@ -315,38 +365,50 @@ class Model(object):
         kms_key=None,
         wait=True,
     ):
-        """Deploy this ``Model`` to an ``Endpoint`` and optionally return a ``Predictor``.
+        """Deploy this ``Model`` to an ``Endpoint`` and optionally return a
+        ``Predictor``.
 
-        Create a SageMaker ``Model`` and ``EndpointConfig``, and deploy an ``Endpoint`` from this ``Model``.
-        If ``self.predictor_cls`` is not None, this method returns a the result of invoking
-        ``self.predictor_cls`` on the created endpoint name.
+        Create a SageMaker ``Model`` and ``EndpointConfig``, and deploy an
+        ``Endpoint`` from this ``Model``. If ``self.predictor_cls`` is not None,
+        this method returns a the result of invoking ``self.predictor_cls`` on
+        the created endpoint name.
 
-        The name of the created model is accessible in the ``name`` field of this ``Model`` after deploy returns
+        The name of the created model is accessible in the ``name`` field of
+        this ``Model`` after deploy returns
 
-        The name of the created endpoint is accessible in the ``endpoint_name``
-        field of this ``Model`` after deploy returns.
+        The name of the created endpoint is accessible in the
+        ``endpoint_name`` field of this ``Model`` after deploy returns.
 
         Args:
-            instance_type (str): The EC2 instance type to deploy this Model to. For example, 'ml.p2.xlarge'.
-            initial_instance_count (int): The initial number of instances to run in the
-                ``Endpoint`` created from this ``Model``.
-            accelerator_type (str): Type of Elastic Inference accelerator to deploy this model for model loading
-                and inference, for example, 'ml.eia1.medium'. If not specified, no Elastic Inference accelerator
-                will be attached to the endpoint.
-                For more information: https://docs.aws.amazon.com/sagemaker/latest/dg/ei.html
-            endpoint_name (str): The name of the endpoint to create (default: None).
-                If not specified, a unique endpoint name will be created.
-            update_endpoint (bool): Flag to update the model in an existing Amazon SageMaker endpoint.
-                If True, this will deploy a new EndpointConfig to an already existing endpoint and delete resources
-                corresponding to the previous EndpointConfig. If False, a new endpoint will be created. Default: False
-            tags(List[dict[str, str]]): The list of tags to attach to this specific endpoint.
-            kms_key (str): The ARN of the KMS key that is used to encrypt the data on the
-                storage volume attached to the instance hosting the endpoint.
-            wait (bool): Whether the call should wait until the deployment of this model completes (default: True).
+            initial_instance_count (int): The initial number of instances to run
+                in the ``Endpoint`` created from this ``Model``.
+            instance_type (str): The EC2 instance type to deploy this Model to.
+                For example, 'ml.p2.xlarge'.
+            accelerator_type (str): Type of Elastic Inference accelerator to
+                deploy this model for model loading and inference, for example,
+                'ml.eia1.medium'. If not specified, no Elastic Inference
+                accelerator will be attached to the endpoint. For more
+                information:
+                https://docs.aws.amazon.com/sagemaker/latest/dg/ei.html
+            endpoint_name (str): The name of the endpoint to create (default:
+                None). If not specified, a unique endpoint name will be created.
+            update_endpoint (bool): Flag to update the model in an existing
+                Amazon SageMaker endpoint. If True, this will deploy a new
+                EndpointConfig to an already existing endpoint and delete
+                resources corresponding to the previous EndpointConfig. If
+                False, a new endpoint will be created. Default: False
+            tags (List[dict[str, str]]): The list of tags to attach to this
+                specific endpoint.
+            kms_key (str): The ARN of the KMS key that is used to encrypt the
+                data on the storage volume attached to the instance hosting the
+                endpoint.
+            wait (bool): Whether the call should wait until the deployment of
+                this model completes (default: True).
 
         Returns:
             callable[string, sagemaker.session.Session] or None: Invocation of ``self.predictor_cls`` on
-                the created endpoint name, if ``self.predictor_cls`` is not None. Otherwise, return None.
+                the created endpoint name, if ``self.predictor_cls`` is not
+                None. Otherwise, return None.
         """
         if not self.sagemaker_session:
             if instance_type in ("local", "local_gpu"):
@@ -411,22 +473,30 @@ class Model(object):
 
         Args:
             instance_count (int): Number of EC2 instances to use.
-            instance_type (str): Type of EC2 instance to use, for example, 'ml.c4.xlarge'.
-            strategy (str): The strategy used to decide how to batch records in a single request (default: None).
-                Valid values: 'MULTI_RECORD' and 'SINGLE_RECORD'.
-            assemble_with (str): How the output is assembled (default: None). Valid values: 'Line' or 'None'.
-            output_path (str): S3 location for saving the transform result. If not specified, results are stored to
-                a default bucket.
-            output_kms_key (str): Optional. KMS key ID for encrypting the transform output (default: None).
-            accept (str): The content type accepted by the endpoint deployed during the transform job.
-            env (dict): Environment variables to be set for use during the transform job (default: None).
-            max_concurrent_transforms (int): The maximum number of HTTP requests to be made to
-                each individual transform container at one time.
-            max_payload (int): Maximum size of the payload in a single HTTP request to the container in MB.
-            tags (list[dict]): List of tags for labeling a transform job. If none specified, then the tags used for
-                the training job are used for the transform job.
-            volume_kms_key (str): Optional. KMS key ID for encrypting the volume attached to the ML
-                compute instance (default: None).
+            instance_type (str): Type of EC2 instance to use, for example,
+                'ml.c4.xlarge'.
+            strategy (str): The strategy used to decide how to batch records in
+                a single request (default: None). Valid values: 'MULTI_RECORD'
+                and 'SINGLE_RECORD'.
+            assemble_with (str): How the output is assembled (default: None).
+                Valid values: 'Line' or 'None'.
+            output_path (str): S3 location for saving the transform result. If
+                not specified, results are stored to a default bucket.
+            output_kms_key (str): Optional. KMS key ID for encrypting the
+                transform output (default: None).
+            accept (str): The content type accepted by the endpoint deployed
+                during the transform job.
+            env (dict): Environment variables to be set for use during the
+                transform job (default: None).
+            max_concurrent_transforms (int): The maximum number of HTTP requests
+                to be made to each individual transform container at one time.
+            max_payload (int): Maximum size of the payload in a single HTTP
+                request to the container in MB.
+            tags (list[dict]): List of tags for labeling a transform job. If
+                none specified, then the tags used for the training job are used
+                for the transform job.
+            volume_kms_key (str): Optional. KMS key ID for encrypting the volume
+                attached to the ML compute instance (default: None).
         """
         self._create_sagemaker_model(instance_type)
         if self.enable_network_isolation():
@@ -455,7 +525,6 @@ class Model(object):
 
         Raises:
             ValueError: if the model is not created yet.
-
         """
         if self.name is None:
             raise ValueError(
@@ -477,7 +546,8 @@ SAGEMAKER_OUTPUT_LOCATION = "sagemaker_s3_output"
 class FrameworkModel(Model):
     """A Model for working with an SageMaker ``Framework``.
 
-    This class hosts user-defined code in S3 and sets code location and configuration in model environment variables.
+    This class hosts user-defined code in S3 and sets code location and
+    configuration in model environment variables.
     """
 
     def __init__(
@@ -501,14 +571,17 @@ class FrameworkModel(Model):
         """Initialize a ``FrameworkModel``.
 
         Args:
-            model_data (str): The S3 location of a SageMaker model data ``.tar.gz`` file.
+            model_data (str): The S3 location of a SageMaker model data
+                ``.tar.gz`` file.
             image (str): A Docker image URI.
-            role (str): An IAM role name or ARN for SageMaker to access AWS resources on your behalf.
-            entry_point (str): Path (absolute or relative) to the Python source file which should be executed
-                as the entry point to model hosting. This should be compatible with either Python 2.7 or Python 3.5.
-                If 'git_config' is provided, 'entry_point' should be a relative location to the Python source file in
-                the Git repo.
-                Example:
+            role (str): An IAM role name or ARN for SageMaker to access AWS
+                resources on your behalf.
+            entry_point (str): Path (absolute or relative) to the Python source
+                file which should be executed as the entry point to model
+                hosting. This should be compatible with either Python 2.7 or
+                Python 3.5. If 'git_config' is provided, 'entry_point' should be
+                a relative location to the Python source file in the Git repo.
+                Example
 
                     With the following GitHub repo directory structure:
 
@@ -518,46 +591,14 @@ class FrameworkModel(Model):
                     >>>         |----- test.py
 
                     You can assign entry_point='src/inference.py'.
-            git_config (dict[str, str]): Git configurations used for cloning files, including ``repo``, ``branch``,
-                ``commit``, ``2FA_enabled``, ``username``, ``password`` and ``token``. The ``repo`` field is required.
-                All other fields are optional. ``repo`` specifies the Git repository where your training script is
-                stored. If you don't provide ``branch``, the default value  'master' is used. If you don't provide
-                ``commit``, the latest commit in the specified branch is used.
-                Example:
-
-                    The following config:
-
-                    >>> git_config = {'repo': 'https://github.com/aws/sagemaker-python-sdk.git',
-                    >>>               'branch': 'test-branch-git-config',
-                    >>>               'commit': '329bfcf884482002c05ff7f44f62599ebc9f445a'}
-
-                    results in cloning the repo specified in 'repo', then checkout the 'master' branch, and checkout
-                    the specified commit.
-                ``2FA_enabled``, ``username``, ``password`` and ``token`` are used for authentication. For GitHub
-                (or other Git) accounts, set ``2FA_enabled`` to 'True' if two-factor authentication is enabled for the
-                account, otherwise set it to 'False'. If you do not provide a value for ``2FA_enabled``, a default
-                value of 'False' is used. CodeCommit does not support two-factor authentication, so do not provide
-                "2FA_enabled" with CodeCommit repositories.
-
-                For GitHub and other Git repos, when SSH URLs are provided, it doesn't matter whether 2FA is
-                enabled or disabled; you should either have no passphrase for the SSH key pairs, or have the ssh-agent
-                configured so that you will not be prompted for SSH passphrase when you do 'git clone' command with SSH
-                URLs. When HTTPS URLs are provided: if 2FA is disabled, then either token or username+password will be
-                used for authentication if provided (token prioritized); if 2FA is enabled, only token will be used for
-                authentication if provided. If required authentication info is not provided, python SDK will try to use
-                local credentials storage to authenticate. If that fails either, an error message will be thrown.
-
-                For CodeCommit repos, 2FA is not supported, so '2FA_enabled' should not be provided. There is no token
-                in CodeCommit, so 'token' should not be provided too. When 'repo' is an SSH URL, the requirements are
-                the same as GitHub-like repos. When 'repo' is an HTTPS URL, username+password will be used for
-                authentication if they are provided; otherwise, python SDK will try to use either CodeCommit credential
-                helper or local credential storage for authentication.
-            source_dir (str): Path (absolute or relative) to a directory with any other training
-                source code dependencies aside from the entry point file (default: None). Structure within this
-                directory will be preserved when training on SageMaker. If 'git_config' is provided,
-                'source_dir' should be a relative location to a directory in the Git repo. If the directory points
-                to S3, no code will be uploaded and the S3 location will be used instead.
-                Example:
+            source_dir (str): Path (absolute or relative) to a directory with
+                any other training source code dependencies aside from the entry
+                point file (default: None). Structure within this directory will
+                be preserved when training on SageMaker. If 'git_config' is
+                provided, 'source_dir' should be a relative location to a
+                directory in the Git repo. If the directory points to S3, no
+                code will be uploaded and the S3 location will be used instead.
+                .. admonition:: Example
 
                     With the following GitHub repo directory structure:
 
@@ -567,17 +608,40 @@ class FrameworkModel(Model):
                     >>>         |----- test.py
 
                     You can assign entry_point='inference.py', source_dir='src'.
-            dependencies (list[str]): A list of paths to directories (absolute or relative) with
-                any additional libraries that will be exported to the container (default: []).
-                The library folders will be copied to SageMaker in the same folder where the entrypoint is copied.
-                If 'git_config' is provided, 'dependencies' should be a list of relative locations to directories
-                with any additional libraries needed in the Git repo. If the ```source_dir``` points to S3, code
-                will be uploaded and the S3 location will be used instead.
-                Example:
+            predictor_cls (callable[string, sagemaker.session.Session]): A
+                function to call to create a predictor (default: None). If not
+                None, ``deploy`` will return the result of invoking this
+                function on the created endpoint name.
+            env (dict[str, str]): Environment variables to run with ``image``
+                when hosted in SageMaker (default: None).
+            name (str): The model name. If None, a default model name will be
+                selected on each ``deploy``.
+            enable_cloudwatch_metrics (bool): Whether training and hosting
+                containers will generate CloudWatch metrics under the
+                AWS/SageMakerContainer namespace (default: False).
+            container_log_level (int): Log level to use within the container
+                (default: logging.INFO). Valid values are defined in the Python
+                logging module.
+            code_location (str): Name of the S3 bucket where custom code is
+                uploaded (default: None). If not specified, default bucket
+                created by ``sagemaker.session.Session`` is used.
+            sagemaker_session (sagemaker.session.Session): A SageMaker Session
+                object, used for SageMaker interactions (default: None). If not
+                specified, one is created using the default AWS configuration
+                chain.
+            dependencies (list[str]): A list of paths to directories (absolute
+                or relative) with any additional libraries that will be exported
+                to the container (default: []). The library folders will be
+                copied to SageMaker in the same folder where the entrypoint is
+                copied. If 'git_config' is provided, 'dependencies' should be a
+                list of relative locations to directories with any additional
+                libraries needed in the Git repo. If the ```source_dir``` points
+                to S3, code will be uploaded and the S3 location will be used
+                instead. .. admonition:: Example
 
-                    The following call
-                    >>> Estimator(entry_point='inference.py', dependencies=['my/libs/common', 'virtual-env'])
-                    results in the following inside the container:
+                    The following call >>> Estimator(entry_point='inference.py',
+                    dependencies=['my/libs/common', 'virtual-env']) results in
+                    the following inside the container:
 
                     >>> $ ls
 
@@ -585,21 +649,55 @@ class FrameworkModel(Model):
                     >>>     |------ inference.py
                     >>>     |------ common
                     >>>     |------ virtual-env
+            git_config (dict[str, str]): Git configurations used for cloning
+                files, including ``repo``, ``branch``, ``commit``,
+                ``2FA_enabled``, ``username``, ``password`` and ``token``. The
+                ``repo`` field is required. All other fields are optional.
+                ``repo`` specifies the Git repository where your training script
+                is stored. If you don't provide ``branch``, the default value
+                'master' is used. If you don't provide ``commit``, the latest
+                commit in the specified branch is used. .. admonition:: Example
 
-            predictor_cls (callable[string, sagemaker.session.Session]): A function to call to create
-               a predictor (default: None). If not None, ``deploy`` will return the result of invoking
-               this function on the created endpoint name.
-            env (dict[str, str]): Environment variables to run with ``image`` when hosted in SageMaker
-               (default: None).
-            name (str): The model name. If None, a default model name will be selected on each ``deploy``.
-            enable_cloudwatch_metrics (bool): Whether training and hosting containers will
-               generate CloudWatch metrics under the AWS/SageMakerContainer namespace (default: False).
-            container_log_level (int): Log level to use within the container (default: logging.INFO).
-                Valid values are defined in the Python logging module.
-            code_location (str): Name of the S3 bucket where custom code is uploaded (default: None).
-                If not specified, default bucket created by ``sagemaker.session.Session`` is used.
-            sagemaker_session (sagemaker.session.Session): A SageMaker Session object, used for SageMaker
-               interactions (default: None). If not specified, one is created using the default AWS configuration chain.
+                    The following config:
+
+                    >>> git_config = {'repo': 'https://github.com/aws/sagemaker-python-sdk.git',
+                    >>>               'branch': 'test-branch-git-config',
+                    >>>               'commit': '329bfcf884482002c05ff7f44f62599ebc9f445a'}
+
+                    results in cloning the repo specified in 'repo', then
+                    checkout the 'master' branch, and checkout the specified
+                    commit.
+
+                ``2FA_enabled``, ``username``, ``password`` and ``token`` are
+                used for authentication. For GitHub (or other Git) accounts, set
+                ``2FA_enabled`` to 'True' if two-factor authentication is
+                enabled for the account, otherwise set it to 'False'. If you do
+                not provide a value for ``2FA_enabled``, a default value of
+                'False' is used. CodeCommit does not support two-factor
+                authentication, so do not provide "2FA_enabled" with CodeCommit
+                repositories.
+
+                For GitHub and other Git repos, when SSH URLs are provided, it
+                doesn't matter whether 2FA is enabled or disabled; you should
+                either have no passphrase for the SSH key pairs, or have the
+                ssh-agent configured so that you will not be prompted for SSH
+                passphrase when you do 'git clone' command with SSH URLs. When
+                HTTPS URLs are provided: if 2FA is disabled, then either token
+                or username+password will be used for authentication if provided
+                (token prioritized); if 2FA is enabled, only token will be used
+                for authentication if provided. If required authentication info
+                is not provided, python SDK will try to use local credentials
+                storage to authenticate. If that fails either, an error message
+                will be thrown.
+
+                For CodeCommit repos, 2FA is not supported, so '2FA_enabled'
+                should not be provided. There is no token in CodeCommit, so
+                'token' should not be provided too. When 'repo' is an SSH URL,
+                the requirements are the same as GitHub-like repos. When 'repo'
+                is an HTTPS URL, username+password will be used for
+                authentication if they are provided; otherwise, python SDK will
+                try to use either CodeCommit credential helper or local
+                credential storage for authentication.
             **kwargs: Keyword arguments passed to the ``Model`` initializer.
         """
         super(FrameworkModel, self).__init__(
@@ -635,17 +733,21 @@ class FrameworkModel(Model):
     def prepare_container_def(
         self, instance_type, accelerator_type=None
     ):  # pylint disable=unused-argument
-        """Return a container definition with framework configuration set in model environment variables.
+        """Return a container definition with framework configuration set in
+        model environment variables.
 
         This also uploads user-supplied code to S3.
 
         Args:
-            instance_type (str): The EC2 instance type to deploy this Model to. For example, 'ml.p2.xlarge'.
-            accelerator_type (str): The Elastic Inference accelerator type to deploy to the instance for loading and
-                making inferences to the model. For example, 'ml.eia1.medium'.
+            instance_type (str): The EC2 instance type to deploy this Model to.
+                For example, 'ml.p2.xlarge'.
+            accelerator_type (str): The Elastic Inference accelerator type to
+                deploy to the instance for loading and making inferences to the
+                model. For example, 'ml.eia1.medium'.
 
         Returns:
-            dict[str, str]: A container definition object usable with the CreateModel API.
+            dict[str, str]: A container definition object usable with the
+            CreateModel API.
         """
         deploy_key_prefix = fw_utils.model_code_key_prefix(self.key_prefix, self.name, self.image)
         self._upload_code(deploy_key_prefix)
@@ -654,6 +756,11 @@ class FrameworkModel(Model):
         return sagemaker.container_def(self.image, self.model_data, deploy_env)
 
     def _upload_code(self, key_prefix, repack=False):
+        """
+        Args:
+            key_prefix:
+            repack:
+        """
         local_code = utils.get_config_value("local.local_code", self.sagemaker_session.config)
         if self.sagemaker_session.local_mode and local_code:
             self.uploaded_code = None
@@ -687,6 +794,7 @@ class FrameworkModel(Model):
             )
 
     def _framework_env_vars(self):
+        """Placeholder docstring"""
         if self.uploaded_code:
             script_name = self.uploaded_code.script_name
             dir_name = self.uploaded_code.s3_prefix
@@ -710,16 +818,19 @@ class ModelPackage(Model):
         """Initialize a SageMaker ModelPackage.
 
         Args:
-            role (str): An AWS IAM role (either name or full ARN). The Amazon SageMaker training jobs and APIs
-                that create Amazon SageMaker endpoints use this role to access training data and model artifacts.
-                After the endpoint is created, the inference code might use the IAM role,
-                if it needs to access an AWS resource.
-            model_data (str): The S3 location of a SageMaker model data ``.tar.gz`` file. Must be
-                provided if algorithm_arn is provided.
-            algorithm_arn (str): algorithm arn used to train the model, can be just the name if your
-                account owns the algorithm. Must also provide ``model_data``.
-            model_package_arn (str): An existing SageMaker Model Package arn, can be just the name if
-                your account owns the Model Package. ``model_data`` is not required.
+            role (str): An AWS IAM role (either name or full ARN). The Amazon
+                SageMaker training jobs and APIs that create Amazon SageMaker
+                endpoints use this role to access training data and model
+                artifacts. After the endpoint is created, the inference code
+                might use the IAM role, if it needs to access an AWS resource.
+            model_data (str): The S3 location of a SageMaker model data
+                ``.tar.gz`` file. Must be provided if algorithm_arn is provided.
+            algorithm_arn (str): algorithm arn used to train the model, can be
+                just the name if your account owns the algorithm. Must also
+                provide ``model_data``.
+            model_package_arn (str): An existing SageMaker Model Package arn,
+                can be just the name if your account owns the Model Package.
+                ``model_data`` is not required.
             **kwargs: Additional kwargs passed to the Model constructor.
         """
         super(ModelPackage, self).__init__(role=role, model_data=model_data, image=None, **kwargs)
@@ -746,6 +857,7 @@ class ModelPackage(Model):
         self._created_model_package_name = None
 
     def _create_sagemaker_model_package(self):
+        """Placeholder docstring"""
         if self.algorithm_arn is None:
             raise ValueError("No algorithm_arn was provided to create a SageMaker Model Pacakge")
 
@@ -757,7 +869,8 @@ class ModelPackage(Model):
         return name
 
     def enable_network_isolation(self):
-        """Whether to enable network isolation when creating a model out of this ModelPackage
+        """Whether to enable network isolation when creating a model out of this
+        ModelPackage
 
         Returns:
             bool: If network isolation should be enabled or not.
@@ -765,6 +878,7 @@ class ModelPackage(Model):
         return self._is_marketplace()
 
     def _is_marketplace(self):
+        """Placeholder docstring"""
         model_package_name = self.model_package_arn or self._created_model_package_name
         if model_package_name is None:
             return True
@@ -785,8 +899,8 @@ class ModelPackage(Model):
         """Create a SageMaker Model Entity
 
         Args:
-            *args: Arguments coming from the caller. This class
-                does not require any so they are ignored.
+            *args: Arguments coming from the caller. This class does not require
+                any so they are ignored.
         """
         if self.algorithm_arn:
             # When ModelPackage is created using an algorithm_arn we need to first

--- a/src/sagemaker/mxnet/__init__.py
+++ b/src/sagemaker/mxnet/__init__.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import absolute_import  # noqa: F401
 
 from sagemaker.mxnet.estimator import MXNet  # noqa: F401

--- a/src/sagemaker/mxnet/defaults.py
+++ b/src/sagemaker/mxnet/defaults.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import absolute_import
 
 MXNET_VERSION = "1.2"

--- a/src/sagemaker/mxnet/estimator.py
+++ b/src/sagemaker/mxnet/estimator.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import absolute_import
 
 import logging
@@ -48,44 +49,57 @@ class MXNet(Framework):
         distributions=None,
         **kwargs
     ):
-        """
-        This ``Estimator`` executes an MXNet script in a managed MXNet execution environment, within a SageMaker
-        Training Job. The managed MXNet environment is an Amazon-built Docker container that executes functions
-        defined in the supplied ``entry_point`` Python script.
+        """This ``Estimator`` executes an MXNet script in a managed MXNet
+        execution environment, within a SageMaker Training Job. The managed
+        MXNet environment is an Amazon-built Docker container that executes
+        functions defined in the supplied ``entry_point`` Python script.
 
-        Training is started by calling :meth:`~sagemaker.amazon.estimator.Framework.fit` on this Estimator.
-        After training is complete, calling :meth:`~sagemaker.amazon.estimator.Framework.deploy` creates a
-        hosted SageMaker endpoint and returns an :class:`~sagemaker.amazon.mxnet.model.MXNetPredictor` instance
-        that can be used to perform inference against the hosted model.
+        Training is started by calling
+        :meth:`~sagemaker.amazon.estimator.Framework.fit` on this Estimator.
+        After training is complete, calling
+        :meth:`~sagemaker.amazon.estimator.Framework.deploy` creates a hosted
+        SageMaker endpoint and returns an
+        :class:`~sagemaker.amazon.mxnet.model.MXNetPredictor` instance that can
+        be used to perform inference against the hosted model.
 
-        Technical documentation on preparing MXNet scripts for SageMaker training and using the MXNet Estimator is
-        available on the project home-page: https://github.com/aws/sagemaker-python-sdk
+        Technical documentation on preparing MXNet scripts for SageMaker
+        training and using the MXNet Estimator is available on the project
+        home-page: https://github.com/aws/sagemaker-python-sdk
 
         Args:
-            entry_point (str): Path (absolute or relative) to the Python source file which should be executed
-                as the entry point to training. This should be compatible with either Python 2.7 or Python 3.5.
-            source_dir (str): Path (absolute or relative) to a directory with any other training
-                source code dependencies aside from tne entry point file (default: None). Structure within this
-                directory are preserved when training on Amazon SageMaker.
-            hyperparameters (dict): Hyperparameters that will be used for training (default: None).
-                The hyperparameters are made accessible as a dict[str, str] to the training code on SageMaker.
-                For convenience, this accepts other types for keys and values, but ``str()`` will be called
-                to convert them before training.
-            py_version (str): Python version you want to use for executing your model training code (default: 'py2').
-                One of 'py2' or 'py3'.
-            framework_version (str): MXNet version you want to use for executing your model training code.
-                List of supported versions https://github.com/aws/sagemaker-python-sdk#mxnet-sagemaker-estimators.
+            entry_point (str): Path (absolute or relative) to the Python source
+                file which should be executed as the entry point to training.
+                This should be compatible with either Python 2.7 or Python 3.5.
+            source_dir (str): Path (absolute or relative) to a directory with
+                any other training source code dependencies aside from tne entry
+                point file (default: None). Structure within this directory are
+                preserved when training on Amazon SageMaker.
+            hyperparameters (dict): Hyperparameters that will be used for
+                training (default: None). The hyperparameters are made
+                accessible as a dict[str, str] to the training code on
+                SageMaker. For convenience, this accepts other types for keys
+                and values, but ``str()`` will be called to convert them before
+                training.
+            py_version (str): Python version you want to use for executing your
+                model training code (default: 'py2'). One of 'py2' or 'py3'.
+            framework_version (str): MXNet version you want to use for executing
+                your model training code. List of supported versions
+                https://github.com/aws/sagemaker-python-sdk#mxnet-sagemaker-estimators.
                 If not specified, this will default to 1.2.1.
             image_name (str): If specified, the estimator will use this image for training and hosting, instead of
-                selecting the appropriate SageMaker official image based on framework_version and py_version. It can
-                be an ECR url or dockerhub image and tag.
+                    selecting the appropriate SageMaker official image based on
+                    framework_version and py_version. It can be an ECR url or
+                    dockerhub image and tag.
 
-                Examples:
-                    123.dkr.ecr.us-west-2.amazonaws.com/my-custom-image:1.0
-                    custom-image:latest.
-             distributions (dict): A dictionary with information on how to run distributed training
-                (default: None).
-            **kwargs: Additional kwargs passed to the :class:`~sagemaker.estimator.Framework` constructor.
+                    Examples:
+                        123.dkr.ecr.us-west-2.amazonaws.com/my-custom-image:1.0
+                        custom-image:latest.
+
+                distributions (dict): A dictionary with information on how to run distributed training
+                    (default: None).
+            distributions:
+            **kwargs: Additional kwargs passed to the
+                :class:`~sagemaker.estimator.Framework` constructor.
         """
         if framework_version is None:
             logger.warning(empty_framework_version_warning(MXNET_VERSION, self.LATEST_VERSION))
@@ -102,6 +116,10 @@ class MXNet(Framework):
         self._configure_distribution(distributions)
 
     def _configure_distribution(self, distributions):
+        """
+        Args:
+            distributions:
+        """
         if distributions is None:
             return
 
@@ -119,21 +137,24 @@ class MXNet(Framework):
     def create_model(
         self, model_server_workers=None, role=None, vpc_config_override=VPC_CONFIG_DEFAULT
     ):
-        """Create a SageMaker ``MXNetModel`` object that can be deployed to an ``Endpoint``.
+        """Create a SageMaker ``MXNetModel`` object that can be deployed to an
+        ``Endpoint``.
 
         Args:
-            role (str): The ``ExecutionRoleArn`` IAM Role ARN for the ``Model``, which is also used during
-                transform jobs. If not specified, the role from the Estimator will be used.
-            model_server_workers (int): Optional. The number of worker processes used by the inference server.
-                If None, server will use one worker per vCPU.
-            vpc_config_override (dict[str, list[str]]): Optional override for VpcConfig set on the model.
-                Default: use subnets and security groups from this Estimator.
+            model_server_workers (int): Optional. The number of worker processes
+                used by the inference server. If None, server will use one
+                worker per vCPU.
+            role (str): The ``ExecutionRoleArn`` IAM Role ARN for the ``Model``,
+                which is also used during transform jobs. If not specified, the
+                role from the Estimator will be used.
+            vpc_config_override (dict[str, list[str]]): Optional override for VpcConfig set on
+                the model. Default: use subnets and security groups from this Estimator.
                 * 'Subnets' (list[str]): List of subnet ids.
                 * 'SecurityGroupIds' (list[str]): List of security group ids.
 
         Returns:
             sagemaker.mxnet.model.MXNetModel: A SageMaker ``MXNetModel`` object.
-                See :func:`~sagemaker.mxnet.model.MXNetModel` for full details.
+            See :func:`~sagemaker.mxnet.model.MXNetModel` for full details.
         """
         role = role or self.role
         return MXNetModel(
@@ -156,15 +177,17 @@ class MXNet(Framework):
 
     @classmethod
     def _prepare_init_params_from_job_description(cls, job_details, model_channel_name=None):
-        """Convert the job description to init params that can be handled by the class constructor
+        """Convert the job description to init params that can be handled by the
+        class constructor
 
         Args:
-            job_details: the returned job details from a describe_training_job API call.
-            model_channel_name (str): Name of the channel where pre-trained model data will be downloaded.
+            job_details: the returned job details from a describe_training_job
+                API call.
+            model_channel_name (str): Name of the channel where pre-trained
+                model data will be downloaded.
 
         Returns:
             dictionary: The transformed init_params
-
         """
         init_params = super(MXNet, cls)._prepare_init_params_from_job_description(
             job_details, model_channel_name

--- a/src/sagemaker/mxnet/model.py
+++ b/src/sagemaker/mxnet/model.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import absolute_import
 
 import logging
@@ -28,16 +29,19 @@ logger = logging.getLogger("sagemaker")
 class MXNetPredictor(RealTimePredictor):
     """A RealTimePredictor for inference against MXNet Endpoints.
 
-    This is able to serialize Python lists, dictionaries, and numpy arrays to multidimensional tensors for MXNet
-    inference."""
+    This is able to serialize Python lists, dictionaries, and numpy arrays to
+    multidimensional tensors for MXNet inference.
+    """
 
     def __init__(self, endpoint_name, sagemaker_session=None):
         """Initialize an ``MXNetPredictor``.
 
         Args:
-            endpoint_name (str): The name of the endpoint to perform inference on.
-            sagemaker_session (sagemaker.session.Session): Session object which manages interactions with
-                Amazon SageMaker APIs and any other AWS services needed. If not specified, the estimator creates one
+            endpoint_name (str): The name of the endpoint to perform inference
+                on.
+            sagemaker_session (sagemaker.session.Session): Session object which
+                manages interactions with Amazon SageMaker APIs and any other
+                AWS services needed. If not specified, the estimator creates one
                 using the default AWS configuration chain.
         """
         super(MXNetPredictor, self).__init__(
@@ -66,22 +70,32 @@ class MXNetModel(FrameworkModel):
         """Initialize an MXNetModel.
 
         Args:
-            model_data (str): The S3 location of a SageMaker model data ``.tar.gz`` file.
-            role (str): An AWS IAM role (either name or full ARN). The Amazon SageMaker training jobs and APIs
-                that create Amazon SageMaker endpoints use this role to access training data and model artifacts.
-                After the endpoint is created, the inference code might use the IAM role,
-                if it needs to access an AWS resource.
-            entry_point (str): Path (absolute or relative) to the Python source file which should be executed
-                as the entry point to model hosting. This should be compatible with either Python 2.7 or Python 3.5.
-            image (str): A Docker image URI (default: None). If not specified, a default image for MXNet will be used.
-            py_version (str): Python version you want to use for executing your model training code (default: 'py2').
-            framework_version (str): MXNet version you want to use for executing your model training code.
-            predictor_cls (callable[str, sagemaker.session.Session]): A function to call to create a predictor
-                with an endpoint name and SageMaker ``Session``. If specified, ``deploy()`` returns the result of
-                invoking this function on the created endpoint name.
-            model_server_workers (int): Optional. The number of worker processes used by the inference server.
-                If None, server will use one worker per vCPU.
-            **kwargs: Keyword arguments passed to the ``FrameworkModel`` initializer.
+            model_data (str): The S3 location of a SageMaker model data
+                ``.tar.gz`` file.
+            role (str): An AWS IAM role (either name or full ARN). The Amazon
+                SageMaker training jobs and APIs that create Amazon SageMaker
+                endpoints use this role to access training data and model
+                artifacts. After the endpoint is created, the inference code
+                might use the IAM role, if it needs to access an AWS resource.
+            entry_point (str): Path (absolute or relative) to the Python source
+                file which should be executed as the entry point to model
+                hosting. This should be compatible with either Python 2.7 or
+                Python 3.5.
+            image (str): A Docker image URI (default: None). If not specified, a
+                default image for MXNet will be used.
+            py_version (str): Python version you want to use for executing your
+                model training code (default: 'py2').
+            framework_version (str): MXNet version you want to use for executing
+                your model training code.
+            predictor_cls (callable[str, sagemaker.session.Session]): A function
+                to call to create a predictor with an endpoint name and
+                SageMaker ``Session``. If specified, ``deploy()`` returns the
+                result of invoking this function on the created endpoint name.
+            model_server_workers (int): Optional. The number of worker processes
+                used by the inference server. If None, server will use one
+                worker per vCPU.
+            **kwargs: Keyword arguments passed to the ``FrameworkModel``
+                initializer.
         """
         super(MXNetModel, self).__init__(
             model_data, image, role, entry_point, predictor_cls=predictor_cls, **kwargs
@@ -95,15 +109,19 @@ class MXNetModel(FrameworkModel):
         self.model_server_workers = model_server_workers
 
     def prepare_container_def(self, instance_type, accelerator_type=None):
-        """Return a container definition with framework configuration set in model environment variables.
+        """Return a container definition with framework configuration set in
+        model environment variables.
 
         Args:
-            instance_type (str): The EC2 instance type to deploy this Model to. For example, 'ml.p2.xlarge'.
-            accelerator_type (str): The Elastic Inference accelerator type to deploy to the instance for loading and
-                making inferences to the model. For example, 'ml.eia1.medium'.
+            instance_type (str): The EC2 instance type to deploy this Model to.
+                For example, 'ml.p2.xlarge'.
+            accelerator_type (str): The Elastic Inference accelerator type to
+                deploy to the instance for loading and making inferences to the
+                model. For example, 'ml.eia1.medium'.
 
         Returns:
-            dict[str, str]: A container definition object usable with the CreateModel API.
+            dict[str, str]: A container definition object usable with the
+            CreateModel API.
         """
         is_mms_version = parse_version(self.framework_version) >= parse_version(
             self._LOWEST_MMS_VERSION

--- a/src/sagemaker/parameter.py
+++ b/src/sagemaker/parameter.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import absolute_import
 import json
 
@@ -17,10 +18,9 @@ from sagemaker.utils import to_str
 
 
 class ParameterRange(object):
-    """Base class for representing parameter ranges. This is used to define
-    what hyperparameters to tune for an Amazon SageMaker hyperparameter tuning job and to verify
-    hyperparameters for Marketplace Algorithms.
-
+    """Base class for representing parameter ranges. This is used to define what
+    hyperparameters to tune for an Amazon SageMaker hyperparameter tuning job
+    and to verify hyperparameters for Marketplace Algorithms.
     """
 
     __all_types__ = ("Continuous", "Categorical", "Integer")
@@ -31,8 +31,9 @@ class ParameterRange(object):
         Args:
             min_value (float or int): The minimum value for the range.
             max_value (float or int): The maximum value for the range.
-            scaling_type (str): The scale used for searching the range during tuning (default: 'Auto').
-                Valid values: 'Auto', 'Linear', 'Logarithmic' and 'ReverseLogarithmic'.
+            scaling_type (str): The scale used for searching the range during
+                tuning (default: 'Auto'). Valid values: 'Auto', 'Linear',
+                'Logarithmic' and 'ReverseLogarithmic'.
         """
         self.min_value = min_value
         self.max_value = max_value
@@ -51,17 +52,22 @@ class ParameterRange(object):
 
     @classmethod
     def cast_to_type(cls, value):
+        """
+        Args:
+            value:
+        """
         return float(value)
 
     def as_tuning_range(self, name):
-        """Represent the parameter range as a dicionary suitable for a request to
-        create an Amazon SageMaker hyperparameter tuning job.
+        """Represent the parameter range as a dicionary suitable for a request
+        to create an Amazon SageMaker hyperparameter tuning job.
 
         Args:
             name (str): The name of the hyperparameter.
 
         Returns:
-            dict[str, str]: A dictionary that contains the name and values of the hyperparameter.
+            dict[str, str]: A dictionary that contains the name and values of
+            the hyperparameter.
         """
         return {
             "Name": name,
@@ -73,6 +79,7 @@ class ParameterRange(object):
 
 class ContinuousParameter(ParameterRange):
     """A class for representing hyperparameters that have a continuous range of possible values.
+
     Args:
             min_value (float): The minimum value for the range.
             max_value (float): The maximum value for the range.
@@ -82,11 +89,16 @@ class ContinuousParameter(ParameterRange):
 
     @classmethod
     def cast_to_type(cls, value):
+        """
+        Args:
+            value:
+        """
         return float(value)
 
 
 class CategoricalParameter(ParameterRange):
-    """A class for representing hyperparameters that have a discrete list of possible values.
+    """A class for representing hyperparameters that have a discrete list of
+    possible values.
     """
 
     __name__ = "Categorical"
@@ -95,8 +107,8 @@ class CategoricalParameter(ParameterRange):
         """Initialize a ``CategoricalParameter``.
 
         Args:
-            values (list or object): The possible values for the hyperparameter. This input will
-                be converted into a list of strings.
+            values (list or object): The possible values for the hyperparameter.
+                This input will be converted into a list of strings.
         """
         if isinstance(values, list):
             self.values = [to_str(v) for v in values]
@@ -104,22 +116,25 @@ class CategoricalParameter(ParameterRange):
             self.values = [to_str(values)]
 
     def as_tuning_range(self, name):
-        """Represent the parameter range as a dicionary suitable for a request to
-        create an Amazon SageMaker hyperparameter tuning job.
+        """Represent the parameter range as a dicionary suitable for a request
+        to create an Amazon SageMaker hyperparameter tuning job.
 
         Args:
             name (str): The name of the hyperparameter.
 
         Returns:
-            dict[str, list[str]]: A dictionary that contains the name and values of the hyperparameter.
+            dict[str, list[str]]: A dictionary that contains the name and values
+            of the hyperparameter.
         """
         return {"Name": name, "Values": self.values}
 
     def as_json_range(self, name):
-        """Represent the parameter range as a dictionary suitable for a request to
-        create an Amazon SageMaker hyperparameter tuning job using one of the deep learning frameworks.
+        """Represent the parameter range as a dictionary suitable for a request
+        to create an Amazon SageMaker hyperparameter tuning job using one of the
+        deep learning frameworks.
 
-        The deep learning framework images require that hyperparameters be serialized as JSON.
+        The deep learning framework images require that hyperparameters be
+        serialized as JSON.
 
         Args:
             name (str): The name of the hyperparameter.
@@ -131,10 +146,18 @@ class CategoricalParameter(ParameterRange):
         return {"Name": name, "Values": [json.dumps(v) for v in self.values]}
 
     def is_valid(self, value):
+        """
+        Args:
+            value:
+        """
         return value in self.values
 
     @classmethod
     def cast_to_type(cls, value):
+        """
+        Args:
+            value:
+        """
         return to_str(value)
 
 
@@ -149,4 +172,8 @@ class IntegerParameter(ParameterRange):
 
     @classmethod
     def cast_to_type(cls, value):
+        """
+        Args:
+            value:
+        """
         return int(value)

--- a/src/sagemaker/pipeline.py
+++ b/src/sagemaker/pipeline.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import absolute_import
 
 import sagemaker
@@ -19,30 +20,39 @@ from sagemaker.transformer import Transformer
 
 
 class PipelineModel(object):
-    """A pipeline of SageMaker ``Model``s that can be deployed to an ``Endpoint``."""
+    """A pipeline of SageMaker
+    ``Model``s that can be deployed to an ``Endpoint``.
+    """
 
     def __init__(
         self, models, role, predictor_cls=None, name=None, vpc_config=None, sagemaker_session=None
     ):
-        """Initialize an SageMaker ``Model`` which can be used to build an Inference Pipeline comprising of multiple
-        model containers.
+        """Initialize an SageMaker ``Model`` which can be used to build an
+        Inference Pipeline comprising of multiple model containers.
 
         Args:
-            models (list[sagemaker.Model]): For using multiple containers to build an inference pipeline,
-            you can pass a list of ``sagemaker.Model`` objects in the order you want the inference to happen.
-            role (str): An AWS IAM role (either name or full ARN). The Amazon SageMaker training jobs and APIs
-                that create Amazon SageMaker endpoints use this role to access training data and model artifacts.
-                After the endpoint is created, the inference code might use the IAM role,
-                if it needs to access an AWS resource.
-            predictor_cls (callable[string, sagemaker.session.Session]): A function to call to create
-               a predictor (default: None). If not None, ``deploy`` will return the result of invoking
-               this function on the created endpoint name.
-            name (str): The model name. If None, a default model name will be selected on each ``deploy``.
-            vpc_config (dict[str, list[str]]): The VpcConfig set on the model (default: None)
+            models (list[sagemaker.Model]): For using multiple containers to
+                build an inference pipeline, you can pass a list of ``sagemaker.Model`` objects
+                in the order you want the inference to happen.
+            role (str): An AWS IAM role (either name or full ARN). The Amazon
+                SageMaker training jobs and APIs that create Amazon SageMaker
+                endpoints use this role to access training data and model
+                artifacts. After the endpoint is created, the inference code
+                might use the IAM role, if it needs to access an AWS resource.
+            predictor_cls (callable[string, sagemaker.session.Session]): A
+                function to call to create a predictor (default: None). If not
+                None, ``deploy`` will return the result of invoking this
+                function on the created endpoint name.
+            name (str): The model name. If None, a default model name will be
+                selected on each ``deploy``.
+            vpc_config (dict[str, list[str]]): The VpcConfig set on the model
+                (default: None)
                 * 'Subnets' (list[str]): List of subnet ids.
                 * 'SecurityGroupIds' (list[str]): List of security group ids.
-            sagemaker_session (sagemaker.session.Session): A SageMaker Session object, used for SageMaker
-               interactions (default: None). If not specified, one is created using the default AWS configuration chain.
+            sagemaker_session (sagemaker.session.Session): A SageMaker Session
+                object, used for SageMaker interactions (default: None). If not
+                specified, one is created using the default AWS configuration
+                chain.
         """
         self.models = models
         self.role = role
@@ -54,18 +64,20 @@ class PipelineModel(object):
         self.endpoint_name = None
 
     def pipeline_container_def(self, instance_type):
-        """Return a dict created by ``sagemaker.pipeline_container_def()`` for deploying this model to a specified
-         instance type.
+        """Return a dict created by ``sagemaker.pipeline_container_def()`` for
+        deploying this model to a specified instance type.
 
-        Subclasses can override this to provide custom container definitions for
-        deployment to a specific instance type. Called by ``deploy()``.
+        Subclasses can override this to provide custom container definitions
+        for deployment to a specific instance type. Called by ``deploy()``.
 
         Args:
-            instance_type (str): The EC2 instance type to deploy this Model to. For example, 'ml.p2.xlarge'.
+            instance_type (str): The EC2 instance type to deploy this Model to.
+                For example, 'ml.p2.xlarge'.
 
         Returns:
-            list[dict[str, str]]: A list of container definition objects usable with the CreateModel API in the scenario
-            of multiple containers (Inference Pipeline).
+            list[dict[str, str]]: A list of container definition objects usable
+            with the CreateModel API in the scenario of multiple containers
+            (Inference Pipeline).
         """
 
         return sagemaker.pipeline_container_def(self.models, instance_type)
@@ -73,29 +85,36 @@ class PipelineModel(object):
     def deploy(
         self, initial_instance_count, instance_type, endpoint_name=None, tags=None, wait=True
     ):
-        """Deploy this ``Model`` to an ``Endpoint`` and optionally return a ``Predictor``.
+        """Deploy this ``Model`` to an ``Endpoint`` and optionally return a
+        ``Predictor``.
 
-        Create a SageMaker ``Model`` and ``EndpointConfig``, and deploy an ``Endpoint`` from this ``Model``.
-        If ``self.predictor_cls`` is not None, this method returns a the result of invoking
-        ``self.predictor_cls`` on the created endpoint name.
+        Create a SageMaker ``Model`` and ``EndpointConfig``, and deploy an
+        ``Endpoint`` from this ``Model``. If ``self.predictor_cls`` is not None,
+        this method returns a the result of invoking ``self.predictor_cls`` on
+        the created endpoint name.
 
-        The name of the created model is accessible in the ``name`` field of this ``Model`` after deploy returns
+        The name of the created model is accessible in the ``name`` field of
+        this ``Model`` after deploy returns
 
-        The name of the created endpoint is accessible in the ``endpoint_name``
-        field of this ``Model`` after deploy returns.
+        The name of the created endpoint is accessible in the
+        ``endpoint_name`` field of this ``Model`` after deploy returns.
 
         Args:
-            instance_type (str): The EC2 instance type to deploy this Model to. For example, 'ml.p2.xlarge'.
-            initial_instance_count (int): The initial number of instances to run in the
-                ``Endpoint`` created from this ``Model``.
-            endpoint_name (str): The name of the endpoint to create (default: None).
-                If not specified, a unique endpoint name will be created.
-            tags(List[dict[str, str]]): The list of tags to attach to this specific endpoint.
-            wait (bool): Whether the call should wait until the deployment of model completes (default: True).
+            initial_instance_count (int): The initial number of instances to run
+                in the ``Endpoint`` created from this ``Model``.
+            instance_type (str): The EC2 instance type to deploy this Model to.
+                For example, 'ml.p2.xlarge'.
+            endpoint_name (str): The name of the endpoint to create (default:
+                None). If not specified, a unique endpoint name will be created.
+            tags (List[dict[str, str]]): The list of tags to attach to this
+                specific endpoint.
+            wait (bool): Whether the call should wait until the deployment of
+                model completes (default: True).
 
         Returns:
             callable[string, sagemaker.session.Session] or None: Invocation of ``self.predictor_cls`` on
-                the created endpoint name, if ``self.predictor_cls`` is not None. Otherwise, return None.
+                the created endpoint name, if ``self.predictor_cls`` is not
+                None. Otherwise, return None.
         """
         if not self.sagemaker_session:
             self.sagemaker_session = Session()
@@ -122,11 +141,9 @@ class PipelineModel(object):
         """Create a SageMaker Model Entity
 
         Args:
-            instance_type (str): The EC2 instance type that this Model will be used for, this is only
-                used to determine if the image needs GPU support or not.
-            accelerator_type (str): Type of Elastic Inference accelerator to attach to an endpoint for model loading
-                and inference, for example, 'ml.eia1.medium'. If not specified, no Elastic Inference accelerator
-                will be attached to the endpoint.
+            instance_type (str): The EC2 instance type that this Model will be
+                used for, this is only used to determine if the image needs GPU
+                support or not.
         """
         if not self.sagemaker_session:
             self.sagemaker_session = Session()
@@ -157,22 +174,30 @@ class PipelineModel(object):
 
         Args:
             instance_count (int): Number of EC2 instances to use.
-            instance_type (str): Type of EC2 instance to use, for example, 'ml.c4.xlarge'.
-            strategy (str): The strategy used to decide how to batch records in a single request (default: None).
-                Valid values: 'MULTI_RECORD' and 'SINGLE_RECORD'.
-            assemble_with (str): How the output is assembled (default: None). Valid values: 'Line' or 'None'.
-            output_path (str): S3 location for saving the transform result. If not specified, results are stored to
-                a default bucket.
-            output_kms_key (str): Optional. KMS key ID for encrypting the transform output (default: None).
-            accept (str): The content type accepted by the endpoint deployed during the transform job.
-            env (dict): Environment variables to be set for use during the transform job (default: None).
-            max_concurrent_transforms (int): The maximum number of HTTP requests to be made to
-                each individual transform container at one time.
-            max_payload (int): Maximum size of the payload in a single HTTP request to the container in MB.
-            tags (list[dict]): List of tags for labeling a transform job. If none specified, then the tags used for
-                the training job are used for the transform job.
-            volume_kms_key (str): Optional. KMS key ID for encrypting the volume attached to the ML
-                compute instance (default: None).
+            instance_type (str): Type of EC2 instance to use, for example,
+                'ml.c4.xlarge'.
+            strategy (str): The strategy used to decide how to batch records in
+                a single request (default: None). Valid values: 'MULTI_RECORD'
+                and 'SINGLE_RECORD'.
+            assemble_with (str): How the output is assembled (default: None).
+                Valid values: 'Line' or 'None'.
+            output_path (str): S3 location for saving the transform result. If
+                not specified, results are stored to a default bucket.
+            output_kms_key (str): Optional. KMS key ID for encrypting the
+                transform output (default: None).
+            accept (str): The content type accepted by the endpoint deployed
+                during the transform job.
+            env (dict): Environment variables to be set for use during the
+                transform job (default: None).
+            max_concurrent_transforms (int): The maximum number of HTTP requests
+                to be made to each individual transform container at one time.
+            max_payload (int): Maximum size of the payload in a single HTTP
+                request to the container in MB.
+            tags (list[dict]): List of tags for labeling a transform job. If
+                none specified, then the tags used for the training job are used
+                for the transform job.
+            volume_kms_key (str): Optional. KMS key ID for encrypting the volume
+                attached to the ML compute instance (default: None).
         """
         self._create_sagemaker_pipeline_model(instance_type)
 
@@ -195,9 +220,9 @@ class PipelineModel(object):
         )
 
     def delete_model(self):
-        """Delete the SageMaker model backing this pipeline model. This does not delete the list of SageMaker models used
-        in multiple containers to build the inference pipeline.
-
+        """Delete the SageMaker model backing this pipeline model. This does not
+        delete the list of SageMaker models used in multiple containers to build
+        the inference pipeline.
         """
 
         if self.name is None:

--- a/src/sagemaker/predictor.py
+++ b/src/sagemaker/predictor.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import print_function, absolute_import
 
 import codecs
@@ -24,8 +25,7 @@ from sagemaker.session import Session
 
 
 class RealTimePredictor(object):
-    """Make prediction requests to an Amazon SageMaker endpoint.
-    """
+    """Make prediction requests to an Amazon SageMaker endpoint."""
 
     def __init__(
         self,
@@ -38,24 +38,33 @@ class RealTimePredictor(object):
     ):
         """Initialize a ``RealTimePredictor``.
 
-        Behavior for serialization of input data and deserialization of result data
-        can be configured through initializer arguments. If not specified, a sequence
-        of bytes is expected and the API sends it in the request body without modifications.
-        In response, the API returns the sequence of bytes from the prediction result without any modifications.
+        Behavior for serialization of input data and deserialization of
+        result data can be configured through initializer arguments. If not
+        specified, a sequence of bytes is expected and the API sends it in the
+        request body without modifications. In response, the API returns the
+        sequence of bytes from the prediction result without any modifications.
 
         Args:
-            endpoint (str): Name of the Amazon SageMaker endpoint to which requests are sent.
-            sagemaker_session (sagemaker.session.Session): A SageMaker Session object, used for SageMaker
-               interactions (default: None). If not specified, one is created using the default AWS configuration chain.
-            serializer (callable): Accepts a single argument, the input data, and returns a sequence
-                of bytes. It may provide a ``content_type`` attribute that defines the endpoint request content type.
-                If not specified, a sequence of bytes is expected for the data.
-            deserializer (callable): Accepts two arguments, the result data and the response content type,
-                and returns a sequence of bytes. It may provide a ``content_type`` attribute that defines the endpoint
-                response's "Accept" content type. If not specified, a sequence of bytes is expected for the data.
-            content_type (str): The invocation's "ContentType", overriding any ``content_type`` from
-                the serializer (default: None).
-            accept (str): The invocation's "Accept", overriding any accept from the deserializer (default: None).
+            endpoint (str): Name of the Amazon SageMaker endpoint to which
+                requests are sent.
+            sagemaker_session (sagemaker.session.Session): A SageMaker Session
+                object, used for SageMaker interactions (default: None). If not
+                specified, one is created using the default AWS configuration
+                chain.
+            serializer (callable): Accepts a single argument, the input data,
+                and returns a sequence of bytes. It may provide a
+                ``content_type`` attribute that defines the endpoint request
+                content type. If not specified, a sequence of bytes is expected
+                for the data.
+            deserializer (callable): Accepts two arguments, the result data and
+                the response content type, and returns a sequence of bytes. It
+                may provide a ``content_type`` attribute that defines the
+                endpoint response's "Accept" content type. If not specified, a
+                sequence of bytes is expected for the data.
+            content_type (str): The invocation's "ContentType", overriding any
+                ``content_type`` from the serializer (default: None).
+            accept (str): The invocation's "Accept", overriding any accept from
+                the deserializer (default: None).
         """
         self.endpoint = endpoint
         self.sagemaker_session = sagemaker_session or Session()
@@ -70,17 +79,20 @@ class RealTimePredictor(object):
         """Return the inference from the specified endpoint.
 
         Args:
-            data (object): Input data for which you want the model to provide inference.
-                If a serializer was specified when creating the RealTimePredictor, the result of the
-                serializer is sent as input data. Otherwise the data must be sequence of bytes, and
-                the predict method then sends the bytes in the request body as is.
+            data (object): Input data for which you want the model to provide
+                inference. If a serializer was specified when creating the
+                RealTimePredictor, the result of the serializer is sent as input
+                data. Otherwise the data must be sequence of bytes, and the
+                predict method then sends the bytes in the request body as is.
             initial_args (dict[str,str]): Optional. Default arguments for boto3
-                ``invoke_endpoint`` call. Default is None (no default arguments).
+                ``invoke_endpoint`` call. Default is None (no default
+                arguments).
 
         Returns:
             object: Inference for the given input. If a deserializer was specified when creating
-                the RealTimePredictor, the result of the deserializer is returned. Otherwise the response
-                returns the sequence of bytes as is.
+                the RealTimePredictor, the result of the deserializer is
+                returned. Otherwise the response returns the sequence of bytes
+                as is.
         """
 
         request_args = self._create_request_args(data, initial_args)
@@ -88,6 +100,10 @@ class RealTimePredictor(object):
         return self._handle_response(response)
 
     def _handle_response(self, response):
+        """
+        Args:
+            response:
+        """
         response_body = response["Body"]
         if self.deserializer is not None:
             # It's the deserializer's responsibility to close the stream
@@ -97,6 +113,11 @@ class RealTimePredictor(object):
         return data
 
     def _create_request_args(self, data, initial_args=None):
+        """
+        Args:
+            data:
+            initial_args:
+        """
         args = dict(initial_args) if initial_args else {}
 
         if "EndpointName" not in args:
@@ -115,20 +136,19 @@ class RealTimePredictor(object):
         return args
 
     def _delete_endpoint_config(self):
-        """Delete the Amazon SageMaker endpoint configuration
-
-        """
+        """Delete the Amazon SageMaker endpoint configuration"""
         self.sagemaker_session.delete_endpoint_config(self._endpoint_config_name)
 
     def delete_endpoint(self, delete_endpoint_config=True):
-        """Delete the Amazon SageMaker endpoint backing this predictor. Also delete the endpoint configuration attached
-        to it if delete_endpoint_config is True.
+        """Delete the Amazon SageMaker endpoint backing this predictor. Also
+        delete the endpoint configuration attached to it if
+        delete_endpoint_config is True.
 
         Args:
-            delete_endpoint_config (bool, optional): Flag to indicate whether to delete endpoint configuration together
-                with endpoint. Defaults to True. If True, both endpoint and endpoint configuration will be deleted. If
-                False, only endpoint will be deleted.
-
+            delete_endpoint_config (bool, optional): Flag to indicate whether to
+                delete endpoint configuration together with endpoint. Defaults
+                to True. If True, both endpoint and endpoint configuration will
+                be deleted. If False, only endpoint will be deleted.
         """
         if delete_endpoint_config:
             self._delete_endpoint_config()
@@ -136,9 +156,7 @@ class RealTimePredictor(object):
         self.sagemaker_session.delete_endpoint(self.endpoint)
 
     def delete_model(self):
-        """Deletes the Amazon SageMaker models backing this predictor.
-
-        """
+        """Deletes the Amazon SageMaker models backing this predictor."""
         request_failed = False
         failed_models = []
         for model_name in self._model_names:
@@ -155,6 +173,7 @@ class RealTimePredictor(object):
             )
 
     def _get_endpoint_config_name(self):
+        """Placeholder docstring"""
         endpoint_desc = self.sagemaker_session.sagemaker_client.describe_endpoint(
             EndpointName=self.endpoint
         )
@@ -162,6 +181,7 @@ class RealTimePredictor(object):
         return endpoint_config_name
 
     def _get_model_names(self):
+        """Placeholder docstring"""
         endpoint_config = self.sagemaker_session.sagemaker_client.describe_endpoint_config(
             EndpointConfigName=self._endpoint_config_name
         )
@@ -170,7 +190,10 @@ class RealTimePredictor(object):
 
 
 class _CsvSerializer(object):
+    """Placeholder docstring"""
+
     def __init__(self):
+        """Placeholder docstring"""
         self.content_type = CONTENT_TYPE_CSV
 
     def __call__(self, data):
@@ -190,6 +213,10 @@ class _CsvSerializer(object):
     @staticmethod
     def _serialize_row(data):
         # Don't attempt to re-serialize a string
+        """
+        Args:
+            data:
+        """
         if isinstance(data, str):
             return data
         if isinstance(data, np.ndarray):
@@ -207,14 +234,26 @@ class _CsvSerializer(object):
 
 
 def _csv_serialize_python_array(data):
+    """
+    Args:
+        data:
+    """
     return _csv_serialize_object(data)
 
 
 def _csv_serialize_from_buffer(buff):
+    """
+    Args:
+        buff:
+    """
     return buff.read()
 
 
 def _csv_serialize_object(data):
+    """
+    Args:
+        data:
+    """
     csv_buffer = StringIO()
 
     csv_writer = csv.writer(csv_buffer, delimiter=",")
@@ -226,10 +265,18 @@ csv_serializer = _CsvSerializer()
 
 
 def _is_mutable_sequence_like(obj):
+    """
+    Args:
+        obj:
+    """
     return _is_sequence_like(obj) and hasattr(obj, "__setitem__")
 
 
 def _is_sequence_like(obj):
+    """
+    Args:
+        obj:
+    """
     # Need to explicitly check on str since str lacks the iterable magic methods in Python 2
     return (  # pylint: disable=consider-using-ternary
         hasattr(obj, "__iter__") and hasattr(obj, "__getitem__")
@@ -237,17 +284,32 @@ def _is_sequence_like(obj):
 
 
 def _row_to_csv(obj):
+    """
+    Args:
+        obj:
+    """
     if isinstance(obj, str):
         return obj
     return ",".join(obj)
 
 
 class _CsvDeserializer(object):
+    """Placeholder docstring"""
+
     def __init__(self, encoding="utf-8"):
+        """
+        Args:
+            encoding:
+        """
         self.accept = CONTENT_TYPE_CSV
         self.encoding = encoding
 
     def __call__(self, stream, content_type):
+        """
+        Args:
+            stream:
+            content_type:
+        """
         try:
             return list(csv.reader(stream.read().decode(self.encoding).splitlines()))
         finally:
@@ -260,14 +322,23 @@ csv_deserializer = _CsvDeserializer()
 class BytesDeserializer(object):
     """Return the response as an undecoded array of bytes.
 
-       Args:
-            accept (str): The Accept header to send to the server (optional).
+    Args:
+        accept (str): The Accept header to send to the server (optional).
     """
 
     def __init__(self, accept=None):
+        """
+        Args:
+            accept:
+        """
         self.accept = accept
 
     def __call__(self, stream, content_type):
+        """
+        Args:
+            stream:
+            content_type:
+        """
         try:
             return stream.read()
         finally:
@@ -277,16 +348,26 @@ class BytesDeserializer(object):
 class StringDeserializer(object):
     """Return the response as a decoded string.
 
-       Args:
-            encoding (str): The string encoding to use (default=utf-8).
-            accept (str): The Accept header to send to the server (optional).
+    Args:
+        encoding (str): The string encoding to use (default=utf-8).
+        accept (str): The Accept header to send to the server (optional).
     """
 
     def __init__(self, encoding="utf-8", accept=None):
+        """
+        Args:
+            encoding:
+            accept:
+        """
         self.encoding = encoding
         self.accept = accept
 
     def __call__(self, stream, content_type):
+        """
+        Args:
+            stream:
+            content_type:
+        """
         try:
             return stream.read().decode(self.encoding)
         finally:
@@ -298,24 +379,37 @@ class StreamDeserializer(object):
        It is the receivers responsibility to close the stream when they're done
        reading the stream.
 
-       Args:
-            accept (str): The Accept header to send to the server (optional).
+    Args:
+        accept (str): The Accept header to send to the server (optional).
     """
 
     def __init__(self, accept=None):
+        """
+        Args:
+            accept:
+        """
         self.accept = accept
 
     def __call__(self, stream, content_type):
+        """
+        Args:
+            stream:
+            content_type:
+        """
         return (stream, content_type)
 
 
 class _JsonSerializer(object):
+    """Placeholder docstring"""
+
     def __init__(self):
+        """Placeholder docstring"""
         self.content_type = CONTENT_TYPE_JSON
 
     def __call__(self, data):
-        """Take data of various formats and serialize them into the expected request body.
-        This uses information about supported input formats for the deployed model.
+        """Take data of various formats and serialize them into the expected
+        request body. This uses information about supported input formats for
+        the deployed model.
 
         Args:
             data (object): Data to be serialized.
@@ -338,15 +432,26 @@ json_serializer = _JsonSerializer()
 
 
 def _ndarray_to_list(data):
+    """
+    Args:
+        data:
+    """
     return data.tolist() if isinstance(data, np.ndarray) else data
 
 
 def _json_serialize_from_buffer(buff):
+    """
+    Args:
+        buff:
+    """
     return buff.read()
 
 
 class _JsonDeserializer(object):
+    """Placeholder docstring"""
+
     def __init__(self):
+        """Placeholder docstring"""
         self.accept = CONTENT_TYPE_JSON
 
     def __call__(self, stream, content_type):
@@ -369,7 +474,14 @@ json_deserializer = _JsonDeserializer()
 
 
 class _NumpyDeserializer(object):
+    """Placeholder docstring"""
+
     def __init__(self, accept=CONTENT_TYPE_NPY, dtype=None):
+        """
+        Args:
+            accept:
+            dtype:
+        """
         self.accept = accept
         self.dtype = dtype
 
@@ -378,7 +490,8 @@ class _NumpyDeserializer(object):
 
         Args:
             stream (stream): The response stream to be deserialized.
-            content_type (str): The content type of the response. Can accept CSV, JSON, or NPY data.
+            content_type (str): The content type of the response. Can accept
+                CSV, JSON, or NPY data.
 
         Returns:
             object: Body of the response deserialized into a Numpy array.
@@ -405,14 +518,19 @@ numpy_deserializer = _NumpyDeserializer()
 
 
 class _NPYSerializer(object):
+    """Placeholder docstring"""
+
     def __init__(self):
+        """Placeholder docstring"""
         self.content_type = CONTENT_TYPE_NPY
 
     def __call__(self, data, dtype=None):
         """Serialize data into the request body in NPY format.
 
         Args:
-            data (object): Data to be serialized. Can be a numpy array, list, file, or buffer.
+            data (object): Data to be serialized. Can be a numpy array, list,
+                file, or buffer.
+            dtype:
 
         Returns:
             object: NPY serialized data used for the request.
@@ -435,6 +553,10 @@ class _NPYSerializer(object):
 
 
 def _npy_serialize(data):
+    """
+    Args:
+        data:
+    """
     buffer = BytesIO()
     np.save(buffer, data)
     return buffer.getvalue()

--- a/src/sagemaker/pytorch/__init__.py
+++ b/src/sagemaker/pytorch/__init__.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import absolute_import
 
 from sagemaker.pytorch.estimator import PyTorch  # noqa: F401

--- a/src/sagemaker/pytorch/defaults.py
+++ b/src/sagemaker/pytorch/defaults.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import absolute_import
 
 PYTORCH_VERSION = "0.4"

--- a/src/sagemaker/pytorch/estimator.py
+++ b/src/sagemaker/pytorch/estimator.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import absolute_import
 
 import logging
@@ -46,41 +47,52 @@ class PyTorch(Framework):
         image_name=None,
         **kwargs
     ):
-        """
-        This ``Estimator`` executes an PyTorch script in a managed PyTorch execution environment, within a SageMaker
-        Training Job. The managed PyTorch environment is an Amazon-built Docker container that executes functions
-        defined in the supplied ``entry_point`` Python script.
+        """This ``Estimator`` executes an PyTorch script in a managed PyTorch
+        execution environment, within a SageMaker Training Job. The managed
+        PyTorch environment is an Amazon-built Docker container that executes
+        functions defined in the supplied ``entry_point`` Python script.
 
-        Training is started by calling :meth:`~sagemaker.amazon.estimator.Framework.fit` on this Estimator.
-        After training is complete, calling :meth:`~sagemaker.amazon.estimator.Framework.deploy` creates a
-        hosted SageMaker endpoint and returns an :class:`~sagemaker.amazon.pytorch.model.PyTorchPredictor` instance
-        that can be used to perform inference against the hosted model.
+        Training is started by calling
+        :meth:`~sagemaker.amazon.estimator.Framework.fit` on this Estimator.
+        After training is complete, calling
+        :meth:`~sagemaker.amazon.estimator.Framework.deploy` creates a hosted
+        SageMaker endpoint and returns an
+        :class:`~sagemaker.amazon.pytorch.model.PyTorchPredictor` instance that
+        can be used to perform inference against the hosted model.
 
-        Technical documentation on preparing PyTorch scripts for SageMaker training and using the PyTorch Estimator is
-        available on the project home-page: https://github.com/aws/sagemaker-python-sdk
+        Technical documentation on preparing PyTorch scripts for SageMaker
+        training and using the PyTorch Estimator is available on the project
+        home-page: https://github.com/aws/sagemaker-python-sdk
 
         Args:
-            entry_point (str): Path (absolute or relative) to the Python source file which should be executed
-                as the entry point to training. This should be compatible with either Python 2.7 or Python 3.5.
-            source_dir (str): Path (absolute or relative) to a directory with any other training
-                source code dependencies aside from tne entry point file (default: None). Structure within this
-                directory are preserved when training on Amazon SageMaker.
-            hyperparameters (dict): Hyperparameters that will be used for training (default: None).
-                The hyperparameters are made accessible as a dict[str, str] to the training code on SageMaker.
-                For convenience, this accepts other types for keys and values, but ``str()`` will be called
-                to convert them before training.
-            py_version (str): Python version you want to use for executing your model training code (default: 'py3').
-                              One of 'py2' or 'py3'.
-            framework_version (str): PyTorch version you want to use for executing your model training code.
-                List of supported versions https://github.com/aws/sagemaker-python-sdk#pytorch-sagemaker-estimators.
+            entry_point (str): Path (absolute or relative) to the Python source
+                file which should be executed as the entry point to training.
+                This should be compatible with either Python 2.7 or Python 3.5.
+            source_dir (str): Path (absolute or relative) to a directory with
+                any other training source code dependencies aside from tne entry
+                point file (default: None). Structure within this directory are
+                preserved when training on Amazon SageMaker.
+            hyperparameters (dict): Hyperparameters that will be used for
+                training (default: None). The hyperparameters are made
+                accessible as a dict[str, str] to the training code on
+                SageMaker. For convenience, this accepts other types for keys
+                and values, but ``str()`` will be called to convert them before
+                training.
+            py_version (str): Python version you want to use for executing your
+                model training code (default: 'py3'). One of 'py2' or 'py3'.
+            framework_version (str): PyTorch version you want to use for
+                executing your model training code. List of supported versions
+                https://github.com/aws/sagemaker-python-sdk#pytorch-sagemaker-estimators.
                 If not specified, this will default to 0.4.
-            image_name (str): If specified, the estimator will use this image for training and hosting, instead of
-                selecting the appropriate SageMaker official image based on framework_version and py_version. It can
-                be an ECR url or dockerhub image and tag.
+            image_name (str): If specified, the estimator will use this image
+                for training and hosting, instead of selecting the appropriate
+                SageMaker official image based on framework_version and
+                py_version. It can be an ECR url or dockerhub image and tag.
                 Examples:
-                    123.dkr.ecr.us-west-2.amazonaws.com/my-custom-image:1.0
-                    custom-image:latest.
-            **kwargs: Additional kwargs passed to the :class:`~sagemaker.estimator.Framework` constructor.
+                123.dkr.ecr.us-west-2.amazonaws.com/my-custom-image:1.0
+                custom-image:latest.
+            **kwargs: Additional kwargs passed to the :class:`~sagemaker.estimator.Framework`
+                constructor.
         """
         if framework_version is None:
             logger.warning(empty_framework_version_warning(PYTORCH_VERSION, PYTORCH_VERSION))
@@ -98,21 +110,24 @@ class PyTorch(Framework):
     def create_model(
         self, model_server_workers=None, role=None, vpc_config_override=VPC_CONFIG_DEFAULT
     ):
-        """Create a SageMaker ``PyTorchModel`` object that can be deployed to an ``Endpoint``.
+        """Create a SageMaker ``PyTorchModel`` object that can be deployed to an
+        ``Endpoint``.
 
         Args:
-            role (str): The ``ExecutionRoleArn`` IAM Role ARN for the ``Model``, which is also used during
-                transform jobs. If not specified, the role from the Estimator will be used.
-            model_server_workers (int): Optional. The number of worker processes used by the inference server.
-                If None, server will use one worker per vCPU.
-            vpc_config_override (dict[str, list[str]]): Optional override for VpcConfig set on the model.
-                Default: use subnets and security groups from this Estimator.
+            model_server_workers (int): Optional. The number of worker processes
+                used by the inference server. If None, server will use one
+                worker per vCPU.
+            role (str): The ``ExecutionRoleArn`` IAM Role ARN for the ``Model``,
+                which is also used during transform jobs. If not specified, the
+                role from the Estimator will be used.
+            vpc_config_override (dict[str, list[str]]): Optional override for VpcConfig set on
+                the model. Default: use subnets and security groups from this Estimator.
                 * 'Subnets' (list[str]): List of subnet ids.
                 * 'SecurityGroupIds' (list[str]): List of security group ids.
 
         Returns:
-            sagemaker.pytorch.model.PyTorchModel: A SageMaker ``PyTorchModel`` object.
-                See :func:`~sagemaker.pytorch.model.PyTorchModel` for full details.
+            sagemaker.pytorch.model.PyTorchModel: A SageMaker ``PyTorchModel``
+            object. See :func:`~sagemaker.pytorch.model.PyTorchModel` for full details.
         """
         role = role or self.role
         return PyTorchModel(
@@ -135,15 +150,17 @@ class PyTorch(Framework):
 
     @classmethod
     def _prepare_init_params_from_job_description(cls, job_details, model_channel_name=None):
-        """Convert the job description to init params that can be handled by the class constructor
+        """Convert the job description to init params that can be handled by the
+        class constructor
 
         Args:
-            job_details: the returned job details from a describe_training_job API call.
-            model_channel_name (str): Name of the channel where pre-trained model data will be downloaded.
+            job_details: the returned job details from a describe_training_job
+                API call.
+            model_channel_name (str): Name of the channel where pre-trained
+                model data will be downloaded.
 
         Returns:
-             dictionary: The transformed init_params
-
+            dictionary: The transformed init_params
         """
         init_params = super(PyTorch, cls)._prepare_init_params_from_job_description(
             job_details, model_channel_name

--- a/src/sagemaker/pytorch/model.py
+++ b/src/sagemaker/pytorch/model.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import absolute_import
 
 import logging
@@ -26,16 +27,19 @@ logger = logging.getLogger("sagemaker")
 class PyTorchPredictor(RealTimePredictor):
     """A RealTimePredictor for inference against PyTorch Endpoints.
 
-    This is able to serialize Python lists, dictionaries, and numpy arrays to multidimensional tensors for PyTorch
-    inference."""
+    This is able to serialize Python lists, dictionaries, and numpy arrays to
+    multidimensional tensors for PyTorch inference.
+    """
 
     def __init__(self, endpoint_name, sagemaker_session=None):
         """Initialize an ``PyTorchPredictor``.
 
         Args:
-            endpoint_name (str): The name of the endpoint to perform inference on.
-            sagemaker_session (sagemaker.session.Session): Session object which manages interactions with
-                Amazon SageMaker APIs and any other AWS services needed. If not specified, the estimator creates one
+            endpoint_name (str): The name of the endpoint to perform inference
+                on.
+            sagemaker_session (sagemaker.session.Session): Session object which
+                manages interactions with Amazon SageMaker APIs and any other
+                AWS services needed. If not specified, the estimator creates one
                 using the default AWS configuration chain.
         """
         super(PyTorchPredictor, self).__init__(
@@ -44,7 +48,9 @@ class PyTorchPredictor(RealTimePredictor):
 
 
 class PyTorchModel(FrameworkModel):
-    """An PyTorch SageMaker ``Model`` that can be deployed to a SageMaker ``Endpoint``."""
+    """An PyTorch SageMaker ``Model`` that can be deployed to a SageMaker
+    ``Endpoint``.
+    """
 
     __framework_name__ = "pytorch"
 
@@ -63,22 +69,32 @@ class PyTorchModel(FrameworkModel):
         """Initialize an PyTorchModel.
 
         Args:
-            model_data (str): The S3 location of a SageMaker model data ``.tar.gz`` file.
-            role (str): An AWS IAM role (either name or full ARN). The Amazon SageMaker training jobs and APIs
-                that create Amazon SageMaker endpoints use this role to access training data and model artifacts.
-                After the endpoint is created, the inference code might use the IAM role,
-                if it needs to access an AWS resource.
-            entry_point (str): Path (absolute or relative) to the Python source file which should be executed
-                as the entry point to model hosting. This should be compatible with either Python 2.7 or Python 3.5.
-            image (str): A Docker image URI (default: None). If not specified, a default image for PyTorch will be used.
-            py_version (str): Python version you want to use for executing your model training code (default: 'py3').
-            framework_version (str): PyTorch version you want to use for executing your model training code.
-            predictor_cls (callable[str, sagemaker.session.Session]): A function to call to create a predictor
-                with an endpoint name and SageMaker ``Session``. If specified, ``deploy()`` returns the result of
-                invoking this function on the created endpoint name.
-            model_server_workers (int): Optional. The number of worker processes used by the inference server.
-                If None, server will use one worker per vCPU.
-            **kwargs: Keyword arguments passed to the ``FrameworkModel`` initializer.
+            model_data (str): The S3 location of a SageMaker model data
+                ``.tar.gz`` file.
+            role (str): An AWS IAM role (either name or full ARN). The Amazon
+                SageMaker training jobs and APIs that create Amazon SageMaker
+                endpoints use this role to access training data and model
+                artifacts. After the endpoint is created, the inference code
+                might use the IAM role, if it needs to access an AWS resource.
+            entry_point (str): Path (absolute or relative) to the Python source
+                file which should be executed as the entry point to model
+                hosting. This should be compatible with either Python 2.7 or
+                Python 3.5.
+            image (str): A Docker image URI (default: None). If not specified, a
+                default image for PyTorch will be used.
+            py_version (str): Python version you want to use for executing your
+                model training code (default: 'py3').
+            framework_version (str): PyTorch version you want to use for
+                executing your model training code.
+            predictor_cls (callable[str, sagemaker.session.Session]): A function
+                to call to create a predictor with an endpoint name and
+                SageMaker ``Session``. If specified, ``deploy()`` returns the
+                result of invoking this function on the created endpoint name.
+            model_server_workers (int): Optional. The number of worker processes
+                used by the inference server. If None, server will use one
+                worker per vCPU.
+            **kwargs: Keyword arguments passed to the ``FrameworkModel``
+                initializer.
         """
         super(PyTorchModel, self).__init__(
             model_data, image, role, entry_point, predictor_cls=predictor_cls, **kwargs
@@ -92,15 +108,19 @@ class PyTorchModel(FrameworkModel):
         self.model_server_workers = model_server_workers
 
     def prepare_container_def(self, instance_type, accelerator_type=None):
-        """Return a container definition with framework configuration set in model environment variables.
+        """Return a container definition with framework configuration set in
+        model environment variables.
 
         Args:
-            instance_type (str): The EC2 instance type to deploy this Model to. For example, 'ml.p2.xlarge'.
-            accelerator_type (str): The Elastic Inference accelerator type to deploy to the instance for loading and
-                making inferences to the model. For example, 'ml.eia1.medium'.
+            instance_type (str): The EC2 instance type to deploy this Model to.
+                For example, 'ml.p2.xlarge'.
+            accelerator_type (str): The Elastic Inference accelerator type to
+                deploy to the instance for loading and making inferences to the
+                model. For example, 'ml.eia1.medium'.
 
         Returns:
-            dict[str, str]: A container definition object usable with the CreateModel API.
+            dict[str, str]: A container definition object usable with the
+            CreateModel API.
         """
         deploy_image = self.image
         if not deploy_image:

--- a/src/sagemaker/rl/__init__.py
+++ b/src/sagemaker/rl/__init__.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import absolute_import
 
 from sagemaker.rl.estimator import (  # noqa: F401

--- a/src/sagemaker/rl/estimator.py
+++ b/src/sagemaker/rl/estimator.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import absolute_import
 
 import enum
@@ -45,11 +46,15 @@ TOOLKIT_FRAMEWORK_VERSION_MAP = {
 
 
 class RLToolkit(enum.Enum):
+    """Placeholder docstring"""
+
     COACH = "coach"
     RAY = "ray"
 
 
 class RLFramework(enum.Enum):
+    """Placeholder docstring"""
+
     TENSORFLOW = "tensorflow"
     MXNET = "mxnet"
 
@@ -74,50 +79,58 @@ class RLEstimator(Framework):
         **kwargs
     ):
         """This Estimator executes an RLEstimator script in a managed
-        Reinforcement Learning (RL) execution environment within a SageMaker Training Job.
-        The managed RL environment is an Amazon-built Docker container that executes
-        functions defined in the supplied ``entry_point`` Python script.
+        Reinforcement Learning (RL) execution environment within a SageMaker
+        Training Job. The managed RL environment is an Amazon-built Docker
+        container that executes functions defined in the supplied
+        ``entry_point`` Python script.
 
-        Training is started by calling :meth:`~sagemaker.amazon.estimator.Framework.fit`
-        on this Estimator. After training is complete, calling
-        :meth:`~sagemaker.amazon.estimator.Framework.deploy` creates a
-        hosted SageMaker endpoint and based on the specified framework returns
-        an :class:`~sagemaker.amazon.mxnet.model.MXNetPredictor` or
-        :class:`~sagemaker.amazon.tensorflow.serving.Predictor` instance
-        that can be used to perform inference against the hosted model.
+        Training is started by calling
+        :meth:`~sagemaker.amazon.estimator.Framework.fit` on this Estimator.
+        After training is complete, calling
+        :meth:`~sagemaker.amazon.estimator.Framework.deploy` creates a hosted
+        SageMaker endpoint and based on the specified framework returns an
+        :class:`~sagemaker.amazon.mxnet.model.MXNetPredictor` or
+        :class:`~sagemaker.amazon.tensorflow.serving.Predictor` instance that
+        can be used to perform inference against the hosted model.
 
-        Technical documentation on preparing RLEstimator scripts for SageMaker training
-        and using the RLEstimator is available on the project homepage:
-        https://github.com/aws/sagemaker-python-sdk
+        Technical documentation on preparing RLEstimator scripts for
+        SageMaker training and using the RLEstimator is available on the project
+        homepage: https://github.com/aws/sagemaker-python-sdk
 
         Args:
-            entry_point (str): Path (absolute or relative) to the Python source file
-                which should be executed as the entry point to training.
-                This should be compatible with Python 3.5 for MXNet or Python 3.6 for TensorFlow.
-            toolkit (sagemaker.rl.RLToolkit): RL toolkit you want to use
-                for executing your model training code.
-            toolkit_version (str): RL toolkit version you want to be use
-                for executing your model training code.
-            framework (sagemaker.rl.RLFramework): Framework (MXNet or TensorFlow)
-                you want to be used as a toolkit backed for reinforcement learning training.
-            source_dir (str): Path (absolute or relative) to a directory with any other training
-                source code dependencies aside from the entry point file (default: None).
-                Structure within this directory is preserved when training on Amazon SageMaker.
-            hyperparameters (dict): Hyperparameters that will be used for training (default: None).
-                The hyperparameters are made accessible as a dict[str, str]
-                to the training code on SageMaker. For convenience, this accepts other types
-                for keys and values.
-            image_name (str): An ECR url. If specified, the estimator will use this image
-                for training and hosting, instead of selecting the appropriate SageMaker
-                official image based on framework_version and py_version.
-                Example: 123.dkr.ecr.us-west-2.amazonaws.com/my-custom-image:1.0
-            metric_definitions (list[dict]): A list of dictionaries that defines the metric(s)
-                used to evaluate the training jobs. Each dictionary contains two keys:
-                'Name' for the name of the metric, and 'Regex' for the regular expression used to
-                extract the metric from the logs. This should be defined only for jobs
-                that don't use an Amazon algorithm.
-            **kwargs: Additional kwargs passed to the :class:`~sagemaker.estimator.Framework`
-                constructor.
+            entry_point (str): Path (absolute or relative) to the Python source
+                file which should be executed as the entry point to training.
+                This should be compatible with Python 3.5 for MXNet or Python
+                3.6 for TensorFlow.
+            toolkit (sagemaker.rl.RLToolkit): RL toolkit you want to use for
+                executing your model training code.
+            toolkit_version (str): RL toolkit version you want to be use for
+                executing your model training code.
+            framework (sagemaker.rl.RLFramework): Framework (MXNet or
+                TensorFlow) you want to be used as a toolkit backed for
+                reinforcement learning training.
+            source_dir (str): Path (absolute or relative) to a directory with
+                any other training source code dependencies aside from the entry
+                point file (default: None). Structure within this directory is
+                preserved when training on Amazon SageMaker.
+            hyperparameters (dict): Hyperparameters that will be used for
+                training (default: None). The hyperparameters are made
+                accessible as a dict[str, str] to the training code on
+                SageMaker. For convenience, this accepts other types for keys
+                and values.
+            image_name (str): An ECR url. If specified, the estimator will use
+                this image for training and hosting, instead of selecting the
+                appropriate SageMaker official image based on framework_version
+                and py_version. Example:
+                123.dkr.ecr.us-west-2.amazonaws.com/my-custom-image:1.0
+            metric_definitions (list[dict]): A list of dictionaries that defines
+                the metric(s) used to evaluate the training jobs. Each
+                dictionary contains two keys: 'Name' for the name of the metric,
+                and 'Regex' for the regular expression used to extract the
+                metric from the logs. This should be defined only for jobs that
+                don't use an Amazon algorithm.
+            **kwargs: Additional kwargs passed to the
+                :class:`~sagemaker.estimator.Framework` constructor.
         """
         self._validate_images_args(toolkit, toolkit_version, framework, image_name)
 
@@ -151,28 +164,31 @@ class RLEstimator(Framework):
         source_dir=None,
         dependencies=None,
     ):
-        """Create a SageMaker ``RLEstimatorModel`` object that can be deployed to an Endpoint.
+        """Create a SageMaker ``RLEstimatorModel`` object that can be deployed
+        to an Endpoint.
 
         Args:
-            role (str): The ``ExecutionRoleArn`` IAM Role ARN for the ``Model``, which is also used
-                during transform jobs. If not specified, the role from the Estimator will be used.
-            vpc_config_override (dict[str, list[str]]): Optional override for VpcConfig
-                set on the model. Default: use subnets and security groups from this Estimator.
-
+            role (str): The ``ExecutionRoleArn`` IAM Role ARN for the ``Model``,
+                which is also used during transform jobs. If not specified, the
+                role from the Estimator will be used.
+            vpc_config_override (dict[str, list[str]]): Optional override for VpcConfig set on
+                the model. Default: use subnets and security groups from this Estimator.
                 * 'Subnets' (list[str]): List of subnet ids.
                 * 'SecurityGroupIds' (list[str]): List of security group ids.
-
-            entry_point (str): Path (absolute or relative) to the Python source file
-                which should be executed as the entry point for MXNet hosting.
-                This should be compatible with Python 3.5 (default: self.entry_point)
-            source_dir (str): Path (absolute or relative) to a directory with any other training
-                source code dependencies aside from tne entry point file (default: self.source_dir).
-                Structure within this directory are preserved when hosting on Amazon SageMaker.
-            dependencies (list[str]): A list of paths to directories (absolute or relative) with
-                any additional libraries that will be exported to the container
-                (default: self.dependencies). The library folders will be copied to SageMaker
-                in the same folder where the entry_point is copied. If the ```source_dir``` points
-                to S3, code will be uploaded and the S3 location will be used instead.
+            entry_point (str): Path (absolute or relative) to the Python source
+                file which should be executed as the entry point for MXNet
+                hosting. This should be compatible with Python 3.5 (default:
+                self.entry_point)
+            source_dir (str): Path (absolute or relative) to a directory with
+                any other training source code dependencies aside from tne entry
+                point file (default: self.source_dir). Structure within this
+                directory are preserved when hosting on Amazon SageMaker.
+            dependencies (list[str]): A list of paths to directories (absolute
+                or relative) with any additional libraries that will be exported
+                to the container (default: self.dependencies). The library
+                folders will be copied to SageMaker in the same folder where the
+                entry_point is copied. If the ```source_dir``` points to S3,
+                code will be uploaded and the S3 location will be used instead.
 
         Returns:
             sagemaker.model.FrameworkModel: Depending on input parameters returns
@@ -238,8 +254,9 @@ class RLEstimator(Framework):
     def train_image(self):
         """Return the Docker image to use for training.
 
-        The :meth:`~sagemaker.estimator.EstimatorBase.fit` method, which does the model training,
-        calls this method to find the image to use for model training.
+        The :meth:`~sagemaker.estimator.EstimatorBase.fit` method, which does
+        the model training, calls this method to find the image to use for model
+        training.
 
         Returns:
             str: The URI of the Docker image.
@@ -256,15 +273,17 @@ class RLEstimator(Framework):
 
     @classmethod
     def _prepare_init_params_from_job_description(cls, job_details, model_channel_name=None):
-        """Convert the job description to init params that can be handled by the class constructor
+        """Convert the job description to init params that can be handled by the
+        class constructor
 
         Args:
-            job_details: the returned job details from a describe_training_job API call.
-            model_channel_name (str): Name of the channel where pre-trained model data will be
-                downloaded.
+            job_details: the returned job details from a describe_training_job
+                API call.
+            model_channel_name (str): Name of the channel where pre-trained
+                model data will be downloaded.
 
         Returns:
-             dictionary: The transformed init_params
+            dictionary: The transformed init_params
         """
         init_params = super(RLEstimator, cls)._prepare_init_params_from_job_description(
             job_details, model_channel_name
@@ -296,7 +315,9 @@ class RLEstimator(Framework):
         return init_params
 
     def hyperparameters(self):
-        """Return hyperparameters used by your custom TensorFlow code during model training."""
+        """Return hyperparameters used by your custom TensorFlow code during
+        model training.
+        """
         hyperparameters = super(RLEstimator, self).hyperparameters()
 
         additional_hyperparameters = {
@@ -310,6 +331,10 @@ class RLEstimator(Framework):
 
     @classmethod
     def _toolkit_and_version_from_tag(cls, image_tag):
+        """
+        Args:
+            image_tag:
+        """
         tag_pattern = re.compile(
             "^([A-Z]*|[a-z]*)(\d.*)-(cpu|gpu)-(py2|py3)$"  # noqa: W605,E501 pylint: disable=anomalous-backslash-in-string
         )
@@ -320,6 +345,10 @@ class RLEstimator(Framework):
 
     @classmethod
     def _validate_framework_format(cls, framework):
+        """
+        Args:
+            framework:
+        """
         if framework and framework not in RLFramework:
             raise ValueError(
                 "Invalid type: {}, valid RL frameworks types are: [{}]".format(
@@ -329,6 +358,10 @@ class RLEstimator(Framework):
 
     @classmethod
     def _validate_toolkit_format(cls, toolkit):
+        """
+        Args:
+            toolkit:
+        """
         if toolkit and toolkit not in RLToolkit:
             raise ValueError(
                 "Invalid type: {}, valid RL toolkits types are: [{}]".format(
@@ -338,6 +371,13 @@ class RLEstimator(Framework):
 
     @classmethod
     def _validate_images_args(cls, toolkit, toolkit_version, framework, image_name):
+        """
+        Args:
+            toolkit:
+            toolkit_version:
+            framework:
+            image_name:
+        """
         cls._validate_toolkit_format(toolkit)
         cls._validate_framework_format(framework)
 
@@ -372,6 +412,12 @@ class RLEstimator(Framework):
 
     @classmethod
     def _is_combination_supported(cls, toolkit, toolkit_version, framework):
+        """
+        Args:
+            toolkit:
+            toolkit_version:
+            framework:
+        """
         supported_versions = TOOLKIT_FRAMEWORK_VERSION_MAP.get(toolkit, None)
         if supported_versions:
             supported_frameworks = supported_versions.get(toolkit_version, None)
@@ -381,6 +427,12 @@ class RLEstimator(Framework):
 
     @classmethod
     def _validate_toolkit_support(cls, toolkit, toolkit_version, framework):
+        """
+        Args:
+            toolkit:
+            toolkit_version:
+            framework:
+        """
         if not cls._is_combination_supported(toolkit, toolkit_version, framework):
             raise AttributeError(
                 "Provided `{}-{}` and `{}` combination is not supported.".format(
@@ -389,9 +441,11 @@ class RLEstimator(Framework):
             )
 
     def _image_version(self):
+        """Placeholder docstring"""
         return "{}{}".format(self.toolkit, self.toolkit_version)
 
     def _image_framework(self):
+        """Placeholder docstring"""
         return "rl-{}".format(self.framework)
 
     @classmethod
@@ -399,7 +453,8 @@ class RLEstimator(Framework):
         """Provides default metric definitions based on provided toolkit.
 
         Args:
-            toolkit(sagemaker.rl.RLToolkit): RL Toolkit to be used for training.
+            toolkit (sagemaker.rl.RLToolkit): RL Toolkit to be used for
+                training.
 
         Returns:
             list: metric definitions

--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import absolute_import, print_function
 
 import json
@@ -48,6 +49,8 @@ _STATUS_CODE_TABLE = {
 
 
 class LogState(object):
+    """Placeholder docstring"""
+
     STARTING = 1
     WAIT_IN_PROGRESS = 2
     TAILING = 3
@@ -121,6 +124,7 @@ class Session(object):  # pylint: disable=too-many-public-methods
 
     @property
     def boto_region_name(self):
+        """Placeholder docstring"""
         return self._region_name
 
     def upload_data(self, path, bucket=None, key_prefix="data", extra_args=None):
@@ -1607,6 +1611,7 @@ class ModelContainer(object):
 def _create_model_request(
     name, role, container_def=None, tags=None
 ):  # pylint: disable=redefined-outer-name
+    """Placeholder docstring"""
     request = {"ModelName": name, "ExecutionRoleArn": role}
 
     if isinstance(container_def, list):
@@ -1621,6 +1626,7 @@ def _create_model_request(
 
 
 def _deployment_entity_exists(describe_fn):
+    """Placeholder docstring"""
     try:
         describe_fn()
         return True
@@ -1635,6 +1641,7 @@ def _deployment_entity_exists(describe_fn):
 
 
 def _train_done(sagemaker_client, job_name, last_desc):
+    """Placeholder docstring"""
     in_progress_statuses = ["InProgress", "Created"]
 
     desc = sagemaker_client.describe_training_job(TrainingJobName=job_name)
@@ -1655,6 +1662,7 @@ def _train_done(sagemaker_client, job_name, last_desc):
 
 
 def _compilation_job_status(sagemaker_client, job_name):
+    """Placeholder docstring"""
     compile_status_codes = {
         "Completed": "!",
         "InProgress": ".",
@@ -1678,6 +1686,7 @@ def _compilation_job_status(sagemaker_client, job_name):
 
 
 def _tuning_job_status(sagemaker_client, job_name):
+    """Placeholder docstring"""
     tuning_status_codes = {
         "Completed": "!",
         "InProgress": ".",
@@ -1703,6 +1712,7 @@ def _tuning_job_status(sagemaker_client, job_name):
 
 
 def _transform_job_status(sagemaker_client, job_name):
+    """Placeholder docstring"""
     transform_job_status_codes = {
         "Completed": "!",
         "InProgress": ".",
@@ -1726,6 +1736,7 @@ def _transform_job_status(sagemaker_client, job_name):
 
 
 def _create_model_package_status(sagemaker_client, model_package_name):
+    """Placeholder docstring"""
     in_progress_statuses = ["InProgress", "Pending"]
 
     desc = sagemaker_client.describe_model_package(ModelPackageName=model_package_name)
@@ -1741,6 +1752,7 @@ def _create_model_package_status(sagemaker_client, model_package_name):
 
 
 def _deploy_done(sagemaker_client, endpoint_name):
+    """Placeholder docstring"""
     hosting_status_codes = {
         "OutOfService": "x",
         "Creating": "-",
@@ -1762,6 +1774,7 @@ def _deploy_done(sagemaker_client, endpoint_name):
 
 
 def _wait_until_training_done(callable_fn, desc, poll=5):
+    """Placeholder docstring"""
     job_desc, finished = callable_fn(desc)
     while not finished:
         time.sleep(poll)
@@ -1770,6 +1783,7 @@ def _wait_until_training_done(callable_fn, desc, poll=5):
 
 
 def _wait_until(callable_fn, poll=5):
+    """Placeholder docstring"""
     result = callable_fn()
     while result is None:
         time.sleep(poll)
@@ -1778,6 +1792,7 @@ def _wait_until(callable_fn, poll=5):
 
 
 def _expand_container_def(c_def):
+    """Placeholder docstring"""
     if isinstance(c_def, six.string_types):
         return container_def(c_def)
     return c_def
@@ -1786,6 +1801,7 @@ def _expand_container_def(c_def):
 def _vpc_config_from_training_job(
     training_job_desc, vpc_config_override=vpc_utils.VPC_CONFIG_DEFAULT
 ):
+    """Placeholder docstring"""
     if vpc_config_override is vpc_utils.VPC_CONFIG_DEFAULT:
         return training_job_desc.get(vpc_utils.VPC_CONFIG_KEY)
     return vpc_utils.sanitize(vpc_config_override)

--- a/src/sagemaker/sklearn/__init__.py
+++ b/src/sagemaker/sklearn/__init__.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import absolute_import
 
 from sagemaker.sklearn.estimator import SKLearn  # noqa: F401

--- a/src/sagemaker/sklearn/defaults.py
+++ b/src/sagemaker/sklearn/defaults.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import absolute_import
 
 SKLEARN_NAME = "scikit-learn"

--- a/src/sagemaker/sklearn/estimator.py
+++ b/src/sagemaker/sklearn/estimator.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import absolute_import
 
 import logging
@@ -43,40 +44,52 @@ class SKLearn(Framework):
         image_name=None,
         **kwargs
     ):
-        """
-        This ``Estimator`` executes an Scikit-learn script in a managed Scikit-learn execution environment, within a
-        SageMaker Training Job. The managed Scikit-learn environment is an Amazon-built Docker container that executes
-        functions defined in the supplied ``entry_point`` Python script.
+        """This ``Estimator`` executes an Scikit-learn script in a managed
+        Scikit-learn execution environment, within a SageMaker Training Job. The
+        managed Scikit-learn environment is an Amazon-built Docker container
+        that executes functions defined in the supplied ``entry_point`` Python
+        script.
 
-        Training is started by calling :meth:`~sagemaker.amazon.estimator.Framework.fit` on this Estimator.
-        After training is complete, calling :meth:`~sagemaker.amazon.estimator.Framework.deploy` creates a
-        hosted SageMaker endpoint and returns an :class:`~sagemaker.amazon.sklearn.model.SKLearnPredictor` instance
-        that can be used to perform inference against the hosted model.
+        Training is started by calling
+        :meth:`~sagemaker.amazon.estimator.Framework.fit` on this Estimator.
+        After training is complete, calling
+        :meth:`~sagemaker.amazon.estimator.Framework.deploy` creates a hosted
+        SageMaker endpoint and returns an
+        :class:`~sagemaker.amazon.sklearn.model.SKLearnPredictor` instance that
+        can be used to perform inference against the hosted model.
 
-        Technical documentation on preparing Scikit-learn scripts for SageMaker training and using the Scikit-learn
-        Estimator is available on the project home-page: https://github.com/aws/sagemaker-python-sdk
+        Technical documentation on preparing Scikit-learn scripts for
+        SageMaker training and using the Scikit-learn Estimator is available on
+        the project home-page: https://github.com/aws/sagemaker-python-sdk
 
         Args:
-            entry_point (str): Path (absolute or relative) to the Python source file which should be executed
-                as the entry point to training. This should be compatible with either Python 2.7 or Python 3.5.
-            source_dir (str): Path (absolute or relative) to a directory with any other training
-                source code dependencies aside from tne entry point file (default: None). Structure within this
-                directory are preserved when training on Amazon SageMaker.
-            hyperparameters (dict): Hyperparameters that will be used for training (default: None).
-                The hyperparameters are made accessible as a dict[str, str] to the training code on SageMaker.
-                For convenience, this accepts other types for keys and values, but ``str()`` will be called
-                to convert them before training.
-            py_version (str): Python version you want to use for executing your model training code (default: 'py2').
-                              One of 'py2' or 'py3'.
-            framework_version (str): Scikit-learn version you want to use for executing your model training code.
-                List of supported versions https://github.com/aws/sagemaker-python-sdk#sklearn-sagemaker-estimators
-            image_name (str): If specified, the estimator will use this image for training and hosting, instead of
-                selecting the appropriate SageMaker official image based on framework_version and py_version. It can
-                be an ECR url or dockerhub image and tag.
+            entry_point (str): Path (absolute or relative) to the Python source
+                file which should be executed as the entry point to training.
+                This should be compatible with either Python 2.7 or Python 3.5.
+            framework_version (str): Scikit-learn version you want to use for
+                executing your model training code. List of supported versions
+                https://github.com/aws/sagemaker-python-sdk#sklearn-sagemaker-estimators
+            source_dir (str): Path (absolute or relative) to a directory with
+                any other training source code dependencies aside from tne entry
+                point file (default: None). Structure within this directory are
+                preserved when training on Amazon SageMaker.
+            hyperparameters (dict): Hyperparameters that will be used for
+                training (default: None). The hyperparameters are made
+                accessible as a dict[str, str] to the training code on
+                SageMaker. For convenience, this accepts other types for keys
+                and values, but ``str()`` will be called to convert them before
+                training.
+            py_version (str): Python version you want to use for executing your
+                model training code (default: 'py2'). One of 'py2' or 'py3'.
+            image_name (str): If specified, the estimator will use this image
+                for training and hosting, instead of selecting the appropriate
+                SageMaker official image based on framework_version and
+                py_version. It can be an ECR url or dockerhub image and tag.
                 Examples:
                     123.dkr.ecr.us-west-2.amazonaws.com/my-custom-image:1.0
                     custom-image:latest.
-            **kwargs: Additional kwargs passed to the :class:`~sagemaker.estimator.Framework` constructor.
+            **kwargs: Additional kwargs passed to the
+                :class:`~sagemaker.estimator.Framework` constructor.
         """
         # SciKit-Learn does not support distributed training or training on GPU instance types. Fail fast.
         train_instance_type = kwargs.get("train_instance_type")
@@ -116,22 +129,25 @@ class SKLearn(Framework):
     def create_model(
         self, model_server_workers=None, role=None, vpc_config_override=VPC_CONFIG_DEFAULT, **kwargs
     ):
-        """Create a SageMaker ``SKLearnModel`` object that can be deployed to an ``Endpoint``.
+        """Create a SageMaker ``SKLearnModel`` object that can be deployed to an
+        ``Endpoint``.
 
         Args:
-            role (str): The ``ExecutionRoleArn`` IAM Role ARN for the ``Model``, which is also used during
-                transform jobs. If not specified, the role from the Estimator will be used.
-            model_server_workers (int): Optional. The number of worker processes used by the inference server.
-                If None, server will use one worker per vCPU.
-            vpc_config_override (dict[str, list[str]]): Optional override for VpcConfig set on the model.
-                Default: use subnets and security groups from this Estimator.
+            model_server_workers (int): Optional. The number of worker processes
+                used by the inference server. If None, server will use one
+                worker per vCPU.
+            role (str): The ``ExecutionRoleArn`` IAM Role ARN for the ``Model``,
+                which is also used during transform jobs. If not specified, the
+                role from the Estimator will be used.
+            vpc_config_override (dict[str, list[str]]): Optional override for VpcConfig set on
+                the model. Default: use subnets and security groups from this Estimator.
                 * 'Subnets' (list[str]): List of subnet ids.
                 * 'SecurityGroupIds' (list[str]): List of security group ids.
             **kwargs: Passed to initialization of ``SKLearnModel``.
 
         Returns:
-            sagemaker.sklearn.model.SKLearnModel: A SageMaker ``SKLearnModel`` object.
-                See :func:`~sagemaker.sklearn.model.SKLearnModel` for full details.
+            sagemaker.sklearn.model.SKLearnModel: A SageMaker ``SKLearnModel``
+            object. See :func:`~sagemaker.sklearn.model.SKLearnModel` for full details.
         """
         role = role or self.role
         return SKLearnModel(
@@ -154,14 +170,16 @@ class SKLearn(Framework):
 
     @classmethod
     def _prepare_init_params_from_job_description(cls, job_details, model_channel_name=None):
-        """Convert the job description to init params that can be handled by the class constructor
+        """Convert the job description to init params that can be handled by the
+        class constructor
 
         Args:
-            job_details: the returned job details from a describe_training_job API call.
+            job_details: the returned job details from a describe_training_job
+                API call.
+            model_channel_name:
 
         Returns:
-             dictionary: The transformed init_params
-
+            dictionary: The transformed init_params
         """
         init_params = super(SKLearn, cls)._prepare_init_params_from_job_description(job_details)
 
@@ -184,6 +202,10 @@ class SKLearn(Framework):
 
 
 def _validate_not_gpu_instance_type(training_instance_type):
+    """
+    Args:
+        training_instance_type:
+    """
     gpu_instance_types = [
         "ml.p2.xlarge",
         "ml.p2.8xlarge",

--- a/src/sagemaker/sklearn/model.py
+++ b/src/sagemaker/sklearn/model.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import absolute_import
 
 import logging
@@ -27,16 +28,19 @@ logger = logging.getLogger("sagemaker")
 class SKLearnPredictor(RealTimePredictor):
     """A RealTimePredictor for inference against Scikit-learn Endpoints.
 
-    This is able to serialize Python lists, dictionaries, and numpy arrays to multidimensional tensors for Scikit-learn
-    inference."""
+    This is able to serialize Python lists, dictionaries, and numpy arrays to
+    multidimensional tensors for Scikit-learn inference.
+    """
 
     def __init__(self, endpoint_name, sagemaker_session=None):
         """Initialize an ``SKLearnPredictor``.
 
         Args:
-            endpoint_name (str): The name of the endpoint to perform inference on.
-            sagemaker_session (sagemaker.session.Session): Session object which manages interactions with
-                Amazon SageMaker APIs and any other AWS services needed. If not specified, the estimator creates one
+            endpoint_name (str): The name of the endpoint to perform inference
+                on.
+            sagemaker_session (sagemaker.session.Session): Session object which
+                manages interactions with Amazon SageMaker APIs and any other
+                AWS services needed. If not specified, the estimator creates one
                 using the default AWS configuration chain.
         """
         super(SKLearnPredictor, self).__init__(
@@ -45,7 +49,9 @@ class SKLearnPredictor(RealTimePredictor):
 
 
 class SKLearnModel(FrameworkModel):
-    """An Scikit-learn SageMaker ``Model`` that can be deployed to a SageMaker ``Endpoint``."""
+    """An Scikit-learn SageMaker ``Model`` that can be deployed to a SageMaker
+    ``Endpoint``.
+    """
 
     __framework_name__ = SKLEARN_NAME
 
@@ -64,23 +70,32 @@ class SKLearnModel(FrameworkModel):
         """Initialize an SKLearnModel.
 
         Args:
-            model_data (str): The S3 location of a SageMaker model data ``.tar.gz`` file.
-            role (str): An AWS IAM role (either name or full ARN). The Amazon SageMaker training jobs and APIs
-                that create Amazon SageMaker endpoints use this role to access training data and model artifacts.
-                After the endpoint is created, the inference code might use the IAM role,
-                if it needs to access an AWS resource.
-            entry_point (str): Path (absolute or relative) to the Python source file which should be executed
-                as the entry point to model hosting. This should be compatible with either Python 2.7 or Python 3.5.
-            image (str): A Docker image URI (default: None). If not specified, a default image for Scikit-learn
-                will be used.
-            py_version (str): Python version you want to use for executing your model training code (default: 'py2').
-            framework_version (str): Scikit-learn version you want to use for executing your model training code.
-            predictor_cls (callable[str, sagemaker.session.Session]): A function to call to create a predictor
-                with an endpoint name and SageMaker ``Session``. If specified, ``deploy()`` returns the result of
-                invoking this function on the created endpoint name.
-            model_server_workers (int): Optional. The number of worker processes used by the inference server.
-                If None, server will use one worker per vCPU.
-            **kwargs: Keyword arguments passed to the ``FrameworkModel`` initializer.
+            model_data (str): The S3 location of a SageMaker model data
+                ``.tar.gz`` file.
+            role (str): An AWS IAM role (either name or full ARN). The Amazon
+                SageMaker training jobs and APIs that create Amazon SageMaker
+                endpoints use this role to access training data and model
+                artifacts. After the endpoint is created, the inference code
+                might use the IAM role, if it needs to access an AWS resource.
+            entry_point (str): Path (absolute or relative) to the Python source
+                file which should be executed as the entry point to model
+                hosting. This should be compatible with either Python 2.7 or
+                Python 3.5.
+            image (str): A Docker image URI (default: None). If not specified, a
+                default image for Scikit-learn will be used.
+            py_version (str): Python version you want to use for executing your
+                model training code (default: 'py2').
+            framework_version (str): Scikit-learn version you want to use for
+                executing your model training code.
+            predictor_cls (callable[str, sagemaker.session.Session]): A function
+                to call to create a predictor with an endpoint name and
+                SageMaker ``Session``. If specified, ``deploy()`` returns the
+                result of invoking this function on the created endpoint name.
+            model_server_workers (int): Optional. The number of worker processes
+                used by the inference server. If None, server will use one
+                worker per vCPU.
+            **kwargs: Keyword arguments passed to the ``FrameworkModel``
+                initializer.
         """
         super(SKLearnModel, self).__init__(
             model_data, image, role, entry_point, predictor_cls=predictor_cls, **kwargs
@@ -94,16 +109,20 @@ class SKLearnModel(FrameworkModel):
         self.model_server_workers = model_server_workers
 
     def prepare_container_def(self, instance_type, accelerator_type=None):
-        """Return a container definition with framework configuration set in model environment variables.
+        """Return a container definition with framework configuration set in
+        model environment variables.
 
         Args:
-            instance_type (str): The EC2 instance type to deploy this Model to. For example, 'ml.p2.xlarge'.
-            accelerator_type (str): The Elastic Inference accelerator type to deploy to the instance for loading and
-                making inferences to the model. For example, 'ml.eia1.medium'. Note: accelerator types are not
-                supported by SKLearnModel.
+            instance_type (str): The EC2 instance type to deploy this Model to.
+                For example, 'ml.p2.xlarge'.
+            accelerator_type (str): The Elastic Inference accelerator type to
+                deploy to the instance for loading and making inferences to the
+                model. For example, 'ml.eia1.medium'. Note: accelerator types
+                are not supported by SKLearnModel.
 
         Returns:
-            dict[str, str]: A container definition object usable with the CreateModel API.
+            dict[str, str]: A container definition object usable with the
+            CreateModel API.
         """
         if accelerator_type:
             raise ValueError("Accelerator types are not supported for Scikit-Learn.")

--- a/src/sagemaker/sparkml/__init__.py
+++ b/src/sagemaker/sparkml/__init__.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import absolute_import
 
 from sagemaker.sparkml.model import SparkMLModel, SparkMLPredictor  # noqa: F401

--- a/src/sagemaker/sparkml/model.py
+++ b/src/sagemaker/sparkml/model.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import absolute_import
 
 from sagemaker import Model, RealTimePredictor, Session
@@ -22,26 +23,28 @@ repo_name = "sagemaker-sparkml-serving"
 
 
 class SparkMLPredictor(RealTimePredictor):
-    """
-    Performs predictions against an MLeap serialized SparkML model.
+    """Performs predictions against an MLeap serialized SparkML model.
 
-    The implementation of :meth:`~sagemaker.predictor.RealTimePredictor.predict` in this
-    `RealTimePredictor` requires a json as input. The input should follow the json format
-    as documented.
+    The implementation of
+    :meth:`~sagemaker.predictor.RealTimePredictor.predict` in this
+    `RealTimePredictor` requires a json as input. The input should follow the
+    json format as documented.
 
-    ``predict()`` returns a csv output, comma separated if the output is a list.
+    ``predict()`` returns a csv output, comma separated if the output is a
+    list.
     """
 
     def __init__(self, endpoint, sagemaker_session=None):
-        """
-        Initializes a SparkMLPredictor which should be used with SparkMLModel to perform predictions against SparkML
-        models serialized via MLeap. The response is returned in text/csv format which is the default response format
-        for SparkML Serving container.
+        """Initializes a SparkMLPredictor which should be used with SparkMLModel
+        to perform predictions against SparkML models serialized via MLeap. The
+        response is returned in text/csv format which is the default response
+        format for SparkML Serving container.
 
         Args:
             endpoint (str): The name of the endpoint to perform inference on.
-            sagemaker_session (sagemaker.session.Session): Session object which manages interactions with
-                Amazon SageMaker APIs and any other AWS services needed. If not specified, the estimator creates one
+            sagemaker_session (sagemaker.session.Session): Session object which
+                manages interactions with Amazon SageMaker APIs and any other
+                AWS services needed. If not specified, the estimator creates one
                 using the default AWS configuration chain.
         """
         sagemaker_session = sagemaker_session or Session()
@@ -54,26 +57,33 @@ class SparkMLPredictor(RealTimePredictor):
 
 
 class SparkMLModel(Model):
-    """
-    Model data and S3 location holder for MLeap serialized SparkML model. Calling
-    :meth:`~sagemaker.model.Model.deploy` creates an Endpoint and return
-    a Predictor to performs predictions against an MLeap serialized SparkML model .
+    """Model data and S3 location holder for MLeap serialized SparkML model.
+    Calling :meth:`~sagemaker.model.Model.deploy` creates an Endpoint and return
+    a Predictor to performs predictions against an MLeap serialized SparkML
+    model .
     """
 
     def __init__(self, model_data, role=None, spark_version=2.2, sagemaker_session=None, **kwargs):
         """Initialize a SparkMLModel.
 
         Args:
-            model_data (str): The S3 location of a SageMaker model data ``.tar.gz`` file. For SparkML, this will be the
-                output that has been produced by the Spark job after serializing the Model via MLeap.
-            role (str): An AWS IAM role (either name or full ARN). The Amazon SageMaker training jobs and APIs
-                that create Amazon SageMaker endpoints use this role to access training data and model artifacts.
-                After the endpoint is created, the inference code might use the IAM role,
-                if it needs to access an AWS resource.
-            spark_version (str): Spark version you want to use for executing the inference (default: '2.2').
-            sagemaker_session (sagemaker.session.Session): Session object which manages interactions with
-                Amazon SageMaker APIs and any other AWS services needed. If not specified, the estimator creates one
-                using the default AWS configuration chain. For local mode, please do not pass this variable.
+            model_data (str): The S3 location of a SageMaker model data
+                ``.tar.gz`` file. For SparkML, this will be the output that has
+                been produced by the Spark job after serializing the Model via
+                MLeap.
+            role (str): An AWS IAM role (either name or full ARN). The Amazon
+                SageMaker training jobs and APIs that create Amazon SageMaker
+                endpoints use this role to access training data and model
+                artifacts. After the endpoint is created, the inference code
+                might use the IAM role, if it needs to access an AWS resource.
+            spark_version (str): Spark version you want to use for executing the
+                inference (default: '2.2').
+            sagemaker_session (sagemaker.session.Session): Session object which
+                manages interactions with Amazon SageMaker APIs and any other
+                AWS services needed. If not specified, the estimator creates one
+                using the default AWS configuration chain. For local mode,
+                please do not pass this variable.
+            **kwargs:
         """
         # for local mode, sagemaker_session should be passed as None but we need a session to get boto_region_name
         region_name = (sagemaker_session or Session()).boto_region_name

--- a/src/sagemaker/tensorflow/__init__.py
+++ b/src/sagemaker/tensorflow/__init__.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import absolute_import
 
 import sys

--- a/src/sagemaker/tensorflow/defaults.py
+++ b/src/sagemaker/tensorflow/defaults.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import absolute_import
 
 TF_VERSION = "1.11"

--- a/src/sagemaker/tensorflow/estimator.py
+++ b/src/sagemaker/tensorflow/estimator.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import absolute_import
 
 import contextlib
@@ -52,6 +53,8 @@ _SCRIPT_MODE_TENSORBOARD_WARNING = (
 
 
 class Tensorboard(threading.Thread):
+    """Placeholder docstring"""
+
     def __init__(self, estimator, logdir=None):
         """Initialize ``Tensorboard`` instance.
 
@@ -66,6 +69,7 @@ class Tensorboard(threading.Thread):
 
     @staticmethod
     def _cmd_exists(cmd):
+        """Placeholder docstring"""
         return any(
             os.access(os.path.join(path, cmd), os.X_OK)
             for path in os.environ["PATH"].split(os.pathsep)
@@ -301,6 +305,7 @@ class TensorFlow(Framework):
         requirements_file,
         checkpoint_path,
     ):
+        """Placeholder docstring"""
 
         if py_version == "py3" or script_mode:
 
@@ -330,11 +335,13 @@ class TensorFlow(Framework):
             self.script_mode = True
 
     def _only_script_mode_supported(self):
+        """Placeholder docstring"""
         return [
             int(s) for s in self.framework_version.split(".")
         ] >= self._LOWEST_SCRIPT_MODE_ONLY_VERSION
 
     def _validate_requirements_file(self, requirements_file):
+        """Placeholder docstring"""
         if not requirements_file:
             return
 
@@ -482,7 +489,7 @@ class TensorFlow(Framework):
 
         Returns:
             sagemaker.tensorflow.model.TensorFlowModel: A SageMaker ``TensorFlowModel`` object.
-                See :func:`~sagemaker.tensorflow.model.TensorFlowModel` for full details.
+            See :func:`~sagemaker.tensorflow.model.TensorFlowModel` for full details.
         """
 
         role = role or self.role
@@ -496,6 +503,7 @@ class TensorFlow(Framework):
         )
 
     def _create_tfs_model(self, role=None, vpc_config_override=VPC_CONFIG_DEFAULT):
+        """Placeholder docstring"""
         return Model(
             model_data=self.model_data,
             role=role,
@@ -508,6 +516,7 @@ class TensorFlow(Framework):
         )
 
     def _create_default_model(self, model_server_workers, role, vpc_config_override):
+        """Placeholder docstring"""
         return TensorFlowModel(
             self.model_data,
             role,
@@ -569,6 +578,7 @@ class TensorFlow(Framework):
         return hyperparameters
 
     def _default_s3_path(self, directory, mpi=False):
+        """Placeholder docstring"""
         local_code = utils.get_config_value("local.local_code", self.sagemaker_session.config)
         if self.sagemaker_session.local_mode and local_code:
             return "/opt/ml/shared/{}".format(directory)
@@ -579,9 +589,11 @@ class TensorFlow(Framework):
         return None
 
     def _script_mode_enabled(self):
+        """Placeholder docstring"""
         return self.py_version == "py3" or self.script_mode
 
     def train_image(self):
+        """Placeholder docstring"""
         if self.image_name:
             return self.image_name
 

--- a/src/sagemaker/tensorflow/model.py
+++ b/src/sagemaker/tensorflow/model.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import absolute_import
 
 import logging
@@ -27,16 +28,19 @@ logger = logging.getLogger("sagemaker")
 class TensorFlowPredictor(RealTimePredictor):
     """A ``RealTimePredictor`` for inference against TensorFlow endpoint.
 
-    This is able to serialize Python lists, dictionaries, and numpy arrays to multidimensional tensors for
-    inference"""
+    This is able to serialize Python lists, dictionaries, and numpy arrays to
+    multidimensional tensors for inference
+    """
 
     def __init__(self, endpoint_name, sagemaker_session=None):
         """Initialize an ``TensorFlowPredictor``.
 
         Args:
-            endpoint_name (str): The name of the endpoint to perform inference on.
-            sagemaker_session (sagemaker.session.Session): Session object which manages interactions with
-                Amazon SageMaker APIs and any other AWS services needed. If not specified, the estimator creates one
+            endpoint_name (str): The name of the endpoint to perform inference
+                on.
+            sagemaker_session (sagemaker.session.Session): Session object which
+                manages interactions with Amazon SageMaker APIs and any other
+                AWS services needed. If not specified, the estimator creates one
                 using the default AWS configuration chain.
         """
         super(TensorFlowPredictor, self).__init__(
@@ -45,6 +49,7 @@ class TensorFlowPredictor(RealTimePredictor):
 
 
 class TensorFlowModel(FrameworkModel):
+    """Placeholder docstring"""
 
     __framework_name__ = "tensorflow"
 
@@ -63,23 +68,32 @@ class TensorFlowModel(FrameworkModel):
         """Initialize an TensorFlowModel.
 
         Args:
-            model_data (str): The S3 location of a SageMaker model data ``.tar.gz`` file.
-            role (str): An AWS IAM role (either name or full ARN). The Amazon SageMaker training jobs and APIs
-                that create Amazon SageMaker endpoints use this role to access training data and model artifacts.
-                After the endpoint is created, the inference code might use the IAM role,
-                if it needs to access an AWS resource.
-            entry_point (str): Path (absolute or relative) to the Python source file which should be executed
-                as the entry point to model hosting. This should be compatible with either Python 2.7 or Python 3.5.
-            image (str): A Docker image URI (default: None). If not specified, a default image for
-                TensorFlow will be used.
-            py_version (str): Python version you want to use for executing your model training code (default: 'py2').
-            framework_version (str): TensorFlow version you want to use for executing your model training code.
-            predictor_cls (callable[str, sagemaker.session.Session]): A function to call to create a predictor
-                with an endpoint name and SageMaker ``Session``. If specified, ``deploy()`` returns the result of
-                invoking this function on the created endpoint name.
-            model_server_workers (int): Optional. The number of worker processes used by the inference server.
-                If None, server will use one worker per vCPU.
-            **kwargs: Keyword arguments passed to the ``FrameworkModel`` initializer.
+            model_data (str): The S3 location of a SageMaker model data
+                ``.tar.gz`` file.
+            role (str): An AWS IAM role (either name or full ARN). The Amazon
+                SageMaker training jobs and APIs that create Amazon SageMaker
+                endpoints use this role to access training data and model
+                artifacts. After the endpoint is created, the inference code
+                might use the IAM role, if it needs to access an AWS resource.
+            entry_point (str): Path (absolute or relative) to the Python source
+                file which should be executed as the entry point to model
+                hosting. This should be compatible with either Python 2.7 or
+                Python 3.5.
+            image (str): A Docker image URI (default: None). If not specified, a
+                default image for TensorFlow will be used.
+            py_version (str): Python version you want to use for executing your
+                model training code (default: 'py2').
+            framework_version (str): TensorFlow version you want to use for
+                executing your model training code.
+            predictor_cls (callable[str, sagemaker.session.Session]): A function
+                to call to create a predictor with an endpoint name and
+                SageMaker ``Session``. If specified, ``deploy()`` returns the
+                result of invoking this function on the created endpoint name.
+            model_server_workers (int): Optional. The number of worker processes
+                used by the inference server. If None, server will use one
+                worker per vCPU.
+            **kwargs: Keyword arguments passed to the ``FrameworkModel``
+                initializer.
         """
         super(TensorFlowModel, self).__init__(
             model_data, image, role, entry_point, predictor_cls=predictor_cls, **kwargs
@@ -93,17 +107,21 @@ class TensorFlowModel(FrameworkModel):
         self.model_server_workers = model_server_workers
 
     def prepare_container_def(self, instance_type, accelerator_type=None):
-        """Return a container definition with framework configuration set in model environment variables.
+        """Return a container definition with framework configuration set in
+        model environment variables.
 
         This also uploads user-supplied code to S3.
 
         Args:
-            instance_type (str): The EC2 instance type to deploy this Model to. For example, 'ml.p2.xlarge'.
-            accelerator_type (str): The Elastic Inference accelerator type to deploy to the instance for loading and
-                making inferences to the model. For example, 'ml.eia1.medium'.
+            instance_type (str): The EC2 instance type to deploy this Model to.
+                For example, 'ml.p2.xlarge'.
+            accelerator_type (str): The Elastic Inference accelerator type to
+                deploy to the instance for loading and making inferences to the
+                model. For example, 'ml.eia1.medium'.
 
         Returns:
-            dict[str, str]: A container definition object usable with the CreateModel API.
+            dict[str, str]: A container definition object usable with the
+            CreateModel API.
         """
         deploy_image = self.image
         if not deploy_image:

--- a/src/sagemaker/tensorflow/predictor.py
+++ b/src/sagemaker/tensorflow/predictor.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import absolute_import
 
 import json
@@ -39,12 +40,18 @@ PREDICT_REQUEST = "PredictRequest"
 
 
 class _TFProtobufSerializer(object):
+    """Placeholder docstring"""
+
     def __init__(self):
         self.content_type = CONTENT_TYPE_OCTET_STREAM
 
     def __call__(self, data):
         # isinstance does not work here because a same protobuf message can be imported from a different module.
         # for example sagemaker.tensorflow.tensorflow_serving.regression_pb2 and tensorflow_serving.apis.regression_pb2
+        """
+        Args:
+            data:
+        """
         predict_type = data.__class__.__name__
 
         available_requests = [
@@ -63,10 +70,18 @@ tf_serializer = _TFProtobufSerializer()
 
 
 class _TFProtobufDeserializer(object):
+    """Placeholder docstring"""
+
     def __init__(self):
+        """Placeholder docstring"""
         self.accept = CONTENT_TYPE_OCTET_STREAM
 
     def __call__(self, stream, content_type):
+        """
+        Args:
+            stream:
+            content_type:
+        """
         try:
             data = stream.read()
         finally:
@@ -88,10 +103,16 @@ tf_deserializer = _TFProtobufDeserializer()
 
 
 class _TFJsonSerializer(object):
+    """Placeholder docstring"""
+
     def __init__(self):
         self.content_type = CONTENT_TYPE_JSON
 
     def __call__(self, data):
+        """
+        Args:
+            data:
+        """
         if isinstance(data, tensor_pb2.TensorProto):
             return json_format.MessageToJson(data)
         return json_serializer(data)
@@ -101,10 +122,17 @@ tf_json_serializer = _TFJsonSerializer()
 
 
 class _TFJsonDeserializer(object):
+    """Placeholder docstring"""
+
     def __init__(self):
         self.accept = CONTENT_TYPE_JSON
 
     def __call__(self, stream, content_type):
+        """
+        Args:
+            stream:
+            content_type:
+        """
         try:
             data = stream.read()
         finally:
@@ -124,10 +152,16 @@ tf_json_deserializer = _TFJsonDeserializer()
 
 
 class _TFCsvSerializer(object):
+    """Placeholder docstring"""
+
     def __init__(self):
         self.content_type = CONTENT_TYPE_CSV
 
     def __call__(self, data):
+        """
+        Args:
+            data:
+        """
         to_serialize = data
         if isinstance(data, tensor_pb2.TensorProto):
             to_serialize = tensor_util.MakeNdarray(data)

--- a/src/sagemaker/tensorflow/serving.py
+++ b/src/sagemaker/tensorflow/serving.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import absolute_import
 
 import logging
@@ -23,7 +24,8 @@ from sagemaker.tensorflow.defaults import TF_VERSION
 
 
 class Predictor(sagemaker.RealTimePredictor):
-    """A ``RealTimePredictor`` implementation for inference against TensorFlow Serving endpoints.
+    """A ``RealTimePredictor`` implementation for inference against TensorFlow
+    Serving endpoints.
     """
 
     def __init__(
@@ -36,23 +38,29 @@ class Predictor(sagemaker.RealTimePredictor):
         model_name=None,
         model_version=None,
     ):
-        """Initialize a ``TFSPredictor``. See ``sagemaker.RealTimePredictor`` for
-        more info about parameters.
+        """Initialize a ``TFSPredictor``. See ``sagemaker.RealTimePredictor``
+        for more info about parameters.
 
         Args:
-            endpoint_name (str): The name of the endpoint to perform inference on.
-            sagemaker_session (sagemaker.session.Session): Session object which manages interactions
-                with Amazon SageMaker APIs and any other AWS services needed. If not specified,
-                the estimator creates one using the default AWS configuration chain.
-            serializer (callable): Optional. Default serializes input data to json. Handles dicts,
-                lists, and numpy arrays.
-            deserializer (callable): Optional. Default parses the response using ``json.load(...)``.
-            content_type (str): Optional. The "ContentType" for invocation requests. If specified,
-                overrides the ``content_type`` from the serializer (default: None).
-            model_name (str): Optional. The name of the SavedModel model that should handle the
-                request. If not specified, the endpoint's default model will handle the request.
-            model_version (str): Optional. The version of the SavedModel model that should handle
-                the request. If not specified, the latest version of the model will be used.
+            endpoint_name (str): The name of the endpoint to perform inference
+                on.
+            sagemaker_session (sagemaker.session.Session): Session object which
+                manages interactions with Amazon SageMaker APIs and any other
+                AWS services needed. If not specified, the estimator creates one
+                using the default AWS configuration chain.
+            serializer (callable): Optional. Default serializes input data to
+                json. Handles dicts, lists, and numpy arrays.
+            deserializer (callable): Optional. Default parses the response using
+                ``json.load(...)``.
+            content_type (str): Optional. The "ContentType" for invocation
+                requests. If specified, overrides the ``content_type`` from the
+                serializer (default: None).
+            model_name (str): Optional. The name of the SavedModel model that
+                should handle the request. If not specified, the endpoint's
+                default model will handle the request.
+            model_version (str): Optional. The version of the SavedModel model
+                that should handle the request. If not specified, the latest
+                version of the model will be used.
         """
         super(Predictor, self).__init__(
             endpoint_name, sagemaker_session, serializer, deserializer, content_type
@@ -66,12 +74,25 @@ class Predictor(sagemaker.RealTimePredictor):
         self._model_attributes = ",".join(attributes) if attributes else None
 
     def classify(self, data):
+        """
+        Args:
+            data:
+        """
         return self._classify_or_regress(data, "classify")
 
     def regress(self, data):
+        """
+        Args:
+            data:
+        """
         return self._classify_or_regress(data, "regress")
 
     def _classify_or_regress(self, data, method):
+        """
+        Args:
+            data:
+            method:
+        """
         if method not in ["classify", "regress"]:
             raise ValueError("invalid TensorFlow Serving method: {}".format(method))
 
@@ -83,6 +104,11 @@ class Predictor(sagemaker.RealTimePredictor):
         return self.predict(data, args)
 
     def predict(self, data, initial_args=None):
+        """
+        Args:
+            data:
+            initial_args:
+        """
         args = dict(initial_args) if initial_args else {}
         if self._model_attributes:
             if "CustomAttributes" in args:
@@ -94,6 +120,8 @@ class Predictor(sagemaker.RealTimePredictor):
 
 
 class Model(sagemaker.model.FrameworkModel):
+    """Placeholder docstring"""
+
     FRAMEWORK_NAME = "tensorflow-serving"
     LOG_LEVEL_PARAM_NAME = "SAGEMAKER_TFS_NGINX_LOGLEVEL"
     LOG_LEVEL_MAP = {
@@ -117,20 +145,26 @@ class Model(sagemaker.model.FrameworkModel):
     ):
         """Initialize a Model.
 
-       Args:
-           model_data (str): The S3 location of a SageMaker model data ``.tar.gz`` file.
-           role (str): An AWS IAM role (either name or full ARN). The Amazon SageMaker APIs that
-                create Amazon SageMaker endpoints use this role to access model artifacts.
-           image (str): A Docker image URI (default: None). If not specified, a default image for
-                TensorFlow Serving will be used.
-           framework_version (str): Optional. TensorFlow Serving version you want to use.
-           container_log_level (int): Log level to use within the container (default: logging.ERROR).
-                Valid values are defined in the Python logging module.
-           predictor_cls (callable[str, sagemaker.session.Session]): A function to call to create a
-                predictor with an endpoint name and SageMaker ``Session``. If specified, ``deploy()``
-                returns the result of invoking this function on the created endpoint name.
-           **kwargs: Keyword arguments passed to the ``Model`` initializer.
-       """
+        Args:
+            model_data (str): The S3 location of a SageMaker model data
+                ``.tar.gz`` file.
+            role (str): An AWS IAM role (either name or full ARN). The Amazon
+                SageMaker APIs that create Amazon SageMaker endpoints use this
+                role to access model artifacts.
+            entry_point:
+            image (str): A Docker image URI (default: None). If not specified, a
+                default image for TensorFlow Serving will be used.
+            framework_version (str): Optional. TensorFlow Serving version you
+                want to use.
+            container_log_level (int): Log level to use within the container
+                (default: logging.ERROR). Valid values are defined in the Python
+                logging module.
+            predictor_cls (callable[str, sagemaker.session.Session]): A function
+                to call to create a predictor with an endpoint name and
+                SageMaker ``Session``. If specified, ``deploy()`` returns the
+                result of invoking this function on the created endpoint name.
+            **kwargs: Keyword arguments passed to the ``Model`` initializer.
+        """
         super(Model, self).__init__(
             model_data=model_data,
             role=role,
@@ -143,6 +177,11 @@ class Model(sagemaker.model.FrameworkModel):
         self._container_log_level = container_log_level
 
     def prepare_container_def(self, instance_type, accelerator_type=None):
+        """
+        Args:
+            instance_type:
+            accelerator_type:
+        """
         image = self._get_image_uri(instance_type, accelerator_type)
         env = self._get_container_env()
 
@@ -166,6 +205,7 @@ class Model(sagemaker.model.FrameworkModel):
         return sagemaker.container_def(image, model_data, env)
 
     def _get_container_env(self):
+        """Placeholder docstring"""
         if not self._container_log_level:
             return self.env
 
@@ -178,6 +218,11 @@ class Model(sagemaker.model.FrameworkModel):
         return env
 
     def _get_image_uri(self, instance_type, accelerator_type=None):
+        """
+        Args:
+            instance_type:
+            accelerator_type:
+        """
         if self.image:
             return self.image
 

--- a/src/sagemaker/transformer.py
+++ b/src/sagemaker/transformer.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import absolute_import
 
 from botocore import exceptions
@@ -20,7 +21,8 @@ from sagemaker.utils import base_name_from_image, name_from_base
 
 
 class Transformer(object):
-    """A class for handling creating and interacting with Amazon SageMaker transform jobs.
+    """A class for handling creating and interacting with Amazon SageMaker
+    transform jobs.
     """
 
     def __init__(
@@ -44,31 +46,42 @@ class Transformer(object):
         """Initialize a ``Transformer``.
 
         Args:
-            model_name (str): Name of the SageMaker model being used for the transform job.
+            model_name (str): Name of the SageMaker model being used for the
+                transform job.
             instance_count (int): Number of EC2 instances to use.
-            instance_type (str): Type of EC2 instance to use, for example, 'ml.c4.xlarge'.
-            strategy (str): The strategy used to decide how to batch records in a single request (default: None).
-                Valid values: 'MultiRecord' and 'SingleRecord'.
-            assemble_with (str): How the output is assembled (default: None). Valid values: 'Line' or 'None'.
-            output_path (str): S3 location for saving the transform result. If not specified, results are stored to
-                a default bucket.
-            output_kms_key (str): Optional. KMS key ID for encrypting the transform output (default: None).
-            accept (str): The content type accepted by the endpoint deployed during the transform job.
-            max_concurrent_transforms (int): The maximum number of HTTP requests to be made to
-                each individual transform container at one time.
-            max_payload (int): Maximum size of the payload in a single HTTP request to the container in MB.
-            env (dict): Environment variables to be set for use during the transform job (default: None).
-            tags (list[dict]): List of tags for labeling a transform job (default: None). For more, see
+            instance_type (str): Type of EC2 instance to use, for example,
+                'ml.c4.xlarge'.
+            strategy (str): The strategy used to decide how to batch records in
+                a single request (default: None). Valid values: 'MultiRecord'
+                and 'SingleRecord'.
+            assemble_with (str): How the output is assembled (default: None).
+                Valid values: 'Line' or 'None'.
+            output_path (str): S3 location for saving the transform result. If
+                not specified, results are stored to a default bucket.
+            output_kms_key (str): Optional. KMS key ID for encrypting the
+                transform output (default: None).
+            accept (str): The content type accepted by the endpoint deployed
+                during the transform job.
+            max_concurrent_transforms (int): The maximum number of HTTP requests
+                to be made to each individual transform container at one time.
+            max_payload (int): Maximum size of the payload in a single HTTP
+                request to the container in MB.
+            tags (list[dict]): List of tags for labeling a transform job
+                (default: None). For more, see
                 https://docs.aws.amazon.com/sagemaker/latest/dg/API_Tag.html.
+            env (dict): Environment variables to be set for use during the
+                transform job (default: None).
             base_transform_job_name (str): Prefix for the transform job when the
-                :meth:`~sagemaker.transformer.Transformer.transform` method launches. If not specified, a default prefix
-                will be generated based on the training image name that was used to train the model associated with
-                the transform job.
-            sagemaker_session (sagemaker.session.Session): Session object which manages interactions with
-                Amazon SageMaker APIs and any other AWS services needed. If not specified, the estimator creates one
+                :meth:`~sagemaker.transformer.Transformer.transform` method
+                launches. If not specified, a default prefix will be generated
+                based on the training image name that was used to train the
+                model associated with the transform job.
+            sagemaker_session (sagemaker.session.Session): Session object which
+                manages interactions with Amazon SageMaker APIs and any other
+                AWS services needed. If not specified, the estimator creates one
                 using the default AWS configuration chain.
-            volume_kms_key (str): Optional. KMS key ID for encrypting the volume attached to the ML
-                compute instance (default: None).
+            volume_kms_key (str): Optional. KMS key ID for encrypting the volume
+                attached to the ML compute instance (default: None).
         """
         self.model_name = model_name
         self.strategy = strategy
@@ -110,28 +123,34 @@ class Transformer(object):
 
         Args:
             data (str): Input data location in S3.
-            data_type (str): What the S3 location defines (default: 'S3Prefix'). Valid values:
+            data_type (str): What the S3 location defines (default: 'S3Prefix').
+                Valid values:
 
                 * 'S3Prefix' - the S3 URI defines a key name prefix. All objects with this prefix will be used as
-                    inputs for the transform job.
-                * 'ManifestFile' - the S3 URI points to a single manifest file listing each S3 object to use as
-                    an input for the transform job.
+                      inputs for the transform job.
 
+                * 'ManifestFile' - the S3 URI points to a single manifest file listing each S3 object to use as
+                      an input for the transform job.
             content_type (str): MIME type of the input data (default: None).
-            compression_type (str): Compression type of the input data, if compressed (default: None).
-                Valid values: 'Gzip', None.
-            split_type (str): The record delimiter for the input object (default: 'None').
-                Valid values: 'None', 'Line', 'RecordIO', and 'TFRecord'.
-            job_name (str): job name (default: None). If not specified, one will be generated.
-            input_filter (str): A JSONPath to select a portion of the input to pass to the algorithm container for
-                inference. If you omit the field, it gets the value '$', representing the entire input.
+            compression_type (str): Compression type of the input data, if
+                compressed (default: None). Valid values: 'Gzip', None.
+            split_type (str): The record delimiter for the input object
+                (default: 'None'). Valid values: 'None', 'Line', 'RecordIO', and
+                'TFRecord'.
+            job_name (str): job name (default: None). If not specified, one will
+                be generated.
+            input_filter (str): A JSONPath to select a portion of the input to
+                pass to the algorithm container for inference. If you omit the
+                field, it gets the value '$', representing the entire input.
                 Some examples: "$[1:]", "$.features"(default: None).
-            output_filter (str): A JSONPath to select a portion of the joined/original output to return as the output.
-                Some examples: "$[1:]", "$.prediction" (default: None).
-            join_source (str): The source of data to be joined to the transform output. It can be set to 'Input'
-                meaning the entire input record will be joined to the inference result.
-                You can use OutputFilter to select the useful portion before uploading to S3. (default: None).
-                Valid values: Input, None.
+            output_filter (str): A JSONPath to select a portion of the
+                joined/original output to return as the output. Some examples:
+                "$[1:]", "$.prediction" (default: None).
+            join_source (str): The source of data to be joined to the transform
+                output. It can be set to 'Input' meaning the entire input record
+                will be joined to the inference result. You can use OutputFilter
+                to select the useful portion before uploading to S3. (default:
+                None). Valid values: Input, None.
         """
         local_mode = self.sagemaker_session.local_mode
         if not local_mode and not data.startswith("s3://"):
@@ -166,12 +185,11 @@ class Transformer(object):
         )
 
     def delete_model(self):
-        """Delete the corresponding SageMaker model for this Transformer.
-
-        """
+        """Delete the corresponding SageMaker model for this Transformer."""
         self.sagemaker_session.delete_model(self.model_name)
 
     def _retrieve_base_name(self):
+        """Placeholder docstring"""
         image_name = self._retrieve_image_name()
 
         if image_name:
@@ -180,6 +198,7 @@ class Transformer(object):
         return self.model_name
 
     def _retrieve_image_name(self):
+        """Placeholder docstring"""
         try:
             model_desc = self.sagemaker_session.sagemaker_client.describe_model(
                 ModelName=self.model_name
@@ -203,10 +222,12 @@ class Transformer(object):
             )
 
     def wait(self):
+        """Placeholder docstring"""
         self._ensure_last_transform_job()
         self.latest_transform_job.wait()
 
     def _ensure_last_transform_job(self):
+        """Placeholder docstring"""
         if self.latest_transform_job is None:
             raise ValueError("No transform job available")
 
@@ -216,13 +237,14 @@ class Transformer(object):
 
         Args:
             transform_job_name (str): Name for the transform job to be attached.
-            sagemaker_session (sagemaker.session.Session): Session object which manages interactions with
-                Amazon SageMaker APIs and any other AWS services needed. If not specified, one will be created
-                using the default AWS configuration chain.
+            sagemaker_session (sagemaker.session.Session): Session object which
+                manages interactions with Amazon SageMaker APIs and any other
+                AWS services needed. If not specified, one will be created using
+                the default AWS configuration chain.
 
         Returns:
-            sagemaker.transformer.Transformer: The Transformer instance with the specified transform job attached.
-
+            sagemaker.transformer.Transformer: The Transformer instance with the
+            specified transform job attached.
         """
         sagemaker_session = sagemaker_session or Session()
 
@@ -239,10 +261,12 @@ class Transformer(object):
 
     @classmethod
     def _prepare_init_params_from_job_description(cls, job_details):
-        """Convert the transform job description to init params that can be handled by the class constructor
+        """Convert the transform job description to init params that can be
+        handled by the class constructor
 
         Args:
-            job_details (dict): the returned job details from a describe_transform_job API call.
+            job_details (dict): the returned job details from a
+                describe_transform_job API call.
 
         Returns:
             dict: The transformed init_params
@@ -266,6 +290,8 @@ class Transformer(object):
 
 
 class _TransformJob(_Job):
+    """Placeholder docstring"""
+
     @classmethod
     def start_new(
         cls,
@@ -279,6 +305,18 @@ class _TransformJob(_Job):
         output_filter,
         join_source,
     ):
+        """
+        Args:
+            transformer:
+            data:
+            data_type:
+            content_type:
+            compression_type:
+            split_type:
+            input_filter:
+            output_filter:
+            join_source:
+        """
         config = _TransformJob._load_config(
             data, data_type, content_type, compression_type, split_type, transformer
         )
@@ -307,6 +345,15 @@ class _TransformJob(_Job):
 
     @staticmethod
     def _load_config(data, data_type, content_type, compression_type, split_type, transformer):
+        """
+        Args:
+            data:
+            data_type:
+            content_type:
+            compression_type:
+            split_type:
+            transformer:
+        """
         input_config = _TransformJob._format_inputs_to_input_config(
             data, data_type, content_type, compression_type, split_type
         )
@@ -330,6 +377,14 @@ class _TransformJob(_Job):
 
     @staticmethod
     def _format_inputs_to_input_config(data, data_type, content_type, compression_type, split_type):
+        """
+        Args:
+            data:
+            data_type:
+            content_type:
+            compression_type:
+            split_type:
+        """
         config = {"DataSource": {"S3DataSource": {"S3DataType": data_type, "S3Uri": data}}}
 
         if content_type is not None:
@@ -345,6 +400,13 @@ class _TransformJob(_Job):
 
     @staticmethod
     def _prepare_output_config(s3_path, kms_key_id, assemble_with, accept):
+        """
+        Args:
+            s3_path:
+            kms_key_id:
+            assemble_with:
+            accept:
+        """
         config = super(_TransformJob, _TransformJob)._prepare_output_config(s3_path, kms_key_id)
 
         if assemble_with is not None:
@@ -357,6 +419,12 @@ class _TransformJob(_Job):
 
     @staticmethod
     def _prepare_resource_config(instance_count, instance_type, volume_kms_key):
+        """
+        Args:
+            instance_count:
+            instance_type:
+            volume_kms_key:
+        """
         config = {"InstanceCount": instance_count, "InstanceType": instance_type}
 
         if volume_kms_key is not None:
@@ -366,6 +434,12 @@ class _TransformJob(_Job):
 
     @staticmethod
     def _prepare_data_processing(input_filter, output_filter, join_source):
+        """
+        Args:
+            input_filter:
+            output_filter:
+            join_source:
+        """
         config = {}
 
         if input_filter is not None:

--- a/src/sagemaker/tuner.py
+++ b/src/sagemaker/tuner.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import absolute_import
 
 import importlib
@@ -52,10 +53,11 @@ WARM_START_TYPE = "WarmStartType"
 
 class WarmStartTypes(Enum):
     """Warm Start Configuration type. There can be two types of warm start jobs:
-        * IdenticalDataAndAlgorithm: Type of warm start that allows users to reuse training results from existing
-        tuning jobs that have the same algorithm code and datasets.
-        * TransferLearning: Type of warm start that allows users to reuse training results from existing tuning jobs
-        that have similar algorithm code and datasets.
+    * IdenticalDataAndAlgorithm: Type of warm start that allows users to reuse
+    training results from existing tuning jobs that have the same algorithm code
+    and datasets. * TransferLearning: Type of warm start that allows users to
+    reuse training results from existing tuning jobs that have similar algorithm
+    code and datasets.
     """
 
     IDENTICAL_DATA_AND_ALGORITHM = "IdenticalDataAndAlgorithm"
@@ -63,8 +65,8 @@ class WarmStartTypes(Enum):
 
 
 class WarmStartConfig(object):
-    """Warm Start Configuration which defines the nature of the warm start ``HyperparameterTuner``, with type and
-    parents for warm start.
+    """Warm Start Configuration which defines the nature of the warm start
+    ``HyperparameterTuner``, with type and parents for warm start.
 
     Examples:
         >>> warm_start_config = WarmStartConfig(type=WarmStartTypes.TransferLearning, parents={"p1","p2"})
@@ -75,12 +77,14 @@ class WarmStartConfig(object):
     """
 
     def __init__(self, warm_start_type, parents):
-        """Initializes the ``WarmStartConfig`` with the provided ``WarmStartTypes`` and parents.
+        """Initializes the ``WarmStartConfig`` with the provided
+        ``WarmStartTypes`` and parents.
 
         Args:
-            warm_start_type (sagemaker.tuner.WarmStartTypes): This should be one of the supported warm start types
-            in WarmStartType
-            parents (set{str}): Set of parent tuning jobs which will be used to warm start the new tuning job.
+            warm_start_type (sagemaker.tuner.WarmStartTypes): This should be one
+                of the supported warm start types in WarmStartType
+            parents (set{str}): Set of parent tuning jobs which will be used to
+                warm start the new tuning job.
         """
 
         if warm_start_type not in WarmStartTypes:
@@ -100,19 +104,8 @@ class WarmStartConfig(object):
 
     @classmethod
     def from_job_desc(cls, warm_start_config):
-        """Creates an instance of ``WarmStartConfig`` class, from warm start configuration response from
-        DescribeTrainingJob.
-
-        Args:
-            warm_start_config (dict): The expected format of the ``warm_start_config`` contains two first-class
-            fields:
-                * "type": Type of warm start tuner, currently two supported types - "IdenticalDataAndAlgorithm" and
-                "TransferLearning".
-                * "parents": List of tuning job names from which the warm start should be done.
-
-        Returns:
-            sagemaker.tuner.WarmStartConfig: De-serialized instance of WarmStartConfig containing the type and parents
-            provided as part of ``warm_start_config``.
+        """Creates an instance of ``WarmStartConfig`` class, from warm start
+        configuration response from DescribeTrainingJob.
 
         Examples:
             >>> warm_start_config = WarmStartConfig.from_job_desc(warm_start_config={
@@ -126,6 +119,15 @@ class WarmStartConfig(object):
             "TransferLearning"
             >>> warm_start_config.parents
             ["p1","p2"]
+
+        Args:
+            warm_start_config (dict): The expected format of the
+                ``warm_start_config`` contains two first-class
+
+        Returns:
+            sagemaker.tuner.WarmStartConfig: De-serialized instance of
+            WarmStartConfig containing the type and parents provided as part of
+            ``warm_start_config``.
         """
         if (
             not warm_start_config
@@ -145,11 +147,11 @@ class WarmStartConfig(object):
     def to_input_req(self):
         """Converts the ``self`` instance to the desired input request format.
 
-        Returns:
-            dict: Containing the "WarmStartType" and "ParentHyperParameterTuningJobs" as the first class fields.
-
         Examples:
-            >>> warm_start_config = WarmStartConfig(warm_start_type=WarmStartTypes.TransferLearning,parents=["p1,p2"])
+            >>> warm_start_config = WarmStartConfig
+            (
+                warm_start_type=WarmStartTypes.TransferLearning,parents=["p1,p2"]
+            )
             >>> warm_start_config.to_input_req()
             {
                 "WarmStartType":"TransferLearning",
@@ -158,6 +160,10 @@ class WarmStartConfig(object):
                     {'HyperParameterTuningJobName': "p2"},
                 ]
             }
+
+        Returns:
+            dict: Containing the "WarmStartType" and
+            "ParentHyperParameterTuningJobs" as the first class fields.
         """
         return {
             WARM_START_TYPE: self.type.value,
@@ -168,8 +174,8 @@ class WarmStartConfig(object):
 
 
 class HyperparameterTuner(object):
-    """A class for creating and interacting with Amazon SageMaker hyperparameter tuning jobs, as well as
-    deploying the resulting model(s).
+    """A class for creating and interacting with Amazon SageMaker hyperparameter
+    tuning jobs, as well as deploying the resulting model(s).
     """
 
     TUNING_JOB_NAME_MAX_LENGTH = 32
@@ -195,37 +201,55 @@ class HyperparameterTuner(object):
         warm_start_config=None,
         early_stopping_type="Off",
     ):
-        """Initialize a ``HyperparameterTuner``. It takes an estimator to obtain configuration information
-        for training jobs that are created as the result of a hyperparameter tuning job.
+        """Initialize a ``HyperparameterTuner``. It takes an estimator to obtain
+        configuration information for training jobs that are created as the
+        result of a hyperparameter tuning job.
 
         Args:
-            estimator (sagemaker.estimator.EstimatorBase): An estimator object that has been initialized with
-                the desired configuration. There does not need to be a training job associated with this instance.
-            objective_metric_name (str): Name of the metric for evaluating training jobs.
-            hyperparameter_ranges (dict[str, sagemaker.parameter.ParameterRange]): Dictionary of parameter ranges.
-                These parameter ranges can be one of three types: Continuous, Integer, or Categorical. The keys of the
-                dictionary are the names of the hyperparameter, and the values are the appropriate parameter range class
-                to represent the range.
-            metric_definitions (list[dict]): A list of dictionaries that defines the metric(s) used to evaluate the
-                training jobs (default: None). Each dictionary contains two keys: 'Name' for the name of the metric, and
-                'Regex' for the regular expression used to extract the metric from the logs. This should be defined only
-                for hyperparameter tuning jobs that don't use an Amazon algorithm.
-            strategy (str): Strategy to be used for hyperparameter estimations (default: 'Bayesian').
-            objective_type (str): The type of the objective metric for evaluating training jobs. This value can be
-                either 'Minimize' or 'Maximize' (default: 'Maximize').
-            max_jobs (int): Maximum total number of training jobs to start for the hyperparameter tuning job
-                (default: 1).
-            max_parallel_jobs (int): Maximum number of parallel training jobs to start (default: 1).
-            tags (list[dict]): List of tags for labeling the tuning job (default: None). For more, see
+            estimator (sagemaker.estimator.EstimatorBase): An estimator object
+                that has been initialized with the desired configuration. There
+                does not need to be a training job associated with this
+                instance.
+            objective_metric_name (str): Name of the metric for evaluating
+                training jobs.
+            hyperparameter_ranges (dict[str, sagemaker.parameter.ParameterRange]): Dictionary of
+                parameter ranges. These parameter ranges can be one
+                of three types: Continuous, Integer, or Categorical. The keys of
+                the dictionary are the names of the hyperparameter, and the
+                values are the appropriate parameter range class to represent
+                the range.
+            metric_definitions (list[dict]): A list of dictionaries that defines
+                the metric(s) used to evaluate the training jobs (default:
+                None). Each dictionary contains two keys: 'Name' for the name of
+                the metric, and 'Regex' for the regular expression used to
+                extract the metric from the logs. This should be defined only
+                for hyperparameter tuning jobs that don't use an Amazon
+                algorithm.
+            strategy (str): Strategy to be used for hyperparameter estimations
+                (default: 'Bayesian').
+            objective_type (str): The type of the objective metric for
+                evaluating training jobs. This value can be either 'Minimize' or
+                'Maximize' (default: 'Maximize').
+            max_jobs (int): Maximum total number of training jobs to start for
+                the hyperparameter tuning job (default: 1).
+            max_parallel_jobs (int): Maximum number of parallel training jobs to
+                start (default: 1).
+            tags (list[dict]): List of tags for labeling the tuning job
+                (default: None). For more, see
                 https://docs.aws.amazon.com/sagemaker/latest/dg/API_Tag.html.
-            base_tuning_job_name (str): Prefix for the hyperparameter tuning job name when the
-                :meth:`~sagemaker.tuner.HyperparameterTuner.fit` method launches. If not specified,
-                a default job name is generated, based on the training image name and current timestamp.
-            warm_start_config (sagemaker.tuner.WarmStartConfig): A ``WarmStartConfig`` object that has been initialized
-                with the configuration defining the nature of warm start tuning job.
-            early_stopping_type (str): Specifies whether early stopping is enabled for the job.
-                Can be either 'Auto' or 'Off' (default: 'Off'). If set to 'Off', early stopping will not be attempted.
-                If set to 'Auto', early stopping of some training jobs may happen, but is not guaranteed to.
+            base_tuning_job_name (str): Prefix for the hyperparameter tuning job
+                name when the :meth:`~sagemaker.tuner.HyperparameterTuner.fit`
+                method launches. If not specified, a default job name is
+                generated, based on the training image name and current
+                timestamp.
+            warm_start_config (sagemaker.tuner.WarmStartConfig): A
+                ``WarmStartConfig`` object that has been initialized with the
+                configuration defining the nature of warm start tuning job.
+            early_stopping_type (str): Specifies whether early stopping is
+                enabled for the job. Can be either 'Auto' or 'Off' (default:
+                'Off'). If set to 'Off', early stopping will not be attempted.
+                If set to 'Auto', early stopping of some training jobs may
+                happen, but is not guaranteed to.
         """
         self._hyperparameter_ranges = hyperparameter_ranges
         if self._hyperparameter_ranges is None or len(self._hyperparameter_ranges) == 0:
@@ -250,6 +274,11 @@ class HyperparameterTuner(object):
         self.static_hyperparameters = None
 
     def _prepare_for_training(self, job_name=None, include_cls_metadata=False):
+        """
+        Args:
+            job_name:
+            include_cls_metadata:
+        """
         if job_name is not None:
             self._current_job_name = job_name
         else:
@@ -280,33 +309,42 @@ class HyperparameterTuner(object):
         """Start a hyperparameter tuning job.
 
         Args:
-            inputs: Information about the training data. Please refer to the ``fit()`` method of
-                the associated estimator, as this can take any of the following forms:
+            inputs: Information about the training data. Please refer to the
+                ``fit()`` method of the associated estimator, as this can take
+                any of the following forms:
 
                 * (str) - The S3 location where training data is saved.
-                * (dict[str, str] or dict[str, sagemaker.session.s3_input]) - If using multiple channels for
-                    training data, you can specify a dict mapping channel names
-                    to strings or :func:`~sagemaker.session.s3_input` objects.
-                * (sagemaker.session.s3_input) - Channel configuration for S3 data sources that can provide
-                    additional information about the training dataset. See :func:`sagemaker.session.s3_input`
-                    for full details.
-                * (sagemaker.amazon.amazon_estimator.RecordSet) - A collection of
-                    Amazon :class:~`Record` objects serialized and stored in S3.
-                    For use with an estimator for an Amazon algorithm.
-                * (list[sagemaker.amazon.amazon_estimator.RecordSet]) - A list of
-                    :class:~`sagemaker.amazon.amazon_estimator.RecordSet` objects, where each instance is
-                    a different channel of training data.
 
-            job_name (str): Tuning job name. If not specified, the tuner generates a default job name,
-                based on the training image name and current timestamp.
-            include_cls_metadata (bool): Whether or not the hyperparameter tuning job should include
-                information about the estimator class (default: False). This information is passed
-                as a hyperparameter, so if the algorithm you are using cannot handle
-                unknown hyperparameters (e.g. an Amazon SageMaker built-in algorithm that
-                does not have a custom estimator in the Python SDK), then set
-                ``include_cls_metadata`` to ``False``.
-            **kwargs: Other arguments needed for training. Please refer to the ``fit()`` method of the associated
-                estimator to see what other arguments are needed.
+                * (dict[str, str] or dict[str, sagemaker.session.s3_input]) - If using multiple
+                      channels for training data, you can specify a dict mapping channel
+                      names to strings or :func:`~sagemaker.session.s3_input`
+                      objects.
+
+                * (sagemaker.session.s3_input) - Channel configuration for S3 data sources that can
+                      provide additional information about the training dataset. See
+                      :func:`sagemaker.session.s3_input` for full details.
+
+                * (sagemaker.amazon.amazon_estimator.RecordSet) - A collection of
+                      Amazon :class:~`Record` objects serialized and stored in
+                      S3. For use with an estimator for an Amazon algorithm.
+
+                * (list[sagemaker.amazon.amazon_estimator.RecordSet]) - A list of
+                      :class:~`sagemaker.amazon.amazon_estimator.RecordSet`
+                      objects, where each instance is a different channel of
+                      training data.
+            job_name (str): Tuning job name. If not specified, the tuner
+                generates a default job name, based on the training image name
+                and current timestamp.
+            include_cls_metadata (bool): Whether or not the hyperparameter
+                tuning job should include information about the estimator class
+                (default: False). This information is passed as a
+                hyperparameter, so if the algorithm you are using cannot handle
+                unknown hyperparameters (e.g. an Amazon SageMaker built-in
+                algorithm that does not have a custom estimator in the Python
+                SDK), then set ``include_cls_metadata`` to ``False``.
+            **kwargs: Other arguments needed for training. Please refer to the
+                ``fit()`` method of the associated estimator to see what other
+                arguments are needed.
         """
         if isinstance(inputs, (list, RecordSet)):
             self.estimator._prepare_for_training(inputs, **kwargs)
@@ -320,21 +358,10 @@ class HyperparameterTuner(object):
     def attach(cls, tuning_job_name, sagemaker_session=None, job_details=None, estimator_cls=None):
         """Attach to an existing hyperparameter tuning job.
 
-        Create a HyperparameterTuner bound to an existing hyperparameter tuning job. After attaching, if there exists a
-        best training job (or any other completed training job), that can be deployed to create
-        an Amazon SageMaker Endpoint and return a ``Predictor``.
-
-        Args:
-            tuning_job_name (str): The name of the hyperparameter tuning job to attach to.
-            sagemaker_session (sagemaker.session.Session): Session object which manages interactions with
-                Amazon SageMaker APIs and any other AWS services needed. If not specified, one is created
-                using the default AWS configuration chain.
-            job_details (dict): The response to a ``DescribeHyperParameterTuningJob`` call. If not specified,
-                the ``HyperparameterTuner`` will perform one such call with the provided hyperparameter tuning job name.
-            estimator_cls (str): The estimator class name associated with the training jobs,
-                e.g. 'sagemaker.estimator.Estimator'. If not specified, the ``HyperparameterTuner`` will try to derive
-                the correct estimator class from training job metadata, defaulting to
-                :class:~`sagemaker.estimator.Estimator` if it is unable to determine a more specific class.
+        Create a HyperparameterTuner bound to an existing hyperparameter
+        tuning job. After attaching, if there exists a best training job (or any
+        other completed training job), that can be deployed to create an Amazon
+        SageMaker Endpoint and return a ``Predictor``.
 
         Examples:
             >>> my_tuner.fit()
@@ -343,9 +370,27 @@ class HyperparameterTuner(object):
             >>> attached_tuner = HyperparameterTuner.attach(job_name)
             >>> attached_tuner.deploy()
 
+        Args:
+            tuning_job_name (str): The name of the hyperparameter tuning job to
+                attach to.
+            sagemaker_session (sagemaker.session.Session): Session object which
+                manages interactions with Amazon SageMaker APIs and any other
+                AWS services needed. If not specified, one is created using the
+                default AWS configuration chain.
+            job_details (dict): The response to a
+                ``DescribeHyperParameterTuningJob`` call. If not specified, the
+                ``HyperparameterTuner`` will perform one such call with the
+                provided hyperparameter tuning job name.
+            estimator_cls (str): The estimator class name associated with the
+                training jobs, e.g. 'sagemaker.estimator.Estimator'. If not
+                specified, the ``HyperparameterTuner`` will try to derive the
+                correct estimator class from training job metadata, defaulting
+                to :class:~`sagemaker.estimator.Estimator` if it is unable to
+                determine a more specific class.
+
         Returns:
-            sagemaker.tuner.HyperparameterTuner: A ``HyperparameterTuner`` instance with the attached hyperparameter
-                tuning job.
+            sagemaker.tuner.HyperparameterTuner: A ``HyperparameterTuner``
+            instance with the attached hyperparameter tuning job.
         """
         sagemaker_session = sagemaker_session or Session()
 
@@ -379,30 +424,38 @@ class HyperparameterTuner(object):
         model_name=None,
         **kwargs
     ):
-        """Deploy the best trained or user specified model to an Amazon SageMaker endpoint and return a
-        ``sagemaker.RealTimePredictor`` object.
+        """Deploy the best trained or user specified model to an Amazon
+        SageMaker endpoint and return a ``sagemaker.RealTimePredictor`` object.
 
-        For more information: http://docs.aws.amazon.com/sagemaker/latest/dg/how-it-works-training.html
+        For more information:
+        http://docs.aws.amazon.com/sagemaker/latest/dg/how-it-works-training.html
 
         Args:
-            initial_instance_count (int): Minimum number of EC2 instances to deploy to an endpoint for prediction.
-            instance_type (str): Type of EC2 instance to deploy to an endpoint for prediction,
-                for example, 'ml.c4.xlarge'.
-            accelerator_type (str): Type of Elastic Inference accelerator to attach to an endpoint for model loading
-                and inference, for example, 'ml.eia1.medium'. If not specified, no Elastic Inference accelerator
-                will be attached to the endpoint.
-                For more information: https://docs.aws.amazon.com/sagemaker/latest/dg/ei.html
-            endpoint_name (str): Name to use for creating an Amazon SageMaker endpoint. If not specified,
-                the name of the training job is used.
-            wait (bool): Whether the call should wait until the deployment of model completes (default: True).
-            model_name (str): Name to use for creating an Amazon SageMaker model. If not specified, the name of
-                the training job is used.
-            **kwargs: Other arguments needed for deployment. Please refer to the ``create_model()`` method of
-                the associated estimator to see what other arguments are needed.
+            initial_instance_count (int): Minimum number of EC2 instances to
+                deploy to an endpoint for prediction.
+            instance_type (str): Type of EC2 instance to deploy to an endpoint
+                for prediction, for example, 'ml.c4.xlarge'.
+            accelerator_type (str): Type of Elastic Inference accelerator to
+                attach to an endpoint for model loading and inference, for
+                example, 'ml.eia1.medium'. If not specified, no Elastic
+                Inference accelerator will be attached to the endpoint. For more
+                information:
+                https://docs.aws.amazon.com/sagemaker/latest/dg/ei.html
+            endpoint_name (str): Name to use for creating an Amazon SageMaker
+                endpoint. If not specified, the name of the training job is
+                used.
+            wait (bool): Whether the call should wait until the deployment of
+                model completes (default: True).
+            model_name (str): Name to use for creating an Amazon SageMaker
+                model. If not specified, the name of the training job is used.
+            **kwargs: Other arguments needed for deployment. Please refer to the
+                ``create_model()`` method of the associated estimator to see
+                what other arguments are needed.
 
         Returns:
             sagemaker.predictor.RealTimePredictor: A predictor that provides a ``predict()`` method,
-                which can be used to send requests to the Amazon SageMaker endpoint and obtain inferences.
+                which can be used to send requests to the Amazon SageMaker
+                endpoint and obtain inferences.
         """
         endpoint_name = endpoint_name or self.best_training_job()
         best_estimator = self.estimator.attach(
@@ -419,22 +472,22 @@ class HyperparameterTuner(object):
         )
 
     def stop_tuning_job(self):
-        """Stop latest running hyperparameter tuning job.
-        """
+        """Stop latest running hyperparameter tuning job."""
         self._ensure_last_tuning_job()
         self.latest_tuning_job.stop()
 
     def wait(self):
-        """Wait for latest hyperparameter tuning job to finish.
-        """
+        """Wait for latest hyperparameter tuning job to finish."""
         self._ensure_last_tuning_job()
         self.latest_tuning_job.wait()
 
     def best_training_job(self):
-        """Return name of the best training job for the latest hyperparameter tuning job.
+        """Return name of the best training job for the latest hyperparameter
+        tuning job.
 
         Raises:
-            Exception: If there is no best training job available for the hyperparameter tuning job.
+            Exception: If there is no best training job available for the
+                hyperparameter tuning job.
         """
         self._ensure_last_tuning_job()
 
@@ -454,8 +507,8 @@ class HyperparameterTuner(object):
     def delete_endpoint(self, endpoint_name=None):
         """Delete an Amazon SageMaker endpoint.
 
-        If an endpoint name is not specified, this defaults to looking for an endpoint that
-        shares a name with the best training job for deletion.
+        If an endpoint name is not specified, this defaults to looking for an
+        endpoint that shares a name with the best training job for deletion.
 
         Args:
             endpoint_name (str): Name of the endpoint to delete
@@ -464,12 +517,18 @@ class HyperparameterTuner(object):
         self.sagemaker_session.delete_endpoint(endpoint_name)
 
     def _ensure_last_tuning_job(self):
+        """Placeholder docstring"""
         if self.latest_tuning_job is None:
             raise ValueError("No tuning job available")
 
     @classmethod
     def _prepare_estimator_cls(cls, estimator_cls, training_details):
         # Check for customer-specified estimator first
+        """
+        Args:
+            estimator_cls:
+            training_details:
+        """
         if estimator_cls is not None:
             module, cls_name = estimator_cls.rsplit(".", 1)
             return getattr(importlib.import_module(module), cls_name)
@@ -498,6 +557,12 @@ class HyperparameterTuner(object):
 
     @classmethod
     def _prepare_estimator_from_job_description(cls, estimator_cls, job_details, sagemaker_session):
+        """
+        Args:
+            estimator_cls:
+            job_details:
+            sagemaker_session:
+        """
         training_details = job_details["TrainingJobDefinition"]
 
         # Swap name for static hyperparameters to what an estimator would expect
@@ -528,6 +593,10 @@ class HyperparameterTuner(object):
 
     @classmethod
     def _prepare_init_params_from_job_description(cls, job_details):
+        """
+        Args:
+            job_details:
+        """
         tuning_config = job_details["HyperParameterTuningJobConfig"]
         return {
             "metric_definitions": job_details["TrainingJobDefinition"]["AlgorithmSpecification"][
@@ -551,6 +620,10 @@ class HyperparameterTuner(object):
 
     @classmethod
     def _prepare_parameter_ranges(cls, parameter_ranges):
+        """
+        Args:
+            parameter_ranges:
+        """
         ranges = {}
 
         for parameter in parameter_ranges["CategoricalParameterRanges"]:
@@ -570,6 +643,10 @@ class HyperparameterTuner(object):
 
     @classmethod
     def _extract_hyperparameters_from_parameter_ranges(cls, parameter_ranges):
+        """
+        Args:
+            parameter_ranges:
+        """
         hyperparameters = {}
 
         for parameter in parameter_ranges["CategoricalParameterRanges"]:
@@ -584,8 +661,8 @@ class HyperparameterTuner(object):
         return hyperparameters
 
     def hyperparameter_ranges(self):
-        """Return the hyperparameter ranges in a dictionary to be used as part of a request for creating a
-        hyperparameter tuning job.
+        """Return the hyperparameter ranges in a dictionary to be used as part
+        of a request for creating a hyperparameter tuning job.
         """
         hyperparameter_ranges = dict()
         for range_type in ParameterRange.__all_types__:
@@ -605,18 +682,21 @@ class HyperparameterTuner(object):
 
     @property
     def sagemaker_session(self):
-        """Convenience method for accessing the :class:`~sagemaker.session.Session` object associated
-        with the estimator for the ``HyperparameterTuner``.
+        """Convenience method for accessing the
+        :class:`~sagemaker.session.Session` object associated with the estimator
+        for the ``HyperparameterTuner``.
         """
         return self.estimator.sagemaker_session
 
     def analytics(self):
-        """An instance of HyperparameterTuningJobAnalytics for this latest tuning job of this tuner.
-        Analytics olbject gives you access to tuning results summarized into a pandas dataframe.
+        """An instance of HyperparameterTuningJobAnalytics for this latest
+        tuning job of this tuner. Analytics olbject gives you access to tuning
+        results summarized into a pandas dataframe.
         """
         return HyperparameterTuningJobAnalytics(self.latest_tuning_job.name, self.sagemaker_session)
 
     def _validate_parameter_ranges(self):
+        """Placeholder docstring"""
         for kls in inspect.getmro(self.estimator.__class__)[::-1]:
             for _, value in kls.__dict__.items():
                 if isinstance(value, hp):
@@ -632,6 +712,11 @@ class HyperparameterTuner(object):
                         pass
 
     def _validate_parameter_range(self, value_hp, parameter_range):
+        """
+        Args:
+            value_hp:
+            parameter_range:
+        """
         for (parameter_range_key, parameter_range_value) in parameter_range.__dict__.items():
             if parameter_range_key == "scaling_type":
                 continue
@@ -645,26 +730,30 @@ class HyperparameterTuner(object):
                 value_hp.validate(parameter_range_value)
 
     def transfer_learning_tuner(self, additional_parents=None, estimator=None):
-        """Creates a new ``HyperparameterTuner`` by copying the request fields from the provided parent to the new
-        instance of ``HyperparameterTuner``. Followed by addition of warm start configuration with the type as
-        "TransferLearning" and parents as the union of provided list of ``additional_parents`` and the ``self``.
-        Also, training image in the new tuner's estimator is updated with the provided ``training_image``.
-
-        Args:
-            additional_parents (set{str}): Set of additional parents along with the self to be used in warm starting
-            the transfer learning tuner.
-            estimator (sagemaker.estimator.EstimatorBase): An estimator object that has been initialized with
-                the desired configuration. There does not need to be a training job associated with this instance.
-
-        Returns:
-            sagemaker.tuner.HyperparameterTuner: ``HyperparameterTuner`` instance which can be used to launch transfer
-            learning tuning job.
+        """Creates a new ``HyperparameterTuner`` by copying the request fields
+        from the provided parent to the new instance of ``HyperparameterTuner``.
+        Followed by addition of warm start configuration with the type as
+        "TransferLearning" and parents as the union of provided list of
+        ``additional_parents`` and the ``self``. Also, training image in the new
+        tuner's estimator is updated with the provided ``training_image``.
 
         Examples:
             >>> parent_tuner = HyperparameterTuner.attach(tuning_job_name="parent-job-1")
             >>> transfer_learning_tuner = parent_tuner.transfer_learning_tuner(additional_parents={"parent-job-2"})
             Later On:
             >>> transfer_learning_tuner.fit(inputs={})
+
+        Args:
+            additional_parents (set{str}): Set of additional parents along with
+                the self to be used in warm starting
+            estimator (sagemaker.estimator.EstimatorBase): An estimator object
+                that has been initialized with the desired configuration. There
+                does not need to be a training job associated with this
+                instance.
+
+        Returns:
+            sagemaker.tuner.HyperparameterTuner: ``HyperparameterTuner``
+            instance which can be used to launch transfer learning tuning job.
         """
 
         return self._create_warm_start_tuner(
@@ -674,17 +763,11 @@ class HyperparameterTuner(object):
         )
 
     def identical_dataset_and_algorithm_tuner(self, additional_parents=None):
-        """Creates a new ``HyperparameterTuner`` by copying the request fields from the provided parent to the new
-        instance of ``HyperparameterTuner``. Followed by addition of warm start configuration with the type as
-        "IdenticalDataAndAlgorithm" and parents as the union of provided list of ``additional_parents`` and the ``self``
-
-        Args:
-            additional_parents (set{str}): Set of additional parents along with the self to be used in warm starting
-            the identical dataset and algorithm tuner.
-
-        Returns:
-            sagemaker.tuner.HyperparameterTuner: HyperparameterTuner instance which can be used to launch identical
-            dataset and algorithm tuning job.
+        """Creates a new ``HyperparameterTuner`` by copying the request fields
+        from the provided parent to the new instance of ``HyperparameterTuner``.
+        Followed by addition of warm start configuration with the type as
+        "IdenticalDataAndAlgorithm" and parents as the union of provided list of
+        ``additional_parents`` and the ``self``
 
         Examples:
             >>> parent_tuner = HyperparameterTuner.attach(tuning_job_name="parent-job-1")
@@ -692,6 +775,15 @@ class HyperparameterTuner(object):
             >>>                                                             additional_parents={"parent-job-2"})
             Later On:
             >>> identical_dataset_algo_tuner.fit(inputs={})
+
+        Args:
+            additional_parents (set{str}): Set of additional parents along with
+                the self to be used in warm starting
+
+        Returns:
+            sagemaker.tuner.HyperparameterTuner: HyperparameterTuner instance
+            which can be used to launch identical dataset and algorithm tuning
+            job.
         """
 
         return self._create_warm_start_tuner(
@@ -700,16 +792,20 @@ class HyperparameterTuner(object):
         )
 
     def _create_warm_start_tuner(self, additional_parents, warm_start_type, estimator=None):
-        """Creates a new ``HyperparameterTuner`` with ``WarmStartConfig``, where type will be equal to
-        ``warm_start_type`` and``parents`` would be equal to union of ``additional_parents`` and self.
+        """Creates a new ``HyperparameterTuner`` with ``WarmStartConfig``, where
+        type will be equal to ``warm_start_type`` and``parents`` would be equal
+        to union of ``additional_parents`` and self.
 
         Args:
-            additional_parents (set{str}): Additional parents along with self, to be used for warm starting.
-            warm_start_type (sagemaker.tuner.WarmStartTypes): Type of warm start job.
+            additional_parents (set{str}): Additional parents along with self,
+                to be used for warm starting.
+            warm_start_type (sagemaker.tuner.WarmStartTypes): Type of warm start
+                job.
+            estimator:
 
         Returns:
-            sagemaker.tuner.HyperparameterTuner: Instance with the request fields copied from self along with the
-            warm start configuration
+            sagemaker.tuner.HyperparameterTuner: Instance with the request
+            fields copied from self along with the warm start configuration
         """
         all_parents = {self.latest_tuning_job.name}
         if additional_parents:
@@ -727,16 +823,22 @@ class HyperparameterTuner(object):
 
 
 class _TuningJob(_Job):
+    """Placeholder docstring"""
+
     @classmethod
     def start_new(cls, tuner, inputs):
-        """Create a new Amazon SageMaker hyperparameter tuning job from the HyperparameterTuner.
+        """Create a new Amazon SageMaker hyperparameter tuning job from the
+        HyperparameterTuner.
 
         Args:
-            tuner (sagemaker.tuner.HyperparameterTuner): HyperparameterTuner object created by the user.
-            inputs (str): Parameters used when called :meth:`~sagemaker.estimator.EstimatorBase.fit`.
+            tuner (sagemaker.tuner.HyperparameterTuner): HyperparameterTuner
+                object created by the user.
+            inputs (str): Parameters used when called
+                :meth:`~sagemaker.estimator.EstimatorBase.fit`.
 
         Returns:
-            sagemaker.tuner._TuningJob: Constructed object that captures all information about the started job.
+            sagemaker.tuner._TuningJob: Constructed object that captures all
+            information about the started job.
         """
         config = _Job._load_config(inputs, tuner.estimator)
 
@@ -783,9 +885,11 @@ class _TuningJob(_Job):
         return cls(tuner.sagemaker_session, tuner._current_job_name)
 
     def stop(self):
+        """Placeholder docstring"""
         self.sagemaker_session.stop_tuning_job(name=self.name)
 
     def wait(self):
+        """Placeholder docstring"""
         self.sagemaker_session.wait_for_tuning_job(self.name)
 
 
@@ -793,21 +897,24 @@ def create_identical_dataset_and_algorithm_tuner(
     parent, additional_parents=None, sagemaker_session=None
 ):
     """Creates a new tuner by copying the request fields from the provided parent to the new instance of
-        ``HyperparameterTuner`` followed by addition of warm start configuration with the type as
-        "IdenticalDataAndAlgorithm" and ``parents`` as the union of provided list of ``additional_parents`` and the
-        ``parent``.
+        ``HyperparameterTuner`` followed by addition of warm start configuration
+        with the type as "IdenticalDataAndAlgorithm" and ``parents`` as the
+        union of provided list of ``additional_parents`` and the ``parent``.
 
     Args:
-        parent (str): Primary parent tuning job's name from which the Tuner and Estimator configuration has to be copied
-        additional_parents (set{str}): Set of additional parent tuning job's names along with the primary parent tuning
-            job name to be used in warm starting the transfer learning tuner.
-        sagemaker_session (sagemaker.session.Session): Session object which manages interactions with
-                Amazon SageMaker APIs and any other AWS services needed. If not specified, one is created
-                using the default AWS configuration chain.
+        parent (str): Primary parent tuning job's name from which the Tuner and
+            Estimator configuration has to be copied
+        additional_parents (set{str}): Set of additional parent tuning job's
+            names along with the primary parent tuning job name to be used in
+            warm starting the transfer learning tuner.
+        sagemaker_session (sagemaker.session.Session): Session object which
+            manages interactions with Amazon SageMaker APIs and any other AWS
+            services needed. If not specified, one is created using the default
+            AWS configuration chain.
 
     Returns:
-        sagemaker.tuner.HyperparameterTuner: a new ``HyperparameterTuner`` object for the warm-started
-        hyperparameter tuning job
+        sagemaker.tuner.HyperparameterTuner: a new ``HyperparameterTuner``
+        object for the warm-started hyperparameter tuning job
     """
 
     parent_tuner = HyperparameterTuner.attach(
@@ -819,22 +926,29 @@ def create_identical_dataset_and_algorithm_tuner(
 def create_transfer_learning_tuner(
     parent, additional_parents=None, estimator=None, sagemaker_session=None
 ):
-    """Creates a new ``HyperParameterTuner`` by copying the request fields from the provided parent to the new instance
-        of ``HyperparameterTuner`` followed by addition of warm start configuration with the type as "TransferLearning"
-        and ``parents`` as the union of provided list of ``additional_parents`` and the ``parent``.
+    """Creates a new ``HyperParameterTuner`` by copying the request fields from the
+    provided parent to the new instance
+        of ``HyperparameterTuner`` followed by addition of warm start
+        configuration with the type as "TransferLearning" and ``parents`` as the
+        union of provided list of ``additional_parents`` and the ``parent``.
 
     Args:
-        parent (str): Primary parent tuning job's name from which the Tuner and Estimator configuration has to be copied
-        additional_parents (set{str}): Set of additional parent tuning job's names along with the primary parent tuning
-            job name to be used in warm starting the identical dataset and algorithm tuner.
-        estimator (sagemaker.estimator.EstimatorBase): An estimator object that has been initialized with
-                the desired configuration. There does not need to be a training job associated with this instance.
-        sagemaker_session (sagemaker.session.Session): Session object which manages interactions with
-                Amazon SageMaker APIs and any other AWS services needed. If not specified, one is created
-                using the default AWS configuration chain.
+        parent (str): Primary parent tuning job's name from which the Tuner and
+            Estimator configuration has to be copied
+        additional_parents (set{str}): Set of additional parent tuning job's
+            names along with the primary parent tuning job name to be used in
+            warm starting the identical dataset and algorithm tuner.
+        estimator (sagemaker.estimator.EstimatorBase): An estimator object that
+            has been initialized with the desired configuration. There does not
+            need to be a training job associated with this instance.
+        sagemaker_session (sagemaker.session.Session): Session object which
+            manages interactions with Amazon SageMaker APIs and any other AWS
+            services needed. If not specified, one is created using the default
+            AWS configuration chain.
 
     Returns:
-        sagemaker.tuner.HyperparameterTuner: New instance of warm started HyperparameterTuner
+        sagemaker.tuner.HyperparameterTuner: New instance of warm started
+        HyperparameterTuner
     """
 
     parent_tuner = HyperparameterTuner.attach(

--- a/src/sagemaker/user_agent.py
+++ b/src/sagemaker/user_agent.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import absolute_import
 
 import platform
@@ -28,6 +29,7 @@ PYTHON_VERSION = "{}.{}.{}".format(
 
 
 def determine_prefix():
+    """Placeholder docstring"""
     prefix = "AWS-SageMaker-Python-SDK/{} Python/{} {}/{} Boto3/{} Botocore/{}".format(
         SDK_VERSION, PYTHON_VERSION, OS_NAME, OS_VERSION, boto3.__version__, botocore.__version__
     )
@@ -45,6 +47,10 @@ def determine_prefix():
 
 
 def prepend_user_agent(client):
+    """
+    Args:
+        client:
+    """
     prefix = determine_prefix()
 
     if client._client_config.user_agent is None:

--- a/src/sagemaker/utils.py
+++ b/src/sagemaker/utils.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import absolute_import
 
 import contextlib
@@ -40,7 +41,8 @@ def name_from_image(image):
         image (str): Image name.
 
     Returns:
-        str: Training job name using the algorithm from the image name and a timestamp.
+        str: Training job name using the algorithm from the image name and a
+        timestamp.
     """
     return name_from_base(base_name_from_image(image))
 
@@ -48,8 +50,9 @@ def name_from_image(image):
 def name_from_base(base, max_length=63, short=False):
     """Append a timestamp to the provided string.
 
-    This function assures that the total length of the resulting string is not
-    longer than the specified max length, trimming the input parameter if necessary.
+    This function assures that the total length of the resulting string is
+    not longer than the specified max length, trimming the input parameter if
+    necessary.
 
     Args:
         base (str): String used as prefix to generate the unique name.
@@ -65,6 +68,11 @@ def name_from_base(base, max_length=63, short=False):
 
 
 def unique_name_from_base(base, max_length=63):
+    """
+    Args:
+        base:
+        max_length:
+    """
     unique = "%04x" % random.randrange(16 ** 4)  # 4-digit hex
     ts = str(int(time.time()))
     available_length = max_length - 2 - len(ts) - len(unique)
@@ -73,7 +81,8 @@ def unique_name_from_base(base, max_length=63):
 
 
 def base_name_from_image(image):
-    """Extract the base name of the image to use as the 'algorithm name' for the job.
+    """Extract the base name of the image to use as the 'algorithm name' for the
+    job.
 
     Args:
         image (str): Image name.
@@ -99,7 +108,11 @@ def sagemaker_short_timestamp():
 
 
 def debug(func):
-    """Print the function name and arguments for debugging."""
+    """Print the function name and arguments for debugging.
+
+    Args:
+        func:
+    """
 
     @wraps(func)
     def wrapper(*args, **kwargs):
@@ -110,6 +123,11 @@ def debug(func):
 
 
 def get_config_value(key_path, config):
+    """
+    Args:
+        key_path:
+        config:
+    """
     if config is None:
         return None
 
@@ -138,15 +156,16 @@ def get_short_version(framework_version):
 def to_str(value):
     """Convert the input to a string, unless it is a unicode string in Python 2.
 
-    Unicode strings are supported as native strings in Python 3, but ``str()`` cannot be
-    invoked on unicode strings in Python 2, so we need to check for that case when
-    converting user-specified values to strings.
+    Unicode strings are supported as native strings in Python 3, but
+    ``str()`` cannot be invoked on unicode strings in Python 2, so we need to
+    check for that case when converting user-specified values to strings.
 
     Args:
         value: The value to convert to a string.
 
     Returns:
-        str or unicode: The string representation of the value or the unicode string itself.
+        str or unicode: The string representation of the value or the unicode
+        string itself.
     """
     if sys.version_info.major < 3 and isinstance(value, six.string_types):
         return value
@@ -154,8 +173,11 @@ def to_str(value):
 
 
 def extract_name_from_job_arn(arn):
-    """Returns the name used in the API given a full ARN for a training job
-    or hyperparameter tuning job.
+    """Returns the name used in the API given a full ARN for a training job or
+    hyperparameter tuning job.
+
+    Args:
+        arn:
     """
     slash_pos = arn.find("/")
     if slash_pos == -1:
@@ -167,12 +189,12 @@ def secondary_training_status_changed(current_job_description, prev_job_descript
     """Returns true if training job's secondary status message has changed.
 
     Args:
-        current_job_desc: Current job description, returned from DescribeTrainingJob call.
-        prev_job_desc: Previous job description, returned from DescribeTrainingJob call.
+        current_job_description: Current job description, returned from DescribeTrainingJob call.
+        prev_job_description: Previous job description, returned from DescribeTrainingJob call.
 
     Returns:
-        boolean: Whether the secondary status message of a training job changed or not.
-
+        boolean: Whether the secondary status message of a training job changed
+        or not.
     """
     current_secondary_status_transitions = current_job_description.get("SecondaryStatusTransitions")
     if (
@@ -200,7 +222,8 @@ def secondary_training_status_changed(current_job_description, prev_job_descript
 
 
 def secondary_training_status_message(job_description, prev_description):
-    """Returns a string contains last modified time and the secondary training job status message.
+    """Returns a string contains last modified time and the secondary training
+    job status message.
 
     Args:
         job_description: Returned response from DescribeTrainingJob call
@@ -208,7 +231,6 @@ def secondary_training_status_message(job_description, prev_description):
 
     Returns:
         str: Job status string to be printed.
-
     """
 
     if (
@@ -253,9 +275,11 @@ def download_folder(bucket_name, prefix, target, sagemaker_session):
 
     Args:
         bucket_name (str): S3 bucket name
-        prefix (str): S3 prefix within the bucket that will be downloaded. Can be a single file.
+        prefix (str): S3 prefix within the bucket that will be downloaded. Can
+            be a single file.
         target (str): destination path where the downloaded items will be placed
-        sagemaker_session (:class:`sagemaker.session.Session`): a sagemaker session to interact with S3.
+        sagemaker_session (sagemaker.session.Session): a sagemaker session to
+            interact with S3.
     """
     boto_session = sagemaker_session.boto_session
 
@@ -293,10 +317,13 @@ def download_folder(bucket_name, prefix, target, sagemaker_session):
 
 def create_tar_file(source_files, target=None):
     """Create a tar file containing all the source_files
+
     Args:
-        source_files (List[str]): List of file paths that will be contained in the tar file
+        source_files: (List[str]): List of file paths that will be contained in the tar file
+        target:
+
     Returns:
-         (str): path to created tar file
+        (str): path to created tar file
     """
     if target:
         filename = target
@@ -312,17 +339,17 @@ def create_tar_file(source_files, target=None):
 
 @contextlib.contextmanager
 def _tmpdir(suffix="", prefix="tmp"):
-    """Create a temporary directory with a context manager. The file is deleted when the context exits.
+    """Create a temporary directory with a context manager. The file is deleted
+    when the context exits.
 
     The prefix, suffix, and dir arguments are the same as for mkstemp().
 
     Args:
-        suffix (str):  If suffix is specified, the file name will end with that suffix, otherwise there will be no
-                        suffix.
-        prefix (str):  If prefix is specified, the file name will begin with that prefix; otherwise,
-                        a default prefix is used.
-        dir (str):  If dir is specified, the file will be created in that directory; otherwise, a default directory is
-                        used.
+        suffix (str): If suffix is specified, the file name will end with that
+            suffix, otherwise there will be no suffix.
+        prefix (str): If prefix is specified, the file name will begin with that
+            prefix; otherwise, a default prefix is used.
+
     Returns:
         str: path to the directory
     """
@@ -339,35 +366,40 @@ def repack_model(
     repacked_model_uri,
     sagemaker_session,
 ):
-    """Unpack model tarball and creates a new model tarball with the provided code script.
+    """Unpack model tarball and creates a new model tarball with the provided
+    code script.
 
-    This function does the following:
-    - uncompresses model tarball from S3 or local system into a temp folder
-    - replaces the inference code from the model with the new code provided
-    - compresses the new model tarball and saves it in S3 or local file system
+    This function does the following: - uncompresses model tarball from S3 or
+    local system into a temp folder - replaces the inference code from the model
+    with the new code provided - compresses the new model tarball and saves it
+    in S3 or local file system
 
     Args:
-        inference_script (str): path or basename of the inference script that will be packed into the model
-        source_directory (str): path including all the files that will be packed into the model
-        dependencies (list[str]): A list of paths to directories (absolute or relative) with
-                any additional libraries that will be exported to the container (default: []).
-                The library folders will be copied to SageMaker in the same folder where the entrypoint is copied.
-                Example:
+        inference_script (str): path or basename of the inference script that
+            will be packed into the model
+        source_directory (str): path including all the files that will be packed
+            into the model
+        dependencies (list[str]): A list of paths to directories (absolute or
+            relative) with any additional libraries that will be exported to the
+            container (default: []). The library folders will be copied to
+            SageMaker in the same folder where the entrypoint is copied.
+            Example
 
-                    The following call
-                    >>> Estimator(entry_point='train.py', dependencies=['my/libs/common', 'virtual-env'])
-                    results in the following inside the container:
+                The following call >>> Estimator(entry_point='train.py',
+                dependencies=['my/libs/common', 'virtual-env']) results in the
+                following inside the container:
 
-                    >>> $ ls
+                >>> $ ls
 
-                    >>> opt/ml/code
-                    >>>     |------ train.py
-                    >>>     |------ common
-                    >>>     |------ virtual-env
-
-        repacked_model_uri (str): path or file system location where the new model will be saved
+                >>> opt/ml/code
+                >>>     |------ train.py
+                >>>     |------ common
+                >>>     |------ virtual-env
         model_uri (str): S3 or file system location of the original model tar
-        sagemaker_session (:class:`sagemaker.session.Session`): a sagemaker session to interact with S3.
+        repacked_model_uri (str): path or file system location where the new
+            model will be saved
+        sagemaker_session (sagemaker.session.Session): a sagemaker session to
+            interact with S3.
 
     Returns:
         str: path to the new packed model
@@ -389,6 +421,12 @@ def repack_model(
 
 
 def _save_model(repacked_model_uri, tmp_model_path, sagemaker_session):
+    """
+    Args:
+        repacked_model_uri:
+        tmp_model_path:
+        sagemaker_session:
+    """
     if repacked_model_uri.lower().startswith("s3://"):
         url = parse.urlparse(repacked_model_uri)
         bucket, key = url.netloc, url.path.lstrip("/")
@@ -404,6 +442,15 @@ def _save_model(repacked_model_uri, tmp_model_path, sagemaker_session):
 def _create_or_update_code_dir(
     model_dir, inference_script, source_directory, dependencies, sagemaker_session, tmp
 ):
+    """
+    Args:
+        model_dir:
+        inference_script:
+        source_directory:
+        dependencies:
+        sagemaker_session:
+        tmp:
+    """
     code_dir = os.path.join(model_dir, "code")
     if os.path.exists(code_dir):
         shutil.rmtree(code_dir, ignore_errors=True)
@@ -428,6 +475,12 @@ def _create_or_update_code_dir(
 
 
 def _extract_model(model_uri, sagemaker_session, tmp):
+    """
+    Args:
+        model_uri:
+        sagemaker_session:
+        tmp:
+    """
     tmp_model_dir = os.path.join(tmp, "model")
     os.mkdir(tmp_model_dir)
     if model_uri.lower().startswith("s3://"):
@@ -441,6 +494,12 @@ def _extract_model(model_uri, sagemaker_session, tmp):
 
 
 def download_file_from_url(url, dst, sagemaker_session):
+    """
+    Args:
+        url:
+        dst:
+        sagemaker_session:
+    """
     url = parse.urlparse(url)
     bucket, key = url.netloc, url.path.lstrip("/")
 
@@ -454,7 +513,8 @@ def download_file(bucket_name, path, target, sagemaker_session):
         bucket_name (str): S3 bucket name
         path (str): file path within the bucket
         target (str): destination directory for the downloaded file.
-        sagemaker_session (:class:`sagemaker.session.Session`): a sagemaker session to interact with S3.
+        sagemaker_session (sagemaker.session.Session): a sagemaker session to
+            interact with S3.
     """
     path = path.lstrip("/")
     boto_session = sagemaker_session.boto_session
@@ -479,10 +539,10 @@ def get_ecr_image_uri_prefix(account, region):
 
 
 class DeferredError(object):
-    """Stores an exception and raises it at a later time if this
-    object is accessed in any way.  Useful to allow soft-dependencies on imports,
-    so that the ImportError can be raised again later if code actually
-    relies on the missing library.
+    """Stores an exception and raises it at a later time if this object is
+    accessed in any way. Useful to allow soft-dependencies on imports, so that
+    the ImportError can be raised again later if code actually relies on the
+    missing library.
 
     Example::
 
@@ -494,11 +554,18 @@ class DeferredError(object):
     """
 
     def __init__(self, exception):
+        """
+        Args:
+            exception:
+        """
         self.exc = exception
 
     def __getattr__(self, name):
-        """Called by Python interpreter before using any method or property
-        on the object.  So this will short-circuit essentially any access to this
+        """Called by Python interpreter before using any method or property on
+        the object. So this will short-circuit essentially any access to this
         object.
+
+        Args:
+            name:
         """
         raise self.exc

--- a/src/sagemaker/vpc_utils.py
+++ b/src/sagemaker/vpc_utils.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import absolute_import
 
 SUBNETS_KEY = "Subnets"
@@ -22,18 +23,19 @@ VPC_CONFIG_DEFAULT = "VPC_CONFIG_DEFAULT"
 
 
 def to_dict(subnets, security_group_ids):
-    """
-    Prepares a VpcConfig dict containing keys 'Subnets' and 'SecurityGroupIds'
-    This is the dict format expected by SageMaker CreateTrainingJob and CreateModel APIs
-    See https://docs.aws.amazon.com/sagemaker/latest/dg/API_VpcConfig.html
+    """Prepares a VpcConfig dict containing keys 'Subnets' and
+    'SecurityGroupIds' This is the dict format expected by SageMaker
+    CreateTrainingJob and CreateModel APIs See
+    https://docs.aws.amazon.com/sagemaker/latest/dg/API_VpcConfig.html
 
     Args:
         subnets (list): list of subnet IDs to use in VpcConfig
-        security_group_ids (list): list of security group IDs to use in VpcConfig
+        security_group_ids (list): list of security group IDs to use in
+            VpcConfig
 
     Returns:
-        A VpcConfig dict containing keys 'Subnets' and 'SecurityGroupIds'
-        If either or both parameters are None, returns None
+        A VpcConfig dict containing keys 'Subnets' and 'SecurityGroupIds' If
+        either or both parameters are None, returns None
     """
     if subnets is None or security_group_ids is None:
         return None
@@ -41,20 +43,22 @@ def to_dict(subnets, security_group_ids):
 
 
 def from_dict(vpc_config, do_sanitize=False):
-    """
-    Extracts subnets and security group ids as lists from a VpcConfig dict
+    """Extracts subnets and security group ids as lists from a VpcConfig dict
 
     Args:
-        vpc_config (dict): a VpcConfig dict containing 'Subnets' and 'SecurityGroupIds'
-        do_sanitize (bool): whether to sanitize the VpcConfig dict before extracting values
+        vpc_config (dict): a VpcConfig dict containing 'Subnets' and
+            'SecurityGroupIds'
+        do_sanitize (bool): whether to sanitize the VpcConfig dict before
+            extracting values
 
     Returns:
-        Tuple of lists as (subnets, security_group_ids)
-        If vpc_config parameter is None, returns (None, None)
+        Tuple of lists as (subnets, security_group_ids) If vpc_config parameter
+        is None, returns (None, None)
 
     Raises:
-        ValueError if sanitize enabled and vpc_config is invalid
-        KeyError if sanitize disabled and vpc_config is missing key(s)
+        * ValueError if sanitize enabled and vpc_config is invalid
+
+        * KeyError if sanitize disabled and vpc_config is missing key(s)
     """
     if do_sanitize:
         vpc_config = sanitize(vpc_config)
@@ -64,16 +68,18 @@ def from_dict(vpc_config, do_sanitize=False):
 
 
 def sanitize(vpc_config):
-    """
-    Checks that an instance of VpcConfig has the expected keys and values, removes unexpected keys,
-    and raises ValueErrors if any expectations are violated
+    """Checks that an instance of VpcConfig has the expected keys and values,
+    removes unexpected keys, and raises ValueErrors if any expectations are
+    violated
 
     Args:
-        vpc_config (dict): a VpcConfig dict containing 'Subnets' and 'SecurityGroupIds'
+        vpc_config (dict): a VpcConfig dict containing 'Subnets' and
+            'SecurityGroupIds'
 
     Returns:
-        A valid VpcConfig dict containing only 'Subnets' and 'SecurityGroupIds' from the vpc_config parameter
-        If vpc_config parameter is None, returns None
+        A valid VpcConfig dict containing only 'Subnets' and 'SecurityGroupIds'
+        from the vpc_config parameter If vpc_config parameter is None, returns
+        None
 
     Raises:
         ValueError if any expectations are violated:

--- a/src/sagemaker/workflow/airflow.py
+++ b/src/sagemaker/workflow/airflow.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+"""Placeholder docstring"""
 from __future__ import print_function, absolute_import
 
 import os
@@ -21,12 +22,14 @@ from sagemaker.amazon import amazon_estimator
 
 
 def prepare_framework(estimator, s3_operations):
-    """Prepare S3 operations (specify where to upload `source_dir`) and environment variables
-    related to framework.
+    """Prepare S3 operations (specify where to upload `source_dir` ) and
+    environment variables related to framework.
 
     Args:
-        estimator (sagemaker.estimator.Estimator): The framework estimator to get information from and update.
-        s3_operations (dict): The dict to specify s3 operations (upload `source_dir`).
+        estimator (sagemaker.estimator.Estimator): The framework estimator to
+            get information from and update.
+        s3_operations (dict): The dict to specify s3 operations (upload
+            `source_dir` ).
     """
     if estimator.code_location is not None:
         bucket, key = fw_utils.parse_s3_url(estimator.code_location)
@@ -59,18 +62,22 @@ def prepare_framework(estimator, s3_operations):
 
 
 def prepare_amazon_algorithm_estimator(estimator, inputs, mini_batch_size=None):
-    """ Set up amazon algorithm estimator, adding the required `feature_dim` hyperparameter from training data.
+    """Set up amazon algorithm estimator, adding the required `feature_dim`
+    hyperparameter from training data.
 
     Args:
-        estimator (sagemaker.amazon.amazon_estimator.AmazonAlgorithmEstimatorBase):
-            An estimator for a built-in Amazon algorithm to get information from and update.
+        estimator (sagemaker.amazon.amazon_estimator.AmazonAlgorithmEstimatorBase): An estimator
+            for a built-in Amazon algorithm to get information from and update.
         inputs: The training data.
-            * (sagemaker.amazon.amazon_estimator.RecordSet) - A collection of
-                Amazon :class:~`Record` objects serialized and stored in S3.
-                For use with an estimator for an Amazon algorithm.
+           * (sagemaker.amazon.amazon_estimator.RecordSet) - A collection of
+
+                Amazon :class:~`Record` objects serialized and stored in S3. For
+                use with an estimator for an Amazon algorithm.
+
             * (list[sagemaker.amazon.amazon_estimator.RecordSet]) - A list of
-                :class:~`sagemaker.amazon.amazon_estimator.RecordSet` objects, where each instance is
-                a different channel of training data.
+                  :class:~`sagemaker.amazon.amazon_estimator.RecordSet` objects,
+                  where each instance is a different channel of training data.
+        mini_batch_size:
     """
     if isinstance(inputs, list):
         for record in inputs:
@@ -88,32 +95,39 @@ def training_base_config(estimator, inputs=None, job_name=None, mini_batch_size=
     """Export Airflow base training config from an estimator
 
     Args:
-        estimator (sagemaker.estimator.EstimatorBase):
-            The estimator to export training config from. Can be a BYO estimator,
-            Framework estimator or Amazon algorithm estimator.
-        inputs: Information about the training data. Please refer to the ``fit()`` method of
-                the associated estimator, as this can take any of the following forms:
+        estimator (sagemaker.estimator.EstimatorBase): The estimator to export
+            training config from. Can be a BYO estimator, Framework estimator or
+            Amazon algorithm estimator.
+        inputs: Information about the training data. Please refer to the ``fit()``
+            method of
+                the associated estimator, as this can take any of the following
+                forms:
 
             * (str) - The S3 location where training data is saved.
-            * (dict[str, str] or dict[str, sagemaker.session.s3_input]) - If using multiple channels for
-                training data, you can specify a dict mapping channel names
-                to strings or :func:`~sagemaker.session.s3_input` objects.
-            * (sagemaker.session.s3_input) - Channel configuration for S3 data sources that can provide
-                additional information about the training dataset. See :func:`sagemaker.session.s3_input`
-                for full details.
-            * (sagemaker.amazon.amazon_estimator.RecordSet) - A collection of
-                Amazon :class:~`Record` objects serialized and stored in S3.
-                For use with an estimator for an Amazon algorithm.
-            * (list[sagemaker.amazon.amazon_estimator.RecordSet]) - A list of
-                :class:~`sagemaker.amazon.amazon_estimator.RecordSet` objects, where each instance is
-                a different channel of training data.
 
+            * (dict[str, str] or dict[str, sagemaker.session.s3_input]) - If using multiple
+                  channels for training data, you can specify a dict mapping channel names to
+                  strings or :func:`~sagemaker.session.s3_input` objects.
+
+            * (sagemaker.session.s3_input) - Channel configuration for S3 data sources that can
+                  provide additional information about the training dataset. See
+                  :func:`sagemaker.session.s3_input` for full details.
+
+            * (sagemaker.amazon.amazon_estimator.RecordSet) - A collection of
+                  Amazon :class:~`Record` objects serialized and stored in S3.
+                  For use with an estimator for an Amazon algorithm.
+
+            * (list[sagemaker.amazon.amazon_estimator.RecordSet]) - A list of
+                  :class:~`sagemaker.amazon.amazon_estimator.RecordSet` objects,
+                  where each instance is a different channel of training data.
         job_name (str): Specify a training job name if needed.
-        mini_batch_size (int): Specify this argument only when estimator is a built-in estimator of an
-            Amazon algorithm. For other estimators, batch size should be specified in the estimator.
+        mini_batch_size (int): Specify this argument only when estimator is a
+            built-in estimator of an Amazon algorithm. For other estimators,
+            batch size should be specified in the estimator.
 
     Returns:
-        dict: Training config that can be directly used by SageMakerTrainingOperator in Airflow.
+        dict: Training config that can be directly used by
+        SageMakerTrainingOperator in Airflow.
     """
     default_bucket = estimator.sagemaker_session.default_bucket()
     s3_operations = {}
@@ -167,32 +181,36 @@ def training_config(estimator, inputs=None, job_name=None, mini_batch_size=None)
     """Export Airflow training config from an estimator
 
     Args:
-        estimator (sagemaker.estimator.EstimatorBase):
-            The estimator to export training config from. Can be a BYO estimator,
-            Framework estimator or Amazon algorithm estimator.
-        inputs: Information about the training data. Please refer to the ``fit()`` method of
-                the associated estimator, as this can take any of the following forms:
-
+        estimator (sagemaker.estimator.EstimatorBase): The estimator to export
+            training config from. Can be a BYO estimator, Framework estimator or
+            Amazon algorithm estimator.
+        inputs: Information about the training data. Please refer to the ``fit()``
+            method of the associated estimator, as this can take any of the following forms:
             * (str) - The S3 location where training data is saved.
-            * (dict[str, str] or dict[str, sagemaker.session.s3_input]) - If using multiple channels for
-                training data, you can specify a dict mapping channel names
-                to strings or :func:`~sagemaker.session.s3_input` objects.
-            * (sagemaker.session.s3_input) - Channel configuration for S3 data sources that can provide
-                additional information about the training dataset. See :func:`sagemaker.session.s3_input`
-                for full details.
-            * (sagemaker.amazon.amazon_estimator.RecordSet) - A collection of
-                Amazon :class:~`Record` objects serialized and stored in S3.
-                For use with an estimator for an Amazon algorithm.
-            * (list[sagemaker.amazon.amazon_estimator.RecordSet]) - A list of
-                :class:~`sagemaker.amazon.amazon_estimator.RecordSet` objects, where each instance is
-                a different channel of training data.
 
+            * (dict[str, str] or dict[str, sagemaker.session.s3_input]) - If using multiple channels for
+                  training data, you can specify a dict mapping channel names to
+                  strings or :func:`~sagemaker.session.s3_input` objects.
+
+            * (sagemaker.session.s3_input) - Channel configuration for S3 data sources that can provide
+                  additional information about the training dataset. See
+                  :func:`sagemaker.session.s3_input` for full details.
+
+            * (sagemaker.amazon.amazon_estimator.RecordSet) - A collection of
+                  Amazon :class:~`Record` objects serialized and stored in S3.
+                  For use with an estimator for an Amazon algorithm.
+
+            * (list[sagemaker.amazon.amazon_estimator.RecordSet]) - A list of
+                  :class:~`sagemaker.amazon.amazon_estimator.RecordSet` objects,
+                  where each instance is a different channel of training data.
         job_name (str): Specify a training job name if needed.
-        mini_batch_size (int): Specify this argument only when estimator is a built-in estimator of an
-            Amazon algorithm. For other estimators, batch size should be specified in the estimator.
+        mini_batch_size (int): Specify this argument only when estimator is a
+            built-in estimator of an Amazon algorithm. For other estimators,
+            batch size should be specified in the estimator.
 
     Returns:
-        dict: Training config that can be directly used by SageMakerTrainingOperator in Airflow.
+        dict: Training config that can be directly used by
+        SageMakerTrainingOperator in Airflow.
     """
 
     train_config = training_base_config(estimator, inputs, job_name, mini_batch_size)
@@ -209,24 +227,29 @@ def tuning_config(tuner, inputs, job_name=None):
     """Export Airflow tuning config from an estimator
 
     Args:
-        tuner (sagemaker.tuner.HyperparameterTuner): The tuner to export tuning config from.
-        inputs: Information about the training data. Please refer to the ``fit()`` method of
-                the associated estimator in the tuner, as this can take any of the following forms:
+        tuner (sagemaker.tuner.HyperparameterTuner): The tuner to export tuning
+            config from.
+        inputs: Information about the training data. Please refer to the ``fit()``
+            method of the associated estimator in the tuner, as this can take any of the
+            following forms:
 
             * (str) - The S3 location where training data is saved.
-            * (dict[str, str] or dict[str, sagemaker.session.s3_input]) - If using multiple channels for
-                training data, you can specify a dict mapping channel names
-                to strings or :func:`~sagemaker.session.s3_input` objects.
-            * (sagemaker.session.s3_input) - Channel configuration for S3 data sources that can provide
-                additional information about the training dataset. See :func:`sagemaker.session.s3_input`
-                for full details.
-            * (sagemaker.amazon.amazon_estimator.RecordSet) - A collection of
-                Amazon :class:~`Record` objects serialized and stored in S3.
-                For use with an estimator for an Amazon algorithm.
-            * (list[sagemaker.amazon.amazon_estimator.RecordSet]) - A list of
-                :class:~`sagemaker.amazon.amazon_estimator.RecordSet` objects, where each instance is
-                a different channel of training data.
 
+            * (dict[str, str] or dict[str, sagemaker.session.s3_input]) - If using multiple channels for
+                  training data, you can specify a dict mapping channel names to
+                  strings or :func:`~sagemaker.session.s3_input` objects.
+
+            * (sagemaker.session.s3_input) - Channel configuration for S3 data sources that can provide
+                  additional information about the training dataset. See
+                  :func:`sagemaker.session.s3_input` for full details.
+
+            * (sagemaker.amazon.amazon_estimator.RecordSet) - A collection of
+                  Amazon :class:~`Record` objects serialized and stored in S3.
+                  For use with an estimator for an Amazon algorithm.
+
+            * (list[sagemaker.amazon.amazon_estimator.RecordSet]) - A list of
+                  :class:~`sagemaker.amazon.amazon_estimator.RecordSet` objects,
+                  where each instance is a different channel of training data.
         job_name (str): Specify a tuning job name if needed.
 
     Returns:
@@ -291,7 +314,8 @@ def update_submit_s3_uri(estimator, job_name):
     """Updated the S3 URI of the framework source directory in given estimator.
 
     Args:
-        estimator (sagemaker.estimator.Framework): The Framework estimator to update.
+        estimator (sagemaker.estimator.Framework): The Framework estimator to
+            update.
         job_name (str): The new job name included in the submit S3 URI
 
     Returns:
@@ -315,10 +339,13 @@ def update_estimator_from_task(estimator, task_id, task_type):
 
     Args:
         estimator (sagemaker.estimator.EstimatorBase): The estimator to update
-        task_id (str): The task id of any airflow.contrib.operators.SageMakerTrainingOperator or
-            airflow.contrib.operators.SageMakerTuningOperator that generates training jobs in the DAG.
-        task_type (str): Whether the task is from SageMakerTrainingOperator or SageMakerTuningOperator. Values can be
-            'training', 'tuning' or None (which means training job is not from any task).
+        task_id (str): The task id of any
+            airflow.contrib.operators.SageMakerTrainingOperator or
+            airflow.contrib.operators.SageMakerTuningOperator that generates
+            training jobs in the DAG.
+        task_type (str): Whether the task is from SageMakerTrainingOperator or
+            SageMakerTuningOperator. Values can be 'training', 'tuning' or None
+            (which means training job is not from any task).
     """
     if task_type is None:
         return
@@ -343,13 +370,15 @@ def update_estimator_from_task(estimator, task_id, task_type):
 
 
 def prepare_framework_container_def(model, instance_type, s3_operations):
-    """Prepare the framework model container information. Specify related S3 operations for Airflow to perform.
-    (Upload `source_dir`)
+    """Prepare the framework model container information. Specify related S3
+    operations for Airflow to perform. (Upload `source_dir` )
 
     Args:
         model (sagemaker.model.FrameworkModel): The framework model
-        instance_type (str): The EC2 instance type to deploy this Model to. For example, 'ml.p2.xlarge'.
-        s3_operations (dict): The dict to specify S3 operations (upload `source_dir`).
+        instance_type (str): The EC2 instance type to deploy this Model to. For
+            example, 'ml.p2.xlarge'.
+        s3_operations (dict): The dict to specify S3 operations (upload
+            `source_dir` ).
 
     Returns:
         dict: The container information of this framework model.
@@ -401,14 +430,17 @@ def model_config(instance_type, model, role=None, image=None):
     """Export Airflow model config from a SageMaker model
 
     Args:
-        instance_type (str): The EC2 instance type to deploy this Model to. For example, 'ml.p2.xlarge'
-        model (sagemaker.model.FrameworkModel): The SageMaker model to export Airflow config from
+        instance_type (str): The EC2 instance type to deploy this Model to. For
+            example, 'ml.p2.xlarge'
+        model (sagemaker.model.FrameworkModel): The SageMaker model to export
+            Airflow config from
         role (str): The ``ExecutionRoleArn`` IAM Role ARN for the model
         image (str): An container image to use for deploying the model
 
     Returns:
-        dict: Model config that can be directly used by SageMakerModelOperator in Airflow. It can also be part
-        of the config used by SageMakerEndpointOperator and SageMakerTransformOperator in Airflow.
+        dict: Model config that can be directly used by SageMakerModelOperator
+        in Airflow. It can also be part of the config used by
+        SageMakerEndpointOperator and SageMakerTransformOperator in Airflow.
     """
     s3_operations = {}
     model.image = image or model.image
@@ -451,22 +483,27 @@ def model_config_from_estimator(
     """Export Airflow model config from a SageMaker estimator
 
     Args:
-        instance_type (str): The EC2 instance type to deploy this Model to. For example, 'ml.p2.xlarge'
-        estimator (sagemaker.model.EstimatorBase): The SageMaker estimator to export Airflow config from.
-            It has to be an estimator associated with a training job.
-        task_id (str): The task id of any airflow.contrib.operators.SageMakerTrainingOperator or
-            airflow.contrib.operators.SageMakerTuningOperator that generates training jobs in the DAG. The model config
-            is built based on the training job generated in this operator.
-        task_type (str): Whether the task is from SageMakerTrainingOperator or SageMakerTuningOperator. Values can be
-            'training', 'tuning' or None (which means training job is not from any task).
+        instance_type (str): The EC2 instance type to deploy this Model to. For
+            example, 'ml.p2.xlarge'
+        estimator (sagemaker.model.EstimatorBase): The SageMaker estimator to
+            export Airflow config from. It has to be an estimator associated
+            with a training job.
+        task_id (str): The task id of any
+            airflow.contrib.operators.SageMakerTrainingOperator or
+            airflow.contrib.operators.SageMakerTuningOperator that generates
+            training jobs in the DAG. The model config is built based on the
+            training job generated in this operator.
+        task_type (str): Whether the task is from SageMakerTrainingOperator or
+            SageMakerTuningOperator. Values can be 'training', 'tuning' or None
+            (which means training job is not from any task).
         role (str): The ``ExecutionRoleArn`` IAM Role ARN for the model
         image (str): An container image to use for deploying the model
         name (str): Name of the model
-        model_server_workers (int): The number of worker processes used by the inference server.
-            If None, server will use one worker per vCPU. Only effective when estimator is a
-            SageMaker framework.
-        vpc_config_override (dict[str, list[str]]): Override for VpcConfig set on the model.
-            Default: use subnets and security groups from this Estimator.
+        model_server_workers (int): The number of worker processes used by the
+            inference server. If None, server will use one worker per vCPU. Only
+            effective when estimator is a SageMaker framework.
+        vpc_config_override (dict[str, list[str]]): Override for VpcConfig set on
+            the model. Default: use subnets and security groups from this Estimator.
             * 'Subnets' (list[str]): List of subnet ids.
             * 'SecurityGroupIds' (list[str]): List of security group ids.
 
@@ -509,25 +546,28 @@ def transform_config(
     """Export Airflow transform config from a SageMaker transformer
 
     Args:
-        transformer (sagemaker.transformer.Transformer): The SageMaker transformer to export Airflow
-            config from.
+        transformer (sagemaker.transformer.Transformer): The SageMaker
+            transformer to export Airflow config from.
         data (str): Input data location in S3.
-        data_type (str): What the S3 location defines (default: 'S3Prefix'). Valid values:
+        data_type (str): What the S3 location defines (default: 'S3Prefix').
+            Valid values:
 
             * 'S3Prefix' - the S3 URI defines a key name prefix. All objects with this prefix will be used as
-                inputs for the transform job.
-            * 'ManifestFile' - the S3 URI points to a single manifest file listing each S3 object to use as
-                an input for the transform job.
+                  inputs for the transform job.
 
+            * 'ManifestFile' - the S3 URI points to a single manifest file listing each S3 object to use as
+                  an input for the transform job.
         content_type (str): MIME type of the input data (default: None).
-        compression_type (str): Compression type of the input data, if compressed (default: None).
-            Valid values: 'Gzip', None.
-        split_type (str): The record delimiter for the input object (default: 'None').
-            Valid values: 'None', 'Line', 'RecordIO', and 'TFRecord'.
-        job_name (str): job name (default: None). If not specified, one will be generated.
+        compression_type (str): Compression type of the input data, if
+            compressed (default: None). Valid values: 'Gzip', None.
+        split_type (str): The record delimiter for the input object (default:
+            'None'). Valid values: 'None', 'Line', 'RecordIO', and 'TFRecord'.
+        job_name (str): job name (default: None). If not specified, one will be
+            generated.
 
     Returns:
-        dict: Transform config that can be directly used by SageMakerTransformOperator in Airflow.
+        dict: Transform config that can be directly used by
+        SageMakerTransformOperator in Airflow.
     """
     if job_name is not None:
         transformer._current_job_name = job_name
@@ -603,57 +643,75 @@ def transform_config_from_estimator(
     """Export Airflow transform config from a SageMaker estimator
 
     Args:
-        estimator (sagemaker.model.EstimatorBase): The SageMaker estimator to export Airflow config from.
-            It has to be an estimator associated with a training job.
-        task_id (str): The task id of any airflow.contrib.operators.SageMakerTrainingOperator or
-            airflow.contrib.operators.SageMakerTuningOperator that generates training jobs in the DAG. The transform
-            config is built based on the training job generated in this operator.
-        task_type (str): Whether the task is from SageMakerTrainingOperator or SageMakerTuningOperator. Values can be
-            'training', 'tuning' or None (which means training job is not from any task).
+        estimator (sagemaker.model.EstimatorBase): The SageMaker estimator to
+            export Airflow config from. It has to be an estimator associated
+            with a training job.
+        task_id (str): The task id of any
+            airflow.contrib.operators.SageMakerTrainingOperator or
+            airflow.contrib.operators.SageMakerTuningOperator that generates
+            training jobs in the DAG. The transform config is built based on the
+            training job generated in this operator.
+        task_type (str): Whether the task is from SageMakerTrainingOperator or
+            SageMakerTuningOperator. Values can be 'training', 'tuning' or None
+            (which means training job is not from any task).
         instance_count (int): Number of EC2 instances to use.
-        instance_type (str): Type of EC2 instance to use, for example, 'ml.c4.xlarge'.
+        instance_type (str): Type of EC2 instance to use, for example,
+            'ml.c4.xlarge'.
         data (str): Input data location in S3.
-        data_type (str): What the S3 location defines (default: 'S3Prefix'). Valid values:
+        data_type (str): What the S3 location defines (default: 'S3Prefix').
+            Valid values:
 
             * 'S3Prefix' - the S3 URI defines a key name prefix. All objects with this prefix will be used as
-                inputs for the transform job.
-            * 'ManifestFile' - the S3 URI points to a single manifest file listing each S3 object to use as
-                an input for the transform job.
+                  inputs for the transform job.
 
+            * 'ManifestFile' - the S3 URI points to a single manifest file listing each S3 object to use as
+                  an input for the transform job.
         content_type (str): MIME type of the input data (default: None).
-        compression_type (str): Compression type of the input data, if compressed (default: None).
-            Valid values: 'Gzip', None.
-        split_type (str): The record delimiter for the input object (default: 'None').
-            Valid values: 'None', 'Line', 'RecordIO', and 'TFRecord'.
-        job_name (str): transform job name (default: None). If not specified, one will be generated.
-        model_name (str): model name (default: None). If not specified, one will be generated.
-        strategy (str): The strategy used to decide how to batch records in a single request (default: None).
-            Valid values: 'MULTI_RECORD' and 'SINGLE_RECORD'.
-        assemble_with (str): How the output is assembled (default: None). Valid values: 'Line' or 'None'.
-        output_path (str): S3 location for saving the transform result. If not specified, results are stored to
-            a default bucket.
-        output_kms_key (str): Optional. KMS key ID for encrypting the transform output (default: None).
-        accept (str): The content type accepted by the endpoint deployed during the transform job.
-        env (dict): Environment variables to be set for use during the transform job (default: None).
-        max_concurrent_transforms (int): The maximum number of HTTP requests to be made to
-            each individual transform container at one time.
-        max_payload (int): Maximum size of the payload in a single HTTP request to the container in MB.
-        tags (list[dict]): List of tags for labeling a transform job. If none specified, then the tags used for
-            the training job are used for the transform job.
-        role (str): The ``ExecutionRoleArn`` IAM Role ARN for the ``Model``, which is also used during
-            transform jobs. If not specified, the role from the Estimator will be used.
-        volume_kms_key (str): Optional. KMS key ID for encrypting the volume attached to the ML
-            compute instance (default: None).
-        model_server_workers (int): Optional. The number of worker processes used by the inference server.
-            If None, server will use one worker per vCPU.
+        compression_type (str): Compression type of the input data, if
+            compressed (default: None). Valid values: 'Gzip', None.
+        split_type (str): The record delimiter for the input object (default:
+            'None'). Valid values: 'None', 'Line', 'RecordIO', and 'TFRecord'.
+        job_name (str): transform job name (default: None). If not specified,
+            one will be generated.
+        model_name (str): model name (default: None). If not specified, one will
+            be generated.
+        strategy (str): The strategy used to decide how to batch records in a
+            single request (default: None). Valid values: 'MULTI_RECORD' and
+            'SINGLE_RECORD'.
+        assemble_with (str): How the output is assembled (default: None). Valid
+            values: 'Line' or 'None'.
+        output_path (str): S3 location for saving the transform result. If not
+            specified, results are stored to a default bucket.
+        output_kms_key (str): Optional. KMS key ID for encrypting the transform
+            output (default: None).
+        accept (str): The content type accepted by the endpoint deployed during
+            the transform job.
+        env (dict): Environment variables to be set for use during the transform
+            job (default: None).
+        max_concurrent_transforms (int): The maximum number of HTTP requests to
+            be made to each individual transform container at one time.
+        max_payload (int): Maximum size of the payload in a single HTTP request
+            to the container in MB.
+        tags (list[dict]): List of tags for labeling a transform job. If none
+            specified, then the tags used for the training job are used for the
+            transform job.
+        role (str): The ``ExecutionRoleArn`` IAM Role ARN for the ``Model``,
+            which is also used during transform jobs. If not specified, the role
+            from the Estimator will be used.
+        volume_kms_key (str): Optional. KMS key ID for encrypting the volume
+            attached to the ML compute instance (default: None).
+        model_server_workers (int): Optional. The number of worker processes
+            used by the inference server. If None, server will use one worker
+            per vCPU.
         image (str): An container image to use for deploying the model
-        vpc_config_override (dict[str, list[str]]): Override for VpcConfig set on the model.
-            Default: use subnets and security groups from this Estimator.
+        vpc_config_override (dict[str, list[str]]): Override for VpcConfig set on
+            the model. Default: use subnets and security groups from this Estimator.
             * 'Subnets' (list[str]): List of subnet ids.
             * 'SecurityGroupIds' (list[str]): List of security group ids.
 
     Returns:
-        dict: Transform config that can be directly used by SageMakerTransformOperator in Airflow.
+        dict: Transform config that can be directly used by
+        SageMakerTransformOperator in Airflow.
     """
     model_base_config = model_config_from_estimator(
         instance_type=instance_type,
@@ -715,18 +773,20 @@ def deploy_config(model, initial_instance_count, instance_type, endpoint_name=No
     """Export Airflow deploy config from a SageMaker model
 
     Args:
-        model (sagemaker.model.Model): The SageMaker model to export the Airflow config from.
-        instance_type (str): The EC2 instance type to deploy this Model to. For example, 'ml.p2.xlarge'.
-        initial_instance_count (int): The initial number of instances to run in the
-            ``Endpoint`` created from this ``Model``.
+        model (sagemaker.model.Model): The SageMaker model to export the Airflow
+            config from.
+        initial_instance_count (int): The initial number of instances to run in
+            the ``Endpoint`` created from this ``Model``.
+        instance_type (str): The EC2 instance type to deploy this Model to. For
+            example, 'ml.p2.xlarge'.
         endpoint_name (str): The name of the endpoint to create (default: None).
             If not specified, a unique endpoint name will be created.
-        tags (list[dict]): List of tags for labeling a training job. For more, see
-            https://docs.aws.amazon.com/sagemaker/latest/dg/API_Tag.html.
+        tags (list[dict]): List of tags for labeling a training job. For more,
+            see https://docs.aws.amazon.com/sagemaker/latest/dg/API_Tag.html.
 
     Returns:
-        dict: Deploy config that can be directly used by SageMakerEndpointOperator in Airflow.
-
+        dict: Deploy config that can be directly used by
+        SageMakerEndpointOperator in Airflow.
     """
     model_base_config = model_config(instance_type, model)
 
@@ -769,27 +829,34 @@ def deploy_config_from_estimator(
     """Export Airflow deploy config from a SageMaker estimator
 
     Args:
-        estimator (sagemaker.model.EstimatorBase): The SageMaker estimator to export Airflow config from.
-            It has to be an estimator associated with a training job.
-        task_id (str): The task id of any airflow.contrib.operators.SageMakerTrainingOperator or
-            airflow.contrib.operators.SageMakerTuningOperator that generates training jobs in the DAG. The endpoint
-            config is built based on the training job generated in this operator.
-        task_type (str): Whether the task is from SageMakerTrainingOperator or SageMakerTuningOperator. Values can be
-            'training', 'tuning' or None (which means training job is not from any task).
-        initial_instance_count (int): Minimum number of EC2 instances to deploy to an endpoint for prediction.
-        instance_type (str): Type of EC2 instance to deploy to an endpoint for prediction,
-            for example, 'ml.c4.xlarge'.
-        model_name (str): Name to use for creating an Amazon SageMaker model. If not specified, one will be generated.
-        endpoint_name (str): Name to use for creating an Amazon SageMaker endpoint. If not specified, the name of
-            the SageMaker model is used.
-        tags (list[dict]): List of tags for labeling a training job. For more, see
-            https://docs.aws.amazon.com/sagemaker/latest/dg/API_Tag.html.
-        **kwargs: Passed to invocation of ``create_model()``. Implementations may customize
-            ``create_model()`` to accept ``**kwargs`` to customize model creation during deploy.
-            For more, see the implementation docs.
+        estimator (sagemaker.model.EstimatorBase): The SageMaker estimator to
+            export Airflow config from. It has to be an estimator associated
+            with a training job.
+        task_id (str): The task id of any
+            airflow.contrib.operators.SageMakerTrainingOperator or
+            airflow.contrib.operators.SageMakerTuningOperator that generates
+            training jobs in the DAG. The endpoint config is built based on the
+            training job generated in this operator.
+        task_type (str): Whether the task is from SageMakerTrainingOperator or
+            SageMakerTuningOperator. Values can be 'training', 'tuning' or None
+            (which means training job is not from any task).
+        initial_instance_count (int): Minimum number of EC2 instances to deploy
+            to an endpoint for prediction.
+        instance_type (str): Type of EC2 instance to deploy to an endpoint for
+            prediction, for example, 'ml.c4.xlarge'.
+        model_name (str): Name to use for creating an Amazon SageMaker model. If
+            not specified, one will be generated.
+        endpoint_name (str): Name to use for creating an Amazon SageMaker
+            endpoint. If not specified, the name of the SageMaker model is used.
+        tags (list[dict]): List of tags for labeling a training job. For more,
+            see https://docs.aws.amazon.com/sagemaker/latest/dg/API_Tag.html.
+        **kwargs: Passed to invocation of ``create_model()``. Implementations
+            may customize ``create_model()`` to accept ``**kwargs`` to customize
+            model creation during deploy. For more, see the implementation docs.
 
     Returns:
-        dict: Deploy config that can be directly used by SageMakerEndpointOperator in Airflow.
+        dict: Deploy config that can be directly used by
+        SageMakerEndpointOperator in Airflow.
     """
     update_estimator_from_task(estimator, task_id, task_type)
     model = estimator.create_model(**kwargs)


### PR DESCRIPTION
This commit will format all existing docstring to follow Google
style: https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html
This commit will also add docstring placeholders to any class or method
previously missing it.

An ideal approach would be to take the time to include meaningful
docstrings in every file. However, since that is not a task that will
be prioritized, I've declared docstring bankruptcy on this package.
This allows us to enforce docstring on all future code changes to this package.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [X] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [X] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#commit-message-guidlines)
- [X] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [X] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
