### PR TITLE
fix: allow Airflow enabled estimators to use absolute path entry_point

### DIFF
--- a/src/sagemaker/workflow/airflow.py
+++ b/src/sagemaker/workflow/airflow.py
@@ -45,7 +45,12 @@ def prepare_framework(estimator, s3_operations):
         code_dir = "s3://{}/{}".format(bucket, key)
         estimator.uploaded_code = fw_utils.UploadedCode(s3_prefix=code_dir, script_name=script)
         s3_operations["S3Upload"] = [
-            {"Path": estimator.source_dir or script, "Bucket": bucket, "Key": key, "Tar": True}
+            {
+                "Path": estimator.source_dir or estimator.entry_point,
+                "Bucket": bucket,
+                "Key": key,
+                "Tar": True,
+            }
         ]
     estimator._hyperparameters[sagemaker.model.DIR_PARAM_NAME] = code_dir
     estimator._hyperparameters[sagemaker.model.SCRIPT_PARAM_NAME] = script

--- a/tests/unit/test_airflow.py
+++ b/tests/unit/test_airflow.py
@@ -164,7 +164,7 @@ def test_byo_training_config_all_args(sagemaker_session):
 @patch("sagemaker.utils.sagemaker_timestamp", MagicMock(return_value=TIME_STAMP))
 def test_framework_training_config_required_args(sagemaker_session):
     tf = tensorflow.TensorFlow(
-        entry_point="{{ entry_point }}",
+        entry_point="/some/script.py",
         framework_version="1.10.0",
         training_steps=1000,
         evaluation_steps=100,
@@ -206,7 +206,7 @@ def test_framework_training_config_required_args(sagemaker_session):
         "HyperParameters": {
             "sagemaker_submit_directory": '"s3://output/sagemaker-tensorflow-%s/source/sourcedir.tar.gz"'
             % TIME_STAMP,
-            "sagemaker_program": '"{{ entry_point }}"',
+            "sagemaker_program": '"script.py"',
             "sagemaker_enable_cloudwatch_metrics": "false",
             "sagemaker_container_log_level": "20",
             "sagemaker_job_name": '"sagemaker-tensorflow-%s"' % TIME_STAMP,
@@ -219,7 +219,7 @@ def test_framework_training_config_required_args(sagemaker_session):
         "S3Operations": {
             "S3Upload": [
                 {
-                    "Path": "{{ entry_point }}",
+                    "Path": "/some/script.py",
                     "Bucket": "output",
                     "Key": "sagemaker-tensorflow-%s/source/sourcedir.tar.gz" % TIME_STAMP,
                     "Tar": True,


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/sagemaker-python-sdk/issues/770
*Description of changes:*

Currently the Airflow logic always uses basename of entry_point when
taring up the source code and upload to s3. So if only the absolute
path of the script is provided the pre-processing will fail. This change
fixes the issue.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#commit-message-guidlines)
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
