### PR TITLE
feature: support for TensorFlow 1.14

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -189,7 +189,7 @@ TensorFlow SageMaker Estimators
 
 By using TensorFlow SageMaker Estimators, you can train and host TensorFlow models on Amazon SageMaker.
 
-Supported versions of TensorFlow: ``1.4.1``, ``1.5.0``, ``1.6.0``, ``1.7.0``, ``1.8.0``, ``1.9.0``, ``1.10.0``, ``1.11.0``, ``1.12.0``, ``1.13.1``.
+Supported versions of TensorFlow: ``1.4.1``, ``1.5.0``, ``1.6.0``, ``1.7.0``, ``1.8.0``, ``1.9.0``, ``1.10.0``, ``1.11.0``, ``1.12.0``, ``1.13.1``, ``1.14``.
 
 Supported versions of TensorFlow for Elastic Inference: ``1.11.0``, ``1.12.0``, ``1.13.0``
 

--- a/README.rst
+++ b/README.rst
@@ -191,7 +191,7 @@ By using TensorFlow SageMaker Estimators, you can train and host TensorFlow mode
 
 Supported versions of TensorFlow: ``1.4.1``, ``1.5.0``, ``1.6.0``, ``1.7.0``, ``1.8.0``, ``1.9.0``, ``1.10.0``, ``1.11.0``, ``1.12.0``, ``1.13.1``, ``1.14``.
 
-Supported versions of TensorFlow for Elastic Inference: ``1.11.0``, ``1.12.0``, ``1.13.0``
+Supported versions of TensorFlow for Elastic Inference: ``1.11.0``, ``1.12.0``, ``1.13.1``
 
 We recommend that you use the latest supported version, because that's where we focus most of our development efforts.
 

--- a/doc/using_tf.rst
+++ b/doc/using_tf.rst
@@ -9,6 +9,9 @@ models on SageMaker Hosting.
 For general information about using the SageMaker Python SDK, see :ref:`overview:Using the SageMaker Python SDK`.
 
 .. warning::
+    The TensorFlow estimator is available only for Python 3, starting by the TensorFlow version 1.14.
+
+.. warning::
     We have added a new format of your TensorFlow training script with TensorFlow version 1.11.
     This new way gives the user script more flexibility.
     This new format is called Script Mode, as opposed to Legacy Mode, which is what we support with TensorFlow 1.11 and older versions.

--- a/src/sagemaker/tensorflow/serving.py
+++ b/src/sagemaker/tensorflow/serving.py
@@ -177,10 +177,32 @@ class Model(sagemaker.model.FrameworkModel):
         self._framework_version = framework_version
         self._container_log_level = container_log_level
 
+    def deploy(
+        self,
+        initial_instance_count,
+        instance_type,
+        accelerator_type=None,
+        endpoint_name=None,
+        update_endpoint=False,
+        tags=None,
+        kms_key=None,
+        wait=True,
+    ):
+
         if not self._eia_supported():
             msg = "The TensorFlow version %s doesn't support EIA." % self._framework_version
 
             raise AttributeError(msg)
+        return super(Model, self).deploy(
+            initial_instance_count,
+            instance_type,
+            accelerator_type,
+            endpoint_name,
+            update_endpoint,
+            tags,
+            kms_key,
+            wait,
+        )
 
     def _eia_supported(self):
         """Return true if TF version is EIA enabled"""

--- a/src/sagemaker/tensorflow/serving.py
+++ b/src/sagemaker/tensorflow/serving.py
@@ -206,7 +206,7 @@ class Model(sagemaker.model.FrameworkModel):
 
     def _eia_supported(self):
         """Return true if TF version is EIA enabled"""
-        return [int(s) for s in self._framework_version.split(".")] <= self.LATEST_EIA_VERSION
+        return [int(s) for s in self._framework_version.split(".")][:2] <= self.LATEST_EIA_VERSION
 
     def prepare_container_def(self, instance_type, accelerator_type=None):
         """

--- a/src/sagemaker/tensorflow/serving.py
+++ b/src/sagemaker/tensorflow/serving.py
@@ -189,7 +189,7 @@ class Model(sagemaker.model.FrameworkModel):
         wait=True,
     ):
 
-        if not self._eia_supported():
+        if accelerator_type and not self._eia_supported():
             msg = "The TensorFlow version %s doesn't support EIA." % self._framework_version
 
             raise AttributeError(msg)

--- a/src/sagemaker/tensorflow/serving.py
+++ b/src/sagemaker/tensorflow/serving.py
@@ -131,6 +131,7 @@ class Model(sagemaker.model.FrameworkModel):
         logging.ERROR: "error",
         logging.CRITICAL: "crit",
     }
+    LATEST_EIA_VERSION = [1, 13]
 
     def __init__(
         self,
@@ -175,6 +176,15 @@ class Model(sagemaker.model.FrameworkModel):
         )
         self._framework_version = framework_version
         self._container_log_level = container_log_level
+
+        if not self._eia_supported():
+            msg = "The TensorFlow version %s doesn't support EIA." % self._framework_version
+
+            raise AttributeError(msg)
+
+    def _eia_supported(self):
+        """Return true if TF version is EIA enabled"""
+        return [int(s) for s in self._framework_version.split(".")] <= self.LATEST_EIA_VERSION
 
     def prepare_container_def(self, instance_type, accelerator_type=None):
         """

--- a/tests/integ/test_tfs.py
+++ b/tests/integ/test_tfs.py
@@ -111,7 +111,7 @@ def tfs_predictor_with_model_and_entry_point_and_dependencies(
 
 
 @pytest.fixture(scope="module")
-def tfs_predictor_with_accelerator(sagemaker_session, tf_full_version):
+def tfs_predictor_with_accelerator(sagemaker_session):
     endpoint_name = sagemaker.utils.unique_name_from_base("sagemaker-tensorflow-serving")
     model_data = sagemaker_session.upload_data(
         path=os.path.join(tests.integ.DATA_DIR, "tensorflow-serving-test-model.tar.gz"),
@@ -121,7 +121,7 @@ def tfs_predictor_with_accelerator(sagemaker_session, tf_full_version):
         model = Model(
             model_data=model_data,
             role="SageMakerRole",
-            framework_version=tf_full_version,
+            framework_version="1.13.1",
             sagemaker_session=sagemaker_session,
         )
         predictor = model.deploy(

--- a/tests/integ/test_tfs.py
+++ b/tests/integ/test_tfs.py
@@ -121,7 +121,7 @@ def tfs_predictor_with_accelerator(sagemaker_session):
         model = Model(
             model_data=model_data,
             role="SageMakerRole",
-            framework_version="1.13.1",
+            framework_version="1.13",
             sagemaker_session=sagemaker_session,
         )
         predictor = model.deploy(

--- a/tests/unit/test_fw_utils.py
+++ b/tests/unit/test_fw_utils.py
@@ -138,6 +138,13 @@ def test_create_image_uri_gov_cloud():
 
 def test_create_image_uri_merged():
     image_uri = fw_utils.create_image_uri(
+        "us-west-2", "tensorflow-scriptmode", "ml.p3.2xlarge", "1.14", "py3"
+    )
+    assert (
+        image_uri == "763104351884.dkr.ecr.us-west-2.amazonaws.com/tensorflow-training:1.14-gpu-py3"
+    )
+
+    image_uri = fw_utils.create_image_uri(
         "us-west-2", "tensorflow-scriptmode", "ml.p3.2xlarge", "1.13.1", "py3"
     )
     assert (

--- a/tests/unit/test_tf_estimator.py
+++ b/tests/unit/test_tf_estimator.py
@@ -25,7 +25,6 @@ from sagemaker.session import s3_input
 from sagemaker.tensorflow import defaults, TensorFlow, TensorFlowModel, TensorFlowPredictor
 import sagemaker.tensorflow.estimator as tfe
 
-
 DATA_DIR = os.path.join(os.path.dirname(__file__), "..", "data")
 SCRIPT_FILE = "dummy_script.py"
 SCRIPT_PATH = os.path.join(DATA_DIR, SCRIPT_FILE)
@@ -954,6 +953,30 @@ def test_script_mode_deprecated_args(sagemaker_session):
     assert _deprecated_args_msg(
         "training_steps, evaluation_steps, requirements_file, checkpoint_path"
     ) in str(e.value)
+
+
+def test_py2_version_deprecated(sagemaker_session):
+    with pytest.raises(AttributeError) as e:
+        _build_tf(sagemaker_session=sagemaker_session, framework_version="1.14", py_version="py2")
+
+    msg = "Python 2 containers are only available until TensorFlow version 1.13.1. Please use a Python 3 container."
+    assert msg in str(e.value)
+
+
+def test_py3_is_default_version_after_tf1_14(sagemaker_session):
+    estimator = _build_tf(sagemaker_session=sagemaker_session, framework_version="1.14")
+
+    assert estimator.py_version == "py3"
+
+
+def test_py3_is_default_version_before_tf1_14(sagemaker_session):
+    estimator = _build_tf(sagemaker_session=sagemaker_session, framework_version="1.13")
+
+    assert estimator.py_version == "py2"
+
+    estimator = _build_tf(sagemaker_session=sagemaker_session, framework_version="1.10")
+
+    assert estimator.py_version == "py2"
 
 
 def test_legacy_mode_deprecated(sagemaker_session):

--- a/tests/unit/test_tfs.py
+++ b/tests/unit/test_tfs.py
@@ -96,9 +96,20 @@ def test_tfs_model_image_accelerator(sagemaker_session, tf_version):
     assert isinstance(predictor, Predictor)
 
 
-def test_tfs_model_image_accelerator_not_supported():
+def test_tfs_model_image_accelerator_not_supported(sagemaker_session):
+    model = Model(
+        "s3://some/data.tar.gz",
+        role=ROLE,
+        framework_version="1.14",
+        sagemaker_session=sagemaker_session,
+    )
+
     with pytest.raises(AttributeError) as e:
-        Model("s3://some/data.tar.gz", role=ROLE, framework_version="1.14")
+        model.deploy(
+            instance_type="ml.c4.xlarge",
+            accelerator_type="ml.eia1.medium",
+            initial_instance_count=1,
+        )
 
     assert str(e.value) == "The TensorFlow version 1.14 doesn't support EIA."
 

--- a/tests/unit/test_tfs.py
+++ b/tests/unit/test_tfs.py
@@ -100,6 +100,19 @@ def test_tfs_model_image_accelerator_not_supported(sagemaker_session):
     model = Model(
         "s3://some/data.tar.gz",
         role=ROLE,
+        framework_version="1.13.1",
+        sagemaker_session=sagemaker_session,
+    )
+
+    # assert error is not raised
+
+    model.deploy(
+        instance_type="ml.c4.xlarge", initial_instance_count=1, accelerator_type="ml.eia1.medium"
+    )
+
+    model = Model(
+        "s3://some/data.tar.gz",
+        role=ROLE,
         framework_version="1.14",
         sagemaker_session=sagemaker_session,
     )

--- a/tests/unit/test_tfs.py
+++ b/tests/unit/test_tfs.py
@@ -106,10 +106,7 @@ def test_tfs_model_image_accelerator_not_supported(sagemaker_session):
 
     # assert error is not raised
 
-    model.deploy(
-        instance_type="ml.c4.xlarge",
-        initial_instance_count=1,
-    )
+    model.deploy(instance_type="ml.c4.xlarge", initial_instance_count=1)
 
     with pytest.raises(AttributeError) as e:
         model.deploy(

--- a/tests/unit/test_tfs.py
+++ b/tests/unit/test_tfs.py
@@ -96,6 +96,13 @@ def test_tfs_model_image_accelerator(sagemaker_session, tf_version):
     assert isinstance(predictor, Predictor)
 
 
+def test_tfs_model_image_accelerator_not_supported():
+    with pytest.raises(AttributeError) as e:
+        Model("s3://some/data.tar.gz", role=ROLE, framework_version="1.14")
+
+    assert str(e.value) == "The TensorFlow version 1.14 doesn't support EIA."
+
+
 def test_tfs_model_with_log_level(sagemaker_session, tf_version):
     model = Model(
         "s3://some/data.tar.gz",

--- a/tests/unit/test_tfs.py
+++ b/tests/unit/test_tfs.py
@@ -104,6 +104,13 @@ def test_tfs_model_image_accelerator_not_supported(sagemaker_session):
         sagemaker_session=sagemaker_session,
     )
 
+    # assert error is not raised
+
+    model.deploy(
+        instance_type="ml.c4.xlarge",
+        initial_instance_count=1,
+    )
+
     with pytest.raises(AttributeError) as e:
         model.deploy(
             instance_type="ml.c4.xlarge",

--- a/tox.ini
+++ b/tox.ini
@@ -33,6 +33,7 @@ ignore =
     FI15,
     FI16,
     FI17,
+    FI18,  # __future__ import "annotations" missing -> check only Python 3.7 compatible
     FI50,
     FI51,
     FI52,


### PR DESCRIPTION
*Description of changes:*
- Support for TensorFlow 1.14
- TensorFlow Python 3 containers are default starting by 1.14 version
- TensorFlow Python 2 containers are not available starting by 1.14 version

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#commit-message-guidlines)
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
