### PR TITLE
 fix: prevent multiple values error in sklearn.transformer()

### DIFF
--- a/src/sagemaker/sklearn/estimator.py
+++ b/src/sagemaker/sklearn/estimator.py
@@ -155,7 +155,7 @@ class SKLearn(Framework):
         # remove unwanted entry_point kwarg
         if "entry_point" in kwargs:
             logger.debug("removing unused entry_point argument: %s", str(kwargs["entry_point"]))
-            kwargs = { k: v for k, v in kwargs.items() if k != "entry_point"}
+            kwargs = {k: v for k, v in kwargs.items() if k != "entry_point"}
 
         return SKLearnModel(
             self.model_data,

--- a/src/sagemaker/sklearn/estimator.py
+++ b/src/sagemaker/sklearn/estimator.py
@@ -151,6 +151,12 @@ class SKLearn(Framework):
             object. See :func:`~sagemaker.sklearn.model.SKLearnModel` for full details.
         """
         role = role or self.role
+
+        # remove unwanted entry_point kwarg
+        if "entry_point" in kwargs:
+            logger.debug("removing unused entry_point argument: %s", str(kwargs["entry_point"]))
+            kwargs = { k: v for k, v in kwargs.items() if k != "entry_point"}
+
         return SKLearnModel(
             self.model_data,
             role,

--- a/tests/unit/test_sklearn.py
+++ b/tests/unit/test_sklearn.py
@@ -317,7 +317,7 @@ def test_transform_multiple_values_for_entry_point_issue(sagemaker_session, skle
 
     sklearn.fit(inputs=inputs)
 
-    transformer = sklearn.transformer(instance_count=1, instance_type='ml.m4.xlarge')
+    transformer = sklearn.transformer(instance_count=1, instance_type="ml.m4.xlarge")
     # if we got here, we didn't get a "multiple values" error
     assert transformer is not None
 

--- a/tests/unit/test_sklearn.py
+++ b/tests/unit/test_sklearn.py
@@ -302,6 +302,26 @@ def test_sklearn(strftime, sagemaker_session, sklearn_version):
     assert isinstance(predictor, SKLearnPredictor)
 
 
+def test_transform_multiple_values_for_entry_point_issue(sagemaker_session, sklearn_version):
+    # https://github.com/aws/sagemaker-python-sdk/issues/974
+    sklearn = SKLearn(
+        entry_point=SCRIPT_PATH,
+        role=ROLE,
+        sagemaker_session=sagemaker_session,
+        train_instance_type=INSTANCE_TYPE,
+        py_version=PYTHON_VERSION,
+        framework_version=sklearn_version,
+    )
+
+    inputs = "s3://mybucket/train"
+
+    sklearn.fit(inputs=inputs)
+
+    transformer = sklearn.transformer(instance_count=1, instance_type='ml.m4.xlarge')
+    # if we got here, we didn't get a "multiple values" error
+    assert transformer is not None
+
+
 def test_fail_distributed_training(sagemaker_session, sklearn_version):
     with pytest.raises(AttributeError) as error:
         SKLearn(


### PR DESCRIPTION
*Issue #, if available:*

fixes #974 

*Description of changes:*

prevent sklearn.transformer()  from passing multiple values of entry_point arg to model constructor.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
