### PR TITLE
change: Integration Tests now dynamically checks AZs

### DIFF
--- a/tests/integ/vpc_test_utils.py
+++ b/tests/integ/vpc_test_utils.py
@@ -52,12 +52,17 @@ def _create_vpc_with_name(ec2_client, region, name):
     print("created vpc: {}".format(vpc_id))
 
     # sagemaker endpoints require subnets in at least 2 different AZs for vpc mode
+    availability_zones = ec2_client.describe_availability_zones()["AvailabilityZones"]
+
+    if len(availability_zones) < 2:
+        raise Exception("Sagemaker vpc mode cannot run in this region, as 2 AZs are required.")
+
     subnet_id_a = ec2_client.create_subnet(
-        CidrBlock="10.0.0.0/24", VpcId=vpc_id, AvailabilityZone=(region + "a")
+        CidrBlock="10.0.0.0/24", VpcId=vpc_id, AvailabilityZone=availability_zones[0]["ZoneName"]
     )["Subnet"]["SubnetId"]
     print("created subnet: {}".format(subnet_id_a))
     subnet_id_b = ec2_client.create_subnet(
-        CidrBlock="10.0.1.0/24", VpcId=vpc_id, AvailabilityZone=(region + "b")
+        CidrBlock="10.0.1.0/24", VpcId=vpc_id, AvailabilityZone=availability_zones[1]["ZoneName"]
     )["Subnet"]["SubnetId"]
     print("created subnet: {}".format(subnet_id_b))
 

--- a/tests/integ/vpc_test_utils.py
+++ b/tests/integ/vpc_test_utils.py
@@ -51,18 +51,16 @@ def _create_vpc_with_name(ec2_client, region, name):
     vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
     print("created vpc: {}".format(vpc_id))
 
-    # sagemaker endpoints require subnets in at least 2 different AZs for vpc mode
-    availability_zones = ec2_client.describe_availability_zones()["AvailabilityZones"]
-
-    if len(availability_zones) < 2:
-        raise Exception("Sagemaker vpc mode cannot run in this region, as 2 AZs are required.")
+    availability_zone_name = ec2_client.describe_availability_zones()["AvailabilityZones"][0][
+        "ZoneName"
+    ]
 
     subnet_id_a = ec2_client.create_subnet(
-        CidrBlock="10.0.0.0/24", VpcId=vpc_id, AvailabilityZone=availability_zones[0]["ZoneName"]
+        CidrBlock="10.0.0.0/24", VpcId=vpc_id, AvailabilityZone=availability_zone_name
     )["Subnet"]["SubnetId"]
     print("created subnet: {}".format(subnet_id_a))
     subnet_id_b = ec2_client.create_subnet(
-        CidrBlock="10.0.1.0/24", VpcId=vpc_id, AvailabilityZone=availability_zones[1]["ZoneName"]
+        CidrBlock="10.0.1.0/24", VpcId=vpc_id, AvailabilityZone=availability_zone_name
     )["Subnet"]["SubnetId"]
     print("created subnet: {}".format(subnet_id_b))
 


### PR DESCRIPTION
Canaries have failed in Tokyo (ap-northeast-1) since inception because
the ap-northeast-1b region doesn't exist.

This commit makes the check dynamic instead of blindly assuming that
a and b exist, as that isn't the case for 3 regions:
ap-northeast-1
ap-northeast-2
sa-east-1

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [X] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [X] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [X] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [X] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
