### PR TITLE
fix: skip efs tests in non us-west-2 regions

### DIFF
--- a/tests/integ/__init__.py
+++ b/tests/integ/__init__.py
@@ -71,6 +71,8 @@ EI_SUPPORTED_REGIONS = [
 NO_LDA_REGIONS = ["eu-west-3", "eu-north-1", "sa-east-1", "ap-east-1"]
 NO_MARKET_PLACE_REGIONS = ["eu-west-3", "eu-north-1", "sa-east-1", "ap-east-1"]
 
+EFS_TEST_ENABLED_REGION = ["us-west-2"]
+
 logging.getLogger("boto3").setLevel(logging.INFO)
 logging.getLogger("botocore").setLevel(logging.INFO)
 

--- a/tests/integ/test_kmeans_efs_fsx.py
+++ b/tests/integ/test_kmeans_efs_fsx.py
@@ -14,14 +14,15 @@ from __future__ import absolute_import
 
 import pytest
 
+import tests.integ
 from sagemaker import KMeans
 from sagemaker.amazon.amazon_estimator import FileSystemRecordSet
 from sagemaker.parameter import IntegerParameter, CategoricalParameter
 from sagemaker.tuner import HyperparameterTuner
 from sagemaker.utils import unique_name_from_base
 from tests.integ import TRAINING_DEFAULT_TIMEOUT_MINUTES, TUNING_DEFAULT_TIMEOUT_MINUTES
-from tests.integ.s3_utils import assert_s3_files_exist
 from tests.integ.file_system_input_utils import set_up_efs_fsx, tear_down
+from tests.integ.s3_utils import assert_s3_files_exist
 from tests.integ.timeout import timeout
 
 TRAIN_INSTANCE_TYPE = "ml.c4.xlarge"
@@ -45,7 +46,10 @@ def efs_fsx_setup(sagemaker_session):
         tear_down(sagemaker_session, fs_resources)
 
 
-@pytest.mark.canary_quick
+@pytest.mark.skipif(
+    tests.integ.test_region() not in tests.integ.EFS_TEST_ENABLED_REGION,
+    reason="EFS integration tests need to be fixed before running in all regions.",
+)
 def test_kmeans_efs(efs_fsx_setup, sagemaker_session):
     with timeout(minutes=TRAINING_DEFAULT_TIMEOUT_MINUTES):
         subnets = [efs_fsx_setup.subnet_id]
@@ -76,7 +80,10 @@ def test_kmeans_efs(efs_fsx_setup, sagemaker_session):
         assert_s3_files_exist(sagemaker_session, model_path, ["model.tar.gz"])
 
 
-@pytest.mark.canary_quick
+@pytest.mark.skipif(
+    tests.integ.test_region() not in tests.integ.EFS_TEST_ENABLED_REGION,
+    reason="EFS integration tests need to be fixed before running in all regions.",
+)
 def test_kmeans_fsx(efs_fsx_setup, sagemaker_session):
     with timeout(minutes=TRAINING_DEFAULT_TIMEOUT_MINUTES):
         subnets = [efs_fsx_setup.subnet_id]
@@ -107,6 +114,10 @@ def test_kmeans_fsx(efs_fsx_setup, sagemaker_session):
         assert_s3_files_exist(sagemaker_session, model_path, ["model.tar.gz"])
 
 
+@pytest.mark.skipif(
+    tests.integ.test_region() not in tests.integ.EFS_TEST_ENABLED_REGION,
+    reason="EFS integration tests need to be fixed before running in all regions.",
+)
 def test_tuning_kmeans_efs(efs_fsx_setup, sagemaker_session):
     subnets = [efs_fsx_setup.subnet_id]
     security_group_ids = efs_fsx_setup.security_group_ids
@@ -163,6 +174,10 @@ def test_tuning_kmeans_efs(efs_fsx_setup, sagemaker_session):
         assert best_training_job
 
 
+@pytest.mark.skipif(
+    tests.integ.test_region() not in tests.integ.EFS_TEST_ENABLED_REGION,
+    reason="EFS integration tests need to be fixed before running in all regions.",
+)
 def test_tuning_kmeans_fsx(efs_fsx_setup, sagemaker_session):
     subnets = [efs_fsx_setup.subnet_id]
     security_group_ids = efs_fsx_setup.security_group_ids

--- a/tests/integ/test_tf_efs_fsx.py
+++ b/tests/integ/test_tf_efs_fsx.py
@@ -17,14 +17,15 @@ import time
 
 import pytest
 
+import tests.integ
 from sagemaker.inputs import FileSystemInput
 from sagemaker.parameter import IntegerParameter
 from sagemaker.tensorflow import TensorFlow
 from sagemaker.tuner import HyperparameterTuner
 from sagemaker.utils import unique_name_from_base
 from tests.integ import TRAINING_DEFAULT_TIMEOUT_MINUTES, TUNING_DEFAULT_TIMEOUT_MINUTES
-from tests.integ.s3_utils import assert_s3_files_exist
 from tests.integ.file_system_input_utils import tear_down, set_up_efs_fsx
+from tests.integ.s3_utils import assert_s3_files_exist
 from tests.integ.timeout import timeout
 
 RESOURCE_PATH = os.path.join(os.path.dirname(__file__), "..", "data")
@@ -48,7 +49,10 @@ def efs_fsx_setup(sagemaker_session):
         tear_down(sagemaker_session, fs_resources)
 
 
-@pytest.mark.canary_quick
+@pytest.mark.skipif(
+    tests.integ.test_region() not in tests.integ.EFS_TEST_ENABLED_REGION,
+    reason="EFS integration tests need to be fixed before running in all regions.",
+)
 def test_mnist_efs(efs_fsx_setup, sagemaker_session):
     role = efs_fsx_setup.role_name
     subnets = [efs_fsx_setup.subnet_id]
@@ -81,7 +85,10 @@ def test_mnist_efs(efs_fsx_setup, sagemaker_session):
     )
 
 
-@pytest.mark.canary_quick
+@pytest.mark.skipif(
+    tests.integ.test_region() not in tests.integ.EFS_TEST_ENABLED_REGION,
+    reason="EFS integration tests need to be fixed before running in all regions.",
+)
 def test_mnist_lustre(efs_fsx_setup, sagemaker_session):
     role = efs_fsx_setup.role_name
     subnets = [efs_fsx_setup.subnet_id]
@@ -114,6 +121,10 @@ def test_mnist_lustre(efs_fsx_setup, sagemaker_session):
     )
 
 
+@pytest.mark.skipif(
+    tests.integ.test_region() not in tests.integ.EFS_TEST_ENABLED_REGION,
+    reason="EFS integration tests need to be fixed before running in all regions.",
+)
 def test_tuning_tf_script_mode_efs(efs_fsx_setup, sagemaker_session):
     role = efs_fsx_setup.role_name
     subnets = [efs_fsx_setup.subnet_id]
@@ -158,6 +169,10 @@ def test_tuning_tf_script_mode_efs(efs_fsx_setup, sagemaker_session):
     assert best_training_job
 
 
+@pytest.mark.skipif(
+    tests.integ.test_region() not in tests.integ.EFS_TEST_ENABLED_REGION,
+    reason="EFS integration tests need to be fixed before running in all regions.",
+)
 def test_tuning_tf_script_mode_lustre(efs_fsx_setup, sagemaker_session):
     role = efs_fsx_setup.role_name
     subnets = [efs_fsx_setup.subnet_id]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Skip EFS tests in non us-west-2 regions because those tests create ec2 instance and using the us-west-2 only AMI ID.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
