### PR TITLE
change: use cpu_instance_type fixture for stop_transform_job test

### DIFF
--- a/tests/integ/test_transformer.py
+++ b/tests/integ/test_transformer.py
@@ -350,7 +350,7 @@ def test_single_transformer_multiple_jobs(sagemaker_session, mxnet_full_version,
         )
 
 
-def test_stop_transform_job(sagemaker_session, mxnet_full_version):
+def test_stop_transform_job(sagemaker_session, mxnet_full_version, cpu_instance_type):
     data_path = os.path.join(DATA_DIR, "mxnet_mnist")
     script_path = os.path.join(data_path, "mnist.py")
     tags = [{"Key": "some-tag", "Value": "value-for-tag"}]
@@ -359,7 +359,7 @@ def test_stop_transform_job(sagemaker_session, mxnet_full_version):
         entry_point=script_path,
         role="SageMakerRole",
         train_instance_count=1,
-        train_instance_type="ml.c4.xlarge",
+        train_instance_type=cpu_instance_type,
         sagemaker_session=sagemaker_session,
         framework_version=mxnet_full_version,
     )
@@ -381,7 +381,7 @@ def test_stop_transform_job(sagemaker_session, mxnet_full_version):
         path=transform_input_path, key_prefix=transform_input_key_prefix
     )
 
-    transformer = mx.transformer(1, "ml.m4.xlarge", tags=tags)
+    transformer = mx.transformer(1, cpu_instance_type, tags=tags)
     transformer.transform(transform_input, content_type="text/csv")
 
     time.sleep(15)


### PR DESCRIPTION
*Description of changes:*
#850 introduced a new test that didn't use the `cpu_instance_type` fixture that got introduced later.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
