### PR TITLE
fix: add enable_network_isolation to generic Estimator class

### DIFF
--- a/src/sagemaker/estimator.py
+++ b/src/sagemaker/estimator.py
@@ -905,6 +905,7 @@ class Estimator(EstimatorBase):
         train_max_wait=None,
         checkpoint_s3_uri=None,
         checkpoint_local_path=None,
+        enable_network_isolation=False,
     ):
         """Initialize an ``Estimator`` instance.
 
@@ -1008,9 +1009,18 @@ class Estimator(EstimatorBase):
                 started. If the path is unset then SageMaker assumes the
                 checkpoints will be provided under `/opt/ml/checkpoints/`.
                 (default: ``None``).
+            enable_network_isolation (bool): Specifies whether container will
+                run in network isolation mode. Network isolation mode restricts
+                the container access to outside networks (such as the Internet).
+                The container does not make any inbound or outbound network
+                calls. If ``True``, a channel named "code" will be created for any
+                user entry script for training. The user entry script, files in
+                source_dir (if specified), and dependencies will be uploaded in
+                a tar to S3. Also known as internet-free mode (default: ``False``).
         """
         self.image_name = image_name
         self.hyperparam_dict = hyperparameters.copy() if hyperparameters else {}
+        self._enable_network_isolation = enable_network_isolation
         super(Estimator, self).__init__(
             role,
             train_instance_count,
@@ -1035,6 +1045,14 @@ class Estimator(EstimatorBase):
             checkpoint_s3_uri=checkpoint_s3_uri,
             checkpoint_local_path=checkpoint_local_path,
         )
+
+    def enable_network_isolation(self):
+        """If this Estimator can use network isolation when running.
+
+        Returns:
+            bool: Whether this Estimator can use network isolation or not.
+        """
+        return self._enable_network_isolation
 
     def train_image(self):
         """Returns the docker image to use for training.

--- a/tests/unit/test_estimator.py
+++ b/tests/unit/test_estimator.py
@@ -1779,6 +1779,24 @@ def test_generic_to_fit_with_encrypt_inter_container_traffic_flag(sagemaker_sess
     assert args["encrypt_inter_container_traffic"] is True
 
 
+def test_generic_to_fit_with_network_isolation(sagemaker_session):
+    e = Estimator(
+        IMAGE_NAME,
+        ROLE,
+        INSTANCE_COUNT,
+        INSTANCE_TYPE,
+        output_path=OUTPUT_PATH,
+        sagemaker_session=sagemaker_session,
+        enable_network_isolation=True,
+    )
+
+    e.fit()
+
+    sagemaker_session.train.assert_called_once()
+    args = sagemaker_session.train.call_args[1]
+    assert args["enable_network_isolation"]
+
+
 def test_generic_to_deploy(sagemaker_session):
     e = Estimator(
         IMAGE_NAME,


### PR DESCRIPTION
*Description of changes:*
There's currently no way to enable network isolation when using a custom image with the generic estimator class

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
