### PR TITLE
Fix get_image_uri warning log for default xgboost version.

### DIFF
--- a/src/sagemaker/amazon/amazon_estimator.py
+++ b/src/sagemaker/amazon/amazon_estimator.py
@@ -538,7 +538,7 @@ def get_image_uri(region_name, repo_name, repo_version=1):
             "There is a more up to date SageMaker XGBoost image."
             "To use the newer image, please set 'repo_version'="
             "'0.90-1. For example:\n"
-            "\tget_image_uri(region, 'xgboost', %s).",
+            "\tget_image_uri(region, 'xgboost', '%s').",
             XGBOOST_LATEST_VERSION,
         )
     repo = "{}:{}".format(repo_name, repo_version)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Added quotes around warning log so customers can copy paste directly.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
