### PR TITLE
change: remove hardcoded creds from integ test

### DIFF
--- a/tests/integ/test_git.py
+++ b/tests/integ/test_git.py
@@ -233,6 +233,7 @@ def test_git_support_with_sklearn_ssh_passphrase_not_configured(
 
 
 @pytest.mark.local_mode
+@pytest.skip(reason="needs a secure authentication approach")
 def test_git_support_codecommit_with_mxnet(sagemaker_local_session):
     script_path = "mnist.py"
     data_path = os.path.join(DATA_DIR, "mxnet_mnist")
@@ -240,7 +241,7 @@ def test_git_support_codecommit_with_mxnet(sagemaker_local_session):
         "repo": CODECOMMIT_REPO,
         "branch": CODECOMMIT_BRANCH,
         "username": "GitTest-at-142577830533",
-        "password": "22LcZpWMtjpDG3fbOuHPooIoKoRxF36rQj7zdUvXooA=",
+        "password": "",  # TODO: assume a role to get temporary credentials
     }
     source_dir = "mxnet"
     dependencies = ["foo/bar.py"]

--- a/tests/integ/test_git.py
+++ b/tests/integ/test_git.py
@@ -233,7 +233,7 @@ def test_git_support_with_sklearn_ssh_passphrase_not_configured(
 
 
 @pytest.mark.local_mode
-@pytest.skip(reason="needs a secure authentication approach")
+@pytest.mark.skip("needs a secure authentication approach")
 def test_git_support_codecommit_with_mxnet(sagemaker_local_session):
     script_path = "mnist.py"
     data_path = os.path.join(DATA_DIR, "mxnet_mnist")


### PR DESCRIPTION
*Description of changes:*
One of the integration tests had a plain-text credential for CodeCommit. I have disabled the access key for that IAM user already, so we should skip this test until we implement a better solution.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
