### PR TITLE
fix: add https to regional STS endpoint

### DIFF
--- a/src/sagemaker/utils.py
+++ b/src/sagemaker/utils.py
@@ -553,7 +553,7 @@ def sts_regional_endpoint(region):
     Returns:
         str: AWS STS regional endpoint
     """
-    return "sts.{}.amazonaws.com".format(region)
+    return "https://sts.{}.amazonaws.com".format(region)
 
 
 class DeferredError(object):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -22,6 +22,7 @@ import re
 import time
 
 from boto3 import exceptions
+import botocore
 import pytest
 from mock import call, patch, Mock, MagicMock
 
@@ -564,4 +565,5 @@ def list_tar_files(tar_ball, tmp):
 
 def test_sts_regional_endpoint():
     endpoint = sagemaker.utils.sts_regional_endpoint("us-west-2")
-    assert endpoint == "sts.us-west-2.amazonaws.com"
+    assert endpoint == "https://sts.us-west-2.amazonaws.com"
+    assert botocore.utils.is_valid_endpoint_url(endpoint)


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/sagemaker-python-sdk/issues/1034

*Description of changes:*
#1026 was incorrect, so here's a PR to fix it.

```python
>>> boto3.client("sts", endpoint_url="https://sts.us-west-2.amazonaws.com")
<botocore.client.STS object at 0x102f62358>
```

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
