### PR TITLE
change: use Estimator.create_model in Estimator.transformer

### DIFF
--- a/tests/unit/test_estimator.py
+++ b/tests/unit/test_estimator.py
@@ -1392,6 +1392,7 @@ def test_ensure_latest_training_job_failure(sagemaker_session):
     assert "Estimator is not associated with a training job" in str(e)
 
 
+@patch("sagemaker.estimator.Estimator.create_model", return_value=Mock())
 def test_estimator_transformer_creation(sagemaker_session):
     estimator = Estimator(
         image_name=IMAGE_NAME,
@@ -1401,11 +1402,9 @@ def test_estimator_transformer_creation(sagemaker_session):
         sagemaker_session=sagemaker_session,
     )
     estimator.latest_training_job = _TrainingJob(sagemaker_session, JOB_NAME)
-    sagemaker_session.create_model_from_job.return_value = JOB_NAME
 
     transformer = estimator.transformer(INSTANCE_COUNT, INSTANCE_TYPE)
 
-    sagemaker_session.create_model_from_job.assert_called_with(JOB_NAME, role=None, tags=None)
     assert isinstance(transformer, Transformer)
     assert transformer.sagemaker_session == sagemaker_session
     assert transformer.instance_count == INSTANCE_COUNT
@@ -1414,6 +1413,7 @@ def test_estimator_transformer_creation(sagemaker_session):
     assert transformer.tags is None
 
 
+@patch("sagemaker.estimator.Estimator.create_model", return_value=Mock())
 def test_estimator_transformer_creation_with_optional_params(sagemaker_session):
     base_name = "foo"
     estimator = Estimator(
@@ -1425,7 +1425,6 @@ def test_estimator_transformer_creation_with_optional_params(sagemaker_session):
         base_job_name=base_name,
     )
     estimator.latest_training_job = _TrainingJob(sagemaker_session, JOB_NAME)
-    sagemaker_session.create_model_from_job.return_value = JOB_NAME
 
     strategy = "MultiRecord"
     assemble_with = "Line"
@@ -1450,7 +1449,6 @@ def test_estimator_transformer_creation_with_optional_params(sagemaker_session):
         role=ROLE,
     )
 
-    sagemaker_session.create_model_from_job.assert_called_with(JOB_NAME, role=ROLE, tags=TAGS)
     assert transformer.strategy == strategy
     assert transformer.assemble_with == assemble_with
     assert transformer.output_path == OUTPUT_PATH


### PR DESCRIPTION
*Description of changes:*
This change in the `Estimator.transformer` implementation should help make sure various parameters don't get lost when going from an estimator to a model. This was specifically seen with network isolation, but there might be similar things in the future.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
