### PR TITLE
change: stop unit test code checks from running in parallel

### DIFF
--- a/buildspec-unittests.yml
+++ b/buildspec-unittests.yml
@@ -7,7 +7,7 @@ phases:
       - TOX_PARALLEL_NO_SPINNER=1
       - PY_COLORS=0
       - start_time=`date +%s`
-      - tox -e flake8,pylint,twine,black-check --parallel all
+      - tox -e flake8,pylint,twine,black-check
       - ./ci-scripts/displaytime.sh 'flake8,pylint,twine,black-check' $start_time
 
       - start_time=`date +%s`


### PR DESCRIPTION
There seems to be a ~5% failure rate when the code checks are run in
parallel. This change adds a minute or two to the unit tests running
in the pipeline, but avoids the small failure rate that may confuse
contributors.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [X] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [X] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [X] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [X] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
