### PR TITLE
Revert "fix: #987 Add Instance_Type in Endpoint_Config_Name"

### DIFF
--- a/src/sagemaker/model.py
+++ b/src/sagemaker/model.py
@@ -446,14 +446,13 @@ class Model(object):
         if endpoint_name:
             self.endpoint_name = endpoint_name
         else:
-            self.endpoint_name = self.name + "-" + instance_type.replace(".", "-")
+            self.endpoint_name = self.name
             if self._is_compiled_model and not self.endpoint_name.endswith(compiled_model_suffix):
                 self.endpoint_name += compiled_model_suffix
 
         if update_endpoint:
-            self.sagemaker_session.delete_endpoint_config(endpoint_config_name=self.endpoint_name)
             endpoint_config_name = self.sagemaker_session.create_endpoint_config(
-                name=self.endpoint_name,
+                name=self.name,
                 model_name=self.name,
                 initial_instance_count=initial_instance_count,
                 instance_type=instance_type,

--- a/tests/integ/test_mxnet_train.py
+++ b/tests/integ/test_mxnet_train.py
@@ -196,7 +196,7 @@ def test_deploy_model_with_update_endpoint(
             EndpointConfigName=new_config_name
         )
 
-        assert old_config_name == new_config_name
+        assert old_config_name != new_config_name
         assert new_config["ProductionVariants"][0]["InstanceType"] == cpu_instance_type
         assert new_config["ProductionVariants"][0]["InitialInstanceCount"] == 1
 

--- a/tests/unit/test_endpoint_from_model_data.py
+++ b/tests/unit/test_endpoint_from_model_data.py
@@ -30,7 +30,6 @@ VPC_CONFIG = {"Subnets": ["foo"], "SecurityGroupIds": ["bar"]}
 DEPLOY_ROLE = "mydeployrole"
 ENV_VARS = {"PYTHONUNBUFFERED": "TRUE", "some": "nonsense"}
 NAME_FROM_IMAGE = "namefromimage"
-DEFAULT_ENDPOINT_NAME = "namefromimage-ml-c4-xlarge"
 REGION = "us-west-2"
 
 
@@ -65,28 +64,28 @@ def test_all_defaults_no_existing_entities(name_from_image_mock, sagemaker_sessi
     )
 
     sagemaker_session.sagemaker_client.describe_endpoint.assert_called_once_with(
-        EndpointName=DEFAULT_ENDPOINT_NAME
+        EndpointName=NAME_FROM_IMAGE
     )
     sagemaker_session.sagemaker_client.describe_model.assert_called_once_with(
         ModelName=NAME_FROM_IMAGE
     )
     sagemaker_session.sagemaker_client.describe_endpoint_config.assert_called_once_with(
-        EndpointConfigName=DEFAULT_ENDPOINT_NAME
+        EndpointConfigName=NAME_FROM_IMAGE
     )
     sagemaker_session.create_model.assert_called_once_with(
         name=NAME_FROM_IMAGE, role=DEPLOY_ROLE, container_defs=CONTAINER_DEF, vpc_config=None
     )
     sagemaker_session.create_endpoint_config.assert_called_once_with(
-        name=DEFAULT_ENDPOINT_NAME,
+        name=NAME_FROM_IMAGE,
         model_name=NAME_FROM_IMAGE,
         initial_instance_count=INITIAL_INSTANCE_COUNT,
         instance_type=INSTANCE_TYPE,
         accelerator_type=None,
     )
     sagemaker_session.create_endpoint.assert_called_once_with(
-        endpoint_name=DEFAULT_ENDPOINT_NAME, config_name=DEFAULT_ENDPOINT_NAME, wait=False
+        endpoint_name=NAME_FROM_IMAGE, config_name=NAME_FROM_IMAGE, wait=False
     )
-    assert returned_name == DEFAULT_ENDPOINT_NAME
+    assert returned_name == NAME_FROM_IMAGE
 
 
 @patch("sagemaker.session.name_from_image", return_value=NAME_FROM_IMAGE)
@@ -153,7 +152,7 @@ def test_model_and_endpoint_config_exist(name_from_image_mock, sagemaker_session
     sagemaker_session.create_model.assert_not_called()
     sagemaker_session.create_endpoint_config.assert_not_called()
     sagemaker_session.create_endpoint.assert_called_once_with(
-        endpoint_name=DEFAULT_ENDPOINT_NAME, config_name=DEFAULT_ENDPOINT_NAME, wait=False
+        endpoint_name=NAME_FROM_IMAGE, config_name=NAME_FROM_IMAGE, wait=False
     )
 
 

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -26,6 +26,7 @@ from mock import MagicMock, Mock, patch
 MODEL_DATA = "s3://bucket/model.tar.gz"
 MODEL_IMAGE = "mi"
 ENTRY_POINT = "blah.py"
+INSTANCE_TYPE = "p2.xlarge"
 ROLE = "some-role"
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), "..", "data")
@@ -39,7 +40,6 @@ ACCELERATOR_TYPE = "ml.eia.medium"
 IMAGE_NAME = "fakeimage"
 REGION = "us-west-2"
 MODEL_NAME = "{}-{}".format(MODEL_IMAGE, TIMESTAMP)
-ENDPOINT_NAME = "{}-{}".format(MODEL_NAME, INSTANCE_TYPE.replace(".", "-"))
 GIT_REPO = "https://github.com/aws/sagemaker-python-sdk.git"
 BRANCH = "test-branch-git-config"
 COMMIT = "ae15c9d7d5b97ea95ea451e4662ee43da3401d73"
@@ -210,7 +210,7 @@ def test_deploy(sagemaker_session, tmpdir):
     model = DummyFrameworkModel(sagemaker_session, source_dir=str(tmpdir))
     model.deploy(instance_type=INSTANCE_TYPE, initial_instance_count=1)
     sagemaker_session.endpoint_from_production_variants.assert_called_with(
-        ENDPOINT_NAME,
+        MODEL_NAME,
         [
             {
                 "InitialVariantWeight": 1,
@@ -255,7 +255,7 @@ def test_deploy_tags(sagemaker_session, tmpdir):
     tags = [{"ModelName": "TestModel"}]
     model.deploy(instance_type=INSTANCE_TYPE, initial_instance_count=1, tags=tags)
     sagemaker_session.endpoint_from_production_variants.assert_called_with(
-        ENDPOINT_NAME,
+        MODEL_NAME,
         [
             {
                 "InitialVariantWeight": 1,
@@ -280,7 +280,7 @@ def test_deploy_accelerator_type(tfo, time, sagemaker_session):
         instance_type=INSTANCE_TYPE, initial_instance_count=1, accelerator_type=ACCELERATOR_TYPE
     )
     sagemaker_session.endpoint_from_production_variants.assert_called_with(
-        ENDPOINT_NAME,
+        MODEL_NAME,
         [
             {
                 "InitialVariantWeight": 1,
@@ -305,7 +305,7 @@ def test_deploy_kms_key(tfo, time, sagemaker_session):
     model = DummyFrameworkModel(sagemaker_session)
     model.deploy(instance_type=INSTANCE_TYPE, initial_instance_count=1, kms_key=key)
     sagemaker_session.endpoint_from_production_variants.assert_called_with(
-        ENDPOINT_NAME,
+        MODEL_NAME,
         [
             {
                 "InitialVariantWeight": 1,
@@ -350,7 +350,7 @@ def test_deploy_update_endpoint(sagemaker_session, tmpdir):
         accelerator_type=ACCELERATOR_TYPE,
     )
     sagemaker_session.create_endpoint_config.assert_called_with(
-        name=endpoint_name,
+        name=model.name,
         model_name=model.name,
         initial_instance_count=INSTANCE_COUNT,
         instance_type=INSTANCE_TYPE,
@@ -359,7 +359,7 @@ def test_deploy_update_endpoint(sagemaker_session, tmpdir):
         kms_key=None,
     )
     config_name = sagemaker_session.create_endpoint_config(
-        name=endpoint_name,
+        name=model.name,
         model_name=model.name,
         initial_instance_count=INSTANCE_COUNT,
         instance_type=INSTANCE_TYPE,


### PR DESCRIPTION
The test [test_deploy_model_with_update_non_existing_endpoint](https://github.com/aws/sagemaker-python-sdk/blob/a907597880cbaaa5520f38256bba4cbc63d4295c/tests/integ/test_mxnet_train.py#L204)  is failing in the canaries because these changes with the following error:

```
----------------------------- Captured log setup ------------------------------ 
session.py                 390 INFO     Creating training-job with name: ·[1mmxnet-training-2019-10-01-01-33-22-030·[0m 
----------------------------- Captured stdout call ----------------------------- 
[·[34m2019-10-01 01:39:20,048·[0m] {·[34msession.py:·[0m770} INFO·[0m - Creating model with name: ·[1mmxnet-inference-2019-10-01-01-39-19-106·[0m·[0m 
[·[34m2019-10-01 01:39:20,430·[0m] {·[34msession.py:·[0m972} INFO·[0m - Creating endpoint with name ·[1mtest-mxnet-deploy-model-2019-10-01-01-39-18-736·[0m·[0m 
----------------------------------------------------------------------------------------------![·[34m2019-10-01 01:48:35,232·[0m] {·[34msession.py:·[0m770} INFO·[0m - Creating model with name: ·[1mmxnet-inference-2019-10-01-01-39-19-106·[0m·[0m 
[·[34m2019-10-01 01:48:35,496·[0m] {·[34msession.py:·[0m783} WARNING·[0m - Using already existing model: ·[1mmxnet-inference-2019-10-01-01-39-19-106·[0m·[0m 
[·[34m2019-10-01 01:48:35,497·[0m] {·[34msession.py:·[0m1026} INFO·[0m - Deleting endpoint configuration with name: ·[1mnon-existing-endpoint·[0m·[0m 
[·[34m2019-10-01 01:48:35,603·[0m] {·[34msession.py:·[0m1016} INFO·[0m - Deleting endpoint with name: ·[1mtest-mxnet-deploy-model-2019-10-01-01-39-18-736·[0m·[0m 
[·[34m2019-10-01 01:48:35,692·[0m] {·[34mtimeout.py:·[0m70} INFO·[0m - deleted endpoint test-mxnet-deploy-model-2019-10-01-01-39-18-736·[0m 
[·[34m2019-10-01 01:48:35,692·[0m] {·[34mtimeout.py:·[0m118} INFO·[0m - cloudwatch logs for log group /aws/sagemaker/Endpoints/test-mxnet-deploy-model-2019-10-01-01-39-18-736:·[0m 
[·[34m2019-10-01 01:48:35,744·[0m] {·[34mtimeout.py:·[0m130} ERROR·[0m - Failure occurred while listing cloudwatch log group ·[1m/aws/sagemaker/Endpoints/test-mxnet-deploy-model-2019-10-01-01-39-18-736·[0m. Swallowing exception but printing stacktrace for debugging.·[0m 
·[31mTraceback (most recent call last): 
  File "/codebuild/output/src294/src/github.com/aws/PRIVATE-sagemaker-python-canary-tests/tests/integ/timeout.py", line 61, in timeout_and_delete_endpoint_by_name 
    yield [t] 
  File "/codebuild/output/src294/src/github.com/aws/PRIVATE-sagemaker-python-canary-tests/tests/integ/test_mxnet_train.py", line 236, in test_deploy_model_with_update_non_existing_endpoint 
    1, cpu_instance_type, update_endpoint=True, endpoint_name="non-existing-endpoint" 
  File "/usr/local/lib/python3.6/dist-packages/sagemaker/model.py", line 454, in deploy 
    self.sagemaker_session.delete_endpoint_config(endpoint_config_name=self.endpoint_name) 
  File "/usr/local/lib/python3.6/dist-packages/sagemaker/session.py", line 1027, in delete_endpoint_config 
    self.sagemaker_client.delete_endpoint_config(EndpointConfigName=endpoint_config_name) 
  File "/usr/local/lib/python3.6/dist-packages/botocore/client.py", line 357, in _api_call 
    return self._make_api_call(operation_name, kwargs) 
  File "/usr/local/lib/python3.6/dist-packages/botocore/client.py", line 661, in _make_api_call 
    raise error_class(parsed_response, operation_name) 
botocore.exceptions.ClientError: An error occurred (ValidationException) when calling the DeleteEndpointConfig operation: Could not find endpoint configuration "arn:aws:sagemaker:ap-southeast-1:030232271307:endpoint-config/non-existing-endpoint". 
 
During handling of the above exception, another exception occurred: 
 
Traceback (most recent call last): 
  File "/codebuild/output/src294/src/github.com/aws/PRIVATE-sagemaker-python-canary-tests/tests/integ/timeout.py", line 125, in _show_logs 
    logs.list_logs() 
  File "/usr/local/lib/python3.6/dist-packages/awslogs/core.py", line 223, in list_logs 
    consumer() 
  File "/usr/local/lib/python3.6/dist-packages/awslogs/core.py", line 164, in consumer 
    for event in generator(): 
  File "/usr/local/lib/python3.6/dist-packages/awslogs/core.py", line 151, in generator 
    response = self.client.filter_log_events(**kwargs) 
  File "/usr/local/lib/python3.6/dist-packages/botocore/client.py", line 357, in _api_call 
    return self._make_api_call(operation_name, kwargs) 
  File "/usr/local/lib/python3.6/dist-packages/botocore/client.py", line 661, in _make_api_call 
    raise error_class(parsed_response, operation_name) 
botocore.exceptions.ClientError: An error occurred (AccessDeniedException) when calling the FilterLogEvents operation: User: arn:aws:sts::030232271307:assumed-role/CanarySIN-CanaryFullRoleB76DAF70-UY6FLLVS52XI/AWSCodeBuild-56a42580-3b0d-4859-b3dc-d592e5bfcfbc is not authorized to perform: logs:FilterLogEvents on resource: arn:aws:logs:ap-southeast-1:030232271307:log-group:/aws/sagemaker/Endpoints/test-mxnet-deploy-model-2019-10-01-01-39-18-736:log-stream:·[0m 
------------------------------ Captured log call ------------------------------- 
session.py                 770 INFO     Creating model with name: ·[1mmxnet-inference-2019-10-01-01-39-19-106·[0m 
session.py                 972 INFO     Creating endpoint with name ·[1mtest-mxnet-deploy-model-2019-10-01-01-39-18-736·[0m 
session.py                 770 INFO     Creating model with name: ·[1mmxnet-inference-2019-10-01-01-39-19-106·[0m 
session.py                 783 WARNING  Using already existing model: ·[1mmxnet-inference-2019-10-01-01-39-19-106·[0m 
session.py                1026 INFO     Deleting endpoint configuration with name: ·[1mnon-existing-endpoint·[0m 
session.py                1016 INFO     Deleting endpoint with name: ·[1mtest-mxnet-deploy-model-2019-10-01-01-39-18-736·[0m 
timeout.py                  70 INFO     deleted endpoint test-mxnet-deploy-model-2019-10-01-01-39-18-736 
timeout.py                 118 INFO     cloudwatch logs for log group /aws/sagemaker/Endpoints/test-mxnet-deploy-model-2019-10-01-01-39-18-736: 
timeout.py                 130 ERROR    Failure occurred while listing cloudwatch log group ·[1m/aws/sagemaker/Endpoints/test-mxnet-deploy-model-2019-10-01-01-39-18-736·[0m. Swallowing exception but printing stacktrace for debugging. 
·[31mTraceback (most recent call last): 
  File "/codebuild/output/src294/src/github.com/aws/PRIVATE-sagemaker-python-canary-tests/tests/integ/timeout.py", line 61, in timeout_and_delete_endpoint_by_name 
    yield [t] 
  File "/codebuild/output/src294/src/github.com/aws/PRIVATE-sagemaker-python-canary-tests/tests/integ/test_mxnet_train.py", line 236, in test_deploy_model_with_update_non_existing_endpoint 
    1, cpu_instance_type, update_endpoint=True, endpoint_name="non-existing-endpoint" 
  File "/usr/local/lib/python3.6/dist-packages/sagemaker/model.py", line 454, in deploy 
    self.sagemaker_session.delete_endpoint_config(endpoint_config_name=self.endpoint_name) 
  File "/usr/local/lib/python3.6/dist-packages/sagemaker/session.py", line 1027, in delete_endpoint_config 
    self.sagemaker_client.delete_endpoint_config(EndpointConfigName=endpoint_config_name) 
  File "/usr/local/lib/python3.6/dist-packages/botocore/client.py", line 357, in _api_call 
    return self._make_api_call(operation_name, kwargs) 
  File "/usr/local/lib/python3.6/dist-packages/botocore/client.py", line 661, in _make_api_call 
    raise error_class(parsed_response, operation_name) 
botocore.exceptions.ClientError: An error occurred (ValidationException) when calling the DeleteEndpointConfig operation: Could not find endpoint configuration "arn:aws:sagemaker:ap-southeast-1:030232271307:endpoint-config/non-existing-endpoint". 
 
During handling of the above exception, another exception occurred: 
 
Traceback (most recent call last): 
  File "/codebuild/output/src294/src/github.com/aws/PRIVATE-sagemaker-python-canary-tests/tests/integ/timeout.py", line 125, in _show_logs 
    logs.list_logs() 
  File "/usr/local/lib/python3.6/dist-packages/awslogs/core.py", line 223, in list_logs 
    consumer() 
  File "/usr/local/lib/python3.6/dist-packages/awslogs/core.py", line 164, in consumer 
    for event in generator(): 
  File "/usr/local/lib/python3.6/dist-packages/awslogs/core.py", line 151, in generator 
    response = self.client.filter_log_events(**kwargs) 
  File "/usr/local/lib/python3.6/dist-packages/botocore/client.py", line 357, in _api_call 
    return self._make_api_call(operation_name, kwargs) 
  File "/usr/local/lib/python3.6/dist-packages/botocore/client.py", line 661, in _make_api_call 
    raise error_class(parsed_response, operation_name) 
botocore.exceptions.ClientError: An error occurred (AccessDeniedException) when calling the FilterLogEvents operation: User: arn:aws:sts::030232271307:assumed-role/CanarySIN-CanaryFullRoleB76DAF70-UY6FLLVS52XI/AWSCodeBuild-56a42580-3b0d-4859-b3dc-d592e5bfcfbc is not authorized to perform: logs:FilterLogEvents on resource: arn:aws:logs:ap-southeast-1:030232271307:log-group:/aws/sagemaker/Endpoints/test-mxnet-deploy-model-2019-10-01-01-39-18-736:log-stream:·[0m 
```