### PR TITLE
fix: support content_type in FileSystemInput

### DIFF
--- a/src/sagemaker/inputs.py
+++ b/src/sagemaker/inputs.py
@@ -106,7 +106,12 @@ class FileSystemInput(object):
     """
 
     def __init__(
-        self, file_system_id, file_system_type, directory_path, file_system_access_mode="ro"
+        self,
+        file_system_id,
+        file_system_type,
+        directory_path,
+        file_system_access_mode="ro",
+        content_type=None,
     ):
         """Create a new file system input used by an SageMaker training job.
 
@@ -144,3 +149,6 @@ class FileSystemInput(object):
                 }
             }
         }
+
+        if content_type:
+            self.config["ContentType"] = content_type

--- a/tests/integ/file_system_input_utils.py
+++ b/tests/integ/file_system_input_utils.py
@@ -107,7 +107,10 @@ def _ami_id_for_region(sagemaker_session):
 def _connect_ec2_instance(ec2_instance):
     public_ip_address = ec2_instance.public_ip_address
     connected_instance = Connection(
-        host=public_ip_address, port=22, user="ec2-user", connect_kwargs={"key_filename": KEY_PATH}
+        host=public_ip_address,
+        port=22,
+        user="ec2-user",
+        connect_kwargs={"key_filename": [KEY_PATH]},
     )
     return connected_instance
 

--- a/tests/integ/test_tf_efs_fsx.py
+++ b/tests/integ/test_tf_efs_fsx.py
@@ -73,8 +73,12 @@ def test_mnist_efs(efs_fsx_setup, sagemaker_session, cpu_instance_type):
     )
 
     file_system_efs_id = efs_fsx_setup["file_system_efs_id"]
+    content_type = "application/json"
     file_system_input = FileSystemInput(
-        file_system_id=file_system_efs_id, file_system_type="EFS", directory_path=EFS_DIR_PATH
+        file_system_id=file_system_efs_id,
+        file_system_type="EFS",
+        directory_path=EFS_DIR_PATH,
+        content_type=content_type,
     )
     with timeout(minutes=TRAINING_DEFAULT_TIMEOUT_MINUTES):
         estimator.fit(inputs=file_system_input, job_name=unique_name_from_base("test-mnist-efs"))

--- a/tests/unit/test_inputs.py
+++ b/tests/unit/test_inputs.py
@@ -113,6 +113,33 @@ def test_file_system_input_all_arguments():
     assert actual.config == expected
 
 
+def test_file_system_input_content_type():
+    file_system_id = "fs-0a48d2a1"
+    file_system_type = "FSxLustre"
+    directory_path = "tensorflow"
+    file_system_access_mode = "rw"
+    content_type = "application/json"
+    actual = FileSystemInput(
+        file_system_id=file_system_id,
+        file_system_type=file_system_type,
+        directory_path=directory_path,
+        file_system_access_mode=file_system_access_mode,
+        content_type=content_type,
+    )
+    expected = {
+        "DataSource": {
+            "FileSystemDataSource": {
+                "FileSystemId": file_system_id,
+                "FileSystemType": file_system_type,
+                "DirectoryPath": directory_path,
+                "FileSystemAccessMode": "rw",
+            }
+        },
+        "ContentType": content_type,
+    }
+    assert actual.config == expected
+
+
 def test_file_system_input_type_invalid():
     with pytest.raises(ValueError) as excinfo:
         file_system_id = "fs-0a48d2a1"


### PR DESCRIPTION
*Issue #, if available:*
content_type parameter is not supported in FileSystemInput

*Description of changes:*
- added an optional param `content_type` in `FileSystemInput`
- fixed a test setup method here: https://github.com/aws/sagemaker-python-sdk/blob/master/tests/integ/file_system_input_utils.py#L110 (key_filename is expecting a list instead of a string)
- since we disabled the EFS integ tests, I manually ran a EFS integ test with content_type

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
