### PR TITLE
fix: add kwargs to create_model for 1p to work with kms

### DIFF
--- a/src/sagemaker/amazon/factorization_machines.py
+++ b/src/sagemaker/amazon/factorization_machines.py
@@ -235,7 +235,7 @@ class FactorizationMachines(AmazonAlgorithmEstimatorBase):
         self.factors_init_sigma = factors_init_sigma
         self.factors_init_value = factors_init_value
 
-    def create_model(self, vpc_config_override=VPC_CONFIG_DEFAULT):
+    def create_model(self, vpc_config_override=VPC_CONFIG_DEFAULT, **kwargs):
         """Return a :class:`~sagemaker.amazon.FactorizationMachinesModel`
         referencing the latest s3 model data produced by this Estimator.
 
@@ -244,12 +244,14 @@ class FactorizationMachines(AmazonAlgorithmEstimatorBase):
                 the model. Default: use subnets and security groups from this Estimator.
                 * 'Subnets' (list[str]): List of subnet ids.
                 * 'SecurityGroupIds' (list[str]): List of security group ids.
+            **kwargs: Additional kwargs passed to the FactorizationMachinesModel constructor.
         """
         return FactorizationMachinesModel(
             self.model_data,
             self.role,
             sagemaker_session=self.sagemaker_session,
             vpc_config=self.get_vpc_config(vpc_config_override),
+            **kwargs
         )
 
 

--- a/src/sagemaker/amazon/ipinsights.py
+++ b/src/sagemaker/amazon/ipinsights.py
@@ -131,7 +131,7 @@ class IPInsights(AmazonAlgorithmEstimatorBase):
         self.shuffled_negative_sampling_rate = shuffled_negative_sampling_rate
         self.weight_decay = weight_decay
 
-    def create_model(self, vpc_config_override=VPC_CONFIG_DEFAULT):
+    def create_model(self, vpc_config_override=VPC_CONFIG_DEFAULT, **kwargs):
         """Create a model for the latest s3 model produced by this estimator.
 
         Args:
@@ -140,6 +140,7 @@ class IPInsights(AmazonAlgorithmEstimatorBase):
                 Default: use subnets and security groups from this Estimator.
                 * 'Subnets' (list[str]): List of subnet ids.
                 * 'SecurityGroupIds' (list[str]): List of security group ids.
+            **kwargs: Additional kwargs passed to the IPInsightsModel constructor.
         Returns:
             :class:`~sagemaker.amazon.IPInsightsModel`: references the latest s3 model
             data produced by this estimator.
@@ -149,6 +150,7 @@ class IPInsights(AmazonAlgorithmEstimatorBase):
             self.role,
             sagemaker_session=self.sagemaker_session,
             vpc_config=self.get_vpc_config(vpc_config_override),
+            **kwargs
         )
 
     def _prepare_for_training(self, records, mini_batch_size=None, job_name=None):

--- a/src/sagemaker/amazon/knn.py
+++ b/src/sagemaker/amazon/knn.py
@@ -145,7 +145,7 @@ class KNN(AmazonAlgorithmEstimatorBase):
                 '"dimension_reduction_target" is required when "dimension_reduction_type" is set.'
             )
 
-    def create_model(self, vpc_config_override=VPC_CONFIG_DEFAULT):
+    def create_model(self, vpc_config_override=VPC_CONFIG_DEFAULT, **kwargs):
         """Return a :class:`~sagemaker.amazon.KNNModel` referencing the latest
         s3 model data produced by this Estimator.
 
@@ -154,12 +154,14 @@ class KNN(AmazonAlgorithmEstimatorBase):
                 the model. Default: use subnets and security groups from this Estimator.
                 * 'Subnets' (list[str]): List of subnet ids.
                 * 'SecurityGroupIds' (list[str]): List of security group ids.
+            **kwargs: Additional kwargs passed to the KNNModel constructor.
         """
         return KNNModel(
             self.model_data,
             self.role,
             sagemaker_session=self.sagemaker_session,
             vpc_config=self.get_vpc_config(vpc_config_override),
+            **kwargs
         )
 
     def _prepare_for_training(self, records, mini_batch_size=None, job_name=None):

--- a/src/sagemaker/amazon/ntm.py
+++ b/src/sagemaker/amazon/ntm.py
@@ -155,7 +155,7 @@ class NTM(AmazonAlgorithmEstimatorBase):
         self.weight_decay = weight_decay
         self.learning_rate = learning_rate
 
-    def create_model(self, vpc_config_override=VPC_CONFIG_DEFAULT):
+    def create_model(self, vpc_config_override=VPC_CONFIG_DEFAULT, **kwargs):
         """Return a :class:`~sagemaker.amazon.NTMModel` referencing the latest
         s3 model data produced by this Estimator.
 
@@ -164,12 +164,14 @@ class NTM(AmazonAlgorithmEstimatorBase):
                 the model. Default: use subnets and security groups from this Estimator.
                 * 'Subnets' (list[str]): List of subnet ids.
                 * 'SecurityGroupIds' (list[str]): List of security group ids.
+            **kwargs: Additional kwargs passed to the NTMModel constructor.
         """
         return NTMModel(
             self.model_data,
             self.role,
             sagemaker_session=self.sagemaker_session,
             vpc_config=self.get_vpc_config(vpc_config_override),
+            **kwargs
         )
 
     def _prepare_for_training(  # pylint: disable=signature-differs

--- a/src/sagemaker/amazon/object2vec.py
+++ b/src/sagemaker/amazon/object2vec.py
@@ -295,7 +295,7 @@ class Object2Vec(AmazonAlgorithmEstimatorBase):
         self.enc0_freeze_pretrained_embedding = enc0_freeze_pretrained_embedding
         self.enc1_freeze_pretrained_embedding = enc1_freeze_pretrained_embedding
 
-    def create_model(self, vpc_config_override=VPC_CONFIG_DEFAULT):
+    def create_model(self, vpc_config_override=VPC_CONFIG_DEFAULT, **kwargs):
         """Return a :class:`~sagemaker.amazon.Object2VecModel` referencing the
         latest s3 model data produced by this Estimator.
 
@@ -304,12 +304,14 @@ class Object2Vec(AmazonAlgorithmEstimatorBase):
                 the model. Default: use subnets and security groups from this Estimator.
                 * 'Subnets' (list[str]): List of subnet ids.
                 * 'SecurityGroupIds' (list[str]): List of security group ids.
+            **kwargs: Additional kwargs passed to the Object2VecModel constructor.
         """
         return Object2VecModel(
             self.model_data,
             self.role,
             sagemaker_session=self.sagemaker_session,
             vpc_config=self.get_vpc_config(vpc_config_override),
+            **kwargs
         )
 
     def _prepare_for_training(self, records, mini_batch_size=None, job_name=None):

--- a/src/sagemaker/amazon/pca.py
+++ b/src/sagemaker/amazon/pca.py
@@ -120,7 +120,7 @@ class PCA(AmazonAlgorithmEstimatorBase):
         self.subtract_mean = subtract_mean
         self.extra_components = extra_components
 
-    def create_model(self, vpc_config_override=VPC_CONFIG_DEFAULT):
+    def create_model(self, vpc_config_override=VPC_CONFIG_DEFAULT, **kwargs):
         """Return a :class:`~sagemaker.amazon.pca.PCAModel` referencing the
         latest s3 model data produced by this Estimator.
 
@@ -129,12 +129,14 @@ class PCA(AmazonAlgorithmEstimatorBase):
                 the model. Default: use subnets and security groups from this Estimator.
                 * 'Subnets' (list[str]): List of subnet ids.
                 * 'SecurityGroupIds' (list[str]): List of security group ids.
+            **kwargs: Additional kwargs passed to the PCAModel constructor.
         """
         return PCAModel(
             self.model_data,
             self.role,
             sagemaker_session=self.sagemaker_session,
             vpc_config=self.get_vpc_config(vpc_config_override),
+            **kwargs
         )
 
     def _prepare_for_training(self, records, mini_batch_size=None, job_name=None):

--- a/src/sagemaker/amazon/randomcutforest.py
+++ b/src/sagemaker/amazon/randomcutforest.py
@@ -113,7 +113,7 @@ class RandomCutForest(AmazonAlgorithmEstimatorBase):
         self.num_trees = num_trees
         self.eval_metrics = eval_metrics
 
-    def create_model(self, vpc_config_override=VPC_CONFIG_DEFAULT):
+    def create_model(self, vpc_config_override=VPC_CONFIG_DEFAULT, **kwargs):
         """Return a :class:`~sagemaker.amazon.RandomCutForestModel` referencing
         the latest s3 model data produced by this Estimator.
 
@@ -122,12 +122,14 @@ class RandomCutForest(AmazonAlgorithmEstimatorBase):
                 the model. Default: use subnets and security groups from this Estimator.
                 * 'Subnets' (list[str]): List of subnet ids.
                 * 'SecurityGroupIds' (list[str]): List of security group ids.
+            **kwargs: Additional kwargs passed to the RandomCutForestModel constructor.
         """
         return RandomCutForestModel(
             self.model_data,
             self.role,
             sagemaker_session=self.sagemaker_session,
             vpc_config=self.get_vpc_config(vpc_config_override),
+            **kwargs
         )
 
     def _prepare_for_training(self, records, mini_batch_size=None, job_name=None):


### PR DESCRIPTION
Reference: 0413038016

*Description of changes:*
Pass kwargs into the create_model function for all 1p algorithms according to the changes introduced in this PR: https://github.com/aws/sagemaker-python-sdk/pull/1061/files#diff-0ca4fc3e292478e04c0a7722f675fdc7R151

The PR above only passed kwargs for LDA, KMeans and Linear Learner.

Due to the passing of the kms_key in the kwargs it has caused errors for any create_model methods that are not expecting it. This will enable using kms_keys for the rest of the 1p Algos.

I have tested these changes against this notebook: https://github.com/awslabs/amazon-sagemaker-examples/blob/master/introduction_to_amazon_algorithms/random_cut_forest/random_cut_forest.ipynb

File showcasing my testing: [tested_notebook.zip](https://github.com/aws/sagemaker-python-sdk/files/3709931/tested_notebook.zip)

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
