### PR TITLE
fix: use us-west-2 endpoint for sts in buildspec

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -25,7 +25,7 @@ phases:
       - |
         if [ -d "ci-lock" ]; then
           FILENAME=$(ls ci-lock/ || true)
-          ACCOUNT=$(aws sts get-caller-identity --output text | awk '{print $1}')
+          ACCOUNT=$(aws sts get-caller-identity --region us-west-2 --output text | awk '{print $1}')
           S3_BUCKET_DIR=s3://sagemaker-us-west-2-${ACCOUNT}/ci-lock/
           aws s3 rm ${S3_BUCKET_DIR}${FILENAME}
         fi


### PR DESCRIPTION
*Description of changes:*
Use us-west-2 endpoint for sts in the buildspec.yml.

According to: https://docs.aws.amazon.com/general/latest/gr/rande.html#sts_region

"AWS recommends using Regional STS endpoints to reduce latency, build in redundancy, and increase session token validity."

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
