### PR TITLE
fix: use sts regional endpoint when creating default bucket

### DIFF
--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -208,8 +208,10 @@ class Session(object):  # pylint: disable=too-many-public-methods
         if self._default_bucket:
             return self._default_bucket
 
-        account = self.boto_session.client("sts").get_caller_identity()["Account"]
         region = self.boto_session.region_name
+        account = self.boto_session.client(
+            "sts", region_name=region, endpoint_url=sts_regional_endpoint(region)
+        ).get_caller_identity()["Account"]
         default_bucket = "sagemaker-{}-{}".format(region, account)
 
         s3 = self.boto_session.resource("s3")
@@ -1400,7 +1402,9 @@ class Session(object):  # pylint: disable=too-many-public-methods
                 )
 
         assumed_role = self.boto_session.client(
-            "sts", endpoint_url=sts_regional_endpoint(self.boto_region_name)
+            "sts",
+            region_name=self.boto_region_name,
+            endpoint_url=sts_regional_endpoint(self.boto_region_name),
         ).get_caller_identity()["Arn"]
 
         if "AmazonSageMaker-ExecutionRole" in assumed_role:


### PR DESCRIPTION
*Description of changes:*
Use regional STS endpoint when utilizing STS in the default_bucket method within Session.

I pass both region_name and endpoint as AWS STS recommends setting both variables as defined here: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html#id_credentials_temp_enable-regions_writing_code

Reasons for the change are due to the benefits described here: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
