### PR TITLE
change: use regional endpoint for STS in builds and tests

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -25,7 +25,7 @@ phases:
       - |
         if [ -d "ci-lock" ]; then
           FILENAME=$(ls ci-lock/ || true)
-          ACCOUNT=$(aws sts get-caller-identity --region us-west-2 --output text | awk '{print $1}')
+          ACCOUNT=$(aws --endpoint-url https://sts.us-west-2.amazonaws.com sts get-caller-identity --region us-west-2 --output text | awk '{print $1}')
           S3_BUCKET_DIR=s3://sagemaker-us-west-2-${ACCOUNT}/ci-lock/
           aws s3 rm ${S3_BUCKET_DIR}${FILENAME}
         fi

--- a/ci-scripts/queue_build.py
+++ b/ci-scripts/queue_build.py
@@ -16,7 +16,9 @@ import os
 import time
 import boto3
 
-account = boto3.client("sts").get_caller_identity()["Account"]
+account = boto3.client(
+    "sts", region_name="us-west-2", endpoint_url="https://sts.us-west-2.amazonaws.com"
+).get_caller_identity()["Account"]
 bucket_name = "sagemaker-us-west-2-%s" % account
 
 

--- a/tests/integ/kms_utils.py
+++ b/tests/integ/kms_utils.py
@@ -160,7 +160,7 @@ KMS_BUCKET_POLICY = """{
 @contextlib.contextmanager
 def bucket_with_encryption(boto_session, sagemaker_role):
     region = boto_session.region_name
-    sts_client = sagemaker_session.boto_session.client(
+    sts_client = boto_session.client(
         "sts", region_name=region, endpoint_url=utils.sts_regional_endpoint(region)
     )
 

--- a/tests/integ/kms_utils.py
+++ b/tests/integ/kms_utils.py
@@ -17,6 +17,8 @@ import json
 
 from botocore import exceptions
 
+from sagemaker import utils
+
 PRINCIPAL_TEMPLATE = (
     '["{account_id}", "{role_arn}", ' '"arn:aws:iam::{account_id}:role/{sagemaker_role}"] '
 )
@@ -108,7 +110,10 @@ def get_or_create_kms_key(
     kms_client = sagemaker_session.boto_session.client("kms")
     kms_key_arn = _get_kms_key_arn(kms_client, alias)
 
-    sts_client = sagemaker_session.boto_session.client("sts")
+    region = sagemaker_session.boto_region_name
+    sts_client = sagemaker_session.boto_session.client(
+        "sts", region_name=region, endpoint_url=utils.sts_regional_endpoint(region)
+    )
     account_id = sts_client.get_caller_identity()["Account"]
 
     if kms_key_arn is None:
@@ -154,8 +159,13 @@ KMS_BUCKET_POLICY = """{
 
 @contextlib.contextmanager
 def bucket_with_encryption(boto_session, sagemaker_role):
-    account = boto_session.client("sts").get_caller_identity()["Account"]
-    role_arn = boto_session.client("sts").get_caller_identity()["Arn"]
+    region = boto_session.region_name
+    sts_client = sagemaker_session.boto_session.client(
+        "sts", region_name=region, endpoint_url=utils.sts_regional_endpoint(region)
+    )
+
+    account = sts_client.get_caller_identity()["Account"]
+    role_arn = sts_client.get_caller_identity()["Arn"]
 
     kms_client = boto_session.client("kms")
     kms_key_arn = _create_kms_key(kms_client, account, role_arn, sagemaker_role, None)


### PR DESCRIPTION
*Description of changes:*
 Part of the effort to use the regional endpoint for STS.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
