### PR TITLE
change: remove red from possible colors when streaming logs

### DIFF
--- a/src/sagemaker/logs.py
+++ b/src/sagemaker/logs.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2017-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You
 # may not use this file except in compliance with the License. A copy of
@@ -31,7 +31,9 @@ class ColorWrap(object):
     cell).
     """
 
-    _stream_colors = [31, 32, 33, 34, 35, 36]
+    # For what color each number represents, see
+    # https://misc.flogisoft.com/bash/tip_colors_and_formatting#colors
+    _stream_colors = [34, 35, 32, 36, 33]
 
     def __init__(self, force=False):
         """Initialize the class.

--- a/tox.ini
+++ b/tox.ini
@@ -57,7 +57,9 @@ passenv =
 
 # {posargs} can be passed in by additional arguments specified when invoking tox.
 # Can be used to specify which tests to run, e.g.: tox -- -s
+# TODO: Remove pip install python-dateutil==2.8.0 once botocore no longer requires a pinned version
 commands =
+    pip install python-dateutil==2.8.0
     coverage run --source sagemaker -m pytest {posargs}
     {env:IGNORE_COVERAGE:} coverage report --fail-under=90 --omit */tensorflow/tensorflow_serving/*
 extras = test
@@ -112,7 +114,9 @@ deps =
 # pip install requirements.txt is separate as RTD does it in separate steps
 # having the requirements.txt installed in deps above results in Double Requirement exception
 # https://github.com/pypa/pip/issues/988
+# TODO: Remove pip install python-dateutil==2.8.0 once botocore no longer requires a pinned version
 commands =
+    pip install python-dateutil==2.8.0
     pip install --exists-action=w -r requirements.txt
     sphinx-build -T -W -b html -d _build/doctrees-readthedocs -D language=en . _build/html
 


### PR DESCRIPTION
*Description of changes:*
there's been some feedback about red logs looking like an error even though everything's actually alright. I changed the order a bit because blue is probably the most neutral and I believe it has the highest contrast ratio against white (given that a lot of people view these logs in Jupyter with its white background).

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
