### PR TITLE
fix: fix tags in deploy call for generic estimators

### DIFF
--- a/src/sagemaker/estimator.py
+++ b/src/sagemaker/estimator.py
@@ -606,6 +606,7 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):
         model_name=None,
         kms_key=None,
         data_capture_config=None,
+        tags=None,
         **kwargs
     ):
         """Deploy the trained model to an Amazon SageMaker endpoint and return a
@@ -639,18 +640,18 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):
                 model completes (default: True).
             model_name (str): Name to use for creating an Amazon SageMaker
                 model. If not specified, the name of the training job is used.
-            tags(List[dict[str, str]]): Optional. The list of tags to attach to this specific
-                endpoint. Example:
-                >>> tags = [{'Key': 'tagname', 'Value': 'tagvalue'}]
-                For more information about tags, see
-                https://boto3.amazonaws.com/v1/documentation\
-                /api/latest/reference/services/sagemaker.html#SageMaker.Client.add_tags
             kms_key (str): The ARN of the KMS key that is used to encrypt the
                 data on the storage volume attached to the instance hosting the
                 endpoint.
             data_capture_config (sagemaker.model_monitor.DataCaptureConfig): Specifies
                 configuration related to Endpoint data capture for use with
                 Amazon SageMaker Model Monitoring. Default: None.
+            tags(List[dict[str, str]]): Optional. The list of tags to attach to this specific
+                endpoint. Example:
+                >>> tags = [{'Key': 'tagname', 'Value': 'tagvalue'}]
+                For more information about tags, see
+                https://boto3.amazonaws.com/v1/documentation\
+                /api/latest/reference/services/sagemaker.html#SageMaker.Client.add_tags
             **kwargs: Passed to invocation of ``create_model()``.
                 Implementations may customize ``create_model()`` to accept
                 ``**kwargs`` to customize model creation during deploy.
@@ -685,7 +686,7 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):
             accelerator_type=accelerator_type,
             endpoint_name=endpoint_name,
             update_endpoint=update_endpoint,
-            tags=self.tags,
+            tags=tags or self.tags,
             wait=wait,
             kms_key=kms_key,
             data_capture_config=data_capture_config,

--- a/tests/unit/test_estimator.py
+++ b/tests/unit/test_estimator.py
@@ -1749,11 +1749,7 @@ def test_fit_deploy_tags_in_estimator(sagemaker_session):
 
 def test_fit_deploy_tags(sagemaker_session):
     estimator = Estimator(
-        IMAGE_NAME,
-        ROLE,
-        INSTANCE_COUNT,
-        INSTANCE_TYPE,
-        sagemaker_session=sagemaker_session,
+        IMAGE_NAME, ROLE, INSTANCE_COUNT, INSTANCE_TYPE, sagemaker_session=sagemaker_session
     )
 
     estimator.fit()


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/sagemaker-python-sdk/issues/1120

Originally, the `estimator's` `deploy` function supported tags by utilizing kwargs. This would run into problems depending on if each inherited `estimator's` `create_model` function was able to handle kwargs in the function. This causes problems as reported for the user above, who is using tags for a generic estimator class. 


*Description of changes:*
Make tags an explicit parameter in the Estimator's `deploy` function, similar to the Model's `deploy` function. This will end up not using kwargs to pass tags and not force `create_model` function to handle it.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
