### PR TITLE
change: make multi algo integration test assertion less specific

### DIFF
--- a/tests/integ/test_tuner_multi_algo.py
+++ b/tests/integ/test_tuner_multi_algo.py
@@ -205,7 +205,7 @@ def _deploy_and_predict(sagemaker_session, tuner, data_set, cpu_instance_type):
 
         assert len(result["predictions"]) == len(data)
         for prediction in result["predictions"]:
-            assert prediction["predicted_label"] is not None
+            assert prediction is not None
 
 
 def _create_training_inputs(sagemaker_session):


### PR DESCRIPTION
*Issue #, if available:*
The canaries are failing randomly due to the prediction result not containing a specific key. To mitigate this, I've done assertion on the prediction object instead of on the specific key, as it is possible an algorithm may have different output bodies.

*Description of changes:*
Assert on the prediction instead of key.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have updated any necessary [documentation](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
