### PR TITLE
fix: specify S3 uri as code location in ScriptProcessor.run

### DIFF
--- a/src/sagemaker/processing.py
+++ b/src/sagemaker/processing.py
@@ -370,7 +370,10 @@ class ScriptProcessor(Processor):
         self._current_job_name = self._generate_current_job_name(job_name=job_name)
 
         user_script_name = self._get_user_script_name(code)
-        user_code_s3_uri = self._upload_code(code)
+        if urlparse(code).scheme == "s3":
+            user_code_s3_uri = code
+        else:
+            user_code_s3_uri = self._upload_code(code)
         inputs_with_code = self._convert_code_and_add_to_inputs(inputs, user_code_s3_uri)
 
         self._set_entrypoint(self.command, user_script_name)


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/sagemaker-python-sdk/issues/1163

*Description of changes:*
Fixed a bug in ScriptProcessor that attempted to upload the user's code to S3 even when it was already an S3 uri.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
