### PR TITLE
fix: use name_from_base in auto_ml.py but unique_name_from_base in tests.

### DIFF
--- a/src/sagemaker/automl/automl.py
+++ b/src/sagemaker/automl/automl.py
@@ -19,7 +19,7 @@ from sagemaker import Model, PipelineModel
 from sagemaker.automl.candidate_estimator import CandidateEstimator
 from sagemaker.job import _Job
 from sagemaker.session import Session
-from sagemaker.utils import unique_name_from_base
+from sagemaker.utils import name_from_base
 
 
 class AutoML(object):
@@ -381,7 +381,7 @@ class AutoML(object):
             else:
                 base_name = "automl"
             # CreateAutoMLJob API validates that member length less than or equal to 32
-            self.current_job_name = unique_name_from_base(base_name, max_length=32)
+            self.current_job_name = name_from_base(base_name, max_length=32)
 
         if self.output_path is None:
             self.output_path = "s3://{}/".format(self.sagemaker_session.default_bucket())

--- a/tests/unit/sagemaker/automl/test_auto_ml.py
+++ b/tests/unit/sagemaker/automl/test_auto_ml.py
@@ -32,7 +32,7 @@ DEFAULT_S3_INPUT_DATA = "s3://{}/data".format(BUCKET_NAME)
 DEFAULT_OUTPUT_PATH = "s3://{}/".format(BUCKET_NAME)
 LOCAL_DATA_PATH = "file://data"
 DEFAULT_MAX_CANDIDATES = 500
-DEFAULT_JOB_NAME = "sagemake-{}".format(TIMESTAMP)
+DEFAULT_JOB_NAME = "automl-{}".format(TIMESTAMP)
 
 JOB_NAME = "default-job-name"
 JOB_NAME_2 = "banana-auto-ml-job"
@@ -284,7 +284,7 @@ def test_auto_ml_additional_optional_params(sagemaker_session):
 
 
 @patch("time.strftime", return_value=TIMESTAMP)
-def test_auto_ml_default_fit(sagemaker_session):
+def test_auto_ml_default_fit(strftime, sagemaker_session):
     auto_ml = AutoML(
         role=ROLE, target_attribute_name=TARGET_ATTRIBUTE_NAME, sagemaker_session=sagemaker_session
     )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Change auto_ml.py back to use ``name_from_base`` instead of ``unique_name_from_base``. Other classes are appending a time string.

*Testing done:* Unit test.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
