### PR TITLE
change: refactor logic in fw_utils and fill in docstrings

### DIFF
--- a/src/sagemaker/fw_utils.py
+++ b/src/sagemaker/fw_utils.py
@@ -138,10 +138,7 @@ def _use_dlc_image(region, framework, py_version, framework_version):
     is_gov_region = region in VALID_ACCOUNTS_BY_REGION
     is_dlc_version = _is_dlc_version(framework, framework_version, py_version)
 
-    return (
-        ((not is_gov_region) or region in ASIMOV_VALID_ACCOUNTS_BY_REGION)
-        and is_dlc_version
-    )
+    return ((not is_gov_region) or region in ASIMOV_VALID_ACCOUNTS_BY_REGION) and is_dlc_version
 
 
 def _registry_id(region, framework, py_version, account, framework_version):

--- a/src/sagemaker/fw_utils.py
+++ b/src/sagemaker/fw_utils.py
@@ -79,7 +79,7 @@ MERGED_FRAMEWORKS_LOWEST_VERSIONS = {
     "tensorflow-serving-eia": [1, 14, 0],
     "mxnet": {"py3": [1, 4, 1], "py2": [1, 6, 0]},
     "mxnet-serving": {"py3": [1, 4, 1], "py2": [1, 6, 0]},
-    "mxnet-serving-eia": [1, 6, 0],
+    "mxnet-serving-eia": [1, 4, 1],
     "pytorch": [1, 2, 0],
     "pytorch-serving": [1, 2, 0],
 }

--- a/src/sagemaker/mxnet/model.py
+++ b/src/sagemaker/mxnet/model.py
@@ -53,7 +53,7 @@ class MXNetModel(FrameworkModel):
     """An MXNet SageMaker ``Model`` that can be deployed to a SageMaker ``Endpoint``."""
 
     __framework_name__ = "mxnet"
-    _LOWEST_MMS_VERSION = "1.4"
+    _LOWEST_MMS_VERSION = "1.4.0"
 
     def __init__(
         self,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
There was a lot of duplicated logic, as well as some convoluted logic around Python versions, so I'm hoping to simplify it (and go back to having all the framework version thresholds in one place).

I also removed some of the usage of "merged" as it was confusing to some. (it referred to the merging of the SageMaker and DLC images, but was vague enough that at first glance it could mean the merging of training/inference images or something else like that.)

*Testing done:*
* `tox -e flake8,pylint,py36 tests/unit`
* also manually pulled the MXNet 1.4.1 EI images to verify which versions existed (I was surprised that the 1.4.1 images are indeed DLC images for both Python 2 and 3)

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
