### PR TITLE
change: Increase number of retries when describing an endpoint.

### DIFF
--- a/tests/integ/test_data_capture_config.py
+++ b/tests/integ/test_data_capture_config.py
@@ -74,9 +74,9 @@ def test_enabling_data_capture_on_endpoint_shows_correct_data_capture_status(
         predictor.enable_data_capture()
 
         # Wait for endpoint to finish updating
-        # Endpoint update takes ~7min. 40 retries * 30s sleeps = 20min timeout
+        # Endpoint update takes ~7min. 50 retries * 30s sleeps = 25min timeout
         for _ in retries(
-            max_retry_count=40,
+            max_retry_count=50,
             exception_message_prefix="Waiting for 'InService' endpoint status",
             seconds_to_sleep=30,
         ):
@@ -159,9 +159,9 @@ def test_disabling_data_capture_on_endpoint_shows_correct_data_capture_status(
         predictor.disable_data_capture()
 
         # Wait for endpoint to finish updating
-        # Endpoint update takes ~7min. 40 retries * 30s sleeps = 20min timeout
+        # Endpoint update takes ~7min. 50 retries * 30s sleeps = 25min timeout
         for _ in retries(
-            max_retry_count=40,
+            max_retry_count=50,
             exception_message_prefix="Waiting for 'InService' endpoint status",
             seconds_to_sleep=30,
         ):
@@ -228,9 +228,9 @@ def test_updating_data_capture_on_endpoint_shows_correct_data_capture_status(
         )
 
         # Wait for endpoint to finish updating
-        # Endpoint update takes ~7min. 40 retries * 30s sleeps = 20min timeout
+        # Endpoint update takes ~7min. 50 retries * 30s sleeps = 25min timeout
         for _ in retries(
-            max_retry_count=40,
+            max_retry_count=50,
             exception_message_prefix="Waiting for 'InService' endpoint status",
             seconds_to_sleep=30,
         ):


### PR DESCRIPTION
Increase number of retries when describing an endpoint since tf-2.0 has larger images and takes longer to start.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [X] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [X] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
