### PR TITLE
fix: increase poll from 5 to 30 for DescribeEndpoint lambda.

### DIFF
--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -2589,7 +2589,7 @@ class Session(object):  # pylint: disable=too-many-public-methods
                 actual_status=status,
             )
 
-    def wait_for_endpoint(self, endpoint, poll=5):
+    def wait_for_endpoint(self, endpoint, poll=30):
         """Wait for an Amazon SageMaker endpoint deployment to complete.
 
         Args:


### PR DESCRIPTION
*Issue #, if available:*
Too frequent DescribeEndpoint polling (5) caused throttling exception in our canary tests.

*Description of changes:*
Changing polling number from 5 to 30.

*Testing done:*
No tests changed.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
