### PR TITLE
fix: make PyTorch empty framework_version warning include the latest PyTorch version

### DIFF
--- a/src/sagemaker/pytorch/estimator.py
+++ b/src/sagemaker/pytorch/estimator.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You
 # may not use this file except in compliance with the License. A copy of
@@ -104,7 +104,7 @@ class PyTorch(Framework):
             :class:`~sagemaker.estimator.EstimatorBase`.
         """
         if framework_version is None:
-            logger.warning(empty_framework_version_warning(PYTORCH_VERSION, PYTORCH_VERSION))
+            logger.warning(empty_framework_version_warning(PYTORCH_VERSION, self.LATEST_VERSION))
         self.framework_version = framework_version or PYTORCH_VERSION
 
         if "enable_sagemaker_metrics" not in kwargs:

--- a/tests/unit/test_pytorch.py
+++ b/tests/unit/test_pytorch.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2017-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You
 # may not use this file except in compliance with the License. A copy of
@@ -529,7 +529,7 @@ def test_empty_framework_version(warning, sagemaker_session):
     )
 
     assert estimator.framework_version == defaults.PYTORCH_VERSION
-    warning.assert_called_with(defaults.PYTORCH_VERSION, defaults.PYTORCH_VERSION)
+    warning.assert_called_with(defaults.PYTORCH_VERSION, estimator.LATEST_VERSION)
 
 
 def test_pt_enable_sm_metrics(sagemaker_session):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The warning when `framework_version` is empty should include the latest version of PyTorch. (The other frameworks already do this.)

*Testing done:*
`tox test/unit`

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.