### PR TITLE
fix: fixed deployment of PyTorchModel on Windows

### DIFF
--- a/src/sagemaker/model.py
+++ b/src/sagemaker/model.py
@@ -817,7 +817,7 @@ class FrameworkModel(Model):
 
         if repack:
             bucket = self.bucket or self.sagemaker_session.default_bucket()
-            repacked_model_data = "s3://" + os.path.join(bucket, key_prefix, "model.tar.gz")
+            repacked_model_data = "s3://" + '/'.join([bucket, key_prefix, "model.tar.gz"])
 
             utils.repack_model(
                 inference_script=self.entry_point,


### PR DESCRIPTION
Starting from version `1.2` deployment of PyTorchModel always [initiates **repacking**](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/pytorch/model.py#L154) when uploading the code.  It is done by calling `_upload_code` with `repack=True` parameter.

 On Windows, this will lead to a crash, because `os.path.join` method used to generate `repacked_model_uri` will use backslashes instead of slashes. So `utils.repack_model` will fail to parse it.

*Description of changes:*
Replaced `os.path.join(bucket, key_prefix, "model.tar.gz")` with `'/'.join(...)` for creating repacked_model_uri.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
