### PR TITLE
change: use unique_name_from_base for multi-algo tuning test

### DIFF
--- a/tests/integ/test_tuner_multi_algo.py
+++ b/tests/integ/test_tuner_multi_algo.py
@@ -19,6 +19,7 @@ import pickle
 import sys
 
 import pytest
+from sagemaker import utils
 from sagemaker.amazon.amazon_estimator import get_image_uri
 from sagemaker.analytics import HyperparameterTuningJobAnalytics
 from sagemaker.content_types import CONTENT_TYPE_JSON
@@ -140,11 +141,13 @@ def test_multi_estimator_tuning(
 
 def _fit_tuner(sagemaker_session, tuner):
     training_inputs = _create_training_inputs(sagemaker_session)
+    job_name = utils.unique_name_from_base("test-multi-algo-tuning")
 
     with timeout(minutes=TUNING_DEFAULT_TIMEOUT_MINUTES):
         tuner.fit(
             inputs={ESTIMATOR_FM: training_inputs, ESTIMATOR_KNN: training_inputs},
             include_cls_metadata={},
+            job_name=job_name,
         )
         tuner.wait()
 

--- a/tests/integ/test_tuner_multi_algo.py
+++ b/tests/integ/test_tuner_multi_algo.py
@@ -141,7 +141,7 @@ def test_multi_estimator_tuning(
 
 def _fit_tuner(sagemaker_session, tuner):
     training_inputs = _create_training_inputs(sagemaker_session)
-    job_name = utils.unique_name_from_base("test-multi-algo-tuning")
+    job_name = utils.unique_name_from_base("test-multi-algo-tuning", max_length=32)
 
     with timeout(minutes=TUNING_DEFAULT_TIMEOUT_MINUTES):
         tuner.fit(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Need to do this to avoid job name collisions with our continuous testing.

*Testing done:*
`tox -e py36 tests/integ/test_tuner_multi_algo.py`

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
