### PR TITLE
fix: add default framework version warning message in Model classes

### DIFF
--- a/src/sagemaker/chainer/defaults.py
+++ b/src/sagemaker/chainer/defaults.py
@@ -17,3 +17,6 @@ CHAINER_VERSION = "4.1.0"
 """Default Chainer version for when the framework version is not specified.
 This is no longer updated so as to not break existing workflows.
 """
+
+LATEST_VERSION = "5.0.0"
+"""The latest version of Chainer included in the SageMaker pre-built Docker images."""

--- a/src/sagemaker/chainer/estimator.py
+++ b/src/sagemaker/chainer/estimator.py
@@ -22,7 +22,7 @@ from sagemaker.fw_utils import (
     empty_framework_version_warning,
     python_deprecation_warning,
 )
-from sagemaker.chainer.defaults import CHAINER_VERSION
+from sagemaker.chainer.defaults import CHAINER_VERSION, LATEST_VERSION
 from sagemaker.chainer.model import ChainerModel
 from sagemaker.vpc_utils import VPC_CONFIG_DEFAULT
 
@@ -40,8 +40,7 @@ class Chainer(Framework):
     _process_slots_per_host = "sagemaker_process_slots_per_host"
     _additional_mpi_options = "sagemaker_additional_mpi_options"
 
-    LATEST_VERSION = "5.0.0"
-    """The latest version of Chainer included in the SageMaker pre-built Docker images."""
+    LATEST_VERSION = LATEST_VERSION
 
     def __init__(
         self,

--- a/src/sagemaker/chainer/model.py
+++ b/src/sagemaker/chainer/model.py
@@ -16,7 +16,8 @@ from __future__ import absolute_import
 import logging
 
 import sagemaker
-from sagemaker.fw_utils import create_image_uri, model_code_key_prefix, python_deprecation_warning
+from sagemaker.fw_utils import create_image_uri, model_code_key_prefix, python_deprecation_warning, \
+    empty_framework_version_warning
 from sagemaker.model import FrameworkModel, MODEL_SERVER_WORKERS_PARAM_NAME
 from sagemaker.chainer.defaults import CHAINER_VERSION
 from sagemaker.predictor import RealTimePredictor, npy_serializer, numpy_deserializer
@@ -54,6 +55,9 @@ class ChainerModel(FrameworkModel):
 
     __framework_name__ = "chainer"
 
+    LATEST_VERSION = "5.0.0"
+    """The latest version of Chainer included in the SageMaker pre-built Docker images."""
+
     def __init__(
         self,
         model_data,
@@ -61,7 +65,7 @@ class ChainerModel(FrameworkModel):
         entry_point,
         image=None,
         py_version="py3",
-        framework_version=CHAINER_VERSION,
+        framework_version=None,
         predictor_cls=ChainerPredictor,
         model_server_workers=None,
         **kwargs
@@ -107,9 +111,11 @@ class ChainerModel(FrameworkModel):
         )
         if py_version == "py2":
             logger.warning(python_deprecation_warning(self.__framework_name__))
+        if framework_version is None:
+            logger.warning(empty_framework_version_warning(CHAINER_VERSION, self.LATEST_VERSION))
 
         self.py_version = py_version
-        self.framework_version = framework_version
+        self.framework_version = framework_version or CHAINER_VERSION
         self.model_server_workers = model_server_workers
 
     def prepare_container_def(self, instance_type, accelerator_type=None):

--- a/src/sagemaker/chainer/model.py
+++ b/src/sagemaker/chainer/model.py
@@ -16,8 +16,12 @@ from __future__ import absolute_import
 import logging
 
 import sagemaker
-from sagemaker.fw_utils import create_image_uri, model_code_key_prefix, python_deprecation_warning, \
-    empty_framework_version_warning
+from sagemaker.fw_utils import (
+    create_image_uri,
+    model_code_key_prefix,
+    python_deprecation_warning,
+    empty_framework_version_warning,
+)
 from sagemaker.model import FrameworkModel, MODEL_SERVER_WORKERS_PARAM_NAME
 from sagemaker.chainer.defaults import CHAINER_VERSION
 from sagemaker.predictor import RealTimePredictor, npy_serializer, numpy_deserializer

--- a/src/sagemaker/chainer/model.py
+++ b/src/sagemaker/chainer/model.py
@@ -23,7 +23,7 @@ from sagemaker.fw_utils import (
     empty_framework_version_warning,
 )
 from sagemaker.model import FrameworkModel, MODEL_SERVER_WORKERS_PARAM_NAME
-from sagemaker.chainer.defaults import CHAINER_VERSION
+from sagemaker.chainer.defaults import CHAINER_VERSION, LATEST_VERSION
 from sagemaker.predictor import RealTimePredictor, npy_serializer, numpy_deserializer
 
 logger = logging.getLogger("sagemaker")
@@ -58,9 +58,6 @@ class ChainerModel(FrameworkModel):
     """
 
     __framework_name__ = "chainer"
-
-    LATEST_VERSION = "5.0.0"
-    """The latest version of Chainer included in the SageMaker pre-built Docker images."""
 
     def __init__(
         self,
@@ -116,7 +113,7 @@ class ChainerModel(FrameworkModel):
         if py_version == "py2":
             logger.warning(python_deprecation_warning(self.__framework_name__))
         if framework_version is None:
-            logger.warning(empty_framework_version_warning(CHAINER_VERSION, self.LATEST_VERSION))
+            logger.warning(empty_framework_version_warning(CHAINER_VERSION, LATEST_VERSION))
 
         self.py_version = py_version
         self.framework_version = framework_version or CHAINER_VERSION

--- a/src/sagemaker/mxnet/defaults.py
+++ b/src/sagemaker/mxnet/defaults.py
@@ -17,3 +17,6 @@ MXNET_VERSION = "1.2"
 """Default MXNet version for when the framework version is not specified.
 This is no longer updated so as to not break existing workflows.
 """
+
+LATEST_VERSION = "1.6.0"
+"""The latest version of MXNet included in the SageMaker pre-built Docker images."""

--- a/src/sagemaker/mxnet/estimator.py
+++ b/src/sagemaker/mxnet/estimator.py
@@ -23,7 +23,7 @@ from sagemaker.fw_utils import (
     python_deprecation_warning,
     is_version_equal_or_higher,
 )
-from sagemaker.mxnet.defaults import MXNET_VERSION
+from sagemaker.mxnet.defaults import MXNET_VERSION, LATEST_VERSION
 from sagemaker.mxnet.model import MXNetModel
 from sagemaker.vpc_utils import VPC_CONFIG_DEFAULT
 
@@ -36,8 +36,7 @@ class MXNet(Framework):
     __framework_name__ = "mxnet"
     _LOWEST_SCRIPT_MODE_VERSION = ["1", "3"]
 
-    LATEST_VERSION = "1.6.0"
-    """The latest version of MXNet included in the SageMaker pre-built Docker images."""
+    LATEST_VERSION = LATEST_VERSION
 
     def __init__(
         self,

--- a/src/sagemaker/mxnet/model.py
+++ b/src/sagemaker/mxnet/model.py
@@ -25,7 +25,7 @@ from sagemaker.fw_utils import (
     empty_framework_version_warning,
 )
 from sagemaker.model import FrameworkModel, MODEL_SERVER_WORKERS_PARAM_NAME
-from sagemaker.mxnet.defaults import MXNET_VERSION
+from sagemaker.mxnet.defaults import MXNET_VERSION, LATEST_VERSION
 from sagemaker.predictor import RealTimePredictor, json_serializer, json_deserializer
 
 logger = logging.getLogger("sagemaker")
@@ -59,9 +59,6 @@ class MXNetModel(FrameworkModel):
 
     __framework_name__ = "mxnet"
     _LOWEST_MMS_VERSION = "1.4.0"
-
-    LATEST_VERSION = "1.6.0"
-    """The latest version of MXNet included in the SageMaker pre-built Docker images."""
 
     def __init__(
         self,
@@ -118,7 +115,7 @@ class MXNetModel(FrameworkModel):
         if py_version == "py2":
             logger.warning(python_deprecation_warning(self.__framework_name__))
         if framework_version is None:
-            logger.warning(empty_framework_version_warning(MXNET_VERSION, self.LATEST_VERSION))
+            logger.warning(empty_framework_version_warning(MXNET_VERSION, LATEST_VERSION))
 
         self.py_version = py_version
         self.framework_version = framework_version or MXNET_VERSION

--- a/src/sagemaker/mxnet/model.py
+++ b/src/sagemaker/mxnet/model.py
@@ -18,8 +18,12 @@ import logging
 from pkg_resources import parse_version
 
 import sagemaker
-from sagemaker.fw_utils import create_image_uri, model_code_key_prefix, python_deprecation_warning, \
-    empty_framework_version_warning
+from sagemaker.fw_utils import (
+    create_image_uri,
+    model_code_key_prefix,
+    python_deprecation_warning,
+    empty_framework_version_warning,
+)
 from sagemaker.model import FrameworkModel, MODEL_SERVER_WORKERS_PARAM_NAME
 from sagemaker.mxnet.defaults import MXNET_VERSION
 from sagemaker.predictor import RealTimePredictor, json_serializer, json_deserializer

--- a/src/sagemaker/mxnet/model.py
+++ b/src/sagemaker/mxnet/model.py
@@ -18,7 +18,8 @@ import logging
 from pkg_resources import parse_version
 
 import sagemaker
-from sagemaker.fw_utils import create_image_uri, model_code_key_prefix, python_deprecation_warning
+from sagemaker.fw_utils import create_image_uri, model_code_key_prefix, python_deprecation_warning, \
+    empty_framework_version_warning
 from sagemaker.model import FrameworkModel, MODEL_SERVER_WORKERS_PARAM_NAME
 from sagemaker.mxnet.defaults import MXNET_VERSION
 from sagemaker.predictor import RealTimePredictor, json_serializer, json_deserializer
@@ -55,6 +56,9 @@ class MXNetModel(FrameworkModel):
     __framework_name__ = "mxnet"
     _LOWEST_MMS_VERSION = "1.4.0"
 
+    LATEST_VERSION = "1.6.0"
+    """The latest version of MXNet included in the SageMaker pre-built Docker images."""
+
     def __init__(
         self,
         model_data,
@@ -62,7 +66,7 @@ class MXNetModel(FrameworkModel):
         entry_point,
         image=None,
         py_version="py2",
-        framework_version=MXNET_VERSION,
+        framework_version=None,
         predictor_cls=MXNetPredictor,
         model_server_workers=None,
         **kwargs
@@ -109,9 +113,11 @@ class MXNetModel(FrameworkModel):
 
         if py_version == "py2":
             logger.warning(python_deprecation_warning(self.__framework_name__))
+        if framework_version is None:
+            logger.warning(empty_framework_version_warning(MXNET_VERSION, self.LATEST_VERSION))
 
         self.py_version = py_version
-        self.framework_version = framework_version
+        self.framework_version = framework_version or MXNET_VERSION
         self.model_server_workers = model_server_workers
 
     def prepare_container_def(self, instance_type, accelerator_type=None):

--- a/src/sagemaker/pytorch/defaults.py
+++ b/src/sagemaker/pytorch/defaults.py
@@ -19,4 +19,7 @@ The latest PyTorch version is 1.1.0, but the default version is no longer update
 break existing workflows.
 """
 
+LATEST_VERSION = "1.3.1"
+"""The latest version of PyTorch included in the SageMaker pre-built Docker images."""
+
 PYTHON_VERSION = "py3"

--- a/src/sagemaker/pytorch/estimator.py
+++ b/src/sagemaker/pytorch/estimator.py
@@ -23,7 +23,7 @@ from sagemaker.fw_utils import (
     python_deprecation_warning,
     is_version_equal_or_higher,
 )
-from sagemaker.pytorch.defaults import PYTORCH_VERSION, PYTHON_VERSION
+from sagemaker.pytorch.defaults import PYTORCH_VERSION, PYTHON_VERSION, LATEST_VERSION
 from sagemaker.pytorch.model import PyTorchModel
 from sagemaker.vpc_utils import VPC_CONFIG_DEFAULT
 
@@ -35,8 +35,7 @@ class PyTorch(Framework):
 
     __framework_name__ = "pytorch"
 
-    LATEST_VERSION = "1.3.1"
-    """The latest version of PyTorch included in the SageMaker pre-built Docker images."""
+    LATEST_VERSION = LATEST_VERSION
 
     def __init__(
         self,

--- a/src/sagemaker/pytorch/model.py
+++ b/src/sagemaker/pytorch/model.py
@@ -17,7 +17,8 @@ import logging
 import pkg_resources
 
 import sagemaker
-from sagemaker.fw_utils import create_image_uri, model_code_key_prefix, python_deprecation_warning
+from sagemaker.fw_utils import create_image_uri, model_code_key_prefix, python_deprecation_warning, \
+    empty_framework_version_warning
 from sagemaker.model import FrameworkModel, MODEL_SERVER_WORKERS_PARAM_NAME
 from sagemaker.pytorch.defaults import PYTORCH_VERSION, PYTHON_VERSION
 from sagemaker.predictor import RealTimePredictor, npy_serializer, numpy_deserializer
@@ -56,6 +57,9 @@ class PyTorchModel(FrameworkModel):
     __framework_name__ = "pytorch"
     _LOWEST_MMS_VERSION = "1.2"
 
+    LATEST_VERSION = "1.3.1"
+    """The latest version of PyTorch included in the SageMaker pre-built Docker images."""
+
     def __init__(
         self,
         model_data,
@@ -63,7 +67,7 @@ class PyTorchModel(FrameworkModel):
         entry_point,
         image=None,
         py_version=PYTHON_VERSION,
-        framework_version=PYTORCH_VERSION,
+        framework_version=None,
         predictor_cls=PyTorchPredictor,
         model_server_workers=None,
         **kwargs
@@ -110,9 +114,11 @@ class PyTorchModel(FrameworkModel):
 
         if py_version == "py2":
             logger.warning(python_deprecation_warning(self.__framework_name__))
+        if framework_version is None:
+            logger.warning(empty_framework_version_warning(PYTORCH_VERSION, self.LATEST_VERSION))
 
         self.py_version = py_version
-        self.framework_version = framework_version
+        self.framework_version = framework_version or PYTORCH_VERSION
         self.model_server_workers = model_server_workers
 
     def prepare_container_def(self, instance_type, accelerator_type=None):

--- a/src/sagemaker/pytorch/model.py
+++ b/src/sagemaker/pytorch/model.py
@@ -24,7 +24,7 @@ from sagemaker.fw_utils import (
     empty_framework_version_warning,
 )
 from sagemaker.model import FrameworkModel, MODEL_SERVER_WORKERS_PARAM_NAME
-from sagemaker.pytorch.defaults import PYTORCH_VERSION, PYTHON_VERSION
+from sagemaker.pytorch.defaults import PYTORCH_VERSION, PYTHON_VERSION, LATEST_VERSION
 from sagemaker.predictor import RealTimePredictor, npy_serializer, numpy_deserializer
 
 logger = logging.getLogger("sagemaker")
@@ -60,9 +60,6 @@ class PyTorchModel(FrameworkModel):
 
     __framework_name__ = "pytorch"
     _LOWEST_MMS_VERSION = "1.2"
-
-    LATEST_VERSION = "1.3.1"
-    """The latest version of PyTorch included in the SageMaker pre-built Docker images."""
 
     def __init__(
         self,
@@ -119,7 +116,7 @@ class PyTorchModel(FrameworkModel):
         if py_version == "py2":
             logger.warning(python_deprecation_warning(self.__framework_name__))
         if framework_version is None:
-            logger.warning(empty_framework_version_warning(PYTORCH_VERSION, self.LATEST_VERSION))
+            logger.warning(empty_framework_version_warning(PYTORCH_VERSION, LATEST_VERSION))
 
         self.py_version = py_version
         self.framework_version = framework_version or PYTORCH_VERSION

--- a/src/sagemaker/pytorch/model.py
+++ b/src/sagemaker/pytorch/model.py
@@ -17,8 +17,12 @@ import logging
 import pkg_resources
 
 import sagemaker
-from sagemaker.fw_utils import create_image_uri, model_code_key_prefix, python_deprecation_warning, \
-    empty_framework_version_warning
+from sagemaker.fw_utils import (
+    create_image_uri,
+    model_code_key_prefix,
+    python_deprecation_warning,
+    empty_framework_version_warning,
+)
 from sagemaker.model import FrameworkModel, MODEL_SERVER_WORKERS_PARAM_NAME
 from sagemaker.pytorch.defaults import PYTORCH_VERSION, PYTHON_VERSION
 from sagemaker.predictor import RealTimePredictor, npy_serializer, numpy_deserializer

--- a/src/sagemaker/tensorflow/defaults.py
+++ b/src/sagemaker/tensorflow/defaults.py
@@ -17,3 +17,6 @@ TF_VERSION = "1.11"
 """Default TF version for when the framework version is not specified.
 This is no longer updated so as to not break existing workflows.
 """
+
+LATEST_VERSION = "2.0.0"
+"""The latest version of TensorFlow included in the SageMaker pre-built Docker images."""

--- a/src/sagemaker/tensorflow/estimator.py
+++ b/src/sagemaker/tensorflow/estimator.py
@@ -25,7 +25,7 @@ import time
 from sagemaker.debugger import DebuggerHookConfig
 from sagemaker.estimator import Framework
 import sagemaker.fw_utils as fw
-from sagemaker.tensorflow.defaults import TF_VERSION
+from sagemaker.tensorflow.defaults import TF_VERSION, LATEST_VERSION
 from sagemaker.tensorflow.model import TensorFlowModel
 from sagemaker.tensorflow.serving import Model
 from sagemaker.transformer import Transformer
@@ -197,8 +197,7 @@ class TensorFlow(Framework):
 
     __framework_name__ = "tensorflow"
 
-    LATEST_VERSION = "2.0.0"
-    """The latest version of TensorFlow included in the SageMaker pre-built Docker images."""
+    LATEST_VERSION = LATEST_VERSION
 
     _LATEST_1X_VERSION = "1.15.0"
 

--- a/src/sagemaker/tensorflow/model.py
+++ b/src/sagemaker/tensorflow/model.py
@@ -16,8 +16,12 @@ from __future__ import absolute_import
 import logging
 
 import sagemaker
-from sagemaker.fw_utils import create_image_uri, model_code_key_prefix, python_deprecation_warning, \
-    empty_framework_version_warning
+from sagemaker.fw_utils import (
+    create_image_uri,
+    model_code_key_prefix,
+    python_deprecation_warning,
+    empty_framework_version_warning,
+)
 from sagemaker.model import FrameworkModel, MODEL_SERVER_WORKERS_PARAM_NAME
 from sagemaker.predictor import RealTimePredictor
 from sagemaker.tensorflow.defaults import TF_VERSION

--- a/src/sagemaker/tensorflow/model.py
+++ b/src/sagemaker/tensorflow/model.py
@@ -16,7 +16,8 @@ from __future__ import absolute_import
 import logging
 
 import sagemaker
-from sagemaker.fw_utils import create_image_uri, model_code_key_prefix, python_deprecation_warning
+from sagemaker.fw_utils import create_image_uri, model_code_key_prefix, python_deprecation_warning, \
+    empty_framework_version_warning
 from sagemaker.model import FrameworkModel, MODEL_SERVER_WORKERS_PARAM_NAME
 from sagemaker.predictor import RealTimePredictor
 from sagemaker.tensorflow.defaults import TF_VERSION
@@ -53,6 +54,9 @@ class TensorFlowModel(FrameworkModel):
 
     __framework_name__ = "tensorflow"
 
+    LATEST_VERSION = "2.0.0"
+    """The latest version of TensorFlow included in the SageMaker pre-built Docker images."""
+
     def __init__(
         self,
         model_data,
@@ -60,7 +64,7 @@ class TensorFlowModel(FrameworkModel):
         entry_point,
         image=None,
         py_version="py2",
-        framework_version=TF_VERSION,
+        framework_version=None,
         predictor_cls=TensorFlowPredictor,
         model_server_workers=None,
         **kwargs
@@ -107,9 +111,11 @@ class TensorFlowModel(FrameworkModel):
 
         if py_version == "py2":
             logger.warning(python_deprecation_warning(self.__framework_name__))
+        if framework_version is None:
+            logger.warning(empty_framework_version_warning(TF_VERSION, self.LATEST_VERSION))
 
         self.py_version = py_version
-        self.framework_version = framework_version
+        self.framework_version = framework_version or TF_VERSION
         self.model_server_workers = model_server_workers
 
     def prepare_container_def(self, instance_type, accelerator_type=None):

--- a/src/sagemaker/tensorflow/model.py
+++ b/src/sagemaker/tensorflow/model.py
@@ -24,7 +24,7 @@ from sagemaker.fw_utils import (
 )
 from sagemaker.model import FrameworkModel, MODEL_SERVER_WORKERS_PARAM_NAME
 from sagemaker.predictor import RealTimePredictor
-from sagemaker.tensorflow.defaults import TF_VERSION
+from sagemaker.tensorflow.defaults import TF_VERSION, LATEST_VERSION
 from sagemaker.tensorflow.predictor import tf_json_serializer, tf_json_deserializer
 
 logger = logging.getLogger("sagemaker")
@@ -57,9 +57,6 @@ class TensorFlowModel(FrameworkModel):
     """Placeholder docstring"""
 
     __framework_name__ = "tensorflow"
-
-    LATEST_VERSION = "2.0.0"
-    """The latest version of TensorFlow included in the SageMaker pre-built Docker images."""
 
     def __init__(
         self,
@@ -116,7 +113,7 @@ class TensorFlowModel(FrameworkModel):
         if py_version == "py2":
             logger.warning(python_deprecation_warning(self.__framework_name__))
         if framework_version is None:
-            logger.warning(empty_framework_version_warning(TF_VERSION, self.LATEST_VERSION))
+            logger.warning(empty_framework_version_warning(TF_VERSION, LATEST_VERSION))
 
         self.py_version = py_version
         self.framework_version = framework_version or TF_VERSION

--- a/tests/unit/test_chainer.py
+++ b/tests/unit/test_chainer.py
@@ -601,3 +601,16 @@ def test_empty_framework_version(warning, sagemaker_session):
 
     assert estimator.framework_version == defaults.CHAINER_VERSION
     warning.assert_called_with(defaults.CHAINER_VERSION, Chainer.LATEST_VERSION)
+
+
+@patch("sagemaker.chainer.model.empty_framework_version_warning")
+def test_model_empty_framework_version(warning, sagemaker_session):
+    model = ChainerModel(
+        MODEL_DATA,
+        role=ROLE,
+        entry_point=SCRIPT_PATH,
+        sagemaker_session=sagemaker_session,
+        framework_version=None,
+    )
+    assert model.framework_version == defaults.CHAINER_VERSION
+    warning.assert_called_with(defaults.CHAINER_VERSION, Chainer.LATEST_VERSION)

--- a/tests/unit/test_chainer.py
+++ b/tests/unit/test_chainer.py
@@ -613,4 +613,4 @@ def test_model_empty_framework_version(warning, sagemaker_session):
         framework_version=None,
     )
     assert model.framework_version == defaults.CHAINER_VERSION
-    warning.assert_called_with(defaults.CHAINER_VERSION, Chainer.LATEST_VERSION)
+    warning.assert_called_with(defaults.CHAINER_VERSION, defaults.LATEST_VERSION)

--- a/tests/unit/test_mxnet.py
+++ b/tests/unit/test_mxnet.py
@@ -722,6 +722,19 @@ def test_empty_framework_version(warning, sagemaker_session):
     warning.assert_called_with(defaults.MXNET_VERSION, mx.LATEST_VERSION)
 
 
+@patch("sagemaker.mxnet.model.empty_framework_version_warning")
+def test_model_empty_framework_version(warning, sagemaker_session):
+    model = MXNetModel(
+        MODEL_DATA,
+        role=ROLE,
+        entry_point=SCRIPT_PATH,
+        sagemaker_session=sagemaker_session,
+        framework_version=None,
+    )
+    assert model.framework_version == defaults.MXNET_VERSION
+    warning.assert_called_with(defaults.MXNET_VERSION, model.LATEST_VERSION)
+
+
 def test_create_model_with_custom_hosting_image(sagemaker_session):
     container_log_level = '"logging.INFO"'
     source_dir = "s3://mybucket/source"

--- a/tests/unit/test_mxnet.py
+++ b/tests/unit/test_mxnet.py
@@ -732,7 +732,7 @@ def test_model_empty_framework_version(warning, sagemaker_session):
         framework_version=None,
     )
     assert model.framework_version == defaults.MXNET_VERSION
-    warning.assert_called_with(defaults.MXNET_VERSION, model.LATEST_VERSION)
+    warning.assert_called_with(defaults.MXNET_VERSION, defaults.LATEST_VERSION)
 
 
 def test_create_model_with_custom_hosting_image(sagemaker_session):

--- a/tests/unit/test_pytorch.py
+++ b/tests/unit/test_pytorch.py
@@ -543,7 +543,7 @@ def test_model_empty_framework_version(warning, sagemaker_session):
     )
 
     assert model.framework_version == defaults.PYTORCH_VERSION
-    warning.assert_called_with(defaults.PYTORCH_VERSION, model.LATEST_VERSION)
+    warning.assert_called_with(defaults.PYTORCH_VERSION, defaults.LATEST_VERSION)
 
 
 def test_pt_enable_sm_metrics(sagemaker_session):

--- a/tests/unit/test_pytorch.py
+++ b/tests/unit/test_pytorch.py
@@ -532,6 +532,20 @@ def test_empty_framework_version(warning, sagemaker_session):
     warning.assert_called_with(defaults.PYTORCH_VERSION, estimator.LATEST_VERSION)
 
 
+@patch("sagemaker.pytorch.model.empty_framework_version_warning")
+def test_model_empty_framework_version(warning, sagemaker_session):
+    model = PyTorchModel(
+        MODEL_DATA,
+        role=ROLE,
+        entry_point=SCRIPT_PATH,
+        sagemaker_session=sagemaker_session,
+        framework_version=None,
+    )
+
+    assert model.framework_version == defaults.PYTORCH_VERSION
+    warning.assert_called_with(defaults.PYTORCH_VERSION, model.LATEST_VERSION)
+
+
 def test_pt_enable_sm_metrics(sagemaker_session):
     pytorch = _pytorch_estimator(sagemaker_session, enable_sagemaker_metrics=True)
     assert pytorch.enable_sagemaker_metrics

--- a/tests/unit/test_tf_estimator.py
+++ b/tests/unit/test_tf_estimator.py
@@ -938,6 +938,17 @@ def test_empty_framework_version(warning, sagemaker_session):
     assert estimator.framework_version == defaults.TF_VERSION
     warning.assert_called_with(defaults.TF_VERSION, estimator.LATEST_VERSION)
 
+    model = TensorFlowModel(
+        MODEL_DATA,
+        role=ROLE,
+        entry_point=SCRIPT_PATH,
+        sagemaker_session=sagemaker_session,
+        framework_version=None,
+    )
+
+    assert model.framework_version == defaults.TF_VERSION
+    warning.assert_called_with(defaults.TF_VERSION, model.LATEST_VERSION)
+
 
 def _deprecated_args_msg(args):
     return "{} are deprecated in script mode. Please do not set {}.".format(

--- a/tests/unit/test_tf_estimator.py
+++ b/tests/unit/test_tf_estimator.py
@@ -947,7 +947,7 @@ def test_empty_framework_version(warning, sagemaker_session):
     )
 
     assert model.framework_version == defaults.TF_VERSION
-    warning.assert_called_with(defaults.TF_VERSION, model.LATEST_VERSION)
+    warning.assert_called_with(defaults.TF_VERSION, defaults.LATEST_VERSION)
 
 
 def _deprecated_args_msg(args):


### PR DESCRIPTION
*Issue #, if available:*
Framework Model classes do not log warning when they are defaulted to default framework versions (not the latest versions) as Estimator classes do.
 
*Description of changes:*
Default ``framework_version`` to ``None`` in Model classes, emit warning message and then assign default values.

*Testing done:*
Unit tests in each modified framework unit tests:
Chainer, MXNet, PyTorch, TensorFlow

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
