### PR TITLE
fix: honor 'wait' flag when updating endpoint

### DIFF
--- a/src/sagemaker/model.py
+++ b/src/sagemaker/model.py
@@ -473,7 +473,9 @@ class Model(object):
                 kms_key=kms_key,
                 data_capture_config_dict=data_capture_config_dict,
             )
-            self.sagemaker_session.update_endpoint(self.endpoint_name, endpoint_config_name)
+            self.sagemaker_session.update_endpoint(
+                self.endpoint_name, endpoint_config_name, wait=wait
+            )
         else:
             self.sagemaker_session.endpoint_from_production_variants(
                 name=self.endpoint_name,

--- a/src/sagemaker/multidatamodel.py
+++ b/src/sagemaker/multidatamodel.py
@@ -243,7 +243,9 @@ class MultiDataModel(Model):
                 kms_key=kms_key,
                 data_capture_config_dict=data_capture_config_dict,
             )
-            self.sagemaker_session.update_endpoint(self.endpoint_name, endpoint_config_name)
+            self.sagemaker_session.update_endpoint(
+                self.endpoint_name, endpoint_config_name, wait=wait
+            )
         else:
             self.sagemaker_session.endpoint_from_production_variants(
                 name=self.endpoint_name,

--- a/src/sagemaker/pipeline.py
+++ b/src/sagemaker/pipeline.py
@@ -159,7 +159,9 @@ class PipelineModel(object):
                 tags=tags,
                 data_capture_config_dict=data_capture_config_dict,
             )
-            self.sagemaker_session.update_endpoint(self.endpoint_name, endpoint_config_name)
+            self.sagemaker_session.update_endpoint(
+                self.endpoint_name, endpoint_config_name, wait=wait
+            )
         else:
             self.sagemaker_session.endpoint_from_production_variants(
                 name=self.endpoint_name,

--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -2363,8 +2363,8 @@ class Session(object):  # pylint: disable=too-many-public-methods
             self.wait_for_endpoint(endpoint_name)
         return endpoint_name
 
-    def update_endpoint(self, endpoint_name, endpoint_config_name):
-        """ Update an Amazon SageMaker ``Endpoint`` according to the endpoint configuration
+    def update_endpoint(self, endpoint_name, endpoint_config_name, wait=True):
+        """Update an Amazon SageMaker ``Endpoint`` according to the endpoint configuration
         specified in the request
 
         Raise an error if endpoint with endpoint_name does not exist.
@@ -2373,10 +2373,14 @@ class Session(object):  # pylint: disable=too-many-public-methods
             endpoint_name (str): Name of the Amazon SageMaker ``Endpoint`` to update.
             endpoint_config_name (str): Name of the Amazon SageMaker endpoint configuration to
                 deploy.
+            wait (bool): Whether to wait for the endpoint deployment to complete before returning
+                (default: True).
 
         Returns:
             str: Name of the Amazon SageMaker ``Endpoint`` being updated.
 
+        Raises:
+            ValueError: if the endpoint does not already exist
         """
         if not _deployment_entity_exists(
             lambda: self.sagemaker_client.describe_endpoint(EndpointName=endpoint_name)
@@ -2389,6 +2393,9 @@ class Session(object):  # pylint: disable=too-many-public-methods
         self.sagemaker_client.update_endpoint(
             EndpointName=endpoint_name, EndpointConfigName=endpoint_config_name
         )
+
+        if wait:
+            self.wait_for_endpoint(endpoint_name)
         return endpoint_name
 
     def delete_endpoint(self, endpoint_name):

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -346,20 +346,13 @@ def test_deploy_creates_correct_session(local_session, session, tmpdir):
 @patch("sagemaker.fw_utils.tar_and_upload_dir", MagicMock())
 def test_deploy_update_endpoint(sagemaker_session, tmpdir):
     model = DummyFrameworkModel(sagemaker_session, source_dir=tmpdir)
-    endpoint_name = "endpoint-name"
-    model.deploy(
-        instance_type=INSTANCE_TYPE,
-        initial_instance_count=1,
-        endpoint_name=endpoint_name,
-        update_endpoint=True,
-        accelerator_type=ACCELERATOR_TYPE,
-    )
+    model.deploy(instance_type=INSTANCE_TYPE, initial_instance_count=1, update_endpoint=True)
     sagemaker_session.create_endpoint_config.assert_called_with(
         name=model.name,
         model_name=model.name,
         initial_instance_count=INSTANCE_COUNT,
         instance_type=INSTANCE_TYPE,
-        accelerator_type=ACCELERATOR_TYPE,
+        accelerator_type=None,
         tags=None,
         kms_key=None,
         data_capture_config_dict=None,
@@ -371,7 +364,48 @@ def test_deploy_update_endpoint(sagemaker_session, tmpdir):
         instance_type=INSTANCE_TYPE,
         accelerator_type=ACCELERATOR_TYPE,
     )
-    sagemaker_session.update_endpoint.assert_called_with(endpoint_name, config_name)
+    sagemaker_session.update_endpoint.assert_called_with(model.name, config_name, wait=True)
+    sagemaker_session.create_endpoint.assert_not_called()
+
+
+@patch("sagemaker.fw_utils.tar_and_upload_dir", MagicMock())
+def test_deploy_update_endpoint_optional_args(sagemaker_session, tmpdir):
+    endpoint_name = "endpoint-name"
+    tags = [{"Key": "Value"}]
+    kms_key = "foo"
+    data_capture_config = MagicMock()
+
+    model = DummyFrameworkModel(sagemaker_session, source_dir=tmpdir)
+    model.deploy(
+        instance_type=INSTANCE_TYPE,
+        initial_instance_count=1,
+        update_endpoint=True,
+        endpoint_name=endpoint_name,
+        accelerator_type=ACCELERATOR_TYPE,
+        tags=tags,
+        kms_key=kms_key,
+        wait=False,
+        data_capture_config=data_capture_config,
+    )
+    sagemaker_session.create_endpoint_config.assert_called_with(
+        name=model.name,
+        model_name=model.name,
+        initial_instance_count=INSTANCE_COUNT,
+        instance_type=INSTANCE_TYPE,
+        accelerator_type=ACCELERATOR_TYPE,
+        tags=tags,
+        kms_key=kms_key,
+        data_capture_config_dict=data_capture_config._to_request_dict(),
+    )
+    config_name = sagemaker_session.create_endpoint_config(
+        name=model.name,
+        model_name=model.name,
+        initial_instance_count=INSTANCE_COUNT,
+        instance_type=INSTANCE_TYPE,
+        accelerator_type=ACCELERATOR_TYPE,
+        wait=False,
+    )
+    sagemaker_session.update_endpoint.assert_called_with(endpoint_name, config_name, wait=False)
     sagemaker_session.create_endpoint.assert_not_called()
 
 

--- a/tests/unit/test_multidatamodel.py
+++ b/tests/unit/test_multidatamodel.py
@@ -295,7 +295,9 @@ def test_deploy_model_update(sagemaker_session):
         instance_type=INSTANCE_TYPE,
         accelerator_type=None,
     )
-    sagemaker_session.update_endpoint.assert_called_with(MULTI_MODEL_ENDPOINT_NAME, config_name)
+    sagemaker_session.update_endpoint.assert_called_with(
+        MULTI_MODEL_ENDPOINT_NAME, config_name, wait=True
+    )
     sagemaker_session.create_endpoint.assert_not_called()
 
 

--- a/tests/unit/test_pipeline_model.py
+++ b/tests/unit/test_pipeline_model.py
@@ -193,7 +193,7 @@ def test_deploy_update_endpoint(tfo, time, sagemaker_session):
         initial_instance_count=INSTANCE_COUNT,
         instance_type=INSTANCE_TYPE,
     )
-    sagemaker_session.update_endpoint.assert_called_with(endpoint_name, config_name)
+    sagemaker_session.update_endpoint.assert_called_with(endpoint_name, config_name, wait=True)
     sagemaker_session.create_endpoint.assert_not_called()
 
 

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -1785,6 +1785,18 @@ def test_update_endpoint_succeed(sagemaker_session):
     assert returned_endpoint_name == endpoint_name
 
 
+def test_update_endpoint_no_wait(sagemaker_session):
+    sagemaker_session.sagemaker_client.describe_endpoint = Mock(
+        return_value={"EndpointStatus": "Updating"}
+    )
+    endpoint_name = "some-endpoint"
+    endpoint_config = "some-endpoint-config"
+    returned_endpoint_name = sagemaker_session.update_endpoint(
+        endpoint_name, endpoint_config, wait=False
+    )
+    assert returned_endpoint_name == endpoint_name
+
+
 def test_update_endpoint_non_existing_endpoint(sagemaker_session):
     error = ClientError(
         {"Error": {"Code": "ValidationException", "Message": "Could not find entity"}}, "foo"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Currently, `wait` is being ignored if `deploy()` is called with `update_endpoint=True`. This change should fix that.

*Testing done:*
`tox test/unit`

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
