### PR TITLE
change: add tests to quick canary

### DIFF
--- a/tests/integ/test_auto_ml.py
+++ b/tests/integ/test_auto_ml.py
@@ -49,6 +49,7 @@ EXPECTED_DEFAULT_JOB_CONFIG = {
     tests.integ.test_region() in tests.integ.NO_AUTO_ML_REGIONS,
     reason="AutoML is not supported in the region yet.",
 )
+@pytest.mark.canary_quick
 def test_auto_ml_fit(sagemaker_session):
     auto_ml = AutoML(
         role=ROLE,
@@ -215,6 +216,7 @@ def test_best_candidate(sagemaker_session):
     tests.integ.test_region() in tests.integ.NO_AUTO_ML_REGIONS,
     reason="AutoML is not supported in the region yet.",
 )
+@pytest.mark.canary_quick
 def test_deploy_best_candidate(sagemaker_session, cpu_instance_type):
     auto_ml_utils.create_auto_ml_job_if_not_exist(sagemaker_session)
 

--- a/tests/integ/test_debugger.py
+++ b/tests/integ/test_debugger.py
@@ -15,6 +15,8 @@ from __future__ import absolute_import
 import os
 import uuid
 
+import pytest
+
 from sagemaker.debugger import Rule
 from sagemaker.debugger import DebuggerHookConfig
 from sagemaker.debugger import TensorBoardOutputConfig
@@ -365,6 +367,7 @@ def test_mxnet_with_tensorboard_output_config(
         _wait_and_assert_that_no_rule_jobs_errored(training_job=mx.latest_training_job)
 
 
+@pytest.mark.canary_quick
 def test_mxnet_with_all_rules_and_configs(sagemaker_session, mxnet_full_version, cpu_instance_type):
     with timeout(minutes=TRAINING_DEFAULT_TIMEOUT_MINUTES):
         rules = [

--- a/tests/integ/test_experiments_analytics.py
+++ b/tests/integ/test_experiments_analytics.py
@@ -3,9 +3,12 @@ from __future__ import absolute_import
 import uuid
 import time
 
+import pytest
+
 from sagemaker.analytics import ExperimentAnalytics
 
 
+@pytest.mark.canary_quick
 def test_experiment_analytics(sagemaker_session):
     sm = sagemaker_session.sagemaker_client
 

--- a/tests/integ/test_model_monitor.py
+++ b/tests/integ/test_model_monitor.py
@@ -14,9 +14,9 @@ from __future__ import absolute_import
 
 import json
 import os
+import uuid
 
 import pytest
-import uuid
 
 import tests.integ
 import tests.integ.timeout
@@ -270,6 +270,7 @@ def updated_output_kms_key(sagemaker_session):
     tests.integ.test_region() in tests.integ.NO_MODEL_MONITORING_REGIONS,
     reason="ModelMonitoring is not yet supported in this region.",
 )
+@pytest.mark.canary_quick
 def test_default_monitor_suggest_baseline_and_create_monitoring_schedule_with_customizations(
     sagemaker_session, output_kms_key, volume_kms_key, predictor
 ):

--- a/tests/integ/test_processing.py
+++ b/tests/integ/test_processing.py
@@ -133,6 +133,7 @@ def test_sklearn(sagemaker_session, sklearn_full_version, cpu_instance_type):
     assert ROLE in job_description["RoleArn"]
 
 
+@pytest.mark.canary_quick
 def test_sklearn_with_customizations(
     sagemaker_session, image_uri, sklearn_full_version, cpu_instance_type, output_kms_key
 ):
@@ -347,6 +348,7 @@ def test_sklearn_with_no_inputs_or_outputs(
     assert job_description["StoppingCondition"] == {"MaxRuntimeInSeconds": 3600}
 
 
+@pytest.mark.canary_quick
 def test_script_processor(sagemaker_session, image_uri, cpu_instance_type, output_kms_key):
     input_file_path = os.path.join(DATA_DIR, "dummy_input.txt")
 
@@ -474,6 +476,7 @@ def test_script_processor_with_no_inputs_or_outputs(
     assert job_description["StoppingCondition"] == {"MaxRuntimeInSeconds": 3600}
 
 
+@pytest.mark.canary_quick
 def test_processor(sagemaker_session, image_uri, cpu_instance_type, output_kms_key):
     script_path = os.path.join(DATA_DIR, "dummy_script.py")
 


### PR DESCRIPTION
**Description of changes:** Flagged re:Invent tests for quick canary. Selected one of each major piece of functionality.

- Debugger: tests/integ/test_debugger.py::test_mxnet_with_all_rules_and_configs => Reasoning: Exercises all variants in a single test.
- Monitoring: tests/integ/test_model_monitor.py::test_default_monitor_suggest_baseline_and_create_monitoring_schedule_with_customizations => Reasoning: These tests are quite slow, so I only want one of them in the quick canary. Given that choice, this is the best test, as it tests the most common use-case (default monitor) with all customizations.
- Processing: Added test_sklearn_with_customizations + test_script_processor + test_processor. => Reasoning: One of each main use-case.
- AutoPilot: One for auto_ml.fit, one for auto_ml.deploy. Reasoning: One of each main use-case.
- Eureka: Added one of the tests. The others were specific use-cases and more specific tests (pagination, etc..).

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [X] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [X] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
