### PR TITLE
fix: ignore private Automatic Model Tuning hyperparameter when attaching AlgorithmEstimator

### DIFF
--- a/src/sagemaker/algorithm.py
+++ b/src/sagemaker/algorithm.py
@@ -553,3 +553,28 @@ class AlgorithmEstimator(EstimatorBase):
             current_input_modes = current_input_modes & supported_input_modes
 
         return current_input_modes
+
+    @classmethod
+    def _prepare_init_params_from_job_description(cls, job_details, model_channel_name=None):
+        """Convert the job description to init params that can be handled by the
+        class constructor
+
+        Args:
+            job_details (dict): the returned job details from a DescribeTrainingJob
+                API call.
+            model_channel_name (str): Name of the channel where pre-trained
+                model data will be downloaded.
+
+        Returns:
+            dict: The transformed init_params
+        """
+        init_params = super(AlgorithmEstimator, cls)._prepare_init_params_from_job_description(
+            job_details, model_channel_name
+        )
+
+        # This hyperparameter is added by Amazon SageMaker Automatic Model Tuning.
+        # It cannot be set through instantiating an estimator.
+        if "_tuning_objective_metric" in init_params["hyperparameters"]:
+            del init_params["hyperparameters"]["_tuning_objective_metric"]
+
+        return init_params

--- a/tests/unit/test_algorithm.py
+++ b/tests/unit/test_algorithm.py
@@ -943,3 +943,75 @@ def test_algorithm_no_required_hyperparameters(session):
         train_instance_count=1,
         sagemaker_session=session,
     )
+
+
+def test_algorithm_attach_from_hyperparameter_tuning():
+    session = Mock()
+    job_name = "training-job-that-is-part-of-a-tuning-job"
+    algo_arn = "arn:aws:sagemaker:us-east-2:000000000000:algorithm/scikit-decision-trees"
+    role_arn = "arn:aws:iam::123412341234:role/SageMakerRole"
+    instance_count = 1
+    instance_type = "ml.m4.xlarge"
+    train_volume_size = 30
+    input_mode = "File"
+
+    session.sagemaker_client.list_tags.return_value = {"Tags": []}
+    session.sagemaker_client.describe_algorithm.return_value = DESCRIBE_ALGORITHM_RESPONSE
+    session.sagemaker_client.describe_training_job.return_value = {
+        "TrainingJobName": job_name,
+        "TrainingJobArn": "arn:aws:sagemaker:us-east-2:123412341234:training-job/%s" % job_name,
+        "TuningJobArn": "arn:aws:sagemaker:us-east-2:123412341234:hyper-parameter-tuning-job/%s"
+        % job_name,
+        "ModelArtifacts": {
+            "S3ModelArtifacts": "s3://sagemaker-us-east-2-123412341234/output/model.tar.gz"
+        },
+        "TrainingJobOutput": {
+            "S3TrainingJobOutput": "s3://sagemaker-us-east-2-123412341234/output/output.tar.gz"
+        },
+        "TrainingJobStatus": "Succeeded",
+        "HyperParameters": {
+            "_tuning_objective_metric": "validation:accuracy",
+            "max_leaf_nodes": 1,
+            "free_text_hp1": "foo",
+        },
+        "AlgorithmSpecification": {"AlgorithmName": algo_arn, "TrainingInputMode": input_mode},
+        "MetricDefinitions": [
+            {"Name": "validation:accuracy", "Regex": "validation-accuracy: (\\S+)"}
+        ],
+        "RoleArn": role_arn,
+        "InputDataConfig": [
+            {
+                "ChannelName": "training",
+                "DataSource": {
+                    "S3DataSource": {
+                        "S3DataType": "S3Prefix",
+                        "S3Uri": "s3://sagemaker-us-east-2-123412341234/input/training.csv",
+                        "S3DataDistributionType": "FullyReplicated",
+                    }
+                },
+                "CompressionType": "None",
+                "RecordWrapperType": "None",
+            }
+        ],
+        "OutputDataConfig": {
+            "KmsKeyId": "",
+            "S3OutputPath": "s3://sagemaker-us-east-2-123412341234/output",
+            "RemoveJobNameFromS3OutputPath": False,
+        },
+        "ResourceConfig": {
+            "InstanceType": instance_type,
+            "InstanceCount": instance_count,
+            "VolumeSizeInGB": train_volume_size,
+        },
+        "StoppingCondition": {"MaxRuntimeInSeconds": 86400},
+    }
+
+    estimator = AlgorithmEstimator.attach(job_name, sagemaker_session=session)
+    assert estimator.hyperparameters() == {"max_leaf_nodes": 1, "free_text_hp1": "foo"}
+    assert estimator.algorithm_arn == algo_arn
+    assert estimator.role == role_arn
+    assert estimator.train_instance_count == instance_count
+    assert estimator.train_instance_type == instance_type
+    assert estimator.train_volume_size == train_volume_size
+    assert estimator.input_mode == input_mode
+    assert estimator.sagemaker_session == session


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
SageMaker Automatic Model Tuning adds a private hyperparameter to all of its training jobs. This can cause an issue when attaching to a training job with the hyperparameter:

```
ValueError: Invalid hyperparameter: _tuning_objective_metric is not supported by <algorithm>
```

I tested this with KMeans, and the private hyperparameter is not included after attaching, so I've gone for the same approach with `AlgorithmEstimator`.

*Testing done:*
Tested manually by adapting the code from [this notebook](https://github.com/awslabs/amazon-sagemaker-examples/blob/master/aws_marketplace/using_data/using_data_from_aws_data_exchange_to_predict_product_popularity/Introduction_to_training_a_model_using_data_from_AWS_Data_Exchange.ipynb) to create a training job to try attaching to.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
