### PR TITLE
fix: Append serving to model framework name

### DIFF
--- a/src/sagemaker/mxnet/model.py
+++ b/src/sagemaker/mxnet/model.py
@@ -183,7 +183,7 @@ class MXNetModel(FrameworkModel):
         """
         return fw_utils.create_image_uri(
             region_name,
-            self.__framework_name__,
+            "-".join([self.__framework_name__, "serving"]),
             instance_type,
             self.framework_version,
             self.py_version,

--- a/src/sagemaker/pytorch/model.py
+++ b/src/sagemaker/pytorch/model.py
@@ -183,7 +183,7 @@ class PyTorchModel(FrameworkModel):
         """
         return fw_utils.create_image_uri(
             region_name,
-            self.__framework_name__,
+            "-".join([self.__framework_name__, "serving"]),
             instance_type,
             self.framework_version,
             self.py_version,

--- a/src/sagemaker/tensorflow/model.py
+++ b/src/sagemaker/tensorflow/model.py
@@ -174,7 +174,7 @@ class TensorFlowModel(FrameworkModel):
         """
         return fw_utils.create_image_uri(
             region_name,
-            self.__framework_name__,
+            "-".join([self.__framework_name__, "serving"]),
             instance_type,
             self.framework_version,
             self.py_version,

--- a/tests/unit/test_airflow.py
+++ b/tests/unit/test_airflow.py
@@ -1051,9 +1051,9 @@ def test_model_config_from_framework_estimator(sagemaker_session):
         task_type="training",
     )
     expected_config = {
-        "ModelName": "sagemaker-mxnet-%s" % TIME_STAMP,
+        "ModelName": "sagemaker-mxnet-serving-%s" % TIME_STAMP,
         "PrimaryContainer": {
-            "Image": "520713654638.dkr.ecr.us-west-2.amazonaws.com/sagemaker-mxnet:1.3.0-cpu-py3",
+            "Image": "520713654638.dkr.ecr.us-west-2.amazonaws.com/sagemaker-mxnet-serving:1.3.0-cpu-py3",
             "Environment": {
                 "SAGEMAKER_PROGRAM": "{{ entry_point }}",
                 "SAGEMAKER_SUBMIT_DIRECTORY": "s3://output/{{ ti.xcom_pull(task_ids='task_id')['Training']"
@@ -1209,9 +1209,9 @@ def test_transform_config_from_framework_estimator(sagemaker_session):
     )
     expected_config = {
         "Model": {
-            "ModelName": "sagemaker-mxnet-%s" % TIME_STAMP,
+            "ModelName": "sagemaker-mxnet-serving-%s" % TIME_STAMP,
             "PrimaryContainer": {
-                "Image": "520713654638.dkr.ecr.us-west-2.amazonaws.com/sagemaker-mxnet:1.3.0-gpu-py3",
+                "Image": "520713654638.dkr.ecr.us-west-2.amazonaws.com/sagemaker-mxnet-serving:1.3.0-gpu-py3",
                 "Environment": {
                     "SAGEMAKER_PROGRAM": "{{ entry_point }}",
                     "SAGEMAKER_SUBMIT_DIRECTORY": "s3://output/{{ ti.xcom_pull(task_ids='task_id')"
@@ -1228,7 +1228,7 @@ def test_transform_config_from_framework_estimator(sagemaker_session):
         },
         "Transform": {
             "TransformJobName": "{{ base_job_name }}-%s" % TIME_STAMP,
-            "ModelName": "sagemaker-mxnet-%s" % TIME_STAMP,
+            "ModelName": "sagemaker-mxnet-serving-%s" % TIME_STAMP,
             "TransformInput": {
                 "DataSource": {
                     "S3DataSource": {"S3DataType": "S3Prefix", "S3Uri": "{{ transform_data }}"}
@@ -1449,9 +1449,9 @@ def test_deploy_config_from_framework_estimator(sagemaker_session):
     )
     expected_config = {
         "Model": {
-            "ModelName": "sagemaker-mxnet-%s" % TIME_STAMP,
+            "ModelName": "sagemaker-mxnet-serving-%s" % TIME_STAMP,
             "PrimaryContainer": {
-                "Image": "520713654638.dkr.ecr.us-west-2.amazonaws.com/sagemaker-mxnet:1.3.0-cpu-py3",
+                "Image": "520713654638.dkr.ecr.us-west-2.amazonaws.com/sagemaker-mxnet-serving:1.3.0-cpu-py3",
                 "Environment": {
                     "SAGEMAKER_PROGRAM": "{{ entry_point }}",
                     "SAGEMAKER_SUBMIT_DIRECTORY": "s3://output/{{ ti.xcom_pull(task_ids='task_id')['Training']"
@@ -1466,12 +1466,12 @@ def test_deploy_config_from_framework_estimator(sagemaker_session):
             "ExecutionRoleArn": "{{ role }}",
         },
         "EndpointConfig": {
-            "EndpointConfigName": "sagemaker-mxnet-%s" % TIME_STAMP,
+            "EndpointConfigName": "sagemaker-mxnet-serving-%s" % TIME_STAMP,
             "ProductionVariants": [
                 {
                     "InstanceType": "ml.c4.large",
                     "InitialInstanceCount": "{{ instance_count}}",
-                    "ModelName": "sagemaker-mxnet-%s" % TIME_STAMP,
+                    "ModelName": "sagemaker-mxnet-serving-%s" % TIME_STAMP,
                     "VariantName": "AllTraffic",
                     "InitialVariantWeight": 1,
                 }
@@ -1479,7 +1479,7 @@ def test_deploy_config_from_framework_estimator(sagemaker_session):
         },
         "Endpoint": {
             "EndpointName": "mxnet-endpoint",
-            "EndpointConfigName": "sagemaker-mxnet-%s" % TIME_STAMP,
+            "EndpointConfigName": "sagemaker-mxnet-serving-%s" % TIME_STAMP,
         },
     }
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/amazon-sagemaker-examples/issues/965

*Description of changes:*
Appends `-serving` to the framework name in PyTorch, MXNet, and TensorFlow models.

*Testing done:*
- ran unit tests
- ran integ tests

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
