### PR TITLE
fix: do not use script for TFS when entry_point is not provided

### DIFF
--- a/src/sagemaker/model.py
+++ b/src/sagemaker/model.py
@@ -844,9 +844,12 @@ class FrameworkModel(Model):
                 dir_name = "/opt/ml/model/code"
             else:
                 dir_name = self.uploaded_code.s3_prefix
-        else:
+        elif self.entry_point is not None:
             script_name = self.entry_point
             dir_name = "file://" + self.source_dir
+        else:
+            script_name = None
+            dir_name = None
 
         return {
             SCRIPT_PARAM_NAME.upper(): script_name,

--- a/src/sagemaker/workflow/airflow.py
+++ b/src/sagemaker/workflow/airflow.py
@@ -522,18 +522,19 @@ def prepare_framework_container_def(model, instance_type, s3_operations):
     model.name = model.name or utils.name_from_base(base_name)
 
     bucket = model.bucket or model.sagemaker_session._default_bucket
-    script = os.path.basename(model.entry_point)
-    key = "{}/source/sourcedir.tar.gz".format(model.name)
+    if model.entry_point is not None:
+        script = os.path.basename(model.entry_point)
+        key = "{}/source/sourcedir.tar.gz".format(model.name)
 
-    if model.source_dir and model.source_dir.lower().startswith("s3://"):
-        code_dir = model.source_dir
-        model.uploaded_code = fw_utils.UploadedCode(s3_prefix=code_dir, script_name=script)
-    else:
-        code_dir = "s3://{}/{}".format(bucket, key)
-        model.uploaded_code = fw_utils.UploadedCode(s3_prefix=code_dir, script_name=script)
-        s3_operations["S3Upload"] = [
-            {"Path": model.source_dir or script, "Bucket": bucket, "Key": key, "Tar": True}
-        ]
+        if model.source_dir and model.source_dir.lower().startswith("s3://"):
+            code_dir = model.source_dir
+            model.uploaded_code = fw_utils.UploadedCode(s3_prefix=code_dir, script_name=script)
+        else:
+            code_dir = "s3://{}/{}".format(bucket, key)
+            model.uploaded_code = fw_utils.UploadedCode(s3_prefix=code_dir, script_name=script)
+            s3_operations["S3Upload"] = [
+                {"Path": model.source_dir or script, "Bucket": bucket, "Key": key, "Tar": True}
+            ]
 
     deploy_env = dict(model.env)
     deploy_env.update(model._framework_env_vars())


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/sagemaker-python-sdk/issues/1201#issuecomment-576389994

*Description of changes:*
TFS does not require an entry point. When an entry point is not provided (and not defaulted, in the case of TFS), this fix removes the expectation of an entry point and does not set the script and code directory.

*Testing done:*
Ran unit tests and `integ/test_airflow_config.py`

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
