### PR TITLE
fix: create the correct session for MultiDataModel

### DIFF
--- a/src/sagemaker/local/local_session.py
+++ b/src/sagemaker/local/local_session.py
@@ -341,6 +341,7 @@ class LocalSagemakerRuntimeClient(object):
         ContentType=None,
         Accept=None,
         CustomAttributes=None,
+        TargetModel=None,
     ):
         """
 
@@ -364,6 +365,9 @@ class LocalSagemakerRuntimeClient(object):
 
         if CustomAttributes is not None:
             headers["X-Amzn-SageMaker-Custom-Attributes"] = CustomAttributes
+
+        if TargetModel is not None:
+            headers["X-Amzn-SageMaker-Target-Model"] = TargetModel
 
         r = self.http.request("POST", url, body=Body, preload_content=False, headers=headers)
 

--- a/src/sagemaker/multidatamodel.py
+++ b/src/sagemaker/multidatamodel.py
@@ -17,7 +17,7 @@ import os
 from six.moves.urllib.parse import urlparse
 
 import sagemaker
-from sagemaker import s3
+from sagemaker import local, s3
 from sagemaker.model import Model
 from sagemaker.session import Session
 
@@ -209,6 +209,9 @@ class MultiDataModel(Model):
 
         if role is None:
             raise ValueError("Role can not be null for deploying a model")
+
+        if instance_type == "local" and not isinstance(self.sagemaker_session, local.LocalSession):
+            self.sagemaker_session = local.LocalSession()
 
         container_def = self.prepare_container_def(instance_type, accelerator_type=accelerator_type)
         self.sagemaker_session.create_model(

--- a/tests/integ/test_multidatamodel.py
+++ b/tests/integ/test_multidatamodel.py
@@ -179,7 +179,7 @@ def test_multi_data_model_deploy_pretrained_models(
 
 @pytest.mark.local_mode
 def test_multi_data_model_deploy_pretrained_models_local_mode(
-    container_image, sagemaker_session, cpu_instance_type
+    container_image, sagemaker_session
 ):
     timestamp = sagemaker_timestamp()
     endpoint_name = "test-multimodel-endpoint-{}".format(timestamp)

--- a/tests/integ/test_multidatamodel.py
+++ b/tests/integ/test_multidatamodel.py
@@ -178,9 +178,7 @@ def test_multi_data_model_deploy_pretrained_models(
 
 
 @pytest.mark.local_mode
-def test_multi_data_model_deploy_pretrained_models_local_mode(
-    container_image, sagemaker_session
-):
+def test_multi_data_model_deploy_pretrained_models_local_mode(container_image, sagemaker_session):
     timestamp = sagemaker_timestamp()
     endpoint_name = "test-multimodel-endpoint-{}".format(timestamp)
     model_name = "test-multimodel-{}".format(timestamp)

--- a/tests/integ/test_multidatamodel.py
+++ b/tests/integ/test_multidatamodel.py
@@ -177,6 +177,69 @@ def test_multi_data_model_deploy_pretrained_models(
         assert "Could not find endpoint" in str(exception.value)
 
 
+@pytest.mark.local_mode
+def test_multi_data_model_deploy_pretrained_models_local_mode(
+    container_image, sagemaker_session, cpu_instance_type
+):
+    timestamp = sagemaker_timestamp()
+    endpoint_name = "test-multimodel-endpoint-{}".format(timestamp)
+    model_name = "test-multimodel-{}".format(timestamp)
+
+    # Define pretrained model local path
+    pretrained_model_data_local_path = os.path.join(DATA_DIR, "sparkml_model", "mleap_model.tar.gz")
+
+    with timeout(minutes=30):
+        model_data_prefix = os.path.join(
+            "s3://", sagemaker_session.default_bucket(), "multimodel-{}/".format(timestamp)
+        )
+        multi_data_model = MultiDataModel(
+            name=model_name,
+            model_data_prefix=model_data_prefix,
+            image=container_image,
+            role=ROLE,
+            sagemaker_session=sagemaker_session,
+        )
+
+        # Add model before deploy
+        multi_data_model.add_model(pretrained_model_data_local_path, PRETRAINED_MODEL_PATH_1)
+        # Deploy model to an endpoint
+        multi_data_model.deploy(1, "local", endpoint_name=endpoint_name)
+        # Add models after deploy
+        multi_data_model.add_model(pretrained_model_data_local_path, PRETRAINED_MODEL_PATH_2)
+
+        endpoint_models = []
+        for model_path in multi_data_model.list_models():
+            endpoint_models.append(model_path)
+        assert PRETRAINED_MODEL_PATH_1 in endpoint_models
+        assert PRETRAINED_MODEL_PATH_2 in endpoint_models
+
+        predictor = RealTimePredictor(
+            endpoint=endpoint_name,
+            sagemaker_session=multi_data_model.sagemaker_session,
+            serializer=npy_serializer,
+            deserializer=string_deserializer,
+        )
+
+        data = numpy.zeros(shape=(1, 1, 28, 28))
+        result = predictor.predict(data, target_model=PRETRAINED_MODEL_PATH_1)
+        assert result == "Invoked model: {}".format(PRETRAINED_MODEL_PATH_1)
+
+        result = predictor.predict(data, target_model=PRETRAINED_MODEL_PATH_2)
+        assert result == "Invoked model: {}".format(PRETRAINED_MODEL_PATH_2)
+
+        # Cleanup
+        multi_data_model.sagemaker_session.sagemaker_client.delete_endpoint_config(
+            EndpointConfigName=endpoint_name
+        )
+        multi_data_model.sagemaker_session.delete_endpoint(endpoint_name)
+        multi_data_model.delete_model()
+    with pytest.raises(Exception) as exception:
+        sagemaker_session.sagemaker_client.describe_model(ModelName=multi_data_model.name)
+        assert "Could not find model" in str(exception.value)
+        sagemaker_session.sagemaker_client.describe_endpoint_config(name=endpoint_name)
+        assert "Could not find endpoint" in str(exception.value)
+
+
 def test_multi_data_model_deploy_trained_model_from_framework_estimator(
     container_image, sagemaker_session, cpu_instance_type
 ):


### PR DESCRIPTION
*Issue #, if available:*
``MultiDataModel.deploy()`` uses the non local session when ``instance_type="local"``

*Description of changes:*
Init ``LocalSession`` when instance_type is "local" and ``MultiDataModel`` object's ``sagemaker_session`` is not ``LocalSession``. The ``sagemaker_session`` needs to be initiated because this class provides a method (``add_model``) that uploads tarball to s3 which requires session.

*Testing done:*
Integration test with local mode.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
