### PR TITLE
fix: create lib dir for dependencies safely.

### DIFF
--- a/src/sagemaker/utils.py
+++ b/src/sagemaker/utils.py
@@ -534,7 +534,8 @@ def _create_or_update_code_dir(
         if os.path.isdir(dependency):
             shutil.copytree(dependency, os.path.join(lib_dir, os.path.basename(dependency)))
         else:
-            os.mkdir(lib_dir)
+            if not os.path.exists(lib_dir):
+                os.mkdir(lib_dir)
             shutil.copy2(dependency, lib_dir)
 
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -444,6 +444,8 @@ def test_repack_model_without_source_dir(tmp, fake_s3):
             "model-dir/model",
             "dependencies/a",
             "dependencies/some/dir/b",
+            "aa",
+            "bb",
             "source-dir/inference.py",
             "source-dir/this-file-should-not-be-included.py",
         ],
@@ -457,6 +459,8 @@ def test_repack_model_without_source_dir(tmp, fake_s3):
         dependencies=[
             os.path.join(tmp, "dependencies/a"),
             os.path.join(tmp, "dependencies/some/dir"),
+            os.path.join(tmp, "aa"),
+            os.path.join(tmp, "bb"),
         ],
         model_uri="s3://fake/location",
         repacked_model_uri="s3://destination-bucket/model.tar.gz",
@@ -466,6 +470,8 @@ def test_repack_model_without_source_dir(tmp, fake_s3):
     assert list_tar_files(fake_s3.fake_upload_path, tmp) == {
         "/model",
         "/code/lib/a",
+        "/code/lib/aa",
+        "/code/lib/bb",
         "/code/lib/dir/b",
         "/code/inference.py",
     }


### PR DESCRIPTION
Create lib dir for dependencies safely (only if it doesn't exist yet).

*Issue #, if available:* TT-0303440807

*Testing done:* unit tests updated to address the missed use case.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [X] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [X] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [X] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [X] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [X] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
