### PR TITLE
infra: properly fail PR build if has-matching-changes fails

### DIFF
--- a/buildspec-localmodetests.yml
+++ b/buildspec-localmodetests.yml
@@ -11,15 +11,17 @@ phases:
 
       # local mode tests
       - start_time=`date +%s`
+      - HAS_MATCHING_CHANGES_OUTPUT=$(has-matching-changes "tests/" "src/*.py" "setup.py" "setup.cfg" "buildspec.yml")
+      - HAS_MATCHING_CHANGES_EXIT_CODE=$?
       - |
-        if has-matching-changes "tests/" "src/*.py" "setup.py" "setup.cfg" "buildspec.yml"; then
+        if [ "$HAS_MATCHING_CHANGES" = "Changes Found" ] ; then
           tox -e py36 -- tests/integ -m local_mode --durations 50
         fi
       - ./ci-scripts/displaytime.sh 'py36 local mode' $start_time
 
       - start_time=`date +%s`
       - |
-        if has-matching-changes "tests/" "src/*.py" "setup.py" "setup.cfg" "buildspec.yml"; then
+        if [ "$HAS_MATCHING_CHANGES" = "Changes Found" ] ; then
           tox -e py27 -- tests/integ -m local_mode --durations 50
         fi
       - ./ci-scripts/displaytime.sh 'py27 local mode' $start_time

--- a/buildspec-localmodetests.yml
+++ b/buildspec-localmodetests.yml
@@ -12,7 +12,6 @@ phases:
       # local mode tests
       - start_time=`date +%s`
       - HAS_MATCHING_CHANGES_OUTPUT=$(has-matching-changes "tests/" "src/*.py" "setup.py" "setup.cfg" "buildspec.yml")
-      - HAS_MATCHING_CHANGES_EXIT_CODE=$?
       - |
         if [ "$HAS_MATCHING_CHANGES" = "Changes Found" ] ; then
           tox -e py36 -- tests/integ -m local_mode --durations 50

--- a/buildspec-notebooktests.yml
+++ b/buildspec-notebooktests.yml
@@ -6,8 +6,10 @@ phases:
       # run notebook test
       - echo "running notebook test"
       - start_time=`date +%s`
+      - HAS_MATCHING_CHANGES_OUTPUT=$(has-matching-changes "src/*.py" "setup.py" "setup.cfg" "tests/scripts/run-notebook-test.sh")
+      - HAS_MATCHING_CHANGES_EXIT_CODE=$?
       - |
-        if has-matching-changes "src/*.py" "setup.py" "setup.cfg" "tests/scripts/run-notebook-test.sh"; then
+        if [ "$HAS_MATCHING_CHANGES" = "Changes Found" ] ; then
           ./tests/scripts/run-notebook-test.sh
         fi
       - ./ci-scripts/displaytime.sh 'notebook test' $start_time

--- a/buildspec-notebooktests.yml
+++ b/buildspec-notebooktests.yml
@@ -7,7 +7,6 @@ phases:
       - echo "running notebook test"
       - start_time=`date +%s`
       - HAS_MATCHING_CHANGES_OUTPUT=$(has-matching-changes "src/*.py" "setup.py" "setup.cfg" "tests/scripts/run-notebook-test.sh")
-      - HAS_MATCHING_CHANGES_EXIT_CODE=$?
       - |
         if [ "$HAS_MATCHING_CHANGES" = "Changes Found" ] ; then
           ./tests/scripts/run-notebook-test.sh

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -14,18 +14,18 @@ phases:
       - HAS_MATCHING_CHANGES_OUTPUT=$(has-matching-changes "tests/" "src/*.py" "setup.py" "setup.cfg" "buildspec.yml")
       - HAS_MATCHING_CHANGES_EXIT_CODE=$?
       - |
-        if [[ $HAS_MATCHING_CHANGES_EXIT_CODE = 1 ]] ; then
+        if [ $HAS_MATCHING_CHANGES_EXIT_CODE -eq 1 ] ; then
           echo "There was an error checking for matching changes. PR will now fail to prevent false negative (success) tests."
           exit 1
         fi
-        if [[ $HAS_MATCHING_CHANGES = "Changes Found" ]] ; then
+        if [ $HAS_MATCHING_CHANGES -eq "Changes Found" ] ; then
           python3 -u ci-scripts/queue_build.py
         fi
       - ./ci-scripts/displaytime.sh 'build queue' $start_time
 
       - start_time=`date +%s`
       - |
-        if [[ $HAS_MATCHING_CHANGES = "Changes Found" ]] ; then
+        if [ $HAS_MATCHING_CHANGES -eq "Changes Found" ] ; then
           tox -e py36 -- tests/integ -m "not local_mode" -n 512 --reruns 3 --reruns-delay 5 --durations 50 --boto-config '{"region_name": "us-east-2"}'
         fi
       - ./ci-scripts/displaytime.sh 'py36 tests/integ' $start_time

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -12,7 +12,6 @@ phases:
       # run integration tests
       - start_time=`date +%s`
       - HAS_MATCHING_CHANGES_OUTPUT=$(has-matching-changes "tests/" "src/*.py" "setup.py" "setup.cfg" "buildspec.yml")
-      - HAS_MATCHING_CHANGES_EXIT_CODE=$?
       - |
         if [ "$HAS_MATCHING_CHANGES" = "Changes Found" ] ; then
           python3 -u ci-scripts/queue_build.py

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -14,10 +14,6 @@ phases:
       - HAS_MATCHING_CHANGES_OUTPUT=$(has-matching-changes "tests/" "src/*.py" "setup.py" "setup.cfg" "buildspec.yml")
       - HAS_MATCHING_CHANGES_EXIT_CODE=$?
       - |
-        if [ $HAS_MATCHING_CHANGES_EXIT_CODE = 1 ] ; then
-          echo "There was an error checking for matching changes. PR will now fail to prevent false negative (success) tests."
-          exit 1
-        fi
         if [ "$HAS_MATCHING_CHANGES" = "Changes Found" ] ; then
           python3 -u ci-scripts/queue_build.py
         fi

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -11,15 +11,21 @@ phases:
 
       # run integration tests
       - start_time=`date +%s`
+      - HAS_MATCHING_CHANGES_OUTPUT=$(has-matching-changes "tests/" "src/*.py" "setup.py" "setup.cfg" "buildspec.yml")
+      - HAS_MATCHING_CHANGES_EXIT_CODE=$?
       - |
-        if has-matching-changes "tests/" "src/*.py" "setup.py" "setup.cfg" "buildspec.yml"; then
+        if [[ $HAS_MATCHING_CHANGES_EXIT_CODE = 1 ]] ; then
+          echo "There was an error checking for matching changes. PR will now fail to prevent false negative (success) tests."
+          exit 1
+        fi
+        if [[ $HAS_MATCHING_CHANGES = "Changes Found" ]] ; then
           python3 -u ci-scripts/queue_build.py
         fi
       - ./ci-scripts/displaytime.sh 'build queue' $start_time
 
       - start_time=`date +%s`
       - |
-        if has-matching-changes "tests/" "src/*.py" "setup.py" "setup.cfg" "buildspec.yml"; then
+        if [[ $HAS_MATCHING_CHANGES = "Changes Found" ]] ; then
           tox -e py36 -- tests/integ -m "not local_mode" -n 512 --reruns 3 --reruns-delay 5 --durations 50 --boto-config '{"region_name": "us-east-2"}'
         fi
       - ./ci-scripts/displaytime.sh 'py36 tests/integ' $start_time

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -18,14 +18,14 @@ phases:
           echo "There was an error checking for matching changes. PR will now fail to prevent false negative (success) tests."
           exit 1
         fi
-        if [ $HAS_MATCHING_CHANGES = "Changes Found" ] ; then
+        if [ "$HAS_MATCHING_CHANGES" = "Changes Found" ] ; then
           python3 -u ci-scripts/queue_build.py
         fi
       - ./ci-scripts/displaytime.sh 'build queue' $start_time
 
       - start_time=`date +%s`
       - |
-        if [ $HAS_MATCHING_CHANGES = "Changes Found" ] ; then
+        if [ "$HAS_MATCHING_CHANGES" = "Changes Found" ] ; then
           tox -e py36 -- tests/integ -m "not local_mode" -n 512 --reruns 3 --reruns-delay 5 --durations 50 --boto-config '{"region_name": "us-east-2"}'
         fi
       - ./ci-scripts/displaytime.sh 'py36 tests/integ' $start_time

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -14,18 +14,18 @@ phases:
       - HAS_MATCHING_CHANGES_OUTPUT=$(has-matching-changes "tests/" "src/*.py" "setup.py" "setup.cfg" "buildspec.yml")
       - HAS_MATCHING_CHANGES_EXIT_CODE=$?
       - |
-        if [ $HAS_MATCHING_CHANGES_EXIT_CODE -eq 1 ] ; then
+        if [ $HAS_MATCHING_CHANGES_EXIT_CODE = 1 ] ; then
           echo "There was an error checking for matching changes. PR will now fail to prevent false negative (success) tests."
           exit 1
         fi
-        if [ $HAS_MATCHING_CHANGES -eq "Changes Found" ] ; then
+        if [ $HAS_MATCHING_CHANGES = "Changes Found" ] ; then
           python3 -u ci-scripts/queue_build.py
         fi
       - ./ci-scripts/displaytime.sh 'build queue' $start_time
 
       - start_time=`date +%s`
       - |
-        if [ $HAS_MATCHING_CHANGES -eq "Changes Found" ] ; then
+        if [ $HAS_MATCHING_CHANGES = "Changes Found" ] ; then
           tox -e py36 -- tests/integ -m "not local_mode" -n 512 --reruns 3 --reruns-delay 5 --durations 50 --boto-config '{"region_name": "us-east-2"}'
         fi
       - ./ci-scripts/displaytime.sh 'py36 tests/integ' $start_time


### PR DESCRIPTION
*Description of changes:* Assigning has-matching-changes script to variable, to expose non-zero exit codes and properly fail the build if the script is unable to get git details.

*Testing done:* Script is run by build.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [X] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [X] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
