### PR TITLE
change: enable smdebug for Horovod (MPI) training setup

### DIFF
--- a/src/sagemaker/tensorflow/estimator.py
+++ b/src/sagemaker/tensorflow/estimator.py
@@ -707,22 +707,19 @@ class TensorFlow(Framework):
 
     def _validate_and_set_debugger_configs(self):
         """
-        Disable Debugger Hook Config for PS and Horovod as they are not
-        supported in smdebug 0.4.13, the current latest version of smdebug
+        Disable Debugger Hook Config for Horovod as it is not
+        supported in smdebug.
 
         Else, set default HookConfig
         """
-        ps_enabled = "parameter_server" in self.distributions and self.distributions[
-            "parameter_server"
-        ].get("enabled", False)
-        mpi_enabled = "mpi" in self.distributions and self.distributions["mpi"].get(
+        ps_enabled = "parameter_server" in self.distributions and self.distributions["parameter_server"].get(
             "enabled", False
         )
-        if ps_enabled or mpi_enabled:
+        if ps_enabled:
             if self.debugger_hook_config is not None or self.debugger_rule_configs is not None:
                 logger.info(
                     "Amazon SageMaker Debugger does not currently support "
-                    "Parameter Server and MPI distributions"
+                    "Parameter Server distribution"
                 )
             self.debugger_hook_config = None
             self.debugger_rule_configs = None

--- a/src/sagemaker/tensorflow/estimator.py
+++ b/src/sagemaker/tensorflow/estimator.py
@@ -707,7 +707,7 @@ class TensorFlow(Framework):
 
     def _validate_and_set_debugger_configs(self):
         """
-        Disable Debugger Hook Config for Horovod as it is not
+        Disable Debugger Hook Config for ParameterServer (PS) as it is not
         supported in smdebug.
 
         Else, set default HookConfig

--- a/src/sagemaker/tensorflow/estimator.py
+++ b/src/sagemaker/tensorflow/estimator.py
@@ -712,9 +712,9 @@ class TensorFlow(Framework):
 
         Else, set default HookConfig
         """
-        ps_enabled = "parameter_server" in self.distributions and self.distributions["parameter_server"].get(
-            "enabled", False
-        )
+        ps_enabled = "parameter_server" in self.distributions and self.distributions[
+            "parameter_server"
+        ].get("enabled", False)
         if ps_enabled:
             if self.debugger_hook_config is not None or self.debugger_rule_configs is not None:
                 logger.info(

--- a/tests/unit/test_tf_estimator.py
+++ b/tests/unit/test_tf_estimator.py
@@ -160,7 +160,7 @@ def _create_train_job(
         "experiment_config": None,
     }
 
-    if not ps and not horovod:
+    if not ps:
         conf["debugger_hook_config"] = {
             "CollectionConfigurations": [],
             "S3OutputPath": "s3://{}/".format(BUCKET_NAME),


### PR DESCRIPTION
*Description of changes:*
SMDebug now supports this, so the hardcoded disabling can be removed.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [X] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [X] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
