### PR TITLE
doc: Remove outdated badges from README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,14 +6,6 @@
 SageMaker Python SDK
 ====================
 
-.. image:: https://travis-ci.org/aws/sagemaker-python-sdk.svg?branch=master
-   :target: https://travis-ci.org/aws/sagemaker-python-sdk
-   :alt: Build Status
-
-.. image:: https://codecov.io/gh/aws/sagemaker-python-sdk/branch/master/graph/badge.svg
-   :target: https://codecov.io/gh/aws/sagemaker-python-sdk
-   :alt: CodeCov
-
 .. image:: https://img.shields.io/pypi/v/sagemaker.svg
    :target: https://pypi.python.org/pypi/sagemaker
    :alt: Latest Version


### PR DESCRIPTION
*Description of changes:*
TravisCI and Codecov are no longer used. The badges have been removed.

*Testing done:*
N/A

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
