### PR TITLE
fix: modify session and kms_utils to check for S3 bucket before creation

### DIFF
--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -342,26 +342,29 @@ class Session(object):  # pylint: disable=too-many-public-methods
             ).get_caller_identity()["Account"]
             default_bucket = "sagemaker-{}-{}".format(region, account)
 
-        self.create_s3_bucket_if_it_does_not_exist(bucket_name=default_bucket, region=region)
+        self._create_s3_bucket_if_it_does_not_exist(bucket_name=default_bucket, region=region)
 
         self._default_bucket = default_bucket
 
         return self._default_bucket
 
-    def create_s3_bucket_if_it_does_not_exist(self, bucket_name, region):
+    def _create_s3_bucket_if_it_does_not_exist(self, bucket_name, region):
         """Creates an S3 Bucket if it does not exist.
-        Also swallows a few common exceptions that indicate that the bucket already exists, or
+        Also swallows a few common exceptions that indicate that the bucket already exists or
         that it is being created.
 
         Args:
             bucket_name (str): Name of the S3 bucket to be created.
             region (str): The region in which to create the bucket.
 
+        Raises:
+            ClientError: If boto S3 throws an unexpected exception.
+
         """
-        s3 = self.boto_session.resource("s3", region_name=region)
         bucket = self.boto_session.resource("s3", region_name=region).Bucket(name=bucket_name)
         if bucket.creation_date is None:
             try:
+                s3 = self.boto_session.resource("s3", region_name=region)
                 if region == "us-east-1":
                     # 'us-east-1' cannot be specified because it is the default region:
                     # https://github.com/boto/boto3/issues/125

--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -358,7 +358,7 @@ class Session(object):  # pylint: disable=too-many-public-methods
             region (str): The region in which to create the bucket.
 
         Raises:
-            ClientError: If boto S3 throws an unexpected exception.
+            ClientError: If S3 throws an unexpected exception.
 
         """
         bucket = self.boto_session.resource("s3", region_name=region).Bucket(name=bucket_name)

--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -358,7 +358,8 @@ class Session(object):  # pylint: disable=too-many-public-methods
             region (str): The region in which to create the bucket.
 
         Raises:
-            botocore.exceptions.ClientError: If S3 throws an unexpected exception during bucket creation.
+            botocore.exceptions.ClientError: If S3 throws an unexpected exception during bucket
+                creation.
                 If the exception is due to the bucket already existing or
                 already being created, no exception is raised.
 

--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -342,8 +342,8 @@ class Session(object):  # pylint: disable=too-many-public-methods
             ).get_caller_identity()["Account"]
             default_bucket = "sagemaker-{}-{}".format(region, account)
 
-        s3 = self.boto_session.resource("s3")
-        bucket = self.boto_session.resource("s3").Bucket(name=default_bucket)
+        s3 = self.boto_session.resource("s3", region_name=region)
+        bucket = self.boto_session.resource("s3", region_name=region).Bucket(name=default_bucket)
         if bucket.creation_date is None:
             try:
                 if region == "us-east-1":

--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -358,7 +358,9 @@ class Session(object):  # pylint: disable=too-many-public-methods
             region (str): The region in which to create the bucket.
 
         Raises:
-            ClientError: If S3 throws an unexpected exception.
+            botocore.exceptions.ClientError: If S3 throws an unexpected exception during bucket creation.
+                If the exception is due to the bucket already existing or
+                already being created, no exception is raised.
 
         """
         bucket = self.boto_session.resource("s3", region_name=region).Bucket(name=bucket_name)

--- a/tests/integ/kms_utils.py
+++ b/tests/integ/kms_utils.py
@@ -173,8 +173,8 @@ def bucket_with_encryption(boto_session, sagemaker_role):
     region = boto_session.region_name
     bucket_name = "sagemaker-{}-{}-with-kms".format(region, account)
 
-    s3 = boto_session.client("s3")
-    bucket = boto_session.resource("s3").Bucket(name=bucket_name)
+    s3 = boto_session.client("s3", region_name=region)
+    bucket = boto_session.resource("s3", region_name=region).Bucket(name=bucket_name)
     if bucket.creation_date is None:
         try:
             if region == "us-east-1":

--- a/tests/integ/kms_utils.py
+++ b/tests/integ/kms_utils.py
@@ -15,8 +15,6 @@ from __future__ import absolute_import
 import contextlib
 import json
 
-from botocore import exceptions
-
 from sagemaker import utils
 
 PRINCIPAL_TEMPLATE = (
@@ -158,7 +156,8 @@ KMS_BUCKET_POLICY = """{
 
 
 @contextlib.contextmanager
-def bucket_with_encryption(boto_session, sagemaker_role):
+def bucket_with_encryption(sagemaker_session, sagemaker_role):
+    boto_session = sagemaker_session.boto_session
     region = boto_session.region_name
     sts_client = boto_session.client(
         "sts", region_name=region, endpoint_url=utils.sts_regional_endpoint(region)
@@ -173,34 +172,10 @@ def bucket_with_encryption(boto_session, sagemaker_role):
     region = boto_session.region_name
     bucket_name = "sagemaker-{}-{}-with-kms".format(region, account)
 
-    s3 = boto_session.client("s3", region_name=region)
-    bucket = boto_session.resource("s3", region_name=region).Bucket(name=bucket_name)
-    if bucket.creation_date is None:
-        try:
-            if region == "us-east-1":
-                # 'us-east-1' cannot be specified because it is the default region:
-                # https://github.com/boto/boto3/issues/125
-                s3.create_bucket(Bucket=bucket_name)
-            else:
-                s3.create_bucket(
-                    Bucket=bucket_name, CreateBucketConfiguration={"LocationConstraint": region}
-                )
-        except exceptions.ClientError as e:
-            error_code = e.response["Error"]["Code"]
-            message = e.response["Error"]["Message"]
+    sagemaker_session.create_bucket_if_it_does_not_exist(bucket_name=bucket_name, region=region)
 
-            if error_code == "BucketAlreadyOwnedByYou":
-                pass
-            elif (
-                error_code == "OperationAborted" and "conflicting conditional operation" in message
-            ):
-                # If this bucket is already being concurrently created, we don't need to create it
-                # again.
-                pass
-            else:
-                raise
-
-    s3.put_bucket_encryption(
+    s3_client = boto_session.client("s3", region_name=region)
+    s3_client.put_bucket_encryption(
         Bucket=bucket_name,
         ServerSideEncryptionConfiguration={
             "Rules": [
@@ -214,7 +189,9 @@ def bucket_with_encryption(boto_session, sagemaker_role):
         },
     )
 
-    s3.put_bucket_policy(Bucket=bucket_name, Policy=KMS_BUCKET_POLICY % (bucket_name, bucket_name))
+    s3_client.put_bucket_policy(
+        Bucket=bucket_name, Policy=KMS_BUCKET_POLICY % (bucket_name, bucket_name)
+    )
 
     yield "s3://" + bucket_name, kms_key_arn
 

--- a/tests/integ/kms_utils.py
+++ b/tests/integ/kms_utils.py
@@ -172,7 +172,7 @@ def bucket_with_encryption(sagemaker_session, sagemaker_role):
     region = boto_session.region_name
     bucket_name = "sagemaker-{}-{}-with-kms".format(region, account)
 
-    sagemaker_session.create_bucket_if_it_does_not_exist(bucket_name=bucket_name, region=region)
+    sagemaker_session.create_s3_bucket_if_it_does_not_exist(bucket_name=bucket_name, region=region)
 
     s3_client = boto_session.client("s3", region_name=region)
     s3_client.put_bucket_encryption(

--- a/tests/integ/kms_utils.py
+++ b/tests/integ/kms_utils.py
@@ -172,7 +172,7 @@ def bucket_with_encryption(sagemaker_session, sagemaker_role):
     region = boto_session.region_name
     bucket_name = "sagemaker-{}-{}-with-kms".format(region, account)
 
-    sagemaker_session.create_s3_bucket_if_it_does_not_exist(bucket_name=bucket_name, region=region)
+    sagemaker_session._create_s3_bucket_if_it_does_not_exist(bucket_name=bucket_name, region=region)
 
     s3_client = boto_session.client("s3", region_name=region)
     s3_client.put_bucket_encryption(

--- a/tests/integ/kms_utils.py
+++ b/tests/integ/kms_utils.py
@@ -174,19 +174,31 @@ def bucket_with_encryption(boto_session, sagemaker_role):
     bucket_name = "sagemaker-{}-{}-with-kms".format(region, account)
 
     s3 = boto_session.client("s3")
-    try:
-        # 'us-east-1' cannot be specified because it is the default region:
-        # https://github.com/boto/boto3/issues/125
-        if region == "us-east-1":
-            s3.create_bucket(Bucket=bucket_name)
-        else:
-            s3.create_bucket(
-                Bucket=bucket_name, CreateBucketConfiguration={"LocationConstraint": region}
-            )
+    bucket = boto_session.resource("s3").Bucket(name=bucket_name)
+    if bucket.creation_date is None:
+        try:
+            if region == "us-east-1":
+                # 'us-east-1' cannot be specified because it is the default region:
+                # https://github.com/boto/boto3/issues/125
+                s3.create_bucket(Bucket=bucket_name)
+            else:
+                s3.create_bucket(
+                    Bucket=bucket_name, CreateBucketConfiguration={"LocationConstraint": region}
+                )
+        except exceptions.ClientError as e:
+            error_code = e.response["Error"]["Code"]
+            message = e.response["Error"]["Message"]
 
-    except exceptions.ClientError as e:
-        if e.response["Error"]["Code"] != "BucketAlreadyOwnedByYou":
-            raise
+            if error_code == "BucketAlreadyOwnedByYou":
+                pass
+            elif (
+                error_code == "OperationAborted" and "conflicting conditional operation" in message
+            ):
+                # If this bucket is already being concurrently created, we don't need to create it
+                # again.
+                pass
+            else:
+                raise
 
     s3.put_bucket_encryption(
         Bucket=bucket_name,

--- a/tests/integ/test_tf_script_mode.py
+++ b/tests/integ/test_tf_script_mode.py
@@ -83,8 +83,7 @@ def test_mnist_with_checkpoint_config(sagemaker_session, instance_type, tf_full_
 
 
 def test_server_side_encryption(sagemaker_session, tf_full_version):
-    boto_session = sagemaker_session.boto_session
-    with kms_utils.bucket_with_encryption(boto_session, ROLE) as (bucket_with_kms, kms_key):
+    with kms_utils.bucket_with_encryption(sagemaker_session, ROLE) as (bucket_with_kms, kms_key):
         output_path = os.path.join(
             bucket_with_kms, "test-server-side-encryption", time.strftime("%y%m%d-%H%M")
         )

--- a/tests/unit/test_default_bucket.py
+++ b/tests/unit/test_default_bucket.py
@@ -26,8 +26,9 @@ DEFAULT_BUCKET_NAME = "sagemaker-{}-{}".format(REGION, ACCOUNT_ID)
 def sagemaker_session():
     boto_mock = Mock(name="boto_session", region_name=REGION)
     boto_mock.client("sts").get_caller_identity.return_value = {"Account": ACCOUNT_ID}
-    ims = sagemaker.Session(boto_session=boto_mock)
-    return ims
+    sagemaker_session = sagemaker.Session(boto_session=boto_mock)
+    sagemaker_session.boto_session.resource("s3").Bucket().creation_date = None
+    return sagemaker_session
 
 
 def test_default_bucket_s3_create_call(sagemaker_session):


### PR DESCRIPTION
*Issue #, if available:* #1258 

*Description of changes:*
Previously, the code would create the bucket and enact business logic
based on the exceptions thrown.
This commit makes it such that the code checks that the bucket exists
before trying to create it.

In addition to being cleaner, this also avoids issues if customers
have no S3 bucket creation permissions.

*Testing done:*
UTs. PR will run ITs.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [X] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [X] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [X] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [X] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [X] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [X] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [X] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
