### PR TITLE
doc: correct broken AutoML API documentation link

### DIFF
--- a/src/sagemaker/automl/README.rst
+++ b/src/sagemaker/automl/README.rst
@@ -64,4 +64,4 @@ The simplest re-run is to feed a new dataset but reuse all other configurations 
 If you want to have more control over the step jobs of the candidate, you can call ``get_steps()`` and construct
 training/tuning jobs by yourself.
 
-For more information about ``CandidateEstimator`` parameters, please refer to: https://sagemaker.readthedocs.io/en/stable/sagemaker.candidate_estimator.html
+For more information about ``CandidateEstimator`` parameters, please refer to: https://sagemaker.readthedocs.io/en/stable/automl.html#sagemaker.automl.candidate_estimator.CandidateEstimator

--- a/src/sagemaker/automl/README.rst
+++ b/src/sagemaker/automl/README.rst
@@ -45,7 +45,7 @@ job. By calling this method, you can view and compare the candidates.
 #. Deploy the best candidate (or any given candidate): ``deploy()`` by default will deploy the best candidate to an
 inference pipeline. But you can also specify a candidate to deploy through ``candidate`` parameter.
 
-For more information about ``AutoML`` parameters, please refer to: https://sagemaker.readthedocs.io/en/stable/sagemaker.automl.html
+For more information about ``AutoML`` parameters, please refer to: https://sagemaker.readthedocs.io/en/stable/automl.html
 
 SageMaker CandidateEstimator Class
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/sagemaker-python-sdk/issues/1276

*Description of changes:* Fixing the broken AutoML API doc link.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [X] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [X] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [X] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [X] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [X] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [X] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [X] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
