### PR TITLE
fix: create Session or LocalSession if not specified in Model

### DIFF
--- a/src/sagemaker/model.py
+++ b/src/sagemaker/model.py
@@ -116,6 +116,10 @@ class Model(object):
         self.model_kms_key = model_kms_key
 
     def _init_sagemaker_session_if_does_not_exist(self, instance_type):
+        """Set ``self.sagemaker_session`` to be a ``LocalSession`` or
+        ``Session`` if it is not already. The type of session object is
+        determined by the instance type.
+        """
         if self.sagemaker_session:
             return
 

--- a/src/sagemaker/model.py
+++ b/src/sagemaker/model.py
@@ -20,6 +20,7 @@ import os
 import sagemaker
 from sagemaker import fw_utils, local, session, utils, git_utils
 from sagemaker.fw_utils import UploadedCode
+from sagemaker.session import Session
 from sagemaker.transformer import Transformer
 
 LOGGER = logging.getLogger("sagemaker")
@@ -108,7 +109,7 @@ class Model(object):
         self.env = env or {}
         self.name = name
         self.vpc_config = vpc_config
-        self.sagemaker_session = sagemaker_session
+        self.sagemaker_session = sagemaker_session or Session()
         self._model_name = None
         self.endpoint_name = None
         self._is_compiled_model = False

--- a/src/sagemaker/model.py
+++ b/src/sagemaker/model.py
@@ -514,6 +514,12 @@ class Model(object):
             volume_kms_key (str): Optional. KMS key ID for encrypting the volume
                 attached to the ML compute instance (default: None).
         """
+        if not self.sagemaker_session:
+            if instance_type in ("local", "local_gpu"):
+                self.sagemaker_session = local.LocalSession()
+            else:
+                self.sagemaker_session = session.Session()
+          
         self._create_sagemaker_model(instance_type, tags=tags)
         if self.enable_network_isolation():
             env = None

--- a/src/sagemaker/model.py
+++ b/src/sagemaker/model.py
@@ -225,7 +225,6 @@ class Model(object):
             else json.dumps(input_shape),
             "Framework": framework,
         }
-
         role = self.sagemaker_session.expand_role(role)
         output_model_config = {
             "TargetDevice": target_instance_type,

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -435,6 +435,21 @@ def test_model_create_transformer(sagemaker_session):
     sagemaker.model.Model._create_sagemaker_model.assert_called_with(instance_type, tags=tags)
 
 
+@patch("sagemaker.session.Session")
+@patch("sagemaker.local.LocalSession")
+@patch("sagemaker.fw_utils.tar_and_upload_dir", MagicMock())
+def test_transformer_creates_correct_session(local_session, session):
+    model = DummyFrameworkModel(sagemaker_session=None)
+    transformer = model.transformer(instance_count=1, instance_type="local")
+    assert model.sagemaker_session == local_session.return_value
+    assert transformer.sagemaker_session == local_session.return_value
+
+    model = DummyFrameworkModel(sagemaker_session=None)
+    transformer = model.transformer(instance_count=1, instance_type="ml.m5.xlarge")
+    assert model.sagemaker_session == session.return_value
+    assert transformer.sagemaker_session == session.return_value
+
+
 def test_model_package_enable_network_isolation_with_no_product_id(sagemaker_session):
     sagemaker_session.sagemaker_client.describe_model_package = Mock(
         return_value=DESCRIBE_MODEL_PACKAGE_RESPONSE
@@ -559,6 +574,21 @@ def test_compile_model_for_cloud(sagemaker_session, tmpdir):
         job_name="compile-model",
     )
     assert model._is_compiled_model is True
+
+
+@patch("sagemaker.session.Session")
+@patch("sagemaker.fw_utils.tar_and_upload_dir", MagicMock())
+def test_compile_creates_session(session):
+    model = DummyFrameworkModel(sagemaker_session=None)
+    model.compile(
+        target_instance_family="ml_c4",
+        input_shape={"data": [1, 3, 1024, 1024]},
+        output_path="s3://output",
+        role="role",
+        framework="tensorflow",
+    )
+
+    assert model.sagemaker_sesion == session.return_value
 
 
 def test_check_neo_region(sagemaker_session, tmpdir):

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -579,6 +579,8 @@ def test_compile_model_for_cloud(sagemaker_session, tmpdir):
 @patch("sagemaker.session.Session")
 @patch("sagemaker.fw_utils.tar_and_upload_dir", MagicMock())
 def test_compile_creates_session(session):
+    session.return_value.boto_region_name = "us-west-2"
+
     model = DummyFrameworkModel(sagemaker_session=None)
     model.compile(
         target_instance_family="ml_c4",
@@ -586,9 +588,10 @@ def test_compile_creates_session(session):
         output_path="s3://output",
         role="role",
         framework="tensorflow",
+        job_name="compile-model",
     )
 
-    assert model.sagemaker_sesion == session.return_value
+    assert model.sagemaker_session == session.return_value
 
 
 def test_check_neo_region(sagemaker_session, tmpdir):


### PR DESCRIPTION
*Issue #, if available:*
#1184 

*Description of changes:*
This is a combination of #1185 and #1156 due to the inactivity on both PRs. I originally thought it would make sense to put this in the constructor of `Model`, but determining which type of session object to include necessitates knowing the instance type :(

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
