### PR TITLE
doc: remove hardcoded list of target devices in compile()

### DIFF
--- a/src/sagemaker/estimator.py
+++ b/src/sagemaker/estimator.py
@@ -484,9 +484,9 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):
 
         Args:
             target_instance_family (str): Identifies the device that you want to
-                run your model after compilation, for example: ml_c5. Allowed
-                strings are: ml_c5, ml_m5, ml_c4, ml_m4, jetsontx1, jetsontx2,
-                ml_p2, ml_p3, deeplens, rasp3b
+                run your model after compilation, for example: ml_c5. For allowed
+                strings see
+                https://docs.aws.amazon.com/sagemaker/latest/dg/API_OutputConfig.html.
             input_shape (dict): Specifies the name and shape of the expected
                 inputs for your trained model in json dictionary form, for
                 example: {'data':[1,3,1024,1024]}, or {'var1': [1,1,28,28],

--- a/src/sagemaker/model.py
+++ b/src/sagemaker/model.py
@@ -284,9 +284,9 @@ class Model(object):
 
         Args:
             target_instance_family (str): Identifies the device that you want to
-                run your model after compilation, for example: ml_c5. Allowed
-                strings are: ml_c5, ml_m5, ml_c4, ml_m4, jetsontx1, jetsontx2,
-                ml_p2, ml_p3, deeplens, rasp3b
+                run your model after compilation, for example: ml_c5. For allowed
+                strings see
+                https://docs.aws.amazon.com/sagemaker/latest/dg/API_OutputConfig.html.
             input_shape (dict): Specifies the name and shape of the expected
                 inputs for your trained model in json dictionary form, for
                 example: {'data':[1,3,1024,1024]}, or {'var1': [1,1,28,28],


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Update inline documentation about valid compilation target devices to point to public AWS docs.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
