### PR TITLE
change: move requests library from required packages to test dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ required_packages = [
     "protobuf>=3.1",
     "scipy>=0.19.0",
     "protobuf3-to-dict>=0.1.5",
-    "requests>=2.20.0, <3",
     "smdebug-rulesconfig==0.1.2",
     "importlib-metadata>=1.4.0",
     "packaging>=20.0",
@@ -74,6 +73,7 @@ extras["test"] = (
         "stopit==1.1.2",
         "apache-airflow==1.10.5",
         "fabric>=2.0",
+        "requests>=2.20.0, <3",
     ],
 )
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
turns out requests is used for [only one integ test](https://github.com/aws/sagemaker-python-sdk/search?q=%22import+requests%22&unscoped_q=%22import+requests%22), so I don't think it needs to be a core dependency of this library.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
