### PR TITLE
fix: fix HyperparameterTuner.attach for Marketplace algorithms

### DIFF
--- a/src/sagemaker/estimator.py
+++ b/src/sagemaker/estimator.py
@@ -753,10 +753,10 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):
         has_hps = "HyperParameters" in job_details
         init_params["hyperparameters"] = job_details["HyperParameters"] if has_hps else {}
 
-        if "TrainingImage" in job_details["AlgorithmSpecification"]:
-            init_params["image"] = job_details["AlgorithmSpecification"]["TrainingImage"]
-        elif "AlgorithmName" in job_details["AlgorithmSpecification"]:
+        if "AlgorithmName" in job_details["AlgorithmSpecification"]:
             init_params["algorithm_arn"] = job_details["AlgorithmSpecification"]["AlgorithmName"]
+        elif "TrainingImage" in job_details["AlgorithmSpecification"]:
+            init_params["image"] = job_details["AlgorithmSpecification"]["TrainingImage"]
         else:
             raise RuntimeError(
                 "Invalid AlgorithmSpecification. Either TrainingImage or "

--- a/tests/unit/test_estimator.py
+++ b/tests/unit/test_estimator.py
@@ -2289,11 +2289,11 @@ def test_prepare_init_params_from_job_description_with_image_training_job():
 
 
 def test_prepare_init_params_from_job_description_with_algorithm_training_job():
-
     algorithm_job_description = RETURNED_JOB_DESCRIPTION.copy()
     algorithm_job_description["AlgorithmSpecification"] = {
         "TrainingInputMode": "File",
         "AlgorithmName": "arn:aws:sagemaker:us-east-2:1234:algorithm/scikit-decision-trees",
+        "TrainingImage": "",
     }
 
     init_params = EstimatorBase._prepare_init_params_from_job_description(


### PR DESCRIPTION
*Issue #, if available:*
follow-up to #1230 

*Description of changes:*
The AlgorithmSpecification for a training job that is part of a hyperparameter tuning job will have TrainingImage set to "", rather than not being present in the training job description. Looking for AlgorithmName first, instead of TrainingImage, fixes the issue of algorithm_arn not being populated when attaching a hyperparameter tuning job.

*Testing done:*
`tox tests/unit`

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
