### PR TITLE
change:enable network isolation for amazon estimators

### DIFF
--- a/src/sagemaker/amazon/amazon_estimator.py
+++ b/src/sagemaker/amazon/amazon_estimator.py
@@ -44,7 +44,13 @@ class AmazonAlgorithmEstimatorBase(EstimatorBase):
     repo_version = None
 
     def __init__(
-        self, role, train_instance_count, train_instance_type, data_location=None, **kwargs
+        self,
+        role,
+        train_instance_count,
+        train_instance_type,
+        data_location=None,
+        enable_network_isolation=False,
+        **kwargs
     ):
         """Initialize an AmazonAlgorithmEstimatorBase.
 
@@ -63,6 +69,10 @@ class AmazonAlgorithmEstimatorBase(EstimatorBase):
                 "s3://example-bucket/some-key-prefix/". Objects will be saved in
                 a unique sub-directory of the specified location. If None, a
                 default data location will be used.
+            enable_network_isolation (bool): Specifies whether container will
+                run in network isolation mode. Network isolation mode restricts
+                the container access to outside networks (such as the internet).
+                Also known as internet-free mode (default: `False`).
             **kwargs: Additional parameters passed to
                 :class:`~sagemaker.estimator.EstimatorBase`.
 
@@ -71,17 +81,6 @@ class AmazonAlgorithmEstimatorBase(EstimatorBase):
             You can find additional parameters for initializing this class at
             :class:`~sagemaker.estimator.EstimatorBase`.
         """
-
-        if "enable_network_isolation" in kwargs:
-            logger.debug(
-                "removing unused enable_network_isolation argument in base class: %s",
-                str(kwargs["enable_network_isolation"]),
-            )
-            self._enable_network_isolation = kwargs["enable_network_isolation"]
-            del kwargs["enable_network_isolation"]
-        else:
-            self._enable_network_isolation = False
-
         super(AmazonAlgorithmEstimatorBase, self).__init__(
             role, train_instance_count, train_instance_type, **kwargs
         )
@@ -90,6 +89,7 @@ class AmazonAlgorithmEstimatorBase(EstimatorBase):
             self.sagemaker_session.default_bucket()
         )
         self._data_location = data_location
+        self._enable_network_isolation = enable_network_isolation
 
     def train_image(self):
         """Placeholder docstring"""

--- a/src/sagemaker/amazon/amazon_estimator.py
+++ b/src/sagemaker/amazon/amazon_estimator.py
@@ -74,10 +74,13 @@ class AmazonAlgorithmEstimatorBase(EstimatorBase):
 
         if "enable_network_isolation" in kwargs:
             logger.debug(
-                "removing unused enable_network_isolation argument: %s",
+                "removing unused enable_network_isolation argument in base class: %s",
                 str(kwargs["enable_network_isolation"]),
             )
+            self._enable_network_isolation = kwargs["enable_network_isolation"]
             del kwargs["enable_network_isolation"]
+        else:
+            self._enable_network_isolation = False
 
         super(AmazonAlgorithmEstimatorBase, self).__init__(
             role, train_instance_count, train_instance_type, **kwargs
@@ -97,6 +100,14 @@ class AmazonAlgorithmEstimatorBase(EstimatorBase):
     def hyperparameters(self):
         """Placeholder docstring"""
         return hp.serialize_all(self)
+
+    def enable_network_isolation(self):
+        """If this Estimator can use network isolation when running.
+
+        Returns:
+            bool: Whether this Estimator can use network isolation or not.
+        """
+        return self._enable_network_isolation
 
     @property
     def data_location(self):

--- a/src/sagemaker/amazon/amazon_estimator.py
+++ b/src/sagemaker/amazon/amazon_estimator.py
@@ -72,7 +72,7 @@ class AmazonAlgorithmEstimatorBase(EstimatorBase):
             enable_network_isolation (bool): Specifies whether container will
                 run in network isolation mode. Network isolation mode restricts
                 the container access to outside networks (such as the internet).
-                Also known as internet-free mode (default: `False`).
+                Also known as internet-free mode (default: ``False``).
             **kwargs: Additional parameters passed to
                 :class:`~sagemaker.estimator.EstimatorBase`.
 

--- a/tests/integ/test_pca.py
+++ b/tests/integ/test_pca.py
@@ -41,6 +41,7 @@ def test_pca(sagemaker_session, cpu_instance_type):
             train_instance_type=cpu_instance_type,
             num_components=48,
             sagemaker_session=sagemaker_session,
+            enable_network_isolation=True,
         )
 
         pca.algorithm_mode = "randomized"
@@ -50,7 +51,10 @@ def test_pca(sagemaker_session, cpu_instance_type):
 
     with timeout_and_delete_endpoint_by_name(job_name, sagemaker_session):
         pca_model = sagemaker.amazon.pca.PCAModel(
-            model_data=pca.model_data, role="SageMakerRole", sagemaker_session=sagemaker_session
+            model_data=pca.model_data,
+            role="SageMakerRole",
+            sagemaker_session=sagemaker_session,
+            enable_network_isolation=True,
         )
         predictor = pca_model.deploy(
             initial_instance_count=1, instance_type=cpu_instance_type, endpoint_name=job_name

--- a/tests/unit/test_amazon_estimator.py
+++ b/tests/unit/test_amazon_estimator.py
@@ -93,6 +93,18 @@ def test_gov_ecr_uri():
 def test_init(sagemaker_session):
     pca = PCA(num_components=55, sagemaker_session=sagemaker_session, **COMMON_ARGS)
     assert pca.num_components == 55
+    assert pca.enable_network_isolation() is False
+
+
+def test_init_enable_network_isolation(sagemaker_session):
+    pca = PCA(
+        num_components=55,
+        sagemaker_session=sagemaker_session,
+        enable_network_isolation=True,
+        **COMMON_ARGS
+    )
+    assert pca.num_components == 55
+    assert pca.enable_network_isolation() is True
 
 
 def test_init_all_pca_hyperparameters(sagemaker_session):


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* 
This enables the network isolation mode for Amazon Estimator, which is the super class for all 1P algorithm estimators. 

*Testing done:*  
unittest and integration test. Verified launched PCA training job and models are with network isolation feature and successful.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
