### PR TITLE
fix: allow download_folder to download file even if bucket is more restricted

### DIFF
--- a/src/sagemaker/utils.py
+++ b/src/sagemaker/utils.py
@@ -23,13 +23,12 @@ import sys
 import tarfile
 import tempfile
 import time
-
-
 from datetime import datetime
 from functools import wraps
 
 import six
 from six.moves.urllib import parse
+import botocore
 
 
 ECR_URI_PATTERN = r"^(\d+)(\.)dkr(\.)ecr(\.)(.+)(\.)(amazonaws.com|c2s.ic.gov)(/)(.*:.*)$"
@@ -338,21 +337,25 @@ def download_folder(bucket_name, prefix, target, sagemaker_session):
             interact with S3.
     """
     boto_session = sagemaker_session.boto_session
+    s3 = boto_session.resource("s3", region_name=boto_session.region_name)
 
-    s3 = boto_session.resource("s3")
     bucket = s3.Bucket(bucket_name)
-
     prefix = prefix.lstrip("/")
 
-    # there is a chance that the prefix points to a file and not a 'directory' if that is the case
-    # we should just download it.
-    objects = list(bucket.objects.filter(Prefix=prefix))
-
-    if len(objects) > 0 and objects[0].key == prefix and prefix[-1] != "/":
+    # Try to download the prefix as an object first, in case it is a file and not a 'directory'.
+    # Do this first, in case the object has broader permissions than the bucket.
+    try:
         s3.Object(bucket_name, prefix).download_file(os.path.join(target, os.path.basename(prefix)))
         return
+    except botocore.exceptions.ClientError as e:
+        if e.response["Error"]["Code"] == "404" and e.response["Error"]["Message"] == "Not Found":
+            # S3 also throws this error if the object is a folder,
+            # so assume that is the case here, and then raise for an actual 404 later.
+            pass
+        else:
+            raise
 
-    # the prefix points to an s3 'directory' download the whole thing
+    # Assume the prefix points to an S3 'directory' and download the whole thing
     for obj_sum in bucket.objects.filter(Prefix=prefix):
         # if obj_sum is a folder object skip it.
         if obj_sum.key != "" and obj_sum.key[-1] == "/":


### PR DESCRIPTION
*Issue #, if available:*
#1283

*Description of changes:*
S3 doesn't provide a way of definitively determining if a prefix is a folder, so originally we used `ListObjects` to try and gauge that. However, `ListObjects` requires extra permissions on the bucket, and so download a public file from a private bucket fails. In this PR, I've changed the logic to try and download the file first, and then if that incurs a 404 because it's a folder (no idea why that's how S3 chooses to implement this...), then the code will proceed with as if the prefix points to a folder.

Side note - I noticed that pylint was requiring me to put `botocore` in the wrong order for the imports. I'll fix that in a separate PR.

*Testing done:*
tried the example S3 path from #1283:

```python
>>> import sagemaker
>>> from sagemaker import utils
>>> utils.download_folder('lausen-public', 'bert_sst.tar.gz', '/tmp', sagemaker.session.Session())
```

```bash
$ ls /tmp/bert_sst.tar.gz
/tmp/bert_sst.tar.gz
```

(also ran `tox tests/unit`)

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
