### PR TITLE
change: dynamically determine AWS domain based on region

### DIFF
--- a/src/sagemaker/utils.py
+++ b/src/sagemaker/utils.py
@@ -26,9 +26,9 @@ import time
 from datetime import datetime
 from functools import wraps
 
+import botocore
 import six
 from six.moves.urllib import parse
-import botocore
 
 
 ECR_URI_PATTERN = r"^(\d+)(\.)dkr(\.)ecr(\.)(.+)(\.)(amazonaws.com|c2s.ic.gov)(/)(.*:.*)$"
@@ -611,8 +611,8 @@ def get_ecr_image_uri_prefix(account, region):
     Returns:
         (str): URI prefix of ECR image
     """
-    domain = _domain_for_region(region)
-    return "{}.dkr.ecr.{}.{}".format(account, region, domain)
+    endpoint_data = _botocore_resolver().construct_endpoint("ecr", region)
+    return "{}.dkr.ecr.{}.{}".format(account, region, endpoint_data["dnsSuffix"])
 
 
 def sts_regional_endpoint(region):
@@ -630,8 +630,8 @@ def sts_regional_endpoint(region):
     Returns:
         str: AWS STS regional endpoint
     """
-    domain = _domain_for_region(region)
-    return "https://sts.{}.{}".format(region, domain)
+    endpoint_data = _botocore_resolver().construct_endpoint("sts", region)
+    return "https://{}".format(endpoint_data["hostname"])
 
 
 def retries(max_retry_count, exception_message_prefix, seconds_to_sleep=DEFAULT_SLEEP_TIME_SECONDS):
@@ -654,7 +654,7 @@ def retries(max_retry_count, exception_message_prefix, seconds_to_sleep=DEFAULT_
     )
 
 
-def _domain_for_region(region):
+def _botocore_resolver():
     """Get the DNS suffix for the given region.
 
     Args:
@@ -663,7 +663,8 @@ def _domain_for_region(region):
     Returns:
         str: the DNS suffix
     """
-    return "c2s.ic.gov" if region == "us-iso-east-1" else "amazonaws.com"
+    loader = botocore.loaders.create_loader()
+    return botocore.regions.EndpointResolver(loader.load_data("endpoints"))
 
 
 class DeferredError(object):

--- a/src/sagemaker/utils.py
+++ b/src/sagemaker/utils.py
@@ -612,7 +612,7 @@ def get_ecr_image_uri_prefix(account, region):
         (str): URI prefix of ECR image
     """
     endpoint_data = _botocore_resolver().construct_endpoint("ecr", region)
-    return "{}.dkr.ecr.{}.{}".format(account, region, endpoint_data["dnsSuffix"])
+    return "{}.dkr.{}".format(account, endpoint_data["hostname"])
 
 
 def sts_regional_endpoint(region):

--- a/tests/unit/test_airflow.py
+++ b/tests/unit/test_airflow.py
@@ -173,7 +173,11 @@ def test_byo_training_config_all_args(sagemaker_session):
         ]
     ),
 )
-def test_framework_training_config_required_args(sagemaker_session):
+@patch(
+    "sagemaker.fw_utils.get_ecr_image_uri_prefix",
+    return_value="520713654638.dkr.ecr.us-west-2.amazonaws.com",
+)
+def test_framework_training_config_required_args(ecr_prefix, sagemaker_session):
     tf = tensorflow.TensorFlow(
         entry_point="/some/script.py",
         framework_version="1.10.0",
@@ -248,7 +252,11 @@ def test_framework_training_config_required_args(sagemaker_session):
     "sagemaker.estimator.parse_s3_url",
     MagicMock(return_value=["{{ output_path }}", "{{ output_path }}"]),
 )
-def test_framework_training_config_all_args(sagemaker_session):
+@patch(
+    "sagemaker.fw_utils.get_ecr_image_uri_prefix",
+    return_value="520713654638.dkr.ecr.us-west-2.amazonaws.com",
+)
+def test_framework_training_config_all_args(ecr_prefix, sagemaker_session):
     tf = tensorflow.TensorFlow(
         entry_point="{{ entry_point }}",
         source_dir="{{ source_dir }}",
@@ -478,7 +486,11 @@ def test_amazon_alg_training_config_all_args(sagemaker_session):
         ]
     ),
 )
-def test_framework_tuning_config(sagemaker_session):
+@patch(
+    "sagemaker.fw_utils.get_ecr_image_uri_prefix",
+    return_value="520713654638.dkr.ecr.us-west-2.amazonaws.com",
+)
+def test_framework_tuning_config(ecr_prefix, sagemaker_session):
     mxnet_estimator = mxnet.MXNet(
         entry_point="{{ entry_point }}",
         source_dir="{{ source_dir }}",
@@ -617,7 +629,15 @@ def test_framework_tuning_config(sagemaker_session):
         ]
     ),
 )
-def test_multi_estimator_tuning_config(sagemaker_session):
+@patch(
+    "sagemaker.fw_utils.get_ecr_image_uri_prefix",
+    return_value="520713654638.dkr.ecr.us-west-2.amazonaws.com",
+)
+@patch(
+    "sagemaker.amazon.amazon_estimator.get_ecr_image_uri_prefix",
+    return_value="174872318107.dkr.ecr.us-west-2.amazonaws.com",
+)
+def test_multi_estimator_tuning_config(algo_ecr_prefix, fw_ecr_prefix, sagemaker_session):
     estimator_dict = {}
     hyperparameter_ranges_dict = {}
     objective_metric_name_dict = {}
@@ -1025,7 +1045,11 @@ def test_amazon_alg_model_config(sagemaker_session):
         ]
     ),
 )
-def test_model_config_from_framework_estimator(sagemaker_session):
+@patch(
+    "sagemaker.fw_utils.get_ecr_image_uri_prefix",
+    return_value="763104351884.dkr.ecr.us-west-2.amazonaws.com",
+)
+def test_model_config_from_framework_estimator(ecr_prefix, sagemaker_session):
     mxnet_estimator = mxnet.MXNet(
         entry_point="{{ entry_point }}",
         source_dir="{{ source_dir }}",
@@ -1179,7 +1203,11 @@ def test_transform_config(sagemaker_session):
         ]
     ),
 )
-def test_transform_config_from_framework_estimator(sagemaker_session):
+@patch(
+    "sagemaker.fw_utils.get_ecr_image_uri_prefix",
+    return_value="763104351884.dkr.ecr.us-west-2.amazonaws.com",
+)
+def test_transform_config_from_framework_estimator(ecr_prefix, sagemaker_session):
     mxnet_estimator = mxnet.MXNet(
         entry_point="{{ entry_point }}",
         source_dir="{{ source_dir }}",
@@ -1420,7 +1448,11 @@ def test_deploy_amazon_alg_model_config(sagemaker_session):
         ]
     ),
 )
-def test_deploy_config_from_framework_estimator(sagemaker_session):
+@patch(
+    "sagemaker.fw_utils.get_ecr_image_uri_prefix",
+    return_value="763104351884.dkr.ecr.us-west-2.amazonaws.com",
+)
+def test_deploy_config_from_framework_estimator(ecr_prefix, sagemaker_session):
     mxnet_estimator = mxnet.MXNet(
         entry_point="{{ entry_point }}",
         source_dir="{{ source_dir }}",

--- a/tests/unit/test_fw_utils.py
+++ b/tests/unit/test_fw_utils.py
@@ -29,7 +29,9 @@ ROLE = "Sagemaker"
 REGION = "us-west-2"
 SCRIPT_PATH = "script.py"
 TIMESTAMP = "2017-10-10-14-14-15"
+ECR_PREFIX_FORMAT = "{}.dkr.ecr.mars-south-3.amazonaws.com"
 
+MOCK_ACCOUNT = "520713654638"
 MOCK_FRAMEWORK = "mlfw"
 MOCK_REGION = "mars-south-3"
 MOCK_ACCELERATOR = "eia1.medium"
@@ -165,7 +167,9 @@ def sagemaker_session():
     return session_mock
 
 
-def test_create_image_uri_cpu():
+@patch("sagemaker.fw_utils.get_ecr_image_uri_prefix")
+def test_create_image_uri_cpu(ecr_prefix):
+    ecr_prefix.return_value = ECR_PREFIX_FORMAT.format("23")
     image_uri = fw_utils.create_image_uri(
         MOCK_REGION, MOCK_FRAMEWORK, "ml.c4.large", "1.0rc", "py2", "23"
     )
@@ -176,6 +180,7 @@ def test_create_image_uri_cpu():
     )
     assert image_uri == "23.dkr.ecr.mars-south-3.amazonaws.com/sagemaker-mlfw:1.0rc-cpu-py2"
 
+    ecr_prefix.return_value = "246785580436.dkr.ecr.us-gov-west-1.amazonaws.com"
     image_uri = fw_utils.create_image_uri(
         "us-gov-west-1", MOCK_FRAMEWORK, "ml.c4.large", "1.0rc", "py2"
     )
@@ -183,13 +188,15 @@ def test_create_image_uri_cpu():
         image_uri == "246785580436.dkr.ecr.us-gov-west-1.amazonaws.com/sagemaker-mlfw:1.0rc-cpu-py2"
     )
 
+    ecr_prefix.return_value = "744548109606.dkr.ecr.us-iso-east-1.c2s.ic.gov"
     image_uri = fw_utils.create_image_uri(
         "us-iso-east-1", MOCK_FRAMEWORK, "ml.c4.large", "1.0rc", "py2"
     )
     assert image_uri == "744548109606.dkr.ecr.us-iso-east-1.c2s.ic.gov/sagemaker-mlfw:1.0rc-cpu-py2"
 
 
-def test_create_image_uri_no_python():
+@patch("sagemaker.fw_utils.get_ecr_image_uri_prefix", return_value=ECR_PREFIX_FORMAT.format("23"))
+def test_create_image_uri_no_python(ecr_prefix):
     image_uri = fw_utils.create_image_uri(
         MOCK_REGION, MOCK_FRAMEWORK, "ml.c4.large", "1.0rc", account="23"
     )
@@ -201,7 +208,8 @@ def test_create_image_uri_bad_python():
         fw_utils.create_image_uri(MOCK_REGION, MOCK_FRAMEWORK, "ml.c4.large", "1.0rc", "py0")
 
 
-def test_create_image_uri_gpu():
+@patch("sagemaker.fw_utils.get_ecr_image_uri_prefix", return_value=ECR_PREFIX_FORMAT.format("23"))
+def test_create_image_uri_gpu(ecr_prefix):
     image_uri = fw_utils.create_image_uri(
         MOCK_REGION, MOCK_FRAMEWORK, "ml.p3.2xlarge", "1.0rc", "py3", "23"
     )
@@ -213,7 +221,8 @@ def test_create_image_uri_gpu():
     assert image_uri == "23.dkr.ecr.mars-south-3.amazonaws.com/sagemaker-mlfw:1.0rc-gpu-py3"
 
 
-def test_create_image_uri_accelerator_tfs():
+@patch("sagemaker.fw_utils.get_ecr_image_uri_prefix", return_value=ECR_PREFIX_FORMAT.format("23"))
+def test_create_image_uri_accelerator_tfs(ecr_prefix):
     image_uri = fw_utils.create_image_uri(
         MOCK_REGION,
         "tensorflow-serving",
@@ -228,7 +237,11 @@ def test_create_image_uri_accelerator_tfs():
     )
 
 
-def test_create_image_uri_default_account():
+@patch(
+    "sagemaker.fw_utils.get_ecr_image_uri_prefix",
+    return_value=ECR_PREFIX_FORMAT.format(MOCK_ACCOUNT),
+)
+def test_create_image_uri_default_account(ecr_prefix):
     image_uri = fw_utils.create_image_uri(
         MOCK_REGION, MOCK_FRAMEWORK, "ml.p3.2xlarge", "1.0rc", "py3"
     )
@@ -511,7 +524,11 @@ def test_create_image_uri_tensorflow(tf_version):
         )
 
 
-def test_create_image_uri_accelerator_tf():
+@patch(
+    "sagemaker.fw_utils.get_ecr_image_uri_prefix",
+    return_value=ECR_PREFIX_FORMAT.format(MOCK_ACCOUNT),
+)
+def test_create_image_uri_accelerator_tf(ecr_prefix):
     image_uri = fw_utils.create_image_uri(
         MOCK_REGION, "tensorflow", "ml.p3.2xlarge", "1.0", "py3", accelerator_type="ml.eia1.medium"
     )
@@ -521,7 +538,11 @@ def test_create_image_uri_accelerator_tf():
     )
 
 
-def test_create_image_uri_accelerator_mxnet_serving():
+@patch(
+    "sagemaker.fw_utils.get_ecr_image_uri_prefix",
+    return_value=ECR_PREFIX_FORMAT.format(MOCK_ACCOUNT),
+)
+def test_create_image_uri_accelerator_mxnet_serving(ecr_prefix):
     image_uri = fw_utils.create_image_uri(
         MOCK_REGION,
         "mxnet-serving",
@@ -536,7 +557,11 @@ def test_create_image_uri_accelerator_mxnet_serving():
     )
 
 
-def test_create_image_uri_local_sagemaker_notebook_accelerator():
+@patch(
+    "sagemaker.fw_utils.get_ecr_image_uri_prefix",
+    return_value=ECR_PREFIX_FORMAT.format(MOCK_ACCOUNT),
+)
+def test_create_image_uri_local_sagemaker_notebook_accelerator(ecr_prefix):
     image_uri = fw_utils.create_image_uri(
         MOCK_REGION,
         "mxnet",
@@ -608,7 +633,11 @@ def test_invalid_instance_type():
         fw_utils.create_image_uri(MOCK_REGION, MOCK_FRAMEWORK, "p3.2xlarge", "1.0.0", "py3")
 
 
-def test_optimized_family():
+@patch(
+    "sagemaker.fw_utils.get_ecr_image_uri_prefix",
+    return_value=ECR_PREFIX_FORMAT.format(MOCK_ACCOUNT),
+)
+def test_optimized_family(ecr_prefix):
     image_uri = fw_utils.create_image_uri(
         MOCK_REGION,
         MOCK_FRAMEWORK,
@@ -622,7 +651,11 @@ def test_optimized_family():
     )
 
 
-def test_unoptimized_cpu_family():
+@patch(
+    "sagemaker.fw_utils.get_ecr_image_uri_prefix",
+    return_value=ECR_PREFIX_FORMAT.format(MOCK_ACCOUNT),
+)
+def test_unoptimized_cpu_family(ecr_prefix):
     image_uri = fw_utils.create_image_uri(
         MOCK_REGION, MOCK_FRAMEWORK, "ml.m4.xlarge", "1.0.0", "py3", optimized_families=["c5", "p3"]
     )
@@ -631,7 +664,11 @@ def test_unoptimized_cpu_family():
     )
 
 
-def test_unoptimized_gpu_family():
+@patch(
+    "sagemaker.fw_utils.get_ecr_image_uri_prefix",
+    return_value=ECR_PREFIX_FORMAT.format(MOCK_ACCOUNT),
+)
+def test_unoptimized_gpu_family(ecr_prefix):
     image_uri = fw_utils.create_image_uri(
         MOCK_REGION, MOCK_FRAMEWORK, "ml.p2.xlarge", "1.0.0", "py3", optimized_families=["c5", "p3"]
     )

--- a/tests/unit/test_processing.py
+++ b/tests/unit/test_processing.py
@@ -28,6 +28,7 @@ from sagemaker.network import NetworkConfig
 BUCKET_NAME = "mybucket"
 REGION = "us-west-2"
 ROLE = "arn:aws:iam::012345678901:role/SageMakerRole"
+ECR_PREFIX = "246618743249.dkr.ecr.us-west-2.amazonaws.com"
 CUSTOM_IMAGE_URI = "012345678901.dkr.ecr.us-west-2.amazonaws.com/my-custom-image-uri"
 
 PROCESSING_JOB_DESCRIPTION = {
@@ -94,9 +95,12 @@ def sagemaker_session():
     return session_mock
 
 
+@patch("sagemaker.fw_registry.get_ecr_image_uri_prefix", return_value=ECR_PREFIX)
 @patch("os.path.exists", return_value=True)
 @patch("os.path.isfile", return_value=True)
-def test_sklearn_processor_with_required_parameters(exists_mock, isfile_mock, sagemaker_session):
+def test_sklearn_processor_with_required_parameters(
+    exists_mock, isfile_mock, ecr_prefix, sagemaker_session
+):
     processor = SKLearnProcessor(
         role=ROLE,
         instance_type="ml.m4.xlarge",
@@ -117,9 +121,10 @@ def test_sklearn_processor_with_required_parameters(exists_mock, isfile_mock, sa
     sagemaker_session.process.assert_called_with(**expected_args)
 
 
+@patch("sagemaker.fw_registry.get_ecr_image_uri_prefix", return_value=ECR_PREFIX)
 @patch("os.path.exists", return_value=True)
 @patch("os.path.isfile", return_value=True)
-def test_sklearn_with_all_parameters(exists_mock, isfile_mock, sagemaker_session):
+def test_sklearn_with_all_parameters(exists_mock, isfile_mock, ecr_prefix, sagemaker_session):
     processor = SKLearnProcessor(
         role=ROLE,
         framework_version="0.20.0",

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -301,7 +301,10 @@ def test_get_caller_identity_arn_from_describe_notebook_instance(boto_session):
 
 @patch("six.moves.builtins.open", mock_open(read_data='{"ResourceName": "SageMakerInstance"}'))
 @patch("os.path.exists", side_effect=mock_exists(NOTEBOOK_METADATA_FILE, True))
-def test_get_caller_identity_arn_from_a_role_after_describe_notebook_exception(boto_session):
+@patch("sagemaker.session.sts_regional_endpoint", return_value=STS_ENDPOINT)
+def test_get_caller_identity_arn_from_a_role_after_describe_notebook_exception(
+    sts_regional_endpoint, boto_session
+):
     sess = Session(boto_session)
     exception = ClientError(
         {"Error": {"Code": "ValidationException", "Message": "RecordNotFound"}}, "Operation"
@@ -329,7 +332,8 @@ def test_get_caller_identity_arn_from_a_role_after_describe_notebook_exception(b
 
 
 @patch("os.path.exists", side_effect=mock_exists(NOTEBOOK_METADATA_FILE, False))
-def test_get_caller_identity_arn_from_an_user(boto_session):
+@patch("sagemaker.session.sts_regional_endpoint", return_value=STS_ENDPOINT)
+def test_get_caller_identity_arn_from_a_user(sts_regional_endpoint, boto_session):
     sess = Session(boto_session)
     arn = "arn:aws:iam::369233609183:user/mia"
     sess.boto_session.client("sts", endpoint_url=STS_ENDPOINT).get_caller_identity.return_value = {
@@ -342,7 +346,10 @@ def test_get_caller_identity_arn_from_an_user(boto_session):
 
 
 @patch("os.path.exists", side_effect=mock_exists(NOTEBOOK_METADATA_FILE, False))
-def test_get_caller_identity_arn_from_an_user_without_permissions(boto_session):
+@patch("sagemaker.session.sts_regional_endpoint", return_value=STS_ENDPOINT)
+def test_get_caller_identity_arn_from_an_user_without_permissions(
+    sts_regional_endpoint, boto_session
+):
     sess = Session(boto_session)
     arn = "arn:aws:iam::369233609183:user/mia"
     sess.boto_session.client("sts", endpoint_url=STS_ENDPOINT).get_caller_identity.return_value = {
@@ -357,7 +364,8 @@ def test_get_caller_identity_arn_from_an_user_without_permissions(boto_session):
 
 
 @patch("os.path.exists", side_effect=mock_exists(NOTEBOOK_METADATA_FILE, False))
-def test_get_caller_identity_arn_from_a_role(boto_session):
+@patch("sagemaker.session.sts_regional_endpoint", return_value=STS_ENDPOINT)
+def test_get_caller_identity_arn_from_a_role(sts_regional_endpoint, boto_session):
     sess = Session(boto_session)
     arn = (
         "arn:aws:sts::369233609183:assumed-role/SageMakerRole/6d009ef3-5306-49d5-8efc-78db644d8122"
@@ -374,7 +382,8 @@ def test_get_caller_identity_arn_from_a_role(boto_session):
 
 
 @patch("os.path.exists", side_effect=mock_exists(NOTEBOOK_METADATA_FILE, False))
-def test_get_caller_identity_arn_from_a_execution_role(boto_session):
+@patch("sagemaker.session.sts_regional_endpoint", return_value=STS_ENDPOINT)
+def test_get_caller_identity_arn_from_an_execution_role(sts_regional_endpoint, boto_session):
     sess = Session(boto_session)
     arn = "arn:aws:sts::369233609183:assumed-role/AmazonSageMaker-ExecutionRole-20171129T072388/SageMaker"
     sess.boto_session.client("sts", endpoint_url=STS_ENDPOINT).get_caller_identity.return_value = {
@@ -390,7 +399,8 @@ def test_get_caller_identity_arn_from_a_execution_role(boto_session):
 
 
 @patch("os.path.exists", side_effect=mock_exists(NOTEBOOK_METADATA_FILE, False))
-def test_get_caller_identity_arn_from_role_with_path(boto_session):
+@patch("sagemaker.session.sts_regional_endpoint", return_value=STS_ENDPOINT)
+def test_get_caller_identity_arn_from_role_with_path(sts_regional_endpoint, boto_session):
     sess = Session(boto_session)
     arn_prefix = "arn:aws:iam::369233609183:role"
     role_name = "name"

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -683,6 +683,14 @@ def list_tar_files(tar_ball, tmp):
     return result if result else {}
 
 
+def test_get_ecr_image_uri_prefix():
+    ecr_prefix = sagemaker.utils.get_ecr_image_uri_prefix("123456789012", "us-west-2")
+    assert ecr_prefix == "123456789012.dkr.ecr.us-west-2.amazonaws.com"
+
+    ecr_prefix = sagemaker.utils.get_ecr_image_uri_prefix("123456789012", "us-iso-east-1")
+    assert ecr_prefix == "123456789012.dkr.ecr.us-iso-east-1.c2s.ic.gov"
+
+
 def test_sts_regional_endpoint():
     endpoint = sagemaker.utils.sts_regional_endpoint("us-west-2")
     assert endpoint == "https://sts.us-west-2.amazonaws.com"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Finally paying back my tech debt from #1054 

*Testing done:*
`tox -e black-format,pylint,py36 tests/unit`

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
