### PR TITLE
fix: don't use os.path.join for S3 path when repacking TFS model

### DIFF
--- a/src/sagemaker/tensorflow/serving.py
+++ b/src/sagemaker/tensorflow/serving.py
@@ -14,7 +14,6 @@
 from __future__ import absolute_import
 
 import logging
-import os
 
 import sagemaker
 from sagemaker.content_types import CONTENT_TYPE_JSON
@@ -229,7 +228,7 @@ class Model(sagemaker.model.FrameworkModel):
             key_prefix = sagemaker.fw_utils.model_code_key_prefix(self.key_prefix, self.name, image)
 
             bucket = self.bucket or self.sagemaker_session.default_bucket()
-            model_data = "s3://" + os.path.join(bucket, key_prefix, "model.tar.gz")
+            model_data = "s3://{}/{}/model.tar.gz".format(bucket, key_prefix)
 
             sagemaker.utils.repack_model(
                 self.entry_point,


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/sagemaker-python-sdk/issues/831#issuecomment-588122114

*Description of changes:*
S3 paths always use forward slashes ("/") regardless of the OS, so using `os.path.join` will cause issues when the user is on Windows.

*Testing done:*
`tox --parallel all tests/unit`

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
