### PR TITLE
change: enable Neo integ tests

### DIFF
--- a/src/sagemaker/model.py
+++ b/src/sagemaker/model.py
@@ -304,8 +304,8 @@ class Model(object):
                 https://docs.aws.amazon.com/sagemaker/latest/dg/API_OutputConfig.html.
             input_shape (dict): Specifies the name and shape of the expected
                 inputs for your trained model in json dictionary form, for
-                example: {'data':[1,3,1024,1024]}, or {'var1': [1,1,28,28],
-                'var2':[1,1,28,28]}
+                example: {'data': [1,3,1024,1024]}, or {'var1': [1,1,28,28],
+                'var2': [1,1,28,28]}
             output_path (str): Specifies where to store the compiled model
             role (str): Execution role
             tags (list[dict]): List of tags for labeling a compilation job. For
@@ -436,7 +436,8 @@ class Model(object):
 
         compiled_model_suffix = "-".join(instance_type.split(".")[:-1])
         if self._is_compiled_model:
-            self.name += compiled_model_suffix
+            name_prefix = self.name or utils.name_from_image(self.image)
+            self.name = "{}{}".format(name_prefix, compiled_model_suffix)
 
         self._create_sagemaker_model(instance_type, accelerator_type, tags)
         production_variant = sagemaker.production_variant(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -286,7 +286,7 @@ def alternative_cpu_instance_type(sagemaker_session, request):
 
 @pytest.fixture(scope="session")
 def cpu_instance_family(cpu_instance_type):
-    "_".join(cpu_instance_type.split(".")[0:2])
+    return "_".join(cpu_instance_type.split(".")[0:2])
 
 
 def pytest_generate_tests(metafunc):

--- a/tests/integ/test_neo_mxnet.py
+++ b/tests/integ/test_neo_mxnet.py
@@ -22,9 +22,11 @@ from tests.integ import DATA_DIR, PYTHON_VERSION, TRAINING_DEFAULT_TIMEOUT_MINUT
 from tests.integ.timeout import timeout, timeout_and_delete_endpoint_by_name
 import time
 
+NEO_MXNET_VERSION = "1.4.1"  # Neo doesn't support MXNet 1.6 yet.
+
 
 @pytest.fixture(scope="module")
-def mxnet_training_job(sagemaker_session, mxnet_full_version, cpu_instance_type):
+def mxnet_training_job(sagemaker_session, cpu_instance_type):
     with timeout(minutes=TRAINING_DEFAULT_TIMEOUT_MINUTES):
         script_path = os.path.join(DATA_DIR, "mxnet_mnist", "mnist_neo.py")
         data_path = os.path.join(DATA_DIR, "mxnet_mnist")
@@ -32,7 +34,7 @@ def mxnet_training_job(sagemaker_session, mxnet_full_version, cpu_instance_type)
         mx = MXNet(
             entry_point=script_path,
             role="SageMakerRole",
-            framework_version=mxnet_full_version,
+            framework_version=NEO_MXNET_VERSION,
             py_version=PYTHON_VERSION,
             train_instance_count=1,
             train_instance_type=cpu_instance_type,
@@ -52,9 +54,6 @@ def mxnet_training_job(sagemaker_session, mxnet_full_version, cpu_instance_type)
 
 @pytest.mark.canary_quick
 @pytest.mark.regional_testing
-@pytest.mark.skip(
-    reason="This should be enabled along with the Boto SDK release for Neo API changes"
-)
 def test_attach_deploy(
     mxnet_training_job, sagemaker_session, cpu_instance_type, cpu_instance_family
 ):
@@ -77,9 +76,6 @@ def test_attach_deploy(
         predictor.predict(data)
 
 
-@pytest.mark.skip(
-    reason="This should be enabled along with the Boto SDK release for Neo API changes"
-)
 def test_deploy_model(
     mxnet_training_job, sagemaker_session, cpu_instance_type, cpu_instance_family
 ):
@@ -97,6 +93,7 @@ def test_deploy_model(
             role,
             entry_point=script_path,
             py_version=PYTHON_VERSION,
+            framework_version=NEO_MXNET_VERSION,
             sagemaker_session=sagemaker_session,
         )
 

--- a/tests/integ/test_neo_mxnet.py
+++ b/tests/integ/test_neo_mxnet.py
@@ -12,15 +12,16 @@
 # language governing permissions and limitations under the License.
 from __future__ import absolute_import
 
-import numpy
 import os
+
+import numpy
 import pytest
+
 from sagemaker.mxnet.estimator import MXNet
 from sagemaker.mxnet.model import MXNetModel
-from sagemaker.utils import sagemaker_timestamp
+from sagemaker.utils import unique_name_from_base
 from tests.integ import DATA_DIR, PYTHON_VERSION, TRAINING_DEFAULT_TIMEOUT_MINUTES
 from tests.integ.timeout import timeout, timeout_and_delete_endpoint_by_name
-import time
 
 NEO_MXNET_VERSION = "1.4.1"  # Neo doesn't support MXNet 1.6 yet.
 
@@ -57,7 +58,7 @@ def mxnet_training_job(sagemaker_session, cpu_instance_type):
 def test_attach_deploy(
     mxnet_training_job, sagemaker_session, cpu_instance_type, cpu_instance_family
 ):
-    endpoint_name = "test-mxnet-attach-deploy-{}".format(sagemaker_timestamp())
+    endpoint_name = unique_name_from_base("test-neo-attach-deploy")
 
     with timeout_and_delete_endpoint_by_name(endpoint_name, sagemaker_session):
         estimator = MXNet.attach(mxnet_training_job, sagemaker_session=sagemaker_session)
@@ -79,7 +80,7 @@ def test_attach_deploy(
 def test_deploy_model(
     mxnet_training_job, sagemaker_session, cpu_instance_type, cpu_instance_family
 ):
-    endpoint_name = "test-mxnet-deploy-model-{}".format(sagemaker_timestamp())
+    endpoint_name = unique_name_from_base("test-neo-deploy-model")
 
     with timeout_and_delete_endpoint_by_name(endpoint_name, sagemaker_session):
         desc = sagemaker_session.sagemaker_client.describe_training_job(
@@ -101,7 +102,7 @@ def test_deploy_model(
             target_instance_family=cpu_instance_family,
             input_shape={"data": [1, 1, 28, 28]},
             role=role,
-            job_name="test-deploy-model-compilation-job-{}".format(int(time.time())),
+            job_name=unique_name_from_base("test-deploy-model-compilation-job"),
             output_path="/".join(model_data.split("/")[:-1]),
         )
         predictor = model.deploy(1, cpu_instance_type, endpoint_name=endpoint_name)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
These tests were introduced as part of re:Invent 2018 (#513). We have the necessary AWS SDK version for these tests, and so after 15 months I think we should probably enable them 😂 

This change also fixes the logic for generating a model name when compiling a model if `self.name` is not already set.

*Testing done:*
`pytest tests/integ/test_neo_mxnet.py`

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
