### PR TITLE
make AutoML.deploy use self.sagemaker_session by default

### DIFF
--- a/src/sagemaker/automl/automl.py
+++ b/src/sagemaker/automl/automl.py
@@ -216,8 +216,7 @@ class AutoML(object):
                 created from it.
             sagemaker_session (sagemaker.session.Session): A SageMaker Session
                 object, used for SageMaker interactions (default: None). If not
-                specified, one is created using the default AWS configuration
-                chain.
+                specified, the one originally associated with the ``AutoML`` instance is used.
             name (str): The pipeline model name. If None, a default model name will
                 be selected on each ``deploy``.
             endpoint_name (str): The name of the endpoint to create (default:
@@ -248,6 +247,8 @@ class AutoML(object):
                 If ``predictor_cls`` is specified, the invocation of ``self.predictor_cls`` on
                 the created endpoint name. Otherwise, ``None``.
         """
+        sagemaker_session = sagemaker_session or self.sagemaker_session
+
         if candidate is None:
             candidate_dict = self.best_candidate()
             candidate = CandidateEstimator(candidate_dict, sagemaker_session=sagemaker_session)

--- a/tests/unit/sagemaker/automl/test_auto_ml.py
+++ b/tests/unit/sagemaker/automl/test_auto_ml.py
@@ -477,16 +477,19 @@ def test_deploy(sagemaker_session, candidate_mock):
     )
 
 
-def test_deploy_optional_args(sagemaker_session, candidate_mock):
+@patch("sagemaker.automl.automl.CandidateEstimator")
+def test_deploy_optional_args(candidate_estimator, sagemaker_session, candidate_mock):
+    candidate_estimator.return_value = candidate_mock
+
     auto_ml = AutoML(
         role=ROLE, target_attribute_name=TARGET_ATTRIBUTE_NAME, sagemaker_session=sagemaker_session
     )
-    auto_ml.best_candidate = Mock(name="best_candidate", return_value=CANDIDATE_DICT)
     auto_ml._deploy_inference_pipeline = Mock("_deploy_inference_pipeline", return_value=None)
 
     auto_ml.deploy(
         initial_instance_count=INSTANCE_COUNT,
         instance_type=INSTANCE_TYPE,
+        candidate=CANDIDATE_DICT,
         sagemaker_session=sagemaker_session,
         name=JOB_NAME,
         endpoint_name=JOB_NAME,
@@ -514,6 +517,8 @@ def test_deploy_optional_args(sagemaker_session, candidate_mock):
         model_kms_key=OUTPUT_KMS_KEY,
         predictor_cls=RealTimePredictor,
     )
+
+    candidate_estimator.assert_called_with(CANDIDATE_DICT, sagemaker_session=sagemaker_session)
 
 
 def test_candidate_estimator_get_steps(sagemaker_session):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
`AutoML` already keeps track of a `sagemaker_session` object, so it seems like it would make sense to use that if another one isn't specified in a `deploy()` call.

*Testing done:*
* unit tests
* integ tests where a `Session()` call on its own will fail

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
