### PR TITLE
infra: programmatically determine partition based on region

### DIFF
--- a/src/sagemaker/utils.py
+++ b/src/sagemaker/utils.py
@@ -15,6 +15,7 @@ from __future__ import absolute_import
 
 import contextlib
 import errno
+import logging
 import os
 import random
 import re
@@ -37,6 +38,8 @@ S3_PREFIX = "s3://"
 HTTP_PREFIX = "http://"
 HTTPS_PREFIX = "https://"
 DEFAULT_SLEEP_TIME_SECONDS = 10
+
+logger = logging.getLogger(__name__)
 
 
 # Use the base name of the image as the job name if the user doesn't give us one
@@ -665,6 +668,31 @@ def _botocore_resolver():
     """
     loader = botocore.loaders.create_loader()
     return botocore.regions.EndpointResolver(loader.load_data("endpoints"))
+
+
+def _partition_by_region(region):
+    """
+    Given a region name (ex: "cn-north-1"), return the corresponding aws partition ("aws-cn").
+    If an error is thrown during calculation, log a warning and return 'aws'.
+
+    Args:
+        region (str): The region name for which to return the corresponding partition.
+        Ex: "cn-north-1"
+
+    Returns:
+        str: partition corresponding to the region name passed in. Ex: "aws-cn"
+    """
+    try:
+        endpoint_data = _botocore_resolver().construct_endpoint("sts", region)
+        return endpoint_data["partition"]
+    except Exception as e:  # pylint: disable=broad-except
+        logger.warning(
+            "Unable to determine partition from region. Falling back to 'aws'. region: %s. \n"
+            "Swallowed Exception: %s",
+            region,
+            e,
+        )
+        return "aws"
 
 
 class DeferredError(object):

--- a/src/sagemaker/utils.py
+++ b/src/sagemaker/utils.py
@@ -670,7 +670,7 @@ def _botocore_resolver():
     return botocore.regions.EndpointResolver(loader.load_data("endpoints"))
 
 
-def _partition_by_region(region):
+def _aws_partition(region):
     """
     Given a region name (ex: "cn-north-1"), return the corresponding aws partition ("aws-cn").
     If an error is thrown during calculation, log a warning and return 'aws'.

--- a/src/sagemaker/utils.py
+++ b/src/sagemaker/utils.py
@@ -673,7 +673,6 @@ def _botocore_resolver():
 def _aws_partition(region):
     """
     Given a region name (ex: "cn-north-1"), return the corresponding aws partition ("aws-cn").
-    If an error is thrown during calculation, log a warning and return 'aws'.
 
     Args:
         region (str): The region name for which to return the corresponding partition.
@@ -682,17 +681,8 @@ def _aws_partition(region):
     Returns:
         str: partition corresponding to the region name passed in. Ex: "aws-cn"
     """
-    try:
-        endpoint_data = _botocore_resolver().construct_endpoint("sts", region)
-        return endpoint_data["partition"]
-    except Exception as e:  # pylint: disable=broad-except
-        logger.warning(
-            "Unable to determine partition from region. Falling back to 'aws'. region: %s. \n"
-            "Swallowed Exception: %s",
-            region,
-            e,
-        )
-        return "aws"
+    endpoint_data = _botocore_resolver().construct_endpoint("sts", region)
+    return endpoint_data["partition"]
 
 
 class DeferredError(object):

--- a/tests/integ/kms_utils.py
+++ b/tests/integ/kms_utils.py
@@ -129,36 +129,36 @@ def get_or_create_kms_key(
     return kms_key_arn
 
 
-KMS_BUCKET_POLICY = """{
+KMS_BUCKET_POLICY = """{{
   "Version": "2012-10-17",
   "Id": "PutObjPolicy",
   "Statement": [
-    {
+    {{
       "Sid": "DenyIncorrectEncryptionHeader",
       "Effect": "Deny",
       "Principal": "*",
       "Action": "s3:PutObject",
       "Resource": "arn:{partition}:s3:::{bucket_name}/*",
-      "Condition": {
-        "StringNotEquals": {
+      "Condition": {{
+        "StringNotEquals": {{
           "s3:x-amz-server-side-encryption": "{partition}:kms"
-        }
-      }
-    },
-    {
+        }}
+      }}
+    }},
+    {{
       "Sid": "DenyUnEncryptedObjectUploads",
       "Effect": "Deny",
       "Principal": "*",
       "Action": "s3:PutObject",
       "Resource": "arn:{partition}:s3:::{bucket_name}/*",
-      "Condition": {
-        "Null": {
+      "Condition": {{
+        "Null": {{
           "s3:x-amz-server-side-encryption": "true"
-        }
-      }
-    }
+        }}
+      }}
+    }}
   ]
-}"""
+}}"""
 
 
 @contextlib.contextmanager

--- a/tests/integ/kms_utils.py
+++ b/tests/integ/kms_utils.py
@@ -64,7 +64,7 @@ def _create_kms_key(
 ):
     if role_arn:
         principal = PRINCIPAL_TEMPLATE.format(
-            partition=utils._partition_by_region(region),
+            partition=utils._aws_partition(region),
             account_id=account_id,
             role_arn=role_arn,
             sagemaker_role=sagemaker_role,
@@ -95,7 +95,7 @@ def _add_role_to_policy(
 
     if role_arn not in principal or sagemaker_role not in principal:
         principal = PRINCIPAL_TEMPLATE.format(
-            partition=utils._partition_by_region(region),
+            partition=utils._aws_partition(region),
             account_id=account_id,
             role_arn=role_arn,
             sagemaker_role=sagemaker_role,
@@ -188,7 +188,7 @@ def bucket_with_encryption(sagemaker_session, sagemaker_role):
                 {
                     "ApplyServerSideEncryptionByDefault": {
                         "SSEAlgorithm": "{partition}:kms".format(
-                            partition=utils._partition_by_region(region)
+                            partition=utils._aws_partition(region)
                         ),
                         "KMSMasterKeyID": kms_key_arn,
                     }
@@ -200,7 +200,7 @@ def bucket_with_encryption(sagemaker_session, sagemaker_role):
     s3_client.put_bucket_policy(
         Bucket=bucket_name,
         Policy=KMS_BUCKET_POLICY.format(
-            partition=utils._partition_by_region(region), bucket_name=bucket_name
+            partition=utils._aws_partition(region), bucket_name=bucket_name
         ),
     )
 

--- a/tests/integ/test_marketplace.py
+++ b/tests/integ/test_marketplace.py
@@ -24,6 +24,7 @@ import tests.integ
 from sagemaker import AlgorithmEstimator, ModelPackage
 from sagemaker.tuner import IntegerParameter, HyperparameterTuner
 from sagemaker.utils import sagemaker_timestamp
+from sagemaker.utils import _partition_by_region
 from tests.integ import DATA_DIR
 from tests.integ.timeout import timeout, timeout_and_delete_endpoint_by_name
 from tests.integ.marketplace_utils import REGION_ACCOUNT_MAP
@@ -39,12 +40,12 @@ from tests.integ.marketplace_utils import REGION_ACCOUNT_MAP
 # Both are written by Amazon and are free to subscribe.
 
 ALGORITHM_ARN = (
-    "arn:aws:sagemaker:%s:%s:algorithm/scikit-decision-trees-"
+    "arn:{partition}:sagemaker:{region}:{account}:algorithm/scikit-decision-trees-"
     "15423055-57b73412d2e93e9239e4e16f83298b8f"
 )
 
 MODEL_PACKAGE_ARN = (
-    "arn:aws:sagemaker:%s:%s:model-package/scikit-iris-detector-"
+    "arn:{partition}:sagemaker:{region}:{account}:model-package/scikit-iris-detector-"
     "154230595-8f00905c1f927a512b73ea29dd09ae30"
 )
 
@@ -63,7 +64,9 @@ def test_marketplace_estimator(sagemaker_session, cpu_instance_type):
         data_path = os.path.join(DATA_DIR, "marketplace", "training")
         region = sagemaker_session.boto_region_name
         account = REGION_ACCOUNT_MAP[region]
-        algorithm_arn = ALGORITHM_ARN % (region, account)
+        algorithm_arn = ALGORITHM_ARN.format(
+            partition=_partition_by_region(region), region=region, account=account
+        )
 
         algo = AlgorithmEstimator(
             algorithm_arn=algorithm_arn,
@@ -103,7 +106,9 @@ def test_marketplace_attach(sagemaker_session, cpu_instance_type):
         data_path = os.path.join(DATA_DIR, "marketplace", "training")
         region = sagemaker_session.boto_region_name
         account = REGION_ACCOUNT_MAP[region]
-        algorithm_arn = ALGORITHM_ARN % (region, account)
+        algorithm_arn = ALGORITHM_ARN.format(
+            partition=_partition_by_region(region), region=region, account=account
+        )
 
         mktplace = AlgorithmEstimator(
             algorithm_arn=algorithm_arn,
@@ -155,7 +160,9 @@ def test_marketplace_attach(sagemaker_session, cpu_instance_type):
 def test_marketplace_model(sagemaker_session, cpu_instance_type):
     region = sagemaker_session.boto_region_name
     account = REGION_ACCOUNT_MAP[region]
-    model_package_arn = MODEL_PACKAGE_ARN % (region, account)
+    model_package_arn = MODEL_PACKAGE_ARN.format(
+        partition=_partition_by_region(region), region=region, account=account
+    )
 
     def predict_wrapper(endpoint, session):
         return sagemaker.RealTimePredictor(
@@ -192,7 +199,9 @@ def test_marketplace_tuning_job(sagemaker_session, cpu_instance_type):
     data_path = os.path.join(DATA_DIR, "marketplace", "training")
     region = sagemaker_session.boto_region_name
     account = REGION_ACCOUNT_MAP[region]
-    algorithm_arn = ALGORITHM_ARN % (region, account)
+    algorithm_arn = ALGORITHM_ARN.format(
+        partition=_partition_by_region(region), region=region, account=account
+    )
 
     mktplace = AlgorithmEstimator(
         algorithm_arn=algorithm_arn,
@@ -233,7 +242,9 @@ def test_marketplace_transform_job(sagemaker_session, cpu_instance_type):
     data_path = os.path.join(DATA_DIR, "marketplace", "training")
     region = sagemaker_session.boto_region_name
     account = REGION_ACCOUNT_MAP[region]
-    algorithm_arn = ALGORITHM_ARN % (region, account)
+    algorithm_arn = ALGORITHM_ARN.format(
+        partition=_partition_by_region(region), region=region, account=account
+    )
 
     algo = AlgorithmEstimator(
         algorithm_arn=algorithm_arn,
@@ -279,7 +290,9 @@ def test_marketplace_transform_job_from_model_package(sagemaker_session, cpu_ins
 
     region = sagemaker_session.boto_region_name
     account = REGION_ACCOUNT_MAP[region]
-    model_package_arn = MODEL_PACKAGE_ARN % (region, account)
+    model_package_arn = MODEL_PACKAGE_ARN.format(
+        partition=_partition_by_region(region), region=region, account=account
+    )
 
     model = ModelPackage(
         role="SageMakerRole",

--- a/tests/integ/test_marketplace.py
+++ b/tests/integ/test_marketplace.py
@@ -24,7 +24,7 @@ import tests.integ
 from sagemaker import AlgorithmEstimator, ModelPackage
 from sagemaker.tuner import IntegerParameter, HyperparameterTuner
 from sagemaker.utils import sagemaker_timestamp
-from sagemaker.utils import _partition_by_region
+from sagemaker.utils import _aws_partition
 from tests.integ import DATA_DIR
 from tests.integ.timeout import timeout, timeout_and_delete_endpoint_by_name
 from tests.integ.marketplace_utils import REGION_ACCOUNT_MAP
@@ -65,7 +65,7 @@ def test_marketplace_estimator(sagemaker_session, cpu_instance_type):
         region = sagemaker_session.boto_region_name
         account = REGION_ACCOUNT_MAP[region]
         algorithm_arn = ALGORITHM_ARN.format(
-            partition=_partition_by_region(region), region=region, account=account
+            partition=_aws_partition(region), region=region, account=account
         )
 
         algo = AlgorithmEstimator(
@@ -107,7 +107,7 @@ def test_marketplace_attach(sagemaker_session, cpu_instance_type):
         region = sagemaker_session.boto_region_name
         account = REGION_ACCOUNT_MAP[region]
         algorithm_arn = ALGORITHM_ARN.format(
-            partition=_partition_by_region(region), region=region, account=account
+            partition=_aws_partition(region), region=region, account=account
         )
 
         mktplace = AlgorithmEstimator(
@@ -161,7 +161,7 @@ def test_marketplace_model(sagemaker_session, cpu_instance_type):
     region = sagemaker_session.boto_region_name
     account = REGION_ACCOUNT_MAP[region]
     model_package_arn = MODEL_PACKAGE_ARN.format(
-        partition=_partition_by_region(region), region=region, account=account
+        partition=_aws_partition(region), region=region, account=account
     )
 
     def predict_wrapper(endpoint, session):
@@ -200,7 +200,7 @@ def test_marketplace_tuning_job(sagemaker_session, cpu_instance_type):
     region = sagemaker_session.boto_region_name
     account = REGION_ACCOUNT_MAP[region]
     algorithm_arn = ALGORITHM_ARN.format(
-        partition=_partition_by_region(region), region=region, account=account
+        partition=_aws_partition(region), region=region, account=account
     )
 
     mktplace = AlgorithmEstimator(
@@ -243,7 +243,7 @@ def test_marketplace_transform_job(sagemaker_session, cpu_instance_type):
     region = sagemaker_session.boto_region_name
     account = REGION_ACCOUNT_MAP[region]
     algorithm_arn = ALGORITHM_ARN.format(
-        partition=_partition_by_region(region), region=region, account=account
+        partition=_aws_partition(region), region=region, account=account
     )
 
     algo = AlgorithmEstimator(
@@ -291,7 +291,7 @@ def test_marketplace_transform_job_from_model_package(sagemaker_session, cpu_ins
     region = sagemaker_session.boto_region_name
     account = REGION_ACCOUNT_MAP[region]
     model_package_arn = MODEL_PACKAGE_ARN.format(
-        partition=_partition_by_region(region), region=region, account=account
+        partition=_aws_partition(region), region=region, account=account
     )
 
     model = ModelPackage(

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -699,3 +699,11 @@ def test_sts_regional_endpoint():
     endpoint = sagemaker.utils.sts_regional_endpoint("us-iso-east-1")
     assert endpoint == "https://sts.us-iso-east-1.c2s.ic.gov"
     assert botocore.utils.is_valid_endpoint_url(endpoint)
+
+
+def test_partition_by_region():
+    assert sagemaker.utils._partition_by_region("us-west-2") == "aws"
+    assert sagemaker.utils._partition_by_region("cn-north-1") == "aws-cn"
+    assert sagemaker.utils._partition_by_region("us-gov-east-1") == "aws-us-gov"
+    assert sagemaker.utils._partition_by_region("us-iso-east-1") == "aws-iso"
+    assert sagemaker.utils._partition_by_region("us-isob-east-1") == "aws-iso-b"

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -702,8 +702,8 @@ def test_sts_regional_endpoint():
 
 
 def test_partition_by_region():
-    assert sagemaker.utils._partition_by_region("us-west-2") == "aws"
-    assert sagemaker.utils._partition_by_region("cn-north-1") == "aws-cn"
-    assert sagemaker.utils._partition_by_region("us-gov-east-1") == "aws-us-gov"
-    assert sagemaker.utils._partition_by_region("us-iso-east-1") == "aws-iso"
-    assert sagemaker.utils._partition_by_region("us-isob-east-1") == "aws-iso-b"
+    assert sagemaker.utils._aws_partition("us-west-2") == "aws"
+    assert sagemaker.utils._aws_partition("cn-north-1") == "aws-cn"
+    assert sagemaker.utils._aws_partition("us-gov-east-1") == "aws-us-gov"
+    assert sagemaker.utils._aws_partition("us-iso-east-1") == "aws-iso"
+    assert sagemaker.utils._aws_partition("us-isob-east-1") == "aws-iso-b"


### PR DESCRIPTION
*Description of changes:* Now dynamically determining partition based on region.

*Testing done:* UTs/ITs.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [X] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [X] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [X] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [X] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [X] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [X] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [X] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
