### PR TITLE
fix: upload estimator code to default session bucket instead of output bucket

### DIFF
--- a/src/sagemaker/estimator.py
+++ b/src/sagemaker/estimator.py
@@ -1470,7 +1470,8 @@ class Framework(EstimatorBase):
                 uploaded (default: None) - don't include a trailing slash since
                 a string prepended with a "/" is appended to ``code_location``. The code
                 file uploaded to S3 is 'code_location/job-name/source/sourcedir.tar.gz'.
-                If not specified, the default ``code location`` is s3://output_bucket/job-name/.
+                If not specified, the default ``code location`` is
+                s3://session_default_bucket/job-name/.
             image_name (str): An alternate image name to use instead of the
                 official Sagemaker image for the framework. This is useful to
                 run one of the Sagemaker supported frameworks with an image
@@ -1690,7 +1691,7 @@ class Framework(EstimatorBase):
             kms_key = None
 
         elif self.code_location is None:
-            code_bucket, _ = parse_s3_url(self.output_path)
+            code_bucket = self.sagemaker_session.default_bucket()
             code_s3_prefix = "{}/{}".format(self._current_job_name, "source")
             kms_key = self.output_kms_key
         else:

--- a/tests/integ/test_sklearn_train.py
+++ b/tests/integ/test_sklearn_train.py
@@ -97,6 +97,13 @@ def test_training_with_network_isolation(
         assert sagemaker_session.sagemaker_client.describe_training_job(TrainingJobName=job_name)[
             "EnableNetworkIsolation"
         ]
+
+        code_location = sklearn.latest_training_job.describe()["InputDataConfig"][2]["DataSource"][
+            "S3DataSource"
+        ]["S3Uri"]
+        assert code_location.startswith("s3://{}".format(sagemaker_session.default_bucket()))
+        assert code_location.endswith("source/sourcedir.tar.gz")
+
         return sklearn.latest_training_job.name
 
 

--- a/tests/unit/test_estimator.py
+++ b/tests/unit/test_estimator.py
@@ -1604,7 +1604,7 @@ def test_different_code_location_kms_key(utils, sagemaker_session):
 
 
 @patch("sagemaker.utils")
-def test_default_code_location_uses_output_path(utils, sagemaker_session):
+def test_default_code_location_uses_session_default_bucket(utils, sagemaker_session):
     fw = DummyFramework(
         entry_point=SCRIPT_PATH,
         role="DummyRole",
@@ -1619,7 +1619,9 @@ def test_default_code_location_uses_output_path(utils, sagemaker_session):
 
     obj = sagemaker_session.boto_session.resource("s3").Object
 
-    obj.assert_called_with("output_path", "%s/source/sourcedir.tar.gz" % fw._current_job_name)
+    obj.assert_called_with(
+        sagemaker_session.default_bucket(), "%s/source/sourcedir.tar.gz" % fw._current_job_name
+    )
 
     extra_args = {"ServerSideEncryption": "aws:kms", "SSEKMSKeyId": "kms-key"}
     obj().upload_file.assert_called_with(utils.create_tar_file(), ExtraArgs=extra_args)


### PR DESCRIPTION
*Description of changes:* Estimators' code was being uploaded to "s3://<output_bucket>/<job_name>/source/..."
Now, Estimators' code is being uploaded to "s3://<session_default_bucket>/<job_name>/source/..."

*Testing done:* UTs/ITs.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [X] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [X] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [X] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [X] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [X] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [X] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [X] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
