### PR TITLE
doc: improve docstring for tuner.best_estimator()

### DIFF
--- a/src/sagemaker/tuner.py
+++ b/src/sagemaker/tuner.py
@@ -763,10 +763,15 @@ class HyperparameterTuner(object):
         Args:
             best_training_job (dict): Dictionary containing "TrainingJobName" and
                 "TrainingJobDefinitionName".
+
                 Example:
+
                 {
+
                 "TrainingJobName": "my_training_job_name",
+
                 "TrainingJobDefinitionName": "my_training_job_definition_name"
+
                 }
 
         Returns:

--- a/src/sagemaker/tuner.py
+++ b/src/sagemaker/tuner.py
@@ -766,13 +766,15 @@ class HyperparameterTuner(object):
 
                 Example:
 
-                {
+                .. code:: python
 
-                "TrainingJobName": "my_training_job_name",
+                    {
 
-                "TrainingJobDefinitionName": "my_training_job_definition_name"
+                        "TrainingJobName": "my_training_job_name",
 
-                }
+                        "TrainingJobDefinitionName": "my_training_job_definition_name"
+
+                    }
 
         Returns:
             sagemaker.estimator.EstimatorBase: The estimator that has the best training job

--- a/src/sagemaker/tuner.py
+++ b/src/sagemaker/tuner.py
@@ -761,7 +761,7 @@ class HyperparameterTuner(object):
         object.
 
         Args:
-            best_training_job (dict): dict: Dictionary containing "TrainingJobName" and
+            best_training_job (dict): Dictionary containing "TrainingJobName" and
                 "TrainingJobDefinitionName".
                 Example:
                 {

--- a/src/sagemaker/tuner.py
+++ b/src/sagemaker/tuner.py
@@ -769,11 +769,8 @@ class HyperparameterTuner(object):
                 .. code:: python
 
                     {
-
                         "TrainingJobName": "my_training_job_name",
-
                         "TrainingJobDefinitionName": "my_training_job_definition_name"
-
                     }
 
         Returns:

--- a/src/sagemaker/tuner.py
+++ b/src/sagemaker/tuner.py
@@ -760,6 +760,19 @@ class HyperparameterTuner(object):
         be deployed to an Amazon SageMaker endpoint and return a ``sagemaker.RealTimePredictor``
         object.
 
+        Args:
+            best_training_job (dict): dict: Dictionary containing "TrainingJobName" and
+                "TrainingJobDefinitionName".
+                Example:
+                {
+                "TrainingJobName": "my_training_job_name",
+                "TrainingJobDefinitionName": "my_training_job_definition_name"
+                }
+
+        Returns:
+            sagemaker.estimator.EstimatorBase: The estimator that has the best training job
+                attached.
+
         Raises:
             Exception: If there is no best training job available for the hyperparameter tuning job.
         """


### PR DESCRIPTION
doc: improve docstring for tuner.best_estimator()

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [X] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [X] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [X] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [X] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [X] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [X] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [X] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
