### PR TITLE
fix: handle empty inputs/outputs in ProcessingJob.from_processing_name()

### DIFF
--- a/src/sagemaker/processing.py
+++ b/src/sagemaker/processing.py
@@ -648,10 +648,9 @@ class ProcessingJob(_Job):
         """
         job_desc = sagemaker_session.describe_processing_job(job_name=processing_job_name)
 
-        return cls(
-            sagemaker_session=sagemaker_session,
-            job_name=processing_job_name,
-            inputs=[
+        inputs = None
+        if job_desc.get("ProcessingInputs"):
+            inputs = [
                 ProcessingInput(
                     source=processing_input["S3Input"]["S3Uri"],
                     destination=processing_input["S3Input"]["LocalPath"],
@@ -664,19 +663,31 @@ class ProcessingJob(_Job):
                     s3_compression_type=processing_input["S3Input"].get("S3CompressionType"),
                 )
                 for processing_input in job_desc["ProcessingInputs"]
-            ],
-            outputs=[
+            ]
+
+        outputs = None
+        if job_desc.get("ProcessingOutputConfig") and job_desc["ProcessingOutputConfig"].get(
+            "Outputs"
+        ):
+            outputs = [
                 ProcessingOutput(
-                    source=job_desc["ProcessingOutputConfig"]["Outputs"][0]["S3Output"][
-                        "LocalPath"
-                    ],
-                    destination=job_desc["ProcessingOutputConfig"]["Outputs"][0]["S3Output"][
-                        "S3Uri"
-                    ],
-                    output_name=job_desc["ProcessingOutputConfig"]["Outputs"][0]["OutputName"],
+                    source=processing_output["S3Output"]["LocalPath"],
+                    destination=processing_output["S3Output"]["S3Uri"],
+                    output_name=processing_output["OutputName"],
                 )
-            ],
-            output_kms_key=job_desc["ProcessingOutputConfig"].get("KmsKeyId"),
+                for processing_output in job_desc["ProcessingOutputConfig"]["Outputs"]
+            ]
+
+        output_kms_key = None
+        if job_desc.get("ProcessingOutputConfig"):
+            output_kms_key = job_desc["ProcessingOutputConfig"].get("KmsKeyId")
+
+        return cls(
+            sagemaker_session=sagemaker_session,
+            job_name=processing_job_name,
+            inputs=inputs,
+            outputs=outputs,
+            output_kms_key=output_kms_key,
         )
 
     @classmethod


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/sagemaker-python-sdk/issues/1341

*Description of changes:* Properly populate local instance of ProcessingJob from description in case inputs and/or outputs are empty.

*Testing done:* UTs/IT.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [X] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [X] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [X] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [X] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [X] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [X] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [X] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
