### PR TITLE
change: Check that session is a LocalSession when using local mode

### DIFF
--- a/src/sagemaker/estimator.py
+++ b/src/sagemaker/estimator.py
@@ -218,7 +218,7 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):
             if self.train_instance_type == "local_gpu" and self.train_instance_count > 1:
                 raise RuntimeError("Distributed Training in Local GPU is not supported")
             self.sagemaker_session = sagemaker_session or LocalSession()
-            if not isinstance(self.sagemaker_session, LocalSession):
+            if not isinstance(self.sagemaker_session, sagemaker.local.LocalSession):
                 raise RuntimeError(
                     "instance_type local or local_gpu is only supported with an"
                     "instance of LocalSession"

--- a/src/sagemaker/estimator.py
+++ b/src/sagemaker/estimator.py
@@ -220,7 +220,8 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):
             self.sagemaker_session = sagemaker_session or LocalSession()
             if not isinstance(self.sagemaker_session, LocalSession):
                 raise RuntimeError(
-                    "instance_type local or local_gpu is only supported with an instance of LocalSession"
+                    "instance_type local or local_gpu is only supported with an"
+                    "instance of LocalSession"
                 )
         else:
             self.sagemaker_session = sagemaker_session or Session()

--- a/src/sagemaker/estimator.py
+++ b/src/sagemaker/estimator.py
@@ -218,6 +218,8 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):
             if self.train_instance_type == "local_gpu" and self.train_instance_count > 1:
                 raise RuntimeError("Distributed Training in Local GPU is not supported")
             self.sagemaker_session = sagemaker_session or LocalSession()
+            if not isinstance(self.sagemaker_session, LocalSession):
+                raise RuntimeError("instance_type local or local_gpu is only supported with an instance of LocalSession")
         else:
             self.sagemaker_session = sagemaker_session or Session()
 

--- a/src/sagemaker/estimator.py
+++ b/src/sagemaker/estimator.py
@@ -219,7 +219,9 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):
                 raise RuntimeError("Distributed Training in Local GPU is not supported")
             self.sagemaker_session = sagemaker_session or LocalSession()
             if not isinstance(self.sagemaker_session, LocalSession):
-                raise RuntimeError("instance_type local or local_gpu is only supported with an instance of LocalSession")
+                raise RuntimeError(
+                    "instance_type local or local_gpu is only supported with an instance of LocalSession"
+                )
         else:
             self.sagemaker_session = sagemaker_session or Session()
 

--- a/tests/integ/test_airflow_config.py
+++ b/tests/integ/test_airflow_config.py
@@ -443,7 +443,7 @@ def test_rcf_airflow_config_uploads_data_source_to_s3(sagemaker_session, cpu_ins
 
 @pytest.mark.canary_quick
 def test_chainer_airflow_config_uploads_data_source_to_s3(
-    sagemaker_session, cpu_instance_type, chainer_full_version
+    sagemaker_local_session, cpu_instance_type, chainer_full_version
 ):
     with timeout(seconds=AIRFLOW_CONFIG_TIMEOUT_IN_SECONDS):
         script_path = os.path.join(DATA_DIR, "chainer_mnist", "mnist.py")

--- a/tests/integ/test_airflow_config.py
+++ b/tests/integ/test_airflow_config.py
@@ -456,7 +456,7 @@ def test_chainer_airflow_config_uploads_data_source_to_s3(
             train_instance_type="local",
             framework_version=chainer_full_version,
             py_version=PYTHON_VERSION,
-            sagemaker_session=sagemaker_session,
+            sagemaker_session=sagemaker_local_session,
             hyperparameters={"epochs": 1},
             use_mpi=True,
             num_processes=2,
@@ -474,7 +474,7 @@ def test_chainer_airflow_config_uploads_data_source_to_s3(
         )
 
         _assert_that_s3_url_contains_data(
-            sagemaker_session,
+            sagemaker_local_session,
             training_config["HyperParameters"]["sagemaker_submit_directory"].strip('"'),
         )
 

--- a/tests/unit/test_estimator.py
+++ b/tests/unit/test_estimator.py
@@ -2233,7 +2233,7 @@ def test_deploy_with_no_model_name(sagemaker_session):
 @patch("sagemaker.estimator.LocalSession")
 @patch("sagemaker.estimator.Session")
 def test_local_mode(session_class, local_session_class):
-    local_session = Mock()
+    local_session = Mock(spec=sagemaker.local.LocalSession)
     local_session.local_mode = True
 
     session = Mock()

--- a/tests/unit/test_estimator.py
+++ b/tests/unit/test_estimator.py
@@ -561,7 +561,7 @@ def test_local_code_location():
         boto_region_name=REGION,
         config=config,
         local_mode=True,
-        spec=sagemaker.local.LocalSession
+        spec=sagemaker.local.LocalSession,
     )
     t = DummyFramework(
         entry_point=SCRIPT_PATH,

--- a/tests/unit/test_estimator.py
+++ b/tests/unit/test_estimator.py
@@ -561,6 +561,7 @@ def test_local_code_location():
         boto_region_name=REGION,
         config=config,
         local_mode=True,
+        spec=sagemaker.local.LocalSession
     )
     t = DummyFramework(
         entry_point=SCRIPT_PATH,

--- a/tests/unit/test_estimator.py
+++ b/tests/unit/test_estimator.py
@@ -30,6 +30,7 @@ from sagemaker.predictor import RealTimePredictor
 from sagemaker.session import s3_input, ShuffleConfig
 from sagemaker.transformer import Transformer
 from botocore.exceptions import ClientError
+import sagemaker.local
 
 MODEL_DATA = "s3://bucket/model.tar.gz"
 MODEL_IMAGE = "mi"
@@ -2259,7 +2260,7 @@ def test_distributed_gpu_local_mode(LocalSession):
 
 @patch("sagemaker.estimator.LocalSession")
 def test_local_mode_file_output_path(local_session_class):
-    local_session = Mock()
+    local_session = Mock(spec=sagemaker.local.LocalSession)
     local_session.local_mode = True
     local_session_class.return_value = local_session
 

--- a/tests/unit/test_estimator.py
+++ b/tests/unit/test_estimator.py
@@ -2392,3 +2392,30 @@ def test_encryption_flag_in_non_vpc_mode_invalid(sagemaker_session):
         '"EnableInterContainerTrafficEncryption" and "VpcConfig" must be provided together'
         in str(error)
     )
+
+
+def test_estimator_local_mode(sagemaker_session):
+    # When using instance local with a session which is not LocalSession we should error out
+    with pytest.raises(RuntimeError) as error:
+        estimator = Estimator(
+            image_name="some-image",
+            role="some_image",
+            train_instance_count=1,
+            train_instance_type="local",
+            sagemaker_session=sagemaker_session,
+            base_job_name="base_job_name",
+        )
+
+def test_estimator_local_mode(sagemaker_local_session):
+    # When using instance local with a session which is not LocalSession we should error out
+    estimator = Estimator(
+        image_name="some-image",
+        role="some_image",
+        train_instance_count=1,
+        train_instance_type="local",
+        sagemaker_session=sagemaker_local_session,
+        base_job_name="base_job_name",
+    )
+
+
+

--- a/tests/unit/test_estimator.py
+++ b/tests/unit/test_estimator.py
@@ -2394,10 +2394,10 @@ def test_encryption_flag_in_non_vpc_mode_invalid(sagemaker_session):
     )
 
 
-def test_estimator_local_mode(sagemaker_session):
+def test_estimator_local_mode_error(sagemaker_session):
     # When using instance local with a session which is not LocalSession we should error out
-    with pytest.raises(RuntimeError) as error:
-        estimator = Estimator(
+    with pytest.raises(RuntimeError):
+        Estimator(
             image_name="some-image",
             role="some_image",
             train_instance_count=1,
@@ -2407,9 +2407,9 @@ def test_estimator_local_mode(sagemaker_session):
         )
 
 
-def test_estimator_local_mode(sagemaker_local_session):
+def test_estimator_local_mode_ok(sagemaker_local_session):
     # When using instance local with a session which is not LocalSession we should error out
-    estimator = Estimator(
+    Estimator(
         image_name="some-image",
         role="some_image",
         train_instance_count=1,

--- a/tests/unit/test_estimator.py
+++ b/tests/unit/test_estimator.py
@@ -2406,6 +2406,7 @@ def test_estimator_local_mode(sagemaker_session):
             base_job_name="base_job_name",
         )
 
+
 def test_estimator_local_mode(sagemaker_local_session):
     # When using instance local with a session which is not LocalSession we should error out
     estimator = Estimator(
@@ -2416,6 +2417,3 @@ def test_estimator_local_mode(sagemaker_local_session):
         sagemaker_session=sagemaker_local_session,
         base_job_name="base_job_name",
     )
-
-
-


### PR DESCRIPTION
if the user passes sagemaker.session.Session the error message is not clear.


*Description of changes:*


If the user passes a session object to the estimator and tries to train in local mode, the fit method returns an error:

```
ClientError: An error occurred (ValidationException) when calling the CreateTrainingJob operation: 1 validation error detected: Value 'local_gpu' at 'resourceConfig.instanceType' failed to satisfy constraint: Member must satisfy enum value set: [ml.p2.xlarge, ml.m5.4xlarge, ml.m4.16xlarge, ml.c5n.xlarge, ml.p3.16xlarge, ml.m5.large, ml.p2.16xlarge, ml.c4.2xlarge, ml.c5.2xlarge, ml.c4.4xlarge, ml.c5.4xlarge, ml.c5n.18xlarge, ml.g4dn.xlarge, ml.g4dn.12xlarge, ml.c4.8xlarge, ml.g4dn.2xlarge, ml.c5.9xlarge, ml.g4dn.4xlarge, ml.c5.xlarge, ml.g4dn.16xlarge, ml.c4.xlarge, ml.g4dn.8xlarge, ml.c5n.2xlarge, ml.c5n.4xlarge, ml.c5.18xlarge, ml.p3dn.24xlarge, ml.p3.2xlarge, ml.m5.xlarge, ml.m4.10xlarge, ml.c5n.9xlarge, ml.m5.12xlarge, ml.m4.xlarge, ml.m5.24xlarge, ml.m4.2xlarge, ml.p2.8xlarge, ml.m5.2xlarge, ml.p3.8xlarge, ml.m4.4xlarge]
```

When using train_instance_type "local" or "local_gpu", session should inherit from LocalSession. This change makes the error happen before and specify the cause more clear `instance_type local or local_gpu is only supported with an instance of LocalSession`.



*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
