### PR TITLE
change: ignore tags with 'aws:' prefix when creating an EndpointConfig based on an existing one

### DIFF
--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -2312,11 +2312,16 @@ class Session(object):  # pylint: disable=too-many-public-methods
             existing_config_name (str): Name of the existing Amazon SageMaker endpoint
                 configuration.
             new_tags(List[dict[str, str]]): Optional. The list of tags to add to the endpoint
-                config.
+                config. If not specified, the tags of the existing endpoint configuration are used.
+                If any of the existing tags are reserved AWS ones (i.e. begin with "aws"),
+                they are not carried over to the new endpoint configuration.
             new_kms_key (str): The KMS key that is used to encrypt the data on the storage volume
-                attached to the instance hosting the endpoint.
+                attached to the instance hosting the endpoint (default: None). If not specified,
+                the KMS key of the existing endpoint configuration is used.
             new_data_capture_config_dict (dict): Specifies configuration related to Endpoint data
-                capture for use with Amazon SageMaker Model Monitoring. Default: None.
+                capture for use with Amazon SageMaker Model Monitoring (default: None).
+                If not specified, the data capture configuration of the existing
+                endpoint configuration is used.
 
         Returns:
             str: Name of the endpoint point configuration created.

--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -2338,22 +2338,9 @@ class Session(object):  # pylint: disable=too-many-public-methods
             "ProductionVariants": existing_endpoint_config_desc["ProductionVariants"],
         }
 
-        request_tags = new_tags
-        if request_tags is None:
-            existing_tags = self.sagemaker_client.list_tags(
-                ResourceArn=existing_endpoint_config_desc["EndpointConfigArn"]
-            )["Tags"]
-
-            # the "aws:" prefix is reserved by AWS and cannot be supplied in tag keys
-            # https://github.com/aws/sagemaker-python-sdk/issues/1301
-            for tag in existing_tags:
-                # there should be only one element in the dictionary,
-                # but dict.keys() doesn't support indexing.
-                for tag_key in tag.keys():
-                    if tag_key.startswith("aws:"):
-                        existing_tags.remove(tag)
-            request_tags = existing_tags
-
+        request_tags = new_tags or self.list_tags(
+            existing_endpoint_config_desc["EndpointConfigArn"]
+        )
         if request_tags:
             request["Tags"] = request_tags
 

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -1820,6 +1820,36 @@ def test_update_endpoint_non_existing_endpoint(sagemaker_session):
         sagemaker_session.update_endpoint("non-existing-endpoint", "non-existing-config")
 
 
+def test_create_endpoint_config_from_existing(sagemaker_session):
+    pvs = [sagemaker.production_variant("A", "ml.m4.xlarge")]
+    tags = [{"aws:cloudformation:stackname": "this-tag-should-be-ignored"}]
+    existing_endpoint_arn = "arn:aws:sagemaker:us-west-2:123412341234:endpoint-config/foo"
+    kms_key = "kms"
+    sagemaker_session.sagemaker_client.describe_endpoint_config.return_value = {
+        "Tags": tags,
+        "ProductionVariants": pvs,
+        "EndpointConfigArn": existing_endpoint_arn,
+        "KmsKeyId": kms_key,
+    }
+    sagemaker_session.sagemaker_client.list_tags.return_value = {"Tags": tags}
+
+    existing_endpoint_name = "foo"
+    new_endpoint_name = "new-foo"
+    sagemaker_session.create_endpoint_config_from_existing(
+        existing_endpoint_name, new_endpoint_name
+    )
+
+    sagemaker_session.sagemaker_client.describe_endpoint_config.assert_called_with(
+        EndpointConfigName=existing_endpoint_name
+    )
+    sagemaker_session.sagemaker_client.list_tags.assert_called_with(
+        ResourceArn=existing_endpoint_arn
+    )
+    sagemaker_session.sagemaker_client.create_endpoint_config.assert_called_with(
+        EndpointConfigName=new_endpoint_name, ProductionVariants=pvs, KmsKeyId=kms_key
+    )
+
+
 @patch("time.sleep")
 def test_wait_for_tuning_job(sleep, sagemaker_session):
     hyperparameter_tuning_job_desc = {"HyperParameterTuningJobStatus": "Completed"}

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -1822,7 +1822,7 @@ def test_update_endpoint_non_existing_endpoint(sagemaker_session):
 
 def test_create_endpoint_config_from_existing(sagemaker_session):
     pvs = [sagemaker.production_variant("A", "ml.m4.xlarge")]
-    tags = [{"aws:cloudformation:stackname": "this-tag-should-be-ignored"}]
+    tags = [{"Key": "aws:cloudformation:stackname", "Value": "this-tag-should-be-ignored"}]
     existing_endpoint_arn = "arn:aws:sagemaker:us-west-2:123412341234:endpoint-config/foo"
     kms_key = "kms"
     sagemaker_session.sagemaker_client.describe_endpoint_config.return_value = {
@@ -1843,7 +1843,7 @@ def test_create_endpoint_config_from_existing(sagemaker_session):
         EndpointConfigName=existing_endpoint_name
     )
     sagemaker_session.sagemaker_client.list_tags.assert_called_with(
-        ResourceArn=existing_endpoint_arn
+        ResourceArn=existing_endpoint_arn, MaxResults=50
     )
     sagemaker_session.sagemaker_client.create_endpoint_config.assert_called_with(
         EndpointConfigName=new_endpoint_name, ProductionVariants=pvs, KmsKeyId=kms_key


### PR DESCRIPTION
*Issue #, if available:*
#1301 

*Description of changes:*
AWS doesn't allow for any tag keys to start with "aws:" so that its own services can make use of such tags.

*Testing done:*
unit tests

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
