### PR TITLE
fix: encode InvokeEndpoint body in Local Mode

### DIFF
--- a/src/sagemaker/local/local_session.py
+++ b/src/sagemaker/local/local_session.py
@@ -369,7 +369,9 @@ class LocalSagemakerRuntimeClient(object):
         if TargetModel is not None:
             headers["X-Amzn-SageMaker-Target-Model"] = TargetModel
 
-        r = self.http.request("POST", url, body=Body, preload_content=False, headers=headers)
+        r = self.http.request(
+            "POST", url, body=Body.encode("utf-8"), preload_content=False, headers=headers
+        )
 
         return {"Body": r, "ContentType": Accept}
 

--- a/src/sagemaker/local/local_session.py
+++ b/src/sagemaker/local/local_session.py
@@ -369,9 +369,9 @@ class LocalSagemakerRuntimeClient(object):
         if TargetModel is not None:
             headers["X-Amzn-SageMaker-Target-Model"] = TargetModel
 
-        r = self.http.request(
-            "POST", url, body=Body.encode("utf-8"), preload_content=False, headers=headers
-        )
+        if isinstance(Body, str):
+            Body = Body.encode("utf-8")
+        r = self.http.request("POST", url, body=Body, preload_content=False, headers=headers)
 
         return {"Body": r, "ContentType": Accept}
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Local Mode doesn't handle special characters in prediction data properly:

> UnicodeEncodeError: 'latin-1' codec can't encode characters in position 111-112: Body ('😄') is not valid Latin-1. Use body.encode('utf-8') if you want to send it encoded in UTF-8

*Testing done:*
* unit tests
* tested manually with a case that worked in SageMaker but not in Local Mode

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
