### PR TITLE
Fix local _SageMakerContainer detached mode (aws#1374)

### DIFF
--- a/src/sagemaker/local/image.py
+++ b/src/sagemaker/local/image.py
@@ -489,11 +489,8 @@ class _SageMakerContainer(object):
             os.path.join(self.container_root, DOCKER_COMPOSE_FILENAME),
             "up",
             "--build",
-            "--abort-on-container-exit",
+            "--abort-on-container-exit" if not detached else "--detach",  # mutually exclusive
         ]
-
-        if detached:
-            command.append("-d")
 
         logger.info("docker command: %s", " ".join(command))
         return command


### PR DESCRIPTION
*Issue #, if available:* aws#1374

*Description of changes:* Set either the `--abort-on-container-exit` or `--detach` docker-compose option but not both.

*Testing done:* Tried the class locally and the container was able to start correctly. I also executed the unit tests per the Contributing Guidelines

## Merge Checklist

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

