### PR TITLE
fix: Pass kwargs from create_model to Model constructors

### DIFF
--- a/src/sagemaker/chainer/estimator.py
+++ b/src/sagemaker/chainer/estimator.py
@@ -203,6 +203,9 @@ class Chainer(Framework):
             sagemaker.chainer.model.ChainerModel: A SageMaker ``ChainerModel``
             object. See :func:`~sagemaker.chainer.model.ChainerModel` for full details.
         """
+        if "image" not in kwargs:
+            kwargs["image"] = self.image_name
+
         return ChainerModel(
             self.model_data,
             role or self.role,
@@ -215,10 +218,10 @@ class Chainer(Framework):
             py_version=self.py_version,
             framework_version=self.framework_version,
             model_server_workers=model_server_workers,
-            image=kwargs["image"] if "image" in kwargs else self.image_name,
             sagemaker_session=self.sagemaker_session,
             vpc_config=self.get_vpc_config(vpc_config_override),
             dependencies=(dependencies or self.dependencies),
+            **kwargs
         )
 
     @classmethod

--- a/src/sagemaker/mxnet/estimator.py
+++ b/src/sagemaker/mxnet/estimator.py
@@ -206,6 +206,9 @@ class MXNet(Framework):
             sagemaker.mxnet.model.MXNetModel: A SageMaker ``MXNetModel`` object.
             See :func:`~sagemaker.mxnet.model.MXNetModel` for full details.
         """
+        if "image" not in kwargs:
+            kwargs["image"] = image_name or self.image_name
+
         return MXNetModel(
             self.model_data,
             role or self.role,
@@ -217,11 +220,11 @@ class MXNet(Framework):
             code_location=self.code_location,
             py_version=self.py_version,
             framework_version=self.framework_version,
-            image=kwargs["image"] if "image" in kwargs else (image_name or self.image_name),
             model_server_workers=model_server_workers,
             sagemaker_session=self.sagemaker_session,
             vpc_config=self.get_vpc_config(vpc_config_override),
             dependencies=(dependencies or self.dependencies),
+            **kwargs
         )
 
     @classmethod

--- a/src/sagemaker/pytorch/estimator.py
+++ b/src/sagemaker/pytorch/estimator.py
@@ -164,6 +164,9 @@ class PyTorch(Framework):
             sagemaker.pytorch.model.PyTorchModel: A SageMaker ``PyTorchModel``
             object. See :func:`~sagemaker.pytorch.model.PyTorchModel` for full details.
         """
+        if "image" not in kwargs:
+            kwargs["image"] = self.image_name
+
         return PyTorchModel(
             self.model_data,
             role or self.role,
@@ -175,11 +178,11 @@ class PyTorch(Framework):
             code_location=self.code_location,
             py_version=self.py_version,
             framework_version=self.framework_version,
-            image=kwargs["image"] if "image" in kwargs else self.image_name,
             model_server_workers=model_server_workers,
             sagemaker_session=self.sagemaker_session,
             vpc_config=self.get_vpc_config(vpc_config_override),
             dependencies=(dependencies or self.dependencies),
+            **kwargs
         )
 
     @classmethod

--- a/tests/unit/test_chainer.py
+++ b/tests/unit/test_chainer.py
@@ -31,6 +31,7 @@ DATA_DIR = os.path.join(os.path.dirname(__file__), "..", "data")
 SCRIPT_PATH = os.path.join(DATA_DIR, "dummy_script.py")
 SERVING_SCRIPT_FILE = "another_dummy_script.py"
 MODEL_DATA = "s3://some/data.tar.gz"
+ENV = {"DUMMY_ENV_VAR": "dummy_value"}
 TIMESTAMP = "2017-11-06-14:14:15.672"
 TIME = 1507167947
 BUCKET_NAME = "mybucket"
@@ -326,12 +327,14 @@ def test_create_model_with_optional_params(sagemaker_session):
         model_server_workers=model_server_workers,
         vpc_config_override=vpc_config,
         entry_point=SERVING_SCRIPT_FILE,
+        env=ENV,
     )
 
     assert model.role == new_role
     assert model.model_server_workers == model_server_workers
     assert model.vpc_config == vpc_config
     assert model.entry_point == SERVING_SCRIPT_FILE
+    assert model.env == ENV
 
 
 def test_create_model_with_custom_image(sagemaker_session):

--- a/tests/unit/test_mxnet.py
+++ b/tests/unit/test_mxnet.py
@@ -30,6 +30,7 @@ DATA_DIR = os.path.join(os.path.dirname(__file__), "..", "data")
 SCRIPT_PATH = os.path.join(DATA_DIR, "dummy_script.py")
 SERVING_SCRIPT_FILE = "another_dummy_script.py"
 MODEL_DATA = "s3://mybucket/model"
+ENV = {"DUMMY_ENV_VAR": "dummy_value"}
 TIMESTAMP = "2017-11-06-14:14:15.672"
 TIME = 1507167947
 BUCKET_NAME = "mybucket"
@@ -231,12 +232,14 @@ def test_create_model_with_optional_params(sagemaker_session):
         model_server_workers=model_server_workers,
         vpc_config_override=vpc_config,
         entry_point=SERVING_SCRIPT_FILE,
+        env=ENV,
     )
 
     assert model.role == new_role
     assert model.model_server_workers == model_server_workers
     assert model.vpc_config == vpc_config
     assert model.entry_point == SERVING_SCRIPT_FILE
+    assert model.env == ENV
 
 
 def test_create_model_with_custom_image(sagemaker_session):

--- a/tests/unit/test_pytorch.py
+++ b/tests/unit/test_pytorch.py
@@ -28,6 +28,7 @@ DATA_DIR = os.path.join(os.path.dirname(__file__), "..", "data")
 SCRIPT_PATH = os.path.join(DATA_DIR, "dummy_script.py")
 SERVING_SCRIPT_FILE = "another_dummy_script.py"
 MODEL_DATA = "s3://some/data.tar.gz"
+ENV = {"DUMMY_ENV_VAR": "dummy_value"}
 TIMESTAMP = "2017-11-06-14:14:15.672"
 TIME = 1507167947
 BUCKET_NAME = "mybucket"
@@ -212,12 +213,14 @@ def test_create_model_with_optional_params(sagemaker_session):
         model_server_workers=model_server_workers,
         vpc_config_override=vpc_config,
         entry_point=SERVING_SCRIPT_FILE,
+        env=ENV,
     )
 
     assert model.role == new_role
     assert model.model_server_workers == model_server_workers
     assert model.vpc_config == vpc_config
     assert model.entry_point == SERVING_SCRIPT_FILE
+    assert model.env == ENV
 
 
 def test_create_model_with_custom_image(sagemaker_session):


### PR DESCRIPTION
*Issue #, if available:*
The docstring in `create_model` indicates that `kwargs` is passed to the Model constructor. This was not the case for PyTorch, MXNet, and Chainer.

*Description of changes:*
`kwargs` has been modified to account for the `image` keyword and passed to the constructor.

*Testing done:*
Ran unit tests. Modified `create_model` unit tests with an `env` keyword argument to test `kwargs` being passed to the Model.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have used the regional endpoint when creating S3 and/or STS clients (if appropriate)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
