### PR TITLE
doc: fix documentation to provide working example.

### DIFF
--- a/doc/using_tf.rst
+++ b/doc/using_tf.rst
@@ -267,19 +267,19 @@ Training with ``MPI`` is configured by specifying following fields in ``distribu
   command executed by SageMaker to launch distributed horovod training.
 
 
-In the below example we create an estimator to launch Horovod distributed training with 2 processes on one host:
+In the below example we create an estimator to launch Horovod distributed training with 4 processes on one host:
 
 .. code:: python
 
     from sagemaker.tensorflow import TensorFlow
 
     tf_estimator = TensorFlow(entry_point='tf-train.py', role='SageMakerRole',
-                              train_instance_count=1, train_instance_type='ml.p2.xlarge',
-                              framework_version='1.12', py_version='py3',
+                              train_instance_count=1, train_instance_type='ml.p3.8xlarge',
+                              framework_version='2.1.0', py_version='py3',
                               distributions={
                                   'mpi': {
                                       'enabled': True,
-                                      'processes_per_host': 2,
+                                      'processes_per_host': 4,
                                       'custom_mpi_options': '--NCCL_DEBUG INFO'
                                   }
                               })


### PR DESCRIPTION
Use instance type with more than 1 GPU (p3.8xlarge has 4 GPUs and p2.xlarge thas only 1) to provide a working example in the documentation.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to any/all clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
