### PR TITLE
fix: correct local mode behavior for CN regions

### DIFF
--- a/doc/using_tf.rst
+++ b/doc/using_tf.rst
@@ -267,19 +267,19 @@ Training with ``MPI`` is configured by specifying following fields in ``distribu
   command executed by SageMaker to launch distributed horovod training.
 
 
-In the below example we create an estimator to launch Horovod distributed training with 2 processes on one host:
+In the below example we create an estimator to launch Horovod distributed training with 4 processes on one host:
 
 .. code:: python
 
     from sagemaker.tensorflow import TensorFlow
 
     tf_estimator = TensorFlow(entry_point='tf-train.py', role='SageMakerRole',
-                              train_instance_count=1, train_instance_type='ml.p2.xlarge',
-                              framework_version='1.12', py_version='py3',
+                              train_instance_count=1, train_instance_type='ml.p3.8xlarge',
+                              framework_version='2.1.0', py_version='py3',
                               distributions={
                                   'mpi': {
                                       'enabled': True,
-                                      'processes_per_host': 2,
+                                      'processes_per_host': 4,
                                       'custom_mpi_options': '--NCCL_DEBUG INFO'
                                   }
                               })

--- a/src/sagemaker/utils.py
+++ b/src/sagemaker/utils.py
@@ -32,7 +32,7 @@ import six
 from six.moves.urllib import parse
 
 
-ECR_URI_PATTERN = r"^(\d+)(\.)dkr(\.)ecr(\.)(.+)(/)(.*:.*)$"
+ECR_URI_PATTERN = r"^(\d+)(\.)dkr(\.)ecr(\.)(.+)(\.)(.*)(/)(.*:.*)$"
 MAX_BUCKET_PATHS_COUNT = 5
 S3_PREFIX = "s3://"
 HTTP_PREFIX = "http://"

--- a/src/sagemaker/utils.py
+++ b/src/sagemaker/utils.py
@@ -32,7 +32,7 @@ import six
 from six.moves.urllib import parse
 
 
-ECR_URI_PATTERN = r"^(\d+)(\.)dkr(\.)ecr(\.)(.+)(\.)(amazonaws.com|c2s.ic.gov)(/)(.*:.*)$"
+ECR_URI_PATTERN = r"^(\d+)(\.)dkr(\.)ecr(\.)(.+)(/)(.*:.*)$"
 MAX_BUCKET_PATHS_COUNT = 5
 S3_PREFIX = "s3://"
 HTTP_PREFIX = "http://"


### PR DESCRIPTION
*Description of changes:* No longer filter on host for ecr image uri validation.

*Testing done:* Local mode IT.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [X] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [X] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [X] I have passed the region in to any/all clients that I've initialized as part of this change.
- [X] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [X] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [X] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [X] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
