### PR TITLE
fix: use .format instead of os.path.join for Processing S3 paths.

### DIFF
--- a/src/sagemaker/processing.py
+++ b/src/sagemaker/processing.py
@@ -213,11 +213,9 @@ class Processor(object):
                 # and save the S3 uri in the ProcessingInput source.
                 parse_result = urlparse(file_input.source)
                 if parse_result.scheme != "s3":
-                    desired_s3_uri = os.path.join(
-                        "s3://",
+                    desired_s3_uri = "s3://{}/{}/input/{}".format(
                         self.sagemaker_session.default_bucket(),
                         self._current_job_name,
-                        "input",
                         file_input.input_name,
                     )
                     s3_uri = S3Uploader.upload(
@@ -475,11 +473,9 @@ class ScriptProcessor(Processor):
             str: The S3 URI of the uploaded file or directory.
 
         """
-        desired_s3_uri = os.path.join(
-            "s3://",
+        desired_s3_uri = "s3://{}/{}/input/{}".format(
             self.sagemaker_session.default_bucket(),
             self._current_job_name,
-            "input",
             self._CODE_CONTAINER_INPUT_NAME,
         )
         return S3Uploader.upload(

--- a/src/sagemaker/processing.py
+++ b/src/sagemaker/processing.py
@@ -257,11 +257,9 @@ class Processor(object):
                 # If the output's destination is not an s3_uri, create one.
                 parse_result = urlparse(output.destination)
                 if parse_result.scheme != "s3":
-                    s3_uri = os.path.join(
-                        "s3://",
+                    s3_uri = "s3://{}/{}/output/{}".format(
                         self.sagemaker_session.default_bucket(),
                         self._current_job_name,
-                        "output",
                         output.output_name,
                     )
                     output.destination = s3_uri


### PR DESCRIPTION
S3 paths always use forward slashes ("/") regardless of the OS,
so using an os.path.join will cause issues when the user is on Windows.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to any/all clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
