### PR TITLE
change: add enable_network_isolation to EstimatorBase

### DIFF
--- a/src/sagemaker/amazon/amazon_estimator.py
+++ b/src/sagemaker/amazon/amazon_estimator.py
@@ -82,14 +82,17 @@ class AmazonAlgorithmEstimatorBase(EstimatorBase):
             :class:`~sagemaker.estimator.EstimatorBase`.
         """
         super(AmazonAlgorithmEstimatorBase, self).__init__(
-            role, train_instance_count, train_instance_type, **kwargs
+            role,
+            train_instance_count,
+            train_instance_type,
+            enable_network_isolation=enable_network_isolation,
+            **kwargs
         )
 
         data_location = data_location or "s3://{}/sagemaker-record-sets/".format(
             self.sagemaker_session.default_bucket()
         )
         self._data_location = data_location
-        self._enable_network_isolation = enable_network_isolation
 
     def train_image(self):
         """Placeholder docstring"""
@@ -100,14 +103,6 @@ class AmazonAlgorithmEstimatorBase(EstimatorBase):
     def hyperparameters(self):
         """Placeholder docstring"""
         return hp.serialize_all(self)
-
-    def enable_network_isolation(self):
-        """If this Estimator can use network isolation when running.
-
-        Returns:
-            bool: Whether this Estimator can use network isolation or not.
-        """
-        return self._enable_network_isolation
 
     @property
     def data_location(self):

--- a/tests/unit/test_estimator.py
+++ b/tests/unit/test_estimator.py
@@ -209,6 +209,7 @@ def test_framework_all_init_args(sagemaker_session):
         checkpoint_s3_uri="s3://bucket/checkpoint",
         checkpoint_local_path="file://local/checkpoint",
         enable_sagemaker_metrics=True,
+        enable_network_isolation=True,
     )
     _TrainingJob.start_new(f, "s3://mydata", None)
     sagemaker_session.train.assert_called_once()
@@ -247,6 +248,7 @@ def test_framework_all_init_args(sagemaker_session):
         "checkpoint_s3_uri": "s3://bucket/checkpoint",
         "checkpoint_local_path": "file://local/checkpoint",
         "enable_sagemaker_metrics": True,
+        "enable_network_isolation": True,
     }
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This removes the need of having redundant logic in each of the subclasses of `EstimatorBase`, since network isolation mode has been added to all of the subclasses now.

*Testing done:*
`tox tests/unit --parallel all`

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to any/all clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
