### PR TITLE
doc: update sagemaker pytorch containers to external link

### DIFF
--- a/doc/using_pytorch.rst
+++ b/doc/using_pytorch.rst
@@ -134,7 +134,7 @@ Using third-party libraries
 ---------------------------
 
 When running your training script on SageMaker, it will have access to some pre-installed third-party libraries including ``torch``, ``torchvision``, and ``numpy``.
-For more information on the runtime environment, including specific package versions, see `SageMaker PyTorch Docker containers <#id4>`__.
+For more information on the runtime environment, including specific package versions, see `SageMaker PyTorch Docker containers <https://github.com/aws/sagemaker-python-sdk/tree/master/src/sagemaker/pytorch#sagemaker-pytorch-docker-containers>`_.
 
 If there are other packages you want to use with your script, you can include a ``requirements.txt`` file in the same directory as your training script to install other dependencies at runtime. Both ``requirements.txt`` and your training script should be put in the same folder. You must specify this folder in ``source_dir`` argument when creating PyTorch estimator.
 
@@ -673,7 +673,7 @@ The following are optional arguments. When you create a ``PyTorch`` object, you 
    model training code.
 -  ``framework_version`` PyTorch version you want to use for executing
    your model training code. You can find the list of supported versions
-   in `SageMaker PyTorch Docker Containers <#id4>`_.
+   in `SageMaker PyTorch Docker Containers <https://github.com/aws/sagemaker-python-sdk/tree/master/src/sagemaker/pytorch#sagemaker-pytorch-docker-containers>`_.
 -  ``train_volume_size`` Size in GB of the EBS volume to use for storing
    input data during training. Must be large enough to store training
    data if input_mode='File' is used (which is the default).
@@ -698,7 +698,7 @@ The following are optional arguments. When you create a ``PyTorch`` object, you 
    serving.  If specified, the estimator will use this image for training and
    hosting, instead of selecting the appropriate SageMaker official image based on
    framework_version and py_version. Refer to: `SageMaker PyTorch Docker Containers
-   <#id4>`_ for details on what the Official images support
+   <https://github.com/aws/sagemaker-python-sdk/tree/master/src/sagemaker/pytorch#sagemaker-pytorch-docker-containers>`_ for details on what the Official images support
    and where to find the source code to build your custom image.
 
 ***********************************


### PR DESCRIPTION
*Issue #, if available:*
The section "SageMaker PyTorch Docker Containers" has a weird url (https://sagemaker.readthedocs.io/en/stable/using_pytorch.html#id3).
 
Because the anchor link is #id3, existing references are broken. For example, under the third party libraries section, "For more information on the runtime environment, including specific package versions, see SageMaker PyTorch Docker containers.". The link is broken because it refers to id4.


*Description of changes:*
Update SageMaker PyTorch Docker containers reference links.

*Testing done:*
tox -e sphinx

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to any/all clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
