### PR TITLE
fix: use valid encryption key arg for S3 downloads

### DIFF
--- a/src/sagemaker/s3.py
+++ b/src/sagemaker/s3.py
@@ -110,7 +110,7 @@ class S3Downloader(object):
         sagemaker_session = session or Session()
         bucket, key_prefix = parse_s3_url(url=s3_uri)
         if kms_key is not None:
-            extra_args = {"SSEKMSKeyId": kms_key}
+            extra_args = {"SSECustomerKey": kms_key}
         else:
             extra_args = None
 

--- a/tests/unit/test_s3.py
+++ b/tests/unit/test_s3.py
@@ -91,5 +91,5 @@ def test_download_with_kms_key(sagemaker_session):
         path="/path/for/download/",
         bucket=BUCKET_NAME,
         key_prefix=os.path.join(CURRENT_JOB_NAME, SOURCE_NAME),
-        extra_args={"SSEKMSKeyId": KMS_KEY},
+        extra_args={"SSECustomerKey": KMS_KEY},
     )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
S3 has a different set of args that are allowed for `ExtraArgs` for downloading vs uploading. docs: https://boto3.amazonaws.com/v1/documentation/api/1.9.42/reference/customizations/s3.html#boto3.s3.transfer.S3Transfer.ALLOWED_DOWNLOAD_ARGS

*Testing done:*
`tox -e py36 tests/unit/test_s3.py`

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to any/all clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
