### PR TITLE
infra: add Model unit tests for delete_model and enable_network_isolation

### DIFF
--- a/tests/unit/sagemaker/model/test_framework_model.py
+++ b/tests/unit/sagemaker/model/test_framework_model.py
@@ -237,29 +237,6 @@ def test_deploy_update_endpoint_optional_args(sagemaker_session, tmpdir):
     sagemaker_session.create_endpoint.assert_not_called()
 
 
-def test_model_enable_network_isolation(sagemaker_session):
-    model = DummyFrameworkModel(sagemaker_session=sagemaker_session)
-    assert model.enable_network_isolation() is False
-
-
-@patch("sagemaker.fw_utils.tar_and_upload_dir", MagicMock())
-@patch("time.strftime", MagicMock(return_value=TIMESTAMP))
-def test_model_delete_model(sagemaker_session, tmpdir):
-    model = DummyFrameworkModel(sagemaker_session, source_dir=str(tmpdir))
-    model.deploy(instance_type=INSTANCE_TYPE, initial_instance_count=1)
-    model.delete_model()
-
-    sagemaker_session.delete_model.assert_called_with(model.name)
-
-
-def test_delete_non_deployed_model(sagemaker_session):
-    model = DummyFrameworkModel(sagemaker_session)
-    with pytest.raises(
-        ValueError, match="The SageMaker model must be created first before attempting to delete."
-    ):
-        model.delete_model()
-
-
 def test_compile_model_for_inferentia(sagemaker_session, tmpdir):
     sagemaker_session.wait_for_compilation_job = Mock(
         return_value=DESCRIBE_COMPILATION_JOB_RESPONSE


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
similar to #1418

*Testing done:*
`pytest tests/unit/sagemaker/model/`

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to any/all clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
