### PR TITLE
feature: add EIA support for TFS 1.15.0 and 2.0.0

### DIFF
--- a/src/sagemaker/tensorflow/README.rst
+++ b/src/sagemaker/tensorflow/README.rst
@@ -20,7 +20,7 @@ Documentation of the previous Legacy Mode versions: `1.4.1 <https://github.com/a
 | You can find the Legacy Mode README `here <https://github.com/aws/sagemaker-python-sdk/tree/v1.12.0/src/sagemaker/tensorflow#tensorflow-sagemaker-estimators-and-models>`_. |
 +-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
-Supported versions of TensorFlow for Elastic Inference: ``1.11``, ``1.12``, ``1.13``, ``1.14``.
+Supported versions of TensorFlow for Elastic Inference: ``1.11``, ``1.12``, ``1.13``, ``1.14``, ``1.15``, ``2.0``.
 
 Supported versions of TensorFlow for Inferentia: ``1.15.0``.
 

--- a/src/sagemaker/tensorflow/serving.py
+++ b/src/sagemaker/tensorflow/serving.py
@@ -130,7 +130,7 @@ class Model(sagemaker.model.FrameworkModel):
         logging.ERROR: "error",
         logging.CRITICAL: "crit",
     }
-    LATEST_EIA_VERSION = [1, 14]
+    LATEST_EIA_VERSION = [2, 0]
 
     def __init__(
         self,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -268,9 +268,13 @@ def tf_full_version(request):
         return tf_version
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="module", params=["1.15.0", "2.0.0"])
 def ei_tf_full_version(request):
-    return request.config.getoption("--ei-tf-full-version")
+    tf_ei_version = request.config.getoption("--ei-tf-full-version")
+    if tf_ei_version is None:
+        return request.param
+    else:
+        return tf_ei_version
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,7 +65,7 @@ def pytest_addoption(parser):
     )
     parser.addoption("--sklearn-full-version", action="store", default=SKLEARN_VERSION)
     parser.addoption("--tf-full-version", action="store")
-    parser.addoption("--ei-tf-full-version", action="store", default=TensorFlow.LATEST_VERSION)
+    parser.addoption("--ei-tf-full-version", action="store")
     parser.addoption("--xgboost-full-version", action="store", default=SKLEARN_VERSION)
 
 

--- a/tests/integ/test_tfs.py
+++ b/tests/integ/test_tfs.py
@@ -111,7 +111,7 @@ def tfs_predictor_with_model_and_entry_point_and_dependencies(
 
 
 @pytest.fixture(scope="module")
-def tfs_predictor_with_accelerator(sagemaker_session, tf_full_version, cpu_instance_type):
+def tfs_predictor_with_accelerator(sagemaker_session, ei_tf_full_version, cpu_instance_type):
     endpoint_name = sagemaker.utils.unique_name_from_base("sagemaker-tensorflow-serving")
     model_data = sagemaker_session.upload_data(
         path=os.path.join(tests.integ.DATA_DIR, "tensorflow-serving-test-model.tar.gz"),
@@ -121,7 +121,7 @@ def tfs_predictor_with_accelerator(sagemaker_session, tf_full_version, cpu_insta
         model = Model(
             model_data=model_data,
             role="SageMakerRole",
-            framework_version="1.14",
+            framework_version=ei_tf_full_version,
             sagemaker_session=sagemaker_session,
         )
         predictor = model.deploy(

--- a/tests/unit/test_fw_utils.py
+++ b/tests/unit/test_fw_utils.py
@@ -302,13 +302,13 @@ def test_tf_eia_images():
         "us-west-2",
         "tensorflow-serving",
         "ml.m4.xlarge",
-        "1.14.0",
+        "2.0.0",
         "py3",
         accelerator_type="ml.eia1.medium",
     )
     assert (
         image_uri
-        == "{}.dkr.ecr.us-west-2.amazonaws.com/tensorflow-inference-eia:1.14.0-cpu".format(
+        == "{}.dkr.ecr.us-west-2.amazonaws.com/tensorflow-inference-eia:2.0.0-cpu".format(
             fw_utils.ASIMOV_PROD_ACCOUNT
         )
     )

--- a/tests/unit/test_tfs.py
+++ b/tests/unit/test_tfs.py
@@ -115,7 +115,7 @@ def test_tfs_model_image_accelerator_not_supported(sagemaker_session):
     model = Model(
         "s3://some/data.tar.gz",
         role=ROLE,
-        framework_version="1.15",
+        framework_version="2.1",
         sagemaker_session=sagemaker_session,
     )
 
@@ -130,7 +130,7 @@ def test_tfs_model_image_accelerator_not_supported(sagemaker_session):
             initial_instance_count=1,
         )
 
-    assert str(e.value) == "The TensorFlow version 1.15 doesn't support EIA."
+    assert str(e.value) == "The TensorFlow version 2.1 doesn't support EIA."
 
 
 def test_tfs_model_with_log_level(sagemaker_session, tf_version):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update documentation of EIA support for TF versions

*Testing done:*
Update create image uri unit test to latest TF version
Update TFS EI integ tests to test 1.15.0 and 2.0.0

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to any/all clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
