### PR TITLE
fix: use format strings intead of os.path.join for Processing paths intended for Unix

### DIFF
--- a/src/sagemaker/processing.py
+++ b/src/sagemaker/processing.py
@@ -495,7 +495,7 @@ class ScriptProcessor(Processor):
         """
         code_file_input = ProcessingInput(
             source=s3_uri,
-            destination=os.path.join(
+            destination="{}{}".format(
                 self._CODE_CONTAINER_BASE_PATH, self._CODE_CONTAINER_INPUT_NAME
             ),
             input_name=self._CODE_CONTAINER_INPUT_NAME,
@@ -508,7 +508,7 @@ class ScriptProcessor(Processor):
         Args:
             user_script_name (str): A filename with an extension.
         """
-        user_script_location = os.path.join(
+        user_script_location = "{}{}/{}".format(
             self._CODE_CONTAINER_BASE_PATH, self._CODE_CONTAINER_INPUT_NAME, user_script_name
         )
         self.entrypoint = command + [user_script_location]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When using the Python SDK to construct paths for Docker containers, no matter what the user's platform is, we still expect the Docker container to use Ubuntu (since that's what all the prebuilt SageMaker images use).

This PR is similar to #1391 

*Testing done:*
unit tests - I did some digging to see if I could write a unit test for the Windows case, but it seems like the `os.path.join` implementation for Unix systems hardcodes "/" (at least in Python 2.7): https://hg.python.org/cpython/file/v2.7.3/Lib/posixpath.py

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to any/all clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
