### PR TITLE
fix: training_config returns MetricDefinitions

### DIFF
--- a/src/sagemaker/workflow/airflow.py
+++ b/src/sagemaker/workflow/airflow.py
@@ -236,6 +236,9 @@ def training_config(estimator, inputs=None, job_name=None, mini_batch_size=None)
     if estimator.tags is not None:
         train_config["Tags"] = estimator.tags
 
+    if estimator.metric_definitions is not None:
+        train_config["AlgorithmSpecification"]["MetricDefinitions"] = estimator.metric_definitions
+
     return train_config
 
 

--- a/tests/unit/test_airflow.py
+++ b/tests/unit/test_airflow.py
@@ -284,6 +284,7 @@ def test_framework_training_config_all_args(ecr_prefix, sagemaker_session):
         tags=[{"{{ key }}": "{{ value }}"}],
         subnets=["{{ subnet }}"],
         security_group_ids=["{{ security_group_ids }}"],
+        metric_definitions=[{"Name": "{{ name }}", "Regex": "{{ regex }}"}],
         sagemaker_session=sagemaker_session,
     )
 
@@ -294,6 +295,7 @@ def test_framework_training_config_all_args(ecr_prefix, sagemaker_session):
         "AlgorithmSpecification": {
             "TrainingImage": "520713654638.dkr.ecr.us-west-2.amazonaws.com/sagemaker-tensorflow:1.10.0-cpu-py2",
             "TrainingInputMode": "Pipe",
+            "MetricDefinitions": [{"Name": "{{ name }}", "Regex": "{{ regex }}"}],
         },
         "OutputDataConfig": {
             "S3OutputPath": "{{ output_path }}",


### PR DESCRIPTION
*Issue #, if available:*
#1448 

*Description of changes:*
If the Estimator has `metric_definitions`, return it in the `train_config`.

*Testing done:*
Added a unit test.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to any/all clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
