### PR TITLE
infra: support Python 3.7

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -90,6 +90,7 @@ SageMaker Python SDK is tested on:
 
 - Python 2.7
 - Python 3.6
+- Python 3.7
 
 AWS Permissions
 ~~~~~~~~~~~~~~~
@@ -117,8 +118,8 @@ You can install the libraries needed to run the tests by running :code:`pip inst
 
 
 We run unit tests with tox, which is a program that lets you run unit tests for multiple Python versions, and also make sure the
-code fits our style guidelines. We run tox with Python 2.7 and 3.6, so to run unit tests
-with the same configuration we do, you'll need to have interpreters for Python 2.7 and Python 3.6 installed.
+code fits our style guidelines. We run tox with Python 2.7, 3.6 and 3.7, so to run unit tests
+with the same configuration we do, you'll need to have interpreters for Python 2.7, Python 3.6 and Python 3.7 installed.
 
 To run the unit tests with tox, run:
 

--- a/buildspec-localmodetests.yml
+++ b/buildspec-localmodetests.yml
@@ -11,5 +11,5 @@ phases:
 
       # local mode tests
       - start_time=`date +%s`
-      - execute-command-if-has-matching-changes "tox -e py27,py36 -- tests/integ -m local_mode --durations 50" "tests/integ" "tests/data" "tests/conftest.py" "tests/__init__.py" "src/*.py" "setup.py" "setup.cfg" "buildspec-localmodetests.yml"
-      - ./ci-scripts/displaytime.sh 'py27,py36 local mode' $start_time
+      - execute-command-if-has-matching-changes "tox -e py27,py37 -- tests/integ -m local_mode --durations 50" "tests/integ" "tests/data" "tests/conftest.py" "tests/__init__.py" "src/*.py" "setup.py" "setup.cfg" "buildspec-localmodetests.yml"
+      - ./ci-scripts/displaytime.sh 'py27,py36,py37 local mode' $start_time

--- a/buildspec-localmodetests.yml
+++ b/buildspec-localmodetests.yml
@@ -12,4 +12,4 @@ phases:
       # local mode tests
       - start_time=`date +%s`
       - execute-command-if-has-matching-changes "tox -e py27,py37 -- tests/integ -m local_mode --durations 50" "tests/integ" "tests/data" "tests/conftest.py" "tests/__init__.py" "src/*.py" "setup.py" "setup.cfg" "buildspec-localmodetests.yml"
-      - ./ci-scripts/displaytime.sh 'py27,py36,py37 local mode' $start_time
+      - ./ci-scripts/displaytime.sh 'py27,py37 local mode' $start_time

--- a/buildspec-release.yml
+++ b/buildspec-release.yml
@@ -18,10 +18,10 @@ phases:
       # run unit tests
       - AWS_ACCESS_KEY_ID= AWS_SECRET_ACCESS_KEY= AWS_SESSION_TOKEN=
         AWS_CONTAINER_CREDENTIALS_RELATIVE_URI= AWS_DEFAULT_REGION=
-        tox -e py27,py36 -- tests/unit
+        tox -e py27,py36,py37 -- tests/unit
 
       # run a subset of the integration tests
-      - IGNORE_COVERAGE=- tox -e py36 -- tests/integ -m canary_quick -n 64 --boxed --reruns 2
+      - IGNORE_COVERAGE=- tox -e py37 -- tests/integ -m canary_quick -n 64 --boxed --reruns 2
 
       # generate the distribution package
       - python3 setup.py sdist

--- a/buildspec-release.yml
+++ b/buildspec-release.yml
@@ -21,7 +21,7 @@ phases:
         tox -e py27,py36,py37 -- tests/unit
 
       # run a subset of the integration tests
-      - IGNORE_COVERAGE=- tox -e py37 -- tests/integ -m canary_quick -n 64 --boxed --reruns 2
+      - IGNORE_COVERAGE=- tox -e py36 -- tests/integ -m canary_quick -n 64 --boxed --reruns 2
 
       # generate the distribution package
       - python3 setup.py sdist

--- a/buildspec-unittests.yml
+++ b/buildspec-unittests.yml
@@ -18,5 +18,5 @@ phases:
       - start_time=`date +%s`
       - AWS_ACCESS_KEY_ID= AWS_SECRET_ACCESS_KEY= AWS_SESSION_TOKEN=
         AWS_CONTAINER_CREDENTIALS_RELATIVE_URI= AWS_DEFAULT_REGION=
-        tox -e py36,py27 --parallel all -- tests/unit
-      - ./ci-scripts/displaytime.sh 'py36,py27 unit' $start_time
+        tox -e py27,py36,py37 --parallel all -- tests/unit
+      - ./ci-scripts/displaytime.sh 'py27,py36,py37 unit' $start_time

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -11,13 +11,13 @@ phases:
 
       # run integration tests
       - start_time=`date +%s`
-      - execute-command-if-has-matching-changes "python3 -u ci-scripts/queue_build.py" "tests/integ" "tests/scripts" "tests/data" "tests/conftest.py" "tests/__init__.py" "src/*.py" "setup.py" "setup.cfg" "buildspec.yml"
+      - execute-command-if-has-matching-changes "python3.7 -u ci-scripts/queue_build.py" "tests/integ" "tests/scripts" "tests/data" "tests/conftest.py" "tests/__init__.py" "src/*.py" "setup.py" "setup.cfg" "buildspec.yml"
       - ./ci-scripts/displaytime.sh 'build queue' $start_time
 
       - start_time=`date +%s`
       - |
-        execute-command-if-has-matching-changes "env -u AWS_DEFAULT_REGION tox -e py36 -- tests/integ -m \"not local_mode\" -n 512 --reruns 3 --reruns-delay 5 --durations 50 --boto-config '{\"region_name\": \"us-east-2\"}'" "tests/integ" "tests/scripts" "tests/data" "tests/conftest.py" "tests/__init__.py" "src/*.py" "setup.py" "setup.cfg" "buildspec.yml"
-      - ./ci-scripts/displaytime.sh 'py36 tests/integ' $start_time
+        execute-command-if-has-matching-changes "env -u AWS_DEFAULT_REGION tox -e py37 -- tests/integ -m \"not local_mode\" -n 512 --reruns 3 --reruns-delay 5 --durations 50 --boto-config '{\"region_name\": \"us-east-2\"}'" "tests/integ" "tests/scripts" "tests/data" "tests/conftest.py" "tests/__init__.py" "src/*.py" "setup.py" "setup.cfg" "buildspec.yml"
+      - ./ci-scripts/displaytime.sh 'py37 tests/integ' $start_time
 
   post_build:
     finally:

--- a/setup.py
+++ b/setup.py
@@ -101,6 +101,7 @@ setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
     ],
     install_requires=required_packages,
     extras_require=extras,

--- a/src/sagemaker/tensorflow/estimator.py
+++ b/src/sagemaker/tensorflow/estimator.py
@@ -73,10 +73,13 @@ class Tensorboard(threading.Thread):
     @staticmethod
     def _cmd_exists(cmd):
         """Placeholder docstring"""
-        return any(
-            os.access(os.path.join(path, cmd), os.X_OK)
-            for path in os.environ["PATH"].split(os.pathsep)
-        )
+        for path in os.environ["PATH"].split(os.pathsep):
+            try:
+                if os.access(os.path.join(path, cmd), os.X_OK):
+                    return True
+            except StopIteration:
+                return False
+        return False
 
     @staticmethod
     def _sync_directories(from_directory, to_directory):

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = black-format,flake8,pylint,twine,sphinx,doc8,py27,py36
+envlist = black-format,flake8,pylint,twine,sphinx,doc8,py27,py36,py37
 
 skip_missing_interpreters = False
 


### PR DESCRIPTION
*Issue #, if available:*
Python SDK py37 support

*Description of changes:*
Add Python3.7 test environment.
Unit tests run against py27, py36, py37.
Integ tests run against py37.
Release build tests run against py36.

Made a change in  src/sagemaker/tensorflow/estimator.py to accommodate Python3.7 change: [PEP 479](https://www.python.org/dev/peps/pep-0479/) is enabled for all code in Python 3.7 

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to any/all clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
