### PR TITLE
doc: add note that v2.0.0 plans have been posted

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,8 @@
++-------------------------------------------------------------------------------------------------+
+| **NOTE**: We are working on v2.0.0. See https://github.com/aws/sagemaker-python-sdk/issues/1459 |
+| for more info on our plans and to leave feedback!                                               |
++-------------------------------------------------------------------------------------------------+
+
 .. image:: https://github.com/aws/sagemaker-python-sdk/raw/master/branding/icon/sagemaker-banner.png
     :height: 100px
     :alt: SageMaker

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,3 +1,7 @@
+.. important::
+    We are working on v2.0.0. See https://github.com/aws/sagemaker-python-sdk/issues/1459
+    for more info on our plans and to leave feedback!
+
 ###########################
 Amazon SageMaker Python SDK
 ###########################


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This adds a link at the top of our main doc pages to https://github.com/aws/sagemaker-python-sdk/issues/1459. Since GitHub doesn't render admonitions (https://github.com/github/markup/issues/68), I made a table instead for the README.

*Testing done:*
built the API docs locally:
<img width="753" alt="image" src="https://user-images.githubusercontent.com/6631887/81345693-c8a03900-906d-11ea-9ea0-75b7394a3460.png">

README:
<img width="995" alt="image" src="https://user-images.githubusercontent.com/6631887/81345743-e53c7100-906d-11ea-9531-7b5e47a9546d.png">


## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to any/all clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
