### PR TITLE
change: add CLI wrapper for v2 migration script

### DIFF
--- a/tools/compatibility/v2/sagemaker_upgrade_v2.py
+++ b/tools/compatibility/v2/sagemaker_upgrade_v2.py
@@ -1,0 +1,43 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+"""A tool to upgrade SageMaker Python SDK code to be compatible with v2."""
+from __future__ import absolute_import
+
+import argparse
+
+import files
+
+
+def _parse_and_validate_args():
+    """Parses CLI arguments"""
+    parser = argparse.ArgumentParser(
+        description="A tool to convert files to be compatible with v2 of the SageMaker Python SDK."
+        "\nSimple usage: sagemaker_upgrade_v2.py --in-file foo.py --out-file bar.py"
+    )
+    parser.add_argument(
+        "--in-file", help="If converting a single file, the name of the file to convert"
+    )
+    parser.add_argument(
+        "--out-file",
+        help="If converting a single file, the output file destination. If needed, "
+        "directories in the output file path are created. If the output file already exists, "
+        "it is overwritten.",
+    )
+
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = _parse_and_validate_args()
+
+    files.PyFileUpdater(input_path=args.in_file, output_path=args.out_file).update()


### PR DESCRIPTION
*Issue #, if available:*
#1478

*Description of changes:*
follow-up to #1497. I did look into [click](https://click.palletsprojects.com/en/7.x/why/#why-not-argparse), but decided against it since this is meant to be just a side tool to the Python SDK. Click is relatively small in size (~500 KB), but it still felt a little weird to add another dependency just for the sake of some CLI-parsing features we won't use in the main part of this repository.

*Testing done:*
```bash
# making sure the description is formatted okay
$ python sagemaker_upgrade_v2.py --help
usage: sagemaker_upgrade_v2.py [-h] [--in-file IN_FILE] [--out-file OUT_FILE]

A tool to convert files to be compatible with v2 of the SageMaker Python SDK.
Simple usage: sagemaker_upgrade_v2.py --in-file foo.py --out-file bar.py

optional arguments:
  -h, --help           show this help message and exit
  --in-file IN_FILE    If converting a single file, the name of the file to
                       convert
  --out-file OUT_FILE  If converting a single file, the output file
                       destination. If needed, directories in the output file
                       path are created. If the output file already exists, it
                       is overwritten.

# testing with a dummy file
$ python sagemaker_upgrade_v2.py --in-file input.py --out-file output.py && cat output.py
from sagemaker.mxnet import MXNet

m = MXNet(framework_version="1.2.0")  # TODO: fill in parameters
m.fit()
```

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to any/all clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
