### PR TITLE
change: add .ipynb file support for v2 migration script

### DIFF
--- a/tools/compatibility/v2/files.py
+++ b/tools/compatibility/v2/files.py
@@ -13,8 +13,10 @@
 """Classes for updating code in files."""
 from __future__ import absolute_import
 
-import os
 import logging
+import json
+import os
+from abc import abstractmethod
 
 import pasta
 
@@ -23,11 +25,9 @@ from ast_transformer import ASTTransformer
 LOGGER = logging.getLogger(__name__)
 
 
-class PyFileUpdater(object):
-    """A class for updating Python (``*.py``) files."""
-
+class FileUpdater(object):
     def __init__(self, input_path, output_path):
-        """Creates a ``PyFileUpdater`` for updating a Python file so that
+        """Creates a ``FileUpdater`` for updating a file so that
         it is compatible with v2 of the SageMaker Python SDK.
 
         Args:
@@ -38,6 +38,17 @@ class PyFileUpdater(object):
         """
         self.input_path = input_path
         self.output_path = output_path
+
+    @abstractmethod
+    def update(self):
+        """Reads the input file, updates the code so that it is
+        compatible with v2 of the SageMaker Python SDK, and writes the
+        updated code to an output file.
+        """
+
+
+class PyFileUpdater(FileUpdater):
+    """A class for updating Python (``*.py``) files."""
 
     def update(self):
         """Reads the input Python file, updates the code so that it is
@@ -60,7 +71,7 @@ class PyFileUpdater(object):
         return ASTTransformer().visit(input_ast)
 
     def _read_input_file(self):
-        """Reads input file and parse as an abstract syntax tree (AST).
+        """Reads input file and parses it as an abstract syntax tree (AST).
 
         Returns:
             ast.Module: AST representation of the input file.
@@ -84,3 +95,84 @@ class PyFileUpdater(object):
 
         with open(self.output_path, "w") as output_file:
             output_file.write(pasta.dump(output))
+
+
+class JupyterNotebookFileUpdater(FileUpdater):
+    """A class for updating Jupyter notebook (``*.ipynb``) files.
+
+    For more on this file format, see
+    https://ipython.org/ipython-doc/dev/notebook/nbformat.html#nbformat.
+    """
+
+    def update(self):
+        """Reads the input Jupyter notebook file, updates the code so that it is
+        compatible with v2 of the SageMaker Python SDK, and writes the
+        updated code to an output file.
+        """
+        nb_json = self._read_input_file()
+        for cell in nb_json["cells"]:
+            if cell["cell_type"] == "code":
+                updated_source = self._update_code_from_cell(cell)
+                cell["source"] = updated_source
+
+        self._write_output_file(nb_json)
+
+    def _update_code_from_cell(self, cell):
+        """Updates the code from a code cell so that it is
+        compatible with v2 of the SageMaker Python SDK.
+
+        Args:
+            cell (dict): A dictionary representation of a code cell from
+                a Jupyter notebook. For more info, see
+                https://ipython.org/ipython-doc/dev/notebook/nbformat.html#code-cells.
+
+        Returns:
+            list[str]: A list of strings containing the lines of updated code that
+                can be used for the "source" attribute of a Jupyter notebook code cell.
+        """
+        code = "".join(cell["source"])
+        updated_ast = ASTTransformer().visit(pasta.parse(code))
+        updated_code = pasta.dump(updated_ast)
+        return self._code_str_to_source_list(updated_code)
+
+    def _code_str_to_source_list(self, code):
+        """Converts a string of code into a list for a Jupyter notebook code cell.
+
+        Args:
+            code (str): Code to be converted.
+
+        Returns:
+            list[str]: A list of strings containing the lines of code that
+                can be used for the "source" attribute of a Jupyter notebook code cell.
+                Each element of the list (i.e. line of code) contains a
+                trailing newline character ("\n") except for the last element.
+        """
+        source_list = ["{}\n".format(s) for s in code.split("\n")]
+        source_list[-1] = source_list[-1].rstrip("\n")
+        return source_list
+
+    def _read_input_file(self):
+        """Reads input file and parses it as JSON.
+
+        Returns:
+            dict: JSON representation of the input file.
+        """
+        with open(self.input_path) as input_file:
+            return json.load(input_file)
+
+    def _write_output_file(self, output):
+        """Writes JSON to output file. Creates the directories for the output path, if needed.
+
+        Args:
+            output (dict): JSON to save as the output file.
+        """
+        output_dir = os.path.dirname(self.output_path)
+        if output_dir and not os.path.exists(output_dir):
+            os.makedirs(output_dir)
+
+        if os.path.exists(self.output_path):
+            LOGGER.warning("Overwriting file %s", self.output_path)
+
+        with open(self.output_path, "w") as output_file:
+            json.dump(output, output_file, indent=1)
+            output_file.write("\n")  # json.dump does not write trailing newline

--- a/tools/compatibility/v2/files.py
+++ b/tools/compatibility/v2/files.py
@@ -13,10 +13,10 @@
 """Classes for updating code in files."""
 from __future__ import absolute_import
 
-import logging
-import json
-import os
 from abc import abstractmethod
+import json
+import logging
+import os
 
 import pasta
 

--- a/tools/compatibility/v2/files.py
+++ b/tools/compatibility/v2/files.py
@@ -26,6 +26,8 @@ LOGGER = logging.getLogger(__name__)
 
 
 class FileUpdater(object):
+    """An abstract class for updating files."""
+
     def __init__(self, input_path, output_path):
         """Creates a ``FileUpdater`` for updating a file so that
         it is compatible with v2 of the SageMaker Python SDK.

--- a/tools/compatibility/v2/sagemaker_upgrade_v2.py
+++ b/tools/compatibility/v2/sagemaker_upgrade_v2.py
@@ -57,8 +57,9 @@ def _parse_args():
         "Simple usage: sagemaker_upgrade_v2.py --in-file foo.py --out-file bar.py"
     )
     parser.add_argument(
-        "--in-file", help="If converting a single file, the file to convert. The file's extension "
-        "must be either '.py' or '.ipynb'."
+        "--in-file",
+        help="If converting a single file, the file to convert. The file's extension "
+        "must be either '.py' or '.ipynb'.",
     )
     parser.add_argument(
         "--out-file",


### PR DESCRIPTION
*Issue #, if available:*
#1478

*Description of changes:*
The notebook counterpart to #1497.

*Testing done:*
Created a simple notebook:

<img width="1140" alt="image" src="https://user-images.githubusercontent.com/6631887/82268274-77246380-9923-11ea-8a41-15bd3e2471ed.png">

Then ran:

```bash
$ python sagemaker_upgrade_v2.py --in-file Untitled.ipynb --out-file output.ipynb
$ diff Untitled.ipynb output.ipynb
30c30
<     "MXNet()"
---
>     "MXNet(framework_version='1.2.0')"
48c48
<     "mx = sagemaker.mxnet.MXNet()"
---
>     "mx = sagemaker.mxnet.MXNet(framework_version='1.2.0')"
```

And also opened up the new notebook:

<img width="1143" alt="image" src="https://user-images.githubusercontent.com/6631887/82268365-aa66f280-9923-11ea-90e4-68922fe56dcb.png">

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to any/all clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
