### PR TITLE
fix: use format strings instead of os.path.join for S3 URI in S3Downloader

### DIFF
--- a/src/sagemaker/s3.py
+++ b/src/sagemaker/s3.py
@@ -14,7 +14,6 @@
 from __future__ import print_function, absolute_import
 
 import logging
-import os
 
 from six.moves.urllib.parse import urlparse
 from sagemaker.session import Session
@@ -184,4 +183,4 @@ class S3Downloader(object):
         bucket, key_prefix = parse_s3_url(url=s3_uri)
 
         file_keys = sagemaker_session.list_s3_files(bucket=bucket, key_prefix=key_prefix)
-        return [os.path.join("s3://", bucket, file_key) for file_key in file_keys]
+        return ["s3://{}/{}".format(bucket, file_key) for file_key in file_keys]


### PR DESCRIPTION
*Issue #, if available:*
#1511 (#1501)

*Description of changes:*
similar to #1435 and #1391 

*Testing done:*
`tox -e py36,flake8,pylint,black-format --parallel all tests/unit`

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to any/all clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
