### PR TITLE
doc: fix TF requirements.txt documentation

### DIFF
--- a/doc/using_tf.rst
+++ b/doc/using_tf.rst
@@ -140,10 +140,10 @@ If there are other packages you want to use with your script, you can use a ``re
 
 For training, support for installing packages using ``requirements.txt`` varies by TensorFlow version as follows:
 
-- For TensorFlow 1.11 or newer using Script Mode without Horovod, TensorFlow 1.15.2 with Python 3.7 or newer, and TensorFlow 2.2 or newer:
+- For TensorFlow 1.15.2 with Python 3.7 or newer, and TensorFlow 2.2 or newer:
     - Include a ``requirements.txt`` file in the same directory as your training script.
     - You must specify this directory using the ``source_dir`` argument when creating a TensorFlow estimator.
-- For older versions of TensorFlow using Script Mode with Horovod:
+- For older versions of TensorFlow using Script Mode (TensorFlow 1.11-1.15.2, 2.0-2.1 with Python 2.7 or 3.6):
     - Write a shell script for your entry point that first calls ``pip install -r requirements.txt``, then runs your training script.
     - For an example of using shell scripts, see `this example notebook <https://github.com/awslabs/amazon-sagemaker-examples/blob/master/sagemaker-python-sdk/tensorflow_script_mode_using_shell_commands/tensorflow_script_mode_using_shell_commands.ipynb>`__.
 - For older versions of TensorFlow using Legacy Mode:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
follow-up to #1512 - TF script mode support for `requirements.txt` for versions before TF 1.15.2 with Python 3.7 and TF 2.2 was a bit of a fluke rather than intended behavior, as indicated by #839. However, it doesn't work consistently, which I verified by trying it out with the TF 1.14 image. This PR is to change the documentation to go with what we "officially recommended" at the time, which was the shell script workaround.

*Testing done:*
here's what I did to make sure that the shell script workaround works for TF 1.14:

```
$ cat src/entry.sh
python -m pip install -r requirements.txt
python hello.py

$ cat src/requirements.txt
pyfiglet

$ cat src/hello.py
from pyfiglet import Figlet

print(Figlet().renderText('hello').strip())

$ cat run.py
from sagemaker.tensorflow import TensorFlow

tf = TensorFlow(
    entry_point='entry.sh',
    source_dir='src',
    framework_version='1.14',
    py_version='py3',
    role='SageMakerRole',
    train_instance_type='local',
    train_instance_count=1,
)

tf.fit()

$ python run.py
```

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to any/all clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
