### PR TITLE
documentation: fix undoc directive; removes extra tabs

### DIFF
--- a/doc/frameworks/tensorflow/sagemaker.tensorflow.rst
+++ b/doc/frameworks/tensorflow/sagemaker.tensorflow.rst
@@ -31,13 +31,13 @@ TensorFlow Serving Model
 
 .. autoclass:: sagemaker.tensorflow.serving.Model
     :members:
-        :undoc-members:
-        :show-inheritance:
+    :undoc-members:
+    :show-inheritance:
 
 TensorFlow Serving Predictor
 ----------------------------
 
 .. autoclass:: sagemaker.tensorflow.serving.Predictor
     :members:
-        :undoc-members:
-        :show-inheritance:
+    :undoc-members:
+    :show-inheritance:


### PR DESCRIPTION
Docs build was failing on some extra tabs.

## Merge Checklist

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
