### PR TITLE
change: make v2 migration script remove legacy run_tensorboard_locally parameter

### DIFF
--- a/src/sagemaker/cli/compatibility/v2/ast_transformer.py
+++ b/src/sagemaker/cli/compatibility/v2/ast_transformer.py
@@ -20,6 +20,7 @@ from sagemaker.cli.compatibility.v2 import modifiers
 FUNCTION_CALL_MODIFIERS = [
     modifiers.framework_version.FrameworkVersionEnforcer(),
     modifiers.tf_legacy_mode.TensorFlowLegacyModeConstructorUpgrader(),
+    modifiers.tf_legacy_mode.TensorBoardParameterRemover(),
 ]
 
 

--- a/tests/unit/sagemaker/cli/compatibility/v2/modifiers/test_tensorboard_remove_param.py
+++ b/tests/unit/sagemaker/cli/compatibility/v2/modifiers/test_tensorboard_remove_param.py
@@ -1,0 +1,63 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from __future__ import absolute_import
+
+import pasta
+
+from sagemaker.cli.compatibility.v2.modifiers import tf_legacy_mode
+
+
+def test_node_should_be_modified_fit_with_tensorboard():
+    fit_calls = (
+        "estimator.fit(run_tensorboard_locally=True)",
+        "tensorflow.fit(run_tensorboard_locally=False)",
+    )
+
+    modifier = tf_legacy_mode.TensorBoardParameterRemover()
+
+    for call in fit_calls:
+        node = _ast_call(call)
+        assert modifier.node_should_be_modified(node) is True
+
+
+def test_node_should_be_modified_fit_without_tensorboard():
+    fit_calls = ("estimator.fit()", "tensorflow.fit()")
+
+    modifier = tf_legacy_mode.TensorBoardParameterRemover()
+
+    for call in fit_calls:
+        node = _ast_call(call)
+        assert modifier.node_should_be_modified(node) is False
+
+
+def test_node_should_be_modified_random_function_call():
+    node = _ast_call("estimator.deploy(1, 'local')")
+    modifier = tf_legacy_mode.TensorBoardParameterRemover()
+    assert modifier.node_should_be_modified(node) is False
+
+
+def test_modify_node():
+    fit_calls = (
+        "estimator.fit(run_tensorboard_locally=True)",
+        "estimator.fit(run_tensorboard_locally=False)",
+    )
+    modifier = tf_legacy_mode.TensorBoardParameterRemover()
+
+    for call in fit_calls:
+        node = _ast_call(call)
+        modifier.modify_node(node)
+        assert "estimator.fit()" == pasta.dump(node)
+
+
+def _ast_call(code):
+    return pasta.parse(code).body[0].value


### PR DESCRIPTION
*Issue #, if available:*
#1462, #1478 

*Description of changes:*
follow-up to #1534 for covering the changes in #1510. I considered checking if the object having fit invoked contained "estimator", "tensorflow", or "tf", but after [Googling "run_tensorboard_locally"](https://www.google.com/search?q="run_tensorboard_locally"), it seems like this is the only place where such a parameter name exists. Even the search suggestions are all SageMaker-related:

![image](https://user-images.githubusercontent.com/6631887/83315424-b7fa6300-a1d4-11ea-812f-9d4e270e18b6.png)

As such, I feel confident that there won't be too many false positives with the criteria for `should_node_be_modified()`

*Testing done:*
unit tests

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to any/all clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
