### PR TITLE
 breaking: rename sagemaker.tensorflow.serving to sagemaker.tensorflow.model

### DIFF
--- a/doc/sagemaker.tensorflow.rst
+++ b/doc/sagemaker.tensorflow.rst
@@ -13,7 +13,7 @@ TensorFlow Estimator
 TensorFlow Serving Model
 ------------------------
 
-.. autoclass:: sagemaker.tensorflow.serving.Model
+.. autoclass:: sagemaker.tensorflow.model.TensorFlowModel
     :members:
         :undoc-members:
         :show-inheritance:
@@ -21,7 +21,7 @@ TensorFlow Serving Model
 TensorFlow Serving Predictor
 ----------------------------
 
-.. autoclass:: sagemaker.tensorflow.serving.Predictor
+.. autoclass:: sagemaker.tensorflow.model.TensorFlowPredictor
     :members:
         :undoc-members:
         :show-inheritance:

--- a/src/sagemaker/cli/tensorflow.py
+++ b/src/sagemaker/cli/tensorflow.py
@@ -68,9 +68,9 @@ class TensorFlowHostCommand(HostCommand):
         Args:
             model_url:
         """
-        from sagemaker.tensorflow.serving import Model
+        from sagemaker.tensorflow.model import TensorFlowModel
 
-        return Model(
+        return TensorFlowModel(
             model_data=model_url,
             role=self.role_name,
             entry_point=self.script,

--- a/src/sagemaker/rl/estimator.py
+++ b/src/sagemaker/rl/estimator.py
@@ -21,6 +21,7 @@ from sagemaker.estimator import Framework
 import sagemaker.fw_utils as fw_utils
 from sagemaker.model import FrameworkModel, SAGEMAKER_OUTPUT_LOCATION
 from sagemaker.mxnet.model import MXNetModel
+from sagemaker.tensorflow.model import TensorFlowModel
 from sagemaker.vpc_utils import VPC_CONFIG_DEFAULT
 
 logger = logging.getLogger("sagemaker")
@@ -90,7 +91,7 @@ class RLEstimator(Framework):
         :meth:`~sagemaker.amazon.estimator.Framework.deploy` creates a hosted
         SageMaker endpoint and based on the specified framework returns an
         :class:`~sagemaker.amazon.mxnet.model.MXNetPredictor` or
-        :class:`~sagemaker.amazon.tensorflow.serving.Predictor` instance that
+        :class:`~sagemaker.amazon.tensorflow.model.TensorFlowPredictor` instance that
         can be used to perform inference against the hosted model.
 
         Technical documentation on preparing RLEstimator scripts for
@@ -205,15 +206,15 @@ class RLEstimator(Framework):
             sagemaker.model.FrameworkModel: Depending on input parameters returns
                 one of the following:
 
-                * :class:`~sagemaker.model.FrameworkModel` - if ``image_name`` was specified
+                * :class:`~sagemaker.model.FrameworkModel` - if ``image_name`` is specified
                     on the estimator;
-                * :class:`~sagemaker.mxnet.MXNetModel` - if ``image_name`` wasn't specified and
-                    MXNet was used as the RL backend;
-                * :class:`~sagemaker.tensorflow.serving.Model` - if ``image_name`` wasn't specified
-                    and TensorFlow was used as the RL backend.
+                * :class:`~sagemaker.mxnet.MXNetModel` - if ``image_name`` isn't specified and
+                    MXNet is used as the RL backend;
+                * :class:`~sagemaker.tensorflow.model.TensorFlowModel` - if ``image_name`` isn't
+                    specified and TensorFlow is used as the RL backend.
 
         Raises:
-            ValueError: If image_name was not specified and framework enum is not valid.
+            ValueError: If image_name is not specified and framework enum is not valid.
         """
         base_args = dict(
             model_data=self.model_data,
@@ -252,9 +253,7 @@ class RLEstimator(Framework):
             )
 
         if self.framework == RLFramework.TENSORFLOW.value:
-            from sagemaker.tensorflow.serving import Model as tfsModel
-
-            return tfsModel(framework_version=self.framework_version, **base_args)
+            return TensorFlowModel(framework_version=self.framework_version, **base_args)
         if self.framework == RLFramework.MXNET.value:
             return MXNetModel(
                 framework_version=self.framework_version, py_version=PYTHON_VERSION, **extended_args

--- a/src/sagemaker/tensorflow/__init__.py
+++ b/src/sagemaker/tensorflow/__init__.py
@@ -14,3 +14,4 @@
 from __future__ import absolute_import
 
 from sagemaker.tensorflow.estimator import TensorFlow  # noqa: F401 (imported but unused)
+from sagemaker.tensorflow.model import TensorFlowModel, TensorFlowPredictor  # noqa: F401

--- a/src/sagemaker/tensorflow/estimator.py
+++ b/src/sagemaker/tensorflow/estimator.py
@@ -23,7 +23,7 @@ from sagemaker.debugger import DebuggerHookConfig
 from sagemaker.estimator import Framework
 import sagemaker.fw_utils as fw
 from sagemaker.tensorflow import defaults
-from sagemaker.tensorflow.serving import Model
+from sagemaker.tensorflow.model import TensorFlowModel
 from sagemaker.transformer import Transformer
 from sagemaker.vpc_utils import VPC_CONFIG_DEFAULT
 
@@ -249,12 +249,13 @@ class TensorFlow(Framework):
         dependencies=None,
         **kwargs
     ):
-        """Create a ``Model`` object that can be used for creating SageMaker model entities,
-        deploying to a SageMaker endpoint, or starting SageMaker Batch Transform jobs.
+        """Create a ``TensorFlowModel`` object that can be used for creating
+        SageMaker model entities, deploying to a SageMaker endpoint, or
+        starting SageMaker Batch Transform jobs.
 
         Args:
-            role (str): The ``ExecutionRoleArn`` IAM Role ARN for the ``Model``, which is also
-                used during transform jobs. If not specified, the role from the Estimator is used.
+            role (str): The ``TensorFlowModel``, which is also used during transform jobs.
+                If not specified, the role from the Estimator is used.
             vpc_config_override (dict[str, list[str]]): Optional override for VpcConfig set on the
                 model. Default: use subnets and security groups from this Estimator.
 
@@ -267,11 +268,12 @@ class TensorFlow(Framework):
                 source code dependencies aside from the entry point file (default: None).
             dependencies (list[str]): A list of paths to directories (absolute or relative) with
                 any additional libraries that will be exported to the container (default: None).
-            **kwargs: Additional kwargs passed to :class:`~sagemaker.tensorflow.serving.Model`.
+            **kwargs: Additional kwargs passed to
+                :class:`~sagemaker.tensorflow.model.TensorFlowModel`.
 
         Returns:
-            sagemaker.tensorflow.serving.Model: A ``Model`` object.
-                See :class:`~sagemaker.tensorflow.serving.Model` for full details.
+            sagemaker.tensorflow.model.TensorFlowModel: A ``TensorFlowModel`` object.
+                See :class:`~sagemaker.tensorflow.model.TensorFlowModel` for full details.
         """
         if "image" not in kwargs:
             kwargs["image"] = self.image_name
@@ -282,7 +284,7 @@ class TensorFlow(Framework):
         if "enable_network_isolation" not in kwargs:
             kwargs["enable_network_isolation"] = self.enable_network_isolation()
 
-        return Model(
+        return TensorFlowModel(
             model_data=self.model_data,
             role=role or self.role,
             container_log_level=self.container_log_level,
@@ -418,9 +420,8 @@ class TensorFlow(Framework):
                 container in MB.
             tags (list[dict]): List of tags for labeling a transform job. If none specified, then
                 the tags used for the training job are used for the transform job.
-            role (str): The ``ExecutionRoleArn`` IAM Role ARN for the ``Model``, which is also
-                used during transform jobs. If not specified, the role from the Estimator will be
-                used.
+            role (str): The IAM Role ARN for the ``TensorFlowModel``, which is also used
+                during transform jobs. If not specified, the role from the Estimator is used.
             volume_kms_key (str): Optional. KMS key ID for encrypting the volume attached to the ML
                 compute instance (default: None).
             entry_point (str): Path (absolute or relative) to the local Python source file which

--- a/tests/integ/test_data_capture_config.py
+++ b/tests/integ/test_data_capture_config.py
@@ -18,7 +18,7 @@ import sagemaker
 import tests.integ
 import tests.integ.timeout
 from sagemaker.model_monitor import DataCaptureConfig, NetworkConfig
-from sagemaker.tensorflow.serving import Model
+from sagemaker.tensorflow.model import TensorFlowModel
 from sagemaker.utils import unique_name_from_base
 from tests.integ.retry import retries
 
@@ -49,7 +49,7 @@ def test_enabling_data_capture_on_endpoint_shows_correct_data_capture_status(
         key_prefix="tensorflow-serving/models",
     )
     with tests.integ.timeout.timeout_and_delete_endpoint_by_name(endpoint_name, sagemaker_session):
-        model = Model(
+        model = TensorFlowModel(
             model_data=model_data,
             role=ROLE,
             framework_version=tf_full_version,
@@ -106,7 +106,7 @@ def test_disabling_data_capture_on_endpoint_shows_correct_data_capture_status(
         key_prefix="tensorflow-serving/models",
     )
     with tests.integ.timeout.timeout_and_delete_endpoint_by_name(endpoint_name, sagemaker_session):
-        model = Model(
+        model = TensorFlowModel(
             model_data=model_data,
             role=ROLE,
             framework_version=tf_full_version,
@@ -192,7 +192,7 @@ def test_updating_data_capture_on_endpoint_shows_correct_data_capture_status(
         key_prefix="tensorflow-serving/models",
     )
     with tests.integ.timeout.timeout_and_delete_endpoint_by_name(endpoint_name, sagemaker_session):
-        model = Model(
+        model = TensorFlowModel(
             model_data=model_data,
             role=ROLE,
             framework_version=tf_full_version,

--- a/tests/integ/test_model_monitor.py
+++ b/tests/integ/test_model_monitor.py
@@ -36,7 +36,7 @@ from sagemaker.model_monitor.data_capture_config import _DATA_CAPTURE_S3_PATH
 from sagemaker.model_monitor import CronExpressionGenerator
 from sagemaker.processing import ProcessingInput
 from sagemaker.processing import ProcessingOutput
-from sagemaker.tensorflow.serving import Model
+from sagemaker.tensorflow.model import TensorFlowModel
 from sagemaker.utils import unique_name_from_base
 
 from tests.integ.kms_utils import get_or_create_kms_key
@@ -97,7 +97,7 @@ def predictor(sagemaker_session, tf_full_version):
     with tests.integ.timeout.timeout_and_delete_endpoint_by_name(
         endpoint_name=endpoint_name, sagemaker_session=sagemaker_session, hours=2
     ):
-        model = Model(
+        model = TensorFlowModel(
             model_data=model_data,
             role=ROLE,
             framework_version=tf_full_version,

--- a/tests/integ/test_tfs.py
+++ b/tests/integ/test_tfs.py
@@ -23,7 +23,7 @@ import sagemaker.predictor
 import sagemaker.utils
 import tests.integ
 import tests.integ.timeout
-from sagemaker.tensorflow.serving import Model, Predictor
+from sagemaker.tensorflow.model import TensorFlowModel, TensorFlowPredictor
 
 
 @pytest.fixture(scope="module")
@@ -34,7 +34,7 @@ def tfs_predictor(sagemaker_session, tf_full_version):
         key_prefix="tensorflow-serving/models",
     )
     with tests.integ.timeout.timeout_and_delete_endpoint_by_name(endpoint_name, sagemaker_session):
-        model = Model(
+        model = TensorFlowModel(
             model_data=model_data,
             role="SageMakerRole",
             framework_version=tf_full_version,
@@ -62,7 +62,7 @@ def tfs_predictor_with_model_and_entry_point_same_tar(
         os.path.join(tests.integ.DATA_DIR, "tfs/tfs-test-model-with-inference"), tmpdir
     )
 
-    model = Model(
+    model = TensorFlowModel(
         model_data="file://" + model_tar,
         role="SageMakerRole",
         framework_version=tf_full_version,
@@ -93,7 +93,7 @@ def tfs_predictor_with_model_and_entry_point_and_dependencies(
         tests.integ.DATA_DIR, "tensorflow-serving-test-model.tar.gz"
     )
 
-    model = Model(
+    model = TensorFlowModel(
         entry_point=entry_point,
         model_data=model_data,
         role="SageMakerRole",
@@ -118,7 +118,7 @@ def tfs_predictor_with_accelerator(sagemaker_session, ei_tf_full_version, cpu_in
         key_prefix="tensorflow-serving/models",
     )
     with tests.integ.timeout.timeout_and_delete_endpoint_by_name(endpoint_name, sagemaker_session):
-        model = Model(
+        model = TensorFlowModel(
             model_data=model_data,
             role="SageMakerRole",
             framework_version=ei_tf_full_version,
@@ -235,7 +235,7 @@ def test_predict_csv(tfs_predictor):
     input_data = "1.0,2.0,5.0\n1.0,2.0,5.0"
     expected_result = {"predictions": [[3.5, 4.0, 5.5], [3.5, 4.0, 5.5]]}
 
-    predictor = Predictor(
+    predictor = TensorFlowPredictor(
         tfs_predictor.endpoint,
         tfs_predictor.sagemaker_session,
         serializer=sagemaker.predictor.csv_serializer,

--- a/tests/unit/sagemaker/tensorflow/test_estimator.py
+++ b/tests/unit/sagemaker/tensorflow/test_estimator.py
@@ -21,7 +21,7 @@ from packaging import version
 import pytest
 
 from sagemaker.estimator import _TrainingJob
-from sagemaker.tensorflow import defaults, serving, TensorFlow
+from sagemaker.tensorflow import defaults, model, TensorFlow
 from tests.unit import DATA_DIR
 
 SCRIPT_FILE = "dummy_script.py"
@@ -188,7 +188,7 @@ def test_create_model(sagemaker_session, tf_version):
     model = tf.create_model()
 
     assert model.sagemaker_session == sagemaker_session
-    assert model._framework_version == tf_version
+    assert model.framework_version == tf_version
     assert model.entry_point is None
     assert model.role == ROLE
     assert model.name == job_name
@@ -372,17 +372,17 @@ def test_script_mode_create_model(sagemaker_session):
     )
     tf._prepare_for_training()  # set output_path and job name as if training happened
 
-    model = tf.create_model()
+    tf_model = tf.create_model()
 
-    assert isinstance(model, serving.Model)
+    assert isinstance(tf_model, model.TensorFlowModel)
 
-    assert model.model_data == tf.model_data
-    assert model.role == tf.role
-    assert model.name == tf._current_job_name
-    assert model.container_log_level == tf.container_log_level
-    assert model._framework_version == "1.11"
-    assert model.sagemaker_session == sagemaker_session
-    assert model.enable_network_isolation()
+    assert tf_model.model_data == tf.model_data
+    assert tf_model.role == tf.role
+    assert tf_model.name == tf._current_job_name
+    assert tf_model.container_log_level == tf.container_log_level
+    assert tf_model.framework_version == "1.11"
+    assert tf_model.sagemaker_session == sagemaker_session
+    assert tf_model.enable_network_isolation()
 
 
 @patch("time.strftime", return_value=TIMESTAMP)

--- a/tests/unit/test_rl.py
+++ b/tests/unit/test_rl.py
@@ -22,7 +22,7 @@ from mock import patch
 
 from sagemaker.mxnet import MXNetModel, MXNetPredictor
 from sagemaker.rl import RLEstimator, RLFramework, RLToolkit, TOOLKIT_FRAMEWORK_VERSION_MAP
-import sagemaker.tensorflow.serving as tfs
+from sagemaker.tensorflow import TensorFlowModel, TensorFlowPredictor
 
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), "..", "data")
@@ -184,9 +184,9 @@ def test_create_tf_model(sagemaker_session, rl_coach_tf_version):
     supported_versions = TOOLKIT_FRAMEWORK_VERSION_MAP[RLToolkit.COACH.value]
     framework_version = supported_versions[rl_coach_tf_version][RLFramework.TENSORFLOW.value]
 
-    assert isinstance(model, tfs.Model)
+    assert isinstance(model, TensorFlowModel)
     assert model.sagemaker_session == sagemaker_session
-    assert model._framework_version == framework_version
+    assert model.framework_version == framework_version
     assert model.role == ROLE
     assert model.name == job_name
     assert model._container_log_level == container_log_level
@@ -366,7 +366,7 @@ def test_deploy_tfs(sagemaker_session, rl_coach_tf_version):
     )
     rl.fit()
     predictor = rl.deploy(1, GPU)
-    assert isinstance(predictor, tfs.Predictor)
+    assert isinstance(predictor, TensorFlowPredictor)
 
 
 @patch("sagemaker.utils.create_tar_file", MagicMock())

--- a/tox.ini
+++ b/tox.ini
@@ -63,7 +63,7 @@ passenv =
 # Can be used to specify which tests to run, e.g.: tox -- -s
 commands =
     coverage run --source sagemaker -m pytest {posargs}
-    {env:IGNORE_COVERAGE:} coverage report --fail-under=85 --omit */tensorflow/tensorflow_serving/*
+    {env:IGNORE_COVERAGE:} coverage report --fail-under=86 --omit */tensorflow/tensorflow_serving/*
 extras = test
 
 [testenv:flake8]


### PR DESCRIPTION
*Issue #, if available:*
#1462 

*Description of changes:*
This changes the following two classes:

* `sagemaker.tensorflow.serving.Model` --> `sagemaker.tensorflow.model.TensorFlowModel`
* `sagemaker.tensorflow.serving.Predictor` --> `sagemaker.tensorflow.model.TensorFlowPredictor`

This PR also changes two attributes to match the other framework model classes:

* `FRAMEWORK_NAME` --> `__framework_name__`
* `_framework_version` --> `framework_version`

*Testing done:*
unit tests, linters

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to any/all clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
