### PR TITLE
feature: Use boto3 DEFAULT_SESSION when no boto3 session specified.

### DIFF
--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -123,7 +123,7 @@ class Session(object):  # pylint: disable=too-many-public-methods
         Creates or uses a boto_session, sagemaker_client and sagemaker_runtime_client.
         Sets the region_name.
         """
-        self.boto_session = boto_session or boto3.Session()
+        self.boto_session = boto_session or boto3.DEFAULT_SESSION or boto3.Session()
 
         self._region_name = self.boto_session.region_name
         if self._region_name is None:

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -19,7 +19,6 @@ import os
 
 import pytest
 import six
-import boto3
 from botocore.exceptions import ClientError
 from mock import ANY, MagicMock, Mock, patch, call, mock_open
 

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -19,6 +19,7 @@ import os
 
 import pytest
 import six
+import boto3
 from botocore.exceptions import ClientError
 from mock import ANY, MagicMock, Mock, patch, call, mock_open
 
@@ -50,6 +51,18 @@ def boto_session():
     )
     boto_mock.client.return_value = client_mock
     return boto_mock
+
+
+@patch("boto3.DEFAULT_SESSION")
+def test_default_session(boto3_default_session):
+    sess = Session()
+    assert sess.boto_session is boto3_default_session
+
+
+@patch("boto3.Session")
+def test_new_session_created(boto3_session):
+    sess = Session()
+    assert sess.boto_session is boto3_session.return_value
 
 
 def test_process(boto_session):


### PR DESCRIPTION
*Issue #:* #1542 

*Description of changes:* Use boto3 DEFAULT_SESSION when no boto3 session specified.

*Testing done:* Unit tests.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to any/all clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
