### PR TITLE
infra: remove TF from optional dependencies

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -14,34 +14,7 @@
 from __future__ import absolute_import
 
 import pkg_resources
-import sys
 from datetime import datetime
-from unittest.mock import MagicMock
-
-
-class Mock(MagicMock):
-    @classmethod
-    def __getattr__(cls, name):
-        """
-        Args:
-            name:
-        """
-        if name == "__version__":
-            return "1.4.0"
-        else:
-            return MagicMock()
-
-
-MOCK_MODULES = [
-    "tensorflow",
-    "tensorflow.core",
-    "tensorflow.core.framework",
-    "tensorflow.python",
-    "tensorflow.python.framework",
-    "tensorflow_serving",
-    "tensorflow_serving.apis",
-]
-sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
 project = u"sagemaker"
 version = pkg_resources.require(project)[0].version

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ def read_version():
 # Declare minimal set for installation
 required_packages = [
     "boto3>=1.13.6",
+    "google-pasta",
     "numpy>=1.9.0",
     "protobuf>=3.1",
     "protobuf3-to-dict>=0.1.5",

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,6 @@ extras = {
         "docker-compose>=1.25.2",
         "PyYAML>=5.3, <6",  # PyYAML version has to match docker-compose requirements
     ],
-    "tensorflow": ["tensorflow>=1.3.0"],
     "scipy": ["scipy>=0.19.0"],
 }
 # Meta dependency groups

--- a/tox.ini
+++ b/tox.ini
@@ -63,7 +63,7 @@ passenv =
 # Can be used to specify which tests to run, e.g.: tox -- -s
 commands =
     coverage run --source sagemaker -m pytest {posargs}
-    {env:IGNORE_COVERAGE:} coverage report --fail-under=86 --omit */tensorflow/tensorflow_serving/*
+    {env:IGNORE_COVERAGE:} coverage report --fail-under=86
 extras = test
 
 [testenv:flake8]


### PR DESCRIPTION
*Issue #, if available:*
#1462

*Description of changes:*
Now that the old serializers have been removed, there's no need to have `tensorflow` installed just to be able to use this SDK for TensorFlow inference.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to any/all clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
