### PR TITLE
fix: look for 'sagemaker.tensorflow.estimator' module in v2 migration tool

### DIFF
--- a/tests/unit/sagemaker/cli/compatibility/v2/modifiers/test_tf_legacy_mode.py
+++ b/tests/unit/sagemaker/cli/compatibility/v2/modifiers/test_tf_legacy_mode.py
@@ -42,6 +42,10 @@ def test_node_should_be_modified_tf_constructor_legacy_mode():
         "sagemaker.tensorflow.TensorFlow(script_mode=None)",
         "sagemaker.tensorflow.TensorFlow(py_version='py2')",
         "sagemaker.tensorflow.TensorFlow()",
+        "sagemaker.tensorflow.estimator.TensorFlow(script_mode=False)",
+        "sagemaker.tensorflow.estimator.TensorFlow(script_mode=None)",
+        "sagemaker.tensorflow.estimator.TensorFlow(py_version='py2')",
+        "sagemaker.tensorflow.estimator.TensorFlow()",
     )
 
     modifier = tf_legacy_mode.TensorFlowLegacyModeConstructorUpgrader()
@@ -61,6 +65,10 @@ def test_node_should_be_modified_tf_constructor_script_mode():
         "sagemaker.tensorflow.TensorFlow(py_version='py3')",
         "sagemaker.tensorflow.TensorFlow(py_version='py37')",
         "sagemaker.tensorflow.TensorFlow(py_version='py3', script_mode=False)",
+        "sagemaker.tensorflow.estimator.TensorFlow(script_mode=True)",
+        "sagemaker.tensorflow.estimator.TensorFlow(py_version='py3')",
+        "sagemaker.tensorflow.estimator.TensorFlow(py_version='py37')",
+        "sagemaker.tensorflow.estimator.TensorFlow(py_version='py3', script_mode=False)",
     )
 
     modifier = tf_legacy_mode.TensorFlowLegacyModeConstructorUpgrader()


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/sagemaker-python-sdk/pull/1540#pullrequestreview-423731071

*Description of changes:*
Addresses @nadiaya's comment on #1540

*Testing done:*
unit test, linters

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to any/all clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
