### PR TITLE
fix: look for 'sagemaker.<framework>.<estimator/model>' module in v2 migration tool

### DIFF
--- a/tests/unit/sagemaker/cli/compatibility/v2/modifiers/test_framework_version.py
+++ b/tests/unit/sagemaker/cli/compatibility/v2/modifiers/test_framework_version.py
@@ -32,24 +32,34 @@ def test_node_should_be_modified_fw_constructor_no_fw_version():
     fw_constructors = (
         "TensorFlow()",
         "sagemaker.tensorflow.TensorFlow()",
+        "sagemaker.tensorflow.estimator.TensorFlow()",
         "TensorFlowModel()",
         "sagemaker.tensorflow.TensorFlowModel()",
+        "sagemaker.tensorflow.model.TensorFlowModel()",
         "MXNet()",
         "sagemaker.mxnet.MXNet()",
+        "sagemaker.mxnet.estimator.MXNet()",
         "MXNetModel()",
         "sagemaker.mxnet.MXNetModel()",
+        "sagemaker.mxnet.model.MXNetModel()",
         "Chainer()",
         "sagemaker.chainer.Chainer()",
+        "sagemaker.chainer.estimator.Chainer()",
         "ChainerModel()",
         "sagemaker.chainer.ChainerModel()",
+        "sagemaker.chainer.model.ChainerModel()",
         "PyTorch()",
         "sagemaker.pytorch.PyTorch()",
+        "sagemaker.pytorch.estimator.PyTorch()",
         "PyTorchModel()",
         "sagemaker.pytorch.PyTorchModel()",
+        "sagemaker.pytorch.model.PyTorchModel()",
         "SKLearn()",
         "sagemaker.sklearn.SKLearn()",
+        "sagemaker.sklearn.estimator.SKLearn()",
         "SKLearnModel()",
         "sagemaker.sklearn.SKLearnModel()",
+        "sagemaker.sklearn.model.SKLearnModel()",
     )
 
     modifier = framework_version.FrameworkVersionEnforcer()
@@ -63,24 +73,34 @@ def test_node_should_be_modified_fw_constructor_with_fw_version():
     fw_constructors = (
         "TensorFlow(framework_version='2.2')",
         "sagemaker.tensorflow.TensorFlow(framework_version='2.2')",
+        "sagemaker.tensorflow.estimator.TensorFlow(framework_version='2.2')",
         "TensorFlowModel(framework_version='1.10')",
         "sagemaker.tensorflow.TensorFlowModel(framework_version='1.10')",
+        "sagemaker.tensorflow.model.TensorFlowModel(framework_version='1.10')",
         "MXNet(framework_version='1.6')",
         "sagemaker.mxnet.MXNet(framework_version='1.6')",
+        "sagemaker.mxnet.estimator.MXNet(framework_version='1.6')",
         "MXNetModel(framework_version='1.6')",
         "sagemaker.mxnet.MXNetModel(framework_version='1.6')",
+        "sagemaker.mxnet.model.MXNetModel(framework_version='1.6')",
         "PyTorch(framework_version='1.4')",
         "sagemaker.pytorch.PyTorch(framework_version='1.4')",
+        "sagemaker.pytorch.estimator.PyTorch(framework_version='1.4')",
         "PyTorchModel(framework_version='1.4')",
         "sagemaker.pytorch.PyTorchModel(framework_version='1.4')",
+        "sagemaker.pytorch.model.PyTorchModel(framework_version='1.4')",
         "Chainer(framework_version='5.0')",
         "sagemaker.chainer.Chainer(framework_version='5.0')",
+        "sagemaker.chainer.estimator.Chainer(framework_version='5.0')",
         "ChainerModel(framework_version='5.0')",
         "sagemaker.chainer.ChainerModel(framework_version='5.0')",
+        "sagemaker.chainer.model.ChainerModel(framework_version='5.0')",
         "SKLearn(framework_version='0.20.0')",
         "sagemaker.sklearn.SKLearn(framework_version='0.20.0')",
+        "sagemaker.sklearn.estimator.SKLearn(framework_version='0.20.0')",
         "SKLearnModel(framework_version='0.20.0')",
         "sagemaker.sklearn.SKLearnModel(framework_version='0.20.0')",
+        "sagemaker.sklearn.model.SKLearnModel(framework_version='0.20.0')",
     )
 
     modifier = framework_version.FrameworkVersionEnforcer()
@@ -97,51 +117,36 @@ def test_node_should_be_modified_random_function_call():
 
 
 def test_modify_node_tf():
-    classes = (
-        "TensorFlow" "sagemaker.tensorflow.TensorFlow",
-        "TensorFlowModel",
-        "sagemaker.tensorflow.TensorFlowModel",
-    )
-    _test_modify_node(classes, "1.11.0")
+    _test_modify_node("TensorFlow", "1.11.0")
 
 
 def test_modify_node_mx():
-    classes = ("MXNet", "sagemaker.mxnet.MXNet", "MXNetModel", "sagemaker.mxnet.MXNetModel")
-    _test_modify_node(classes, "1.2.0")
+    _test_modify_node("MXNet", "1.2.0")
 
 
 def test_modify_node_chainer():
-    classes = (
-        "Chainer",
-        "sagemaker.chainer.Chainer",
-        "ChainerModel",
-        "sagemaker.chainer.ChainerModel",
-    )
-    _test_modify_node(classes, "4.1.0")
+    _test_modify_node("Chainer", "4.1.0")
 
 
 def test_modify_node_pt():
-    classes = (
-        "PyTorch",
-        "sagemaker.pytorch.PyTorch",
-        "PyTorchModel",
-        "sagemaker.pytorch.PyTorchModel",
-    )
-    _test_modify_node(classes, "0.4.0")
+    _test_modify_node("PyTorch", "0.4.0")
 
 
 def test_modify_node_sklearn():
-    classes = (
-        "SKLearn",
-        "sagemaker.sklearn.SKLearn",
-        "SKLearnModel",
-        "sagemaker.sklearn.SKLearnModel",
-    )
-    _test_modify_node(classes, "0.20.0")
+    _test_modify_node("SKLearn", "0.20.0")
 
 
-def _test_modify_node(classes, default_version):
+def _test_modify_node(framework, default_version):
     modifier = framework_version.FrameworkVersionEnforcer()
+
+    classes = (
+        "{}".format(framework),
+        "sagemaker.{}.{}".format(framework.lower(), framework),
+        "sagemaker.{}.estimator.{}".format(framework.lower(), framework),
+        "{}Model".format(framework),
+        "sagemaker.{}.{}Model".format(framework.lower(), framework),
+        "sagemaker.{}.model.{}Model".format(framework.lower(), framework),
+    )
     for cls in classes:
         node = ast_call("{}()".format(cls))
         modifier.modify_node(node)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
same thing as https://github.com/aws/sagemaker-python-sdk/pull/1550, but for the framework version modifier

*Testing done:*
unit tests, linters

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to any/all clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
