### PR TITLE
change: require framework_version, py_version for xgboost

### DIFF
--- a/src/sagemaker/xgboost/estimator.py
+++ b/src/sagemaker/xgboost/estimator.py
@@ -85,7 +85,7 @@ class XGBoost(Framework):
                 on SageMaker. For convenience, this accepts other types for keys and values, but
                 ``str()`` will be called to convert them before training.
             py_version (str): Python version you want to use for executing your model
-                training code (default: 'py3'). One of 'py2' or 'py3'.
+                training code (default: 'py3').
             image_name (str): If specified, the estimator will use this image for training and
                 hosting, instead of selecting the appropriate SageMaker official image
                 based on framework_version and py_version. It can be an ECR url or

--- a/src/sagemaker/xgboost/model.py
+++ b/src/sagemaker/xgboost/model.py
@@ -79,7 +79,7 @@ class XGBoostModel(FrameworkModel):
             image (str): A Docker image URI (default: None). If not specified, a default image for
                 XGBoos will be used.
             py_version (str): Python version you want to use for executing your model training code
-                (default: 'py2').
+                (default: 'py3').
             framework_version (str): XGBoost version you want to use for executing your model
                 training code.
             predictor_cls (callable[str, sagemaker.session.Session]): A function to call to create

--- a/tests/integ/__init__.py
+++ b/tests/integ/__init__.py
@@ -23,7 +23,7 @@ TRAINING_DEFAULT_TIMEOUT_MINUTES = 20
 TUNING_DEFAULT_TIMEOUT_MINUTES = 20
 TRANSFORM_DEFAULT_TIMEOUT_MINUTES = 20
 AUTO_ML_DEFAULT_TIMEMOUT_MINUTES = 60
-PYTHON_VERSION = "py" + str(sys.version_info.major)
+PYTHON_VERSION = "py{}".format(sys.version_info.major)
 
 # these regions have some p2 and p3 instances, but not enough for continuous testing
 HOSTING_NO_P2_REGIONS = [

--- a/tests/integ/test_airflow_config.py
+++ b/tests/integ/test_airflow_config.py
@@ -582,6 +582,7 @@ def test_tf_airflow_config_uploads_data_source_to_s3(sagemaker_session, cpu_inst
 
 
 @pytest.mark.canary_quick
+@pytest.mark.skipif(PYTHON_VERSION == "py2", reason="XGBoost container does not support Python 2.")
 def test_xgboost_airflow_config_uploads_data_source_to_s3(sagemaker_session, cpu_instance_type):
     with timeout(seconds=AIRFLOW_CONFIG_TIMEOUT_IN_SECONDS):
         xgboost = XGBoost(

--- a/tox.ini
+++ b/tox.ini
@@ -66,6 +66,10 @@ commands =
     {env:IGNORE_COVERAGE:} coverage report --fail-under=86
 extras = test
 
+[testenv:py27]
+setenv =
+    IGNORE_COVERAGE = true
+
 [testenv:flake8]
 basepython = python3
 skipdist = true


### PR DESCRIPTION
During work of requiring `framework_version` for all frameworks, some small doc and test improvements.

*Issue #, if available:* #1465

*Description of changes:*

changes include:

* small updates to docstrings
* small updates to tests

*Testing done:*

```
 % tox --parallel 3 tests/unit
✔ OK black-format in 12.047 seconds
✔ OK flake8 in 25.667 seconds
✔ OK twine in 15.207 seconds
✔ OK pylint in 39.186 seconds
✔ OK doc8 in 22.472 seconds
✔ OK py36 in 35.675 seconds
✔ OK py37 in 37.08 seconds
✔ OK sphinx in 1 minute, 43.377 seconds
✔ OK py27 in 1 minute, 48.411 seconds
```
## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to any/all clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
