### PR TITLE
breaking: require framework_version, py_version for sklearn

### DIFF
--- a/doc/frameworks/sklearn/using_sklearn.rst
+++ b/doc/frameworks/sklearn/using_sklearn.rst
@@ -31,7 +31,7 @@ To train a Scikit-learn model by using the SageMaker Python SDK:
 Prepare a Scikit-learn Training Script
 ======================================
 
-Your Scikit-learn training script must be a Python 2.7 or 3.6 compatible source file.
+Your Scikit-learn training script must be a Python 3.6 compatible source file.
 
 The training script is similar to a training script you might run outside of SageMaker, but you
 can access useful properties about the training environment through various environment variables.
@@ -465,8 +465,10 @@ The following code sample shows how to do this, using the ``SKLearnModel`` class
 
 .. code:: python
 
-    sklearn_model = SKLearnModel(model_data="s3://bucket/model.tar.gz", role="SageMakerRole",
-        entry_point="transform_script.py")
+    sklearn_model = SKLearnModel(model_data="s3://bucket/model.tar.gz",
+                                 role="SageMakerRole",
+                                 entry_point="transform_script.py",
+                                 framework_version="0.20.0")
 
     predictor = sklearn_model.deploy(instance_type="ml.c4.xlarge", initial_instance_count=1)
 

--- a/tests/integ/test_git.py
+++ b/tests/integ/test_git.py
@@ -173,6 +173,7 @@ def test_private_github_with_2fa(sagemaker_local_session, sklearn_full_version):
                 model_data,
                 "SageMakerRole",
                 entry_point=script_path,
+                framework_version=sklearn_full_version,
                 source_dir=source_dir,
                 sagemaker_session=sagemaker_local_session,
                 git_config=git_config,

--- a/tests/integ/test_sklearn_train.py
+++ b/tests/integ/test_sklearn_train.py
@@ -36,7 +36,7 @@ def sklearn_training_job(sagemaker_session, sklearn_full_version, cpu_instance_t
     sagemaker_session.boto_region_name
 
 
-@pytest.mark.skipif(PYTHON_VERSION != "py3", reason="Scikit-learn image supports only python 3.")
+@pytest.mark.skipif(PYTHON_VERSION != "py3", reason="Scikit-learn image supports only Python 3.")
 def test_training_with_additional_hyperparameters(
     sagemaker_session, sklearn_full_version, cpu_instance_type
 ):
@@ -66,7 +66,7 @@ def test_training_with_additional_hyperparameters(
         return sklearn.latest_training_job.name
 
 
-@pytest.mark.skipif(PYTHON_VERSION != "py3", reason="Scikit-learn image supports only python 3.")
+@pytest.mark.skipif(PYTHON_VERSION != "py3", reason="Scikit-learn image supports only Python 3.")
 def test_training_with_network_isolation(
     sagemaker_session, sklearn_full_version, cpu_instance_type
 ):
@@ -121,7 +121,9 @@ def test_attach_deploy(sklearn_training_job, sagemaker_session, cpu_instance_typ
     reason="This test has always failed, but the failure was masked by a bug. "
     "This test should be fixed. Details in https://github.com/aws/sagemaker-python-sdk/pull/968"
 )
-def test_deploy_model(sklearn_training_job, sagemaker_session, cpu_instance_type):
+def test_deploy_model(
+    sklearn_training_job, sagemaker_session, cpu_instance_type, sklearn_full_version
+):
     endpoint_name = "test-sklearn-deploy-model-{}".format(sagemaker_timestamp())
     with timeout_and_delete_endpoint_by_name(endpoint_name, sagemaker_session):
         desc = sagemaker_session.sagemaker_client.describe_training_job(
@@ -133,6 +135,7 @@ def test_deploy_model(sklearn_training_job, sagemaker_session, cpu_instance_type
             model_data,
             "SageMakerRole",
             entry_point=script_path,
+            framework_version=sklearn_full_version,
             sagemaker_session=sagemaker_session,
         )
         predictor = model.deploy(1, cpu_instance_type, endpoint_name=endpoint_name)


### PR DESCRIPTION
require framework_version and py_version for sklearn

*Issue #, if available:* #1465 

*Description of changes:*

changes include:

* framework_version, py_version required for framework SKLearn
* framework_version, py_version required for framework SKLearnModel
* py_version requires py3 or None, as py2 support dropped
* image_name required if either framework_version or py_version None
* unit and integ testing updates
* doc updates

*Testing done:*

unit:
```
 % tox --parallel 3 tests/unit
✔ OK black-format in 11.287 seconds
✔ OK flake8 in 23.448 seconds
✔ OK twine in 13.898 seconds
✔ OK pylint in 35.064 seconds
✔ OK doc8 in 18.61 seconds
✔ OK py36 in 35.846 seconds
✔ OK sphinx in 1 minute, 26.284 seconds
✔ OK py37 in 36.384 seconds
✔ OK py27 in 1 minute, 50.325 seconds
```

integ:

```
% export IGNORE_COVERAGE=- ; tox -e py37 -- -s tests/integ/test_sklearn_train.py; unset IGNORE_COVERAGE
...
tests/integ/test_sklearn_train.py::test_training_with_additional_hyperparameters
...
Billable seconds: 71
PASSED
tests/integ/test_sklearn_train.py::test_attach_deploy SKIPPED
...
```
## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to any/all clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
