### PR TITLE
breaking: change Model parameter order to make model_data optional

### DIFF
--- a/src/sagemaker/amazon/factorization_machines.py
+++ b/src/sagemaker/amazon/factorization_machines.py
@@ -310,8 +310,8 @@ class FactorizationMachinesModel(Model):
         repo = "{}:{}".format(FactorizationMachines.repo_name, FactorizationMachines.repo_version)
         image = "{}/{}".format(registry(sagemaker_session.boto_session.region_name), repo)
         super(FactorizationMachinesModel, self).__init__(
-            model_data,
             image,
+            model_data,
             role,
             predictor_cls=FactorizationMachinesPredictor,
             sagemaker_session=sagemaker_session,

--- a/src/sagemaker/amazon/ipinsights.py
+++ b/src/sagemaker/amazon/ipinsights.py
@@ -216,8 +216,8 @@ class IPInsightsModel(Model):
         )
 
         super(IPInsightsModel, self).__init__(
-            model_data,
             image,
+            model_data,
             role,
             predictor_cls=IPInsightsPredictor,
             sagemaker_session=sagemaker_session,

--- a/src/sagemaker/amazon/kmeans.py
+++ b/src/sagemaker/amazon/kmeans.py
@@ -241,8 +241,8 @@ class KMeansModel(Model):
         repo = "{}:{}".format(KMeans.repo_name, KMeans.repo_version)
         image = "{}/{}".format(registry(sagemaker_session.boto_session.region_name), repo)
         super(KMeansModel, self).__init__(
-            model_data,
             image,
+            model_data,
             role,
             predictor_cls=KMeansPredictor,
             sagemaker_session=sagemaker_session,

--- a/src/sagemaker/amazon/knn.py
+++ b/src/sagemaker/amazon/knn.py
@@ -231,8 +231,8 @@ class KNNModel(Model):
             registry(sagemaker_session.boto_session.region_name, KNN.repo_name), repo
         )
         super(KNNModel, self).__init__(
-            model_data,
             image,
+            model_data,
             role,
             predictor_cls=KNNPredictor,
             sagemaker_session=sagemaker_session,

--- a/src/sagemaker/amazon/lda.py
+++ b/src/sagemaker/amazon/lda.py
@@ -215,8 +215,8 @@ class LDAModel(Model):
             registry(sagemaker_session.boto_session.region_name, LDA.repo_name), repo
         )
         super(LDAModel, self).__init__(
-            model_data,
             image,
+            model_data,
             role,
             predictor_cls=LDAPredictor,
             sagemaker_session=sagemaker_session,

--- a/src/sagemaker/amazon/linear_learner.py
+++ b/src/sagemaker/amazon/linear_learner.py
@@ -474,8 +474,8 @@ class LinearLearnerModel(Model):
         repo = "{}:{}".format(LinearLearner.repo_name, LinearLearner.repo_version)
         image = "{}/{}".format(registry(sagemaker_session.boto_session.region_name), repo)
         super(LinearLearnerModel, self).__init__(
-            model_data,
             image,
+            model_data,
             role,
             predictor_cls=LinearLearnerPredictor,
             sagemaker_session=sagemaker_session,

--- a/src/sagemaker/amazon/ntm.py
+++ b/src/sagemaker/amazon/ntm.py
@@ -245,8 +245,8 @@ class NTMModel(Model):
             registry(sagemaker_session.boto_session.region_name, NTM.repo_name), repo
         )
         super(NTMModel, self).__init__(
-            model_data,
             image,
+            model_data,
             role,
             predictor_cls=NTMPredictor,
             sagemaker_session=sagemaker_session,

--- a/src/sagemaker/amazon/object2vec.py
+++ b/src/sagemaker/amazon/object2vec.py
@@ -355,8 +355,8 @@ class Object2VecModel(Model):
             registry(sagemaker_session.boto_session.region_name, Object2Vec.repo_name), repo
         )
         super(Object2VecModel, self).__init__(
-            model_data,
             image,
+            model_data,
             role,
             predictor_cls=RealTimePredictor,
             sagemaker_session=sagemaker_session,

--- a/src/sagemaker/amazon/pca.py
+++ b/src/sagemaker/amazon/pca.py
@@ -225,8 +225,8 @@ class PCAModel(Model):
         repo = "{}:{}".format(PCA.repo_name, PCA.repo_version)
         image = "{}/{}".format(registry(sagemaker_session.boto_session.region_name), repo)
         super(PCAModel, self).__init__(
-            model_data,
             image,
+            model_data,
             role,
             predictor_cls=PCAPredictor,
             sagemaker_session=sagemaker_session,

--- a/src/sagemaker/amazon/randomcutforest.py
+++ b/src/sagemaker/amazon/randomcutforest.py
@@ -206,8 +206,8 @@ class RandomCutForestModel(Model):
             registry(sagemaker_session.boto_session.region_name, RandomCutForest.repo_name), repo
         )
         super(RandomCutForestModel, self).__init__(
-            model_data,
             image,
+            model_data,
             role,
             predictor_cls=RandomCutForestPredictor,
             sagemaker_session=sagemaker_session,

--- a/src/sagemaker/estimator.py
+++ b/src/sagemaker/estimator.py
@@ -1398,8 +1398,8 @@ class Estimator(EstimatorBase):
             kwargs["enable_network_isolation"] = self.enable_network_isolation()
 
         return Model(
-            self.model_data,
             image or self.train_image(),
+            self.model_data,
             role,
             vpc_config=self.get_vpc_config(vpc_config_override),
             sagemaker_session=self.sagemaker_session,

--- a/src/sagemaker/model.py
+++ b/src/sagemaker/model.py
@@ -60,8 +60,8 @@ class Model(object):
 
     def __init__(
         self,
-        model_data,
         image,
+        model_data=None,
         role=None,
         predictor_cls=None,
         env=None,
@@ -74,9 +74,9 @@ class Model(object):
         """Initialize an SageMaker ``Model``.
 
         Args:
-            model_data (str): The S3 location of a SageMaker model data
-                ``.tar.gz`` file.
             image (str): A Docker image URI.
+            model_data (str): The S3 location of a SageMaker model data
+                ``.tar.gz`` file (default: None).
             role (str): An AWS IAM role (either name or full ARN). The Amazon
                 SageMaker training jobs and APIs that create Amazon SageMaker
                 endpoints use this role to access training data and model
@@ -361,6 +361,8 @@ class Model(object):
             )
         if job_name is None:
             raise ValueError("You must provide a compilation job name")
+        if self.model_data is None:
+            raise ValueError("You must provide an S3 path to the compressed model artifacts.")
 
         framework = framework.upper()
         framework_version = self._get_framework_version() or framework_version
@@ -778,8 +780,8 @@ class FrameworkModel(Model):
             :class:`~sagemaker.model.Model`.
         """
         super(FrameworkModel, self).__init__(
-            model_data,
             image,
+            model_data,
             role,
             predictor_cls=predictor_cls,
             env=env,

--- a/src/sagemaker/multidatamodel.py
+++ b/src/sagemaker/multidatamodel.py
@@ -103,8 +103,8 @@ class MultiDataModel(Model):
         # Set the ``Model`` parameters if the model parameter is not specified
         if not self.model:
             super(MultiDataModel, self).__init__(
-                self.model_data_prefix,
                 image,
+                self.model_data_prefix,
                 role,
                 name=self.name,
                 sagemaker_session=self.sagemaker_session,

--- a/src/sagemaker/sparkml/model.py
+++ b/src/sagemaker/sparkml/model.py
@@ -96,8 +96,8 @@ class SparkMLModel(Model):
         region_name = (sagemaker_session or Session()).boto_region_name
         image = "{}/{}:{}".format(registry(region_name, framework_name), repo_name, spark_version)
         super(SparkMLModel, self).__init__(
-            model_data,
             image,
+            model_data,
             role,
             predictor_cls=SparkMLPredictor,
             sagemaker_session=sagemaker_session,

--- a/tests/unit/sagemaker/model/test_deploy.py
+++ b/tests/unit/sagemaker/model/test_deploy.py
@@ -54,7 +54,7 @@ def test_deploy(name_from_image, prepare_container_def, production_variant, sage
     container_def = {"Image": MODEL_IMAGE, "Environment": {}, "ModelDataUrl": MODEL_DATA}
     prepare_container_def.return_value = container_def
 
-    model = Model(MODEL_DATA, MODEL_IMAGE, role=ROLE, sagemaker_session=sagemaker_session)
+    model = Model(MODEL_IMAGE, MODEL_DATA, role=ROLE, sagemaker_session=sagemaker_session)
     model.deploy(instance_type=INSTANCE_TYPE, initial_instance_count=INSTANCE_COUNT)
 
     name_from_image.assert_called_with(MODEL_IMAGE)
@@ -81,7 +81,7 @@ def test_deploy(name_from_image, prepare_container_def, production_variant, sage
 @patch("sagemaker.production_variant")
 def test_deploy_accelerator_type(production_variant, create_sagemaker_model, sagemaker_session):
     model = Model(
-        MODEL_DATA, MODEL_IMAGE, role=ROLE, name=MODEL_NAME, sagemaker_session=sagemaker_session
+        MODEL_IMAGE, MODEL_DATA, role=ROLE, name=MODEL_NAME, sagemaker_session=sagemaker_session
     )
 
     production_variant_result = copy.deepcopy(BASE_PRODUCTION_VARIANT)
@@ -113,7 +113,7 @@ def test_deploy_accelerator_type(production_variant, create_sagemaker_model, sag
 @patch("sagemaker.model.Model._create_sagemaker_model", Mock())
 @patch("sagemaker.production_variant", return_value=BASE_PRODUCTION_VARIANT)
 def test_deploy_endpoint_name(sagemaker_session):
-    model = Model(MODEL_DATA, MODEL_IMAGE, role=ROLE, sagemaker_session=sagemaker_session)
+    model = Model(MODEL_IMAGE, MODEL_DATA, role=ROLE, sagemaker_session=sagemaker_session)
 
     endpoint_name = "blah"
     model.deploy(
@@ -136,7 +136,7 @@ def test_deploy_endpoint_name(sagemaker_session):
 @patch("sagemaker.model.Model._create_sagemaker_model")
 def test_deploy_tags(create_sagemaker_model, production_variant, sagemaker_session):
     model = Model(
-        MODEL_DATA, MODEL_IMAGE, role=ROLE, name=MODEL_NAME, sagemaker_session=sagemaker_session
+        MODEL_IMAGE, MODEL_DATA, role=ROLE, name=MODEL_NAME, sagemaker_session=sagemaker_session
     )
 
     tags = [{"Key": "ModelName", "Value": "TestModel"}]
@@ -157,7 +157,7 @@ def test_deploy_tags(create_sagemaker_model, production_variant, sagemaker_sessi
 @patch("sagemaker.production_variant", return_value=BASE_PRODUCTION_VARIANT)
 def test_deploy_kms_key(production_variant, sagemaker_session):
     model = Model(
-        MODEL_DATA, MODEL_IMAGE, role=ROLE, name=MODEL_NAME, sagemaker_session=sagemaker_session
+        MODEL_IMAGE, MODEL_DATA, role=ROLE, name=MODEL_NAME, sagemaker_session=sagemaker_session
     )
 
     key = "some-key-arn"
@@ -177,7 +177,7 @@ def test_deploy_kms_key(production_variant, sagemaker_session):
 @patch("sagemaker.production_variant", return_value=BASE_PRODUCTION_VARIANT)
 def test_deploy_async(production_variant, sagemaker_session):
     model = Model(
-        MODEL_DATA, MODEL_IMAGE, role=ROLE, name=MODEL_NAME, sagemaker_session=sagemaker_session
+        MODEL_IMAGE, MODEL_DATA, role=ROLE, name=MODEL_NAME, sagemaker_session=sagemaker_session
     )
 
     model.deploy(instance_type=INSTANCE_TYPE, initial_instance_count=INSTANCE_COUNT, wait=False)
@@ -196,7 +196,7 @@ def test_deploy_async(production_variant, sagemaker_session):
 @patch("sagemaker.production_variant", return_value=BASE_PRODUCTION_VARIANT)
 def test_deploy_data_capture_config(production_variant, sagemaker_session):
     model = Model(
-        MODEL_DATA, MODEL_IMAGE, role=ROLE, name=MODEL_NAME, sagemaker_session=sagemaker_session
+        MODEL_IMAGE, MODEL_DATA, role=ROLE, name=MODEL_NAME, sagemaker_session=sagemaker_session
     )
 
     data_capture_config = Mock()
@@ -223,12 +223,12 @@ def test_deploy_data_capture_config(production_variant, sagemaker_session):
 @patch("sagemaker.local.LocalSession")
 def test_deploy_creates_correct_session(local_session, session):
     # We expect a LocalSession when deploying to instance_type = 'local'
-    model = Model(MODEL_DATA, MODEL_IMAGE, role=ROLE)
+    model = Model(MODEL_IMAGE, MODEL_DATA, role=ROLE)
     model.deploy(endpoint_name="blah", instance_type="local", initial_instance_count=1)
     assert model.sagemaker_session == local_session.return_value
 
     # We expect a real Session when deploying to instance_type != local/local_gpu
-    model = Model(MODEL_DATA, MODEL_IMAGE, role=ROLE)
+    model = Model(MODEL_IMAGE, MODEL_DATA, role=ROLE)
     model.deploy(
         endpoint_name="remote_endpoint", instance_type="ml.m4.4xlarge", initial_instance_count=2
     )
@@ -236,7 +236,7 @@ def test_deploy_creates_correct_session(local_session, session):
 
 
 def test_deploy_no_role(sagemaker_session):
-    model = Model(MODEL_DATA, MODEL_IMAGE, sagemaker_session=sagemaker_session)
+    model = Model(MODEL_IMAGE, MODEL_DATA, sagemaker_session=sagemaker_session)
 
     with pytest.raises(ValueError, match="Role can not be null for deploying a model"):
         model.deploy(instance_type=INSTANCE_TYPE, initial_instance_count=INSTANCE_COUNT)
@@ -248,8 +248,8 @@ def test_deploy_no_role(sagemaker_session):
 @patch("sagemaker.production_variant", return_value=BASE_PRODUCTION_VARIANT)
 def test_deploy_predictor_cls(production_variant, sagemaker_session):
     model = Model(
-        MODEL_DATA,
         MODEL_IMAGE,
+        MODEL_DATA,
         role=ROLE,
         name=MODEL_NAME,
         predictor_cls=sagemaker.predictor.RealTimePredictor,
@@ -269,7 +269,7 @@ def test_deploy_predictor_cls(production_variant, sagemaker_session):
 
 
 def test_deploy_update_endpoint(sagemaker_session):
-    model = Model(MODEL_DATA, MODEL_IMAGE, role=ROLE, sagemaker_session=sagemaker_session)
+    model = Model(MODEL_IMAGE, MODEL_DATA, role=ROLE, sagemaker_session=sagemaker_session)
     model.deploy(
         instance_type=INSTANCE_TYPE, initial_instance_count=INSTANCE_COUNT, update_endpoint=True
     )
@@ -300,7 +300,7 @@ def test_deploy_update_endpoint_optional_args(sagemaker_session):
     kms_key = "foo"
     data_capture_config = Mock()
 
-    model = Model(MODEL_DATA, MODEL_IMAGE, role=ROLE, sagemaker_session=sagemaker_session)
+    model = Model(MODEL_IMAGE, MODEL_DATA, role=ROLE, sagemaker_session=sagemaker_session)
     model.deploy(
         instance_type=INSTANCE_TYPE,
         initial_instance_count=INSTANCE_COUNT,

--- a/tests/unit/sagemaker/model/test_model.py
+++ b/tests/unit/sagemaker/model/test_model.py
@@ -33,9 +33,17 @@ def sagemaker_session():
     return Mock()
 
 
-def test_prepare_container_def():
+def test_prepare_container_def_with_model_data():
+    model = Model(MODEL_IMAGE)
+    container_def = model.prepare_container_def(INSTANCE_TYPE, "ml.eia.medium")
+
+    expected = {"Image": MODEL_IMAGE, "Environment": {}}
+    assert expected == container_def
+
+
+def test_prepare_container_def_with_model_data_and_env():
     env = {"FOO": "BAR"}
-    model = Model(MODEL_DATA, MODEL_IMAGE, env=env)
+    model = Model(MODEL_IMAGE, MODEL_DATA, env=env)
 
     container_def = model.prepare_container_def(INSTANCE_TYPE, "ml.eia.medium")
 
@@ -44,10 +52,10 @@ def test_prepare_container_def():
 
 
 def test_model_enable_network_isolation():
-    model = Model(MODEL_DATA, MODEL_IMAGE)
+    model = Model(MODEL_IMAGE, MODEL_DATA)
     assert model.enable_network_isolation() is False
 
-    model = Model(MODEL_DATA, MODEL_IMAGE, enable_network_isolation=True)
+    model = Model(MODEL_IMAGE, MODEL_DATA, enable_network_isolation=True)
     assert model.enable_network_isolation()
 
 
@@ -59,7 +67,7 @@ def test_create_sagemaker_model(name_from_image, prepare_container_def, sagemake
     container_def = {"Image": MODEL_IMAGE, "Environment": {}, "ModelDataUrl": MODEL_DATA}
     prepare_container_def.return_value = container_def
 
-    model = Model(MODEL_DATA, MODEL_IMAGE, sagemaker_session=sagemaker_session)
+    model = Model(MODEL_IMAGE, MODEL_DATA, sagemaker_session=sagemaker_session)
     model._create_sagemaker_model(INSTANCE_TYPE)
 
     prepare_container_def.assert_called_with(INSTANCE_TYPE, accelerator_type=None)
@@ -73,7 +81,7 @@ def test_create_sagemaker_model(name_from_image, prepare_container_def, sagemake
 @patch("sagemaker.utils.name_from_image", Mock())
 @patch("sagemaker.model.Model.prepare_container_def")
 def test_create_sagemaker_model_accelerator_type(prepare_container_def, sagemaker_session):
-    model = Model(MODEL_DATA, MODEL_IMAGE, sagemaker_session=sagemaker_session)
+    model = Model(MODEL_IMAGE, MODEL_DATA, sagemaker_session=sagemaker_session)
 
     accelerator_type = "ml.eia.medium"
     model._create_sagemaker_model(INSTANCE_TYPE, accelerator_type=accelerator_type)
@@ -89,7 +97,7 @@ def test_create_sagemaker_model_tags(name_from_image, prepare_container_def, sag
 
     name_from_image.return_value = MODEL_NAME
 
-    model = Model(MODEL_DATA, MODEL_IMAGE, sagemaker_session=sagemaker_session)
+    model = Model(MODEL_IMAGE, MODEL_DATA, sagemaker_session=sagemaker_session)
 
     tags = {"Key": "foo", "Value": "bar"}
     model._create_sagemaker_model(INSTANCE_TYPE, tags=tags)
@@ -110,8 +118,8 @@ def test_create_sagemaker_model_optional_model_params(
     vpc_config = {"Subnets": ["123"], "SecurityGroupIds": ["456", "789"]}
 
     model = Model(
-        MODEL_DATA,
         MODEL_IMAGE,
+        MODEL_DATA,
         name=MODEL_NAME,
         role=ROLE,
         vpc_config=vpc_config,
@@ -135,11 +143,11 @@ def test_create_sagemaker_model_optional_model_params(
 @patch("sagemaker.session.Session")
 @patch("sagemaker.local.LocalSession")
 def test_create_sagemaker_model_creates_correct_session(local_session, session):
-    model = Model(MODEL_DATA, MODEL_IMAGE)
+    model = Model(MODEL_IMAGE, MODEL_DATA)
     model._create_sagemaker_model("local")
     assert model.sagemaker_session == local_session.return_value
 
-    model = Model(MODEL_DATA, MODEL_IMAGE)
+    model = Model(MODEL_IMAGE, MODEL_DATA)
     model._create_sagemaker_model("ml.m5.xlarge")
     assert model.sagemaker_session == session.return_value
 
@@ -147,7 +155,7 @@ def test_create_sagemaker_model_creates_correct_session(local_session, session):
 @patch("sagemaker.model.Model._create_sagemaker_model")
 def test_model_create_transformer(create_sagemaker_model, sagemaker_session):
     model_name = "auto-generated-model"
-    model = Model(MODEL_DATA, MODEL_IMAGE, name=model_name, sagemaker_session=sagemaker_session)
+    model = Model(MODEL_IMAGE, MODEL_DATA, name=model_name, sagemaker_session=sagemaker_session)
 
     instance_type = "ml.m4.xlarge"
     transformer = model.transformer(instance_count=1, instance_type=instance_type)
@@ -175,7 +183,7 @@ def test_model_create_transformer(create_sagemaker_model, sagemaker_session):
 
 @patch("sagemaker.model.Model._create_sagemaker_model")
 def test_model_create_transformer_optional_params(create_sagemaker_model, sagemaker_session):
-    model = Model(MODEL_DATA, MODEL_IMAGE, sagemaker_session=sagemaker_session)
+    model = Model(MODEL_IMAGE, MODEL_DATA, sagemaker_session=sagemaker_session)
 
     instance_type = "ml.m4.xlarge"
     strategy = "MultiRecord"
@@ -221,7 +229,7 @@ def test_model_create_transformer_optional_params(create_sagemaker_model, sagema
 @patch("sagemaker.model.Model._create_sagemaker_model")
 def test_model_create_transformer_network_isolation(create_sagemaker_model, sagemaker_session):
     model = Model(
-        MODEL_DATA, MODEL_IMAGE, sagemaker_session=sagemaker_session, enable_network_isolation=True
+        MODEL_IMAGE, MODEL_DATA, sagemaker_session=sagemaker_session, enable_network_isolation=True
     )
 
     transformer = model.transformer(1, "ml.m4.xlarge", env={"should_be": "overwritten"})
@@ -231,26 +239,26 @@ def test_model_create_transformer_network_isolation(create_sagemaker_model, sage
 @patch("sagemaker.session.Session")
 @patch("sagemaker.local.LocalSession")
 def test_transformer_creates_correct_session(local_session, session):
-    model = Model(MODEL_DATA, MODEL_IMAGE, sagemaker_session=None)
+    model = Model(MODEL_IMAGE, MODEL_DATA, sagemaker_session=None)
     transformer = model.transformer(instance_count=1, instance_type="local")
     assert model.sagemaker_session == local_session.return_value
     assert transformer.sagemaker_session == local_session.return_value
 
-    model = Model(MODEL_DATA, MODEL_IMAGE, sagemaker_session=None)
+    model = Model(MODEL_IMAGE, MODEL_DATA, sagemaker_session=None)
     transformer = model.transformer(instance_count=1, instance_type="ml.m5.xlarge")
     assert model.sagemaker_session == session.return_value
     assert transformer.sagemaker_session == session.return_value
 
 
 def test_delete_model(sagemaker_session):
-    model = Model(MODEL_DATA, MODEL_IMAGE, name=MODEL_NAME, sagemaker_session=sagemaker_session)
+    model = Model(MODEL_IMAGE, MODEL_DATA, name=MODEL_NAME, sagemaker_session=sagemaker_session)
 
     model.delete_model()
     sagemaker_session.delete_model.assert_called_with(model.name)
 
 
 def test_delete_model_no_name(sagemaker_session):
-    model = Model(MODEL_DATA, MODEL_IMAGE, sagemaker_session=sagemaker_session)
+    model = Model(MODEL_IMAGE, MODEL_DATA, sagemaker_session=sagemaker_session)
 
     with pytest.raises(
         ValueError, match="The SageMaker model must be created first before attempting to delete."

--- a/tests/unit/sagemaker/model/test_neo.py
+++ b/tests/unit/sagemaker/model/test_neo.py
@@ -37,7 +37,7 @@ def sagemaker_session():
 
 
 def _create_model(sagemaker_session=None):
-    return Model(MODEL_DATA, MODEL_IMAGE, sagemaker_session=sagemaker_session)
+    return Model(MODEL_IMAGE, MODEL_DATA, sagemaker_session=sagemaker_session)
 
 
 def test_compile_model_for_inferentia(sagemaker_session):
@@ -142,6 +142,62 @@ def test_compile_creates_session(session):
     )
 
     assert session.return_value == model.sagemaker_session
+
+
+def test_compile_validates_framework():
+    model = _create_model()
+
+    with pytest.raises(ValueError) as e:
+        model.compile(
+            target_instance_family="ml_c4",
+            input_shape={"data": [1, 3, 1024, 1024]},
+            output_path="s3://output",
+            role="role",
+        )
+
+    assert "You must specify framework" in str(e)
+
+    with pytest.raises(ValueError) as e:
+        model.compile(
+            target_instance_family="ml_c4",
+            input_shape={"data": [1, 3, 1024, 1024]},
+            output_path="s3://output",
+            role="role",
+            framework="not-a-real-framework",
+        )
+
+    assert "You must provide valid framework" in str(e)
+
+
+def test_compile_validates_job_name():
+    model = _create_model()
+
+    with pytest.raises(ValueError) as e:
+        model.compile(
+            target_instance_family="ml_c4",
+            input_shape={"data": [1, 3, 1024, 1024]},
+            output_path="s3://output",
+            role="role",
+            framework="tensorflow",
+        )
+
+    assert "You must provide a compilation job name" in str(e)
+
+
+def test_compile_validates_model_data():
+    model = Model(MODEL_IMAGE)
+
+    with pytest.raises(ValueError) as e:
+        model.compile(
+            target_instance_family="ml_c4",
+            input_shape={"data": [1, 3, 1024, 1024]},
+            output_path="s3://output",
+            role="role",
+            framework="tensorflow",
+            job_name="compile-model",
+        )
+
+    assert "You must provide an S3 path to the compressed model artifacts." in str(e)
 
 
 def test_check_neo_region(sagemaker_session):


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/sagemaker-python-sdk/issues/1459#issuecomment-625936632

*Description of changes:*
I'm not sure why we original made `model_data` required when it's technically not required for `CreateModel`. I did build my own Docker image to verify that I could make a working SageMaker Model with only an image for the container definition in `CreateModel` before making this change.

This change should affect only the interface for the generic `Model` class. I didn't want to change the other ones (i.e. first-party algos, frameworks) because afaik the Docker images associated with those do require model data in S3.

*Testing done:*
unit tests

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to any/all clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
