### PR TITLE
breaking: drop Python 2 support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -93,7 +93,6 @@ Supported Python Versions
 
 SageMaker Python SDK is tested on:
 
-- Python 2.7
 - Python 3.6
 - Python 3.7
 
@@ -121,10 +120,9 @@ You can install the libraries needed to run the tests by running :code:`pip inst
 
 **Unit tests**
 
-
 We run unit tests with tox, which is a program that lets you run unit tests for multiple Python versions, and also make sure the
-code fits our style guidelines. We run tox with Python 2.7, 3.6 and 3.7, so to run unit tests
-with the same configuration we do, you'll need to have interpreters for Python 2.7, Python 3.6 and Python 3.7 installed.
+code fits our style guidelines. We run tox with `all of our supported Python versions <#supported-python-versions>`_, so to run unit tests
+with the same configuration we do, you need to have interpreters for those Python versions installed.
 
 To run the unit tests with tox, run:
 

--- a/buildspec-localmodetests.yml
+++ b/buildspec-localmodetests.yml
@@ -11,5 +11,5 @@ phases:
 
       # local mode tests
       - start_time=`date +%s`
-      - execute-command-if-has-matching-changes "tox -e py27,py37 -- tests/integ -m local_mode --durations 50" "tests/integ" "tests/data" "tests/conftest.py" "tests/__init__.py" "src/*.py" "setup.py" "setup.cfg" "buildspec-localmodetests.yml"
-      - ./ci-scripts/displaytime.sh 'py27,py37 local mode' $start_time
+      - execute-command-if-has-matching-changes "tox -e py37 -- tests/integ -m local_mode --durations 50" "tests/integ" "tests/data" "tests/conftest.py" "tests/__init__.py" "src/*.py" "setup.py" "setup.cfg" "buildspec-localmodetests.yml"
+      - ./ci-scripts/displaytime.sh 'py37 local mode' $start_time

--- a/buildspec-release.yml
+++ b/buildspec-release.yml
@@ -18,7 +18,7 @@ phases:
       # run unit tests
       - AWS_ACCESS_KEY_ID= AWS_SECRET_ACCESS_KEY= AWS_SESSION_TOKEN=
         AWS_CONTAINER_CREDENTIALS_RELATIVE_URI= AWS_DEFAULT_REGION=
-        tox -e py27,py36,py37 -- tests/unit
+        tox -e py36,py37 -- tests/unit
 
       # run a subset of the integration tests
       - IGNORE_COVERAGE=- tox -e py36 -- tests/integ -m canary_quick -n 64 --boxed --reruns 2

--- a/buildspec-unittests.yml
+++ b/buildspec-unittests.yml
@@ -20,10 +20,3 @@ phases:
         AWS_CONTAINER_CREDENTIALS_RELATIVE_URI= AWS_DEFAULT_REGION=
         tox -e py36,py37 --parallel all -- tests/unit
       - ./ci-scripts/displaytime.sh 'py36,py37 unit' $start_time
-
-      # Remove once https://github.com/aws/sagemaker-python-sdk/issues/1461 is addressed.
-      - start_time=`date +%s`
-      - AWS_ACCESS_KEY_ID= AWS_SECRET_ACCESS_KEY= AWS_SESSION_TOKEN=
-        AWS_CONTAINER_CREDENTIALS_RELATIVE_URI= AWS_DEFAULT_REGION=
-        IGNORE_COVERAGE=- tox -e py27 --parallel all -- tests/unit
-      - ./ci-scripts/displaytime.sh 'py27 unit' $start_time

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@ from __future__ import absolute_import
 
 import os
 from glob import glob
-import sys
 
 from setuptools import setup, find_packages
 
@@ -77,10 +76,6 @@ extras["test"] = (
     ],
 )
 
-# enum is introduced in Python 3.4. Installing enum back port
-if sys.version_info < (3, 4):
-    required_packages.append("enum34>=1.1.6")
-
 setup(
     name="sagemaker",
     version=read_version(),
@@ -99,7 +94,6 @@ setup(
         "Natural Language :: English",
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
     ],

--- a/src/sagemaker/__init__.py
+++ b/src/sagemaker/__init__.py
@@ -13,8 +13,6 @@
 """Placeholder docstring"""
 from __future__ import absolute_import
 
-import logging
-import sys
 import importlib_metadata
 
 from sagemaker import estimator, parameter, tuner  # noqa: F401
@@ -63,10 +61,3 @@ from sagemaker.automl.automl import AutoML, AutoMLJob, AutoMLInput  # noqa: F401
 from sagemaker.automl.candidate_estimator import CandidateEstimator, CandidateStep  # noqa: F401
 
 __version__ = importlib_metadata.version("sagemaker")
-
-if sys.version[0] == "2":
-    logging.getLogger("sagemaker").warning(
-        "SageMaker Python SDK v2 will no longer support Python 2. "
-        "Please see https://github.com/aws/sagemaker-python-sdk/issues/1459 "
-        "for more information"
-    )

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = black-format,flake8,pylint,twine,sphinx,doc8,py27,py36,py37,py38
+envlist = black-format,flake8,pylint,twine,sphinx,doc8,py36,py37,py38
 
 skip_missing_interpreters = False
 
@@ -19,7 +19,6 @@ exclude =
     .tox
     tests/data/
     venv/
-    *service_pb2_grpc.py
 
 max-complexity = 10
 
@@ -65,10 +64,6 @@ commands =
     coverage run --source sagemaker -m pytest {posargs}
     {env:IGNORE_COVERAGE:} coverage report --fail-under=86
 extras = test
-
-[testenv:py27]
-setenv =
-    IGNORE_COVERAGE = -
 
 [testenv:flake8]
 basepython = python3


### PR DESCRIPTION
*Issue #, if available:*
#1461, #1469 

*Description of changes:*
finally :)

note: updating our tests to no longer rely on having both py27 and py36 tox runs in the buildspecs will come in a series of subsequent PRs.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
