### PR TITLE
infra: use fixture for Python version in PyTorch integ tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,7 +46,6 @@ def pytest_addoption(parser):
     parser.addoption("--chainer-full-version", action="store", default="5.0.0")
     parser.addoption("--mxnet-full-version", action="store", default="1.6.0")
     parser.addoption("--ei-mxnet-full-version", action="store", default="1.5.1")
-    parser.addoption("--pytorch-full-version", action="store", default="1.5.0")
     parser.addoption(
         "--rl-coach-mxnet-full-version",
         action="store",
@@ -266,8 +265,18 @@ def ei_mxnet_full_version(request):
 
 
 @pytest.fixture(scope="module")
-def pytorch_full_version(request):
-    return request.config.getoption("--pytorch-full-version")
+def pytorch_full_version():
+    return "1.5.0"
+
+
+@pytest.fixture(scope="module")
+def pytorch_full_py_version():
+    return "py3"
+
+
+@pytest.fixture(scope="module")
+def pytorch_full_ei_version():
+    return "1.3.1"
 
 
 @pytest.fixture(scope="module")

--- a/tests/integ/test_airflow_config.py
+++ b/tests/integ/test_airflow_config.py
@@ -611,39 +611,14 @@ def test_xgboost_airflow_config_uploads_data_source_to_s3(
 
 @pytest.mark.canary_quick
 def test_pytorch_airflow_config_uploads_data_source_to_s3_when_inputs_not_provided(
-    sagemaker_session, cpu_instance_type, pytorch_full_version
+    sagemaker_session, cpu_instance_type, pytorch_full_version, pytorch_full_py_version,
 ):
     with timeout(seconds=AIRFLOW_CONFIG_TIMEOUT_IN_SECONDS):
         estimator = PyTorch(
             entry_point=PYTORCH_MNIST_SCRIPT,
             role=ROLE,
             framework_version=pytorch_full_version,
-            py_version="py3",
-            train_instance_count=2,
-            train_instance_type=cpu_instance_type,
-            hyperparameters={"epochs": 6, "backend": "gloo"},
-            sagemaker_session=sagemaker_session,
-        )
-
-        training_config = _build_airflow_workflow(
-            estimator=estimator, instance_type=cpu_instance_type
-        )
-
-        _assert_that_s3_url_contains_data(
-            sagemaker_session,
-            training_config["HyperParameters"]["sagemaker_submit_directory"].strip('"'),
-        )
-
-
-def test_pytorch_12_airflow_config_uploads_data_source_to_s3_when_inputs_not_provided(
-    sagemaker_session, cpu_instance_type
-):
-    with timeout(seconds=AIRFLOW_CONFIG_TIMEOUT_IN_SECONDS):
-        estimator = PyTorch(
-            entry_point=PYTORCH_MNIST_SCRIPT,
-            role=ROLE,
-            framework_version="1.2.0",
-            py_version="py3",
+            py_version=pytorch_full_py_version,
             train_instance_count=2,
             train_instance_type=cpu_instance_type,
             hyperparameters={"epochs": 6, "backend": "gloo"},

--- a/tests/integ/test_source_dirs.py
+++ b/tests/integ/test_source_dirs.py
@@ -17,9 +17,8 @@ import os
 import pytest
 
 import tests.integ.lock as lock
-from tests.integ import DATA_DIR, PYTHON_VERSION
-
 from sagemaker.pytorch.estimator import PyTorch
+from tests.integ import DATA_DIR
 
 
 @pytest.mark.local_mode
@@ -38,7 +37,7 @@ def test_source_dirs(tmpdir, sagemaker_local_session):
         source_dir=source_dir,
         dependencies=[lib],
         framework_version="0.4",  # hard-code to last known good pytorch for now (see TODO above)
-        py_version=PYTHON_VERSION,
+        py_version="py3",
         train_instance_count=1,
         train_instance_type="local",
         sagemaker_session=sagemaker_local_session,

--- a/tests/integ/test_transformer.py
+++ b/tests/integ/test_transformer.py
@@ -159,7 +159,11 @@ def test_attach_transform_kmeans(sagemaker_session, cpu_instance_type):
 
 
 def test_transform_pytorch_vpc_custom_model_bucket(
-    sagemaker_session, pytorch_full_version, cpu_instance_type, custom_bucket_name
+    sagemaker_session,
+    pytorch_full_version,
+    pytorch_full_py_version,
+    cpu_instance_type,
+    custom_bucket_name,
 ):
     data_dir = os.path.join(DATA_DIR, "pytorch_mnist")
 
@@ -177,7 +181,7 @@ def test_transform_pytorch_vpc_custom_model_bucket(
         entry_point=os.path.join(data_dir, "mnist.py"),
         role="SageMakerRole",
         framework_version=pytorch_full_version,
-        py_version="py3",
+        py_version=pytorch_full_py_version,
         sagemaker_session=sagemaker_session,
         vpc_config={"Subnets": subnet_ids, "SecurityGroupIds": [security_group_id]},
         code_location="s3://{}".format(custom_bucket_name),

--- a/tests/integ/test_tuner.py
+++ b/tests/integ/test_tuner.py
@@ -762,7 +762,9 @@ def test_tuning_chainer(sagemaker_session, chainer_full_version, cpu_instance_ty
     reason="This test has always failed, but the failure was masked by a bug. "
     "This test should be fixed. Details in https://github.com/aws/sagemaker-python-sdk/pull/968"
 )
-def test_attach_tuning_pytorch(sagemaker_session, cpu_instance_type, pytorch_full_version):
+def test_attach_tuning_pytorch(
+    sagemaker_session, cpu_instance_type, pytorch_full_version, pytorch_full_py_version
+):
     mnist_dir = os.path.join(DATA_DIR, "pytorch_mnist")
     mnist_script = os.path.join(mnist_dir, "mnist.py")
 
@@ -771,7 +773,7 @@ def test_attach_tuning_pytorch(sagemaker_session, cpu_instance_type, pytorch_ful
         role="SageMakerRole",
         train_instance_count=1,
         framework_version=pytorch_full_version,
-        py_version="py3",
+        py_version=pytorch_full_py_version,
         train_instance_type=cpu_instance_type,
         sagemaker_session=sagemaker_session,
     )


### PR DESCRIPTION
*Issue #, if available:*
#1461 (follow-up to #1609)

*Description of changes:*
Because we no longer run our tests with Python 2, the `PYTHON_VERSION` constant is less meaningful. Plus, our integ tests our for testing the Python SDK, not images, so it should be sufficient for us to just test on the latest framework/Python version combination. (The unit tests can still test every combination.)

I chose to make top-level fixtures because the greater plan is to have the fixtures generated once #1464 is done.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
