### PR TITLE
infra: use fixture for Python version in MXNet integ tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,7 +44,6 @@ def pytest_addoption(parser):
     parser.addoption("--sagemaker-runtime-config", action="store", default=None)
     parser.addoption("--boto-config", action="store", default=None)
     parser.addoption("--chainer-full-version", action="store", default="5.0.0")
-    parser.addoption("--mxnet-full-version", action="store", default="1.6.0")
     parser.addoption("--ei-mxnet-full-version", action="store", default="1.5.1")
     parser.addoption(
         "--rl-coach-mxnet-full-version",
@@ -255,8 +254,13 @@ def chainer_full_version(request):
 
 
 @pytest.fixture(scope="module")
-def mxnet_full_version(request):
-    return request.config.getoption("--mxnet-full-version")
+def mxnet_full_version():
+    return "1.6.0"
+
+
+@pytest.fixture(scope="module")
+def mxnet_full_py_version():
+    return "py3"
 
 
 @pytest.fixture(scope="module")

--- a/tests/integ/test_airflow_config.py
+++ b/tests/integ/test_airflow_config.py
@@ -480,7 +480,7 @@ def test_chainer_airflow_config_uploads_data_source_to_s3(
 
 @pytest.mark.canary_quick
 def test_mxnet_airflow_config_uploads_data_source_to_s3(
-    sagemaker_session, cpu_instance_type, mxnet_full_version
+    sagemaker_session, cpu_instance_type, mxnet_full_version, mxnet_full_py_version
 ):
     with timeout(seconds=AIRFLOW_CONFIG_TIMEOUT_IN_SECONDS):
         script_path = os.path.join(DATA_DIR, "chainer_mnist", "mnist.py")
@@ -490,7 +490,7 @@ def test_mxnet_airflow_config_uploads_data_source_to_s3(
             entry_point=script_path,
             role=ROLE,
             framework_version=mxnet_full_version,
-            py_version=PYTHON_VERSION,
+            py_version=mxnet_full_py_version,
             train_instance_count=SINGLE_INSTANCE_COUNT,
             train_instance_type=cpu_instance_type,
             sagemaker_session=sagemaker_session,

--- a/tests/integ/test_airflow_config.py
+++ b/tests/integ/test_airflow_config.py
@@ -573,7 +573,7 @@ def test_xgboost_airflow_config_uploads_data_source_to_s3(
 
 @pytest.mark.canary_quick
 def test_pytorch_airflow_config_uploads_data_source_to_s3_when_inputs_not_provided(
-    sagemaker_session, cpu_instance_type, pytorch_full_version, pytorch_full_py_version,
+    sagemaker_session, cpu_instance_type, pytorch_full_version, pytorch_full_py_version
 ):
     with timeout(seconds=AIRFLOW_CONFIG_TIMEOUT_IN_SECONDS):
         estimator = PyTorch(

--- a/tests/integ/test_debugger.py
+++ b/tests/integ/test_debugger.py
@@ -17,13 +17,9 @@ import uuid
 
 import pytest
 
-from sagemaker.debugger import Rule
-from sagemaker.debugger import DebuggerHookConfig
-from sagemaker.debugger import TensorBoardOutputConfig
-
-from sagemaker.debugger import rule_configs
+from sagemaker.debugger import DebuggerHookConfig, Rule, rule_configs, TensorBoardOutputConfig
 from sagemaker.mxnet.estimator import MXNet
-from tests.integ import DATA_DIR, PYTHON_VERSION, TRAINING_DEFAULT_TIMEOUT_MINUTES
+from tests.integ import DATA_DIR, TRAINING_DEFAULT_TIMEOUT_MINUTES
 from tests.integ.retry import retries
 from tests.integ.timeout import timeout
 
@@ -60,7 +56,9 @@ CUSTOM_RULE_CONTAINERS_ACCOUNTS_MAP = {
 # TODO-reinvent-2019: test get_debugger_artifacts_path and get_tensorboard_artifacts_path
 
 
-def test_mxnet_with_rules(sagemaker_session, mxnet_full_version, cpu_instance_type):
+def test_mxnet_with_rules(
+    sagemaker_session, mxnet_full_version, mxnet_full_py_version, cpu_instance_type
+):
     with timeout(minutes=TRAINING_DEFAULT_TIMEOUT_MINUTES):
         rules = [
             Rule.sagemaker(rule_configs.vanishing_gradient()),
@@ -77,7 +75,7 @@ def test_mxnet_with_rules(sagemaker_session, mxnet_full_version, cpu_instance_ty
             entry_point=script_path,
             role="SageMakerRole",
             framework_version=mxnet_full_version,
-            py_version=PYTHON_VERSION,
+            py_version=mxnet_full_py_version,
             train_instance_count=1,
             train_instance_type=cpu_instance_type,
             sagemaker_session=sagemaker_session,
@@ -119,7 +117,9 @@ def test_mxnet_with_rules(sagemaker_session, mxnet_full_version, cpu_instance_ty
         _wait_and_assert_that_no_rule_jobs_errored(training_job=mx.latest_training_job)
 
 
-def test_mxnet_with_custom_rule(sagemaker_session, mxnet_full_version, cpu_instance_type):
+def test_mxnet_with_custom_rule(
+    sagemaker_session, mxnet_full_version, mxnet_full_py_version, cpu_instance_type
+):
     with timeout(minutes=TRAINING_DEFAULT_TIMEOUT_MINUTES):
         rules = [_get_custom_rule(sagemaker_session)]
 
@@ -130,7 +130,7 @@ def test_mxnet_with_custom_rule(sagemaker_session, mxnet_full_version, cpu_insta
             entry_point=script_path,
             role="SageMakerRole",
             framework_version=mxnet_full_version,
-            py_version=PYTHON_VERSION,
+            py_version=mxnet_full_py_version,
             train_instance_count=1,
             train_instance_type=cpu_instance_type,
             sagemaker_session=sagemaker_session,
@@ -166,7 +166,9 @@ def test_mxnet_with_custom_rule(sagemaker_session, mxnet_full_version, cpu_insta
         _wait_and_assert_that_no_rule_jobs_errored(training_job=mx.latest_training_job)
 
 
-def test_mxnet_with_debugger_hook_config(sagemaker_session, mxnet_full_version, cpu_instance_type):
+def test_mxnet_with_debugger_hook_config(
+    sagemaker_session, mxnet_full_version, mxnet_full_py_version, cpu_instance_type
+):
     with timeout(minutes=TRAINING_DEFAULT_TIMEOUT_MINUTES):
         debugger_hook_config = DebuggerHookConfig(
             s3_output_path=os.path.join(
@@ -181,7 +183,7 @@ def test_mxnet_with_debugger_hook_config(sagemaker_session, mxnet_full_version, 
             entry_point=script_path,
             role="SageMakerRole",
             framework_version=mxnet_full_version,
-            py_version=PYTHON_VERSION,
+            py_version=mxnet_full_py_version,
             train_instance_count=1,
             train_instance_type=cpu_instance_type,
             sagemaker_session=sagemaker_session,
@@ -204,7 +206,7 @@ def test_mxnet_with_debugger_hook_config(sagemaker_session, mxnet_full_version, 
 
 
 def test_mxnet_with_rules_and_debugger_hook_config(
-    sagemaker_session, mxnet_full_version, cpu_instance_type
+    sagemaker_session, mxnet_full_version, mxnet_full_py_version, cpu_instance_type
 ):
     with timeout(minutes=TRAINING_DEFAULT_TIMEOUT_MINUTES):
         rules = [
@@ -227,7 +229,7 @@ def test_mxnet_with_rules_and_debugger_hook_config(
             entry_point=script_path,
             role="SageMakerRole",
             framework_version=mxnet_full_version,
-            py_version=PYTHON_VERSION,
+            py_version=mxnet_full_py_version,
             train_instance_count=1,
             train_instance_type=cpu_instance_type,
             sagemaker_session=sagemaker_session,
@@ -272,7 +274,7 @@ def test_mxnet_with_rules_and_debugger_hook_config(
 
 
 def test_mxnet_with_custom_rule_and_debugger_hook_config(
-    sagemaker_session, mxnet_full_version, cpu_instance_type
+    sagemaker_session, mxnet_full_version, mxnet_full_py_version, cpu_instance_type
 ):
     with timeout(minutes=TRAINING_DEFAULT_TIMEOUT_MINUTES):
         rules = [_get_custom_rule(sagemaker_session)]
@@ -289,7 +291,7 @@ def test_mxnet_with_custom_rule_and_debugger_hook_config(
             entry_point=script_path,
             role="SageMakerRole",
             framework_version=mxnet_full_version,
-            py_version=PYTHON_VERSION,
+            py_version=mxnet_full_py_version,
             train_instance_count=1,
             train_instance_type=cpu_instance_type,
             sagemaker_session=sagemaker_session,
@@ -328,7 +330,7 @@ def test_mxnet_with_custom_rule_and_debugger_hook_config(
 
 
 def test_mxnet_with_tensorboard_output_config(
-    sagemaker_session, mxnet_full_version, cpu_instance_type
+    sagemaker_session, mxnet_full_version, mxnet_full_py_version, cpu_instance_type
 ):
     with timeout(minutes=TRAINING_DEFAULT_TIMEOUT_MINUTES):
         tensorboard_output_config = TensorBoardOutputConfig(
@@ -344,7 +346,7 @@ def test_mxnet_with_tensorboard_output_config(
             entry_point=script_path,
             role="SageMakerRole",
             framework_version=mxnet_full_version,
-            py_version=PYTHON_VERSION,
+            py_version=mxnet_full_py_version,
             train_instance_count=1,
             train_instance_type=cpu_instance_type,
             sagemaker_session=sagemaker_session,
@@ -370,7 +372,9 @@ def test_mxnet_with_tensorboard_output_config(
 
 
 @pytest.mark.canary_quick
-def test_mxnet_with_all_rules_and_configs(sagemaker_session, mxnet_full_version, cpu_instance_type):
+def test_mxnet_with_all_rules_and_configs(
+    sagemaker_session, mxnet_full_version, mxnet_full_py_version, cpu_instance_type
+):
     with timeout(minutes=TRAINING_DEFAULT_TIMEOUT_MINUTES):
         rules = [
             Rule.sagemaker(rule_configs.vanishing_gradient()),
@@ -398,7 +402,7 @@ def test_mxnet_with_all_rules_and_configs(sagemaker_session, mxnet_full_version,
             entry_point=script_path,
             role="SageMakerRole",
             framework_version=mxnet_full_version,
-            py_version=PYTHON_VERSION,
+            py_version=mxnet_full_py_version,
             train_instance_count=1,
             train_instance_type=cpu_instance_type,
             sagemaker_session=sagemaker_session,
@@ -441,7 +445,7 @@ def test_mxnet_with_all_rules_and_configs(sagemaker_session, mxnet_full_version,
 
 
 def test_mxnet_with_debugger_hook_config_disabled(
-    sagemaker_session, mxnet_full_version, cpu_instance_type
+    sagemaker_session, mxnet_full_version, mxnet_full_py_version, cpu_instance_type
 ):
     with timeout(minutes=TRAINING_DEFAULT_TIMEOUT_MINUTES):
         script_path = os.path.join(DATA_DIR, "mxnet_mnist", "mnist_gluon.py")
@@ -451,7 +455,7 @@ def test_mxnet_with_debugger_hook_config_disabled(
             entry_point=script_path,
             role="SageMakerRole",
             framework_version=mxnet_full_version,
-            py_version=PYTHON_VERSION,
+            py_version=mxnet_full_py_version,
             train_instance_count=1,
             train_instance_type=cpu_instance_type,
             sagemaker_session=sagemaker_session,

--- a/tests/integ/test_git.py
+++ b/tests/integ/test_git.py
@@ -24,7 +24,7 @@ from sagemaker.mxnet.estimator import MXNet
 from sagemaker.pytorch.estimator import PyTorch
 from sagemaker.sklearn.estimator import SKLearn
 from sagemaker.sklearn.model import SKLearnModel
-from tests.integ import DATA_DIR, PYTHON_VERSION
+from tests.integ import DATA_DIR
 
 
 GIT_REPO = "https://github.com/aws/sagemaker-python-sdk.git"

--- a/tests/integ/test_git.py
+++ b/tests/integ/test_git.py
@@ -81,7 +81,7 @@ def test_github(sagemaker_local_session, pytorch_full_version, pytorch_full_py_v
 
 @pytest.mark.local_mode
 @pytest.mark.skip("needs a secure authentication approach")
-def test_private_github(sagemaker_local_session, mxnet_full_version):
+def test_private_github(sagemaker_local_session, mxnet_full_version, mxnet_full_py_version):
     script_path = "mnist.py"
     data_path = os.path.join(DATA_DIR, "mxnet_mnist")
     git_config = {
@@ -100,7 +100,7 @@ def test_private_github(sagemaker_local_session, mxnet_full_version):
         source_dir=source_dir,
         dependencies=dependencies,
         framework_version=mxnet_full_version,
-        py_version=PYTHON_VERSION,
+        py_version=mxnet_full_py_version,
         train_instance_count=1,
         train_instance_type="local",
         sagemaker_session=sagemaker_local_session,
@@ -219,7 +219,7 @@ def test_github_with_ssh_passphrase_not_configured(sagemaker_local_session, skle
 
 @pytest.mark.local_mode
 @pytest.mark.skip("needs a secure authentication approach")
-def test_codecommit(sagemaker_local_session, mxnet_full_version):
+def test_codecommit(sagemaker_local_session, mxnet_full_version, mxnet_full_py_version):
     script_path = "mnist.py"
     data_path = os.path.join(DATA_DIR, "mxnet_mnist")
     git_config = {
@@ -236,7 +236,7 @@ def test_codecommit(sagemaker_local_session, mxnet_full_version):
         source_dir=source_dir,
         dependencies=dependencies,
         framework_version=mxnet_full_version,
-        py_version=PYTHON_VERSION,
+        py_version=mxnet_full_py_version,
         train_instance_count=1,
         train_instance_type="local",
         sagemaker_session=sagemaker_local_session,

--- a/tests/integ/test_local_mode.py
+++ b/tests/integ/test_local_mode.py
@@ -23,7 +23,7 @@ import tempfile
 import stopit
 
 import tests.integ.lock as lock
-from tests.integ import DATA_DIR, PYTHON_VERSION
+from tests.integ import DATA_DIR
 
 from sagemaker.local import LocalSession, LocalSagemakerRuntimeClient, LocalSagemakerClient
 from sagemaker.mxnet import MXNet
@@ -54,7 +54,7 @@ class LocalNoS3Session(LocalSession):
 
 
 @pytest.fixture(scope="module")
-def mxnet_model(sagemaker_local_session, mxnet_full_version):
+def mxnet_model(sagemaker_local_session, mxnet_full_version, mxnet_full_py_version):
     def _create_model(output_path):
         script_path = os.path.join(DATA_DIR, "mxnet_mnist", "mnist.py")
         data_path = os.path.join(DATA_DIR, "mxnet_mnist")
@@ -66,7 +66,7 @@ def mxnet_model(sagemaker_local_session, mxnet_full_version):
             train_instance_type="local",
             output_path=output_path,
             framework_version=mxnet_full_version,
-            py_version=PYTHON_VERSION,
+            py_version=mxnet_full_py_version,
             sagemaker_session=sagemaker_local_session,
         )
 
@@ -85,7 +85,9 @@ def mxnet_model(sagemaker_local_session, mxnet_full_version):
 
 
 @pytest.mark.local_mode
-def test_local_mode_serving_from_s3_model(sagemaker_local_session, mxnet_model, mxnet_full_version):
+def test_local_mode_serving_from_s3_model(
+    sagemaker_local_session, mxnet_model, mxnet_full_version, mxnet_full_py_version
+):
     path = "s3://%s" % sagemaker_local_session.default_bucket()
     s3_model = mxnet_model(path)
     s3_model.sagemaker_session = sagemaker_local_session
@@ -119,14 +121,14 @@ def test_local_mode_serving_from_local_model(tmpdir, sagemaker_local_session, mx
 
 
 @pytest.mark.local_mode
-def test_mxnet_local_mode(sagemaker_local_session, mxnet_full_version):
+def test_mxnet_local_mode(sagemaker_local_session, mxnet_full_version, mxnet_full_py_version):
     script_path = os.path.join(DATA_DIR, "mxnet_mnist", "mnist.py")
     data_path = os.path.join(DATA_DIR, "mxnet_mnist")
 
     mx = MXNet(
         entry_point=script_path,
         role="SageMakerRole",
-        py_version=PYTHON_VERSION,
+        py_version=mxnet_full_py_version,
         train_instance_count=1,
         train_instance_type="local",
         sagemaker_session=sagemaker_local_session,
@@ -153,14 +155,16 @@ def test_mxnet_local_mode(sagemaker_local_session, mxnet_full_version):
 
 
 @pytest.mark.local_mode
-def test_mxnet_distributed_local_mode(sagemaker_local_session, mxnet_full_version):
+def test_mxnet_distributed_local_mode(
+    sagemaker_local_session, mxnet_full_version, mxnet_full_py_version
+):
     script_path = os.path.join(DATA_DIR, "mxnet_mnist", "mnist.py")
     data_path = os.path.join(DATA_DIR, "mxnet_mnist")
 
     mx = MXNet(
         entry_point=script_path,
         role="SageMakerRole",
-        py_version=PYTHON_VERSION,
+        py_version=mxnet_full_py_version,
         train_instance_count=2,
         train_instance_type="local",
         sagemaker_session=sagemaker_local_session,
@@ -179,7 +183,7 @@ def test_mxnet_distributed_local_mode(sagemaker_local_session, mxnet_full_versio
 
 
 @pytest.mark.local_mode
-def test_mxnet_local_data_local_script(mxnet_full_version):
+def test_mxnet_local_data_local_script(mxnet_full_version, mxnet_full_py_version):
     data_path = os.path.join(DATA_DIR, "mxnet_mnist")
     script_path = os.path.join(data_path, "mnist.py")
 
@@ -189,7 +193,7 @@ def test_mxnet_local_data_local_script(mxnet_full_version):
         train_instance_count=1,
         train_instance_type="local",
         framework_version=mxnet_full_version,
-        py_version=PYTHON_VERSION,
+        py_version=mxnet_full_py_version,
         sagemaker_session=LocalNoS3Session(),
     )
 
@@ -209,14 +213,16 @@ def test_mxnet_local_data_local_script(mxnet_full_version):
 
 
 @pytest.mark.local_mode
-def test_mxnet_training_failure(sagemaker_local_session, mxnet_full_version, tmpdir):
+def test_mxnet_training_failure(
+    sagemaker_local_session, mxnet_full_version, mxnet_full_py_version, tmpdir
+):
     script_path = os.path.join(DATA_DIR, "mxnet_mnist", "failure_script.py")
 
     mx = MXNet(
         entry_point=script_path,
         role="SageMakerRole",
         framework_version=mxnet_full_version,
-        py_version=PYTHON_VERSION,
+        py_version=mxnet_full_py_version,
         train_instance_count=1,
         train_instance_type="local",
         sagemaker_session=sagemaker_local_session,
@@ -233,7 +239,7 @@ def test_mxnet_training_failure(sagemaker_local_session, mxnet_full_version, tmp
 
 @pytest.mark.local_mode
 def test_local_transform_mxnet(
-    sagemaker_local_session, tmpdir, mxnet_full_version, cpu_instance_type
+    sagemaker_local_session, tmpdir, mxnet_full_version, mxnet_full_py_version, cpu_instance_type
 ):
     data_path = os.path.join(DATA_DIR, "mxnet_mnist")
     script_path = os.path.join(data_path, "mnist.py")
@@ -244,7 +250,7 @@ def test_local_transform_mxnet(
         train_instance_count=1,
         train_instance_type="local",
         framework_version=mxnet_full_version,
-        py_version=PYTHON_VERSION,
+        py_version=mxnet_full_py_version,
         sagemaker_session=sagemaker_local_session,
     )
 

--- a/tests/integ/test_multidatamodel.py
+++ b/tests/integ/test_multidatamodel.py
@@ -240,16 +240,20 @@ def test_multi_data_model_deploy_pretrained_models_local_mode(container_image, s
 
 
 def test_multi_data_model_deploy_trained_model_from_framework_estimator(
-    container_image, sagemaker_session, cpu_instance_type
+    container_image, sagemaker_session, cpu_instance_type, mxnet_full_version, mxnet_full_py_version
 ):
     timestamp = sagemaker_timestamp()
     endpoint_name = "test-multimodel-endpoint-{}".format(timestamp)
     model_name = "test-multimodel-{}".format(timestamp)
-    mxnet_version = "1.4.1"
 
     with timeout_and_delete_endpoint_by_name(endpoint_name, sagemaker_session):
-        mxnet_model_1 = __mxnet_training_job(
-            sagemaker_session, container_image, mxnet_version, cpu_instance_type, 0.1
+        mxnet_model_1 = _mxnet_training_job(
+            sagemaker_session,
+            container_image,
+            mxnet_full_version,
+            mxnet_full_py_version,
+            cpu_instance_type,
+            0.1,
         )
         model_data_prefix = os.path.join(
             "s3://", sagemaker_session.default_bucket(), "multimodel-{}/".format(timestamp)
@@ -267,8 +271,13 @@ def test_multi_data_model_deploy_trained_model_from_framework_estimator(
         multi_data_model.deploy(1, cpu_instance_type, endpoint_name=endpoint_name)
 
         # Train another model
-        mxnet_model_2 = __mxnet_training_job(
-            sagemaker_session, container_image, mxnet_version, cpu_instance_type, 0.01
+        mxnet_model_2 = _mxnet_training_job(
+            sagemaker_session,
+            container_image,
+            mxnet_full_version,
+            mxnet_full_py_version,
+            cpu_instance_type,
+            0.01,
         )
         # Deploy newly trained model
         multi_data_model.add_model(mxnet_model_2.model_data, PRETRAINED_MODEL_PATH_2)
@@ -308,7 +317,7 @@ def test_multi_data_model_deploy_trained_model_from_framework_estimator(
         assert "Could not find endpoint" in str(exception.value)
 
 
-def __mxnet_training_job(
+def _mxnet_training_job(
     sagemaker_session,
     container_image,
     mxnet_full_version,

--- a/tests/integ/test_multidatamodel.py
+++ b/tests/integ/test_multidatamodel.py
@@ -318,12 +318,7 @@ def test_multi_data_model_deploy_trained_model_from_framework_estimator(
 
 
 def _mxnet_training_job(
-    sagemaker_session,
-    container_image,
-    mxnet_version,
-    py_version,
-    cpu_instance_type,
-    learning_rate,
+    sagemaker_session, container_image, mxnet_version, py_version, cpu_instance_type, learning_rate
 ):
     with timeout(minutes=TRAINING_DEFAULT_TIMEOUT_MINUTES):
         script_path = os.path.join(DATA_DIR, "mxnet_mnist", "mnist.py")

--- a/tests/integ/test_multidatamodel.py
+++ b/tests/integ/test_multidatamodel.py
@@ -320,8 +320,8 @@ def test_multi_data_model_deploy_trained_model_from_framework_estimator(
 def _mxnet_training_job(
     sagemaker_session,
     container_image,
-    mxnet_full_version,
-    mxnet_full_py_version,
+    mxnet_version,
+    py_version,
     cpu_instance_type,
     learning_rate,
 ):
@@ -332,8 +332,8 @@ def _mxnet_training_job(
         mx = MXNet(
             entry_point=script_path,
             role=ROLE,
-            framework_version=mxnet_full_version,
-            py_version=mxnet_full_py_version,
+            framework_version=mxnet_version,
+            py_version=py_version,
             train_instance_count=1,
             train_instance_type=cpu_instance_type,
             sagemaker_session=sagemaker_session,

--- a/tests/integ/test_multidatamodel.py
+++ b/tests/integ/test_multidatamodel.py
@@ -28,7 +28,7 @@ from sagemaker.multidatamodel import MultiDataModel
 from sagemaker.mxnet import MXNet
 from sagemaker.predictor import RealTimePredictor, StringDeserializer, npy_serializer
 from sagemaker.utils import sagemaker_timestamp, unique_name_from_base, get_ecr_image_uri_prefix
-from tests.integ import DATA_DIR, PYTHON_VERSION, TRAINING_DEFAULT_TIMEOUT_MINUTES
+from tests.integ import DATA_DIR, TRAINING_DEFAULT_TIMEOUT_MINUTES
 from tests.integ.retry import retries
 from tests.integ.timeout import timeout, timeout_and_delete_endpoint_by_name
 
@@ -309,7 +309,12 @@ def test_multi_data_model_deploy_trained_model_from_framework_estimator(
 
 
 def __mxnet_training_job(
-    sagemaker_session, container_image, mxnet_full_version, cpu_instance_type, learning_rate
+    sagemaker_session,
+    container_image,
+    mxnet_full_version,
+    mxnet_full_py_version,
+    cpu_instance_type,
+    learning_rate,
 ):
     with timeout(minutes=TRAINING_DEFAULT_TIMEOUT_MINUTES):
         script_path = os.path.join(DATA_DIR, "mxnet_mnist", "mnist.py")
@@ -319,7 +324,7 @@ def __mxnet_training_job(
             entry_point=script_path,
             role=ROLE,
             framework_version=mxnet_full_version,
-            py_version=PYTHON_VERSION,
+            py_version=mxnet_full_py_version,
             train_instance_count=1,
             train_instance_type=cpu_instance_type,
             sagemaker_session=sagemaker_session,

--- a/tests/integ/test_neo_mxnet.py
+++ b/tests/integ/test_neo_mxnet.py
@@ -132,7 +132,7 @@ def test_inferentia_deploy_model(
             role,
             entry_point=script_path,
             framework_version=INF_MXNET_VERSION,
-            py_version=PYTHON_VERSION,
+            py_version=NEO_PYTHON_VERSION,
             sagemaker_session=sagemaker_session,
         )
 

--- a/tests/integ/test_neo_mxnet.py
+++ b/tests/integ/test_neo_mxnet.py
@@ -20,11 +20,12 @@ import pytest
 from sagemaker.mxnet.estimator import MXNet
 from sagemaker.mxnet.model import MXNetModel
 from sagemaker.utils import unique_name_from_base
-from tests.integ import DATA_DIR, PYTHON_VERSION, TRAINING_DEFAULT_TIMEOUT_MINUTES
+from tests.integ import DATA_DIR, TRAINING_DEFAULT_TIMEOUT_MINUTES
 from tests.integ.timeout import timeout, timeout_and_delete_endpoint_by_name
 
 NEO_MXNET_VERSION = "1.4.1"  # Neo doesn't support MXNet 1.6 yet.
 INF_MXNET_VERSION = "1.5.1"
+NEO_PYTHON_VERSION = "py3"
 
 
 @pytest.fixture(scope="module")
@@ -37,7 +38,7 @@ def mxnet_training_job(sagemaker_session, cpu_instance_type):
             entry_point=script_path,
             role="SageMakerRole",
             framework_version=NEO_MXNET_VERSION,
-            py_version=PYTHON_VERSION,
+            py_version=NEO_PYTHON_VERSION,
             train_instance_count=1,
             train_instance_type=cpu_instance_type,
             sagemaker_session=sagemaker_session,
@@ -94,7 +95,7 @@ def test_deploy_model(
             model_data,
             role,
             entry_point=script_path,
-            py_version=PYTHON_VERSION,
+            py_version=NEO_PYTHON_VERSION,
             framework_version=NEO_MXNET_VERSION,
             sagemaker_session=sagemaker_session,
         )

--- a/tests/integ/test_transformer.py
+++ b/tests/integ/test_transformer.py
@@ -42,7 +42,9 @@ MXNET_MNIST_PATH = os.path.join(DATA_DIR, "mxnet_mnist")
 
 
 @pytest.fixture(scope="module")
-def mxnet_estimator(sagemaker_session, mxnet_full_version, cpu_instance_type):
+def mxnet_estimator(
+    sagemaker_session, mxnet_full_version, mxnet_full_py_version, cpu_instance_type
+):
     mx = MXNet(
         entry_point=os.path.join(MXNET_MNIST_PATH, "mnist.py"),
         role="SageMakerRole",
@@ -50,7 +52,7 @@ def mxnet_estimator(sagemaker_session, mxnet_full_version, cpu_instance_type):
         train_instance_type=cpu_instance_type,
         sagemaker_session=sagemaker_session,
         framework_version=mxnet_full_version,
-        py_version=PYTHON_VERSION,
+        py_version=mxnet_full_py_version,
     )
 
     train_input = mx.sagemaker_session.upload_data(

--- a/tests/integ/test_tuner.py
+++ b/tests/integ/test_tuner.py
@@ -538,7 +538,9 @@ def test_stop_tuning_job(sagemaker_session, cpu_instance_type):
 
 
 @pytest.mark.canary_quick
-def test_tuning_mxnet(sagemaker_session, mxnet_full_version, mxnet_full_py_version, cpu_instance_type):
+def test_tuning_mxnet(
+    sagemaker_session, mxnet_full_version, mxnet_full_py_version, cpu_instance_type
+):
     with timeout(minutes=TUNING_DEFAULT_TIMEOUT_MINUTES):
         script_path = os.path.join(DATA_DIR, "mxnet_mnist", "mnist.py")
         data_path = os.path.join(DATA_DIR, "mxnet_mnist")

--- a/tests/integ/test_tuner.py
+++ b/tests/integ/test_tuner.py
@@ -538,7 +538,7 @@ def test_stop_tuning_job(sagemaker_session, cpu_instance_type):
 
 
 @pytest.mark.canary_quick
-def test_tuning_mxnet(sagemaker_session, mxnet_full_version, cpu_instance_type):
+def test_tuning_mxnet(sagemaker_session, mxnet_full_version, mxnet_full_py_version, cpu_instance_type):
     with timeout(minutes=TUNING_DEFAULT_TIMEOUT_MINUTES):
         script_path = os.path.join(DATA_DIR, "mxnet_mnist", "mnist.py")
         data_path = os.path.join(DATA_DIR, "mxnet_mnist")
@@ -546,7 +546,7 @@ def test_tuning_mxnet(sagemaker_session, mxnet_full_version, cpu_instance_type):
         estimator = MXNet(
             entry_point=script_path,
             role="SageMakerRole",
-            py_version=PYTHON_VERSION,
+            py_version=mxnet_full_py_version,
             train_instance_count=1,
             train_instance_type=cpu_instance_type,
             framework_version=mxnet_full_version,


### PR DESCRIPTION
*Issue #, if available:*
#1461 (follow-up to #1609)

*Description of changes:*
see description of #1612 

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
