### PR TITLE
breaking: deprecate sagemaker.utils.to_str()

### DIFF
--- a/src/sagemaker/parameter.py
+++ b/src/sagemaker/parameter.py
@@ -14,8 +14,6 @@
 from __future__ import absolute_import
 import json
 
-from sagemaker.utils import to_str
-
 
 class ParameterRange(object):
     """Base class for representing parameter ranges. This is used to define what
@@ -71,8 +69,8 @@ class ParameterRange(object):
         """
         return {
             "Name": name,
-            "MinValue": to_str(self.min_value),
-            "MaxValue": to_str(self.max_value),
+            "MinValue": str(self.min_value),
+            "MaxValue": str(self.max_value),
             "ScalingType": self.scaling_type,
         }
 
@@ -111,9 +109,9 @@ class CategoricalParameter(ParameterRange):
                 This input will be converted into a list of strings.
         """
         if isinstance(values, list):
-            self.values = [to_str(v) for v in values]
+            self.values = [str(v) for v in values]
         else:
-            self.values = [to_str(values)]
+            self.values = [str(values)]
 
     def as_tuning_range(self, name):
         """Represent the parameter range as a dicionary suitable for a request
@@ -158,7 +156,7 @@ class CategoricalParameter(ParameterRange):
         Args:
             value:
         """
-        return to_str(value)
+        return str(value)
 
 
 class IntegerParameter(ParameterRange):

--- a/src/sagemaker/tuner.py
+++ b/src/sagemaker/tuner.py
@@ -37,7 +37,7 @@ from sagemaker.parameter import (
 )
 from sagemaker.session import Session
 from sagemaker.session import s3_input
-from sagemaker.utils import base_name_from_image, name_from_base, to_str
+from sagemaker.utils import base_name_from_image, name_from_base
 
 AMAZON_ESTIMATOR_MODULE = "sagemaker"
 AMAZON_ESTIMATOR_CLS_NAMES = {
@@ -345,9 +345,7 @@ class HyperparameterTuner(object):
     ):
         """Prepare static hyperparameters for one estimator before tuning"""
         # Remove any hyperparameter that will be tuned
-        static_hyperparameters = {
-            to_str(k): to_str(v) for (k, v) in estimator.hyperparameters().items()
-        }
+        static_hyperparameters = {str(k): str(v) for (k, v) in estimator.hyperparameters().items()}
         for hyperparameter_name in hyperparameter_ranges.keys():
             static_hyperparameters.pop(hyperparameter_name, None)
 

--- a/src/sagemaker/utils.py
+++ b/src/sagemaker/utils.py
@@ -20,7 +20,6 @@ import os
 import random
 import re
 import shutil
-import sys
 import tarfile
 import tempfile
 import time
@@ -160,25 +159,6 @@ def get_short_version(framework_version):
         str: The short version string
     """
     return ".".join(framework_version.split(".")[:2])
-
-
-def to_str(value):
-    """Convert the input to a string, unless it is a unicode string in Python 2.
-
-    Unicode strings are supported as native strings in Python 3, but
-    ``str()`` cannot be invoked on unicode strings in Python 2, so we need to
-    check for that case when converting user-specified values to strings.
-
-    Args:
-        value: The value to convert to a string.
-
-    Returns:
-        str or unicode: The string representation of the value or the unicode
-        string itself.
-    """
-    if sys.version_info.major < 3 and isinstance(value, six.string_types):
-        return value
-    return str(value)
 
 
 def extract_name_from_job_arn(arn):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -92,16 +92,6 @@ def test_unique_name_from_base_truncated():
     )
 
 
-def test_to_str_with_native_string():
-    value = "some string"
-    assert sagemaker.utils.to_str(value) == value
-
-
-def test_to_str_with_unicode_string():
-    value = u"åñøthér strîng"
-    assert sagemaker.utils.to_str(value) == value
-
-
 def test_name_from_tuning_arn():
     arn = "arn:aws:sagemaker:us-west-2:968277160000:hyper-parameter-tuning-job/resnet-sgd-tuningjob-11-07-34-11"
     name = sagemaker.utils.extract_name_from_job_arn(arn)


### PR DESCRIPTION
*Issue #, if available:*
#1461

*Description of changes:*
This method was written for Python 2 compatibility. For Python 3+, it is the same as simply calling `str()`.

*Testing done:*
`tox tests/unit/ --parallel all`

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
