### PR TITLE
breaking: remove check for Python 2 string in sagemaker.predictor._is_sequence_like()

### DIFF
--- a/src/sagemaker/predictor.py
+++ b/src/sagemaker/predictor.py
@@ -395,10 +395,7 @@ def _is_sequence_like(obj):
     Args:
         obj:
     """
-    # Need to explicitly check on str since str lacks the iterable magic methods in Python 2
-    return (  # pylint: disable=consider-using-ternary
-        hasattr(obj, "__iter__") and hasattr(obj, "__getitem__")
-    ) or isinstance(obj, str)
+    return hasattr(obj, "__iter__") and hasattr(obj, "__getitem__")
 
 
 def _row_to_csv(obj):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This is a pretty boring change, but one that gets to be made because of #1460 

*Testing done:*
`tox -e py36,py37,py38,black-format,flake8,pylint tests/unit/ --parallel all`

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
