### PR TITLE
breaking: refactor name of RealTimePredictor to Predictor

### DIFF
--- a/doc/api/inference/predictors.rst
+++ b/doc/api/inference/predictors.rst
@@ -3,7 +3,7 @@ Predictors
 
 Make real-time predictions against SageMaker endpoints with Python objects
 
-.. autoclass:: sagemaker.predictor.RealTimePredictor
+.. autoclass:: sagemaker.predictor.Predictor
     :members:
     :undoc-members:
     :show-inheritance:

--- a/doc/frameworks/chainer/using_chainer.rst
+++ b/doc/frameworks/chainer/using_chainer.rst
@@ -325,7 +325,7 @@ You can provide your own implementations for these functions in your hosting scr
 If you omit any definition then the SageMaker Chainer model server will use its default implementation for that
 function.
 
-The ``RealTimePredictor`` used by Chainer in the SageMaker Python SDK serializes NumPy arrays to the `NPY <https://docs.scipy.org/doc/numpy/neps/npy-format.html>`_ format
+The ``Predictor`` used by Chainer in the SageMaker Python SDK serializes NumPy arrays to the `NPY <https://docs.scipy.org/doc/numpy/neps/npy-format.html>`_ format
 by default, with Content-Type ``application/x-npy``. The SageMaker Chainer model server can deserialize NPY-formatted
 data (along with JSON and CSV data).
 

--- a/doc/frameworks/pytorch/using_pytorch.rst
+++ b/doc/frameworks/pytorch/using_pytorch.rst
@@ -417,7 +417,7 @@ You can provide your own implementations for these functions in your hosting scr
 If you omit any definition then the SageMaker PyTorch model server will use its default implementation for that
 function.
 
-The ``RealTimePredictor`` used by PyTorch in the SageMaker Python SDK serializes NumPy arrays to the `NPY <https://docs.scipy.org/doc/numpy/neps/npy-format.html>`_ format
+The ``Predictor`` used by PyTorch in the SageMaker Python SDK serializes NumPy arrays to the `NPY <https://docs.scipy.org/doc/numpy/neps/npy-format.html>`_ format
 by default, with Content-Type ``application/x-npy``. The SageMaker PyTorch model server can deserialize NPY-formatted
 data (along with JSON and CSV data).
 

--- a/doc/frameworks/sklearn/using_sklearn.rst
+++ b/doc/frameworks/sklearn/using_sklearn.rst
@@ -299,7 +299,7 @@ You can provide your own implementations for these functions in your hosting scr
 If you omit any definition then the SageMaker Scikit-learn model server will use its default implementation for that
 function.
 
-The ``RealTimePredictor`` used by Scikit-learn in the SageMaker Python SDK serializes NumPy arrays to the `NPY <https://docs.scipy.org/doc/numpy/neps/npy-format.html>`_ format
+The ``Predictor`` used by Scikit-learn in the SageMaker Python SDK serializes NumPy arrays to the `NPY <https://docs.scipy.org/doc/numpy/neps/npy-format.html>`_ format
 by default, with Content-Type ``application/x-npy``. The SageMaker Scikit-learn model server can deserialize NPY-formatted
 data (along with JSON and CSV data).
 

--- a/doc/frameworks/tensorflow/upgrade_from_legacy.rst
+++ b/doc/frameworks/tensorflow/upgrade_from_legacy.rst
@@ -206,16 +206,16 @@ From a model:
 Predictors
 ----------
 
-If you want to use your model for endpoints, then you can use the :class:`sagemaker.predictor.RealTimePredictor` class instead of the legacy ``sagemaker.tensorflow.TensorFlowPredictor`` class:
+If you want to use your model for endpoints, then you can use the :class:`sagemaker.predictor.Predictor` class instead of the legacy ``sagemaker.tensorflow.TensorFlowPredictor`` class:
 
 .. code:: python
 
     from sagemaker.model import FrameworkModel
-    from sagemaker.predictor import RealTimePredictor
+    from sagemaker.predictor import Predictor
 
     model = FrameworkModel(
         ...
-        predictor_cls=RealTimePredictor,
+        predictor_cls=Predictor,
     )
 
     predictor = model.deploy(...)

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -1124,7 +1124,7 @@ How do I make predictions against an existing endpoint?
 Create a ``Predictor`` object and provide it with your endpoint name,
 then call its ``predict()`` method with your input.
 
-You can use either the generic ``RealTimePredictor`` class, which by default does not perform any serialization/deserialization transformations on your input,
+You can use either the generic ``Predictor`` class, which by default does not perform any serialization/deserialization transformations on your input,
 but can be configured to do so through constructor arguments:
 http://sagemaker.readthedocs.io/en/stable/predictors.html
 

--- a/src/sagemaker/__init__.py
+++ b/src/sagemaker/__init__.py
@@ -49,7 +49,7 @@ from sagemaker.local.local_session import LocalSession  # noqa: F401
 
 from sagemaker.model import Model, ModelPackage  # noqa: F401
 from sagemaker.pipeline import PipelineModel  # noqa: F401
-from sagemaker.predictor import RealTimePredictor  # noqa: F401
+from sagemaker.predictor import Predictor  # noqa: F401
 from sagemaker.processing import Processor, ScriptProcessor  # noqa: F401
 from sagemaker.session import Session  # noqa: F401
 from sagemaker.session import container_def, pipeline_container_def  # noqa: F401

--- a/src/sagemaker/algorithm.py
+++ b/src/sagemaker/algorithm.py
@@ -18,7 +18,7 @@ import sagemaker.parameter
 from sagemaker import vpc_utils
 from sagemaker.estimator import EstimatorBase
 from sagemaker.transformer import Transformer
-from sagemaker.predictor import RealTimePredictor
+from sagemaker.predictor import Predictor
 
 
 class AlgorithmEstimator(EstimatorBase):
@@ -246,7 +246,7 @@ class AlgorithmEstimator(EstimatorBase):
         """Create a model to deploy.
 
         The serializer, deserializer, content_type, and accept arguments are
-        only used to define a default RealTimePredictor. They are ignored if an
+        only used to define a default Predictor. They are ignored if an
         explicit predictor class is passed in. Other arguments are passed
         through to the Model class.
 
@@ -254,7 +254,7 @@ class AlgorithmEstimator(EstimatorBase):
             role (str): The ``ExecutionRoleArn`` IAM Role ARN for the ``Model``,
                 which is also used during transform jobs. If not specified, the
                 role from the Estimator will be used.
-            predictor_cls (RealTimePredictor): The predictor class to use when
+            predictor_cls (Predictor): The predictor class to use when
                 deploying the model.
             serializer (callable): Should accept a single argument, the input
                 data, and return a sequence of bytes. May provide a content_type
@@ -285,9 +285,7 @@ class AlgorithmEstimator(EstimatorBase):
         if predictor_cls is None:
 
             def predict_wrapper(endpoint, session):
-                return RealTimePredictor(
-                    endpoint, session, serializer, deserializer, content_type, accept
-                )
+                return Predictor(endpoint, session, serializer, deserializer, content_type, accept)
 
             predictor_cls = predict_wrapper
 

--- a/src/sagemaker/amazon/factorization_machines.py
+++ b/src/sagemaker/amazon/factorization_machines.py
@@ -17,7 +17,7 @@ from sagemaker.amazon.amazon_estimator import AmazonAlgorithmEstimatorBase, regi
 from sagemaker.amazon.common import numpy_to_record_serializer, record_deserializer
 from sagemaker.amazon.hyperparameter import Hyperparameter as hp  # noqa
 from sagemaker.amazon.validation import gt, isin, ge
-from sagemaker.predictor import RealTimePredictor
+from sagemaker.predictor import Predictor
 from sagemaker.model import Model
 from sagemaker.session import Session
 from sagemaker.vpc_utils import VPC_CONFIG_DEFAULT
@@ -261,13 +261,13 @@ class FactorizationMachines(AmazonAlgorithmEstimatorBase):
         )
 
 
-class FactorizationMachinesPredictor(RealTimePredictor):
+class FactorizationMachinesPredictor(Predictor):
     """Performs binary-classification or regression prediction from input
     vectors.
 
     The implementation of
-    :meth:`~sagemaker.predictor.RealTimePredictor.predict` in this
-    `RealTimePredictor` requires a numpy ``ndarray`` as input. The array should
+    :meth:`~sagemaker.predictor.Predictor.predict` in this
+    `Predictor` requires a numpy ``ndarray`` as input. The array should
     contain the same number of columns as the feature-dimension of the data used
     to fit the model this Predictor performs inference on.
 

--- a/src/sagemaker/amazon/ipinsights.py
+++ b/src/sagemaker/amazon/ipinsights.py
@@ -16,7 +16,7 @@ from __future__ import absolute_import
 from sagemaker.amazon.amazon_estimator import AmazonAlgorithmEstimatorBase, registry
 from sagemaker.amazon.hyperparameter import Hyperparameter as hp  # noqa
 from sagemaker.amazon.validation import ge, le
-from sagemaker.predictor import RealTimePredictor, csv_serializer, json_deserializer
+from sagemaker.predictor import Predictor, csv_serializer, json_deserializer
 from sagemaker.model import Model
 from sagemaker.session import Session
 from sagemaker.vpc_utils import VPC_CONFIG_DEFAULT
@@ -173,13 +173,13 @@ class IPInsights(AmazonAlgorithmEstimatorBase):
         )
 
 
-class IPInsightsPredictor(RealTimePredictor):
+class IPInsightsPredictor(Predictor):
     """Returns dot product of entity and IP address embeddings as a score for
     compatibility.
 
     The implementation of
-    :meth:`~sagemaker.predictor.RealTimePredictor.predict` in this
-    `RealTimePredictor` requires a numpy ``ndarray`` as input. The array should
+    :meth:`~sagemaker.predictor.Predictor.predict` in this
+    `Predictor` requires a numpy ``ndarray`` as input. The array should
     contain two columns. The first column should contain the entity ID. The
     second column should contain the IPv4 address in dot notation.
     """

--- a/src/sagemaker/amazon/kmeans.py
+++ b/src/sagemaker/amazon/kmeans.py
@@ -17,7 +17,7 @@ from sagemaker.amazon.amazon_estimator import AmazonAlgorithmEstimatorBase, regi
 from sagemaker.amazon.common import numpy_to_record_serializer, record_deserializer
 from sagemaker.amazon.hyperparameter import Hyperparameter as hp  # noqa
 from sagemaker.amazon.validation import gt, isin, ge, le
-from sagemaker.predictor import RealTimePredictor
+from sagemaker.predictor import Predictor
 from sagemaker.model import Model
 from sagemaker.session import Session
 from sagemaker.vpc_utils import VPC_CONFIG_DEFAULT
@@ -194,12 +194,12 @@ class KMeans(AmazonAlgorithmEstimatorBase):
         return hp_dict
 
 
-class KMeansPredictor(RealTimePredictor):
+class KMeansPredictor(Predictor):
     """Assigns input vectors to their closest cluster in a KMeans model.
 
     The implementation of
-    :meth:`~sagemaker.predictor.RealTimePredictor.predict` in this
-    `RealTimePredictor` requires a numpy ``ndarray`` as input. The array should
+    :meth:`~sagemaker.predictor.Predictor.predict` in this
+    `Predictor` requires a numpy ``ndarray`` as input. The array should
     contain the same number of columns as the feature-dimension of the data used
     to fit the model this Predictor performs inference on.
 

--- a/src/sagemaker/amazon/knn.py
+++ b/src/sagemaker/amazon/knn.py
@@ -17,7 +17,7 @@ from sagemaker.amazon.amazon_estimator import AmazonAlgorithmEstimatorBase, regi
 from sagemaker.amazon.common import numpy_to_record_serializer, record_deserializer
 from sagemaker.amazon.hyperparameter import Hyperparameter as hp  # noqa
 from sagemaker.amazon.validation import ge, isin
-from sagemaker.predictor import RealTimePredictor
+from sagemaker.predictor import Predictor
 from sagemaker.model import Model
 from sagemaker.session import Session
 from sagemaker.vpc_utils import VPC_CONFIG_DEFAULT
@@ -182,12 +182,12 @@ class KNN(AmazonAlgorithmEstimatorBase):
         )
 
 
-class KNNPredictor(RealTimePredictor):
+class KNNPredictor(Predictor):
     """Performs classification or regression prediction from input vectors.
 
     The implementation of
-    :meth:`~sagemaker.predictor.RealTimePredictor.predict` in this
-    `RealTimePredictor` requires a numpy ``ndarray`` as input. The array should
+    :meth:`~sagemaker.predictor.Predictor.predict` in this
+    `Predictor` requires a numpy ``ndarray`` as input. The array should
     contain the same number of columns as the feature-dimension of the data used
     to fit the model this Predictor performs inference on.
 

--- a/src/sagemaker/amazon/lda.py
+++ b/src/sagemaker/amazon/lda.py
@@ -17,7 +17,7 @@ from sagemaker.amazon.amazon_estimator import AmazonAlgorithmEstimatorBase, regi
 from sagemaker.amazon.common import numpy_to_record_serializer, record_deserializer
 from sagemaker.amazon.hyperparameter import Hyperparameter as hp  # noqa
 from sagemaker.amazon.validation import gt
-from sagemaker.predictor import RealTimePredictor
+from sagemaker.predictor import Predictor
 from sagemaker.model import Model
 from sagemaker.session import Session
 from sagemaker.vpc_utils import VPC_CONFIG_DEFAULT
@@ -166,12 +166,12 @@ class LDA(AmazonAlgorithmEstimatorBase):
         )
 
 
-class LDAPredictor(RealTimePredictor):
+class LDAPredictor(Predictor):
     """Transforms input vectors to lower-dimesional representations.
 
     The implementation of
-    :meth:`~sagemaker.predictor.RealTimePredictor.predict` in this
-    `RealTimePredictor` requires a numpy ``ndarray`` as input. The array should
+    :meth:`~sagemaker.predictor.Predictor.predict` in this
+    `Predictor` requires a numpy ``ndarray`` as input. The array should
     contain the same number of columns as the feature-dimension of the data used
     to fit the model this Predictor performs inference on.
 

--- a/src/sagemaker/amazon/linear_learner.py
+++ b/src/sagemaker/amazon/linear_learner.py
@@ -17,7 +17,7 @@ from sagemaker.amazon.amazon_estimator import AmazonAlgorithmEstimatorBase, regi
 from sagemaker.amazon.common import numpy_to_record_serializer, record_deserializer
 from sagemaker.amazon.hyperparameter import Hyperparameter as hp  # noqa
 from sagemaker.amazon.validation import isin, gt, lt, ge, le
-from sagemaker.predictor import RealTimePredictor
+from sagemaker.predictor import Predictor
 from sagemaker.model import Model
 from sagemaker.session import Session
 from sagemaker.vpc_utils import VPC_CONFIG_DEFAULT
@@ -426,13 +426,13 @@ class LinearLearner(AmazonAlgorithmEstimatorBase):
         )
 
 
-class LinearLearnerPredictor(RealTimePredictor):
+class LinearLearnerPredictor(Predictor):
     """Performs binary-classification or regression prediction from input
     vectors.
 
     The implementation of
-    :meth:`~sagemaker.predictor.RealTimePredictor.predict` in this
-    `RealTimePredictor` requires a numpy ``ndarray`` as input. The array should
+    :meth:`~sagemaker.predictor.Predictor.predict` in this
+    `Predictor` requires a numpy ``ndarray`` as input. The array should
     contain the same number of columns as the feature-dimension of the data used
     to fit the model this Predictor performs inference on.
 

--- a/src/sagemaker/amazon/ntm.py
+++ b/src/sagemaker/amazon/ntm.py
@@ -17,7 +17,7 @@ from sagemaker.amazon.amazon_estimator import AmazonAlgorithmEstimatorBase, regi
 from sagemaker.amazon.common import numpy_to_record_serializer, record_deserializer
 from sagemaker.amazon.hyperparameter import Hyperparameter as hp  # noqa
 from sagemaker.amazon.validation import ge, le, isin
-from sagemaker.predictor import RealTimePredictor
+from sagemaker.predictor import Predictor
 from sagemaker.model import Model
 from sagemaker.session import Session
 from sagemaker.vpc_utils import VPC_CONFIG_DEFAULT
@@ -196,12 +196,12 @@ class NTM(AmazonAlgorithmEstimatorBase):
         )
 
 
-class NTMPredictor(RealTimePredictor):
+class NTMPredictor(Predictor):
     """Transforms input vectors to lower-dimesional representations.
 
     The implementation of
-    :meth:`~sagemaker.predictor.RealTimePredictor.predict` in this
-    `RealTimePredictor` requires a numpy ``ndarray`` as input. The array should
+    :meth:`~sagemaker.predictor.Predictor.predict` in this
+    `Predictor` requires a numpy ``ndarray`` as input. The array should
     contain the same number of columns as the feature-dimension of the data used
     to fit the model this Predictor performs inference on.
 

--- a/src/sagemaker/amazon/object2vec.py
+++ b/src/sagemaker/amazon/object2vec.py
@@ -16,7 +16,7 @@ from __future__ import absolute_import
 from sagemaker.amazon.amazon_estimator import AmazonAlgorithmEstimatorBase, registry
 from sagemaker.amazon.hyperparameter import Hyperparameter as hp  # noqa
 from sagemaker.amazon.validation import ge, le, isin
-from sagemaker.predictor import RealTimePredictor
+from sagemaker.predictor import Predictor
 from sagemaker.model import Model
 from sagemaker.session import Session
 from sagemaker.vpc_utils import VPC_CONFIG_DEFAULT
@@ -184,7 +184,7 @@ class Object2Vec(AmazonAlgorithmEstimatorBase):
         may be deployed to an Amazon SageMaker Endpoint by invoking
         :meth:`~sagemaker.amazon.estimator.EstimatorBase.deploy`. As well as
         deploying an Endpoint, deploy returns a
-        :class:`~sagemaker.amazon.RealTimePredictor` object that can be used for
+        :class:`~sagemaker.amazon.Predictor` object that can be used for
         inference calls using the trained model hosted in the SageMaker
         Endpoint.
 
@@ -358,7 +358,7 @@ class Object2VecModel(Model):
             image,
             model_data,
             role,
-            predictor_cls=RealTimePredictor,
+            predictor_cls=Predictor,
             sagemaker_session=sagemaker_session,
             **kwargs
         )

--- a/src/sagemaker/amazon/pca.py
+++ b/src/sagemaker/amazon/pca.py
@@ -17,7 +17,7 @@ from sagemaker.amazon.amazon_estimator import AmazonAlgorithmEstimatorBase, regi
 from sagemaker.amazon.common import numpy_to_record_serializer, record_deserializer
 from sagemaker.amazon.hyperparameter import Hyperparameter as hp  # noqa
 from sagemaker.amazon.validation import gt, isin
-from sagemaker.predictor import RealTimePredictor
+from sagemaker.predictor import Predictor
 from sagemaker.model import Model
 from sagemaker.session import Session
 from sagemaker.vpc_utils import VPC_CONFIG_DEFAULT
@@ -178,12 +178,12 @@ class PCA(AmazonAlgorithmEstimatorBase):
         )
 
 
-class PCAPredictor(RealTimePredictor):
+class PCAPredictor(Predictor):
     """Transforms input vectors to lower-dimesional representations.
 
     The implementation of
-    :meth:`~sagemaker.predictor.RealTimePredictor.predict` in this
-    `RealTimePredictor` requires a numpy ``ndarray`` as input. The array should
+    :meth:`~sagemaker.predictor.Predictor.predict` in this
+    `Predictor` requires a numpy ``ndarray`` as input. The array should
     contain the same number of columns as the feature-dimension of the data used
     to fit the model this Predictor performs inference on.
 

--- a/src/sagemaker/amazon/randomcutforest.py
+++ b/src/sagemaker/amazon/randomcutforest.py
@@ -17,7 +17,7 @@ from sagemaker.amazon.amazon_estimator import AmazonAlgorithmEstimatorBase, regi
 from sagemaker.amazon.common import numpy_to_record_serializer, record_deserializer
 from sagemaker.amazon.hyperparameter import Hyperparameter as hp  # noqa
 from sagemaker.amazon.validation import ge, le
-from sagemaker.predictor import RealTimePredictor
+from sagemaker.predictor import Predictor
 from sagemaker.model import Model
 from sagemaker.session import Session
 from sagemaker.vpc_utils import VPC_CONFIG_DEFAULT
@@ -157,12 +157,12 @@ class RandomCutForest(AmazonAlgorithmEstimatorBase):
         )
 
 
-class RandomCutForestPredictor(RealTimePredictor):
+class RandomCutForestPredictor(Predictor):
     """Assigns an anomaly score to each of the datapoints provided.
 
     The implementation of
-    :meth:`~sagemaker.predictor.RealTimePredictor.predict` in this
-    `RealTimePredictor` requires a numpy ``ndarray`` as input. The array should
+    :meth:`~sagemaker.predictor.Predictor.predict` in this
+    `Predictor` requires a numpy ``ndarray`` as input. The array should
     contain the same number of columns as the feature-dimension of the data used
     to fit the model this Predictor performs inference on.
 

--- a/src/sagemaker/chainer/model.py
+++ b/src/sagemaker/chainer/model.py
@@ -24,13 +24,13 @@ from sagemaker.fw_utils import (
 )
 from sagemaker.model import FrameworkModel, MODEL_SERVER_WORKERS_PARAM_NAME
 from sagemaker.chainer import defaults
-from sagemaker.predictor import RealTimePredictor, npy_serializer, numpy_deserializer
+from sagemaker.predictor import Predictor, npy_serializer, numpy_deserializer
 
 logger = logging.getLogger("sagemaker")
 
 
-class ChainerPredictor(RealTimePredictor):
-    """A RealTimePredictor for inference against Chainer Endpoints.
+class ChainerPredictor(Predictor):
+    """A Predictor for inference against Chainer Endpoints.
 
     This is able to serialize Python lists, dictionaries, and numpy arrays to
     multidimensional tensors for Chainer inference.

--- a/src/sagemaker/estimator.py
+++ b/src/sagemaker/estimator.py
@@ -52,7 +52,7 @@ from sagemaker.model import (
     JOB_NAME_PARAM_NAME,
     SAGEMAKER_REGION_PARAM_NAME,
 )
-from sagemaker.predictor import RealTimePredictor
+from sagemaker.predictor import Predictor
 from sagemaker.session import Session
 from sagemaker.session import s3_input
 from sagemaker.transformer import Transformer
@@ -638,7 +638,7 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):
         **kwargs
     ):
         """Deploy the trained model to an Amazon SageMaker endpoint and return a
-        ``sagemaker.RealTimePredictor`` object.
+        ``sagemaker.Predictor`` object.
 
         More information:
         http://docs.aws.amazon.com/sagemaker/latest/dg/how-it-works-training.html
@@ -686,7 +686,7 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):
                 For more, see the implementation docs.
 
         Returns:
-            sagemaker.predictor.RealTimePredictor: A predictor that provides a ``predict()`` method,
+            sagemaker.predictor.Predictor: A predictor that provides a ``predict()`` method,
                 which can be used to send requests to the Amazon SageMaker
                 endpoint and obtain inferences.
         """
@@ -1346,7 +1346,7 @@ class Estimator(EstimatorBase):
         """Create a model to deploy.
 
         The serializer, deserializer, content_type, and accept arguments are only used to define a
-        default RealTimePredictor. They are ignored if an explicit predictor class is passed in.
+        default Predictor. They are ignored if an explicit predictor class is passed in.
         Other arguments are passed through to the Model class.
 
         Args:
@@ -1355,7 +1355,7 @@ class Estimator(EstimatorBase):
                 role from the Estimator will be used.
             image (str): An container image to use for deploying the model.
                 Defaults to the image used for training.
-            predictor_cls (RealTimePredictor): The predictor class to use when
+            predictor_cls (Predictor): The predictor class to use when
                 deploying the model.
             serializer (callable): Should accept a single argument, the input
                 data, and return a sequence of bytes. May provide a content_type
@@ -1386,9 +1386,7 @@ class Estimator(EstimatorBase):
         if predictor_cls is None:
 
             def predict_wrapper(endpoint, session):
-                return RealTimePredictor(
-                    endpoint, session, serializer, deserializer, content_type, accept
-                )
+                return Predictor(endpoint, session, serializer, deserializer, content_type, accept)
 
             predictor_cls = predict_wrapper
 

--- a/src/sagemaker/mxnet/model.py
+++ b/src/sagemaker/mxnet/model.py
@@ -26,13 +26,13 @@ from sagemaker.fw_utils import (
 )
 from sagemaker.model import FrameworkModel, MODEL_SERVER_WORKERS_PARAM_NAME
 from sagemaker.mxnet import defaults
-from sagemaker.predictor import RealTimePredictor, json_serializer, json_deserializer
+from sagemaker.predictor import Predictor, json_serializer, json_deserializer
 
 logger = logging.getLogger("sagemaker")
 
 
-class MXNetPredictor(RealTimePredictor):
-    """A RealTimePredictor for inference against MXNet Endpoints.
+class MXNetPredictor(Predictor):
+    """A Predictor for inference against MXNet Endpoints.
 
     This is able to serialize Python lists, dictionaries, and numpy arrays to
     multidimensional tensors for MXNet inference.

--- a/src/sagemaker/predictor.py
+++ b/src/sagemaker/predictor.py
@@ -32,7 +32,7 @@ from sagemaker.model_monitor.model_monitoring import (
 )
 
 
-class RealTimePredictor(object):
+class Predictor(object):
     """Make prediction requests to an Amazon SageMaker endpoint."""
 
     def __init__(
@@ -44,7 +44,7 @@ class RealTimePredictor(object):
         content_type=None,
         accept=None,
     ):
-        """Initialize a ``RealTimePredictor``.
+        """Initialize a ``Predictor``.
 
         Behavior for serialization of input data and deserialization of
         result data can be configured through initializer arguments. If not
@@ -89,7 +89,7 @@ class RealTimePredictor(object):
         Args:
             data (object): Input data for which you want the model to provide
                 inference. If a serializer was specified when creating the
-                RealTimePredictor, the result of the serializer is sent as input
+                Predictor, the result of the serializer is sent as input
                 data. Otherwise the data must be sequence of bytes, and the
                 predict method then sends the bytes in the request body as is.
             initial_args (dict[str,str]): Optional. Default arguments for boto3
@@ -104,7 +104,7 @@ class RealTimePredictor(object):
 
         Returns:
             object: Inference for the given input. If a deserializer was specified when creating
-                the RealTimePredictor, the result of the deserializer is
+                the Predictor, the result of the deserializer is
                 returned. Otherwise the response returns the sequence of bytes
                 as is.
         """

--- a/src/sagemaker/pytorch/model.py
+++ b/src/sagemaker/pytorch/model.py
@@ -25,13 +25,13 @@ from sagemaker.fw_utils import (
 )
 from sagemaker.model import FrameworkModel, MODEL_SERVER_WORKERS_PARAM_NAME
 from sagemaker.pytorch import defaults
-from sagemaker.predictor import RealTimePredictor, npy_serializer, numpy_deserializer
+from sagemaker.predictor import Predictor, npy_serializer, numpy_deserializer
 
 logger = logging.getLogger("sagemaker")
 
 
-class PyTorchPredictor(RealTimePredictor):
-    """A RealTimePredictor for inference against PyTorch Endpoints.
+class PyTorchPredictor(Predictor):
+    """A Predictor for inference against PyTorch Endpoints.
 
     This is able to serialize Python lists, dictionaries, and numpy arrays to
     multidimensional tensors for PyTorch inference.

--- a/src/sagemaker/sklearn/model.py
+++ b/src/sagemaker/sklearn/model.py
@@ -19,14 +19,14 @@ import sagemaker
 from sagemaker.fw_registry import default_framework_uri
 from sagemaker.fw_utils import model_code_key_prefix, validate_version_or_image_args
 from sagemaker.model import FrameworkModel, MODEL_SERVER_WORKERS_PARAM_NAME
-from sagemaker.predictor import RealTimePredictor, npy_serializer, numpy_deserializer
+from sagemaker.predictor import Predictor, npy_serializer, numpy_deserializer
 from sagemaker.sklearn import defaults
 
 logger = logging.getLogger("sagemaker")
 
 
-class SKLearnPredictor(RealTimePredictor):
-    """A RealTimePredictor for inference against Scikit-learn Endpoints.
+class SKLearnPredictor(Predictor):
+    """A Predictor for inference against Scikit-learn Endpoints.
 
     This is able to serialize Python lists, dictionaries, and numpy arrays to
     multidimensional tensors for Scikit-learn inference.

--- a/src/sagemaker/sparkml/model.py
+++ b/src/sagemaker/sparkml/model.py
@@ -13,7 +13,7 @@
 """Placeholder docstring"""
 from __future__ import absolute_import
 
-from sagemaker import Model, RealTimePredictor, Session
+from sagemaker import Model, Predictor, Session
 from sagemaker.content_types import CONTENT_TYPE_CSV
 from sagemaker.fw_registry import registry
 from sagemaker.predictor import csv_serializer
@@ -22,12 +22,12 @@ framework_name = "sparkml-serving"
 repo_name = "sagemaker-sparkml-serving"
 
 
-class SparkMLPredictor(RealTimePredictor):
+class SparkMLPredictor(Predictor):
     """Performs predictions against an MLeap serialized SparkML model.
 
     The implementation of
-    :meth:`~sagemaker.predictor.RealTimePredictor.predict` in this
-    `RealTimePredictor` requires a json as input. The input should follow the
+    :meth:`~sagemaker.predictor.Predictor.predict` in this
+    `Predictor` requires a json as input. The input should follow the
     json format as documented.
 
     ``predict()`` returns a csv output, comma separated if the output is a

--- a/src/sagemaker/tensorflow/model.py
+++ b/src/sagemaker/tensorflow/model.py
@@ -18,11 +18,11 @@ import logging
 import sagemaker
 from sagemaker.content_types import CONTENT_TYPE_JSON
 from sagemaker.fw_utils import create_image_uri
-from sagemaker.predictor import json_serializer, json_deserializer
+from sagemaker.predictor import json_serializer, json_deserializer, Predictor
 
 
-class TensorFlowPredictor(sagemaker.RealTimePredictor):
-    """A ``RealTimePredictor`` implementation for inference against TensorFlow
+class TensorFlowPredictor(Predictor):
+    """A ``Predictor`` implementation for inference against TensorFlow
     Serving endpoints.
     """
 
@@ -36,7 +36,7 @@ class TensorFlowPredictor(sagemaker.RealTimePredictor):
         model_name=None,
         model_version=None,
     ):
-        """Initialize a ``TensorFlowPredictor``. See :class:`~sagemaker.predictor.RealTimePredictor`
+        """Initialize a ``TensorFlowPredictor``. See :class:`~sagemaker.predictor.Predictor`
         for more info about parameters.
 
         Args:

--- a/src/sagemaker/tuner.py
+++ b/src/sagemaker/tuner.py
@@ -690,7 +690,7 @@ class HyperparameterTuner(object):
         **kwargs
     ):
         """Deploy the best trained or user specified model to an Amazon
-        SageMaker endpoint and return a ``sagemaker.RealTimePredictor`` object.
+        SageMaker endpoint and return a ``sagemaker.Predictor`` object.
 
         For more information:
         http://docs.aws.amazon.com/sagemaker/latest/dg/how-it-works-training.html
@@ -724,7 +724,7 @@ class HyperparameterTuner(object):
                 what other arguments are needed.
 
         Returns:
-            sagemaker.predictor.RealTimePredictor: A predictor that provides a ``predict()``
+            sagemaker.predictor.Predictor: A predictor that provides a ``predict()``
                 method, which can be used to send requests to the Amazon SageMaker endpoint
                 and obtain inferences.
         """
@@ -755,7 +755,7 @@ class HyperparameterTuner(object):
 
     def best_estimator(self, best_training_job=None):
         """Return the estimator that has best training job attached. The trained model can then
-        be deployed to an Amazon SageMaker endpoint and return a ``sagemaker.RealTimePredictor``
+        be deployed to an Amazon SageMaker endpoint and return a ``sagemaker.Predictor``
         object.
 
         Args:

--- a/src/sagemaker/xgboost/model.py
+++ b/src/sagemaker/xgboost/model.py
@@ -19,14 +19,14 @@ import sagemaker
 from sagemaker.fw_utils import model_code_key_prefix
 from sagemaker.fw_registry import default_framework_uri
 from sagemaker.model import FrameworkModel, MODEL_SERVER_WORKERS_PARAM_NAME
-from sagemaker.predictor import RealTimePredictor, npy_serializer, csv_deserializer
+from sagemaker.predictor import Predictor, npy_serializer, csv_deserializer
 from sagemaker.xgboost.defaults import XGBOOST_NAME
 
 logger = logging.getLogger("sagemaker")
 
 
-class XGBoostPredictor(RealTimePredictor):
-    """A RealTimePredictor for inference against XGBoost Endpoints.
+class XGBoostPredictor(Predictor):
+    """A Predictor for inference against XGBoost Endpoints.
 
     This is able to serialize Python lists, dictionaries, and numpy arrays to xgb.DMatrix
      for XGBoost inference."""

--- a/tests/integ/test_inference_pipeline.py
+++ b/tests/integ/test_inference_pipeline.py
@@ -26,7 +26,7 @@ from sagemaker.amazon.amazon_estimator import get_image_uri
 from sagemaker.content_types import CONTENT_TYPE_CSV
 from sagemaker.model import Model
 from sagemaker.pipeline import PipelineModel
-from sagemaker.predictor import RealTimePredictor, json_serializer
+from sagemaker.predictor import Predictor, json_serializer
 from sagemaker.sparkml.model import SparkMLModel
 from sagemaker.utils import sagemaker_timestamp
 from tests.integ.retry import retries
@@ -129,7 +129,7 @@ def test_inference_pipeline_model_deploy(sagemaker_session, cpu_instance_type):
             name=endpoint_name,
         )
         model.deploy(1, cpu_instance_type, endpoint_name=endpoint_name)
-        predictor = RealTimePredictor(
+        predictor = Predictor(
             endpoint=endpoint_name,
             sagemaker_session=sagemaker_session,
             serializer=json_serializer,

--- a/tests/integ/test_ipinsights.py
+++ b/tests/integ/test_ipinsights.py
@@ -15,7 +15,7 @@ from __future__ import absolute_import
 import os
 
 from sagemaker import IPInsights, IPInsightsModel
-from sagemaker.predictor import RealTimePredictor
+from sagemaker.predictor import Predictor
 from sagemaker.utils import unique_name_from_base
 from tests.integ import DATA_DIR, TRAINING_DEFAULT_TIMEOUT_MINUTES
 from tests.integ.record_set import prepare_record_set_from_local_files
@@ -53,7 +53,7 @@ def test_ipinsights(sagemaker_session, cpu_instance_type):
             ipinsights.model_data, role="SageMakerRole", sagemaker_session=sagemaker_session
         )
         predictor = model.deploy(1, cpu_instance_type, endpoint_name=job_name)
-        assert isinstance(predictor, RealTimePredictor)
+        assert isinstance(predictor, Predictor)
 
         predict_input = [["user_1", "1.1.1.1"]]
         result = predictor.predict(predict_input)

--- a/tests/integ/test_marketplace.py
+++ b/tests/integ/test_marketplace.py
@@ -165,9 +165,7 @@ def test_marketplace_model(sagemaker_session, cpu_instance_type):
     )
 
     def predict_wrapper(endpoint, session):
-        return sagemaker.RealTimePredictor(
-            endpoint, session, serializer=sagemaker.predictor.csv_serializer
-        )
+        return sagemaker.Predictor(endpoint, session, serializer=sagemaker.predictor.csv_serializer)
 
     model = ModelPackage(
         role="SageMakerRole",

--- a/tests/integ/test_multi_variant_endpoint.py
+++ b/tests/integ/test_multi_variant_endpoint.py
@@ -25,7 +25,7 @@ from sagemaker.utils import sagemaker_timestamp
 from sagemaker.content_types import CONTENT_TYPE_CSV
 from sagemaker.utils import unique_name_from_base
 from sagemaker.amazon.amazon_estimator import get_image_uri
-from sagemaker.predictor import csv_serializer, RealTimePredictor
+from sagemaker.predictor import csv_serializer, Predictor
 
 
 import tests.integ
@@ -166,7 +166,7 @@ def test_target_variant_invocation(sagemaker_session, multi_variant_endpoint):
 
 
 def test_predict_invocation_with_target_variant(sagemaker_session, multi_variant_endpoint):
-    predictor = RealTimePredictor(
+    predictor = Predictor(
         endpoint=multi_variant_endpoint.endpoint_name,
         sagemaker_session=sagemaker_session,
         serializer=csv_serializer,
@@ -294,7 +294,7 @@ def test_predict_invocation_with_target_variant_local_mode(
     if sagemaker_session._region_name is None:
         sagemaker_session._region_name = DEFAULT_REGION
 
-    predictor = RealTimePredictor(
+    predictor = Predictor(
         endpoint=multi_variant_endpoint.endpoint_name,
         sagemaker_session=sagemaker_session,
         serializer=csv_serializer,

--- a/tests/integ/test_multidatamodel.py
+++ b/tests/integ/test_multidatamodel.py
@@ -26,7 +26,7 @@ from sagemaker import utils
 from sagemaker.amazon.randomcutforest import RandomCutForest
 from sagemaker.multidatamodel import MultiDataModel
 from sagemaker.mxnet import MXNet
-from sagemaker.predictor import RealTimePredictor, StringDeserializer, npy_serializer
+from sagemaker.predictor import Predictor, StringDeserializer, npy_serializer
 from sagemaker.utils import sagemaker_timestamp, unique_name_from_base, get_ecr_image_uri_prefix
 from tests.integ import DATA_DIR, TRAINING_DEFAULT_TIMEOUT_MINUTES
 from tests.integ.retry import retries
@@ -154,7 +154,7 @@ def test_multi_data_model_deploy_pretrained_models(
         assert PRETRAINED_MODEL_PATH_1 in endpoint_models
         assert PRETRAINED_MODEL_PATH_2 in endpoint_models
 
-        predictor = RealTimePredictor(
+        predictor = Predictor(
             endpoint=endpoint_name,
             sagemaker_session=sagemaker_session,
             serializer=npy_serializer,
@@ -212,7 +212,7 @@ def test_multi_data_model_deploy_pretrained_models_local_mode(container_image, s
         assert PRETRAINED_MODEL_PATH_1 in endpoint_models
         assert PRETRAINED_MODEL_PATH_2 in endpoint_models
 
-        predictor = RealTimePredictor(
+        predictor = Predictor(
             endpoint=endpoint_name,
             sagemaker_session=multi_data_model.sagemaker_session,
             serializer=npy_serializer,
@@ -291,7 +291,7 @@ def test_multi_data_model_deploy_trained_model_from_framework_estimator(
         # Define a predictor to set `serializer` parameter with npy_serializer
         # instead of `json_serializer` in the default predictor returned by `MXNetPredictor`
         # Since we are using a placeholder container image the prediction results are not accurate.
-        predictor = RealTimePredictor(
+        predictor = Predictor(
             endpoint=endpoint_name,
             sagemaker_session=sagemaker_session,
             serializer=npy_serializer,
@@ -392,7 +392,7 @@ def test_multi_data_model_deploy_train_model_from_amazon_first_party_estimator(
         # Define a predictor to set `serializer` parameter with npy_serializer
         # instead of `json_serializer` in the default predictor returned by `MXNetPredictor`
         # Since we are using a placeholder container image the prediction results are not accurate.
-        predictor = RealTimePredictor(
+        predictor = Predictor(
             endpoint=endpoint_name,
             sagemaker_session=sagemaker_session,
             serializer=npy_serializer,
@@ -482,7 +482,7 @@ def test_multi_data_model_deploy_pretrained_models_update_endpoint(
         assert PRETRAINED_MODEL_PATH_1 in endpoint_models
         assert PRETRAINED_MODEL_PATH_2 in endpoint_models
 
-        predictor = RealTimePredictor(
+        predictor = Predictor(
             endpoint=endpoint_name,
             sagemaker_session=sagemaker_session,
             serializer=npy_serializer,

--- a/tests/integ/test_object2vec.py
+++ b/tests/integ/test_object2vec.py
@@ -16,7 +16,7 @@ import os
 
 import pytest
 
-from sagemaker.predictor import RealTimePredictor
+from sagemaker.predictor import Predictor
 from sagemaker import Object2Vec, Object2VecModel
 from sagemaker.utils import unique_name_from_base
 from tests.integ import DATA_DIR, TRAINING_DEFAULT_TIMEOUT_MINUTES
@@ -67,7 +67,7 @@ def test_object2vec(sagemaker_session, cpu_instance_type):
             object2vec.model_data, role="SageMakerRole", sagemaker_session=sagemaker_session
         )
         predictor = model.deploy(1, cpu_instance_type, endpoint_name=job_name)
-        assert isinstance(predictor, RealTimePredictor)
+        assert isinstance(predictor, Predictor)
 
         predict_input = {"instances": [{"in0": [354, 623], "in1": [16]}]}
 

--- a/tests/integ/test_tfs.py
+++ b/tests/integ/test_tfs.py
@@ -184,7 +184,7 @@ def test_predict_jsons_json_content_type(tfs_predictor):
     input_data = "[1.0, 2.0, 5.0]\n[1.0, 2.0, 5.0]"
     expected_result = {"predictions": [[3.5, 4.0, 5.5], [3.5, 4.0, 5.5]]}
 
-    predictor = sagemaker.RealTimePredictor(
+    predictor = sagemaker.Predictor(
         tfs_predictor.endpoint,
         tfs_predictor.sagemaker_session,
         serializer=None,
@@ -201,7 +201,7 @@ def test_predict_jsons(tfs_predictor):
     input_data = "[1.0, 2.0, 5.0]\n[1.0, 2.0, 5.0]"
     expected_result = {"predictions": [[3.5, 4.0, 5.5], [3.5, 4.0, 5.5]]}
 
-    predictor = sagemaker.RealTimePredictor(
+    predictor = sagemaker.Predictor(
         tfs_predictor.endpoint,
         tfs_predictor.sagemaker_session,
         serializer=None,
@@ -218,7 +218,7 @@ def test_predict_jsonlines(tfs_predictor):
     input_data = "[1.0, 2.0, 5.0]\n[1.0, 2.0, 5.0]"
     expected_result = {"predictions": [[3.5, 4.0, 5.5], [3.5, 4.0, 5.5]]}
 
-    predictor = sagemaker.RealTimePredictor(
+    predictor = sagemaker.Predictor(
         tfs_predictor.endpoint,
         tfs_predictor.sagemaker_session,
         serializer=None,

--- a/tests/integ/timeout.py
+++ b/tests/integ/timeout.py
@@ -20,7 +20,7 @@ from awslogs.core import AWSLogs
 from botocore.exceptions import ClientError
 import stopit
 
-from sagemaker import RealTimePredictor
+from sagemaker import Predictor
 from tests.integ.retry import retries
 
 LOGGER = logging.getLogger("timeout")
@@ -129,7 +129,7 @@ def _delete_schedules_associated_with_endpoint(sagemaker_session, endpoint_name)
         endpoint_name (str): The name of the endpoint to delete schedules from.
 
     """
-    predictor = RealTimePredictor(endpoint=endpoint_name, sagemaker_session=sagemaker_session)
+    predictor = Predictor(endpoint=endpoint_name, sagemaker_session=sagemaker_session)
     monitors = predictor.list_monitors()
     for monitor in monitors:
         try:

--- a/tests/unit/sagemaker/automl/test_auto_ml.py
+++ b/tests/unit/sagemaker/automl/test_auto_ml.py
@@ -17,7 +17,7 @@ import copy
 import pytest
 from mock import Mock, patch
 from sagemaker import AutoML, AutoMLJob, AutoMLInput, CandidateEstimator, PipelineModel
-from sagemaker.predictor import RealTimePredictor
+from sagemaker.predictor import Predictor
 
 MODEL_DATA = "s3://bucket/model.tar.gz"
 MODEL_IMAGE = "mi"
@@ -556,7 +556,7 @@ def test_deploy_optional_args(candidate_estimator, sagemaker_session, candidate_
         vpc_config=VPC_CONFIG,
         enable_network_isolation=True,
         model_kms_key=OUTPUT_KMS_KEY,
-        predictor_cls=RealTimePredictor,
+        predictor_cls=Predictor,
         inference_response_keys=None,
     )
 
@@ -569,7 +569,7 @@ def test_deploy_optional_args(candidate_estimator, sagemaker_session, candidate_
         vpc_config=VPC_CONFIG,
         enable_network_isolation=True,
         model_kms_key=OUTPUT_KMS_KEY,
-        predictor_cls=RealTimePredictor,
+        predictor_cls=Predictor,
     )
 
     mock_pipeline.deploy.assert_called_once()

--- a/tests/unit/sagemaker/model/test_deploy.py
+++ b/tests/unit/sagemaker/model/test_deploy.py
@@ -243,8 +243,8 @@ def test_deploy_no_role(sagemaker_session):
 
 
 @patch("sagemaker.model.Model._create_sagemaker_model", Mock())
-@patch("sagemaker.predictor.RealTimePredictor._get_endpoint_config_name", Mock())
-@patch("sagemaker.predictor.RealTimePredictor._get_model_names", Mock())
+@patch("sagemaker.predictor.Predictor._get_endpoint_config_name", Mock())
+@patch("sagemaker.predictor.Predictor._get_model_names", Mock())
 @patch("sagemaker.production_variant", return_value=BASE_PRODUCTION_VARIANT)
 def test_deploy_predictor_cls(production_variant, sagemaker_session):
     model = Model(
@@ -252,7 +252,7 @@ def test_deploy_predictor_cls(production_variant, sagemaker_session):
         MODEL_DATA,
         role=ROLE,
         name=MODEL_NAME,
-        predictor_cls=sagemaker.predictor.RealTimePredictor,
+        predictor_cls=sagemaker.predictor.Predictor,
         sagemaker_session=sagemaker_session,
     )
 
@@ -263,7 +263,7 @@ def test_deploy_predictor_cls(production_variant, sagemaker_session):
         endpoint_name=endpoint_name,
     )
 
-    assert isinstance(predictor, sagemaker.predictor.RealTimePredictor)
+    assert isinstance(predictor, sagemaker.predictor.Predictor)
     assert predictor.endpoint == endpoint_name
     assert predictor.sagemaker_session == sagemaker_session
 

--- a/tests/unit/sagemaker/model/test_framework_model.py
+++ b/tests/unit/sagemaker/model/test_framework_model.py
@@ -16,7 +16,7 @@ import os
 import subprocess
 
 from sagemaker.model import FrameworkModel
-from sagemaker.predictor import RealTimePredictor
+from sagemaker.predictor import Predictor
 
 import pytest
 from mock import MagicMock, Mock, patch
@@ -60,7 +60,7 @@ class DummyFrameworkModel(FrameworkModel):
         )
 
     def create_predictor(self, endpoint_name):
-        return RealTimePredictor(endpoint_name, sagemaker_session=self.sagemaker_session)
+        return Predictor(endpoint_name, sagemaker_session=self.sagemaker_session)
 
 
 class DummyFrameworkModelForGit(FrameworkModel):
@@ -75,7 +75,7 @@ class DummyFrameworkModelForGit(FrameworkModel):
         )
 
     def create_predictor(self, endpoint_name):
-        return RealTimePredictor(endpoint_name, sagemaker_session=self.sagemaker_session)
+        return Predictor(endpoint_name, sagemaker_session=self.sagemaker_session)
 
 
 @pytest.fixture()

--- a/tests/unit/test_estimator.py
+++ b/tests/unit/test_estimator.py
@@ -26,7 +26,7 @@ from sagemaker.amazon.amazon_estimator import registry
 from sagemaker.algorithm import AlgorithmEstimator
 from sagemaker.estimator import Estimator, EstimatorBase, Framework, _TrainingJob
 from sagemaker.model import FrameworkModel
-from sagemaker.predictor import RealTimePredictor
+from sagemaker.predictor import Predictor
 from sagemaker.session import s3_input, ShuffleConfig
 from sagemaker.transformer import Transformer
 from botocore.exceptions import ClientError
@@ -2043,7 +2043,7 @@ def test_generic_to_deploy(sagemaker_session):
     assert args[2]["ModelDataUrl"] == MODEL_DATA
     assert kwargs["vpc_config"] is None
 
-    assert isinstance(predictor, RealTimePredictor)
+    assert isinstance(predictor, Predictor)
     assert predictor.endpoint.startswith(IMAGE_NAME)
     assert predictor.sagemaker_session == sagemaker_session
 

--- a/tests/unit/test_object2vec.py
+++ b/tests/unit/test_object2vec.py
@@ -16,7 +16,7 @@ import pytest
 from mock import Mock, patch
 
 from sagemaker.amazon.object2vec import Object2Vec
-from sagemaker.predictor import RealTimePredictor
+from sagemaker.predictor import Predictor
 from sagemaker.amazon.amazon_estimator import registry, RecordSet
 
 ROLE = "myrole"
@@ -323,4 +323,4 @@ def test_predictor_type(sagemaker_session):
     model = object2vec.create_model()
     predictor = model.deploy(1, TRAIN_INSTANCE_TYPE)
 
-    assert isinstance(predictor, RealTimePredictor)
+    assert isinstance(predictor, Predictor)

--- a/tests/unit/test_pipeline_model.py
+++ b/tests/unit/test_pipeline_model.py
@@ -17,7 +17,7 @@ from mock import Mock, patch
 
 from sagemaker.model import FrameworkModel
 from sagemaker.pipeline import PipelineModel
-from sagemaker.predictor import RealTimePredictor
+from sagemaker.predictor import Predictor
 from sagemaker.session import ModelContainer
 from sagemaker.sparkml import SparkMLModel
 
@@ -54,7 +54,7 @@ class DummyFrameworkModel(FrameworkModel):
         )
 
     def create_predictor(self, endpoint_name):
-        return RealTimePredictor(endpoint_name, self.sagemaker_session)
+        return Predictor(endpoint_name, self.sagemaker_session)
 
 
 @pytest.fixture()

--- a/tests/unit/test_predictor.py
+++ b/tests/unit/test_predictor.py
@@ -20,7 +20,7 @@ from mock import Mock, call
 
 import numpy as np
 
-from sagemaker.predictor import RealTimePredictor
+from sagemaker.predictor import Predictor
 from sagemaker.predictor import (
     json_serializer,
     json_deserializer,
@@ -371,7 +371,7 @@ def empty_sagemaker_session():
 
 def test_predict_call_pass_through():
     sagemaker_session = empty_sagemaker_session()
-    predictor = RealTimePredictor(ENDPOINT, sagemaker_session)
+    predictor = Predictor(ENDPOINT, sagemaker_session)
 
     data = "untouched"
     result = predictor.predict(data)
@@ -387,7 +387,7 @@ def test_predict_call_pass_through():
 
 def test_predict_call_with_headers():
     sagemaker_session = empty_sagemaker_session()
-    predictor = RealTimePredictor(
+    predictor = Predictor(
         ENDPOINT, sagemaker_session, content_type=DEFAULT_CONTENT_TYPE, accept=DEFAULT_CONTENT_TYPE
     )
 
@@ -410,7 +410,7 @@ def test_predict_call_with_headers():
 
 def test_predict_call_with_target_variant():
     sagemaker_session = empty_sagemaker_session()
-    predictor = RealTimePredictor(
+    predictor = Predictor(
         ENDPOINT, sagemaker_session, content_type=DEFAULT_CONTENT_TYPE, accept=DEFAULT_CONTENT_TYPE
     )
 
@@ -435,7 +435,7 @@ def test_predict_call_with_target_variant():
 
 def test_multi_model_predict_call_with_headers():
     sagemaker_session = empty_sagemaker_session()
-    predictor = RealTimePredictor(
+    predictor = Predictor(
         ENDPOINT, sagemaker_session, content_type=DEFAULT_CONTENT_TYPE, accept=DEFAULT_CONTENT_TYPE
     )
 
@@ -479,7 +479,7 @@ def json_sagemaker_session():
 
 def test_predict_call_with_headers_and_json():
     sagemaker_session = json_sagemaker_session()
-    predictor = RealTimePredictor(
+    predictor = Predictor(
         ENDPOINT,
         sagemaker_session,
         content_type="not/json",
@@ -526,7 +526,7 @@ def ret_csv_sagemaker_session():
 
 def test_predict_call_with_headers_and_csv():
     sagemaker_session = ret_csv_sagemaker_session()
-    predictor = RealTimePredictor(
+    predictor = Predictor(
         ENDPOINT, sagemaker_session, accept=CSV_CONTENT_TYPE, serializer=csv_serializer
     )
 
@@ -552,7 +552,7 @@ def test_delete_endpoint_with_config():
     sagemaker_session.sagemaker_client.describe_endpoint = Mock(
         return_value={"EndpointConfigName": "endpoint-config"}
     )
-    predictor = RealTimePredictor(ENDPOINT, sagemaker_session=sagemaker_session)
+    predictor = Predictor(ENDPOINT, sagemaker_session=sagemaker_session)
     predictor.delete_endpoint()
 
     sagemaker_session.delete_endpoint.assert_called_with(ENDPOINT)
@@ -561,7 +561,7 @@ def test_delete_endpoint_with_config():
 
 def test_delete_endpoint_only():
     sagemaker_session = empty_sagemaker_session()
-    predictor = RealTimePredictor(ENDPOINT, sagemaker_session=sagemaker_session)
+    predictor = Predictor(ENDPOINT, sagemaker_session=sagemaker_session)
     predictor.delete_endpoint(delete_endpoint_config=False)
 
     sagemaker_session.delete_endpoint.assert_called_with(ENDPOINT)
@@ -570,7 +570,7 @@ def test_delete_endpoint_only():
 
 def test_delete_model():
     sagemaker_session = empty_sagemaker_session()
-    predictor = RealTimePredictor(ENDPOINT, sagemaker_session=sagemaker_session)
+    predictor = Predictor(ENDPOINT, sagemaker_session=sagemaker_session)
 
     predictor.delete_model()
 
@@ -587,7 +587,7 @@ def test_delete_model_fail():
     )
     expected_error_message = "One or more models cannot be deleted, please retry."
 
-    predictor = RealTimePredictor(ENDPOINT, sagemaker_session=sagemaker_session)
+    predictor = Predictor(ENDPOINT, sagemaker_session=sagemaker_session)
 
     with pytest.raises(Exception) as exception:
         predictor.delete_model()

--- a/tests/unit/test_tuner.py
+++ b/tests/unit/test_tuner.py
@@ -19,7 +19,7 @@ import re
 import pytest
 from mock import Mock, patch
 
-from sagemaker import RealTimePredictor
+from sagemaker import Predictor
 from sagemaker.amazon.amazon_estimator import RecordSet
 from sagemaker.estimator import Framework
 from sagemaker.mxnet import MXNet
@@ -806,7 +806,7 @@ def test_deploy_default(tuner):
     assert args[2]["Image"] == IMAGE_NAME
     assert args[2]["ModelDataUrl"] == MODEL_DATA
 
-    assert isinstance(predictor, RealTimePredictor)
+    assert isinstance(predictor, Predictor)
     assert predictor.endpoint.startswith(JOB_NAME)
     assert predictor.sagemaker_session == tuner.sagemaker_session
 
@@ -845,7 +845,7 @@ def test_deploy_estimator_dict(tuner):
     assert args[2]["Image"] == IMAGE_NAME
     assert args[2]["ModelDataUrl"] == MODEL_DATA
 
-    assert isinstance(predictor, RealTimePredictor)
+    assert isinstance(predictor, Predictor)
     assert predictor.endpoint.startswith(JOB_NAME)
     assert predictor.sagemaker_session == tuner.sagemaker_session
 


### PR DESCRIPTION
*Issue #, if available:* #1473 

*Description of changes:*

changes include:

* rename `RealTimePredictor` as `Predictor` and refactor derived classes
* update tests and docs

*Testing done:*

unit, integ

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
