### PR TITLE
infra: use fixture for Python version in scikit-learn tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,7 +57,6 @@ def pytest_addoption(parser):
     parser.addoption(
         "--rl-ray-full-version", action="store", default=RLEstimator.RAY_LATEST_VERSION
     )
-    parser.addoption("--sklearn-full-version", action="store", default="0.20.0")
     parser.addoption("--ei-tf-full-version", action="store")
     parser.addoption("--xgboost-full-version", action="store", default="1.0-1")
 
@@ -299,8 +298,13 @@ def rl_ray_full_version(request):
 
 
 @pytest.fixture(scope="module")
-def sklearn_full_version(request):
-    return request.config.getoption("--sklearn-full-version")
+def sklearn_full_version():
+    return "0.20.0"
+
+
+@pytest.fixture(scope="module")
+def sklearn_full_py_version():
+    return "py3"
 
 
 @pytest.fixture(scope="module")

--- a/tests/integ/test_airflow_config.py
+++ b/tests/integ/test_airflow_config.py
@@ -475,7 +475,7 @@ def test_mxnet_airflow_config_uploads_data_source_to_s3(
 
 @pytest.mark.canary_quick
 def test_sklearn_airflow_config_uploads_data_source_to_s3(
-    sagemaker_session, cpu_instance_type, sklearn_full_version
+    sagemaker_session, cpu_instance_type, sklearn_full_version, sklearn_full_py_version
 ):
     with timeout(seconds=AIRFLOW_CONFIG_TIMEOUT_IN_SECONDS):
         script_path = os.path.join(DATA_DIR, "sklearn_mnist", "mnist.py")
@@ -486,7 +486,7 @@ def test_sklearn_airflow_config_uploads_data_source_to_s3(
             role=ROLE,
             train_instance_type=cpu_instance_type,
             framework_version=sklearn_full_version,
-            py_version=PYTHON_VERSION,
+            py_version=sklearn_full_py_version,
             sagemaker_session=sagemaker_session,
             hyperparameters={"epochs": 1},
         )

--- a/tests/integ/test_git.py
+++ b/tests/integ/test_git.py
@@ -133,7 +133,9 @@ def test_private_github(sagemaker_local_session, mxnet_full_version, mxnet_full_
 
 @pytest.mark.local_mode
 @pytest.mark.skip("needs a secure authentication approach")
-def test_private_github_with_2fa(sagemaker_local_session, sklearn_full_version):
+def test_private_github_with_2fa(
+    sagemaker_local_session, sklearn_full_version, sklearn_full_py_version
+):
     script_path = "mnist.py"
     data_path = os.path.join(DATA_DIR, "sklearn_mnist")
     git_config = {
@@ -149,7 +151,7 @@ def test_private_github_with_2fa(sagemaker_local_session, sklearn_full_version):
         entry_point=script_path,
         role="SageMakerRole",
         source_dir=source_dir,
-        py_version="py3",  # Scikit-learn supports only Python 3
+        py_version=sklearn_full_py_version,
         train_instance_count=1,
         train_instance_type="local",
         sagemaker_session=sagemaker_local_session,
@@ -187,7 +189,9 @@ def test_private_github_with_2fa(sagemaker_local_session, sklearn_full_version):
 
 
 @pytest.mark.local_mode
-def test_github_with_ssh_passphrase_not_configured(sagemaker_local_session, sklearn_full_version):
+def test_github_with_ssh_passphrase_not_configured(
+    sagemaker_local_session, sklearn_full_version, sklearn_full_py_version
+):
     script_path = "mnist.py"
     data_path = os.path.join(DATA_DIR, "sklearn_mnist")
     git_config = {
@@ -201,11 +205,11 @@ def test_github_with_ssh_passphrase_not_configured(sagemaker_local_session, skle
         entry_point=script_path,
         role="SageMakerRole",
         source_dir=source_dir,
-        py_version="py3",  # Scikit-learn supports only Python 3
         train_instance_count=1,
         train_instance_type="local",
         sagemaker_session=sagemaker_local_session,
         framework_version=sklearn_full_version,
+        py_version=sklearn_full_py_version,
         hyperparameters={"epochs": 1},
         git_config=git_config,
     )


### PR DESCRIPTION
*Issue #, if available:*
#1461 (follow-up to #1609)

*Description of changes:*
see description of #1612

*Testing done:*
linters

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
