### PR TITLE
infra: use fixture for Chainer and XGBoost Python version, clean up remaining version fixtures

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,21 +44,6 @@ def pytest_addoption(parser):
     parser.addoption("--sagemaker-client-config", action="store", default=None)
     parser.addoption("--sagemaker-runtime-config", action="store", default=None)
     parser.addoption("--boto-config", action="store", default=None)
-    parser.addoption("--chainer-full-version", action="store", default="5.0.0")
-    parser.addoption("--ei-mxnet-full-version", action="store", default="1.5.1")
-    parser.addoption(
-        "--rl-coach-mxnet-full-version",
-        action="store",
-        default=RLEstimator.COACH_LATEST_VERSION_MXNET,
-    )
-    parser.addoption(
-        "--rl-coach-tf-full-version", action="store", default=RLEstimator.COACH_LATEST_VERSION_TF
-    )
-    parser.addoption(
-        "--rl-ray-full-version", action="store", default=RLEstimator.RAY_LATEST_VERSION
-    )
-    parser.addoption("--ei-tf-full-version", action="store")
-    parser.addoption("--xgboost-full-version", action="store", default="1.0-1")
 
 
 def pytest_configure(config):
@@ -248,8 +233,13 @@ def rl_ray_version(request):
 
 
 @pytest.fixture(scope="module")
-def chainer_full_version(request):
-    return request.config.getoption("--chainer-full-version")
+def chainer_full_version():
+    return "5.0.0"
+
+
+@pytest.fixture(scope="module")
+def chainer_full_py_version():
+    return "py3"
 
 
 @pytest.fixture(scope="module")
@@ -263,8 +253,8 @@ def mxnet_full_py_version():
 
 
 @pytest.fixture(scope="module")
-def ei_mxnet_full_version(request):
-    return request.config.getoption("--ei-mxnet-full-version")
+def ei_mxnet_full_version():
+    return "1.5.1"
 
 
 @pytest.fixture(scope="module")
@@ -283,18 +273,18 @@ def pytorch_full_ei_version():
 
 
 @pytest.fixture(scope="module")
-def rl_coach_mxnet_full_version(request):
-    return request.config.getoption("--rl-coach-mxnet-full-version")
+def rl_coach_mxnet_full_version():
+    return RLEstimator.COACH_LATEST_VERSION_MXNET
 
 
 @pytest.fixture(scope="module")
-def rl_coach_tf_full_version(request):
-    return request.config.getoption("--rl-coach-tf-full-version")
+def rl_coach_tf_full_version():
+    return RLEstimator.COACH_LATEST_VERSION_TF
 
 
 @pytest.fixture(scope="module")
-def rl_ray_full_version(request):
-    return request.config.getoption("--rl-ray-full-version")
+def rl_ray_full_version():
+    return RLEstimator.RAY_LATEST_VERSION
 
 
 @pytest.fixture(scope="module")
@@ -347,13 +337,19 @@ def tf_full_py_version(tf_full_version):
     return "py37"
 
 
-@pytest.fixture(scope="module", params=["1.15.0", "2.0.0"])
-def ei_tf_full_version(request):
-    tf_ei_version = request.config.getoption("--ei-tf-full-version")
-    if tf_ei_version is None:
-        return request.param
-    else:
-        tf_ei_version
+@pytest.fixture(scope="module")
+def ei_tf_full_version():
+    return "2.0.0"
+
+
+@pytest.fixture(scope="module")
+def xgboost_full_version():
+    return "1.0-1"
+
+
+@pytest.fixture(scope="module")
+def xgboost_full_py_version():
+    return "py3"
 
 
 @pytest.fixture(scope="session")
@@ -409,8 +405,3 @@ def pytest_generate_tests(metafunc):
         ):
             params.append("ml.p2.xlarge")
         metafunc.parametrize("instance_type", params, scope="session")
-
-
-@pytest.fixture(scope="module")
-def xgboost_full_version(request):
-    return request.config.getoption("--xgboost-full-version")

--- a/tests/integ/__init__.py
+++ b/tests/integ/__init__.py
@@ -14,7 +14,6 @@ from __future__ import absolute_import
 
 import logging
 import os
-import sys
 
 import boto3
 
@@ -23,7 +22,6 @@ TRAINING_DEFAULT_TIMEOUT_MINUTES = 20
 TUNING_DEFAULT_TIMEOUT_MINUTES = 20
 TRANSFORM_DEFAULT_TIMEOUT_MINUTES = 20
 AUTO_ML_DEFAULT_TIMEMOUT_MINUTES = 60
-PYTHON_VERSION = "py{}".format(sys.version_info.major)
 
 # these regions have some p2 and p3 instances, but not enough for continuous testing
 HOSTING_NO_P2_REGIONS = [

--- a/tests/integ/test_airflow_config.py
+++ b/tests/integ/test_airflow_config.py
@@ -45,7 +45,7 @@ from sagemaker.tensorflow import TensorFlow
 from sagemaker.utils import sagemaker_timestamp
 from sagemaker.workflow import airflow as sm_airflow
 from sagemaker.xgboost import XGBoost
-from tests.integ import datasets, DATA_DIR, PYTHON_VERSION
+from tests.integ import datasets, DATA_DIR
 from tests.integ.record_set import prepare_record_set_from_local_files
 from tests.integ.timeout import timeout
 
@@ -404,7 +404,7 @@ def test_rcf_airflow_config_uploads_data_source_to_s3(sagemaker_session, cpu_ins
 
 @pytest.mark.canary_quick
 def test_chainer_airflow_config_uploads_data_source_to_s3(
-    sagemaker_local_session, cpu_instance_type, chainer_full_version
+    sagemaker_local_session, cpu_instance_type, chainer_full_version, chainer_full_py_version
 ):
     with timeout(seconds=AIRFLOW_CONFIG_TIMEOUT_IN_SECONDS):
         script_path = os.path.join(DATA_DIR, "chainer_mnist", "mnist.py")
@@ -416,7 +416,7 @@ def test_chainer_airflow_config_uploads_data_source_to_s3(
             train_instance_count=SINGLE_INSTANCE_COUNT,
             train_instance_type="local",
             framework_version=chainer_full_version,
-            py_version=PYTHON_VERSION,
+            py_version=chainer_full_py_version,
             sagemaker_session=sagemaker_local_session,
             hyperparameters={"epochs": 1},
             use_mpi=True,
@@ -545,20 +545,19 @@ def test_tf_airflow_config_uploads_data_source_to_s3(
 
 
 @pytest.mark.canary_quick
-@pytest.mark.skipif(PYTHON_VERSION == "py2", reason="XGBoost container does not support Python 2.")
 def test_xgboost_airflow_config_uploads_data_source_to_s3(
-    sagemaker_session, cpu_instance_type, xgboost_full_version
+    sagemaker_session, cpu_instance_type, xgboost_full_version, xgboost_full_py_version
 ):
     with timeout(seconds=AIRFLOW_CONFIG_TIMEOUT_IN_SECONDS):
         xgboost = XGBoost(
             entry_point=os.path.join(DATA_DIR, "dummy_script.py"),
             framework_version=xgboost_full_version,
+            py_version=xgboost_full_py_version,
             role=ROLE,
             sagemaker_session=sagemaker_session,
             train_instance_type=cpu_instance_type,
             train_instance_count=SINGLE_INSTANCE_COUNT,
             base_job_name="XGBoost job",
-            py_version=PYTHON_VERSION,
         )
 
         training_config = _build_airflow_workflow(

--- a/tests/integ/test_chainer_train.py
+++ b/tests/integ/test_chainer_train.py
@@ -20,7 +20,7 @@ import pytest
 from sagemaker.chainer.estimator import Chainer
 from sagemaker.chainer.model import ChainerModel
 from sagemaker.utils import unique_name_from_base
-from tests.integ import DATA_DIR, PYTHON_VERSION, TRAINING_DEFAULT_TIMEOUT_MINUTES
+from tests.integ import DATA_DIR, TRAINING_DEFAULT_TIMEOUT_MINUTES
 from tests.integ.timeout import timeout, timeout_and_delete_endpoint_by_name
 
 
@@ -35,7 +35,9 @@ def test_distributed_cpu_training(sagemaker_local_session, chainer_full_version)
 
 
 @pytest.mark.local_mode
-def test_training_with_additional_hyperparameters(sagemaker_local_session, chainer_full_version):
+def test_training_with_additional_hyperparameters(
+    sagemaker_local_session, chainer_full_version, chainer_full_py_version
+):
     script_path = os.path.join(DATA_DIR, "chainer_mnist", "mnist.py")
     data_path = os.path.join(DATA_DIR, "chainer_mnist")
 
@@ -45,7 +47,7 @@ def test_training_with_additional_hyperparameters(sagemaker_local_session, chain
         train_instance_count=1,
         train_instance_type="local",
         framework_version=chainer_full_version,
-        py_version=PYTHON_VERSION,
+        py_version=chainer_full_py_version,
         sagemaker_session=sagemaker_local_session,
         hyperparameters={"epochs": 1},
         use_mpi=True,
@@ -62,7 +64,9 @@ def test_training_with_additional_hyperparameters(sagemaker_local_session, chain
 
 @pytest.mark.canary_quick
 @pytest.mark.regional_testing
-def test_attach_deploy(sagemaker_session, chainer_full_version, cpu_instance_type):
+def test_attach_deploy(
+    sagemaker_session, chainer_full_version, chainer_full_py_version, cpu_instance_type
+):
     with timeout(minutes=TRAINING_DEFAULT_TIMEOUT_MINUTES):
         script_path = os.path.join(DATA_DIR, "chainer_mnist", "mnist.py")
         data_path = os.path.join(DATA_DIR, "chainer_mnist")
@@ -71,7 +75,7 @@ def test_attach_deploy(sagemaker_session, chainer_full_version, cpu_instance_typ
             entry_point=script_path,
             role="SageMakerRole",
             framework_version=chainer_full_version,
-            py_version=PYTHON_VERSION,
+            py_version=chainer_full_py_version,
             train_instance_count=1,
             train_instance_type=cpu_instance_type,
             sagemaker_session=sagemaker_session,
@@ -100,7 +104,12 @@ def test_attach_deploy(sagemaker_session, chainer_full_version, cpu_instance_typ
 
 
 @pytest.mark.local_mode
-def test_deploy_model(chainer_local_training_job, sagemaker_local_session, chainer_full_version):
+def test_deploy_model(
+    chainer_local_training_job,
+    sagemaker_local_session,
+    chainer_full_version,
+    chainer_full_py_version,
+):
     script_path = os.path.join(DATA_DIR, "chainer_mnist", "mnist.py")
 
     model = ChainerModel(
@@ -109,7 +118,7 @@ def test_deploy_model(chainer_local_training_job, sagemaker_local_session, chain
         entry_point=script_path,
         sagemaker_session=sagemaker_local_session,
         framework_version=chainer_full_version,
-        py_version=PYTHON_VERSION,
+        py_version=chainer_full_py_version,
     )
 
     predictor = model.deploy(1, "local")
@@ -120,7 +129,7 @@ def test_deploy_model(chainer_local_training_job, sagemaker_local_session, chain
 
 
 def _run_mnist_training_job(
-    sagemaker_session, instance_type, instance_count, chainer_full_version, wait=True
+    sagemaker_session, instance_type, instance_count, chainer_version, py_version, wait=True
 ):
     script_path = (
         os.path.join(DATA_DIR, "chainer_mnist", "mnist.py")
@@ -133,8 +142,8 @@ def _run_mnist_training_job(
     chainer = Chainer(
         entry_point=script_path,
         role="SageMakerRole",
-        framework_version=chainer_full_version,
-        py_version=PYTHON_VERSION,
+        framework_version=chainer_version,
+        py_version=py_version,
         train_instance_count=instance_count,
         train_instance_type=instance_type,
         sagemaker_session=sagemaker_session,

--- a/tests/integ/test_chainer_train.py
+++ b/tests/integ/test_chainer_train.py
@@ -25,13 +25,21 @@ from tests.integ.timeout import timeout, timeout_and_delete_endpoint_by_name
 
 
 @pytest.fixture(scope="module")
-def chainer_local_training_job(sagemaker_local_session, chainer_full_version):
-    return _run_mnist_training_job(sagemaker_local_session, "local", 1, chainer_full_version)
+def chainer_local_training_job(
+    sagemaker_local_session, chainer_full_version, chainer_full_py_version
+):
+    return _run_mnist_training_job(
+        sagemaker_local_session, "local", 1, chainer_full_version, chainer_full_py_version
+    )
 
 
 @pytest.mark.local_mode
-def test_distributed_cpu_training(sagemaker_local_session, chainer_full_version):
-    _run_mnist_training_job(sagemaker_local_session, "local", 2, chainer_full_version)
+def test_distributed_cpu_training(
+    sagemaker_local_session, chainer_full_version, chainer_full_py_version
+):
+    _run_mnist_training_job(
+        sagemaker_local_session, "local", 2, chainer_full_version, chainer_full_py_version
+    )
 
 
 @pytest.mark.local_mode
@@ -129,7 +137,7 @@ def test_deploy_model(
 
 
 def _run_mnist_training_job(
-    sagemaker_session, instance_type, instance_count, chainer_version, py_version, wait=True
+    sagemaker_session, instance_type, instance_count, chainer_version, py_version
 ):
     script_path = (
         os.path.join(DATA_DIR, "chainer_mnist", "mnist.py")
@@ -156,7 +164,7 @@ def _run_mnist_training_job(
     test_input = "file://" + os.path.join(data_path, "test")
 
     job_name = unique_name_from_base("test-chainer-training")
-    chainer.fit({"train": train_input, "test": test_input}, wait=wait, job_name=job_name)
+    chainer.fit({"train": train_input, "test": test_input}, job_name=job_name)
     return chainer
 
 

--- a/tests/integ/test_rl.py
+++ b/tests/integ/test_rl.py
@@ -19,12 +19,11 @@ import pytest
 
 from sagemaker.rl import RLEstimator, RLFramework, RLToolkit
 from sagemaker.utils import sagemaker_timestamp, unique_name_from_base
-from tests.integ import DATA_DIR, PYTHON_VERSION
+from tests.integ import DATA_DIR
 from tests.integ.timeout import timeout, timeout_and_delete_endpoint_by_name
 
 
 @pytest.mark.canary_quick
-@pytest.mark.skipif(PYTHON_VERSION != "py3", reason="RL images supports only Python 3.")
 def test_coach_mxnet(sagemaker_session, rl_coach_mxnet_full_version, cpu_instance_type):
     estimator = _test_coach(
         sagemaker_session, RLFramework.MXNET, rl_coach_mxnet_full_version, cpu_instance_type
@@ -52,7 +51,6 @@ def test_coach_mxnet(sagemaker_session, rl_coach_mxnet_full_version, cpu_instanc
     assert 0 < action[0][1] < 1
 
 
-@pytest.mark.skipif(PYTHON_VERSION != "py3", reason="RL images supports only Python 3.")
 def test_coach_tf(sagemaker_session, rl_coach_tf_full_version, cpu_instance_type):
     estimator = _test_coach(
         sagemaker_session, RLFramework.TENSORFLOW, rl_coach_tf_full_version, cpu_instance_type
@@ -98,7 +96,6 @@ def _test_coach(sagemaker_session, rl_framework, rl_coach_version, cpu_instance_
 
 
 @pytest.mark.canary_quick
-@pytest.mark.skipif(PYTHON_VERSION != "py3", reason="RL images supports only Python 3.")
 def test_ray_tf(sagemaker_session, rl_ray_full_version, cpu_instance_type):
     source_dir = os.path.join(DATA_DIR, "ray_cartpole")
     cartpole = "train_ray.py"

--- a/tests/integ/test_tuner.py
+++ b/tests/integ/test_tuner.py
@@ -45,7 +45,6 @@ from tests.integ import (
     datasets,
     vpc_test_utils,
     DATA_DIR,
-    PYTHON_VERSION,
     TUNING_DEFAULT_TIMEOUT_MINUTES,
 )
 from tests.integ.record_set import prepare_record_set_from_local_files
@@ -687,7 +686,9 @@ def test_tuning_tf_vpc_multi(
 
 
 @pytest.mark.canary_quick
-def test_tuning_chainer(sagemaker_session, chainer_full_version, cpu_instance_type):
+def test_tuning_chainer(
+    sagemaker_session, chainer_full_version, chainer_full_py_version, cpu_instance_type
+):
     with timeout(minutes=TUNING_DEFAULT_TIMEOUT_MINUTES):
         script_path = os.path.join(DATA_DIR, "chainer_mnist", "mnist.py")
         data_path = os.path.join(DATA_DIR, "chainer_mnist")
@@ -696,7 +697,7 @@ def test_tuning_chainer(sagemaker_session, chainer_full_version, cpu_instance_ty
             entry_point=script_path,
             role="SageMakerRole",
             framework_version=chainer_full_version,
-            py_version=PYTHON_VERSION,
+            py_version=chainer_full_py_version,
             train_instance_count=1,
             train_instance_type=cpu_instance_type,
             sagemaker_session=sagemaker_session,


### PR DESCRIPTION
*Issue #, if available:*
#1461 (follow-up to #1609)

*Description of changes:*
see description of #1612

I also cleaned up the remaining framework version fixtures that hadn't been caught in the previous PRs.

*Testing done:*
linters

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
