### PR TITLE
infra: fix tox test dependencies and bump coverage threshold to 86%

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -58,13 +58,12 @@ passenv =
     AWS_SESSION_TOKEN
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI
     AWS_DEFAULT_REGION
-
 # {posargs} can be passed in by additional arguments specified when invoking tox.
 # Can be used to specify which tests to run, e.g.: tox -- -s
 commands =
     coverage run --source sagemaker -m pytest {posargs}
-    {env:IGNORE_COVERAGE:} coverage report --fail-under=85 --omit */tensorflow/tensorflow_serving/*
-extras = test
+    {env:IGNORE_COVERAGE:} coverage report --fail-under=86 --omit */tensorflow/tensorflow_serving/*
+deps = .[test]
 
 [testenv:flake8]
 basepython = python3


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
as I discovered in #1633, [Python 3.8 introduced a change that required changes in `coverage`](https://github.com/nedbat/coveragepy/issues/707). This has been fixed in `coverage>=4.5.2`, and even though the builds were claiming that `coverage==5.1` was installed,  the coverage check was failing for only Python 3.8. Turns out [tox has some interesting caching behavior](https://github.com/tox-dev/tox/issues/149).

*Testing done:*
`tox -e py38 tests/unit` (and tried it out in #1633)

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
