### PR TITLE
breaking: create new inference resources during estimator.deploy() or estimator.transformer()

### DIFF
--- a/src/sagemaker/algorithm.py
+++ b/src/sagemaker/algorithm.py
@@ -391,6 +391,11 @@ class AlgorithmEstimator(EstimatorBase):
         """Placeholder docstring"""
         return "ProductId" in self.algorithm_spec
 
+    def _ensure_base_job_name(self):
+        """Set ``self.base_job_name`` if it is not set already."""
+        if self.base_job_name is None:
+            self.base_job_name = self.algorithm_arn.split("/")[-1]
+
     def _prepare_for_training(self, job_name=None):
         # Validate hyperparameters
         # an explicit call to set_hyperparameters() will also validate the hyperparameters

--- a/src/sagemaker/chainer/estimator.py
+++ b/src/sagemaker/chainer/estimator.py
@@ -15,6 +15,7 @@ from __future__ import absolute_import
 
 import logging
 
+from sagemaker import utils
 from sagemaker.estimator import Framework
 from sagemaker.fw_utils import (
     framework_name_from_image,
@@ -210,7 +211,8 @@ class Chainer(Framework):
             kwargs["image"] = self.image_name
 
         if "name" not in kwargs:
-            kwargs["name"] = self._current_job_name
+            self._ensure_base_job_name()
+            kwargs["name"] = utils.name_from_base(self.base_job_name)
 
         return ChainerModel(
             self.model_data,

--- a/src/sagemaker/chainer/estimator.py
+++ b/src/sagemaker/chainer/estimator.py
@@ -15,7 +15,6 @@ from __future__ import absolute_import
 
 import logging
 
-from sagemaker import utils
 from sagemaker.estimator import Framework
 from sagemaker.fw_utils import (
     framework_name_from_image,
@@ -207,12 +206,10 @@ class Chainer(Framework):
             sagemaker.chainer.model.ChainerModel: A SageMaker ``ChainerModel``
             object. See :func:`~sagemaker.chainer.model.ChainerModel` for full details.
         """
+        kwargs["name"] = self._get_or_create_name(kwargs.get("name"))
+
         if "image" not in kwargs:
             kwargs["image"] = self.image_name
-
-        if "name" not in kwargs:
-            self._ensure_base_job_name()
-            kwargs["name"] = utils.name_from_base(self.base_job_name)
 
         return ChainerModel(
             self.model_data,

--- a/src/sagemaker/estimator.py
+++ b/src/sagemaker/estimator.py
@@ -329,10 +329,12 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):
         self._prepare_for_training(job_name=job_name)
 
     def _ensure_base_job_name(self):
+        """Set ``self.base_job_name`` if it is not set already."""
         # honor supplied base_job_name or generate it
         if self.base_job_name:
             return
-        elif isinstance(self, sagemaker.algorithm.AlgorithmEstimator):
+
+        if isinstance(self, sagemaker.algorithm.AlgorithmEstimator):
             self.base_job_name = self.algorithm_arn.split("/")[-1]  # pylint: disable=no-member
         else:
             self.base_job_name = base_name_from_image(self.train_image())

--- a/src/sagemaker/estimator.py
+++ b/src/sagemaker/estimator.py
@@ -140,7 +140,7 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):
                 training output (default: None).
             base_job_name (str): Prefix for training job name when the
                 :meth:`~sagemaker.estimator.EstimatorBase.fit` method launches.
-                If not specified, the estimator generates a default job name,
+                If not specified, the estimator generates a default job name
                 based on the training image name and current timestamp.
             sagemaker_session (sagemaker.session.Session): Session object which
                 manages interactions with Amazon SageMaker APIs and any other
@@ -328,6 +328,15 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):
         """
         self._prepare_for_training(job_name=job_name)
 
+    def _ensure_base_job_name(self):
+        # honor supplied base_job_name or generate it
+        if self.base_job_name:
+            return
+        elif isinstance(self, sagemaker.algorithm.AlgorithmEstimator):
+            self.base_job_name = self.algorithm_arn.split("/")[-1]  # pylint: disable=no-member
+        else:
+            self.base_job_name = base_name_from_image(self.train_image())
+
     def _prepare_for_training(self, job_name=None):
         """Set any values in the estimator that need to be set before training.
 
@@ -339,15 +348,8 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):
         if job_name is not None:
             self._current_job_name = job_name
         else:
-            # honor supplied base_job_name or generate it
-            if self.base_job_name:
-                base_name = self.base_job_name
-            elif isinstance(self, sagemaker.algorithm.AlgorithmEstimator):
-                base_name = self.algorithm_arn.split("/")[-1]  # pylint: disable=no-member
-            else:
-                base_name = base_name_from_image(self.train_image())
-
-            self._current_job_name = name_from_base(base_name)
+            self._ensure_base_job_name()
+            self._current_job_name = name_from_base(self.base_job_name)
 
         # if output_path was specified we use it otherwise initialize here.
         # For Local Mode with local_code=True we don't need an explicit output_path
@@ -483,7 +485,7 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):
                 compatibility, boolean values are also accepted and converted to strings.
                 Only meaningful when wait is True.
             job_name (str): Training job name. If not specified, the estimator generates
-                a default job name, based on the training image name and current timestamp.
+                a default job name based on the training image name and current timestamp.
             experiment_config (dict[str, str]): Experiment management configuration.
                 Dictionary contains three optional keys,
                 'ExperimentName', 'TrialName', and 'TrialComponentDisplayName'.
@@ -667,7 +669,8 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):
             wait (bool): Whether the call should wait until the deployment of
                 model completes (default: True).
             model_name (str): Name to use for creating an Amazon SageMaker
-                model. If not specified, the name of the training job is used.
+                model. If not specified, the estimator generates a default job name
+                based on the training image name and current timestamp.
             kms_key (str): The ARN of the KMS key that is used to encrypt the
                 data on the storage volume attached to the instance hosting the
                 endpoint.
@@ -691,8 +694,11 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):
                 endpoint and obtain inferences.
         """
         self._ensure_latest_training_job()
-        endpoint_name = endpoint_name or self.latest_training_job.name
-        model_name = model_name or self.latest_training_job.name
+        self._ensure_base_job_name()
+        default_name = name_from_base(self.base_job_name)
+        endpoint_name = endpoint_name or default_name
+        model_name = model_name or default_name
+
         self.deploy_instance_type = instance_type
         if use_compiled_model:
             family = "_".join(instance_type.split(".")[:-1])
@@ -898,18 +904,20 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):
                 If not specified, this setting is taken from the estimator's
                 current configuration.
             model_name (str): Name to use for creating an Amazon SageMaker
-                model. If not specified, the name of the training job is used.
+                model. If not specified, the estimator generates a default job name
+                based on the training image name and current timestamp.
         """
         tags = tags or self.tags
+
+        self._ensure_base_job_name()
+        model_name = model_name or name_from_base(self.base_job_name)
 
         if self.latest_training_job is None:
             logging.warning(
                 "No finished training job found associated with this estimator. Please make sure "
                 "this estimator is only used for building workflow config"
             )
-            model_name = model_name or self._current_job_name
         else:
-            model_name = model_name or self.latest_training_job.name
             if enable_network_isolation is None:
                 enable_network_isolation = self.enable_network_isolation()
 
@@ -1993,7 +2001,8 @@ class Framework(EstimatorBase):
                 If not specified, this setting is taken from the estimator's
                 current configuration.
             model_name (str): Name to use for creating an Amazon SageMaker
-                model. If not specified, the name of the training job is used.
+                model. If not specified, the estimator generates a default job name
+                based on the training image name and current timestamp.
 
         Returns:
             sagemaker.transformer.Transformer: a ``Transformer`` object that can be used to start a
@@ -2001,6 +2010,9 @@ class Framework(EstimatorBase):
         """
         role = role or self.role
         tags = tags or self.tags
+
+        self._ensure_base_job_name()
+        model_name = model_name or name_from_base(self.base_job_name)
 
         if self.latest_training_job is not None:
             if enable_network_isolation is None:
@@ -2017,7 +2029,6 @@ class Framework(EstimatorBase):
             )
             model._create_sagemaker_model(instance_type, tags=tags)
 
-            model_name = model.name
             transform_env = model.env.copy()
             if env is not None:
                 transform_env.update(env)
@@ -2026,7 +2037,6 @@ class Framework(EstimatorBase):
                 "No finished training job found associated with this estimator. Please make sure "
                 "this estimator is only used for building workflow config"
             )
-            model_name = model_name or self._current_job_name
             transform_env = env or {}
 
         return Transformer(

--- a/src/sagemaker/mxnet/estimator.py
+++ b/src/sagemaker/mxnet/estimator.py
@@ -15,7 +15,6 @@ from __future__ import absolute_import
 
 import logging
 
-from sagemaker import utils
 from sagemaker.estimator import Framework
 from sagemaker.fw_utils import (
     framework_name_from_image,
@@ -219,9 +218,7 @@ class MXNet(Framework):
         if "image" not in kwargs:
             kwargs["image"] = image_name or self.image_name
 
-        if "name" not in kwargs:
-            self._ensure_base_job_name()
-            kwargs["name"] = utils.name_from_base(self.base_job_name)
+        kwargs["name"] = self._get_or_create_name(kwargs.get("name"))
 
         return MXNetModel(
             self.model_data,

--- a/src/sagemaker/mxnet/estimator.py
+++ b/src/sagemaker/mxnet/estimator.py
@@ -15,6 +15,7 @@ from __future__ import absolute_import
 
 import logging
 
+from sagemaker import utils
 from sagemaker.estimator import Framework
 from sagemaker.fw_utils import (
     framework_name_from_image,
@@ -219,7 +220,8 @@ class MXNet(Framework):
             kwargs["image"] = image_name or self.image_name
 
         if "name" not in kwargs:
-            kwargs["name"] = self._current_job_name
+            self._ensure_base_job_name()
+            kwargs["name"] = utils.name_from_base(self.base_job_name)
 
         return MXNetModel(
             self.model_data,

--- a/src/sagemaker/predictor.py
+++ b/src/sagemaker/predictor.py
@@ -303,7 +303,7 @@ class Predictor(object):
             EndpointConfigName=self._endpoint_config_name
         )
         production_variants = endpoint_config["ProductionVariants"]
-        return map(lambda d: d["ModelName"], production_variants)
+        return [d["ModelName"] for d in production_variants]
 
 
 class _CsvSerializer(object):

--- a/src/sagemaker/pytorch/estimator.py
+++ b/src/sagemaker/pytorch/estimator.py
@@ -15,7 +15,6 @@ from __future__ import absolute_import
 
 import logging
 
-from sagemaker import utils
 from sagemaker.estimator import Framework
 from sagemaker.fw_utils import (
     framework_name_from_image,
@@ -171,9 +170,7 @@ class PyTorch(Framework):
         if "image" not in kwargs:
             kwargs["image"] = self.image_name
 
-        if "name" not in kwargs:
-            self._ensure_base_job_name()
-            kwargs["name"] = utils.name_from_base(self.base_job_name)
+        kwargs["name"] = self._get_or_create_name(kwargs.get("name"))
 
         return PyTorchModel(
             self.model_data,

--- a/src/sagemaker/pytorch/estimator.py
+++ b/src/sagemaker/pytorch/estimator.py
@@ -15,6 +15,7 @@ from __future__ import absolute_import
 
 import logging
 
+from sagemaker import utils
 from sagemaker.estimator import Framework
 from sagemaker.fw_utils import (
     framework_name_from_image,
@@ -171,7 +172,8 @@ class PyTorch(Framework):
             kwargs["image"] = self.image_name
 
         if "name" not in kwargs:
-            kwargs["name"] = self._current_job_name
+            self._ensure_base_job_name()
+            kwargs["name"] = utils.name_from_base(self.base_job_name)
 
         return PyTorchModel(
             self.model_data,

--- a/src/sagemaker/rl/estimator.py
+++ b/src/sagemaker/rl/estimator.py
@@ -17,8 +17,8 @@ import enum
 import logging
 import re
 
+from sagemaker import fw_utils, utils
 from sagemaker.estimator import Framework
-import sagemaker.fw_utils as fw_utils
 from sagemaker.model import FrameworkModel, SAGEMAKER_OUTPUT_LOCATION
 from sagemaker.mxnet.model import MXNetModel
 from sagemaker.tensorflow.model import TensorFlowModel
@@ -218,11 +218,13 @@ class RLEstimator(Framework):
         Raises:
             ValueError: If image_name is not specified and framework enum is not valid.
         """
+        self._ensure_base_job_name()
+
         base_args = dict(
             model_data=self.model_data,
             role=role or self.role,
             image=kwargs.get("image", self.image_name),
-            name=kwargs.get("name", self._current_job_name),
+            name=kwargs.get("name", utils.name_from_base(self.base_job_name)),
             container_log_level=self.container_log_level,
             sagemaker_session=self.sagemaker_session,
             vpc_config=self.get_vpc_config(vpc_config_override),

--- a/src/sagemaker/rl/estimator.py
+++ b/src/sagemaker/rl/estimator.py
@@ -218,7 +218,6 @@ class RLEstimator(Framework):
         Raises:
             ValueError: If image_name is not specified and framework enum is not valid.
         """
-
         base_args = dict(
             model_data=self.model_data,
             role=role or self.role,

--- a/src/sagemaker/rl/estimator.py
+++ b/src/sagemaker/rl/estimator.py
@@ -17,7 +17,7 @@ import enum
 import logging
 import re
 
-from sagemaker import fw_utils, utils
+from sagemaker import fw_utils
 from sagemaker.estimator import Framework
 from sagemaker.model import FrameworkModel, SAGEMAKER_OUTPUT_LOCATION
 from sagemaker.mxnet.model import MXNetModel
@@ -218,17 +218,17 @@ class RLEstimator(Framework):
         Raises:
             ValueError: If image_name is not specified and framework enum is not valid.
         """
-        self._ensure_base_job_name()
 
         base_args = dict(
             model_data=self.model_data,
             role=role or self.role,
             image=kwargs.get("image", self.image_name),
-            name=kwargs.get("name", utils.name_from_base(self.base_job_name)),
             container_log_level=self.container_log_level,
             sagemaker_session=self.sagemaker_session,
             vpc_config=self.get_vpc_config(vpc_config_override),
         )
+
+        base_args["name"] = self._get_or_create_name(kwargs.get("name"))
 
         if not entry_point and (source_dir or dependencies):
             raise AttributeError("Please provide an `entry_point`.")

--- a/src/sagemaker/sklearn/estimator.py
+++ b/src/sagemaker/sklearn/estimator.py
@@ -15,6 +15,7 @@ from __future__ import absolute_import
 
 import logging
 
+from sagemaker import utils
 from sagemaker.estimator import Framework
 from sagemaker.fw_registry import default_framework_uri
 from sagemaker.fw_utils import (
@@ -194,7 +195,8 @@ class SKLearn(Framework):
             kwargs["enable_network_isolation"] = self.enable_network_isolation()
 
         if "name" not in kwargs:
-            kwargs["name"] = self._current_job_name
+            self._ensure_base_job_name()
+            kwargs["name"] = utils.name_from_base(self.base_job_name)
 
         return SKLearnModel(
             self.model_data,

--- a/src/sagemaker/sklearn/estimator.py
+++ b/src/sagemaker/sklearn/estimator.py
@@ -15,7 +15,6 @@ from __future__ import absolute_import
 
 import logging
 
-from sagemaker import utils
 from sagemaker.estimator import Framework
 from sagemaker.fw_registry import default_framework_uri
 from sagemaker.fw_utils import (
@@ -187,16 +186,13 @@ class SKLearn(Framework):
             object. See :func:`~sagemaker.sklearn.model.SKLearnModel` for full details.
         """
         role = role or self.role
+        kwargs["name"] = self._get_or_create_name(kwargs.get("name"))
 
         if "image" not in kwargs:
             kwargs["image"] = self.image_name
 
         if "enable_network_isolation" not in kwargs:
             kwargs["enable_network_isolation"] = self.enable_network_isolation()
-
-        if "name" not in kwargs:
-            self._ensure_base_job_name()
-            kwargs["name"] = utils.name_from_base(self.base_job_name)
 
         return SKLearnModel(
             self.model_data,

--- a/src/sagemaker/tensorflow/estimator.py
+++ b/src/sagemaker/tensorflow/estimator.py
@@ -270,12 +270,10 @@ class TensorFlow(Framework):
             sagemaker.tensorflow.model.TensorFlowModel: A ``TensorFlowModel`` object.
                 See :class:`~sagemaker.tensorflow.model.TensorFlowModel` for full details.
         """
+        kwargs["name"] = self._get_or_create_name(kwargs.get("name"))
+
         if "image" not in kwargs:
             kwargs["image"] = self.image_name
-
-        if "name" not in kwargs:
-            self._ensure_base_job_name()
-            kwargs["name"] = utils.name_from_base(self.base_job_name)
 
         if "enable_network_isolation" not in kwargs:
             kwargs["enable_network_isolation"] = self.enable_network_isolation()
@@ -446,9 +444,7 @@ class TensorFlow(Framework):
                 based on the training image name and current timestamp.
         """
         role = role or self.role
-
-        self._ensure_base_job_name()
-        model_name = model_name or utils.name_from_base(self.base_job_name)
+        model_name = self._get_or_create_name(model_name)
 
         if self.latest_training_job is None:
             logging.warning(

--- a/src/sagemaker/xgboost/estimator.py
+++ b/src/sagemaker/xgboost/estimator.py
@@ -15,7 +15,6 @@ from __future__ import absolute_import
 
 import logging
 
-from sagemaker import utils
 from sagemaker.estimator import Framework, _TrainingJob
 from sagemaker.fw_registry import default_framework_uri
 from sagemaker.fw_utils import (
@@ -165,13 +164,10 @@ class XGBoost(Framework):
                 See :func:`~sagemaker.xgboost.model.XGBoostModel` for full details.
         """
         role = role or self.role
+        kwargs["name"] = self._get_or_create_name(kwargs.get("name"))
 
         if "image" not in kwargs:
             kwargs["image"] = self.image_name
-
-        if "name" not in kwargs:
-            self._ensure_base_job_name()
-            kwargs["name"] = utils.name_from_base(self.base_job_name)
 
         return XGBoostModel(
             self.model_data,

--- a/src/sagemaker/xgboost/estimator.py
+++ b/src/sagemaker/xgboost/estimator.py
@@ -15,6 +15,7 @@ from __future__ import absolute_import
 
 import logging
 
+from sagemaker import utils
 from sagemaker.estimator import Framework, _TrainingJob
 from sagemaker.fw_registry import default_framework_uri
 from sagemaker.fw_utils import (
@@ -169,7 +170,8 @@ class XGBoost(Framework):
             kwargs["image"] = self.image_name
 
         if "name" not in kwargs:
-            kwargs["name"] = self._current_job_name
+            self._ensure_base_job_name()
+            kwargs["name"] = utils.name_from_base(self.base_job_name)
 
         return XGBoostModel(
             self.model_data,

--- a/tests/integ/test_mxnet_train.py
+++ b/tests/integ/test_mxnet_train.py
@@ -71,10 +71,7 @@ def test_attach_deploy(mxnet_training_job, sagemaker_session, cpu_instance_type)
 
 
 def test_deploy_estimator_with_different_instance_types(
-    mxnet_training_job,
-    sagemaker_session,
-    cpu_instance_type,
-    alternative_cpu_instance_type,
+    mxnet_training_job, sagemaker_session, cpu_instance_type, alternative_cpu_instance_type,
 ):
     def _deploy_estimator_and_assert_instance_type(estimator, instance_type):
         # don't use timeout_and_delete_endpoint_by_name because this tests if
@@ -100,6 +97,7 @@ def test_deploy_estimator_with_different_instance_types(
         return (model_name, endpoint_name, config_name)
 
     estimator = MXNet.attach(mxnet_training_job, sagemaker_session)
+    estimator.base_job_name = "test-mxnet-deploy-twice"
 
     old_model_name, old_endpoint_name, old_config_name = _deploy_estimator_and_assert_instance_type(
         estimator, cpu_instance_type

--- a/tests/integ/test_mxnet_train.py
+++ b/tests/integ/test_mxnet_train.py
@@ -81,9 +81,8 @@ def test_deploy_estimator_with_different_instance_types(
                 predictor = estimator.deploy(1, instance_type)
 
                 model_name = predictor._model_names[0]
-                endpoint_name = predictor.endpoint
                 config_name = sagemaker_session.sagemaker_client.describe_endpoint(
-                    EndpointName=endpoint_name
+                    EndpointName=predictor.endpoint_name
                 )["EndpointConfigName"]
                 config = sagemaker_session.sagemaker_client.describe_endpoint_config(
                     EndpointConfigName=config_name
@@ -94,7 +93,7 @@ def test_deploy_estimator_with_different_instance_types(
 
         assert config["ProductionVariants"][0]["InstanceType"] == instance_type
 
-        return (model_name, endpoint_name, config_name)
+        return (model_name, predictor.endpoint_name, config_name)
 
     estimator = MXNet.attach(mxnet_training_job, sagemaker_session)
     estimator.base_job_name = "test-mxnet-deploy-twice"

--- a/tests/integ/test_mxnet_train.py
+++ b/tests/integ/test_mxnet_train.py
@@ -70,6 +70,49 @@ def test_attach_deploy(mxnet_training_job, sagemaker_session, cpu_instance_type)
         assert result is not None
 
 
+def test_deploy_estimator_with_different_instance_types(
+    mxnet_training_job,
+    sagemaker_session,
+    cpu_instance_type,
+    alternative_cpu_instance_type,
+):
+    def _deploy_estimator_and_assert_instance_type(estimator, instance_type):
+        # don't use timeout_and_delete_endpoint_by_name because this tests if
+        # deploy() creates a new endpoint config/endpoint each time
+        with timeout(minutes=45):
+            try:
+                predictor = estimator.deploy(1, instance_type)
+
+                model_name = predictor._model_names[0]
+                endpoint_name = predictor.endpoint
+                config_name = sagemaker_session.sagemaker_client.describe_endpoint(
+                    EndpointName=endpoint_name
+                )["EndpointConfigName"]
+                config = sagemaker_session.sagemaker_client.describe_endpoint_config(
+                    EndpointConfigName=config_name
+                )
+            finally:
+                predictor.delete_model()
+                predictor.delete_endpoint()
+
+        assert config["ProductionVariants"][0]["InstanceType"] == instance_type
+
+        return (model_name, endpoint_name, config_name)
+
+    estimator = MXNet.attach(mxnet_training_job, sagemaker_session)
+
+    old_model_name, old_endpoint_name, old_config_name = _deploy_estimator_and_assert_instance_type(
+        estimator, cpu_instance_type
+    )
+    new_model_name, new_endpoint_name, new_config_name = _deploy_estimator_and_assert_instance_type(
+        estimator, alternative_cpu_instance_type
+    )
+
+    assert old_model_name != new_model_name
+    assert old_endpoint_name != new_endpoint_name
+    assert old_config_name != new_config_name
+
+
 def test_deploy_model(
     mxnet_training_job,
     sagemaker_session,

--- a/tests/unit/sagemaker/tensorflow/test_estimator.py
+++ b/tests/unit/sagemaker/tensorflow/test_estimator.py
@@ -163,7 +163,7 @@ def _build_tf(
     )
 
 
-@patch("sagemaker.utils.name_from_base")
+@patch("sagemaker.estimator.name_from_base")
 def test_create_model(name_from_base, sagemaker_session, tf_version, tf_py_version):
     if version.Version(tf_version) < version.Version("1.11"):
         pytest.skip(
@@ -356,7 +356,7 @@ def test_transformer_creation_with_optional_args(
 
 
 @patch("sagemaker.tensorflow.estimator.TensorFlow.create_model")
-@patch("sagemaker.utils.name_from_base")
+@patch("sagemaker.estimator.name_from_base")
 def test_transformer_creation_without_optional_args(
     name_from_base, create_model, sagemaker_session, tf_version, tf_py_version
 ):

--- a/tests/unit/test_chainer.py
+++ b/tests/unit/test_chainer.py
@@ -231,7 +231,7 @@ def test_attach_with_additional_hyperparameters(
     assert estimator.additional_mpi_options == "-x MY_ENVIRONMENT_VARIABLE"
 
 
-@patch("sagemaker.utils.name_from_base")
+@patch("sagemaker.estimator.name_from_base")
 def test_create_model(name_from_base, sagemaker_session, chainer_version, chainer_py_version):
     container_log_level = '"logging.INFO"'
     source_dir = "s3://mybucket/source"

--- a/tests/unit/test_mxnet.py
+++ b/tests/unit/test_mxnet.py
@@ -181,7 +181,7 @@ def _neo_inference_image(mxnet_version):
     )
 
 
-@patch("sagemaker.utils.name_from_base")
+@patch("sagemaker.estimator.name_from_base")
 @patch("sagemaker.utils.create_tar_file", MagicMock())
 def test_create_model(name_from_base, sagemaker_session, mxnet_version, mxnet_py_version):
     container_log_level = '"logging.INFO"'
@@ -262,7 +262,7 @@ def test_create_model_with_optional_params(sagemaker_session, mxnet_version, mxn
     assert model.name == model_name
 
 
-@patch("sagemaker.utils.name_from_base")
+@patch("sagemaker.estimator.name_from_base")
 def test_create_model_with_custom_image(name_from_base, sagemaker_session):
     container_log_level = '"logging.INFO"'
     source_dir = "s3://mybucket/source"

--- a/tests/unit/test_pytorch.py
+++ b/tests/unit/test_pytorch.py
@@ -157,7 +157,7 @@ def _create_train_job(version, py_version):
     }
 
 
-@patch("sagemaker.utils.name_from_base")
+@patch("sagemaker.estimator.name_from_base")
 def test_create_model(name_from_base, sagemaker_session, pytorch_version, pytorch_py_version):
     container_log_level = '"logging.INFO"'
     source_dir = "s3://mybucket/source"
@@ -236,7 +236,7 @@ def test_create_model_with_optional_params(sagemaker_session, pytorch_version, p
     assert model.name == model_name
 
 
-@patch("sagemaker.utils.name_from_base")
+@patch("sagemaker.estimator.name_from_base")
 def test_create_model_with_custom_image(name_from_base, sagemaker_session):
     container_log_level = '"logging.INFO"'
     source_dir = "s3://mybucket/source"

--- a/tests/unit/test_rl.py
+++ b/tests/unit/test_rl.py
@@ -162,7 +162,7 @@ def _create_train_job(toolkit, toolkit_version, framework):
     }
 
 
-@patch("sagemaker.utils.name_from_base")
+@patch("sagemaker.estimator.name_from_base")
 def test_create_tf_model(name_from_base, sagemaker_session, rl_coach_tf_version):
     container_log_level = '"logging.INFO"'
     source_dir = "s3://mybucket/source"
@@ -199,7 +199,7 @@ def test_create_tf_model(name_from_base, sagemaker_session, rl_coach_tf_version)
     name_from_base.assert_called_with("sagemaker-rl-tensorflow")
 
 
-@patch("sagemaker.utils.name_from_base")
+@patch("sagemaker.estimator.name_from_base")
 def test_create_mxnet_model(name_from_base, sagemaker_session, rl_coach_mxnet_version):
     container_log_level = '"logging.INFO"'
     source_dir = "s3://mybucket/source"
@@ -271,7 +271,7 @@ def test_create_model_with_optional_params(sagemaker_session, rl_coach_mxnet_ver
     assert model.name == model_name
 
 
-@patch("sagemaker.utils.name_from_base")
+@patch("sagemaker.estimator.name_from_base")
 def test_create_model_with_custom_image(name_from_base, sagemaker_session):
     container_log_level = '"logging.INFO"'
     source_dir = "s3://mybucket/source"

--- a/tests/unit/test_sklearn.py
+++ b/tests/unit/test_sklearn.py
@@ -198,7 +198,7 @@ def test_create_model_with_network_isolation(upload, sagemaker_session, sklearn_
     assert model_values["ModelDataUrl"] == repacked_model_data
 
 
-@patch("sagemaker.utils.name_from_base")
+@patch("sagemaker.estimator.name_from_base")
 def test_create_model_from_estimator(name_from_base, sagemaker_session, sklearn_version):
     container_log_level = '"logging.INFO"'
     source_dir = "s3://mybucket/source"

--- a/tests/unit/test_tuner.py
+++ b/tests/unit/test_tuner.py
@@ -801,7 +801,7 @@ def test_deploy_default(tuner):
 
     tuner.sagemaker_session.create_model.assert_called_once()
     args = tuner.sagemaker_session.create_model.call_args[0]
-    assert args[0] == TRAINING_JOB_NAME
+    assert args[0].startswith(TRAINING_JOB_NAME)
     assert args[1] == ROLE
     assert args[2]["Image"] == IMAGE_NAME
     assert args[2]["ModelDataUrl"] == MODEL_DATA
@@ -840,7 +840,7 @@ def test_deploy_estimator_dict(tuner):
 
     tuner.sagemaker_session.create_model.assert_called_once()
     args = tuner.sagemaker_session.create_model.call_args[0]
-    assert args[0] == TRAINING_JOB_NAME
+    assert args[0].startswith(TRAINING_JOB_NAME)
     assert args[1] == ROLE
     assert args[2]["Image"] == IMAGE_NAME
     assert args[2]["ModelDataUrl"] == MODEL_DATA

--- a/tests/unit/test_xgboost.py
+++ b/tests/unit/test_xgboost.py
@@ -187,7 +187,7 @@ def test_create_model(sagemaker_session, xgboost_full_version):
     assert model_values["Image"] == default_image_uri
 
 
-@patch("sagemaker.utils.name_from_base")
+@patch("sagemaker.estimator.name_from_base")
 def test_create_model_from_estimator(name_from_base, sagemaker_session, xgboost_version):
     container_log_level = '"logging.INFO"'
     source_dir = "s3://mybucket/source"


### PR DESCRIPTION
*Issue #, if available:*
#1470, #987 

*Description of changes:*
By reusing the training job name for models, endpoint configs, and endpoints, trying to call `deploy()` twice on the same estimator can lead to a frustrating experience (e.g. #987).

I thought about letting the respective Model classes handle the name generation, but thought it would be nice to honor `base_job_name`, so that's why I went with what I did.

*Testing done:*
unit and integ tests

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
