### PR TITLE
fix: ensure generated names are < 63 characters when deploying compiled models

### DIFF
--- a/src/sagemaker/model.py
+++ b/src/sagemaker/model.py
@@ -477,8 +477,10 @@ class Model(object):
 
         compiled_model_suffix = "-".join(instance_type.split(".")[:-1])
         if self._is_compiled_model:
-            name_prefix = self.name or utils.name_from_image(self.image)
-            self.name = "{}{}".format(name_prefix, compiled_model_suffix)
+            name_prefix = self.name or utils.name_from_image(
+                self.image, max_length=(62 - len(compiled_model_suffix))
+            )
+            self.name = "{}-{}".format(name_prefix, compiled_model_suffix)
 
         self._create_sagemaker_model(instance_type, accelerator_type, tags)
         production_variant = sagemaker.production_variant(

--- a/src/sagemaker/utils.py
+++ b/src/sagemaker/utils.py
@@ -42,7 +42,7 @@ logger = logging.getLogger(__name__)
 
 
 # Use the base name of the image as the job name if the user doesn't give us one
-def name_from_image(image):
+def name_from_image(image, max_length=63):
     """Create a training job name based on the image name and a timestamp.
 
     Args:
@@ -50,9 +50,10 @@ def name_from_image(image):
 
     Returns:
         str: Training job name using the algorithm from the image name and a
-        timestamp.
+            timestamp.
+        max_length (int): Maximum length for the resulting string (default: 63).
     """
-    return name_from_base(base_name_from_image(image))
+    return name_from_base(base_name_from_image(image), max_length=max_length)
 
 
 def name_from_base(base, max_length=63, short=False):
@@ -64,8 +65,8 @@ def name_from_base(base, max_length=63, short=False):
 
     Args:
         base (str): String used as prefix to generate the unique name.
-        max_length (int): Maximum length for the resulting string.
-        short (bool): Whether or not to use a truncated timestamp.
+        max_length (int): Maximum length for the resulting string (default: 63).
+        short (bool): Whether or not to use a truncated timestamp (default: False).
 
     Returns:
         str: Input parameter with appended timestamp.

--- a/tests/unit/sagemaker/model/test_neo.py
+++ b/tests/unit/sagemaker/model/test_neo.py
@@ -210,3 +210,16 @@ def test_check_neo_region(sagemaker_session):
     for partition in boto_session.get_available_partitions():
         for region_name in boto_session.get_available_regions("ec2", partition_name=partition):
             assert (region_name in NEO_REGION_LIST) is model.check_neo_region(region_name)
+
+
+def test_deploy_valid_model_name(sagemaker_session):
+    model = Model(
+        image="long-base-name-that-is-over-the-63-character-limit-for-model-names",
+        model_data=MODEL_DATA,
+        role="role",
+        sagemaker_session=sagemaker_session,
+    )
+    model._is_compiled_model = True
+
+    model.deploy(1, "ml.c4.xlarge")
+    assert len(model.name) <= 63

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -69,6 +69,17 @@ def test_bad_import():
         pd.DataFrame()
 
 
+@patch("sagemaker.utils.name_from_base")
+@patch("sagemaker.utils.base_name_from_image")
+def test_name_from_image(base_name_from_image, name_from_base):
+    image = "image:latest"
+    max_length = 32
+
+    sagemaker.utils.name_from_image(image, max_length=max_length)
+    base_name_from_image.assert_called_with(image)
+    name_from_base.assert_called_with(base_name_from_image.return_value, max_length=max_length)
+
+
 @patch("sagemaker.utils.sagemaker_timestamp")
 def test_name_from_base(sagemaker_timestamp):
     sagemaker.utils.name_from_base(NAME, short=False)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
discovered this from the test failures in #1639 

*Testing done:*
unit tests, linters

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
