### PR TITLE
breaking: deprecate delete_endpoint() for estimators and HyperparameterTuner

### DIFF
--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -116,7 +116,7 @@ Here is an end to end example of how to use a SageMaker Estimator:
     # Deletes the SageMaker model
     mxnet_predictor.delete_model()
 
-The example above will eventually delete both the SageMaker endpoint and endpoint configuration through ``delete_endpoint()``. If you want to keep your SageMaker endpoint configuration, use the value False for the ``delete_endpoint_config`` parameter, as shown below.
+The example above will eventually delete both the SageMaker endpoint and endpoint configuration through ``delete_endpoint()``. If you want to keep your SageMaker endpoint configuration, use the value ``False`` for the ``delete_endpoint_config`` parameter, as shown below.
 
 .. code:: python
 

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -116,7 +116,7 @@ Here is an end to end example of how to use a SageMaker Estimator:
     # Deletes the SageMaker model
     mxnet_predictor.delete_model()
 
-The example above will eventually delete both the SageMaker endpoint and endpoint configuration through `delete_endpoint()`. If you want to keep your SageMaker endpoint configuration, use the value False for the `delete_endpoint_config` parameter, as shown below.
+The example above will eventually delete both the SageMaker endpoint and endpoint configuration through ``delete_endpoint()``. If you want to keep your SageMaker endpoint configuration, use the value False for the ``delete_endpoint_config`` parameter, as shown below.
 
 .. code:: python
 
@@ -180,10 +180,10 @@ Here is an example:
         train_input = algo.sagemaker_session.upload_data(path='/path/to/your/data')
 
         algo.fit({'training': train_input})
-        algo.deploy(1, 'ml.m4.xlarge')
+        predictor = algo.deploy(1, 'ml.m4.xlarge')
 
         # When you are done using your endpoint
-        algo.delete_endpoint()
+        predictor.delete_endpoint()
 
 Use Scripts Stored in a Git Repository
 --------------------------------------
@@ -609,7 +609,7 @@ Here is a basic example of how to use it:
     response = my_predictor.predict(my_prediction_data)
 
     # Tear down the SageMaker endpoint
-    my_tuner.delete_endpoint()
+    my_predictor.delete_endpoint()
 
 This example shows a hyperparameter tuning job that creates up to 100 training jobs, running up to 10 training jobs at a time.
 Each training job's learning rate is a value between 0.05 and 0.06, but this value will differ between training jobs.

--- a/src/sagemaker/estimator.py
+++ b/src/sagemaker/estimator.py
@@ -820,15 +820,6 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):
 
         return init_params
 
-    def delete_endpoint(self):
-        """Delete an Amazon SageMaker ``Endpoint``.
-
-        Raises:
-            botocore.exceptions.ClientError: If the endpoint does not exist.
-        """
-        self._ensure_latest_training_job(error_message="Endpoint was not created yet")
-        self.sagemaker_session.delete_endpoint(self.latest_training_job.name)
-
     def transformer(
         self,
         instance_count,

--- a/src/sagemaker/tuner.py
+++ b/src/sagemaker/tuner.py
@@ -820,18 +820,6 @@ class HyperparameterTuner(object):
                 )
             )
 
-    def delete_endpoint(self, endpoint_name=None):
-        """Delete an Amazon SageMaker endpoint.
-
-        If an endpoint name is not specified, this defaults to looking for an
-        endpoint that shares a name with the best training job for deletion.
-
-        Args:
-            endpoint_name (str): Name of the endpoint to delete
-        """
-        endpoint_name = endpoint_name or self.best_training_job()
-        self.sagemaker_session.delete_endpoint(endpoint_name)
-
     def _ensure_last_tuning_job(self):
         """Placeholder docstring"""
         if self.latest_tuning_job is None:

--- a/tests/integ/test_local_mode.py
+++ b/tests/integ/test_local_mode.py
@@ -151,7 +151,7 @@ def test_mxnet_local_mode(sagemaker_local_session, mxnet_full_version, mxnet_ful
             data = numpy.zeros(shape=(1, 1, 28, 28))
             predictor.predict(data)
         finally:
-            mx.delete_endpoint()
+            predictor.delete_endpoint()
 
 
 @pytest.mark.local_mode
@@ -209,7 +209,7 @@ def test_mxnet_local_data_local_script(mxnet_full_version, mxnet_full_py_version
             data = numpy.zeros(shape=(1, 1, 28, 28))
             predictor.predict(data)
         finally:
-            mx.delete_endpoint()
+            predictor.delete_endpoint()
 
 
 @pytest.mark.local_mode

--- a/tests/integ/test_source_dirs.py
+++ b/tests/integ/test_source_dirs.py
@@ -51,4 +51,4 @@ def test_source_dirs(tmpdir, sagemaker_local_session):
             predict_response = predictor.predict([7])
             assert predict_response == [49]
         finally:
-            estimator.delete_endpoint()
+            predictor.delete_endpoint()

--- a/tests/unit/test_estimator.py
+++ b/tests/unit/test_estimator.py
@@ -636,42 +636,6 @@ def test_start_new_wait_called(strftime, sagemaker_session):
     assert sagemaker_session.wait_for_job.assert_called_once
 
 
-def test_delete_endpoint(sagemaker_session):
-    t = DummyFramework(
-        entry_point=SCRIPT_PATH,
-        role="DummyRole",
-        sagemaker_session=sagemaker_session,
-        train_instance_count=INSTANCE_COUNT,
-        train_instance_type=INSTANCE_TYPE,
-        container_log_level=logging.INFO,
-    )
-
-    class tj(object):
-        @property
-        def name(self):
-            return "myjob"
-
-    t.latest_training_job = tj()
-
-    t.delete_endpoint()
-
-    sagemaker_session.delete_endpoint.assert_called_with("myjob")
-
-
-def test_delete_endpoint_without_endpoint(sagemaker_session):
-    t = DummyFramework(
-        entry_point=SCRIPT_PATH,
-        role="DummyRole",
-        sagemaker_session=sagemaker_session,
-        train_instance_count=INSTANCE_COUNT,
-        train_instance_type=INSTANCE_TYPE,
-    )
-
-    with pytest.raises(ValueError) as error:
-        t.delete_endpoint()
-    assert "Endpoint was not created yet" in str(error)
-
-
 def test_enable_cloudwatch_metrics(sagemaker_session):
     fw = DummyFramework(
         entry_point=SCRIPT_PATH,

--- a/tests/unit/test_tuner.py
+++ b/tests/unit/test_tuner.py
@@ -917,18 +917,6 @@ def test_wait(tuner):
     tuner.estimator.sagemaker_session.wait_for_tuning_job.assert_called_once_with(JOB_NAME)
 
 
-def test_delete_endpoint(tuner):
-    tuner.latest_tuning_job = _TuningJob(tuner.estimator.sagemaker_session, JOB_NAME)
-
-    tuning_job_description = {"BestTrainingJob": {"TrainingJobName": JOB_NAME}}
-    tuner.estimator.sagemaker_session.sagemaker_client.describe_hyper_parameter_tuning_job = Mock(
-        name="describe_hyper_parameter_tuning_job", return_value=tuning_job_description
-    )
-
-    tuner.delete_endpoint()
-    tuner.sagemaker_session.delete_endpoint.assert_called_with(JOB_NAME)
-
-
 def test_fit_no_inputs(tuner, sagemaker_session):
     script_path = os.path.join(DATA_DIR, "mxnet_mnist", "failure_script.py")
     tuner.estimator = MXNet(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This is a direct consequence of #1639 (and why the local mode tests aren't getting properly cleaned up in that PR build).

*Testing done:*
linters

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
