### PR TITLE
infra: add cli modifier for RealTimePredictor and derived classes

### DIFF
--- a/src/sagemaker/cli/compatibility/v2/ast_transformer.py
+++ b/src/sagemaker/cli/compatibility/v2/ast_transformer.py
@@ -18,6 +18,7 @@ import ast
 from sagemaker.cli.compatibility.v2 import modifiers
 
 FUNCTION_CALL_MODIFIERS = [
+    modifiers.predictors.PredictorConstructorRefactor(),
     modifiers.framework_version.FrameworkVersionEnforcer(),
     modifiers.tf_legacy_mode.TensorFlowLegacyModeConstructorUpgrader(),
     modifiers.tf_legacy_mode.TensorBoardParameterRemover(),
@@ -28,7 +29,10 @@ FUNCTION_CALL_MODIFIERS = [
 
 IMPORT_MODIFIERS = [modifiers.tfs.TensorFlowServingImportRenamer()]
 
-IMPORT_FROM_MODIFIERS = [modifiers.tfs.TensorFlowServingImportFromRenamer()]
+IMPORT_FROM_MODIFIERS = [
+    modifiers.predictors.PredictorImportFromRenamer(),
+    modifiers.tfs.TensorFlowServingImportFromRenamer(),
+]
 
 
 class ASTTransformer(ast.NodeTransformer):

--- a/src/sagemaker/cli/compatibility/v2/modifiers/__init__.py
+++ b/src/sagemaker/cli/compatibility/v2/modifiers/__init__.py
@@ -17,6 +17,7 @@ from sagemaker.cli.compatibility.v2.modifiers import (  # noqa: F401 (imported b
     airflow,
     deprecated_params,
     framework_version,
+    predictors,
     tf_legacy_mode,
     tfs,
 )

--- a/tests/unit/sagemaker/cli/compatibility/v2/modifiers/test_predictors.py
+++ b/tests/unit/sagemaker/cli/compatibility/v2/modifiers/test_predictors.py
@@ -1,0 +1,128 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from __future__ import absolute_import
+
+import pasta
+import pytest
+
+from sagemaker.cli.compatibility.v2.modifiers import predictors
+from tests.unit.sagemaker.cli.compatibility.v2.modifiers.ast_converter import ast_call, ast_import
+
+
+@pytest.fixture
+def base_constructors():
+    return (
+        "sagemaker.predictor.RealTimePredictor(endpoint='a')",
+        "sagemaker.RealTimePredictor(endpoint='b')",
+        "RealTimePredictor(endpoint='c')",
+    )
+
+
+@pytest.fixture
+def sparkml_constructors():
+    return (
+        "sagemaker.sparkml.model.SparkMLPredictor(endpoint='a')",
+        "sagemaker.sparkml.SparkMLPredictor(endpoint='b')",
+        "SparkMLPredictor(endpoint='c')",
+    )
+
+
+@pytest.fixture
+def other_constructors():
+    return (
+        "sagemaker.amazon.knn.KNNPredictor(endpoint='a')",
+        "sagemaker.KNNPredictor(endpoint='b')",
+        "KNNPredictor(endpoint='c')",
+    )
+
+
+@pytest.fixture
+def import_statements():
+    return (
+        "from sagemaker.predictor import RealTimePredictor",
+        "from sagemaker import RealTimePredictor",
+    )
+
+
+def test_constructor_node_should_be_modified_base(base_constructors):
+    modifier = predictors.PredictorConstructorRefactor()
+    for constructor in base_constructors:
+        node = ast_call(constructor)
+        assert modifier.node_should_be_modified(node)
+
+
+def test_constructor_node_should_be_modified_sparkml(sparkml_constructors):
+    modifier = predictors.PredictorConstructorRefactor()
+    for constructor in sparkml_constructors:
+        node = ast_call(constructor)
+        assert modifier.node_should_be_modified(node)
+
+
+def test_constructor_node_should_be_modified_other(other_constructors):
+    modifier = predictors.PredictorConstructorRefactor()
+    for constructor in other_constructors:
+        node = ast_call(constructor)
+        assert modifier.node_should_be_modified(node)
+
+
+def test_constructor_node_should_be_modified_random_call():
+    modifier = predictors.PredictorConstructorRefactor()
+    node = ast_call("Model()")
+    assert not modifier.node_should_be_modified(node)
+
+
+def test_constructor_modify_node():
+    modifier = predictors.PredictorConstructorRefactor()
+
+    node = ast_call("sagemaker.RealTimePredictor(endpoint='a')")
+    modifier.modify_node(node)
+    assert "sagemaker.Predictor(endpoint_name='a')" == pasta.dump(node)
+
+    node = ast_call("RealTimePredictor(endpoint='a')")
+    modifier.modify_node(node)
+    assert "Predictor(endpoint_name='a')" == pasta.dump(node)
+
+    node = ast_call("sagemaker.amazon.kmeans.KMeansPredictor(endpoint='a')")
+    modifier.modify_node(node)
+    assert "sagemaker.amazon.kmeans.KMeansPredictor(endpoint_name='a')" == pasta.dump(node)
+
+    node = ast_call("KMeansPredictor(endpoint='a')")
+    modifier.modify_node(node)
+    assert "KMeansPredictor(endpoint_name='a')" == pasta.dump(node)
+
+
+def test_import_from_node_should_be_modified_predictor_module(import_statements):
+    modifier = predictors.PredictorImportFromRenamer()
+    for statement in import_statements:
+        node = ast_import(statement)
+        assert modifier.node_should_be_modified(node)
+
+
+def test_import_from_node_should_be_modified_random_import():
+    modifier = predictors.PredictorImportFromRenamer()
+    node = ast_import("from sagemaker import Session")
+    assert not modifier.node_should_be_modified(node)
+
+
+def test_import_from_modify_node():
+    modifier = predictors.PredictorImportFromRenamer()
+
+    node = ast_import("from sagemaker.predictor import BytesDeserializer, RealTimePredictor")
+    modifier.modify_node(node)
+    expected_result = "from sagemaker.predictor import BytesDeserializer, Predictor"
+    assert expected_result == pasta.dump(node)
+
+    node = ast_import("from sagemaker.predictor import RealTimePredictor as RTP")
+    modifier.modify_node(node)
+    expected_result = "from sagemaker.predictor import Predictor as RTP"
+    assert expected_result == pasta.dump(node)


### PR DESCRIPTION
*Issue #, if available:* #1473 

*Description of changes:*

changes include:

* rename `RealTimePredictor` constructors as `Predictor`
* rename `endpoint` to `endpoint_name` in relevant Predictor base and derived classes
* rename `RealTimePredictor` in imports where appropriate

*Testing done:*

unit

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
