### PR TITLE
infra: refactor matching logic in v2 migration tool

### DIFF
--- a/src/sagemaker/cli/compatibility/v2/ast_transformer.py
+++ b/src/sagemaker/cli/compatibility/v2/ast_transformer.py
@@ -18,12 +18,12 @@ import ast
 from sagemaker.cli.compatibility.v2 import modifiers
 
 FUNCTION_CALL_MODIFIERS = [
-    modifiers.predictors.PredictorConstructorRefactor(),
     modifiers.framework_version.FrameworkVersionEnforcer(),
     modifiers.tf_legacy_mode.TensorFlowLegacyModeConstructorUpgrader(),
     modifiers.tf_legacy_mode.TensorBoardParameterRemover(),
     modifiers.deprecated_params.TensorFlowScriptModeParameterRemover(),
     modifiers.tfs.TensorFlowServingConstructorRenamer(),
+    modifiers.predictors.PredictorConstructorRefactor(),
     modifiers.airflow.ModelConfigArgModifier(),
 ]
 

--- a/src/sagemaker/cli/compatibility/v2/modifiers/airflow.py
+++ b/src/sagemaker/cli/compatibility/v2/modifiers/airflow.py
@@ -15,13 +15,16 @@ from __future__ import absolute_import
 
 import ast
 
+from sagemaker.cli.compatibility.v2.modifiers import matching
 from sagemaker.cli.compatibility.v2.modifiers.modifier import Modifier
+
+FUNCTION_NAMES = ("model_config", "model_config_from_estimator")
+NAMESPACES = ("sagemaker.workflow.airflow", "workflow.airflow", "airflow")
+FUNCTIONS = {name: NAMESPACES for name in FUNCTION_NAMES}
 
 
 class ModelConfigArgModifier(Modifier):
     """A class to handle argument changes for Airflow model config functions."""
-
-    FUNCTION_NAMES = ("model_config", "model_config_from_estimator")
 
     def node_should_be_modified(self, node):
         """Checks if the ``ast.Call`` node creates an Airflow model config and
@@ -44,27 +47,7 @@ class ModelConfigArgModifier(Modifier):
             bool: If the ``ast.Call`` is either a ``model_config`` call or
                 a ``model_config_from_estimator`` call and has positional arguments.
         """
-        return self._is_model_config_call(node) and len(node.args) > 0
-
-    def _is_model_config_call(self, node):
-        """Checks if the node is a ``model_config`` or  ``model_config_from_estimator`` call."""
-        if isinstance(node.func, ast.Name):
-            return node.func.id in self.FUNCTION_NAMES
-
-        if not (isinstance(node.func, ast.Attribute) and node.func.attr in self.FUNCTION_NAMES):
-            return False
-
-        return self._is_in_module(node.func, "sagemaker.workflow.airflow".split("."))
-
-    def _is_in_module(self, node, module):
-        """Checks if the node is in the module, including partial matches to the module path."""
-        if isinstance(node.value, ast.Name):
-            return node.value.id == module[-1]
-
-        if isinstance(node.value, ast.Attribute) and node.value.attr == module[-1]:
-            return self._is_in_module(node.value, module[:-1])
-
-        return False
+        return matching.matches_any(node, FUNCTIONS) and len(node.args) > 0
 
     def modify_node(self, node):
         """Modifies the ``ast.Call`` node's arguments.

--- a/src/sagemaker/cli/compatibility/v2/modifiers/matching.py
+++ b/src/sagemaker/cli/compatibility/v2/modifiers/matching.py
@@ -1,0 +1,103 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+"""Functions for checking AST nodes for matches."""
+from __future__ import absolute_import
+
+import ast
+
+
+def matches_any(node, name_to_namespaces_dict):
+    """Determines if the ``ast.Call`` node matches any of the provided names and namespaces.
+
+    Args:
+        node (ast.Call): a node that represents a function call. For more,
+            see https://docs.python.org/3/library/ast.html#abstract-grammar.
+        name_to_namespaces_dict (dict[str, tuple]): a mapping of names to appropriate namespaces.
+
+    Returns:
+        bool: if the node matches any of the names and namespaces.
+    """
+    return any(
+        matches_name_or_namespaces(node, name, namespaces)
+        for name, namespaces in name_to_namespaces_dict.items()
+    )
+
+
+def matches_name_or_namespaces(node, name, namespaces):
+    """Determines if the ``ast.Call`` node matches the function name in the right namespace.
+
+    Args:
+        node (ast.Call): a node that represents a function call. For more,
+            see https://docs.python.org/3/library/ast.html#abstract-grammar.
+        name (str): the function name.
+        namespaces (tuple): the possible namespaces to match to.
+
+    Returns:
+        bool: if the node matches the name and any of the namespaces.
+    """
+    if matches_name(node, name):
+        return True
+
+    if not matches_attr(node, name):
+        return False
+
+    return any(matches_namespace(node, namespace) for namespace in namespaces)
+
+
+def matches_name(node, name):
+    """Determines if the ``ast.Call`` node points to an ``ast.Name`` node with a matching name.
+
+    Args:
+        node (ast.Call): a node that represents a function call. For more,
+            see https://docs.python.org/3/library/ast.html#abstract-grammar.
+        name (str): the function name.
+
+    Returns:
+        bool: if ``node.func`` is an ``ast.Name`` node with a matching name.
+    """
+    return isinstance(node.func, ast.Name) and node.func.id == name
+
+
+def matches_attr(node, name):
+    """Determines if the ``ast.Call`` node points to an ``ast.Attribute`` node with a matching name.
+
+    Args:
+        node (ast.Call): a node that represents a function call. For more,
+            see https://docs.python.org/3/library/ast.html#abstract-grammar.
+        name (str): the function name.
+
+    Returns:
+        bool: if ``node.func`` is an ``ast.Attribute`` node with a matching name.
+    """
+    return isinstance(node.func, ast.Attribute) and node.func.attr == name
+
+
+def matches_namespace(node, namespace):
+    """Determines if the ``ast.Call`` node corresponds to a matching namespace.
+
+    Args:
+        node (ast.Call): a node that represents a function call. For more,
+            see https://docs.python.org/3/library/ast.html#abstract-grammar.
+        namespace (str): the namespace.
+
+    Returns:
+        bool: if the node's namespaces matches the given namespace.
+    """
+    names = namespace.split(".")
+    name, value = names.pop(), node.func.value
+    while isinstance(value, ast.Attribute) and len(names) > 0:
+        if value.attr != name:
+            return False
+        name, value = names.pop(), value.value
+
+    return isinstance(value, ast.Name) and value.id == name

--- a/tests/unit/sagemaker/cli/compatibility/v2/modifiers/test_matching.py
+++ b/tests/unit/sagemaker/cli/compatibility/v2/modifiers/test_matching.py
@@ -1,0 +1,68 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from __future__ import absolute_import
+
+from sagemaker.cli.compatibility.v2.modifiers import matching
+from tests.unit.sagemaker.cli.compatibility.v2.modifiers.ast_converter import ast_call
+
+
+def test_matches_any():
+    name_to_namespaces_dict = {
+        "KMeansPredictor": ("sagemaker", "sagemaker.amazon.kmeans"),
+        "Predictor": ("sagemaker.tensorflow.serving",),
+    }
+
+    matches = (
+        "KMeansPredictor()",
+        "sagemaker.KMeansPredictor()",
+        "sagemaker.amazon.kmeans.KMeansPredictor()",
+        "Predictor()",
+        "sagemaker.tensorflow.serving.Predictor()",
+    )
+
+    for call in matches:
+        assert matching.matches_any(ast_call(call), name_to_namespaces_dict)
+
+    non_matches = ("MXNet()", "sagemaker.mxnet.MXNet()")
+    for call in non_matches:
+        assert not matching.matches_any(ast_call(call), name_to_namespaces_dict)
+
+
+def test_matches_name_or_namespaces():
+    name = "KMeans"
+    namespaces = ("sagemaker", "sagemaker.amazon.kmeans")
+
+    matches = ("KMeans()", "sagemaker.KMeans()")
+    for call in matches:
+        assert matching.matches_name_or_namespaces(ast_call(call), name, namespaces)
+
+    non_matches = ("MXNet()", "sagemaker.mxnet.MXNet()")
+    for call in non_matches:
+        assert not matching.matches_name_or_namespaces(ast_call(call), name, namespaces)
+
+
+def test_matches_name():
+    assert matching.matches_name(ast_call("KMeans()"), "KMeans")
+    assert not matching.matches_name(ast_call("sagemaker.KMeans()"), "KMeans")
+    assert not matching.matches_name(ast_call("MXNet()"), "KMeans")
+
+
+def test_matches_attr():
+    assert matching.matches_attr(ast_call("sagemaker.amazon.kmeans.KMeans()"), "KMeans")
+    assert not matching.matches_attr(ast_call("KMeans()"), "KMeans")
+    assert not matching.matches_attr(ast_call("sagemaker.mxnet.MXNet()"), "KMeans")
+
+
+def test_matches_namespace():
+    assert matching.matches_namespace(ast_call("sagemaker.mxnet.MXNet()"), "sagemaker.mxnet")
+    assert not matching.matches_namespace(ast_call("sagemaker.KMeans()"), "sagemaker.mxnet")


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/sagemaker-python-sdk/pull/1653#discussion_r447897193

*Description of changes:*
I was about to add another modifier and realized I might as well get this refactoring done so I don't re-implement this logic again.

*Testing done:*
unit tests, linters

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
