### PR TITLE
feature: add Predictor.update_endpoint()

### DIFF
--- a/src/sagemaker/predictor.py
+++ b/src/sagemaker/predictor.py
@@ -172,22 +172,22 @@ class Predictor(object):
 
         This creates a new EndpointConfig in the process. If ``initial_instance_count``,
         ``instance_type``, ``accelerator_type``, or ``model_name`` is specified, then a new
-        ``ProductionVariant`` configuration is created; values from the existing configuration
+        ProductionVariant configuration is created; values from the existing configuration
         are not preserved if any of those parameters are specified.
 
         Args:
             initial_instance_count (int): The initial number of instances to run in the endpoint.
                 This is required if ``instance_type``, ``accelerator_type``, or ``model_name`` is
                 specified. Otherwise, the values from the existing endpoint configuration's
-                ``ProductionVariant``s are used.
+                ProductionVariants are used.
             instance_type (str): The EC2 instance type to deploy the endpoint to.
                 This is required if ``initial_instance_count`` or ``accelerator_type`` is specified.
                 Otherwise, the values from the existing endpoint configuration's
-                ``ProductionVariant``s are used.
+                ``ProductionVariants`` are used.
             accelerator_type (str): The type of Elastic Inference accelerator to attach to
-                the endpoint, e.g. 'ml.eia1.medium'. If not specified, and
+                the endpoint, e.g. "ml.eia1.medium". If not specified, and
                 ``initial_instance_count``, ``instance_type``, and ``model_name`` are also ``None``,
-                the values from the existing endpoint configuration's ``ProductionVariant``s are
+                the values from the existing endpoint configuration's ``ProductionVariants`` are
                 used. Otherwise, no Elastic Inference accelerator is attached to the endpoint.
             model_name (str): The name of the model to be associated with the endpoint.
                 This is required if ``initial_instance_count``, ``instance_type``, or

--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -2333,6 +2333,7 @@ class Session(object):  # pylint: disable=too-many-public-methods
         new_tags=None,
         new_kms_key=None,
         new_data_capture_config_dict=None,
+        new_production_variants=None,
     ):
         """Create an Amazon SageMaker endpoint configuration from an existing one. Updating any
         values that were passed in.
@@ -2346,7 +2347,7 @@ class Session(object):  # pylint: disable=too-many-public-methods
             new_config_name (str): Name of the Amazon SageMaker endpoint configuration to create.
             existing_config_name (str): Name of the existing Amazon SageMaker endpoint
                 configuration.
-            new_tags(List[dict[str, str]]): Optional. The list of tags to add to the endpoint
+            new_tags (list[dict[str, str]]): Optional. The list of tags to add to the endpoint
                 config. If not specified, the tags of the existing endpoint configuration are used.
                 If any of the existing tags are reserved AWS ones (i.e. begin with "aws"),
                 they are not carried over to the new endpoint configuration.
@@ -2357,6 +2358,9 @@ class Session(object):  # pylint: disable=too-many-public-methods
                 capture for use with Amazon SageMaker Model Monitoring (default: None).
                 If not specified, the data capture configuration of the existing
                 endpoint configuration is used.
+            new_production_variants (list[dict]): The configuration for which model(s) to host and
+                the resources to deploy for hosting the model(s). If not specified,
+                the ``ProductionVariants`` of the existing endpoint configuration is used.
 
         Returns:
             str: Name of the endpoint point configuration created.
@@ -2370,8 +2374,11 @@ class Session(object):  # pylint: disable=too-many-public-methods
 
         request = {
             "EndpointConfigName": new_config_name,
-            "ProductionVariants": existing_endpoint_config_desc["ProductionVariants"],
         }
+
+        request["ProductionVariants"] = (
+            new_production_variants or existing_endpoint_config_desc["ProductionVariants"]
+        )
 
         request_tags = new_tags or self.list_tags(
             existing_endpoint_config_desc["EndpointConfigArn"]

--- a/tests/integ/test_inference_pipeline.py
+++ b/tests/integ/test_inference_pipeline.py
@@ -178,6 +178,7 @@ def test_inference_pipeline_model_deploy_and_update_endpoint(
         model = PipelineModel(
             models=[sparkml_model, xgb_model],
             role="SageMakerRole",
+            predictor_cls=Predictor,
             sagemaker_session=sagemaker_session,
         )
         predictor = model.deploy(1, alternative_cpu_instance_type, endpoint_name=endpoint_name)

--- a/tests/integ/test_inference_pipeline.py
+++ b/tests/integ/test_inference_pipeline.py
@@ -29,7 +29,6 @@ from sagemaker.pipeline import PipelineModel
 from sagemaker.predictor import Predictor, json_serializer
 from sagemaker.sparkml.model import SparkMLModel
 from sagemaker.utils import sagemaker_timestamp
-from tests.integ.retry import retries
 
 SPARKML_DATA_PATH = os.path.join(DATA_DIR, "sparkml_model")
 XGBOOST_DATA_PATH = os.path.join(DATA_DIR, "xgboost_model")
@@ -151,7 +150,7 @@ def test_inference_pipeline_model_deploy(sagemaker_session, cpu_instance_type):
         assert "Could not find model" in str(exception.value)
 
 
-def test_inference_pipeline_model_deploy_with_update_endpoint(
+def test_inference_pipeline_model_deploy_and_update_endpoint(
     sagemaker_session, cpu_instance_type, alternative_cpu_instance_type
 ):
     sparkml_data_path = os.path.join(DATA_DIR, "sparkml_model")
@@ -181,24 +180,18 @@ def test_inference_pipeline_model_deploy_with_update_endpoint(
             role="SageMakerRole",
             sagemaker_session=sagemaker_session,
         )
-        model.deploy(1, alternative_cpu_instance_type, endpoint_name=endpoint_name)
-        old_endpoint = sagemaker_session.sagemaker_client.describe_endpoint(
+        predictor = model.deploy(1, alternative_cpu_instance_type, endpoint_name=endpoint_name)
+        endpoint_desc = sagemaker_session.sagemaker_client.describe_endpoint(
             EndpointName=endpoint_name
         )
-        old_config_name = old_endpoint["EndpointConfigName"]
+        old_config_name = endpoint_desc["EndpointConfigName"]
 
-        model.deploy(1, cpu_instance_type, update_endpoint=True, endpoint_name=endpoint_name)
+        predictor.update_endpoint(initial_instance_count=1, instance_type=cpu_instance_type)
 
-        # Wait for endpoint to finish updating
-        # Endpoint update takes ~7min. 40 retries * 30s sleeps = 20min timeout
-        for _ in retries(40, "Waiting for 'InService' endpoint status", seconds_to_sleep=30):
-            new_endpoint = sagemaker_session.sagemaker_client.describe_endpoint(
-                EndpointName=endpoint_name
-            )
-            if new_endpoint["EndpointStatus"] == "InService":
-                break
-
-        new_config_name = new_endpoint["EndpointConfigName"]
+        endpoint_desc = sagemaker_session.sagemaker_client.describe_endpoint(
+            EndpointName=endpoint_name
+        )
+        new_config_name = endpoint_desc["EndpointConfigName"]
         new_config = sagemaker_session.sagemaker_client.describe_endpoint_config(
             EndpointConfigName=new_config_name
         )


### PR DESCRIPTION
*Issue #, if available:*
#1470 

*Description of changes:*
tangentially related to #1470 is to move the endpoint-related methods away from estimators. Deprecating the `update_endpoint` arg in `deploy()` will come in a separate PR.

I chose not to take values from an existing `ProductionVariant` because I thought it would complicate the logic too much. Open to being convinced otherwise.

*Testing done:*
unit tests, linters, the affected integ tests

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
