### PR TITLE
breaking: rename distributions to distribution in TF/MXNet estimators

### DIFF
--- a/doc/frameworks/mxnet/using_mxnet.rst
+++ b/doc/frameworks/mxnet/using_mxnet.rst
@@ -200,7 +200,7 @@ If you want to use parameter servers for distributed training, set the following
 
 .. code:: python
 
-    distributions={'parameter_server': {'enabled': True}}
+    distribution={'parameter_server': {'enabled': True}}
 
 Then, when writing a distributed training script, use an MXNet kvstore to store and share model parameters.
 During training, Amazon SageMaker automatically starts an MXNet kvstore server and scheduler processes on hosts in your training job cluster.

--- a/doc/frameworks/tensorflow/using_tf.rst
+++ b/doc/frameworks/tensorflow/using_tf.rst
@@ -212,12 +212,12 @@ Distributed Training
 
 To run your training job with multiple instances in a distributed fashion, set ``train_instance_count``
 to a number larger than 1. We support two different types of distributed training, parameter server and Horovod.
-The ``distributions`` parameter is used to configure which distributed training strategy to use.
+The ``distribution`` parameter is used to configure which distributed training strategy to use.
 
 Training with parameter servers
 -------------------------------
 
-If you specify parameter_server as the value of the distributions parameter, the container launches a parameter server
+If you specify parameter_server as the value of the distribution parameter, the container launches a parameter server
 thread on each instance in the training cluster, and then executes your training code. You can find more information on
 TensorFlow distributed training at `TensorFlow docs <https://www.tensorflow.org/deploy/distributed>`__.
 To enable parameter server training:
@@ -229,7 +229,7 @@ To enable parameter server training:
   tf_estimator = TensorFlow(entry_point='tf-train.py', role='SageMakerRole',
                             train_instance_count=2, train_instance_type='ml.p2.xlarge',
                             framework_version='1.11', py_version='py3',
-                            distributions={'parameter_server': {'enabled': True}})
+                            distribution={'parameter_server': {'enabled': True}})
   tf_estimator.fit('s3://bucket/path/to/training/data')
 
 Training with Horovod
@@ -241,7 +241,7 @@ You can find more details at `Horovod README <https://github.com/uber/horovod>`_
 The container sets up the MPI environment and executes the ``mpirun`` command, enabling you to run any Horovod
 training script.
 
-Training with ``MPI`` is configured by specifying following fields in ``distributions``:
+Training with ``MPI`` is configured by specifying following fields in ``distribution``:
 
 - ``enabled (bool)``: If set to ``True``, the MPI setup is performed and ``mpirun`` command is executed.
 - ``processes_per_host (int)``: Number of processes MPI should launch on each host. Note, this should not be
@@ -260,7 +260,7 @@ In the below example we create an estimator to launch Horovod distributed traini
     tf_estimator = TensorFlow(entry_point='tf-train.py', role='SageMakerRole',
                               train_instance_count=1, train_instance_type='ml.p3.8xlarge',
                               framework_version='2.1.0', py_version='py3',
-                              distributions={
+                              distribution={
                                   'mpi': {
                                       'enabled': True,
                                       'processes_per_host': 4,

--- a/src/sagemaker/cli/compatibility/v2/ast_transformer.py
+++ b/src/sagemaker/cli/compatibility/v2/ast_transformer.py
@@ -25,6 +25,7 @@ FUNCTION_CALL_MODIFIERS = [
     modifiers.tfs.TensorFlowServingConstructorRenamer(),
     modifiers.predictors.PredictorConstructorRefactor(),
     modifiers.airflow.ModelConfigArgModifier(),
+    modifiers.estimators.DistributionParameterRenamer(),
 ]
 
 IMPORT_MODIFIERS = [modifiers.tfs.TensorFlowServingImportRenamer()]

--- a/src/sagemaker/cli/compatibility/v2/modifiers/__init__.py
+++ b/src/sagemaker/cli/compatibility/v2/modifiers/__init__.py
@@ -16,6 +16,7 @@ from __future__ import absolute_import
 from sagemaker.cli.compatibility.v2.modifiers import (  # noqa: F401 (imported but unused)
     airflow,
     deprecated_params,
+    estimators,
     framework_version,
     predictors,
     tf_legacy_mode,

--- a/src/sagemaker/cli/compatibility/v2/modifiers/estimators.py
+++ b/src/sagemaker/cli/compatibility/v2/modifiers/estimators.py
@@ -1,0 +1,72 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+"""Classes to modify Predictor code to be compatible
+with version 2.0 and later of the SageMaker Python SDK.
+"""
+from __future__ import absolute_import
+
+from sagemaker.cli.compatibility.v2.modifiers import matching
+from sagemaker.cli.compatibility.v2.modifiers.modifier import Modifier
+
+ESTIMATORS_WITH_DISTRIBUTION_PARAM = {
+    "TensorFlow": ("sagemaker.tensorflow", "sagemaker.tensorflow.estimator"),
+    "MXNet": ("sagemaker.mxnet", "sagemaker.mxnet.estimator"),
+}
+
+
+class DistributionParameterRenamer(Modifier):
+    """A class to rename the ``distributions`` attribute in MXNet and TensorFlow estimators."""
+
+    def node_should_be_modified(self, node):
+        """Checks if the ``ast.Call`` node instantiates an MXNet or TensorFlow estimator and
+        contains the ``distributions`` parameter.
+
+        This looks for the following calls:
+
+        - ``<Framework>``
+        - ``sagemaker.<framework>.<Framework>``
+        - ``sagemaker.<framework>.estimator.<Framework>``
+
+        where ``<Framework>`` is either ``TensorFlow`` or ``MXNet``.
+
+        Args:
+            node (ast.Call): a node that represents a function call. For more,
+                see https://docs.python.org/3/library/ast.html#abstract-grammar.
+
+        Returns:
+            bool: If the ``ast.Call`` instantiates an MXNet or TensorFlow estimator with
+                the ``distributions`` parameter.
+        """
+        return matching.matches_any(
+            node, ESTIMATORS_WITH_DISTRIBUTION_PARAM
+        ) and self._has_distribution_arg(node)
+
+    def _has_distribution_arg(self, node):
+        """Checks if the node has the ``distributions`` parameter in its keywords."""
+        for kw in node.keywords:
+            if kw.arg == "distributions":
+                return True
+
+        return False
+
+    def modify_node(self, node):
+        """Modifies the ``ast.Call`` node to rename the ``distributions`` attribute to
+        ``distribution``.
+
+        Args:
+            node (ast.Call): a node that represents an MXNet or TensorFlow constructor.
+        """
+        for kw in node.keywords:
+            if kw.arg == "distributions":
+                kw.arg = "distribution"
+                break

--- a/src/sagemaker/fw_utils.py
+++ b/src/sagemaker/fw_utils.py
@@ -599,7 +599,7 @@ def later_framework_version_warning(latest_version):
     return LATER_FRAMEWORK_VERSION_WARNING.format(latest=latest_version)
 
 
-def warn_if_parameter_server_with_multi_gpu(training_instance_type, distributions):
+def warn_if_parameter_server_with_multi_gpu(training_instance_type, distribution):
     """Warn the user that training will not fully leverage all the GPU
     cores if parameter server is enabled and a multi-GPU instance is selected.
     Distributed training with the default parameter server setup doesn't
@@ -607,7 +607,7 @@ def warn_if_parameter_server_with_multi_gpu(training_instance_type, distribution
 
     Args:
         training_instance_type (str): A string representing the type of training instance selected.
-        distributions (dict): A dictionary with information to enable distributed training.
+        distribution (dict): A dictionary with information to enable distributed training.
             (Defaults to None if distributed training is not enabled.) For example:
 
             .. code:: python
@@ -621,7 +621,7 @@ def warn_if_parameter_server_with_multi_gpu(training_instance_type, distribution
 
 
     """
-    if training_instance_type == "local" or distributions is None:
+    if training_instance_type == "local" or distribution is None:
         return
 
     is_multi_gpu_instance = (
@@ -629,7 +629,7 @@ def warn_if_parameter_server_with_multi_gpu(training_instance_type, distribution
         or training_instance_type.split(".")[1].startswith("p")
     ) and training_instance_type not in SINGLE_GPU_INSTANCE_TYPES
 
-    ps_enabled = "parameter_server" in distributions and distributions["parameter_server"].get(
+    ps_enabled = "parameter_server" in distribution and distribution["parameter_server"].get(
         "enabled", False
     )
 

--- a/src/sagemaker/mxnet/estimator.py
+++ b/src/sagemaker/mxnet/estimator.py
@@ -21,7 +21,6 @@ from sagemaker.fw_utils import (
     framework_version_from_tag,
     is_version_equal_or_higher,
     python_deprecation_warning,
-    parameter_v2_rename_warning,
     validate_version_or_image_args,
     warn_if_parameter_server_with_multi_gpu,
 )
@@ -46,7 +45,7 @@ class MXNet(Framework):
         source_dir=None,
         hyperparameters=None,
         image_name=None,
-        distributions=None,
+        distribution=None,
         **kwargs
     ):
         """This ``Estimator`` executes an MXNet script in a managed MXNet
@@ -100,7 +99,7 @@ class MXNet(Framework):
                 If ``framework_version`` or ``py_version`` are ``None``, then
                 ``image_name`` is required. If also ``None``, then a ``ValueError``
                 will be raised.
-            distributions (dict): A dictionary with information on how to run distributed
+            distribution (dict): A dictionary with information on how to run distributed
                 training (default: None). To have parameter servers launched for training,
                 set this value to be ``{'parameter_server': {'enabled': True}}``.
             **kwargs: Additional kwargs passed to the
@@ -131,21 +130,20 @@ class MXNet(Framework):
             entry_point, source_dir, hyperparameters, image_name=image_name, **kwargs
         )
 
-        if distributions is not None:
-            logger.warning(parameter_v2_rename_warning("distributions", "distribution"))
+        if distribution is not None:
             train_instance_type = kwargs.get("train_instance_type")
             warn_if_parameter_server_with_multi_gpu(
-                training_instance_type=train_instance_type, distributions=distributions
+                training_instance_type=train_instance_type, distribution=distribution
             )
 
-        self._configure_distribution(distributions)
+        self._configure_distribution(distribution)
 
-    def _configure_distribution(self, distributions):
+    def _configure_distribution(self, distribution):
         """
         Args:
-            distributions:
+            distribution:
         """
-        if distributions is None:
+        if distribution is None:
             return
 
         if (
@@ -153,13 +151,13 @@ class MXNet(Framework):
             and self.framework_version.split(".") < self._LOWEST_SCRIPT_MODE_VERSION
         ):
             raise ValueError(
-                "The distributions option is valid for only versions {} and higher".format(
+                "The distribution option is valid for only versions {} and higher".format(
                     ".".join(self._LOWEST_SCRIPT_MODE_VERSION)
                 )
             )
 
-        if "parameter_server" in distributions:
-            enabled = distributions["parameter_server"].get("enabled", False)
+        if "parameter_server" in distribution:
+            enabled = distribution["parameter_server"].get("enabled", False)
             self._hyperparameters[self.LAUNCH_PS_ENV_NAME] = enabled
 
     def create_model(

--- a/src/sagemaker/tensorflow/estimator.py
+++ b/src/sagemaker/tensorflow/estimator.py
@@ -45,7 +45,7 @@ class TensorFlow(Framework):
         framework_version=None,
         model_dir=None,
         image_name=None,
-        distributions=None,
+        distribution=None,
         **kwargs
     ):
         """Initialize a ``TensorFlow`` estimator.
@@ -81,7 +81,7 @@ class TensorFlow(Framework):
                 If ``framework_version`` or ``py_version`` are ``None``, then
                 ``image_name`` is required. If also ``None``, then a ``ValueError``
                 will be raised.
-            distributions (dict): A dictionary with information on how to run distributed training
+            distribution (dict): A dictionary with information on how to run distributed training
                 (default: None). Currently we support distributed training with parameter servers
                 and MPI.
                 To enable parameter server use the following setup:
@@ -122,11 +122,10 @@ class TensorFlow(Framework):
         self.framework_version = framework_version
         self.py_version = py_version
 
-        if distributions is not None:
-            logger.warning(fw.parameter_v2_rename_warning("distribution", distributions))
+        if distribution is not None:
             train_instance_type = kwargs.get("train_instance_type")
             fw.warn_if_parameter_server_with_multi_gpu(
-                training_instance_type=train_instance_type, distributions=distributions
+                training_instance_type=train_instance_type, distribution=distribution
             )
 
         if "enable_sagemaker_metrics" not in kwargs:
@@ -137,7 +136,7 @@ class TensorFlow(Framework):
         super(TensorFlow, self).__init__(image_name=image_name, **kwargs)
 
         self.model_dir = model_dir
-        self.distributions = distributions or {}
+        self.distribution = distribution or {}
 
         self._validate_args(py_version=py_version)
 
@@ -295,13 +294,13 @@ class TensorFlow(Framework):
         hyperparameters = super(TensorFlow, self).hyperparameters()
         additional_hyperparameters = {}
 
-        if "parameter_server" in self.distributions:
-            ps_enabled = self.distributions["parameter_server"].get("enabled", False)
+        if "parameter_server" in self.distribution:
+            ps_enabled = self.distribution["parameter_server"].get("enabled", False)
             additional_hyperparameters[self.LAUNCH_PS_ENV_NAME] = ps_enabled
 
         mpi_enabled = False
-        if "mpi" in self.distributions:
-            mpi_dict = self.distributions["mpi"]
+        if "mpi" in self.distribution:
+            mpi_dict = self.distribution["mpi"]
             mpi_enabled = mpi_dict.get("enabled", False)
             additional_hyperparameters[self.LAUNCH_MPI_ENV_NAME] = mpi_enabled
 
@@ -338,7 +337,7 @@ class TensorFlow(Framework):
 
         Else, set default HookConfig
         """
-        ps_enabled = "parameter_server" in self.distributions and self.distributions[
+        ps_enabled = "parameter_server" in self.distribution and self.distribution[
             "parameter_server"
         ].get("enabled", False)
         if ps_enabled:

--- a/tests/integ/test_horovod.py
+++ b/tests/integ/test_horovod.py
@@ -82,7 +82,7 @@ def test_horovod_local_mode(
         output_path=output_path,
         framework_version=tf_training_latest_version,
         py_version=tf_training_latest_py_version,
-        distributions={"mpi": {"enabled": True, "processes_per_host": processes}},
+        distribution={"mpi": {"enabled": True, "processes_per_host": processes}},
     )
 
     with timeout.timeout(minutes=integ.TRAINING_DEFAULT_TIMEOUT_MINUTES):
@@ -128,7 +128,7 @@ def _create_and_fit_estimator(sagemaker_session, tf_version, py_version, instanc
         sagemaker_session=sagemaker_session,
         py_version=py_version,
         framework_version=tf_version,
-        distributions={"mpi": {"enabled": True}},
+        distribution={"mpi": {"enabled": True}},
     )
 
     with timeout.timeout(minutes=integ.TRAINING_DEFAULT_TIMEOUT_MINUTES):

--- a/tests/integ/test_local_mode.py
+++ b/tests/integ/test_local_mode.py
@@ -169,7 +169,7 @@ def test_mxnet_distributed_local_mode(
         train_instance_type="local",
         sagemaker_session=sagemaker_local_session,
         framework_version=mxnet_full_version,
-        distributions={"parameter_server": {"enabled": True}},
+        distribution={"parameter_server": {"enabled": True}},
     )
 
     train_input = mx.sagemaker_session.upload_data(

--- a/tests/integ/test_mxnet_train.py
+++ b/tests/integ/test_mxnet_train.py
@@ -300,7 +300,7 @@ def test_async_fit(sagemaker_session, mxnet_full_version, mxnet_full_py_version,
             train_instance_type=cpu_instance_type,
             sagemaker_session=sagemaker_session,
             framework_version=mxnet_full_version,
-            distributions={"parameter_server": {"enabled": True}},
+            distribution={"parameter_server": {"enabled": True}},
         )
 
         train_input = mx.sagemaker_session.upload_data(

--- a/tests/integ/test_tf.py
+++ b/tests/integ/test_tf.py
@@ -134,7 +134,7 @@ def test_mnist_distributed(
         sagemaker_session=sagemaker_session,
         framework_version=tf_training_latest_version,
         py_version=tf_training_latest_py_version,
-        distributions=PARAMETER_SERVER_DISTRIBUTION,
+        distribution=PARAMETER_SERVER_DISTRIBUTION,
     )
     inputs = estimator.sagemaker_session.upload_data(
         path=os.path.join(MNIST_RESOURCE_PATH, "data"), key_prefix="scriptmode/distributed_mnist"

--- a/tests/unit/sagemaker/cli/compatibility/v2/modifiers/test_distribution.py
+++ b/tests/unit/sagemaker/cli/compatibility/v2/modifiers/test_distribution.py
@@ -1,0 +1,64 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from __future__ import absolute_import
+
+import pasta
+
+from sagemaker.cli.compatibility.v2.modifiers import estimators
+from tests.unit.sagemaker.cli.compatibility.v2.modifiers.ast_converter import ast_call
+
+
+def test_node_should_be_modified():
+    constructors = (
+        "TensorFlow(distributions={})",
+        "sagemaker.tensorflow.TensorFlow(distributions={})",
+        "sagemaker.tensorflow.estimator.TensorFlow(distributions={})",
+        "MXNet(distributions={})",
+        "sagemaker.mxnet.MXNet(distributions={})",
+        "sagemaker.mxnet.estimator.MXNet(distributions={})",
+    )
+
+    modifier = estimators.DistributionParameterRenamer()
+
+    for call in constructors:
+        assert modifier.node_should_be_modified(ast_call(call))
+
+
+def test_node_should_be_modified_no_distribution():
+    constructors = (
+        "TensorFlow()",
+        "sagemaker.tensorflow.TensorFlow()",
+        "sagemaker.tensorflow.estimator.TensorFlow()",
+        "MXNet()",
+        "sagemaker.mxnet.MXNet()",
+        "sagemaker.mxnet.estimator.MXNet()",
+    )
+
+    modifier = estimators.DistributionParameterRenamer()
+
+    for call in constructors:
+        assert not modifier.node_should_be_modified(ast_call(call))
+
+
+def test_node_should_be_modified_random_function_call():
+    modifier = estimators.DistributionParameterRenamer()
+    assert not modifier.node_should_be_modified(ast_call("Session()"))
+
+
+def test_modify_node():
+    node = ast_call("TensorFlow(distributions={'parameter_server': {'enabled': True}})")
+    modifier = estimators.DistributionParameterRenamer()
+    modifier.modify_node(node)
+
+    expected = "TensorFlow(distribution={'parameter_server': {'enabled': True}})"
+    assert expected == pasta.dump(node)

--- a/tests/unit/sagemaker/tensorflow/test_estimator.py
+++ b/tests/unit/sagemaker/tensorflow/test_estimator.py
@@ -38,7 +38,7 @@ REGION = "us-west-2"
 IMAGE_URI_FORMAT_STRING = (
     "520713654638.dkr.ecr.{}.amazonaws.com/sagemaker-tensorflow-scriptmode:{}-cpu-{}"
 )
-DISTRIBUTION_ENABLED = {"parameter_server": {"enabled": True}}
+DISTRIBUTION_PS_ENABLED = {"parameter_server": {"enabled": True}}
 DISTRIBUTION_MPI_ENABLED = {
     "mpi": {"enabled": True, "custom_mpi_options": "options", "processes_per_host": 2}
 }
@@ -451,7 +451,7 @@ def test_fit_ps(time, strftime, sagemaker_session):
         train_instance_type=INSTANCE_TYPE,
         train_instance_count=1,
         source_dir=DATA_DIR,
-        distributions=DISTRIBUTION_ENABLED,
+        distribution=DISTRIBUTION_PS_ENABLED,
     )
 
     inputs = "s3://mybucket/train"
@@ -481,7 +481,7 @@ def test_fit_mpi(time, strftime, sagemaker_session):
         train_instance_type=INSTANCE_TYPE,
         train_instance_count=1,
         source_dir=DATA_DIR,
-        distributions=DISTRIBUTION_MPI_ENABLED,
+        distribution=DISTRIBUTION_MPI_ENABLED,
     )
 
     inputs = "s3://mybucket/train"

--- a/tests/unit/test_fw_utils.py
+++ b/tests/unit/test_fw_utils.py
@@ -1266,20 +1266,20 @@ def test_region_supports_debugger_feature_returns_false_for_unsupported_regions(
 
 def test_warn_if_parameter_server_with_multi_gpu(caplog):
     train_instance_type = "ml.p2.8xlarge"
-    distributions = {"parameter_server": {"enabled": True}}
+    distribution = {"parameter_server": {"enabled": True}}
 
     fw_utils.warn_if_parameter_server_with_multi_gpu(
-        training_instance_type=train_instance_type, distributions=distributions
+        training_instance_type=train_instance_type, distribution=distribution
     )
     assert fw_utils.PARAMETER_SERVER_MULTI_GPU_WARNING in caplog.text
 
 
 def test_warn_if_parameter_server_with_local_multi_gpu(caplog):
     train_instance_type = "local_gpu"
-    distributions = {"parameter_server": {"enabled": True}}
+    distribution = {"parameter_server": {"enabled": True}}
 
     fw_utils.warn_if_parameter_server_with_multi_gpu(
-        training_instance_type=train_instance_type, distributions=distributions
+        training_instance_type=train_instance_type, distribution=distribution
     )
     assert fw_utils.PARAMETER_SERVER_MULTI_GPU_WARNING in caplog.text
 

--- a/tests/unit/test_mxnet.py
+++ b/tests/unit/test_mxnet.py
@@ -45,7 +45,7 @@ REGION = "us-west-2"
 GPU = "ml.p2.xlarge"
 CPU = "ml.c4.xlarge"
 CPU_C5 = "ml.c5.xlarge"
-LAUNCH_PS_DISTRIBUTIONS_DICT = {"parameter_server": {"enabled": True}}
+LAUNCH_PS_DISTRIBUTION_DICT = {"parameter_server": {"enabled": True}}
 
 ENDPOINT_DESC = {"EndpointConfigName": "test-endpoint"}
 
@@ -669,22 +669,6 @@ def test_attach_custom_image(sagemaker_session):
     assert estimator.train_image() == training_image
 
 
-@patch("sagemaker.mxnet.estimator.parameter_v2_rename_warning")
-def test_estimator_script_mode_launch_parameter_server(warning, sagemaker_session):
-    mx = MXNet(
-        entry_point=SCRIPT_PATH,
-        framework_version="1.3.0",
-        py_version="py2",
-        role=ROLE,
-        sagemaker_session=sagemaker_session,
-        train_instance_count=INSTANCE_COUNT,
-        train_instance_type=INSTANCE_TYPE,
-        distributions=LAUNCH_PS_DISTRIBUTIONS_DICT,
-    )
-    assert mx.hyperparameters().get(MXNet.LAUNCH_PS_ENV_NAME) == "true"
-    warning.assert_called_with("distributions", "distribution")
-
-
 def test_estimator_script_mode_dont_launch_parameter_server(sagemaker_session):
     mx = MXNet(
         entry_point=SCRIPT_PATH,
@@ -694,7 +678,7 @@ def test_estimator_script_mode_dont_launch_parameter_server(sagemaker_session):
         sagemaker_session=sagemaker_session,
         train_instance_count=INSTANCE_COUNT,
         train_instance_type=INSTANCE_TYPE,
-        distributions={"parameter_server": {"enabled": False}},
+        distribution={"parameter_server": {"enabled": False}},
     )
     assert mx.hyperparameters().get(MXNet.LAUNCH_PS_ENV_NAME) == "false"
 
@@ -709,9 +693,9 @@ def test_estimator_wrong_version_launch_parameter_server(sagemaker_session):
             sagemaker_session=sagemaker_session,
             train_instance_count=INSTANCE_COUNT,
             train_instance_type=INSTANCE_TYPE,
-            distributions=LAUNCH_PS_DISTRIBUTIONS_DICT,
+            distribution=LAUNCH_PS_DISTRIBUTION_DICT,
         )
-    assert "The distributions option is valid for only versions 1.3 and higher" in str(e)
+    assert "The distribution option is valid for only versions 1.3 and higher" in str(e)
 
 
 @patch("sagemaker.mxnet.estimator.python_deprecation_warning")


### PR DESCRIPTION
*Issue #, if available:*
#1473

*Description of changes:*
This was a typo that wasn't caught until after a couple releases, so the consensus was to wait until other breaking changes to fix this.

*Testing done:*
unit tests, linters

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
