### PR TITLE
breaking: rename session parameter to sagemaker_session in S3 utilities

### DIFF
--- a/src/sagemaker/estimator.py
+++ b/src/sagemaker/estimator.py
@@ -404,7 +404,7 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):
                         s3_uri = S3Uploader.upload(
                             local_path=rule.rule_parameters["source_s3_uri"],
                             desired_s3_uri=desired_s3_uri,
-                            session=self.sagemaker_session,
+                            sagemaker_session=self.sagemaker_session,
                         )
                         rule.rule_parameters["source_s3_uri"] = s3_uri
                 # Save the request dictionary for the rule.

--- a/src/sagemaker/model_monitor/model_monitoring.py
+++ b/src/sagemaker/model_monitor/model_monitoring.py
@@ -871,7 +871,7 @@ class ModelMonitor(object):
                     S3Uploader.upload(
                         local_path=file_input.source,
                         desired_s3_uri=s3_uri,
-                        session=self.sagemaker_session,
+                        sagemaker_session=self.sagemaker_session,
                     )
                     file_input.source = s3_uri
                 normalized_inputs.append(file_input)
@@ -944,7 +944,7 @@ class ModelMonitor(object):
                 str(uuid.uuid4()),
             )
             S3Uploader.upload(
-                local_path=path, desired_s3_uri=s3_uri, session=self.sagemaker_session
+                local_path=path, desired_s3_uri=s3_uri, sagemaker_session=self.sagemaker_session
             )
             path = os.path.join(s3_uri, os.path.basename(path))
         return path
@@ -1771,7 +1771,7 @@ class DefaultModelMonitor(ModelMonitor):
                 name,
             )
             S3Uploader.upload(
-                local_path=source, desired_s3_uri=s3_uri, session=self.sagemaker_session
+                local_path=source, desired_s3_uri=s3_uri, sagemaker_session=self.sagemaker_session
             )
             source = s3_uri
 

--- a/src/sagemaker/model_monitor/monitoring_files.py
+++ b/src/sagemaker/model_monitor/monitoring_files.py
@@ -72,7 +72,7 @@ class ModelMonitoringFile(object):
             body=json.dumps(self.body_dict),
             desired_s3_uri=self.file_s3_uri,
             kms_key=self.kms_key,
-            session=self.session,
+            sagemaker_session=self.session,
         )
 
 
@@ -119,7 +119,9 @@ class Statistics(ModelMonitoringFile):
         """
         try:
             body_dict = json.loads(
-                S3Downloader.read_file(s3_uri=statistics_file_s3_uri, session=sagemaker_session)
+                S3Downloader.read_file(
+                    s3_uri=statistics_file_s3_uri, sagemaker_session=sagemaker_session
+                )
             )
         except ClientError as error:
             print(
@@ -163,7 +165,7 @@ class Statistics(ModelMonitoringFile):
             body=statistics_file_string,
             desired_s3_uri=desired_s3_uri,
             kms_key=kms_key,
-            session=sagemaker_session,
+            sagemaker_session=sagemaker_session,
         )
 
         return Statistics.from_s3_uri(
@@ -243,7 +245,9 @@ class Constraints(ModelMonitoringFile):
         """
         try:
             body_dict = json.loads(
-                S3Downloader.read_file(s3_uri=constraints_file_s3_uri, session=sagemaker_session)
+                S3Downloader.read_file(
+                    s3_uri=constraints_file_s3_uri, sagemaker_session=sagemaker_session
+                )
             )
         except ClientError as error:
             print(
@@ -290,7 +294,7 @@ class Constraints(ModelMonitoringFile):
             body=constraints_file_string,
             desired_s3_uri=desired_s3_uri,
             kms_key=kms_key,
-            session=sagemaker_session,
+            sagemaker_session=sagemaker_session,
         )
 
         return Constraints.from_s3_uri(
@@ -396,7 +400,7 @@ class ConstraintViolations(ModelMonitoringFile):
         try:
             body_dict = json.loads(
                 S3Downloader.read_file(
-                    s3_uri=constraint_violations_file_s3_uri, session=sagemaker_session
+                    s3_uri=constraint_violations_file_s3_uri, sagemaker_session=sagemaker_session
                 )
             )
         except ClientError as error:
@@ -445,7 +449,7 @@ class ConstraintViolations(ModelMonitoringFile):
             body=constraint_violations_file_string,
             desired_s3_uri=desired_s3_uri,
             kms_key=kms_key,
-            session=sagemaker_session,
+            sagemaker_session=sagemaker_session,
         )
 
         return ConstraintViolations.from_s3_uri(

--- a/src/sagemaker/processing.py
+++ b/src/sagemaker/processing.py
@@ -222,7 +222,7 @@ class Processor(object):
                     s3_uri = S3Uploader.upload(
                         local_path=file_input.source,
                         desired_s3_uri=desired_s3_uri,
-                        session=self.sagemaker_session,
+                        sagemaker_session=self.sagemaker_session,
                     )
                     file_input.source = s3_uri
                 normalized_inputs.append(file_input)
@@ -480,7 +480,7 @@ class ScriptProcessor(Processor):
             self._CODE_CONTAINER_INPUT_NAME,
         )
         return S3Uploader.upload(
-            local_path=code, desired_s3_uri=desired_s3_uri, session=self.sagemaker_session
+            local_path=code, desired_s3_uri=desired_s3_uri, sagemaker_session=self.sagemaker_session
         )
 
     def _convert_code_and_add_to_inputs(self, inputs, s3_uri):

--- a/src/sagemaker/s3.py
+++ b/src/sagemaker/s3.py
@@ -20,19 +20,6 @@ from sagemaker.session import Session
 
 logger = logging.getLogger("sagemaker")
 
-SESSION_V2_RENAME_MESSAGE = (
-    "Parameter 'session' will be renamed to 'sagemaker_session' in SageMaker Python SDK v2."
-)
-
-
-def _session_v2_rename_warning(session):
-    """
-    Args:
-        session (sagemaker.session.Session):
-    """
-    if session is not None:
-        logger.warning(SESSION_V2_RENAME_MESSAGE)
-
 
 def parse_s3_url(url):
     """Returns an (s3 bucket, key name/prefix) tuple from a url with an s3
@@ -53,7 +40,7 @@ class S3Uploader(object):
     """Contains static methods for uploading directories or files to S3."""
 
     @staticmethod
-    def upload(local_path, desired_s3_uri, kms_key=None, session=None):
+    def upload(local_path, desired_s3_uri, kms_key=None, sagemaker_session=None):
         """Static method that uploads a given file or directory to S3.
 
         Args:
@@ -61,7 +48,7 @@ class S3Uploader(object):
             desired_s3_uri (str): The desired S3 location to upload to. It is the prefix to
                 which the local filename will be added.
             kms_key (str): The KMS key to use to encrypt the files.
-            session (sagemaker.session.Session): Session object which
+            sagemaker_session (sagemaker.session.Session): Session object which
                 manages interactions with Amazon SageMaker APIs and any other
                 AWS services needed. If not specified, the estimator creates one
                 using the default AWS configuration chain.
@@ -70,10 +57,7 @@ class S3Uploader(object):
             The S3 uri of the uploaded file(s).
 
         """
-        if session is not None:
-            _session_v2_rename_warning(session)
-
-        sagemaker_session = session or Session()
+        sagemaker_session = sagemaker_session or Session()
         bucket, key_prefix = parse_s3_url(url=desired_s3_uri)
         if kms_key is not None:
             extra_args = {"SSEKMSKeyId": kms_key}
@@ -85,24 +69,23 @@ class S3Uploader(object):
         )
 
     @staticmethod
-    def upload_string_as_file_body(body, desired_s3_uri=None, kms_key=None, session=None):
+    def upload_string_as_file_body(body, desired_s3_uri=None, kms_key=None, sagemaker_session=None):
         """Static method that uploads a given file or directory to S3.
 
         Args:
             body (str): String representing the body of the file.
             desired_s3_uri (str): The desired S3 uri to upload to.
             kms_key (str): The KMS key to use to encrypt the files.
-            session (sagemaker.session.Session): AWS session to use. Automatically
-                generates one if not provided.
+            sagemaker_session (sagemaker.session.Session): Session object which
+                manages interactions with Amazon SageMaker APIs and any other
+                AWS services needed. If not specified, the estimator creates one
+                using the default AWS configuration chain.
 
         Returns:
             str: The S3 uri of the uploaded file(s).
 
         """
-        if session is not None:
-            _session_v2_rename_warning(session)
-
-        sagemaker_session = session or Session()
+        sagemaker_session = sagemaker_session or Session()
         bucket, key = parse_s3_url(desired_s3_uri)
 
         sagemaker_session.upload_string_as_file_body(
@@ -116,23 +99,19 @@ class S3Downloader(object):
     """Contains static methods for downloading directories or files from S3."""
 
     @staticmethod
-    def download(s3_uri, local_path, kms_key=None, session=None):
+    def download(s3_uri, local_path, kms_key=None, sagemaker_session=None):
         """Static method that downloads a given S3 uri to the local machine.
 
         Args:
             s3_uri (str): An S3 uri to download from.
             local_path (str): A local path to download the file(s) to.
             kms_key (str): The KMS key to use to decrypt the files.
-            session (sagemaker.session.Session): Session object which
+            sagemaker_session (sagemaker.session.Session): Session object which
                 manages interactions with Amazon SageMaker APIs and any other
                 AWS services needed. If not specified, the estimator creates one
                 using the default AWS configuration chain.
-
         """
-        if session is not None:
-            _session_v2_rename_warning(session)
-
-        sagemaker_session = session or Session()
+        sagemaker_session = sagemaker_session or Session()
         bucket, key_prefix = parse_s3_url(url=s3_uri)
         if kms_key is not None:
             extra_args = {"SSECustomerKey": kms_key}
@@ -144,43 +123,39 @@ class S3Downloader(object):
         )
 
     @staticmethod
-    def read_file(s3_uri, session=None):
+    def read_file(s3_uri, sagemaker_session=None):
         """Static method that returns the contents of an s3 uri file body as a string.
 
         Args:
             s3_uri (str): An S3 uri that refers to a single file.
-            session (sagemaker.session.Session): AWS session to use. Automatically
-                generates one if not provided.
+            sagemaker_session (sagemaker.session.Session): Session object which
+                manages interactions with Amazon SageMaker APIs and any other
+                AWS services needed. If not specified, the estimator creates one
+                using the default AWS configuration chain.
 
         Returns:
             str: The body of the file.
-
         """
-        if session is not None:
-            _session_v2_rename_warning(session)
-
-        sagemaker_session = session or Session()
+        sagemaker_session = sagemaker_session or Session()
         bucket, key_prefix = parse_s3_url(url=s3_uri)
 
         return sagemaker_session.read_s3_file(bucket=bucket, key_prefix=key_prefix)
 
     @staticmethod
-    def list(s3_uri, session=None):
+    def list(s3_uri, sagemaker_session=None):
         """Static method that lists the contents of an S3 uri.
 
         Args:
             s3_uri (str): The S3 base uri to list objects in.
-            session (sagemaker.session.Session): AWS session to use. Automatically
-                generates one if not provided.
+            sagemaker_session (sagemaker.session.Session): Session object which
+                manages interactions with Amazon SageMaker APIs and any other
+                AWS services needed. If not specified, the estimator creates one
+                using the default AWS configuration chain.
 
         Returns:
             [str]: The list of S3 URIs in the given S3 base uri.
-
         """
-        if session is not None:
-            _session_v2_rename_warning(session)
-
-        sagemaker_session = session or Session()
+        sagemaker_session = sagemaker_session or Session()
         bucket, key_prefix = parse_s3_url(url=s3_uri)
 
         file_keys = sagemaker_session.list_s3_files(bucket=bucket, key_prefix=key_prefix)

--- a/tests/integ/test_model_monitor.py
+++ b/tests/integ/test_model_monitor.py
@@ -1509,7 +1509,7 @@ def test_default_monitor_monitoring_execution_interactions(
     desired_s3_uri = os.path.join(executions[-1].output.destination, file_name)
 
     S3Uploader.upload_string_as_file_body(
-        body=file_body, desired_s3_uri=desired_s3_uri, session=sagemaker_session
+        body=file_body, desired_s3_uri=desired_s3_uri, sagemaker_session=sagemaker_session
     )
 
     statistics = my_attached_monitor.latest_monitoring_statistics()
@@ -1522,7 +1522,7 @@ def test_default_monitor_monitoring_execution_interactions(
     desired_s3_uri = os.path.join(executions[-1].output.destination, file_name)
 
     S3Uploader.upload_string_as_file_body(
-        body=file_body, desired_s3_uri=desired_s3_uri, session=sagemaker_session
+        body=file_body, desired_s3_uri=desired_s3_uri, sagemaker_session=sagemaker_session
     )
 
     constraint_violations = my_attached_monitor.latest_monitoring_constraint_violations()
@@ -2473,7 +2473,7 @@ def test_byoc_monitor_monitoring_execution_interactions(
     desired_s3_uri = os.path.join(executions[-1].output.destination, file_name)
 
     S3Uploader.upload_string_as_file_body(
-        body=file_body, desired_s3_uri=desired_s3_uri, session=sagemaker_session
+        body=file_body, desired_s3_uri=desired_s3_uri, sagemaker_session=sagemaker_session
     )
 
     statistics = my_attached_monitor.latest_monitoring_statistics()
@@ -2486,7 +2486,7 @@ def test_byoc_monitor_monitoring_execution_interactions(
     desired_s3_uri = os.path.join(executions[-1].output.destination, file_name)
 
     S3Uploader.upload_string_as_file_body(
-        body=file_body, desired_s3_uri=desired_s3_uri, session=sagemaker_session
+        body=file_body, desired_s3_uri=desired_s3_uri, sagemaker_session=sagemaker_session
     )
 
     constraint_violations = my_attached_monitor.latest_monitoring_constraint_violations()
@@ -2557,10 +2557,10 @@ def _upload_captured_data_to_endpoint(sagemaker_session, predictor):
     S3Uploader.upload(
         local_path=os.path.join(DATA_DIR, "monitor/captured-data.jsonl"),
         desired_s3_uri=s3_uri_previous_hour,
-        session=sagemaker_session,
+        sagemaker_session=sagemaker_session,
     )
     S3Uploader.upload(
         local_path=os.path.join(DATA_DIR, "monitor/captured-data.jsonl"),
         desired_s3_uri=s3_uri_current_hour,
-        session=sagemaker_session,
+        sagemaker_session=sagemaker_session,
     )

--- a/tests/integ/test_monitoring_files.py
+++ b/tests/integ/test_monitoring_files.py
@@ -108,7 +108,7 @@ def test_statistics_object_creation_from_s3_uri_with_customizations(
         body=file_body,
         desired_s3_uri=desired_s3_uri,
         kms_key=monitoring_files_kms_key,
-        session=sagemaker_session,
+        sagemaker_session=sagemaker_session,
     )
 
     statistics = Statistics.from_s3_uri(
@@ -137,7 +137,7 @@ def test_statistics_object_creation_from_s3_uri_without_customizations(sagemaker
     )
 
     s3_uri = S3Uploader.upload_string_as_file_body(
-        body=file_body, desired_s3_uri=desired_s3_uri, session=sagemaker_session
+        body=file_body, desired_s3_uri=desired_s3_uri, sagemaker_session=sagemaker_session
     )
 
     statistics = Statistics.from_s3_uri(
@@ -259,7 +259,7 @@ def test_constraints_object_creation_from_s3_uri_with_customizations(
         body=file_body,
         desired_s3_uri=desired_s3_uri,
         kms_key=monitoring_files_kms_key,
-        session=sagemaker_session,
+        sagemaker_session=sagemaker_session,
     )
 
     constraints = Constraints.from_s3_uri(
@@ -288,7 +288,7 @@ def test_constraints_object_creation_from_s3_uri_without_customizations(sagemake
     )
 
     s3_uri = S3Uploader.upload_string_as_file_body(
-        body=file_body, desired_s3_uri=desired_s3_uri, session=sagemaker_session
+        body=file_body, desired_s3_uri=desired_s3_uri, sagemaker_session=sagemaker_session
     )
 
     constraints = Constraints.from_s3_uri(
@@ -388,7 +388,7 @@ def test_constraint_violations_object_creation_from_s3_uri_with_customizations(
         body=file_body,
         desired_s3_uri=desired_s3_uri,
         kms_key=monitoring_files_kms_key,
-        session=sagemaker_session,
+        sagemaker_session=sagemaker_session,
     )
 
     constraint_violations = ConstraintViolations.from_s3_uri(
@@ -419,7 +419,7 @@ def test_constraint_violations_object_creation_from_s3_uri_without_customization
     )
 
     s3_uri = S3Uploader.upload_string_as_file_body(
-        body=file_body, desired_s3_uri=desired_s3_uri, session=sagemaker_session
+        body=file_body, desired_s3_uri=desired_s3_uri, sagemaker_session=sagemaker_session
     )
 
     constraint_violations = ConstraintViolations.from_s3_uri(

--- a/tests/integ/test_multi_variant_endpoint.py
+++ b/tests/integ/test_multi_variant_endpoint.py
@@ -92,8 +92,8 @@ def multi_variant_endpoint(sagemaker_session):
         prefix = "sagemaker/DEMO-VariantTargeting"
         model_url = S3Uploader.upload(
             local_path=XG_BOOST_MODEL_LOCAL_PATH,
-            desired_s3_uri="s3://" + bucket + "/" + prefix,
-            session=sagemaker_session,
+            desired_s3_uri="s3://{}/{}".format(bucket, prefix),
+            sagemaker_session=sagemaker_session,
         )
 
         image_uri = get_image_uri(sagemaker_session.boto_session.region_name, "xgboost", "0.90-1")

--- a/tests/integ/test_s3.py
+++ b/tests/integ/test_s3.py
@@ -51,23 +51,27 @@ def test_s3_uploader_and_downloader_reads_files_when_given_file_name_uris(
         body=file_1_body,
         desired_s3_uri=file_1_s3_uri,
         kms_key=s3_files_kms_key,
-        session=sagemaker_session,
+        sagemaker_session=sagemaker_session,
     )
 
     S3Uploader.upload_string_as_file_body(
         body=file_2_body,
         desired_s3_uri=file_2_s3_uri,
         kms_key=s3_files_kms_key,
-        session=sagemaker_session,
+        sagemaker_session=sagemaker_session,
     )
 
-    s3_uris = S3Downloader.list(s3_uri=base_s3_uri, session=sagemaker_session)
+    s3_uris = S3Downloader.list(s3_uri=base_s3_uri, sagemaker_session=sagemaker_session)
 
     assert file_1_name in s3_uris[0]
     assert file_2_name in s3_uris[1]
 
-    assert file_1_body == S3Downloader.read_file(s3_uri=s3_uris[0], session=sagemaker_session)
-    assert file_2_body == S3Downloader.read_file(s3_uri=s3_uris[1], session=sagemaker_session)
+    assert file_1_body == S3Downloader.read_file(
+        s3_uri=s3_uris[0], sagemaker_session=sagemaker_session
+    )
+    assert file_2_body == S3Downloader.read_file(
+        s3_uri=s3_uris[1], sagemaker_session=sagemaker_session
+    )
 
 
 def test_s3_uploader_and_downloader_downloads_files_when_given_file_name_uris(
@@ -90,23 +94,27 @@ def test_s3_uploader_and_downloader_downloads_files_when_given_file_name_uris(
         body=file_1_body,
         desired_s3_uri=file_1_s3_uri,
         kms_key=s3_files_kms_key,
-        session=sagemaker_session,
+        sagemaker_session=sagemaker_session,
     )
 
     S3Uploader.upload_string_as_file_body(
         body=file_2_body,
         desired_s3_uri=file_2_s3_uri,
         kms_key=s3_files_kms_key,
-        session=sagemaker_session,
+        sagemaker_session=sagemaker_session,
     )
 
-    s3_uris = S3Downloader.list(s3_uri=base_s3_uri, session=sagemaker_session)
+    s3_uris = S3Downloader.list(s3_uri=base_s3_uri, sagemaker_session=sagemaker_session)
 
     assert file_1_name in s3_uris[0]
     assert file_2_name in s3_uris[1]
 
-    S3Downloader.download(s3_uri=s3_uris[0], local_path=TMP_BASE_PATH, session=sagemaker_session)
-    S3Downloader.download(s3_uri=s3_uris[1], local_path=TMP_BASE_PATH, session=sagemaker_session)
+    S3Downloader.download(
+        s3_uri=s3_uris[0], local_path=TMP_BASE_PATH, sagemaker_session=sagemaker_session
+    )
+    S3Downloader.download(
+        s3_uri=s3_uris[1], local_path=TMP_BASE_PATH, sagemaker_session=sagemaker_session
+    )
 
     with open(os.path.join(TMP_BASE_PATH, file_1_name), "r") as f:
         assert file_1_body == f.read()
@@ -135,25 +143,31 @@ def test_s3_uploader_and_downloader_downloads_files_when_given_directory_uris_wi
         body=file_1_body,
         desired_s3_uri=file_1_s3_uri,
         kms_key=s3_files_kms_key,
-        session=sagemaker_session,
+        sagemaker_session=sagemaker_session,
     )
 
     S3Uploader.upload_string_as_file_body(
         body=file_2_body,
         desired_s3_uri=file_2_s3_uri,
         kms_key=s3_files_kms_key,
-        session=sagemaker_session,
+        sagemaker_session=sagemaker_session,
     )
 
-    s3_uris = S3Downloader.list(s3_uri=base_s3_uri, session=sagemaker_session)
+    s3_uris = S3Downloader.list(s3_uri=base_s3_uri, sagemaker_session=sagemaker_session)
 
     assert file_1_name in s3_uris[0]
     assert file_2_name in s3_uris[1]
 
-    assert file_1_body == S3Downloader.read_file(s3_uri=s3_uris[0], session=sagemaker_session)
-    assert file_2_body == S3Downloader.read_file(s3_uri=s3_uris[1], session=sagemaker_session)
+    assert file_1_body == S3Downloader.read_file(
+        s3_uri=s3_uris[0], sagemaker_session=sagemaker_session
+    )
+    assert file_2_body == S3Downloader.read_file(
+        s3_uri=s3_uris[1], sagemaker_session=sagemaker_session
+    )
 
-    S3Downloader.download(s3_uri=base_s3_uri, local_path=TMP_BASE_PATH, session=sagemaker_session)
+    S3Downloader.download(
+        s3_uri=base_s3_uri, local_path=TMP_BASE_PATH, sagemaker_session=sagemaker_session
+    )
 
     with open(os.path.join(TMP_BASE_PATH, file_1_name), "r") as f:
         assert file_1_body == f.read()
@@ -187,23 +201,27 @@ def test_s3_uploader_and_downloader_downloads_files_when_given_directory_uris_wi
         body=file_1_body,
         desired_s3_uri=file_1_s3_uri,
         kms_key=s3_files_kms_key,
-        session=sagemaker_session,
+        sagemaker_session=sagemaker_session,
     )
 
     S3Uploader.upload_string_as_file_body(
         body=file_2_body,
         desired_s3_uri=file_2_s3_uri,
         kms_key=s3_files_kms_key,
-        session=sagemaker_session,
+        sagemaker_session=sagemaker_session,
     )
 
-    s3_uris = S3Downloader.list(s3_uri=base_s3_uri, session=sagemaker_session)
+    s3_uris = S3Downloader.list(s3_uri=base_s3_uri, sagemaker_session=sagemaker_session)
 
     assert file_1_name in s3_uris[0]
     assert file_2_name in s3_uris[1]
 
-    assert file_1_body == S3Downloader.read_file(s3_uri=s3_uris[0], session=sagemaker_session)
-    assert file_2_body == S3Downloader.read_file(s3_uri=s3_uris[1], session=sagemaker_session)
+    assert file_1_body == S3Downloader.read_file(
+        s3_uri=s3_uris[0], sagemaker_session=sagemaker_session
+    )
+    assert file_2_body == S3Downloader.read_file(
+        s3_uri=s3_uris[1], sagemaker_session=sagemaker_session
+    )
 
     s3_directory_with_directory_underneath = os.path.join(
         "s3://", sagemaker_session.default_bucket(), "integ-test-test-s3-list", my_uuid
@@ -212,7 +230,7 @@ def test_s3_uploader_and_downloader_downloads_files_when_given_directory_uris_wi
     S3Downloader.download(
         s3_uri=s3_directory_with_directory_underneath,
         local_path=TMP_BASE_PATH,
-        session=sagemaker_session,
+        sagemaker_session=sagemaker_session,
     )
 
     with open(os.path.join(TMP_BASE_PATH, my_inner_directory_uuid, file_1_name), "r") as f:

--- a/tests/integ/test_transformer.py
+++ b/tests/integ/test_transformer.py
@@ -391,7 +391,7 @@ def test_transform_tf_kms_network_isolation(
         s3.S3Downloader.download(
             s3_uri=output_path,
             local_path=os.path.join(tmpdir, "tf-batch-output"),
-            session=sagemaker_session,
+            sagemaker_session=sagemaker_session,
         )
 
         with open(os.path.join(tmpdir, "tf-batch-output", "data.csv.out")) as f:

--- a/tests/unit/test_s3.py
+++ b/tests/unit/test_s3.py
@@ -43,7 +43,9 @@ def sagemaker_session():
 def test_upload(sagemaker_session, caplog):
     desired_s3_uri = os.path.join("s3://", BUCKET_NAME, CURRENT_JOB_NAME, SOURCE_NAME)
     S3Uploader.upload(
-        local_path="/path/to/app.jar", desired_s3_uri=desired_s3_uri, session=sagemaker_session
+        local_path="/path/to/app.jar",
+        desired_s3_uri=desired_s3_uri,
+        sagemaker_session=sagemaker_session,
     )
     sagemaker_session.upload_data.assert_called_with(
         path="/path/to/app.jar",
@@ -51,10 +53,6 @@ def test_upload(sagemaker_session, caplog):
         key_prefix=os.path.join(CURRENT_JOB_NAME, SOURCE_NAME),
         extra_args=None,
     )
-    warning_message = (
-        "Parameter 'session' will be renamed to 'sagemaker_session' " "in SageMaker Python SDK v2."
-    )
-    assert warning_message in caplog.text
 
 
 def test_upload_with_kms_key(sagemaker_session):
@@ -63,7 +61,7 @@ def test_upload_with_kms_key(sagemaker_session):
         local_path="/path/to/app.jar",
         desired_s3_uri=desired_s3_uri,
         kms_key=KMS_KEY,
-        session=sagemaker_session,
+        sagemaker_session=sagemaker_session,
     )
     sagemaker_session.upload_data.assert_called_with(
         path="/path/to/app.jar",
@@ -76,7 +74,7 @@ def test_upload_with_kms_key(sagemaker_session):
 def test_download(sagemaker_session):
     s3_uri = os.path.join("s3://", BUCKET_NAME, CURRENT_JOB_NAME, SOURCE_NAME)
     S3Downloader.download(
-        s3_uri=s3_uri, local_path="/path/for/download/", session=sagemaker_session
+        s3_uri=s3_uri, local_path="/path/for/download/", sagemaker_session=sagemaker_session
     )
     sagemaker_session.download_data.assert_called_with(
         path="/path/for/download/",
@@ -89,7 +87,10 @@ def test_download(sagemaker_session):
 def test_download_with_kms_key(sagemaker_session):
     s3_uri = os.path.join("s3://", BUCKET_NAME, CURRENT_JOB_NAME, SOURCE_NAME)
     S3Downloader.download(
-        s3_uri=s3_uri, local_path="/path/for/download/", kms_key=KMS_KEY, session=sagemaker_session
+        s3_uri=s3_uri,
+        local_path="/path/for/download/",
+        kms_key=KMS_KEY,
+        sagemaker_session=sagemaker_session,
     )
     sagemaker_session.download_data.assert_called_with(
         path="/path/for/download/",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This is for consistency with the sagemaker_session parameter that is used everywhere else in this library.

I'll do the migration tool changes in a separate PR.

*Testing done:*
unit tests, linters

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
