### PR TITLE
breaking: create new inference resources during model.deploy() and model.transformer()

### DIFF
--- a/src/sagemaker/pipeline.py
+++ b/src/sagemaker/pipeline.py
@@ -60,7 +60,6 @@ class PipelineModel(object):
         self.name = name
         self.vpc_config = vpc_config
         self.sagemaker_session = sagemaker_session
-        self._model_name = None
         self.endpoint_name = None
 
     def pipeline_container_def(self, instance_type):

--- a/tests/unit/sagemaker/model/test_model.py
+++ b/tests/unit/sagemaker/model/test_model.py
@@ -63,37 +63,30 @@ def test_model_enable_network_isolation():
 
 
 @patch("sagemaker.model.Model.prepare_container_def")
-@patch("sagemaker.utils.name_from_image")
-def test_create_sagemaker_model(name_from_image, prepare_container_def, sagemaker_session):
-    name_from_image.return_value = MODEL_NAME
-
+def test_create_sagemaker_model(prepare_container_def, sagemaker_session):
     container_def = {"Image": MODEL_IMAGE, "Environment": {}, "ModelDataUrl": MODEL_DATA}
     prepare_container_def.return_value = container_def
 
-    model = Model(MODEL_DATA, MODEL_IMAGE, sagemaker_session=sagemaker_session)
+    model = Model(MODEL_DATA, MODEL_IMAGE, name=MODEL_NAME, sagemaker_session=sagemaker_session)
     model._create_sagemaker_model()
 
     prepare_container_def.assert_called_with(None, accelerator_type=None)
-    name_from_image.assert_called_with(MODEL_IMAGE)
-
     sagemaker_session.create_model.assert_called_with(
         MODEL_NAME, None, container_def, vpc_config=None, enable_network_isolation=False, tags=None
     )
 
 
-@patch("sagemaker.utils.name_from_image", Mock())
 @patch("sagemaker.model.Model.prepare_container_def")
 def test_create_sagemaker_model_instance_type(prepare_container_def, sagemaker_session):
-    model = Model(MODEL_DATA, MODEL_IMAGE, sagemaker_session=sagemaker_session)
+    model = Model(MODEL_DATA, MODEL_IMAGE, name=MODEL_NAME, sagemaker_session=sagemaker_session)
     model._create_sagemaker_model(INSTANCE_TYPE)
 
     prepare_container_def.assert_called_with(INSTANCE_TYPE, accelerator_type=None)
 
 
-@patch("sagemaker.utils.name_from_image", Mock())
 @patch("sagemaker.model.Model.prepare_container_def")
 def test_create_sagemaker_model_accelerator_type(prepare_container_def, sagemaker_session):
-    model = Model(MODEL_IMAGE, MODEL_DATA, sagemaker_session=sagemaker_session)
+    model = Model(MODEL_IMAGE, MODEL_DATA, name=MODEL_NAME, sagemaker_session=sagemaker_session)
 
     accelerator_type = "ml.eia.medium"
     model._create_sagemaker_model(INSTANCE_TYPE, accelerator_type=accelerator_type)
@@ -102,14 +95,11 @@ def test_create_sagemaker_model_accelerator_type(prepare_container_def, sagemake
 
 
 @patch("sagemaker.model.Model.prepare_container_def")
-@patch("sagemaker.utils.name_from_image")
-def test_create_sagemaker_model_tags(name_from_image, prepare_container_def, sagemaker_session):
+def test_create_sagemaker_model_tags(prepare_container_def, sagemaker_session):
     container_def = {"Image": MODEL_IMAGE, "Environment": {}, "ModelDataUrl": MODEL_DATA}
     prepare_container_def.return_value = container_def
 
-    name_from_image.return_value = MODEL_NAME
-
-    model = Model(MODEL_IMAGE, MODEL_DATA, sagemaker_session=sagemaker_session)
+    model = Model(MODEL_IMAGE, MODEL_DATA, name=MODEL_NAME, sagemaker_session=sagemaker_session)
 
     tags = {"Key": "foo", "Value": "bar"}
     model._create_sagemaker_model(INSTANCE_TYPE, tags=tags)
@@ -120,9 +110,10 @@ def test_create_sagemaker_model_tags(name_from_image, prepare_container_def, sag
 
 
 @patch("sagemaker.model.Model.prepare_container_def")
-@patch("sagemaker.utils.name_from_image")
+@patch("sagemaker.utils.name_from_base")
+@patch("sagemaker.utils.base_name_from_image")
 def test_create_sagemaker_model_optional_model_params(
-    name_from_image, prepare_container_def, sagemaker_session
+    base_name_from_image, name_from_base, prepare_container_def, sagemaker_session
 ):
     container_def = {"Image": MODEL_IMAGE, "Environment": {}, "ModelDataUrl": MODEL_DATA}
     prepare_container_def.return_value = container_def
@@ -140,7 +131,8 @@ def test_create_sagemaker_model_optional_model_params(
     )
     model._create_sagemaker_model(INSTANCE_TYPE)
 
-    name_from_image.assert_not_called()
+    base_name_from_image.assert_not_called()
+    name_from_base.assert_not_called()
 
     sagemaker_session.create_model.assert_called_with(
         MODEL_NAME,
@@ -150,6 +142,44 @@ def test_create_sagemaker_model_optional_model_params(
         enable_network_isolation=True,
         tags=None,
     )
+
+
+@patch("sagemaker.model.Model.prepare_container_def")
+@patch("sagemaker.utils.name_from_base", return_value=MODEL_NAME)
+@patch("sagemaker.utils.base_name_from_image")
+def test_create_sagemaker_model_generates_model_name(
+    base_name_from_image, name_from_base, prepare_container_def, sagemaker_session
+):
+    container_def = {"Image": MODEL_IMAGE, "Environment": {}, "ModelDataUrl": MODEL_DATA}
+    prepare_container_def.return_value = container_def
+
+    model = Model(MODEL_IMAGE, MODEL_DATA, sagemaker_session=sagemaker_session,)
+    model._create_sagemaker_model(INSTANCE_TYPE)
+
+    base_name_from_image.assert_called_with(MODEL_IMAGE)
+    name_from_base.assert_called_with(base_name_from_image.return_value)
+
+    sagemaker_session.create_model.assert_called_with(
+        MODEL_NAME, None, container_def, vpc_config=None, enable_network_isolation=False, tags=None,
+    )
+
+
+@patch("sagemaker.model.Model.prepare_container_def")
+@patch("sagemaker.utils.name_from_base", return_value=MODEL_NAME)
+@patch("sagemaker.utils.base_name_from_image")
+def test_create_sagemaker_model_generates_model_name_each_time(
+    base_name_from_image, name_from_base, prepare_container_def, sagemaker_session
+):
+    container_def = {"Image": MODEL_IMAGE, "Environment": {}, "ModelDataUrl": MODEL_DATA}
+    prepare_container_def.return_value = container_def
+
+    model = Model(MODEL_IMAGE, MODEL_DATA, sagemaker_session=sagemaker_session,)
+    model._create_sagemaker_model(INSTANCE_TYPE)
+    model._create_sagemaker_model(INSTANCE_TYPE)
+
+    base_name_from_image.assert_called_once_with(MODEL_IMAGE)
+    name_from_base.assert_called_with(base_name_from_image.return_value)
+    assert 2 == name_from_base.call_count
 
 
 @patch("sagemaker.session.Session")
@@ -238,14 +268,25 @@ def test_model_create_transformer_optional_params(create_sagemaker_model, sagema
     assert transformer.volume_kms_key == kms_key
 
 
-@patch("sagemaker.model.Model._create_sagemaker_model")
-def test_model_create_transformer_network_isolation(create_sagemaker_model, sagemaker_session):
+@patch("sagemaker.model.Model._create_sagemaker_model", Mock())
+def test_model_create_transformer_network_isolation(sagemaker_session):
     model = Model(
         MODEL_IMAGE, MODEL_DATA, sagemaker_session=sagemaker_session, enable_network_isolation=True
     )
 
     transformer = model.transformer(1, "ml.m4.xlarge", env={"should_be": "overwritten"})
     assert transformer.env is None
+
+
+@patch("sagemaker.model.Model._create_sagemaker_model", Mock())
+def test_model_create_transformer_base_name(sagemaker_session):
+    model = Model(MODEL_IMAGE, MODEL_DATA, sagemaker_session=sagemaker_session)
+
+    base_name = "foo"
+    model._base_name = base_name
+
+    transformer = model.transformer(1, "ml.m4.xlarge")
+    assert base_name == transformer.base_transform_job_name
 
 
 @patch("sagemaker.session.Session")

--- a/tests/unit/sagemaker/model/test_neo.py
+++ b/tests/unit/sagemaker/model/test_neo.py
@@ -37,7 +37,7 @@ def sagemaker_session():
 
 
 def _create_model(sagemaker_session=None):
-    return Model(MODEL_IMAGE, MODEL_DATA, sagemaker_session=sagemaker_session)
+    return Model(MODEL_IMAGE, MODEL_DATA, role="role", sagemaker_session=sagemaker_session)
 
 
 def test_compile_model_for_inferentia(sagemaker_session):
@@ -212,14 +212,33 @@ def test_check_neo_region(sagemaker_session):
             assert (region_name in NEO_REGION_LIST) is model.check_neo_region(region_name)
 
 
-def test_deploy_valid_model_name(sagemaker_session):
-    model = Model(
-        image="long-base-name-that-is-over-the-63-character-limit-for-model-names",
-        model_data=MODEL_DATA,
-        role="role",
-        sagemaker_session=sagemaker_session,
-    )
+def test_deploy_honors_provided_model_name(sagemaker_session):
+    model = _create_model(sagemaker_session)
+    model._is_compiled_model = True
+
+    model_name = "foo"
+    model.name = model_name
+
+    model.deploy(1, "ml.c4.xlarge")
+    assert model_name == model.name
+
+
+def test_deploy_add_compiled_model_suffix_to_generated_resource_names(sagemaker_session):
+    model = _create_model(sagemaker_session)
     model._is_compiled_model = True
 
     model.deploy(1, "ml.c4.xlarge")
-    assert len(model.name) <= 63
+    assert model.name.startswith("mi-ml-c4")
+    assert model.endpoint_name.startswith("mi-ml-c4")
+
+
+@patch("sagemaker.model.Model._create_sagemaker_model", Mock())
+def test_deploy_add_compiled_model_suffix_to_endpoint_name_from_model_name(sagemaker_session):
+    model = _create_model(sagemaker_session)
+    model._is_compiled_model = True
+
+    model_name = "foo"
+    model.name = model_name
+
+    model.deploy(1, "ml.c4.xlarge")
+    assert model.endpoint_name.startswith("{}-ml-c4".format(model_name))


### PR DESCRIPTION
*Issue #, if available:*
#1470 

*Description of changes:*
This also changes how model and endpoint names are generated for compiled models, and removes the unused private attribute `model._model_name`.

*Testing done:*
unit tests, linters

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
