### PR TITLE
feature: add spot instance support for AlgorithmEstimator

### DIFF
--- a/src/sagemaker/algorithm.py
+++ b/src/sagemaker/algorithm.py
@@ -53,6 +53,8 @@ class AlgorithmEstimator(EstimatorBase):
         model_channel_name="model",
         metric_definitions=None,
         encrypt_inter_container_traffic=False,
+        train_use_spot_instances=False,
+        train_max_wait=None,
         **kwargs  # pylint: disable=W0613
     ):
         """Initialize an ``AlgorithmEstimator`` instance.
@@ -125,6 +127,17 @@ class AlgorithmEstimator(EstimatorBase):
                 expression used to extract the metric from the logs.
             encrypt_inter_container_traffic (bool): Specifies whether traffic between training
                 containers is encrypted for the training job (default: ``False``).
+            train_use_spot_instances (bool): Specifies whether to use SageMaker
+                Managed Spot instances for training. If enabled then the
+                `train_max_wait` arg should also be set.
+
+                More information:
+                https://docs.aws.amazon.com/sagemaker/latest/dg/model-managed-spot-training.html
+                (default: ``False``).
+            train_max_wait (int): Timeout in seconds waiting for spot training
+                instances (default: None). After this amount of time Amazon
+                SageMaker will stop waiting for Spot instances to become
+                available (default: ``None``).
             **kwargs: Additional kwargs. This is unused. It's only added for AlgorithmEstimator
                 to ignore the irrelevant arguments.
         """
@@ -148,6 +161,8 @@ class AlgorithmEstimator(EstimatorBase):
             model_channel_name=model_channel_name,
             metric_definitions=metric_definitions,
             encrypt_inter_container_traffic=encrypt_inter_container_traffic,
+            train_use_spot_instances=train_use_spot_instances,
+            train_max_wait=train_max_wait,
         )
 
         self.algorithm_spec = self.sagemaker_session.sagemaker_client.describe_algorithm(

--- a/tests/unit/test_algorithm.py
+++ b/tests/unit/test_algorithm.py
@@ -1015,3 +1015,18 @@ def test_algorithm_attach_from_hyperparameter_tuning():
     assert estimator.train_volume_size == train_volume_size
     assert estimator.input_mode == input_mode
     assert estimator.sagemaker_session == session
+
+
+@patch("sagemaker.Session")
+def test_algorithm_supported_with_spot_instances(session):
+    session.sagemaker_client.describe_algorithm = Mock(return_value=DESCRIBE_ALGORITHM_RESPONSE)
+
+    assert AlgorithmEstimator(
+        algorithm_arn="arn:aws:sagemaker:us-east-2:1234:algorithm/scikit-decision-trees",
+        role="SageMakerRole",
+        train_instance_type="ml.m4.xlarge",
+        train_instance_count=1,
+        train_use_spot_instances=True,
+        train_max_wait=500,
+        sagemaker_session=session,
+    )


### PR DESCRIPTION
*Issue #, if available:* #1658 

*Description of changes:*

changes include:

* adding defaulted `train_use_spot_instances` and `train_max_wait` to the constructor and passing them on to the base class

*Testing done:*

unit:
```
❯ tox --parallel 3 -- -rfE --disable-warnings tests/unit
✔ OK black-format in 10.938 seconds
✔ OK flake8 in 28.519 seconds
✔ OK twine in 22.751 seconds
✔ OK pylint in 49.668 seconds
✔ OK doc8 in 34.081 seconds
✔ OK sphinx in 56.674 seconds
✔ OK py36 in 48.587 seconds
✔ OK py37 in 47.733 seconds
✔ OK py38 in 41.45 seconds
✔ OK py27 in 2 minutes, 40.219 seconds
```

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
