### PR TITLE
change: handle image_uri rename in Airflow model config functions in v2 migration tool

### DIFF
--- a/src/sagemaker/cli/compatibility/v2/ast_transformer.py
+++ b/src/sagemaker/cli/compatibility/v2/ast_transformer.py
@@ -25,6 +25,7 @@ FUNCTION_CALL_MODIFIERS = [
     modifiers.tfs.TensorFlowServingConstructorRenamer(),
     modifiers.predictors.PredictorConstructorRefactor(),
     modifiers.airflow.ModelConfigArgModifier(),
+    modifiers.airflow.ModelConfigImageURIRenamer(),
     modifiers.renamed_params.DistributionParameterRenamer(),
     modifiers.renamed_params.S3SessionRenamer(),
 ]

--- a/src/sagemaker/cli/compatibility/v2/modifiers/airflow.py
+++ b/src/sagemaker/cli/compatibility/v2/modifiers/airflow.py
@@ -15,7 +15,7 @@ from __future__ import absolute_import
 
 import ast
 
-from sagemaker.cli.compatibility.v2.modifiers import matching
+from sagemaker.cli.compatibility.v2.modifiers import matching, renamed_params
 from sagemaker.cli.compatibility.v2.modifiers.modifier import Modifier
 
 FUNCTION_NAMES = ("model_config", "model_config_from_estimator")
@@ -61,3 +61,32 @@ class ModelConfigArgModifier(Modifier):
         """
         instance_type = node.args.pop(0)
         node.keywords.append(ast.keyword(arg="instance_type", value=instance_type))
+
+
+class ModelConfigImageURIRenamer(renamed_params.ParamRenamer):
+    """A class to rename the ``image`` attribute to ``image_uri`` in Airflow model config functions.
+
+    This looks for the following formats:
+
+    - ``model_config``
+    - ``airflow.model_config``
+    - ``workflow.airflow.model_config``
+    - ``sagemaker.workflow.airflow.model_config``
+
+    where ``model_config`` is either ``model_config`` or ``model_config_from_estimator``.
+    """
+
+    @property
+    def calls_to_modify(self):
+        """A dictionary mapping Airflow model config functions to their respective namespaces."""
+        return FUNCTIONS
+
+    @property
+    def old_param_name(self):
+        """The previous name for the image URI argument."""
+        return "image"
+
+    @property
+    def new_param_name(self):
+        """The new name for the image URI argument."""
+        return "image_uri"

--- a/src/sagemaker/cli/compatibility/v2/modifiers/framework_version.py
+++ b/src/sagemaker/cli/compatibility/v2/modifiers/framework_version.py
@@ -15,7 +15,7 @@ from __future__ import absolute_import
 
 import ast
 
-from sagemaker.cli.compatibility.v2.modifiers import matching
+from sagemaker.cli.compatibility.v2.modifiers import matching, parsing
 from sagemaker.cli.compatibility.v2.modifiers.modifier import Modifier
 
 FRAMEWORK_ARG = "framework_version"
@@ -98,13 +98,13 @@ class FrameworkVersionEnforcer(Modifier):
         framework, is_model = _framework_from_node(node)
 
         # if framework_version is not supplied, get default and append keyword
-        framework_version = _arg_value(node, FRAMEWORK_ARG)
+        framework_version = parsing.arg_value(node, FRAMEWORK_ARG)
         if framework_version is None:
             framework_version = FRAMEWORK_DEFAULTS[framework]
             node.keywords.append(ast.keyword(arg=FRAMEWORK_ARG, value=ast.Str(s=framework_version)))
 
         # if py_version is not supplied, get a conditional default, and if not None, append keyword
-        py_version = _arg_value(node, PY_ARG)
+        py_version = parsing.arg_value(node, PY_ARG)
         if py_version is None:
             py_version = _py_version_defaults(framework, framework_version, is_model)
             if py_version:
@@ -175,12 +175,12 @@ def _version_args_needed(node, image_arg):
     Applies similar logic as ``validate_version_or_image_args``
     """
     # if image_arg is present, no need to supply version arguments
-    image_name = _arg_value(node, image_arg)
+    image_name = parsing.arg_value(node, image_arg)
     if image_name:
         return False
 
     # if framework_version is None, need args
-    framework_version = _arg_value(node, FRAMEWORK_ARG)
+    framework_version = parsing.arg_value(node, FRAMEWORK_ARG)
     if framework_version is None:
         return True
 
@@ -188,15 +188,7 @@ def _version_args_needed(node, image_arg):
     framework, is_model = _framework_from_node(node)
     expecting_py_version = _py_version_defaults(framework, framework_version, is_model)
     if expecting_py_version:
-        py_version = _arg_value(node, PY_ARG)
+        py_version = parsing.arg_value(node, PY_ARG)
         return py_version is None
 
     return False
-
-
-def _arg_value(node, arg):
-    """Gets the value associated with the arg keyword, if present"""
-    for kw in node.keywords:
-        if kw.arg == arg and kw.value:
-            return kw.value.s
-    return None

--- a/src/sagemaker/cli/compatibility/v2/modifiers/framework_version.py
+++ b/src/sagemaker/cli/compatibility/v2/modifiers/framework_version.py
@@ -98,14 +98,14 @@ class FrameworkVersionEnforcer(Modifier):
         framework, is_model = _framework_from_node(node)
 
         # if framework_version is not supplied, get default and append keyword
-        framework_version = parsing.arg_value(node, FRAMEWORK_ARG)
-        if framework_version is None:
+        if matching.has_arg(node, FRAMEWORK_ARG):
+            framework_version = parsing.arg_value(node, FRAMEWORK_ARG)
+        else:
             framework_version = FRAMEWORK_DEFAULTS[framework]
             node.keywords.append(ast.keyword(arg=FRAMEWORK_ARG, value=ast.Str(s=framework_version)))
 
         # if py_version is not supplied, get a conditional default, and if not None, append keyword
-        py_version = parsing.arg_value(node, PY_ARG)
-        if py_version is None:
+        if not matching.has_arg(node, PY_ARG):
             py_version = _py_version_defaults(framework, framework_version, is_model)
             if py_version:
                 node.keywords.append(ast.keyword(arg=PY_ARG, value=ast.Str(s=py_version)))
@@ -175,13 +175,13 @@ def _version_args_needed(node, image_arg):
     Applies similar logic as ``validate_version_or_image_args``
     """
     # if image_arg is present, no need to supply version arguments
-    image_name = parsing.arg_value(node, image_arg)
-    if image_name:
+    if matching.has_arg(node, image_arg):
         return False
 
     # if framework_version is None, need args
-    framework_version = parsing.arg_value(node, FRAMEWORK_ARG)
-    if framework_version is None:
+    if matching.has_arg(node, FRAMEWORK_ARG):
+        framework_version = parsing.arg_value(node, FRAMEWORK_ARG)
+    else:
         return True
 
     # check if we expect py_version and we don't get it -- framework and model dependent

--- a/src/sagemaker/cli/compatibility/v2/modifiers/matching.py
+++ b/src/sagemaker/cli/compatibility/v2/modifiers/matching.py
@@ -116,4 +116,7 @@ def has_arg(node, arg):
     Returns:
         bool: if the node has the given argument.
     """
-    return parsing.arg_value(node, arg) is not None
+    try:
+        return parsing.arg_value(node, arg) is not None
+    except KeyError:
+        return False

--- a/src/sagemaker/cli/compatibility/v2/modifiers/matching.py
+++ b/src/sagemaker/cli/compatibility/v2/modifiers/matching.py
@@ -15,6 +15,8 @@ from __future__ import absolute_import
 
 import ast
 
+from sagemaker.cli.compatibility.v2.modifiers import parsing
+
 
 def matches_any(node, name_to_namespaces_dict):
     """Determines if the ``ast.Call`` node matches any of the provided names and namespaces.
@@ -101,3 +103,17 @@ def matches_namespace(node, namespace):
         name, value = names.pop(), value.value
 
     return isinstance(value, ast.Name) and value.id == name
+
+
+def has_arg(node, arg):
+    """Checks if the call has the given argument.
+
+    Args:
+        node (ast.Call): a node that represents a function call. For more,
+            see https://docs.python.org/3/library/ast.html#abstract-grammar.
+        arg (str): the name of the argument.
+
+    Returns:
+        bool: if the node has the given argument.
+    """
+    return parsing.arg_value(node, arg) is not None

--- a/src/sagemaker/cli/compatibility/v2/modifiers/parsing.py
+++ b/src/sagemaker/cli/compatibility/v2/modifiers/parsing.py
@@ -1,0 +1,50 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+"""Functions for parsing AST nodes."""
+from __future__ import absolute_import
+
+
+def arg_from_keywords(node, arg):
+    """Retrieves a keyword argument from the node's keywords.
+
+    Args:
+        node (ast.Call): a node that represents a function call. For more,
+            see https://docs.python.org/3/library/ast.html#abstract-grammar.
+        arg (str): the name of the argument.
+
+    Returns:
+        ast.keyword: the keyword argument if it is present. Otherwise, this returns ``None``.
+    """
+    for kw in node.keywords:
+        if kw.arg == arg:
+            return kw
+
+    return None
+
+
+def arg_value(node, arg):
+    """Retrieves a keyword argument's value from the node's keywords.
+
+    Args:
+        node (ast.Call): a node that represents a function call. For more,
+            see https://docs.python.org/3/library/ast.html#abstract-grammar.
+        arg (str): the name of the argument.
+
+    Returns:
+        obj: the keyword argument's value if it is present. Otherwise, this returns ``None``.
+    """
+    keyword = arg_from_keywords(node, arg)
+    if keyword and keyword.value:
+        return getattr(keyword.value, keyword.value._fields[0], None)
+
+    return None

--- a/src/sagemaker/cli/compatibility/v2/modifiers/parsing.py
+++ b/src/sagemaker/cli/compatibility/v2/modifiers/parsing.py
@@ -13,6 +13,8 @@
 """Functions for parsing AST nodes."""
 from __future__ import absolute_import
 
+import pasta
+
 
 def arg_from_keywords(node, arg):
     """Retrieves a keyword argument from the node's keywords.
@@ -41,10 +43,13 @@ def arg_value(node, arg):
         arg (str): the name of the argument.
 
     Returns:
-        obj: the keyword argument's value if it is present. Otherwise, this returns ``None``.
+        obj: the keyword argument's value.
+
+    Raises:
+        KeyError: if the node's keywords do not contain the argument.
     """
     keyword = arg_from_keywords(node, arg)
-    if keyword and keyword.value:
-        return getattr(keyword.value, keyword.value._fields[0], None)
+    if keyword is None:
+        raise KeyError("arg '{}' not found in call: {}".format(arg, pasta.dump(node)))
 
-    return None
+    return getattr(keyword.value, keyword.value._fields[0], None) if keyword.value else None

--- a/tests/unit/sagemaker/cli/compatibility/v2/modifiers/test_matching.py
+++ b/tests/unit/sagemaker/cli/compatibility/v2/modifiers/test_matching.py
@@ -66,3 +66,8 @@ def test_matches_attr():
 def test_matches_namespace():
     assert matching.matches_namespace(ast_call("sagemaker.mxnet.MXNet()"), "sagemaker.mxnet")
     assert not matching.matches_namespace(ast_call("sagemaker.KMeans()"), "sagemaker.mxnet")
+
+
+def test_has_arg():
+    assert matching.has_arg(ast_call("MXNet(framework_version=mxnet_version)"), "framework_version")
+    assert not matching.has_arg(ast_call("MXNet()"), "framework_version")

--- a/tests/unit/sagemaker/cli/compatibility/v2/modifiers/test_parsing.py
+++ b/tests/unit/sagemaker/cli/compatibility/v2/modifiers/test_parsing.py
@@ -12,6 +12,8 @@
 # language governing permissions and limitations under the License.
 from __future__ import absolute_import
 
+import pytest
+
 from sagemaker.cli.compatibility.v2.modifiers import parsing
 from tests.unit.sagemaker.cli.compatibility.v2.modifiers.ast_converter import ast_call
 
@@ -45,7 +47,14 @@ def test_arg_value():
     call = ast_call("MXNet(enable_network_isolation=True)")
     assert parsing.arg_value(call, "enable_network_isolation") is True
 
+    call = ast_call("MXNet(source_dir=None)")
+    assert parsing.arg_value(call, "source_dir") is None
+
 
 def test_arg_value_absent_keyword():
-    call = ast_call("MXNet(entry_point='run')")
-    assert parsing.arg_value(call, "framework_version") is None
+    code = "MXNet(entry_point='run')"
+
+    with pytest.raises(KeyError) as e:
+        parsing.arg_value(ast_call(code), "framework_version")
+
+    assert "arg 'framework_version' not found in call: {}".format(code) in str(e.value)

--- a/tests/unit/sagemaker/cli/compatibility/v2/modifiers/test_parsing.py
+++ b/tests/unit/sagemaker/cli/compatibility/v2/modifiers/test_parsing.py
@@ -1,0 +1,51 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from __future__ import absolute_import
+
+from sagemaker.cli.compatibility.v2.modifiers import parsing
+from tests.unit.sagemaker.cli.compatibility.v2.modifiers.ast_converter import ast_call
+
+
+def test_arg_from_keywords():
+    kw_name = "framework_version"
+    kw_value = "1.6.0"
+
+    call = ast_call("MXNet({}='{}', py_version='py3', entry_point='run')".format(kw_name, kw_value))
+    returned_kw = parsing.arg_from_keywords(call, kw_name)
+
+    assert kw_name == returned_kw.arg
+    assert kw_value == returned_kw.value.s
+
+
+def test_arg_from_keywords_absent_keyword():
+    call = ast_call("MXNet(entry_point='run')")
+    assert parsing.arg_from_keywords(call, "framework_version") is None
+
+
+def test_arg_value():
+    call = ast_call("MXNet(framework_version='1.6.0')")
+    assert "1.6.0" == parsing.arg_value(call, "framework_version")
+
+    call = ast_call("MXNet(framework_version=mxnet_version)")
+    assert "mxnet_version" == parsing.arg_value(call, "framework_version")
+
+    call = ast_call("MXNet(instance_count=1)")
+    assert 1 == parsing.arg_value(call, "instance_count")
+
+    call = ast_call("MXNet(enable_network_isolation=True)")
+    assert parsing.arg_value(call, "enable_network_isolation") is True
+
+
+def test_arg_value_absent_keyword():
+    call = ast_call("MXNet(entry_point='run')")
+    assert parsing.arg_value(call, "framework_version") is None


### PR DESCRIPTION
*Issue #, if available:*
#1473

*Description of changes:*
follow-up to #1667 and #1670. Going to do the migration tool changes in pieces to try and keep the amount of changes per PR down.

This PR also adds some more utility functions for parsing and checking AST nodes.

*Testing done:*
unit tests, linters

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
