### PR TITLE
breaking: Add BytesDeserializer

### DIFF
--- a/src/sagemaker/deserializers.py
+++ b/src/sagemaker/deserializers.py
@@ -39,3 +39,24 @@ class BaseDeserializer(abc.ABC):
     @abc.abstractmethod
     def ACCEPT(self):
         """The content type that is expected from the inference endpoint."""
+
+
+class BytesDeserializer(BaseDeserializer):
+    """Deserialize a stream of bytes into a bytes object."""
+
+    ACCEPT = "application/octet-stream"
+
+    def deserialize(self, data, content_type):
+        """Read a stream of bytes returned from an inference endpoint.
+
+        Args:
+            data (object): A stream of bytes.
+            content_type (str): The MIME type of the data.
+
+        Returns:
+            bytes: The bytes object read from the stream.
+        """
+        try:
+            return data.read()
+        finally:
+            data.close()

--- a/src/sagemaker/predictor.py
+++ b/src/sagemaker/predictor.py
@@ -623,32 +623,6 @@ class _CsvDeserializer(object):
 csv_deserializer = _CsvDeserializer()
 
 
-class BytesDeserializer(object):
-    """Return the response as an undecoded array of bytes.
-
-    Args:
-        accept (str): The Accept header to send to the server (optional).
-    """
-
-    def __init__(self, accept=None):
-        """
-        Args:
-            accept:
-        """
-        self.accept = accept
-
-    def __call__(self, stream, content_type):
-        """
-        Args:
-            stream:
-            content_type:
-        """
-        try:
-            return stream.read()
-        finally:
-            stream.close()
-
-
 class StringDeserializer(object):
     """Return the response as a decoded string.
 

--- a/tests/unit/sagemaker/cli/compatibility/v2/modifiers/test_predictors.py
+++ b/tests/unit/sagemaker/cli/compatibility/v2/modifiers/test_predictors.py
@@ -117,9 +117,11 @@ def test_import_from_node_should_be_modified_random_import():
 def test_import_from_modify_node():
     modifier = predictors.PredictorImportFromRenamer()
 
-    node = ast_import("from sagemaker.predictor import BytesDeserializer, RealTimePredictor")
+    node = ast_import(
+        "from sagemaker.predictor import ClassThatHasntBeenRenamed, RealTimePredictor"
+    )
     modifier.modify_node(node)
-    expected_result = "from sagemaker.predictor import BytesDeserializer, Predictor"
+    expected_result = "from sagemaker.predictor import ClassThatHasntBeenRenamed, Predictor"
     assert expected_result == pasta.dump(node)
 
     node = ast_import("from sagemaker.predictor import RealTimePredictor as RTP")

--- a/tests/unit/sagemaker/test_deserializers.py
+++ b/tests/unit/sagemaker/test_deserializers.py
@@ -1,0 +1,25 @@
+# Copyright 2017-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from __future__ import absolute_import
+
+import io
+
+from sagemaker.deserializers import BytesDeserializer
+
+
+def test_bytes_deserializer():
+    deserializer = BytesDeserializer()
+
+    result = deserializer.deserialize(io.BytesIO(b"[1, 2, 3]"), "application/json")
+
+    assert result == b"[1, 2, 3]"

--- a/tests/unit/test_predictor.py
+++ b/tests/unit/test_predictor.py
@@ -20,7 +20,6 @@ import numpy as np
 import pytest
 from mock import Mock, call, patch
 
-from sagemaker.deserializers import BytesDeserializer
 from sagemaker.predictor import Predictor
 from sagemaker.predictor import (
     json_serializer,
@@ -182,12 +181,6 @@ def test_json_deserializer_invalid_data():
     with pytest.raises(ValueError) as error:
         json_deserializer(io.BytesIO(b"[[1]"), "application/json")
     assert "column" in str(error)
-
-
-def test_bytes_deserializer():
-    result = BytesDeserializer().deserialize(io.BytesIO(b"[1, 2, 3]"), "application/json")
-
-    assert result == b"[1, 2, 3]"
 
 
 def test_string_deserializer():

--- a/tests/unit/test_predictor.py
+++ b/tests/unit/test_predictor.py
@@ -20,13 +20,13 @@ import numpy as np
 import pytest
 from mock import Mock, call, patch
 
+from sagemaker.deserializers import BytesDeserializer
 from sagemaker.predictor import Predictor
 from sagemaker.predictor import (
     json_serializer,
     json_deserializer,
     csv_serializer,
     csv_deserializer,
-    BytesDeserializer,
     StringDeserializer,
     StreamDeserializer,
     numpy_deserializer,
@@ -185,7 +185,7 @@ def test_json_deserializer_invalid_data():
 
 
 def test_bytes_deserializer():
-    result = BytesDeserializer()(io.BytesIO(b"[1, 2, 3]"), "application/json")
+    result = BytesDeserializer().deserialize(io.BytesIO(b"[1, 2, 3]"), "application/json")
 
     assert result == b"[1, 2, 3]"
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Added BytesDeserializer to sagemaker.deserializers
* Removed BytesDeserializer from sagemaker.predictor

*Testing done:*
* Added test to tests.unit.sagemaker.test_deserializers

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
