### PR TITLE
change: handle image_uri rename for Session methods

### DIFF
--- a/src/sagemaker/cli/compatibility/v2/modifiers/renamed_params.py
+++ b/src/sagemaker/cli/compatibility/v2/modifiers/renamed_params.py
@@ -218,6 +218,39 @@ class ModelImageURIRenamer(ParamRenamer):
         return "image_uri"
 
 
+class EstimatorCreateModelImageURIRenamer(MethodParamRenamer):
+    """A class to rename ``image`` to ``image_uri`` in estimator ``create_model()`` methods."""
+
+    @property
+    def calls_to_modify(self):
+        """A mapping of ``create_model`` to common variable names for estimators."""
+        return {
+            "create_model": (
+                "estimator",
+                "chainer",
+                "mxnet",
+                "mx",
+                "pytorch",
+                "rl",
+                "sklearn",
+                "tensorflow",
+                "tf",
+                "xgboost",
+                "xgb",
+            )
+        }
+
+    @property
+    def old_param_name(self):
+        """The previous name for the image URI argument."""
+        return "image"
+
+    @property
+    def new_param_name(self):
+        """The new name for the the image URI argument."""
+        return "image_uri"
+
+
 class SessionCreateModelImageURIRenamer(MethodParamRenamer):
     """A class to rename ``primary_container_image`` to ``image_uri``.
 

--- a/src/sagemaker/cli/compatibility/v2/modifiers/renamed_params.py
+++ b/src/sagemaker/cli/compatibility/v2/modifiers/renamed_params.py
@@ -69,7 +69,11 @@ class ParamRenamer(Modifier):
 
 
 class MethodParamRenamer(ParamRenamer):
-    """Abstract class to handle parameter renames for methods that belong to objects."""
+    """Abstract class to handle parameter renames for methods that belong to objects.
+
+    This differs from ``ParamRenamer`` in that a node for a standalone function call
+    (i.e. where ``node.func`` is an ``ast.Name`` rather than an ``ast.Attribute``) is not modified.
+    """
 
     def node_should_be_modified(self, node):
         """Checks if the node matches any of the relevant functions and
@@ -77,6 +81,14 @@ class MethodParamRenamer(ParamRenamer):
 
         This looks for a call of the form ``<object>.<method>``, and
         assumes the method cannot be called on its own.
+
+        Args:
+            node (ast.Call): a node that represents a function call. For more,
+                see https://docs.python.org/3/library/ast.html#abstract-grammar.
+
+        Returns:
+            bool: If the ``ast.Call`` matches the relevant function calls and
+                contains the parameter to be renamed.
         """
         if isinstance(node.func, ast.Name):
             return False

--- a/src/sagemaker/cli/compatibility/v2/modifiers/renamed_params.py
+++ b/src/sagemaker/cli/compatibility/v2/modifiers/renamed_params.py
@@ -215,6 +215,7 @@ class ModelImageURIRenamer(ParamRenamer):
     @property
     def new_param_name(self):
         """The new name for the image URI argument."""
+        return "image_uri"
 
 
 class SessionCreateModelImageURIRenamer(MethodParamRenamer):

--- a/tests/unit/sagemaker/cli/compatibility/v2/modifiers/test_estimator_create_model.py
+++ b/tests/unit/sagemaker/cli/compatibility/v2/modifiers/test_estimator_create_model.py
@@ -1,0 +1,62 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from __future__ import absolute_import
+
+import pasta
+
+from sagemaker.cli.compatibility.v2.modifiers import renamed_params
+from tests.unit.sagemaker.cli.compatibility.v2.modifiers.ast_converter import ast_call
+
+ESTIMATORS = (
+    "estimator",
+    "chainer",
+    "mxnet",
+    "mx",
+    "pytorch",
+    "rl",
+    "sklearn",
+    "tensorflow",
+    "tf",
+    "xgboost",
+    "xgb",
+)
+
+
+def test_node_should_be_modified():
+    modifier = renamed_params.EstimatorCreateModelImageURIRenamer()
+
+    for estimator in ESTIMATORS:
+        call = "{}.create_model(image='my-image:latest')".format(estimator)
+        assert modifier.node_should_be_modified(ast_call(call))
+
+
+def test_node_should_be_modified_no_distribution():
+    modifier = renamed_params.EstimatorCreateModelImageURIRenamer()
+
+    for estimator in ESTIMATORS:
+        call = "{}.create_model()".format(estimator)
+        assert not modifier.node_should_be_modified(ast_call(call))
+
+
+def test_node_should_be_modified_random_function_call():
+    modifier = renamed_params.EstimatorCreateModelImageURIRenamer()
+    assert not modifier.node_should_be_modified(ast_call("create_model()"))
+
+
+def test_modify_node():
+    node = ast_call("estimator.create_model(image=my_image)")
+    modifier = renamed_params.EstimatorCreateModelImageURIRenamer()
+    modifier.modify_node(node)
+
+    expected = "estimator.create_model(image_uri=my_image)"
+    assert expected == pasta.dump(node)

--- a/tests/unit/sagemaker/cli/compatibility/v2/modifiers/test_session_image_uri.py
+++ b/tests/unit/sagemaker/cli/compatibility/v2/modifiers/test_session_image_uri.py
@@ -1,0 +1,94 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from __future__ import absolute_import
+
+import pasta
+
+from sagemaker.cli.compatibility.v2.modifiers import renamed_params
+from tests.unit.sagemaker.cli.compatibility.v2.modifiers.ast_converter import ast_call
+
+CREATE_MODEL_TEMPLATES = (
+    "sagemaker_session.create_model_from_job({})",
+    "sess.create_model_from_job({})",
+)
+
+CREATE_ENDPOINT_TEMPLATES = (
+    "sagemaker_session.endpoint_from_job({})",
+    "sagemaker_session.endpoint_from_model_data({})",
+    "sess.endpoint_from_job({})",
+    "sess.endpoint_from_model_data({})",
+)
+
+
+def test_create_model_node_should_be_modified():
+    modifier = renamed_params.SessionCreateModelImageURIRenamer()
+
+    for template in CREATE_MODEL_TEMPLATES:
+        call = ast_call(template.format("primary_container_image=my_image"))
+        assert modifier.node_should_be_modified(call)
+
+
+def test_create_model_node_should_be_modified_no_image():
+    modifier = renamed_params.SessionCreateModelImageURIRenamer()
+
+    for template in CREATE_MODEL_TEMPLATES:
+        call = ast_call(template.format(""))
+        assert not modifier.node_should_be_modified(call)
+
+
+def test_create_model_node_should_be_modified_random_function_call():
+    modifier = renamed_params.SessionCreateModelImageURIRenamer()
+    assert not modifier.node_should_be_modified(ast_call("create_model()"))
+
+
+def test_create_model_modify_node():
+    modifier = renamed_params.SessionCreateModelImageURIRenamer()
+
+    for template in CREATE_MODEL_TEMPLATES:
+        call = ast_call(template.format("primary_container_image=my_image"))
+        modifier.modify_node(call)
+
+        expected = template.format("image_uri=my_image")
+        assert expected == pasta.dump(call)
+
+
+def test_create_endpoint_node_should_be_modified():
+    modifier = renamed_params.SessionCreateEndpointImageURIRenamer()
+
+    for template in CREATE_ENDPOINT_TEMPLATES:
+        call = ast_call(template.format("deployment_image=my_image"))
+        assert modifier.node_should_be_modified(call)
+
+
+def test_create_endpoint_node_should_be_modified_no_image():
+    modifier = renamed_params.SessionCreateEndpointImageURIRenamer()
+
+    for template in CREATE_ENDPOINT_TEMPLATES:
+        call = ast_call(template.format(""))
+        assert not modifier.node_should_be_modified(call)
+
+
+def test_create_endpoint_node_should_be_modified_random_function_call():
+    modifier = renamed_params.SessionCreateEndpointImageURIRenamer()
+    assert not modifier.node_should_be_modified(ast_call("create_endpoint()"))
+
+
+def test_create_endpoint_modify_node():
+    modifier = renamed_params.SessionCreateEndpointImageURIRenamer()
+
+    for template in CREATE_ENDPOINT_TEMPLATES:
+        call = ast_call(template.format("deployment_image=my_image"))
+        modifier.modify_node(call)
+
+        expected = template.format("image_uri=my_image")
+        assert expected == pasta.dump(call)


### PR DESCRIPTION
*Issue #, if available:*
#1473 

*Description of changes:*
follow-up to #1667, #1670, #1673, and #1675.

for `create_model()`, I did a bunch of GitHub searches to verify that nothing I added to the "potential estimator name" list had a good chance for collision with non-SageMaker code. I thought about looking for anything with "estimator" in the name, but that had a few potential collisions.

*Testing done:*
unit tests, linters

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
