### PR TITLE
breaking: rename record_deserializer to RecordDeserializer

### DIFF
--- a/src/sagemaker/amazon/common.py
+++ b/src/sagemaker/amazon/common.py
@@ -21,6 +21,7 @@ import sys
 import numpy as np
 
 from sagemaker.amazon.record_pb2 import Record
+from sagemaker.deserializers import BaseDeserializer
 from sagemaker.utils import DeferredError
 
 
@@ -48,26 +49,24 @@ class numpy_to_record_serializer(object):
         return buf
 
 
-class record_deserializer(object):
-    """Placeholder docstring"""
+class RecordDeserializer(BaseDeserializer):
+    """Deserialize RecordIO Protobuf data from an inference endpoint."""
 
-    def __init__(self, accept="application/x-recordio-protobuf"):
-        """
-        Args:
-            accept:
-        """
-        self.accept = accept
+    ACCEPT = "application/x-recordio-protobuf"
 
-    def __call__(self, stream, content_type):
-        """
+    def deserialize(self, data, content_type):
+        """Deserialize RecordIO Protobuf data from an inference endpoint.
+
         Args:
-            stream:
-            content_type:
+            data (object): The protobuf message to deserialize.
+            content_type (str): The MIME type of the data.
+        Returns:
+            list: A list of records.
         """
         try:
-            return read_records(stream)
+            return read_records(data)
         finally:
-            stream.close()
+            data.close()
 
 
 def _write_feature_tensor(resolved_type, record, vector):

--- a/src/sagemaker/amazon/factorization_machines.py
+++ b/src/sagemaker/amazon/factorization_machines.py
@@ -14,7 +14,7 @@
 from __future__ import absolute_import
 
 from sagemaker.amazon.amazon_estimator import AmazonAlgorithmEstimatorBase, registry
-from sagemaker.amazon.common import numpy_to_record_serializer, record_deserializer
+from sagemaker.amazon.common import numpy_to_record_serializer, RecordDeserializer
 from sagemaker.amazon.hyperparameter import Hyperparameter as hp  # noqa
 from sagemaker.amazon.validation import gt, isin, ge
 from sagemaker.predictor import Predictor
@@ -290,7 +290,7 @@ class FactorizationMachinesPredictor(Predictor):
             endpoint_name,
             sagemaker_session,
             serializer=numpy_to_record_serializer(),
-            deserializer=record_deserializer(),
+            deserializer=RecordDeserializer(),
         )
 
 

--- a/src/sagemaker/amazon/kmeans.py
+++ b/src/sagemaker/amazon/kmeans.py
@@ -14,7 +14,7 @@
 from __future__ import absolute_import
 
 from sagemaker.amazon.amazon_estimator import AmazonAlgorithmEstimatorBase, registry
-from sagemaker.amazon.common import numpy_to_record_serializer, record_deserializer
+from sagemaker.amazon.common import numpy_to_record_serializer, RecordDeserializer
 from sagemaker.amazon.hyperparameter import Hyperparameter as hp  # noqa
 from sagemaker.amazon.validation import gt, isin, ge, le
 from sagemaker.predictor import Predictor
@@ -223,7 +223,7 @@ class KMeansPredictor(Predictor):
             endpoint_name,
             sagemaker_session,
             serializer=numpy_to_record_serializer(),
-            deserializer=record_deserializer(),
+            deserializer=RecordDeserializer(),
         )
 
 

--- a/src/sagemaker/amazon/knn.py
+++ b/src/sagemaker/amazon/knn.py
@@ -14,7 +14,7 @@
 from __future__ import absolute_import
 
 from sagemaker.amazon.amazon_estimator import AmazonAlgorithmEstimatorBase, registry
-from sagemaker.amazon.common import numpy_to_record_serializer, record_deserializer
+from sagemaker.amazon.common import numpy_to_record_serializer, RecordDeserializer
 from sagemaker.amazon.hyperparameter import Hyperparameter as hp  # noqa
 from sagemaker.amazon.validation import ge, isin
 from sagemaker.predictor import Predictor
@@ -211,7 +211,7 @@ class KNNPredictor(Predictor):
             endpoint_name,
             sagemaker_session,
             serializer=numpy_to_record_serializer(),
-            deserializer=record_deserializer(),
+            deserializer=RecordDeserializer(),
         )
 
 

--- a/src/sagemaker/amazon/lda.py
+++ b/src/sagemaker/amazon/lda.py
@@ -14,7 +14,7 @@
 from __future__ import absolute_import
 
 from sagemaker.amazon.amazon_estimator import AmazonAlgorithmEstimatorBase, registry
-from sagemaker.amazon.common import numpy_to_record_serializer, record_deserializer
+from sagemaker.amazon.common import numpy_to_record_serializer, RecordDeserializer
 from sagemaker.amazon.hyperparameter import Hyperparameter as hp  # noqa
 from sagemaker.amazon.validation import gt
 from sagemaker.predictor import Predictor
@@ -195,7 +195,7 @@ class LDAPredictor(Predictor):
             endpoint_name,
             sagemaker_session,
             serializer=numpy_to_record_serializer(),
-            deserializer=record_deserializer(),
+            deserializer=RecordDeserializer(),
         )
 
 

--- a/src/sagemaker/amazon/linear_learner.py
+++ b/src/sagemaker/amazon/linear_learner.py
@@ -14,7 +14,7 @@
 from __future__ import absolute_import
 
 from sagemaker.amazon.amazon_estimator import AmazonAlgorithmEstimatorBase, registry
-from sagemaker.amazon.common import numpy_to_record_serializer, record_deserializer
+from sagemaker.amazon.common import numpy_to_record_serializer, RecordDeserializer
 from sagemaker.amazon.hyperparameter import Hyperparameter as hp  # noqa
 from sagemaker.amazon.validation import isin, gt, lt, ge, le
 from sagemaker.predictor import Predictor
@@ -454,7 +454,7 @@ class LinearLearnerPredictor(Predictor):
             endpoint_name,
             sagemaker_session,
             serializer=numpy_to_record_serializer(),
-            deserializer=record_deserializer(),
+            deserializer=RecordDeserializer(),
         )
 
 

--- a/src/sagemaker/amazon/ntm.py
+++ b/src/sagemaker/amazon/ntm.py
@@ -14,7 +14,7 @@
 from __future__ import absolute_import
 
 from sagemaker.amazon.amazon_estimator import AmazonAlgorithmEstimatorBase, registry
-from sagemaker.amazon.common import numpy_to_record_serializer, record_deserializer
+from sagemaker.amazon.common import numpy_to_record_serializer, RecordDeserializer
 from sagemaker.amazon.hyperparameter import Hyperparameter as hp  # noqa
 from sagemaker.amazon.validation import ge, le, isin
 from sagemaker.predictor import Predictor
@@ -225,7 +225,7 @@ class NTMPredictor(Predictor):
             endpoint_name,
             sagemaker_session,
             serializer=numpy_to_record_serializer(),
-            deserializer=record_deserializer(),
+            deserializer=RecordDeserializer(),
         )
 
 

--- a/src/sagemaker/amazon/pca.py
+++ b/src/sagemaker/amazon/pca.py
@@ -14,7 +14,7 @@
 from __future__ import absolute_import
 
 from sagemaker.amazon.amazon_estimator import AmazonAlgorithmEstimatorBase, registry
-from sagemaker.amazon.common import numpy_to_record_serializer, record_deserializer
+from sagemaker.amazon.common import numpy_to_record_serializer, RecordDeserializer
 from sagemaker.amazon.hyperparameter import Hyperparameter as hp  # noqa
 from sagemaker.amazon.validation import gt, isin
 from sagemaker.predictor import Predictor
@@ -207,7 +207,7 @@ class PCAPredictor(Predictor):
             endpoint_name,
             sagemaker_session,
             serializer=numpy_to_record_serializer(),
-            deserializer=record_deserializer(),
+            deserializer=RecordDeserializer(),
         )
 
 

--- a/src/sagemaker/amazon/randomcutforest.py
+++ b/src/sagemaker/amazon/randomcutforest.py
@@ -14,7 +14,7 @@
 from __future__ import absolute_import
 
 from sagemaker.amazon.amazon_estimator import AmazonAlgorithmEstimatorBase, registry
-from sagemaker.amazon.common import numpy_to_record_serializer, record_deserializer
+from sagemaker.amazon.common import numpy_to_record_serializer, RecordDeserializer
 from sagemaker.amazon.hyperparameter import Hyperparameter as hp  # noqa
 from sagemaker.amazon.validation import ge, le
 from sagemaker.predictor import Predictor
@@ -184,7 +184,7 @@ class RandomCutForestPredictor(Predictor):
             endpoint_name,
             sagemaker_session,
             serializer=numpy_to_record_serializer(),
-            deserializer=record_deserializer(),
+            deserializer=RecordDeserializer(),
         )
 
 

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -18,7 +18,7 @@ import pytest
 import itertools
 from scipy.sparse import coo_matrix
 from sagemaker.amazon.common import (
-    record_deserializer,
+    RecordDeserializer,
     write_numpy_to_dense_tensor,
     read_recordio,
     numpy_to_record_serializer,
@@ -51,8 +51,8 @@ def test_deserializer():
     array_data = [[1.0, 2.0, 3.0], [10.0, 20.0, 30.0]]
     s = numpy_to_record_serializer()
     buf = s(np.array(array_data))
-    d = record_deserializer()
-    for record, expected in zip(d(buf, "who cares"), array_data):
+    d = RecordDeserializer()
+    for record, expected in zip(d.deserialize(buf, "who cares"), array_data):
         assert record.features["values"].float64_tensor.values == expected
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Renamed record_deserializer to RecordDeserializer and subclass BaseSerializer.

*Testing done:*
Fixed record_deserialzier tests.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
