### PR TITLE
breaking: Move _NumpyDeserializer to sagemaker.deserializers.NumpyDeserializer

### DIFF
--- a/src/sagemaker/chainer/model.py
+++ b/src/sagemaker/chainer/model.py
@@ -24,7 +24,8 @@ from sagemaker.fw_utils import (
 )
 from sagemaker.model import FrameworkModel, MODEL_SERVER_WORKERS_PARAM_NAME
 from sagemaker.chainer import defaults
-from sagemaker.predictor import Predictor, npy_serializer, numpy_deserializer
+from sagemaker.deserializers import NumpyDeserializer
+from sagemaker.predictor import Predictor, npy_serializer
 
 logger = logging.getLogger("sagemaker")
 
@@ -48,7 +49,7 @@ class ChainerPredictor(Predictor):
                 using the default AWS configuration chain.
         """
         super(ChainerPredictor, self).__init__(
-            endpoint_name, sagemaker_session, npy_serializer, numpy_deserializer
+            endpoint_name, sagemaker_session, npy_serializer, NumpyDeserializer()
         )
 
 

--- a/src/sagemaker/deserializers.py
+++ b/src/sagemaker/deserializers.py
@@ -14,6 +14,11 @@
 from __future__ import absolute_import
 
 import abc
+import codecs
+import io
+import json
+
+import numpy as np
 
 
 class BaseDeserializer(abc.ABC):
@@ -111,3 +116,41 @@ class StreamDeserializer(BaseDeserializer):
             tuple: A two-tuple containing the stream and content-type.
         """
         return data, content_type
+
+
+class NumpyDeserializer(BaseDeserializer):
+    """Deserialize a stream of data in the .npy format."""
+
+    ACCEPT = "application/x-npy"
+
+    def __init__(self, dtype=None):
+        """Initialize the dtype.
+
+        Args:
+            dtype (str): The dtype of the data.
+        """
+        self.dtype = dtype
+
+    def deserialize(self, data, content_type):
+        """Deserialize data from an inference endpoint into a NumPy array.
+
+        Args:
+            data (botocore.response.StreamingBody): Data to be deserialized.
+            content_type (str): The MIME type of the data.
+
+        Returns:
+            numpy.ndarray: The data deserialized into a NumPy array.
+        """
+        try:
+            if content_type == "text/csv":
+                return np.genfromtxt(
+                    codecs.getreader("utf-8")(data), delimiter=",", dtype=self.dtype
+                )
+            if content_type == "application/json":
+                return np.array(json.load(codecs.getreader("utf-8")(data)), dtype=self.dtype)
+            if content_type == "application/x-npy":
+                return np.load(io.BytesIO(data.read()))
+        finally:
+            data.close()
+
+        raise ValueError("%s cannot read content type %s." % (__class__.__name__, content_type))

--- a/src/sagemaker/predictor.py
+++ b/src/sagemaker/predictor.py
@@ -698,50 +698,6 @@ class _JsonDeserializer(object):
 json_deserializer = _JsonDeserializer()
 
 
-class _NumpyDeserializer(object):
-    """Placeholder docstring"""
-
-    def __init__(self, accept=CONTENT_TYPE_NPY, dtype=None):
-        """
-        Args:
-            accept:
-            dtype:
-        """
-        self.accept = accept
-        self.dtype = dtype
-
-    def __call__(self, stream, content_type=CONTENT_TYPE_NPY):
-        """Decode from serialized data into a Numpy array.
-
-        Args:
-            stream (stream): The response stream to be deserialized.
-            content_type (str): The content type of the response. Can accept
-                CSV, JSON, or NPY data.
-
-        Returns:
-            object: Body of the response deserialized into a Numpy array.
-        """
-        try:
-            if content_type == CONTENT_TYPE_CSV:
-                return np.genfromtxt(
-                    codecs.getreader("utf-8")(stream), delimiter=",", dtype=self.dtype
-                )
-            if content_type == CONTENT_TYPE_JSON:
-                return np.array(json.load(codecs.getreader("utf-8")(stream)), dtype=self.dtype)
-            if content_type == CONTENT_TYPE_NPY:
-                return np.load(BytesIO(stream.read()))
-        finally:
-            stream.close()
-        raise ValueError(
-            "content_type must be one of the following: CSV, JSON, NPY. content_type: {}".format(
-                content_type
-            )
-        )
-
-
-numpy_deserializer = _NumpyDeserializer()
-
-
 class _NPYSerializer(object):
     """Placeholder docstring"""
 

--- a/src/sagemaker/pytorch/model.py
+++ b/src/sagemaker/pytorch/model.py
@@ -17,6 +17,7 @@ import logging
 import packaging.version
 
 import sagemaker
+from sagemaker.deserializers import NumpyDeserializer
 from sagemaker.fw_utils import (
     create_image_uri,
     model_code_key_prefix,
@@ -25,7 +26,7 @@ from sagemaker.fw_utils import (
 )
 from sagemaker.model import FrameworkModel, MODEL_SERVER_WORKERS_PARAM_NAME
 from sagemaker.pytorch import defaults
-from sagemaker.predictor import Predictor, npy_serializer, numpy_deserializer
+from sagemaker.predictor import Predictor, npy_serializer
 
 logger = logging.getLogger("sagemaker")
 
@@ -49,7 +50,7 @@ class PyTorchPredictor(Predictor):
                 using the default AWS configuration chain.
         """
         super(PyTorchPredictor, self).__init__(
-            endpoint_name, sagemaker_session, npy_serializer, numpy_deserializer
+            endpoint_name, sagemaker_session, npy_serializer, NumpyDeserializer()
         )
 
 

--- a/src/sagemaker/sklearn/model.py
+++ b/src/sagemaker/sklearn/model.py
@@ -16,10 +16,11 @@ from __future__ import absolute_import
 import logging
 
 import sagemaker
+from sagemaker.deserializers import NumpyDeserializer
 from sagemaker.fw_registry import default_framework_uri
 from sagemaker.fw_utils import model_code_key_prefix, validate_version_or_image_args
 from sagemaker.model import FrameworkModel, MODEL_SERVER_WORKERS_PARAM_NAME
-from sagemaker.predictor import Predictor, npy_serializer, numpy_deserializer
+from sagemaker.predictor import Predictor, npy_serializer
 from sagemaker.sklearn import defaults
 
 logger = logging.getLogger("sagemaker")
@@ -44,7 +45,7 @@ class SKLearnPredictor(Predictor):
                 using the default AWS configuration chain.
         """
         super(SKLearnPredictor, self).__init__(
-            endpoint_name, sagemaker_session, npy_serializer, numpy_deserializer
+            endpoint_name, sagemaker_session, npy_serializer, NumpyDeserializer()
         )
 
 

--- a/tests/unit/sagemaker/test_deserializers.py
+++ b/tests/unit/sagemaker/test_deserializers.py
@@ -14,7 +14,15 @@ from __future__ import absolute_import
 
 import io
 
-from sagemaker.deserializers import StringDeserializer, BytesDeserializer, StreamDeserializer
+import numpy as np
+import pytest
+
+from sagemaker.deserializers import (
+    StringDeserializer,
+    BytesDeserializer,
+    StreamDeserializer,
+    NumpyDeserializer,
+)
 
 
 def test_string_deserializer():
@@ -44,3 +52,70 @@ def test_stream_deserializer():
 
     assert result == b"[1, 2, 3]"
     assert content_type == "application/json"
+
+
+@pytest.fixture
+def numpy_deserializer():
+    return NumpyDeserializer()
+
+
+def test_numpy_deserializer_from_csv(numpy_deserializer):
+    stream = io.BytesIO(b"1,2,3\n4,5,6")
+    array = numpy_deserializer.deserialize(stream, "text/csv")
+    assert np.array_equal(array, np.array([[1, 2, 3], [4, 5, 6]]))
+
+
+def test_numpy_deserializer_from_csv_ragged(numpy_deserializer):
+    stream = io.BytesIO(b"1,2,3\n4,5,6,7")
+    with pytest.raises(ValueError) as error:
+        numpy_deserializer.deserialize(stream, "text/csv")
+    assert "errors were detected" in str(error)
+
+
+def test_numpy_deserializer_from_csv_alpha():
+    numpy_deserializer = NumpyDeserializer(dtype="U5")
+    stream = io.BytesIO(b"hello,2,3\n4,5,6")
+    array = numpy_deserializer.deserialize(stream, "text/csv")
+    assert np.array_equal(array, np.array([["hello", 2, 3], [4, 5, 6]]))
+
+
+def test_numpy_deserializer_from_json(numpy_deserializer):
+    stream = io.BytesIO(b"[[1,2,3],\n[4,5,6]]")
+    array = numpy_deserializer.deserialize(stream, "application/json")
+    assert np.array_equal(array, np.array([[1, 2, 3], [4, 5, 6]]))
+
+
+# Sadly, ragged arrays work fine in JSON (giving us a 1D array of Python lists
+def test_numpy_deserializer_from_json_ragged(numpy_deserializer):
+    stream = io.BytesIO(b"[[1,2,3],\n[4,5,6,7]]")
+    array = numpy_deserializer.deserialize(stream, "application/json")
+    assert np.array_equal(array, np.array([[1, 2, 3], [4, 5, 6, 7]]))
+
+
+def test_numpy_deserializer_from_json_alpha():
+    numpy_deserializer = NumpyDeserializer(dtype="U5")
+    stream = io.BytesIO(b'[["hello",2,3],\n[4,5,6]]')
+    array = numpy_deserializer.deserialize(stream, "application/json")
+    assert np.array_equal(array, np.array([["hello", 2, 3], [4, 5, 6]]))
+
+
+def test_numpy_deserializer_from_npy(numpy_deserializer):
+    array = np.ones((2, 3))
+    stream = io.BytesIO()
+    np.save(stream, array)
+    stream.seek(0)
+
+    result = numpy_deserializer.deserialize(stream, "application/x-npy")
+
+    assert np.array_equal(array, result)
+
+
+def test_numpy_deserializer_from_npy_object_array(numpy_deserializer):
+    array = np.array(["one", "two"])
+    stream = io.BytesIO()
+    np.save(stream, array)
+    stream.seek(0)
+
+    result = numpy_deserializer.deserialize(stream, "application/x-npy")
+
+    assert np.array_equal(array, result)

--- a/tests/unit/sagemaker/test_deserializers.py
+++ b/tests/unit/sagemaker/test_deserializers.py
@@ -85,7 +85,7 @@ def test_numpy_deserializer_from_json(numpy_deserializer):
     assert np.array_equal(array, np.array([[1, 2, 3], [4, 5, 6]]))
 
 
-# Sadly, ragged arrays work fine in JSON (giving us a 1D array of Python lists
+# Sadly, ragged arrays work fine in JSON (giving us a 1D array of Python lists)
 def test_numpy_deserializer_from_json_ragged(numpy_deserializer):
     stream = io.BytesIO(b"[[1,2,3],\n[4,5,6,7]]")
     array = numpy_deserializer.deserialize(stream, "application/json")

--- a/tests/unit/test_predictor.py
+++ b/tests/unit/test_predictor.py
@@ -26,9 +26,7 @@ from sagemaker.predictor import (
     json_deserializer,
     csv_serializer,
     csv_deserializer,
-    numpy_deserializer,
     npy_serializer,
-    _NumpyDeserializer,
 )
 from tests.unit import DATA_DIR
 
@@ -257,62 +255,6 @@ def test_npy_serializer_python_invalid_empty():
     with pytest.raises(ValueError) as error:
         npy_serializer([])
     assert "empty array" in str(error)
-
-
-def test_numpy_deser_from_csv():
-    arr = numpy_deserializer(io.BytesIO(b"1,2,3\n4,5,6"), "text/csv")
-    assert np.array_equal(arr, np.array([[1, 2, 3], [4, 5, 6]]))
-
-
-def test_numpy_deser_from_csv_ragged():
-    with pytest.raises(ValueError) as error:
-        numpy_deserializer(io.BytesIO(b"1,2,3\n4,5,6,7"), "text/csv")
-    assert "errors were detected" in str(error)
-
-
-def test_numpy_deser_from_csv_alpha():
-    arr = _NumpyDeserializer(dtype="U5")(io.BytesIO(b"hello,2,3\n4,5,6"), "text/csv")
-    assert np.array_equal(arr, np.array([["hello", 2, 3], [4, 5, 6]]))
-
-
-def test_numpy_deser_from_json():
-    arr = numpy_deserializer(io.BytesIO(b"[[1,2,3],\n[4,5,6]]"), "application/json")
-    assert np.array_equal(arr, np.array([[1, 2, 3], [4, 5, 6]]))
-
-
-# Sadly, ragged arrays work fine in JSON (giving us a 1D array of Python lists
-def test_numpy_deser_from_json_ragged():
-    arr = numpy_deserializer(io.BytesIO(b"[[1,2,3],\n[4,5,6,7]]"), "application/json")
-    assert np.array_equal(arr, np.array([[1, 2, 3], [4, 5, 6, 7]]))
-
-
-def test_numpy_deser_from_json_alpha():
-    arr = _NumpyDeserializer(dtype="U5")(
-        io.BytesIO(b'[["hello",2,3],\n[4,5,6]]'), "application/json"
-    )
-    assert np.array_equal(arr, np.array([["hello", 2, 3], [4, 5, 6]]))
-
-
-def test_numpy_deser_from_npy():
-    array = np.ones((2, 3))
-    stream = io.BytesIO()
-    np.save(stream, array)
-    stream.seek(0)
-
-    result = numpy_deserializer(stream)
-
-    assert np.array_equal(array, result)
-
-
-def test_numpy_deser_from_npy_object_array():
-    array = np.array(["one", "two"])
-    stream = io.BytesIO()
-    np.save(stream, array)
-    stream.seek(0)
-
-    result = numpy_deserializer(stream)
-
-    assert np.array_equal(array, result)
 
 
 # testing 'predict' invocations


### PR DESCRIPTION
*Issue #, if available:* #1694 

*Description of changes:*
Moved `sagemaker.predictor._NumpyDeserializer` to `sagemaker.deserializers.NumpyDeserializer`. 

*Testing done:*
Moved relevant tests from `tests.unit.test_predictor` to `tests.unit.sagemaker.test_deserializers`

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
