### PR TITLE
breaking: Move _JsonSerializer to sagemaker.serializers.JSONSerializer

### DIFF
--- a/doc/frameworks/tensorflow/upgrade_from_legacy.rst
+++ b/doc/frameworks/tensorflow/upgrade_from_legacy.rst
@@ -245,10 +245,10 @@ For example, if you want to use JSON serialization and deserialization:
 
 .. code:: python
 
-    from sagemaker.predictor import json_deserializer, json_serializer
+    from sagemaker.predictor import json_deserializer
+    from sagemaker.serializers import JSONSerializer
 
-    predictor.content_type = "application/json"
-    predictor.serializer = json_serializer
+    predictor.serializer = JSONSerializer()
     predictor.accept = "application/json"
     predictor.deserializer = json_deserializer
 

--- a/src/sagemaker/mxnet/model.py
+++ b/src/sagemaker/mxnet/model.py
@@ -26,7 +26,8 @@ from sagemaker.fw_utils import (
 )
 from sagemaker.model import FrameworkModel, MODEL_SERVER_WORKERS_PARAM_NAME
 from sagemaker.mxnet import defaults
-from sagemaker.predictor import Predictor, json_serializer, json_deserializer
+from sagemaker.predictor import Predictor, json_deserializer
+from sagemaker.serializers import JSONSerializer
 
 logger = logging.getLogger("sagemaker")
 
@@ -50,7 +51,7 @@ class MXNetPredictor(Predictor):
                 using the default AWS configuration chain.
         """
         super(MXNetPredictor, self).__init__(
-            endpoint_name, sagemaker_session, json_serializer, json_deserializer
+            endpoint_name, sagemaker_session, JSONSerializer(), json_deserializer
         )
 
 

--- a/src/sagemaker/predictor.py
+++ b/src/sagemaker/predictor.py
@@ -16,7 +16,6 @@ from __future__ import print_function, absolute_import
 import codecs
 import csv
 import json
-import six
 from six import StringIO, BytesIO
 import numpy as np
 
@@ -621,55 +620,6 @@ class _CsvDeserializer(object):
 
 
 csv_deserializer = _CsvDeserializer()
-
-
-class _JsonSerializer(object):
-    """Placeholder docstring"""
-
-    def __init__(self):
-        """Placeholder docstring"""
-        self.content_type = CONTENT_TYPE_JSON
-
-    def __call__(self, data):
-        """Take data of various formats and serialize them into the expected
-        request body. This uses information about supported input formats for
-        the deployed model.
-
-        Args:
-            data (object): Data to be serialized.
-
-        Returns:
-            object: Serialized data used for the request.
-        """
-        if isinstance(data, dict):
-            # convert each value in dict from a numpy array to a list if necessary, so they can be
-            # json serialized
-            return json.dumps({k: _ndarray_to_list(v) for k, v in six.iteritems(data)})
-
-        # files and buffers
-        if hasattr(data, "read"):
-            return _json_serialize_from_buffer(data)
-
-        return json.dumps(_ndarray_to_list(data))
-
-
-json_serializer = _JsonSerializer()
-
-
-def _ndarray_to_list(data):
-    """
-    Args:
-        data:
-    """
-    return data.tolist() if isinstance(data, np.ndarray) else data
-
-
-def _json_serialize_from_buffer(buff):
-    """
-    Args:
-        buff:
-    """
-    return buff.read()
 
 
 class _JsonDeserializer(object):

--- a/src/sagemaker/serializers.py
+++ b/src/sagemaker/serializers.py
@@ -14,6 +14,9 @@
 from __future__ import absolute_import
 
 import abc
+import json
+
+import numpy as np
 
 
 class BaseSerializer(abc.ABC):
@@ -38,3 +41,34 @@ class BaseSerializer(abc.ABC):
     @abc.abstractmethod
     def CONTENT_TYPE(self):
         """The MIME type of the data sent to the inference endpoint."""
+
+
+class JSONSerializer(BaseSerializer):
+    """Serialize data to a JSON formatted string."""
+
+    CONTENT_TYPE = "application/json"
+
+    def serialize(self, data):
+        """Serialize data of various formats to a JSON formatted string.
+
+        Args:
+            data (object): Data to be serialized.
+
+        Returns:
+            str: The data serialized as a JSON string.
+        """
+        if isinstance(data, dict):
+            return json.dumps(
+                {
+                    key: value.tolist() if isinstance(value, np.ndarray) else value
+                    for key, value in data.items()
+                }
+            )
+
+        if hasattr(data, "read"):
+            return data.read()
+
+        if isinstance(data, np.ndarray):
+            return json.dumps(data.tolist())
+
+        return json.dumps(data)

--- a/src/sagemaker/tensorflow/model.py
+++ b/src/sagemaker/tensorflow/model.py
@@ -18,7 +18,8 @@ import logging
 import sagemaker
 from sagemaker.content_types import CONTENT_TYPE_JSON
 from sagemaker.fw_utils import create_image_uri
-from sagemaker.predictor import json_serializer, json_deserializer, Predictor
+from sagemaker.predictor import json_deserializer, Predictor
+from sagemaker.serializers import JSONSerializer
 
 
 class TensorFlowPredictor(Predictor):
@@ -30,7 +31,7 @@ class TensorFlowPredictor(Predictor):
         self,
         endpoint_name,
         sagemaker_session=None,
-        serializer=json_serializer,
+        serializer=JSONSerializer(),
         deserializer=json_deserializer,
         content_type=None,
         model_name=None,

--- a/tests/integ/test_inference_pipeline.py
+++ b/tests/integ/test_inference_pipeline.py
@@ -26,7 +26,8 @@ from sagemaker.amazon.amazon_estimator import get_image_uri
 from sagemaker.content_types import CONTENT_TYPE_CSV
 from sagemaker.model import Model
 from sagemaker.pipeline import PipelineModel
-from sagemaker.predictor import Predictor, json_serializer
+from sagemaker.predictor import Predictor
+from sagemaker.serializers import JSONSerializer
 from sagemaker.sparkml.model import SparkMLModel
 from sagemaker.utils import sagemaker_timestamp
 
@@ -128,7 +129,7 @@ def test_inference_pipeline_model_deploy(sagemaker_session, cpu_instance_type):
         predictor = Predictor(
             endpoint_name=endpoint_name,
             sagemaker_session=sagemaker_session,
-            serializer=json_serializer,
+            serializer=JSONSerializer,
             content_type=CONTENT_TYPE_CSV,
             accept=CONTENT_TYPE_CSV,
         )

--- a/tests/integ/test_multidatamodel.py
+++ b/tests/integ/test_multidatamodel.py
@@ -290,7 +290,7 @@ def test_multi_data_model_deploy_trained_model_from_framework_estimator(
         assert PRETRAINED_MODEL_PATH_2 in endpoint_models
 
         # Define a predictor to set `serializer` parameter with npy_serializer
-        # instead of `json_serializer` in the default predictor returned by `MXNetPredictor`
+        # instead of `JSONSerializer` in the default predictor returned by `MXNetPredictor`
         # Since we are using a placeholder container image the prediction results are not accurate.
         predictor = Predictor(
             endpoint_name=endpoint_name,
@@ -391,7 +391,7 @@ def test_multi_data_model_deploy_train_model_from_amazon_first_party_estimator(
         assert PRETRAINED_MODEL_PATH_2 in endpoint_models
 
         # Define a predictor to set `serializer` parameter with npy_serializer
-        # instead of `json_serializer` in the default predictor returned by `MXNetPredictor`
+        # instead of `JSONSerializer` in the default predictor returned by `MXNetPredictor`
         # Since we are using a placeholder container image the prediction results are not accurate.
         predictor = Predictor(
             endpoint_name=endpoint_name,

--- a/tests/unit/sagemaker/test_serializers.py
+++ b/tests/unit/sagemaker/test_serializers.py
@@ -1,0 +1,74 @@
+# Copyright 2017-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from __future__ import absolute_import
+
+import json
+import os
+
+import numpy as np
+import pytest
+
+from sagemaker.serializers import JSONSerializer
+from tests.unit import DATA_DIR
+
+
+@pytest.fixture
+def json_serializer():
+    return JSONSerializer()
+
+
+def test_json_serializer_numpy_valid(json_serializer):
+    result = json_serializer.serialize(np.array([1, 2, 3]))
+
+    assert result == "[1, 2, 3]"
+
+
+def test_json_serializer_numpy_valid_2dimensional(json_serializer):
+    result = json_serializer.serialize(np.array([[1, 2, 3], [3, 4, 5]]))
+
+    assert result == "[[1, 2, 3], [3, 4, 5]]"
+
+
+def test_json_serializer_empty(json_serializer):
+    assert json_serializer.serialize(np.array([])) == "[]"
+
+
+def test_json_serializer_python_array(json_serializer):
+    result = json_serializer.serialize([1, 2, 3])
+
+    assert result == "[1, 2, 3]"
+
+
+def test_json_serializer_python_dictionary(json_serializer):
+    d = {"gender": "m", "age": 22, "city": "Paris"}
+
+    result = json_serializer.serialize(d)
+
+    assert json.loads(result) == d
+
+
+def test_json_serializer_python_invalid_empty(json_serializer):
+    assert json_serializer.serialize([]) == "[]"
+
+
+def test_json_serializer_python_dictionary_invalid_empty(json_serializer):
+    assert json_serializer.serialize({}) == "{}"
+
+
+def test_json_serializer_csv_buffer(json_serializer):
+    csv_file_path = os.path.join(DATA_DIR, "with_integers.csv")
+    with open(csv_file_path) as csv_file:
+        validation_value = csv_file.read()
+        csv_file.seek(0)
+        result = json_serializer.serialize(csv_file)
+        assert result == validation_value

--- a/tests/unit/test_predictor.py
+++ b/tests/unit/test_predictor.py
@@ -22,62 +22,15 @@ from mock import Mock, call, patch
 
 from sagemaker.predictor import Predictor
 from sagemaker.predictor import (
-    json_serializer,
     json_deserializer,
     csv_serializer,
     csv_deserializer,
     npy_serializer,
 )
+from sagemaker.serializers import JSONSerializer
 from tests.unit import DATA_DIR
 
 # testing serialization functions
-
-
-def test_json_serializer_numpy_valid():
-    result = json_serializer(np.array([1, 2, 3]))
-
-    assert result == "[1, 2, 3]"
-
-
-def test_json_serializer_numpy_valid_2dimensional():
-    result = json_serializer(np.array([[1, 2, 3], [3, 4, 5]]))
-
-    assert result == "[[1, 2, 3], [3, 4, 5]]"
-
-
-def test_json_serializer_empty():
-    assert json_serializer(np.array([])) == "[]"
-
-
-def test_json_serializer_python_array():
-    result = json_serializer([1, 2, 3])
-
-    assert result == "[1, 2, 3]"
-
-
-def test_json_serializer_python_dictionary():
-    d = {"gender": "m", "age": 22, "city": "Paris"}
-
-    result = json_serializer(d)
-
-    assert json.loads(result) == d
-
-
-def test_json_serializer_python_invalid_empty():
-    assert json_serializer([]) == "[]"
-
-
-def test_json_serializer_python_dictionary_invalid_empty():
-    assert json_serializer({}) == "{}"
-
-
-def test_json_serializer_csv_buffer():
-    csv_file_path = os.path.join(DATA_DIR, "with_integers.csv")
-    with open(csv_file_path) as csv_file:
-        validation_value = csv_file.read()
-        csv_file.seek(0)
-        result = json_serializer(csv_file)
-        assert result == validation_value
 
 
 def test_csv_serializer_str():
@@ -404,7 +357,7 @@ def test_predict_call_with_headers_and_json():
         sagemaker_session,
         content_type="not/json",
         accept="also/not-json",
-        serializer=json_serializer,
+        serializer=JSONSerializer(),
     )
 
     data = [1, 2]


### PR DESCRIPTION
*Issue #, if available:* #1694 

*Description of changes:*
Moved `sagemaker.serializers._JsonSerializer` to `sagemaker.serializers.JSONSerializer`

*Testing done:*
Moved related tests from `tests.unit.test_predicctor` to `tests.unit.sagemaker.test_serializers`.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
