### PR TITLE
fix: handle named variables in v2 migration tool

### DIFF
--- a/tests/unit/sagemaker/cli/compatibility/v2/modifiers/test_framework_version.py
+++ b/tests/unit/sagemaker/cli/compatibility/v2/modifiers/test_framework_version.py
@@ -12,7 +12,6 @@
 # language governing permissions and limitations under the License.
 from __future__ import absolute_import
 
-import pasta
 import pytest
 
 from sagemaker.cli.compatibility.v2.modifiers import framework_version
@@ -36,8 +35,10 @@ class Template:
         self.py_version = py_version
         self.py_version_for_model = py_version_for_model
 
-    def constructors(self, versions=False, image=False):
-        return self._frameworks(versions, image) + self._models(versions, image)
+    def constructors(self, fw_version=False, py_version=False, image=False):
+        return self._frameworks(fw_version, py_version, image) + self._models(
+            fw_version, py_version, image
+        )
 
     def _templates(self, model=False):
         module = self.framework.lower()
@@ -54,30 +55,38 @@ class Template:
             for template in templates
         )
 
-    def _frameworks(self, versions=False, image=False):
-        keywords = dict()
-        if image:
-            keywords["image_uri"] = "my:image"
-        if versions:
-            keywords["framework_version"] = self.framework_version
-            keywords["py_version"] = self.py_version
+    def _frameworks(self, fw_version=False, py_version=False, image=False):
+        keywords = self._base_keywords(fw_version, image)
+        if py_version:
+            keywords["py_version"] = (
+                "py_version" if py_version == "named" else "'{}'".format(self.py_version)
+            )
         return _format_templates(keywords, self._templates())
 
-    def _models(self, versions=False, image=False):
+    def _models(self, fw_version=False, py_version=False, image=False):
+        keywords = self._base_keywords(fw_version, image)
+        if py_version and self.py_version_for_model:
+            keywords["py_version"] = (
+                "py_version" if py_version == "named" else "'{}'".format(self.py_version)
+            )
+        return _format_templates(keywords, self._templates(model=True))
+
+    def _base_keywords(self, fw_version=False, image=False):
         keywords = dict()
         if image:
-            keywords["image_uri"] = "my:image"
-        if versions:
-            keywords["framework_version"] = self.framework_version
-            if self.py_version_for_model:
-                keywords["py_version"] = self.py_version
-        return _format_templates(keywords, self._templates(model=True))
+            keywords["image_uri"] = "'my:image'"
+        if fw_version:
+            keywords["framework_version"] = (
+                "fw_version" if fw_version == "named" else "'{}'".format(self.framework_version)
+            )
+        return keywords
 
 
 def _format_templates(keywords, templates):
     args = ", ".join(
-        "{key}='{value}'".format(key=key, value=value) for key, value in keywords.items()
+        "{key}={value}".format(key=key, value=value) for key, value in keywords.items()
     )
+
     return [template.format(args) for template in templates]
 
 
@@ -100,8 +109,12 @@ TEMPLATES = [
 ]
 
 
-def constructors(versions=False, image=False):
-    return [ctr for template in TEMPLATES for ctr in template.constructors(versions, image)]
+def constructors(fw_version=False, py_version=False, image=False):
+    return [
+        ctr
+        for template in TEMPLATES
+        for ctr in template.constructors(fw_version, py_version, image)
+    ]
 
 
 @pytest.fixture
@@ -110,18 +123,34 @@ def constructors_empty():
 
 
 @pytest.fixture
-def constructors_with_versions():
-    return constructors(versions=True)
+def constructors_with_only_fw_version_that_need_py_version():
+    ctrs = []
+    for template in TEMPLATES:
+        if template.py_version_for_model:
+            ctrs.extend(template.constructors(fw_version=True))
+        else:
+            ctrs.extend(template._frameworks(fw_version=True))
+    return ctrs
+
+
+@pytest.fixture
+def constructors_with_only_fw_version():
+    return constructors(fw_version=True)
+
+
+@pytest.fixture
+def constructors_with_only_py_version():
+    return constructors(py_version=True)
+
+
+@pytest.fixture
+def constructors_with_both_versions():
+    return constructors(fw_version=True, py_version=True)
 
 
 @pytest.fixture
 def constructors_with_image():
     return constructors(image=True)
-
-
-@pytest.fixture
-def constructors_with_both():
-    return constructors(versions=True, image=True)
 
 
 def _test_node_should_be_modified(ctrs, should_modify=True):
@@ -138,8 +167,20 @@ def test_node_should_be_modified_empty(constructors_empty):
     _test_node_should_be_modified(constructors_empty, should_modify=True)
 
 
-def test_node_should_be_modified_with_versions(constructors_with_versions):
-    _test_node_should_be_modified(constructors_with_versions, should_modify=False)
+def test_node_should_be_modified_with_only_fw_versions(
+    constructors_with_only_fw_version_that_need_py_version,
+):
+    _test_node_should_be_modified(
+        constructors_with_only_fw_version_that_need_py_version, should_modify=True
+    )
+
+
+def test_node_should_be_modified_with_only_py_versions(constructors_with_only_py_version):
+    _test_node_should_be_modified(constructors_with_only_py_version, should_modify=True)
+
+
+def test_node_should_be_modified_with_versions(constructors_with_both_versions):
+    _test_node_should_be_modified(constructors_with_both_versions, should_modify=False)
 
 
 def test_node_should_be_modified_with_image(constructors_with_image):
@@ -155,17 +196,40 @@ def _test_modify_node(ctrs_before, ctrs_expected):
     for before, expected in zip(ctrs_before, ctrs_expected):
         node = ast_call(before)
         modifier.modify_node(node)
-        # NOTE: this type of equality with pasta depends on ordering of args...
-        assert expected == pasta.dump(node)
+        _assert_equal_kwargs(ast_call(expected), node)
 
 
-def test_modify_node_empty(constructors_empty, constructors_with_versions):
-    _test_modify_node(constructors_empty, constructors_with_versions)
+def _assert_equal_kwargs(expected, actual):
+    assert _keywords_for_node(expected) == _keywords_for_node(actual)
 
 
-def test_modify_node_with_versions(constructors_with_versions):
-    _test_modify_node(constructors_with_versions, constructors_with_versions)
+def _keywords_for_node(node):
+    return {kw.arg: getattr(kw.value, kw.value._fields[0]) for kw in node.keywords}
 
 
-def test_modify_node_with_image(constructors_with_image, constructors_with_both):
-    _test_modify_node(constructors_with_image, constructors_with_both)
+def test_modify_node_empty(constructors_empty, constructors_with_both_versions):
+    _test_modify_node(constructors_empty, constructors_with_both_versions)
+
+
+def test_modify_node_only_fw_version(
+    constructors_with_only_fw_version, constructors_with_both_versions
+):
+    _test_modify_node(constructors_with_only_fw_version, constructors_with_both_versions)
+
+
+def test_modify_node_only_py_version(
+    constructors_with_only_py_version, constructors_with_both_versions
+):
+    _test_modify_node(constructors_with_only_py_version, constructors_with_both_versions)
+
+
+def test_modify_node_only_named_fw_version():
+    _test_modify_node(
+        constructors(fw_version="named"), constructors(fw_version="named", py_version="literal")
+    )
+
+
+def test_modify_node_only_named_py_version():
+    _test_modify_node(
+        constructors(py_version="named"), constructors(fw_version="literal", py_version="named")
+    )

--- a/tests/unit/sagemaker/cli/compatibility/v2/modifiers/test_tf_legacy_mode.py
+++ b/tests/unit/sagemaker/cli/compatibility/v2/modifiers/test_tf_legacy_mode.py
@@ -51,14 +51,20 @@ def test_node_should_be_modified_tf_constructor_script_mode():
         "TensorFlow(py_version='py3')",
         "TensorFlow(py_version='py37')",
         "TensorFlow(py_version='py3', script_mode=False)",
+        "TensorFlow(py_version=py_version, script_mode=False)",
+        "TensorFlow(py_version='py3', script_mode=script_mode)",
         "sagemaker.tensorflow.TensorFlow(script_mode=True)",
         "sagemaker.tensorflow.TensorFlow(py_version='py3')",
         "sagemaker.tensorflow.TensorFlow(py_version='py37')",
         "sagemaker.tensorflow.TensorFlow(py_version='py3', script_mode=False)",
+        "sagemaker.tensorflow.TensorFlow(py_version=py_version, script_mode=False)",
+        "sagemaker.tensorflow.TensorFlow(py_version='py3', script_mode=script_mode)",
         "sagemaker.tensorflow.estimator.TensorFlow(script_mode=True)",
         "sagemaker.tensorflow.estimator.TensorFlow(py_version='py3')",
         "sagemaker.tensorflow.estimator.TensorFlow(py_version='py37')",
         "sagemaker.tensorflow.estimator.TensorFlow(py_version='py3', script_mode=False)",
+        "sagemaker.tensorflow.estimator.TensorFlow(py_version=py_version, script_mode=False)",
+        "sagemaker.tensorflow.estimator.TensorFlow(py_version='py3', script_mode=script_mode)",
     )
 
     modifier = tf_legacy_mode.TensorFlowLegacyModeConstructorUpgrader()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
admittedly not my best code, but I didn't want to tamper too much with the setup in `test_framework_version`

*Testing done:*
unit tests, linters

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
