### PR TITLE
feature: support TFS 2.2

### DIFF
--- a/src/sagemaker/tensorflow/defaults.py
+++ b/src/sagemaker/tensorflow/defaults.py
@@ -21,7 +21,7 @@ This is no longer updated so as to not break existing workflows.
 LATEST_VERSION = "2.2.0"
 """The latest version of TensorFlow included in the SageMaker pre-built Docker images."""
 
-LATEST_SERVING_VERSION = "2.1.0"
+LATEST_SERVING_VERSION = "2.2.0"
 """The latest version of TensorFlow Serving included in the SageMaker pre-built Docker images."""
 
 LATEST_PY2_VERSION = "2.1.0"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,7 +28,7 @@ from sagemaker.pytorch import PyTorch
 from sagemaker.rl import RLEstimator
 from sagemaker.sklearn.defaults import SKLEARN_VERSION
 from sagemaker.tensorflow import TensorFlow
-from sagemaker.tensorflow.defaults import LATEST_VERSION, LATEST_SERVING_VERSION
+from sagemaker.tensorflow.defaults import LATEST_VERSION
 
 DEFAULT_REGION = "us-west-2"
 CUSTOM_BUCKET_NAME_PREFIX = "sagemaker-custom-bucket"
@@ -336,10 +336,3 @@ def pytest_generate_tests(metafunc):
 @pytest.fixture(scope="module")
 def xgboost_full_version(request):
     return request.config.getoption("--xgboost-full-version")
-
-
-@pytest.fixture(scope="module")
-def tf_serving_version(tf_full_version):
-    if tf_full_version == LATEST_VERSION:
-        return LATEST_SERVING_VERSION
-    return tf_full_version

--- a/tests/integ/test_data_capture_config.py
+++ b/tests/integ/test_data_capture_config.py
@@ -41,7 +41,7 @@ CUSTOM_JSON_CONTENT_TYPES = ["application/jsontype1", "application/jsontype2"]
 
 
 def test_enabling_data_capture_on_endpoint_shows_correct_data_capture_status(
-    sagemaker_session, tf_serving_version
+    sagemaker_session, tf_full_version
 ):
     endpoint_name = unique_name_from_base("sagemaker-tensorflow-serving")
     model_data = sagemaker_session.upload_data(
@@ -52,7 +52,7 @@ def test_enabling_data_capture_on_endpoint_shows_correct_data_capture_status(
         model = Model(
             model_data=model_data,
             role=ROLE,
-            framework_version=tf_serving_version,
+            framework_version=tf_full_version,
             sagemaker_session=sagemaker_session,
         )
         predictor = model.deploy(
@@ -98,7 +98,7 @@ def test_enabling_data_capture_on_endpoint_shows_correct_data_capture_status(
 
 
 def test_disabling_data_capture_on_endpoint_shows_correct_data_capture_status(
-    sagemaker_session, tf_serving_version
+    sagemaker_session, tf_full_version
 ):
     endpoint_name = unique_name_from_base("sagemaker-tensorflow-serving")
     model_data = sagemaker_session.upload_data(
@@ -109,7 +109,7 @@ def test_disabling_data_capture_on_endpoint_shows_correct_data_capture_status(
         model = Model(
             model_data=model_data,
             role=ROLE,
-            framework_version=tf_serving_version,
+            framework_version=tf_full_version,
             sagemaker_session=sagemaker_session,
         )
         destination_s3_uri = os.path.join(
@@ -184,7 +184,7 @@ def test_disabling_data_capture_on_endpoint_shows_correct_data_capture_status(
 
 
 def test_updating_data_capture_on_endpoint_shows_correct_data_capture_status(
-    sagemaker_session, tf_serving_version
+    sagemaker_session, tf_full_version
 ):
     endpoint_name = sagemaker.utils.unique_name_from_base("sagemaker-tensorflow-serving")
     model_data = sagemaker_session.upload_data(
@@ -195,7 +195,7 @@ def test_updating_data_capture_on_endpoint_shows_correct_data_capture_status(
         model = Model(
             model_data=model_data,
             role=ROLE,
-            framework_version=tf_serving_version,
+            framework_version=tf_full_version,
             sagemaker_session=sagemaker_session,
         )
         destination_s3_uri = os.path.join(

--- a/tests/integ/test_model_monitor.py
+++ b/tests/integ/test_model_monitor.py
@@ -88,7 +88,7 @@ FIVE_MIN_CRON_EXPRESSION = "cron(0/5 * ? * * *)"
 
 
 @pytest.fixture(scope="module")
-def predictor(sagemaker_session, tf_serving_version):
+def predictor(sagemaker_session, tf_full_version):
     endpoint_name = unique_name_from_base("sagemaker-tensorflow-serving")
     model_data = sagemaker_session.upload_data(
         path=os.path.join(tests.integ.DATA_DIR, "tensorflow-serving-test-model.tar.gz"),
@@ -100,7 +100,7 @@ def predictor(sagemaker_session, tf_serving_version):
         model = Model(
             model_data=model_data,
             role=ROLE,
-            framework_version=tf_serving_version,
+            framework_version=tf_full_version,
             sagemaker_session=sagemaker_session,
         )
         predictor = model.deploy(

--- a/tests/integ/test_tfs.py
+++ b/tests/integ/test_tfs.py
@@ -27,7 +27,7 @@ from sagemaker.tensorflow.serving import Model, Predictor
 
 
 @pytest.fixture(scope="module")
-def tfs_predictor(sagemaker_session, tf_serving_version):
+def tfs_predictor(sagemaker_session, tf_full_version):
     endpoint_name = sagemaker.utils.unique_name_from_base("sagemaker-tensorflow-serving")
     model_data = sagemaker_session.upload_data(
         path=os.path.join(tests.integ.DATA_DIR, "tensorflow-serving-test-model.tar.gz"),
@@ -37,7 +37,7 @@ def tfs_predictor(sagemaker_session, tf_serving_version):
         model = Model(
             model_data=model_data,
             role="SageMakerRole",
-            framework_version=tf_serving_version,
+            framework_version=tf_full_version,
             sagemaker_session=sagemaker_session,
         )
         predictor = model.deploy(1, "ml.c5.xlarge", endpoint_name=endpoint_name)
@@ -54,7 +54,7 @@ def tar_dir(directory, tmpdir):
 
 @pytest.fixture
 def tfs_predictor_with_model_and_entry_point_same_tar(
-    sagemaker_local_session, tf_serving_version, tmpdir
+    sagemaker_local_session, tf_full_version, tmpdir
 ):
     endpoint_name = sagemaker.utils.unique_name_from_base("sagemaker-tensorflow-serving")
 
@@ -65,7 +65,7 @@ def tfs_predictor_with_model_and_entry_point_same_tar(
     model = Model(
         model_data="file://" + model_tar,
         role="SageMakerRole",
-        framework_version=tf_serving_version,
+        framework_version=tf_full_version,
         sagemaker_session=sagemaker_local_session,
     )
     predictor = model.deploy(1, "local", endpoint_name=endpoint_name)
@@ -78,7 +78,7 @@ def tfs_predictor_with_model_and_entry_point_same_tar(
 
 @pytest.fixture(scope="module")
 def tfs_predictor_with_model_and_entry_point_and_dependencies(
-    sagemaker_local_session, tf_serving_version
+    sagemaker_local_session, tf_full_version
 ):
     endpoint_name = sagemaker.utils.unique_name_from_base("sagemaker-tensorflow-serving")
 
@@ -98,7 +98,7 @@ def tfs_predictor_with_model_and_entry_point_and_dependencies(
         model_data=model_data,
         role="SageMakerRole",
         dependencies=dependencies,
-        framework_version=tf_serving_version,
+        framework_version=tf_full_version,
         sagemaker_session=sagemaker_local_session,
     )
 

--- a/tests/integ/test_transformer.py
+++ b/tests/integ/test_transformer.py
@@ -379,9 +379,9 @@ def test_transform_tf_kms_network_isolation(
         role="SageMakerRole",
         train_instance_count=1,
         train_instance_type=cpu_instance_type,
-        framework_version=py_version,
+        framework_version=tf_full_version,
         script_mode=True,
-        py_version=PYTHON_VERSION,
+        py_version=py_version,
         sagemaker_session=sagemaker_session,
     )
 

--- a/tests/integ/test_transformer.py
+++ b/tests/integ/test_transformer.py
@@ -25,7 +25,7 @@ from sagemaker import KMeans, s3
 from sagemaker.mxnet import MXNet
 from sagemaker.pytorch import PyTorchModel
 from sagemaker.tensorflow import TensorFlow
-from sagemaker.tensorflow.defaults import LATEST_SERVING_VERSION
+from sagemaker.tensorflow.defaults import LATEST_VERSION
 from sagemaker.transformer import Transformer
 from sagemaker.estimator import Estimator
 from sagemaker.utils import unique_name_from_base
@@ -40,6 +40,11 @@ from tests.integ.timeout import timeout, timeout_and_delete_model_with_transform
 from tests.integ.vpc_test_utils import get_or_create_vpc_resources
 
 MXNET_MNIST_PATH = os.path.join(DATA_DIR, "mxnet_mnist")
+
+
+@pytest.fixture(scope="module")
+def py_version(tf_full_version):
+    return "py37" if tf_full_version == LATEST_VERSION else PYTHON_VERSION
 
 
 @pytest.fixture(scope="module")
@@ -364,7 +369,9 @@ def test_transform_mxnet_logs(
         transformer.wait()
 
 
-def test_transform_tf_kms_network_isolation(sagemaker_session, cpu_instance_type, tmpdir):
+def test_transform_tf_kms_network_isolation(
+    sagemaker_session, cpu_instance_type, tmpdir, tf_full_version, py_version
+):
     data_path = os.path.join(DATA_DIR, "tensorflow_mnist")
 
     tf = TensorFlow(
@@ -372,7 +379,7 @@ def test_transform_tf_kms_network_isolation(sagemaker_session, cpu_instance_type
         role="SageMakerRole",
         train_instance_count=1,
         train_instance_type=cpu_instance_type,
-        framework_version=LATEST_SERVING_VERSION,
+        framework_version=py_version,
         script_mode=True,
         py_version=PYTHON_VERSION,
         sagemaker_session=sagemaker_session,

--- a/tests/unit/test_fw_utils.py
+++ b/tests/unit/test_fw_utils.py
@@ -109,7 +109,8 @@ def is_mxnet_1_4_py2(framework, framework_version, py_version):
 
 
 @pytest.fixture(
-    scope="module", params=["1.11", "1.11.0", "1.12", "1.12.0", "1.14", "1.14.0", "1.15", "1.15.0"]
+    scope="module",
+    params=["1.11", "1.11.0", "1.12", "1.12.0", "1.14", "1.14.0", "1.15", "1.15.0", "2.0", "2.2.0"]
 )
 def tf_version(request):
     return request.param

--- a/tests/unit/test_fw_utils.py
+++ b/tests/unit/test_fw_utils.py
@@ -110,7 +110,7 @@ def is_mxnet_1_4_py2(framework, framework_version, py_version):
 
 @pytest.fixture(
     scope="module",
-    params=["1.11", "1.11.0", "1.12", "1.12.0", "1.14", "1.14.0", "1.15", "1.15.0", "2.0", "2.2.0"]
+    params=["1.11", "1.11.0", "1.12", "1.12.0", "1.14", "1.14.0", "1.15", "1.15.0", "2.0", "2.2.0"],
 )
 def tf_version(request):
     return request.param


### PR DESCRIPTION
*Issue #, if available:*
duplicate of #1595 

*Description of changes:*
update TensorFlow.defaults.LATEST_SERVING_VERSION to 2.2.0

*Testing done:*
update tf and related integ tests to use py_version fixture

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
