### PR TITLE
feature: Add model monitor support for us-gov-west-1

### DIFF
--- a/src/sagemaker/model_monitor/model_monitoring.py
+++ b/src/sagemaker/model_monitor/model_monitoring.py
@@ -57,6 +57,7 @@ _DEFAULT_MONITOR_IMAGE_REGION_ACCOUNT_MAPPING = {
     "ca-central-1": "536280801234",
     "cn-north-1": "453000072557",
     "cn-northwest-1": "453252182341",
+    "us-gov-west-1": "362178532790",
 }
 
 STATISTICS_JSON_DEFAULT_FILE_NAME = "statistics.json"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add information of Amazon-provided analysis image used by Model Monitor

*Testing done:*
Tested by running sample Model Monitor notebooks with this monkey-patched in.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
