### PR TITLE
change: make image_scope optional for some images in image_uris.retrieve()

### DIFF
--- a/src/sagemaker/image_uri_config/image-classification-neo.json
+++ b/src/sagemaker/image_uri_config/image-classification-neo.json
@@ -1,5 +1,5 @@
 {
-    "scope": ["inference", "training"],
+    "scope": ["inference"],
     "versions": {
         "latest": {
             "registries": {

--- a/src/sagemaker/image_uri_config/xgboost-neo.json
+++ b/src/sagemaker/image_uri_config/xgboost-neo.json
@@ -1,5 +1,5 @@
 {
-    "scope": ["inference", "training"],
+    "scope": ["inference"],
     "versions": {
         "latest": {
             "registries": {

--- a/tests/unit/sagemaker/image_uris/test_algos.py
+++ b/tests/unit/sagemaker/image_uris/test_algos.py
@@ -170,9 +170,8 @@ def test_algo_uris(algo):
     accounts = _accounts_for_algo(algo)
 
     for region in regions.regions():
-        for scope in ("training", "inference"):
-            uri = image_uris.retrieve(algo, region, image_scope=scope)
-            assert expected_uris.algo_uri(algo, accounts[region], region) == uri
+        uri = image_uris.retrieve(algo, region)
+        assert expected_uris.algo_uri(algo, accounts[region], region) == uri
 
 
 def test_lda():
@@ -180,11 +179,10 @@ def test_lda():
     accounts = _accounts_for_algo(algo)
 
     for region in regions.regions():
-        for scope in ("training", "inference"):
-            if region in accounts:
-                uri = image_uris.retrieve(algo, region, image_scope=scope)
-                assert expected_uris.algo_uri(algo, accounts[region], region) == uri
-            else:
-                with pytest.raises(ValueError) as e:
-                    image_uris.retrieve(algo, region, image_scope=scope)
-                assert "Unsupported region: {}.".format(region) in str(e.value)
+        if region in accounts:
+            uri = image_uris.retrieve(algo, region)
+            assert expected_uris.algo_uri(algo, accounts[region], region) == uri
+        else:
+            with pytest.raises(ValueError) as e:
+                image_uris.retrieve(algo, region)
+            assert "Unsupported region: {}.".format(region) in str(e.value)

--- a/tests/unit/sagemaker/image_uris/test_neo.py
+++ b/tests/unit/sagemaker/image_uris/test_neo.py
@@ -49,12 +49,11 @@ ACCOUNTS = {
 @pytest.mark.parametrize("algo", ALGO_NAMES)
 def test_algo_uris(algo):
     for region in regions.regions():
-        for scope in ("training", "inference"):
-            if region in NEO_REGION_LIST:
-                uri = image_uris.retrieve(algo, region, image_scope=scope)
-                expected = expected_uris.algo_uri(algo, ACCOUNTS[region], region, version="latest")
-                assert expected == uri
-            else:
-                with pytest.raises(ValueError) as e:
-                    image_uris.retrieve(algo, region, image_scope=scope)
-                assert "Unsupported region: {}.".format(region) in str(e.value)
+        if region in NEO_REGION_LIST:
+            uri = image_uris.retrieve(algo, region)
+            expected = expected_uris.algo_uri(algo, ACCOUNTS[region], region, version="latest")
+            assert expected == uri
+        else:
+            with pytest.raises(ValueError) as e:
+                image_uris.retrieve(algo, region)
+            assert "Unsupported region: {}.".format(region) in str(e.value)

--- a/tests/unit/sagemaker/image_uris/test_retrieve.py
+++ b/tests/unit/sagemaker/image_uris/test_retrieve.py
@@ -65,6 +65,48 @@ def test_retrieve_unsupported_image_scope(config_for_framework):
     assert "Unsupported image scope: invalid-image-scope." in str(e.value)
     assert "Supported image scope(s): training, inference." in str(e.value)
 
+    config = copy.deepcopy(BASE_CONFIG)
+    config["scope"].append("eia")
+    config_for_framework.return_value = config
+
+    with pytest.raises(ValueError) as e:
+        image_uris.retrieve(
+            framework="useless-string",
+            version="1.0.0",
+            py_version="py3",
+            instance_type="ml.c4.xlarge",
+            region="us-west-2",
+        )
+    assert "Unsupported image scope: None." in str(e.value)
+    assert "Supported image scope(s): training, inference, eia." in str(e.value)
+
+
+@patch("sagemaker.image_uris.config_for_framework", return_value=BASE_CONFIG)
+def test_retrieve_default_image_scope(config_for_framework, caplog):
+    uri = image_uris.retrieve(
+        framework="useless-string",
+        version="1.0.0",
+        py_version="py3",
+        instance_type="ml.c4.xlarge",
+        region="us-west-2",
+    )
+    assert "123412341234.dkr.ecr.us-west-2.amazonaws.com/dummy:1.0.0-cpu-py3" == uri
+
+    config = copy.deepcopy(BASE_CONFIG)
+    config["scope"] = ["eia"]
+    config_for_framework.return_value = config
+
+    uri = image_uris.retrieve(
+        framework="useless-string",
+        version="1.0.0",
+        py_version="py3",
+        instance_type="ml.c4.xlarge",
+        region="us-west-2",
+        image_scope="ignorable-scope",
+    )
+    assert "123412341234.dkr.ecr.us-west-2.amazonaws.com/dummy:1.0.0-cpu-py3" == uri
+    assert "Ignoring image scope: ignorable-scope." in caplog.text
+
 
 @patch("sagemaker.image_uris.config_for_framework")
 def test_retrieve_eia(config_for_framework, caplog):

--- a/tests/unit/sagemaker/image_uris/test_xgboost.py
+++ b/tests/unit/sagemaker/image_uris/test_xgboost.py
@@ -71,35 +71,30 @@ FRAMEWORK_REGISTRIES = {
 
 def test_xgboost_framework(xgboost_framework_version):
     for region in regions.regions():
-        for scope in ("training", "inference"):
-            uri = image_uris.retrieve(
-                framework="xgboost",
-                region=region,
-                version=xgboost_framework_version,
-                py_version="py3",
-                instance_type="ml.c4.xlarge",
-                image_scope=scope,
-            )
+        uri = image_uris.retrieve(
+            framework="xgboost",
+            region=region,
+            version=xgboost_framework_version,
+            py_version="py3",
+            instance_type="ml.c4.xlarge",
+        )
 
-            expected = expected_uris.framework_uri(
-                "sagemaker-xgboost",
-                xgboost_framework_version,
-                FRAMEWORK_REGISTRIES[region],
-                py_version="py3",
-                region=region,
-            )
-            assert expected == uri
+        expected = expected_uris.framework_uri(
+            "sagemaker-xgboost",
+            xgboost_framework_version,
+            FRAMEWORK_REGISTRIES[region],
+            py_version="py3",
+            region=region,
+        )
+        assert expected == uri
 
 
 @pytest.mark.parametrize("xgboost_algo_version", ("1", "latest"))
 def test_xgboost_algo(xgboost_algo_version):
     for region in regions.regions():
-        for scope in ("training", "inference"):
-            uri = image_uris.retrieve(
-                framework="xgboost", region=region, version=xgboost_algo_version, image_scope=scope,
-            )
+        uri = image_uris.retrieve(framework="xgboost", region=region, version=xgboost_algo_version)
 
-            expected = expected_uris.algo_uri(
-                "xgboost", ALGO_REGISTRIES[region], region, version=xgboost_algo_version
-            )
-            assert expected == uri
+        expected = expected_uris.algo_uri(
+            "xgboost", ALGO_REGISTRIES[region], region, version=xgboost_algo_version
+        )
+        assert expected == uri


### PR DESCRIPTION
*Issue #, if available:*
#1464 

*Description of changes:*
This was common enough that I decided to go ahead and add logic for the case where a single image is used for both training and inference. This should also hopefully help with making it easier to migrate from `sagemaker.amazon.amazon_estimator.get_image_uri` to `sagemaker.image_uris.retrieve`

*Testing done:*
unit tests

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
