### PR TITLE
change: use image_uris.retrieve instead of fw_utils.create_image_uri for DLC frameworks

### DIFF
--- a/src/sagemaker/chainer/model.py
+++ b/src/sagemaker/chainer/model.py
@@ -16,8 +16,8 @@ from __future__ import absolute_import
 import logging
 
 import sagemaker
+from sagemaker import image_uris
 from sagemaker.fw_utils import (
-    create_image_uri,
     model_code_key_prefix,
     python_deprecation_warning,
     validate_version_or_image_args,
@@ -175,11 +175,12 @@ class ChainerModel(FrameworkModel):
             str: The appropriate image URI based on the given parameters.
 
         """
-        return create_image_uri(
-            region_name,
+        return image_uris.retrieve(
             self.__framework_name__,
-            instance_type,
-            self.framework_version,
-            self.py_version,
+            region_name,
+            version=self.framework_version,
+            py_version=self.py_version,
+            instance_type=instance_type,
             accelerator_type=accelerator_type,
+            image_scope="inference",
         )

--- a/src/sagemaker/cli/compatibility/v2/modifiers/tf_legacy_mode.py
+++ b/src/sagemaker/cli/compatibility/v2/modifiers/tf_legacy_mode.py
@@ -22,7 +22,7 @@ import six
 
 from sagemaker.cli.compatibility.v2.modifiers import framework_version, matching
 from sagemaker.cli.compatibility.v2.modifiers.modifier import Modifier
-from sagemaker import fw_utils
+from sagemaker import image_uris
 
 TF_NAMESPACES = ("sagemaker.tensorflow", "sagemaker.tensorflow.estimator")
 LEGACY_MODE_PARAMETERS = (
@@ -169,9 +169,14 @@ class TensorFlowLegacyModeConstructorUpgrader(Modifier):
                 instance_type = kw.value.s if isinstance(kw.value, ast.Str) else None
 
         if tf_version and instance_type:
-            return fw_utils.create_image_uri(
-                self.region, "tensorflow", instance_type, tf_version, "py2"
-            )
+            return image_uris.retrieve(
+                "tensorflow",
+                self.region,
+                version=tf_version,
+                py_version="py2",
+                instance_type=instance_type,
+                image_scope="training",
+            ).replace("-scriptmode", "")
 
         return None
 

--- a/src/sagemaker/estimator.py
+++ b/src/sagemaker/estimator.py
@@ -25,7 +25,7 @@ from six import with_metaclass
 from six import string_types
 from six.moves.urllib.parse import urlparse
 import sagemaker
-from sagemaker import git_utils
+from sagemaker import git_utils, image_uris
 from sagemaker.analytics import TrainingJobAnalytics
 from sagemaker.debugger import DebuggerHookConfig
 from sagemaker.debugger import TensorBoardOutputConfig  # noqa: F401 # pylint: disable=unused-import
@@ -33,7 +33,6 @@ from sagemaker.debugger import get_rule_container_image_uri
 from sagemaker.s3 import S3Uploader
 
 from sagemaker.fw_utils import (
-    create_image_uri,
     tar_and_upload_dir,
     parse_s3_url,
     UploadedCode,
@@ -1822,12 +1821,13 @@ class Framework(EstimatorBase):
         """
         if self.image_uri:
             return self.image_uri
-        return create_image_uri(
-            self.sagemaker_session.boto_region_name,
+        return image_uris.retrieve(
             self.__framework_name__,
-            self.instance_type,
-            self.framework_version,  # pylint: disable=no-member
+            self.sagemaker_session.boto_region_name,
+            instance_type=self.instance_type,
+            version=self.framework_version,  # pylint: disable=no-member
             py_version=self.py_version,  # pylint: disable=no-member
+            image_scope="training",
         )
 
     @classmethod

--- a/src/sagemaker/mxnet/model.py
+++ b/src/sagemaker/mxnet/model.py
@@ -18,9 +18,9 @@ import logging
 import packaging.version
 
 import sagemaker
+from sagemaker import image_uris
 from sagemaker.deserializers import JSONDeserializer
 from sagemaker.fw_utils import (
-    create_image_uri,
     model_code_key_prefix,
     python_deprecation_warning,
     validate_version_or_image_args,
@@ -183,17 +183,14 @@ class MXNetModel(FrameworkModel):
             str: The appropriate image URI based on the given parameters.
 
         """
-        framework_name = self.__framework_name__
-        if self._is_mms_version():
-            framework_name = "{}-serving".format(framework_name)
-
-        return create_image_uri(
+        return image_uris.retrieve(
+            self.__framework_name__,
             region_name,
-            framework_name,
-            instance_type,
-            self.framework_version,
-            self.py_version,
+            version=self.framework_version,
+            py_version=self.py_version,
+            instance_type=instance_type,
             accelerator_type=accelerator_type,
+            image_scope="inference",
         )
 
     def _is_mms_version(self):

--- a/src/sagemaker/pytorch/model.py
+++ b/src/sagemaker/pytorch/model.py
@@ -17,9 +17,9 @@ import logging
 import packaging.version
 
 import sagemaker
+from sagemaker import image_uris
 from sagemaker.deserializers import NumpyDeserializer
 from sagemaker.fw_utils import (
-    create_image_uri,
     model_code_key_prefix,
     python_deprecation_warning,
     validate_version_or_image_args,
@@ -182,17 +182,14 @@ class PyTorchModel(FrameworkModel):
             str: The appropriate image URI based on the given parameters.
 
         """
-        framework_name = self.__framework_name__
-        if self._is_mms_version():
-            framework_name = "{}-serving".format(framework_name)
-
-        return create_image_uri(
+        return image_uris.retrieve(
+            self.__framework_name__,
             region_name,
-            framework_name,
-            instance_type,
-            self.framework_version,
-            self.py_version,
+            version=self.framework_version,
+            py_version=self.py_version,
+            instance_type=instance_type,
             accelerator_type=accelerator_type,
+            image_scope="inference",
         )
 
     def _is_mms_version(self):

--- a/src/sagemaker/tensorflow/model.py
+++ b/src/sagemaker/tensorflow/model.py
@@ -16,9 +16,9 @@ from __future__ import absolute_import
 import logging
 
 import sagemaker
+from sagemaker import image_uris
 from sagemaker.content_types import CONTENT_TYPE_JSON
 from sagemaker.deserializers import JSONDeserializer
-from sagemaker.fw_utils import create_image_uri
 from sagemaker.predictor import Predictor
 from sagemaker.serializers import JSONSerializer
 
@@ -122,7 +122,7 @@ class TensorFlowPredictor(Predictor):
 class TensorFlowModel(sagemaker.model.FrameworkModel):
     """A ``FrameworkModel`` implementation for inference with TensorFlow Serving."""
 
-    __framework_name__ = "tensorflow-serving"
+    __framework_name__ = "tensorflow"
     LOG_LEVEL_PARAM_NAME = "SAGEMAKER_TFS_NGINX_LOGLEVEL"
     LOG_LEVEL_MAP = {
         logging.DEBUG: "debug",
@@ -286,13 +286,13 @@ class TensorFlowModel(sagemaker.model.FrameworkModel):
         if self.image_uri:
             return self.image_uri
 
-        region_name = self.sagemaker_session.boto_region_name
-        return create_image_uri(
-            region_name,
+        return image_uris.retrieve(
             self.__framework_name__,
-            instance_type,
-            self.framework_version,
+            self.sagemaker_session.boto_region_name,
+            version=self.framework_version,
+            instance_type=instance_type,
             accelerator_type=accelerator_type,
+            image_scope="inference",
         )
 
     def serving_image_uri(

--- a/tests/unit/sagemaker/tensorflow/test_estimator.py
+++ b/tests/unit/sagemaker/tensorflow/test_estimator.py
@@ -187,10 +187,10 @@ def test_create_model(
         container_log_level=container_log_level,
         base_job_name=base_job_name,
         enable_network_isolation=True,
+        output_path="s3://mybucket/output",
     )
 
-    job_name = "doing something"
-    tf.fit(inputs="s3://mybucket/train", job_name=job_name)
+    tf._current_job_name = "doing something"
 
     model_name = "doing something else"
     name_from_base.return_value = model_name
@@ -233,10 +233,10 @@ def test_create_model_with_optional_params(
         base_job_name="job",
         source_dir=source_dir,
         enable_cloudwatch_metrics=enable_cloudwatch_metrics,
+        output_path="s3://mybucket/output",
     )
 
-    job_name = "doing something"
-    tf.fit(inputs="s3://mybucket/train", job_name=job_name)
+    tf._current_job_name = "doing something"
 
     new_role = "role"
     vpc_config = {"Subnets": ["foo"], "SecurityGroupIds": ["bar"]}

--- a/tests/unit/test_airflow.py
+++ b/tests/unit/test_airflow.py
@@ -174,10 +174,10 @@ def test_byo_training_config_all_args(sagemaker_session):
     ),
 )
 @patch(
-    "sagemaker.fw_utils.get_ecr_image_uri_prefix",
-    return_value="763104351884.dkr.ecr.us-west-2.amazonaws.com",
+    "sagemaker.image_uris.retrieve",
+    return_value="763104351884.dkr.ecr.us-west-2.amazonaws.com/tensorflow-training:1.15.2-cpu-py3",
 )
-def test_framework_training_config_required_args(ecr_prefix, sagemaker_session):
+def test_framework_training_config_required_args(retrieve_image_uri, sagemaker_session):
     tf = tensorflow.TensorFlow(
         entry_point="/some/script.py",
         framework_version="1.15.2",
@@ -249,10 +249,10 @@ def test_framework_training_config_required_args(ecr_prefix, sagemaker_session):
     MagicMock(return_value=["{{ output_path }}", "{{ output_path }}"]),
 )
 @patch(
-    "sagemaker.fw_utils.get_ecr_image_uri_prefix",
-    return_value="763104351884.dkr.ecr.us-west-2.amazonaws.com",
+    "sagemaker.image_uris.retrieve",
+    return_value="763104351884.dkr.ecr.us-west-2.amazonaws.com/tensorflow-training:1.15.2-cpu-py3",
 )
-def test_framework_training_config_all_args(ecr_prefix, sagemaker_session):
+def test_framework_training_config_all_args(retrieve_image_uri, sagemaker_session):
     tf = tensorflow.TensorFlow(
         entry_point="{{ entry_point }}",
         source_dir="{{ source_dir }}",
@@ -480,10 +480,10 @@ def test_amazon_alg_training_config_all_args(sagemaker_session):
     ),
 )
 @patch(
-    "sagemaker.fw_utils.get_ecr_image_uri_prefix",
-    return_value="520713654638.dkr.ecr.us-west-2.amazonaws.com",
+    "sagemaker.image_uris.retrieve",
+    return_value="520713654638.dkr.ecr.us-west-2.amazonaws.com/sagemaker-mxnet:1.3.0-cpu-py3",
 )
-def test_framework_tuning_config(ecr_prefix, sagemaker_session):
+def test_framework_tuning_config(retrieve_image_uri, sagemaker_session):
     mxnet_estimator = mxnet.MXNet(
         entry_point="{{ entry_point }}",
         source_dir="{{ source_dir }}",
@@ -622,15 +622,12 @@ def test_framework_tuning_config(ecr_prefix, sagemaker_session):
         ]
     ),
 )
-@patch(
-    "sagemaker.fw_utils.get_ecr_image_uri_prefix",
-    return_value="520713654638.dkr.ecr.us-west-2.amazonaws.com",
-)
-@patch(
-    "sagemaker.amazon.amazon_estimator.get_ecr_image_uri_prefix",
-    return_value="174872318107.dkr.ecr.us-west-2.amazonaws.com",
-)
-def test_multi_estimator_tuning_config(algo_ecr_prefix, fw_ecr_prefix, sagemaker_session):
+@patch("sagemaker.utils._botocore_resolver")
+def test_multi_estimator_tuning_config(botocore_resolver, sagemaker_session):
+    botocore_resolver.return_value.construct_endpoint.return_value = {
+        "hostname": "ecr.us-west-2.amazonaws.com"
+    }
+
     estimator_dict = {}
     hyperparameter_ranges_dict = {}
     objective_metric_name_dict = {}
@@ -1039,10 +1036,10 @@ def test_amazon_alg_model_config(sagemaker_session):
     ),
 )
 @patch(
-    "sagemaker.fw_utils.get_ecr_image_uri_prefix",
-    return_value="763104351884.dkr.ecr.us-west-2.amazonaws.com",
+    "sagemaker.image_uris.retrieve",
+    return_value="763104351884.dkr.ecr.us-west-2.amazonaws.com/mxnet-inference:1.6.0-cpu-py3",
 )
-def test_model_config_from_framework_estimator(ecr_prefix, sagemaker_session):
+def test_model_config_from_framework_estimator(retrieve_image_uri, sagemaker_session):
     mxnet_estimator = mxnet.MXNet(
         entry_point="{{ entry_point }}",
         source_dir="{{ source_dir }}",
@@ -1205,10 +1202,10 @@ def test_transform_config(sagemaker_session):
     ),
 )
 @patch(
-    "sagemaker.fw_utils.get_ecr_image_uri_prefix",
-    return_value="763104351884.dkr.ecr.us-west-2.amazonaws.com",
+    "sagemaker.image_uris.retrieve",
+    return_value="763104351884.dkr.ecr.us-west-2.amazonaws.com/mxnet-inference:1.6.0-gpu-py3",
 )
-def test_transform_config_from_framework_estimator(ecr_prefix, sagemaker_session):
+def test_transform_config_from_framework_estimator(retrieve_image_uri, sagemaker_session):
     mxnet_estimator = mxnet.MXNet(
         entry_point="{{ entry_point }}",
         source_dir="{{ source_dir }}",
@@ -1458,10 +1455,10 @@ def test_deploy_amazon_alg_model_config(sagemaker_session):
     ),
 )
 @patch(
-    "sagemaker.fw_utils.get_ecr_image_uri_prefix",
-    return_value="763104351884.dkr.ecr.us-west-2.amazonaws.com",
+    "sagemaker.image_uris.retrieve",
+    return_value="763104351884.dkr.ecr.us-west-2.amazonaws.com/mxnet-inference:1.6.0-cpu-py3",
 )
-def test_deploy_config_from_framework_estimator(ecr_prefix, sagemaker_session):
+def test_deploy_config_from_framework_estimator(retrieve_image_uri, sagemaker_session):
     mxnet_estimator = mxnet.MXNet(
         entry_point="{{ entry_point }}",
         source_dir="{{ source_dir }}",

--- a/tests/unit/test_mxnet.py
+++ b/tests/unit/test_mxnet.py
@@ -306,11 +306,9 @@ def test_create_model_with_custom_image(name_from_base, sagemaker_session):
 @patch("sagemaker.utils.create_tar_file")
 @patch("sagemaker.utils.repack_model")
 @patch("time.strftime", return_value=TIMESTAMP)
-@patch("sagemaker.mxnet.model.create_image_uri", return_value=IMAGE)
-@patch("sagemaker.estimator.create_image_uri", return_value=IMAGE)
+@patch("sagemaker.image_uris.retrieve", return_value=IMAGE)
 def test_mxnet(
-    train_image_uri,
-    model_image_uri,
+    retrieve_image_uri,
     strftime,
     repack_model,
     create_tar_file,
@@ -470,9 +468,9 @@ def test_model_mms_version(
 
 @patch("sagemaker.fw_utils.tar_and_upload_dir")
 @patch("sagemaker.utils.repack_model")
-@patch("sagemaker.mxnet.model.create_image_uri", return_value=IMAGE)
+@patch("sagemaker.image_uris.retrieve", return_value=IMAGE)
 def test_model_image_accelerator(
-    create_image_uri,
+    retrieve_image_uri,
     repack_model,
     tar_and_upload,
     sagemaker_session,

--- a/tests/unit/test_pytorch.py
+++ b/tests/unit/test_pytorch.py
@@ -409,9 +409,7 @@ def test_model_image_accelerator(sagemaker_session):
             py_version="py2",
         )
         model.deploy(1, CPU, accelerator_type=ACCELERATOR_TYPE)
-    assert "pytorch-serving is not supported with Amazon Elastic Inference in Python 2." in str(
-        error
-    )
+    assert "Unsupported Python version: py2." in str(error)
 
 
 def test_model_prepare_container_def_no_instance_type_or_image():


### PR DESCRIPTION
*Issue #, if available:*
#1464 

*Description of changes:*
still need to add configuration for inferentia, Neo, and RL before fully deprecating `create_image_uri`

*Testing done:*
unit tests

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
