### PR TITLE
breaking: deprecate sagemaker.amazon.amazon_estimator.get_image_uri()

### DIFF
--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -993,12 +993,17 @@ the ML Pipeline.
 
 .. code:: python
 
-   xgb_image = get_image_uri(sess.boto_region_name, 'xgboost', repo_version="latest")
-   xgb_model = Model(model_data='s3://path/to/model.tar.gz', image_uri=xgb_image)
-   sparkml_model = SparkMLModel(model_data='s3://path/to/model.tar.gz', env={'SAGEMAKER_SPARKML_SCHEMA': schema})
+   from sagemaker import image_uris, session
+   from sagemaker.model import Model
+   from sagemaker.pipeline import PipelineModel
+   from sagemaker.sparkml import SparkMLModel
 
-   model_name = 'inference-pipeline-model'
-   endpoint_name = 'inference-pipeline-endpoint'
+   xgb_image = image_uris.retrieve("xgboost", session.Session().boto_region_name, repo_version="latest")
+   xgb_model = Model(model_data="s3://path/to/model.tar.gz", image_uri=xgb_image)
+   sparkml_model = SparkMLModel(model_data="s3://path/to/model.tar.gz", env={"SAGEMAKER_SPARKML_SCHEMA": schema})
+
+   model_name = "inference-pipeline-model"
+   endpoint_name = "inference-pipeline-endpoint"
    sm_model = PipelineModel(name=model_name, role=sagemaker_role, models=[sparkml_model, xgb_model])
 
 This defines a ``PipelineModel`` consisting of SparkML model and an XGBoost model stacked sequentially.

--- a/src/sagemaker/amazon/amazon_estimator.py
+++ b/src/sagemaker/amazon/amazon_estimator.py
@@ -19,13 +19,13 @@ import tempfile
 
 from six.moves.urllib.parse import urlparse
 
+from sagemaker import image_uris
 from sagemaker.amazon import validation
 from sagemaker.amazon.hyperparameter import Hyperparameter as hp  # noqa
 from sagemaker.amazon.common import write_numpy_to_dense_tensor
 from sagemaker.estimator import EstimatorBase, _TrainingJob
 from sagemaker.inputs import FileSystemInput, TrainingInput
-from sagemaker.model import NEO_IMAGE_ACCOUNT
-from sagemaker.utils import sagemaker_timestamp, get_ecr_image_uri_prefix
+from sagemaker.utils import sagemaker_timestamp
 
 logger = logging.getLogger(__name__)
 
@@ -93,8 +93,8 @@ class AmazonAlgorithmEstimatorBase(EstimatorBase):
 
     def train_image(self):
         """Placeholder docstring"""
-        return get_image_uri(
-            self.sagemaker_session.boto_region_name, type(self).repo_name, type(self).repo_version
+        return image_uris.retrieve(
+            self.repo_name, self.sagemaker_session.boto_region_name, version=self.repo_version,
         )
 
     def hyperparameters(self):
@@ -452,167 +452,3 @@ def upload_numpy_to_s3_shards(
                 s3.Object(bucket, key_prefix + file).delete()
         finally:
             raise ex
-
-
-def registry(region_name, algorithm=None):
-    """Return docker registry for the given AWS region
-
-    Note: Not all the algorithms listed below have an Amazon Estimator
-    implemented. For full list of pre-implemented Estimators, look at:
-
-    https://github.com/aws/sagemaker-python-sdk/tree/master/src/sagemaker/amazon
-
-    Args:
-        region_name (str): The region name for the account.
-        algorithm (str): The algorithm for the account.
-
-    Raises:
-        ValueError: If invalid algorithm passed in or if mapping does not exist for given algorithm
-            and region.
-    """
-    region_to_accounts = {}
-    if algorithm in [
-        None,
-        "pca",
-        "kmeans",
-        "linear-learner",
-        "factorization-machines",
-        "ntm",
-        "randomcutforest",
-        "knn",
-        "object2vec",
-        "ipinsights",
-    ]:
-        region_to_accounts = {
-            "us-east-1": "382416733822",
-            "us-east-2": "404615174143",
-            "us-west-2": "174872318107",
-            "eu-west-1": "438346466558",
-            "eu-central-1": "664544806723",
-            "ap-northeast-1": "351501993468",
-            "ap-northeast-2": "835164637446",
-            "ap-southeast-2": "712309505854",
-            "us-gov-west-1": "226302683700",
-            "ap-southeast-1": "475088953585",
-            "ap-south-1": "991648021394",
-            "ca-central-1": "469771592824",
-            "eu-west-2": "644912444149",
-            "us-west-1": "632365934929",
-            "us-iso-east-1": "490574956308",
-            "ap-east-1": "286214385809",
-            "eu-north-1": "669576153137",
-            "eu-west-3": "749696950732",
-            "sa-east-1": "855470959533",
-            "me-south-1": "249704162688",
-            "cn-north-1": "390948362332",
-            "cn-northwest-1": "387376663083",
-        }
-    elif algorithm in ["lda"]:
-        region_to_accounts = {
-            "us-east-1": "766337827248",
-            "us-east-2": "999911452149",
-            "us-west-2": "266724342769",
-            "eu-west-1": "999678624901",
-            "eu-central-1": "353608530281",
-            "ap-northeast-1": "258307448986",
-            "ap-northeast-2": "293181348795",
-            "ap-southeast-2": "297031611018",
-            "us-gov-west-1": "226302683700",
-            "ap-southeast-1": "475088953585",
-            "ap-south-1": "991648021394",
-            "ca-central-1": "469771592824",
-            "eu-west-2": "644912444149",
-            "us-west-1": "632365934929",
-            "us-iso-east-1": "490574956308",
-        }
-    elif algorithm in ["forecasting-deepar"]:
-        region_to_accounts = {
-            "us-east-1": "522234722520",
-            "us-east-2": "566113047672",
-            "us-west-2": "156387875391",
-            "eu-west-1": "224300973850",
-            "eu-central-1": "495149712605",
-            "ap-northeast-1": "633353088612",
-            "ap-northeast-2": "204372634319",
-            "ap-southeast-2": "514117268639",
-            "us-gov-west-1": "226302683700",
-            "ap-southeast-1": "475088953585",
-            "ap-south-1": "991648021394",
-            "ca-central-1": "469771592824",
-            "eu-west-2": "644912444149",
-            "us-west-1": "632365934929",
-            "us-iso-east-1": "490574956308",
-            "ap-east-1": "286214385809",
-            "eu-north-1": "669576153137",
-            "eu-west-3": "749696950732",
-            "sa-east-1": "855470959533",
-            "me-south-1": "249704162688",
-            "cn-north-1": "390948362332",
-            "cn-northwest-1": "387376663083",
-        }
-    elif algorithm in [
-        "xgboost",
-        "seq2seq",
-        "image-classification",
-        "blazingtext",
-        "object-detection",
-        "semantic-segmentation",
-    ]:
-        region_to_accounts = {
-            "us-east-1": "811284229777",
-            "us-east-2": "825641698319",
-            "us-west-2": "433757028032",
-            "eu-west-1": "685385470294",
-            "eu-central-1": "813361260812",
-            "ap-northeast-1": "501404015308",
-            "ap-northeast-2": "306986355934",
-            "ap-southeast-2": "544295431143",
-            "us-gov-west-1": "226302683700",
-            "ap-southeast-1": "475088953585",
-            "ap-south-1": "991648021394",
-            "ca-central-1": "469771592824",
-            "eu-west-2": "644912444149",
-            "us-west-1": "632365934929",
-            "us-iso-east-1": "490574956308",
-            "ap-east-1": "286214385809",
-            "eu-north-1": "669576153137",
-            "eu-west-3": "749696950732",
-            "sa-east-1": "855470959533",
-            "me-south-1": "249704162688",
-            "cn-north-1": "390948362332",
-            "cn-northwest-1": "387376663083",
-        }
-    elif algorithm in ["image-classification-neo", "xgboost-neo"]:
-        region_to_accounts = NEO_IMAGE_ACCOUNT
-    else:
-        raise ValueError(
-            "Algorithm class:{} does not have mapping to account_id with images".format(algorithm)
-        )
-
-    if region_name in region_to_accounts:
-        account_id = region_to_accounts[region_name]
-        return get_ecr_image_uri_prefix(account_id, region_name)
-
-    raise ValueError(
-        "Algorithm ({algorithm}) is unsupported for region ({region_name}).".format(
-            algorithm=algorithm, region_name=region_name
-        )
-    )
-
-
-def get_image_uri(region_name, repo_name, repo_version=1):
-    """Return algorithm image URI for the given AWS region, repository name, and
-    repository version
-
-    Args:
-        region_name:
-        repo_name:
-        repo_version:
-    """
-    logger.warning(
-        "'get_image_uri' method will be deprecated in favor of 'ImageURIProvider' class "
-        "in SageMaker Python SDK v2."
-    )
-
-    repo = "{}:{}".format(repo_name, repo_version)
-    return "{}/{}".format(registry(region_name, repo_name), repo)

--- a/src/sagemaker/amazon/factorization_machines.py
+++ b/src/sagemaker/amazon/factorization_machines.py
@@ -13,7 +13,8 @@
 """Placeholder docstring"""
 from __future__ import absolute_import
 
-from sagemaker.amazon.amazon_estimator import AmazonAlgorithmEstimatorBase, registry
+from sagemaker import image_uris
+from sagemaker.amazon.amazon_estimator import AmazonAlgorithmEstimatorBase
 from sagemaker.amazon.common import RecordSerializer, RecordDeserializer
 from sagemaker.amazon.hyperparameter import Hyperparameter as hp  # noqa
 from sagemaker.amazon.validation import gt, isin, ge
@@ -309,8 +310,11 @@ class FactorizationMachinesModel(Model):
             **kwargs:
         """
         sagemaker_session = sagemaker_session or Session()
-        repo = "{}:{}".format(FactorizationMachines.repo_name, FactorizationMachines.repo_version)
-        image_uri = "{}/{}".format(registry(sagemaker_session.boto_session.region_name), repo)
+        image_uri = image_uris.retrieve(
+            FactorizationMachines.repo_name,
+            sagemaker_session.boto_region_name,
+            version=FactorizationMachines.repo_version,
+        )
         super(FactorizationMachinesModel, self).__init__(
             image_uri,
             model_data,

--- a/src/sagemaker/amazon/ipinsights.py
+++ b/src/sagemaker/amazon/ipinsights.py
@@ -13,7 +13,8 @@
 """Placeholder docstring"""
 from __future__ import absolute_import
 
-from sagemaker.amazon.amazon_estimator import AmazonAlgorithmEstimatorBase, registry
+from sagemaker import image_uris
+from sagemaker.amazon.amazon_estimator import AmazonAlgorithmEstimatorBase
 from sagemaker.amazon.hyperparameter import Hyperparameter as hp  # noqa
 from sagemaker.amazon.validation import ge, le
 from sagemaker.deserializers import JSONDeserializer
@@ -219,11 +220,11 @@ class IPInsightsModel(Model):
             **kwargs:
         """
         sagemaker_session = sagemaker_session or Session()
-        repo = "{}:{}".format(IPInsights.repo_name, IPInsights.repo_version)
-        image_uri = "{}/{}".format(
-            registry(sagemaker_session.boto_session.region_name, IPInsights.repo_name), repo
+        image_uri = image_uris.retrieve(
+            IPInsights.repo_name,
+            sagemaker_session.boto_region_name,
+            version=IPInsights.repo_version,
         )
-
         super(IPInsightsModel, self).__init__(
             image_uri,
             model_data,

--- a/src/sagemaker/amazon/kmeans.py
+++ b/src/sagemaker/amazon/kmeans.py
@@ -13,7 +13,8 @@
 """Placeholder docstring"""
 from __future__ import absolute_import
 
-from sagemaker.amazon.amazon_estimator import AmazonAlgorithmEstimatorBase, registry
+from sagemaker import image_uris
+from sagemaker.amazon.amazon_estimator import AmazonAlgorithmEstimatorBase
 from sagemaker.amazon.common import RecordSerializer, RecordDeserializer
 from sagemaker.amazon.hyperparameter import Hyperparameter as hp  # noqa
 from sagemaker.amazon.validation import gt, isin, ge, le
@@ -242,8 +243,9 @@ class KMeansModel(Model):
             **kwargs:
         """
         sagemaker_session = sagemaker_session or Session()
-        repo = "{}:{}".format(KMeans.repo_name, KMeans.repo_version)
-        image_uri = "{}/{}".format(registry(sagemaker_session.boto_session.region_name), repo)
+        image_uri = image_uris.retrieve(
+            KMeans.repo_name, sagemaker_session.boto_region_name, version=KMeans.repo_version,
+        )
         super(KMeansModel, self).__init__(
             image_uri,
             model_data,

--- a/src/sagemaker/amazon/knn.py
+++ b/src/sagemaker/amazon/knn.py
@@ -13,7 +13,8 @@
 """Placeholder docstring"""
 from __future__ import absolute_import
 
-from sagemaker.amazon.amazon_estimator import AmazonAlgorithmEstimatorBase, registry
+from sagemaker import image_uris
+from sagemaker.amazon.amazon_estimator import AmazonAlgorithmEstimatorBase
 from sagemaker.amazon.common import RecordSerializer, RecordDeserializer
 from sagemaker.amazon.hyperparameter import Hyperparameter as hp  # noqa
 from sagemaker.amazon.validation import ge, isin
@@ -230,12 +231,11 @@ class KNNModel(Model):
             **kwargs:
         """
         sagemaker_session = sagemaker_session or Session()
-        repo = "{}:{}".format(KNN.repo_name, KNN.repo_version)
-        image = "{}/{}".format(
-            registry(sagemaker_session.boto_session.region_name, KNN.repo_name), repo
+        image_uri = image_uris.retrieve(
+            KNN.repo_name, sagemaker_session.boto_region_name, version=KNN.repo_version,
         )
         super(KNNModel, self).__init__(
-            image,
+            image_uri,
             model_data,
             role,
             predictor_cls=KNNPredictor,

--- a/src/sagemaker/amazon/lda.py
+++ b/src/sagemaker/amazon/lda.py
@@ -13,7 +13,8 @@
 """Placeholder docstring"""
 from __future__ import absolute_import
 
-from sagemaker.amazon.amazon_estimator import AmazonAlgorithmEstimatorBase, registry
+from sagemaker import image_uris
+from sagemaker.amazon.amazon_estimator import AmazonAlgorithmEstimatorBase
 from sagemaker.amazon.common import RecordSerializer, RecordDeserializer
 from sagemaker.amazon.hyperparameter import Hyperparameter as hp  # noqa
 from sagemaker.amazon.validation import gt
@@ -214,9 +215,8 @@ class LDAModel(Model):
             **kwargs:
         """
         sagemaker_session = sagemaker_session or Session()
-        repo = "{}:{}".format(LDA.repo_name, LDA.repo_version)
-        image_uri = "{}/{}".format(
-            registry(sagemaker_session.boto_session.region_name, LDA.repo_name), repo
+        image_uri = image_uris.retrieve(
+            LDA.repo_name, sagemaker_session.boto_region_name, version=LDA.repo_version,
         )
         super(LDAModel, self).__init__(
             image_uri,

--- a/src/sagemaker/amazon/linear_learner.py
+++ b/src/sagemaker/amazon/linear_learner.py
@@ -13,7 +13,8 @@
 """Placeholder docstring"""
 from __future__ import absolute_import
 
-from sagemaker.amazon.amazon_estimator import AmazonAlgorithmEstimatorBase, registry
+from sagemaker import image_uris
+from sagemaker.amazon.amazon_estimator import AmazonAlgorithmEstimatorBase
 from sagemaker.amazon.common import RecordSerializer, RecordDeserializer
 from sagemaker.amazon.hyperparameter import Hyperparameter as hp  # noqa
 from sagemaker.amazon.validation import isin, gt, lt, ge, le
@@ -473,8 +474,11 @@ class LinearLearnerModel(Model):
             **kwargs:
         """
         sagemaker_session = sagemaker_session or Session()
-        repo = "{}:{}".format(LinearLearner.repo_name, LinearLearner.repo_version)
-        image_uri = "{}/{}".format(registry(sagemaker_session.boto_session.region_name), repo)
+        image_uri = image_uris.retrieve(
+            LinearLearner.repo_name,
+            sagemaker_session.boto_region_name,
+            version=LinearLearner.repo_version,
+        )
         super(LinearLearnerModel, self).__init__(
             image_uri,
             model_data,

--- a/src/sagemaker/amazon/ntm.py
+++ b/src/sagemaker/amazon/ntm.py
@@ -13,7 +13,8 @@
 """Placeholder docstring"""
 from __future__ import absolute_import
 
-from sagemaker.amazon.amazon_estimator import AmazonAlgorithmEstimatorBase, registry
+from sagemaker import image_uris
+from sagemaker.amazon.amazon_estimator import AmazonAlgorithmEstimatorBase
 from sagemaker.amazon.common import RecordSerializer, RecordDeserializer
 from sagemaker.amazon.hyperparameter import Hyperparameter as hp  # noqa
 from sagemaker.amazon.validation import ge, le, isin
@@ -244,9 +245,8 @@ class NTMModel(Model):
             **kwargs:
         """
         sagemaker_session = sagemaker_session or Session()
-        repo = "{}:{}".format(NTM.repo_name, NTM.repo_version)
-        image_uri = "{}/{}".format(
-            registry(sagemaker_session.boto_session.region_name, NTM.repo_name), repo
+        image_uri = image_uris.retrieve(
+            NTM.repo_name, sagemaker_session.boto_region_name, version=NTM.repo_version,
         )
         super(NTMModel, self).__init__(
             image_uri,

--- a/src/sagemaker/amazon/object2vec.py
+++ b/src/sagemaker/amazon/object2vec.py
@@ -13,7 +13,8 @@
 """Placeholder docstring"""
 from __future__ import absolute_import
 
-from sagemaker.amazon.amazon_estimator import AmazonAlgorithmEstimatorBase, registry
+from sagemaker import image_uris
+from sagemaker.amazon.amazon_estimator import AmazonAlgorithmEstimatorBase
 from sagemaker.amazon.hyperparameter import Hyperparameter as hp  # noqa
 from sagemaker.amazon.validation import ge, le, isin
 from sagemaker.predictor import Predictor
@@ -350,9 +351,10 @@ class Object2VecModel(Model):
             **kwargs:
         """
         sagemaker_session = sagemaker_session or Session()
-        repo = "{}:{}".format(Object2Vec.repo_name, Object2Vec.repo_version)
-        image_uri = "{}/{}".format(
-            registry(sagemaker_session.boto_session.region_name, Object2Vec.repo_name), repo
+        image_uri = image_uris.retrieve(
+            Object2Vec.repo_name,
+            sagemaker_session.boto_region_name,
+            version=Object2Vec.repo_version,
         )
         super(Object2VecModel, self).__init__(
             image_uri,

--- a/src/sagemaker/amazon/pca.py
+++ b/src/sagemaker/amazon/pca.py
@@ -13,7 +13,8 @@
 """Placeholder docstring"""
 from __future__ import absolute_import
 
-from sagemaker.amazon.amazon_estimator import AmazonAlgorithmEstimatorBase, registry
+from sagemaker import image_uris
+from sagemaker.amazon.amazon_estimator import AmazonAlgorithmEstimatorBase
 from sagemaker.amazon.common import RecordSerializer, RecordDeserializer
 from sagemaker.amazon.hyperparameter import Hyperparameter as hp  # noqa
 from sagemaker.amazon.validation import gt, isin
@@ -226,8 +227,9 @@ class PCAModel(Model):
             **kwargs:
         """
         sagemaker_session = sagemaker_session or Session()
-        repo = "{}:{}".format(PCA.repo_name, PCA.repo_version)
-        image_uri = "{}/{}".format(registry(sagemaker_session.boto_session.region_name), repo)
+        image_uri = image_uris.retrieve(
+            PCA.repo_name, sagemaker_session.boto_region_name, version=PCA.repo_version,
+        )
         super(PCAModel, self).__init__(
             image_uri,
             model_data,

--- a/src/sagemaker/amazon/randomcutforest.py
+++ b/src/sagemaker/amazon/randomcutforest.py
@@ -13,7 +13,8 @@
 """Placeholder docstring"""
 from __future__ import absolute_import
 
-from sagemaker.amazon.amazon_estimator import AmazonAlgorithmEstimatorBase, registry
+from sagemaker import image_uris
+from sagemaker.amazon.amazon_estimator import AmazonAlgorithmEstimatorBase
 from sagemaker.amazon.common import RecordSerializer, RecordDeserializer
 from sagemaker.amazon.hyperparameter import Hyperparameter as hp  # noqa
 from sagemaker.amazon.validation import ge, le
@@ -203,9 +204,10 @@ class RandomCutForestModel(Model):
             **kwargs:
         """
         sagemaker_session = sagemaker_session or Session()
-        repo = "{}:{}".format(RandomCutForest.repo_name, RandomCutForest.repo_version)
-        image_uri = "{}/{}".format(
-            registry(sagemaker_session.boto_session.region_name, RandomCutForest.repo_name), repo
+        image_uri = image_uris.retrieve(
+            RandomCutForest.repo_name,
+            sagemaker_session.boto_region_name,
+            version=RandomCutForest.repo_version,
         )
         super(RandomCutForestModel, self).__init__(
             image_uri,

--- a/tests/integ/test_airflow_config.py
+++ b/tests/integ/test_airflow_config.py
@@ -33,8 +33,8 @@ from sagemaker import (
     NTM,
     PCA,
     RandomCutForest,
+    image_uris,
 )
-from sagemaker.amazon.amazon_estimator import get_image_uri
 from sagemaker.amazon.common import read_records
 from sagemaker.chainer import Chainer
 from sagemaker.estimator import Estimator
@@ -73,8 +73,8 @@ def test_byo_airflow_config_uploads_data_source_to_s3_when_inputs_provided(
         )
 
         estimator = Estimator(
-            image_uri=get_image_uri(
-                sagemaker_session.boto_session.region_name, "factorization-machines"
+            image_uri=image_uris.retrieve(
+                "factorization-machines", sagemaker_session.boto_region_name
             ),
             role=ROLE,
             instance_count=SINGLE_INSTANCE_COUNT,
@@ -522,9 +522,6 @@ def test_tf_airflow_config_uploads_data_source_to_s3(
 ):
     with timeout(seconds=AIRFLOW_CONFIG_TIMEOUT_IN_SECONDS):
         tf = TensorFlow(
-            image_uri=get_image_uri(
-                sagemaker_session.boto_session.region_name, "factorization-machines"
-            ),
             entry_point=SCRIPT,
             role=ROLE,
             instance_count=SINGLE_INSTANCE_COUNT,

--- a/tests/integ/test_airflow_config.py
+++ b/tests/integ/test_airflow_config.py
@@ -515,10 +515,7 @@ def test_sklearn_airflow_config_uploads_data_source_to_s3(
 
 @pytest.mark.canary_quick
 def test_tf_airflow_config_uploads_data_source_to_s3(
-    sagemaker_session,
-    cpu_instance_type,
-    tensorflow_training_latest_version,
-    tensorflow_training_latest_py_version,
+    sagemaker_session, cpu_instance_type, tf_full_version, tf_full_py_version,
 ):
     with timeout(seconds=AIRFLOW_CONFIG_TIMEOUT_IN_SECONDS):
         tf = TensorFlow(
@@ -527,8 +524,8 @@ def test_tf_airflow_config_uploads_data_source_to_s3(
             instance_count=SINGLE_INSTANCE_COUNT,
             instance_type=cpu_instance_type,
             sagemaker_session=sagemaker_session,
-            framework_version=tensorflow_training_latest_version,
-            py_version=tensorflow_training_latest_py_version,
+            framework_version=tf_full_version,
+            py_version=tf_full_py_version,
             metric_definitions=[
                 {"Name": "train:global_steps", "Regex": r"global_step\/sec:\s(.*)"}
             ],

--- a/tests/integ/test_byo_estimator.py
+++ b/tests/integ/test_byo_estimator.py
@@ -18,7 +18,7 @@ import os
 import pytest
 
 import sagemaker
-from sagemaker.amazon.amazon_estimator import get_image_uri
+from sagemaker import image_uris
 from sagemaker.estimator import Estimator
 from sagemaker.utils import unique_name_from_base
 from tests.integ import DATA_DIR, TRAINING_DEFAULT_TIMEOUT_MINUTES, datasets
@@ -54,7 +54,7 @@ def test_byo_estimator(sagemaker_session, region, cpu_instance_type, training_se
     Default predictor is updated with json serializer and deserializer.
 
     """
-    image_uri = get_image_uri(region, "factorization-machines")
+    image_uri = image_uris.retrieve("factorization-machines", region)
     training_data_path = os.path.join(DATA_DIR, "dummy_tensor")
     job_name = unique_name_from_base("byo")
 
@@ -96,7 +96,7 @@ def test_byo_estimator(sagemaker_session, region, cpu_instance_type, training_se
 
 
 def test_async_byo_estimator(sagemaker_session, region, cpu_instance_type, training_set):
-    image_uri = get_image_uri(region, "factorization-machines")
+    image_uri = image_uris.retrieve("factorization-machines", region)
     endpoint_name = unique_name_from_base("byo")
     training_data_path = os.path.join(DATA_DIR, "dummy_tensor")
     job_name = unique_name_from_base("byo")

--- a/tests/integ/test_tuner.py
+++ b/tests/integ/test_tuner.py
@@ -21,8 +21,7 @@ import pytest
 from botocore.exceptions import ClientError
 
 import tests.integ
-from sagemaker import KMeans, LDA, RandomCutForest
-from sagemaker.amazon.amazon_estimator import get_image_uri
+from sagemaker import KMeans, LDA, RandomCutForest, image_uris
 from sagemaker.amazon.common import read_records
 from sagemaker.chainer import Chainer
 from sagemaker.deserializers import JSONDeserializer
@@ -855,7 +854,7 @@ def test_tuning_byo_estimator(sagemaker_session, cpu_instance_type):
     Later the trained model is deployed and prediction is called against the endpoint.
     Default predictor is updated with json serializer and deserializer.
     """
-    image_uri = get_image_uri(sagemaker_session.boto_session.region_name, "factorization-machines")
+    image_uri = image_uris.retrieve("factorization-machines", sagemaker_session.boto_region_name)
     training_data_path = os.path.join(DATA_DIR, "dummy_tensor")
 
     with timeout(minutes=TUNING_DEFAULT_TIMEOUT_MINUTES):

--- a/tests/integ/test_tuner_multi_algo.py
+++ b/tests/integ/test_tuner_multi_algo.py
@@ -17,8 +17,7 @@ import os
 
 import pytest
 
-from sagemaker import utils
-from sagemaker.amazon.amazon_estimator import get_image_uri
+from sagemaker import image_uris, utils
 from sagemaker.analytics import HyperparameterTuningJobAnalytics
 from sagemaker.content_types import CONTENT_TYPE_JSON
 from sagemaker.deserializers import JSONDeserializer
@@ -63,9 +62,7 @@ def data_set():
 
 @pytest.fixture(scope="function")
 def estimator_fm(sagemaker_session, cpu_instance_type):
-    fm_image = get_image_uri(
-        sagemaker_session.boto_session.region_name, "factorization-machines", repo_version="1"
-    )
+    fm_image = image_uris.retrieve("factorization-machines", sagemaker_session.boto_region_name)
 
     estimator = Estimator(
         image_uri=fm_image,
@@ -84,7 +81,7 @@ def estimator_fm(sagemaker_session, cpu_instance_type):
 
 @pytest.fixture(scope="function")
 def estimator_knn(sagemaker_session, cpu_instance_type):
-    knn_image = get_image_uri(sagemaker_session.boto_session.region_name, "knn", repo_version="1")
+    knn_image = image_uris.retrieve("knn", sagemaker_session.boto_region_name)
 
     estimator = Estimator(
         image_uri=knn_image,

--- a/tests/unit/test_airflow.py
+++ b/tests/unit/test_airflow.py
@@ -622,15 +622,12 @@ def test_framework_tuning_config(ecr_prefix, sagemaker_session):
         ]
     ),
 )
-@patch(
-    "sagemaker.fw_utils.get_ecr_image_uri_prefix",
-    return_value="520713654638.dkr.ecr.us-west-2.amazonaws.com",
-)
-@patch(
-    "sagemaker.amazon.amazon_estimator.get_ecr_image_uri_prefix",
-    return_value="174872318107.dkr.ecr.us-west-2.amazonaws.com",
-)
-def test_multi_estimator_tuning_config(algo_ecr_prefix, fw_ecr_prefix, sagemaker_session):
+@patch("sagemaker.utils._botocore_resolver")
+def test_multi_estimator_tuning_config(botocore_resolver, sagemaker_session):
+    botocore_resolver.return_value.construct_endpoint.return_value = {
+        "hostname": "ecr.us-west-2.amazonaws.com"
+    }
+
     estimator_dict = {}
     hyperparameter_ranges_dict = {}
     objective_metric_name_dict = {}

--- a/tests/unit/test_estimator.py
+++ b/tests/unit/test_estimator.py
@@ -23,7 +23,7 @@ from botocore.exceptions import ClientError
 from mock import ANY, MagicMock, Mock, patch
 
 import sagemaker.local
-from sagemaker import image_uris, TrainingInput, utils, vpc_utils
+from sagemaker import TrainingInput, utils, vpc_utils
 from sagemaker.algorithm import AlgorithmEstimator
 from sagemaker.estimator import Estimator, EstimatorBase, Framework, _TrainingJob
 from sagemaker.model import FrameworkModel

--- a/tests/unit/test_estimator.py
+++ b/tests/unit/test_estimator.py
@@ -19,18 +19,17 @@ import subprocess
 from time import sleep
 
 import pytest
+from botocore.exceptions import ClientError
 from mock import ANY, MagicMock, Mock, patch
 
-from sagemaker import TrainingInput, utils, vpc_utils
-from sagemaker.amazon.amazon_estimator import registry
+import sagemaker.local
+from sagemaker import image_uris, TrainingInput, utils, vpc_utils
 from sagemaker.algorithm import AlgorithmEstimator
 from sagemaker.estimator import Estimator, EstimatorBase, Framework, _TrainingJob
 from sagemaker.model import FrameworkModel
 from sagemaker.predictor import Predictor
 from sagemaker.session import ShuffleConfig
 from sagemaker.transformer import Transformer
-from botocore.exceptions import ClientError
-import sagemaker.local
 
 MODEL_DATA = "s3://bucket/model.tar.gz"
 MODEL_IMAGE = "mi"
@@ -2373,10 +2372,9 @@ def test_prepare_for_training_with_name_based_on_algorithm(sagemaker_session):
     ),
 )
 def test_encryption_flag_in_non_vpc_mode_invalid(sagemaker_session):
-    image_uri = registry("us-west-2") + "/factorization-machines:1"
     with pytest.raises(ClientError) as error:
         estimator = Estimator(
-            image_uri=image_uri,
+            image_uri="some-image",
             role="SageMakerRole",
             instance_count=1,
             instance_type="ml.c4.xlarge",

--- a/tests/unit/test_fm.py
+++ b/tests/unit/test_fm.py
@@ -15,11 +15,12 @@ from __future__ import absolute_import
 import pytest
 from mock import Mock, patch
 
+from sagemaker import image_uris
 from sagemaker.amazon.factorization_machines import (
     FactorizationMachines,
     FactorizationMachinesPredictor,
 )
-from sagemaker.amazon.amazon_estimator import registry, RecordSet
+from sagemaker.amazon.amazon_estimator import RecordSet
 
 ROLE = "myrole"
 INSTANCE_COUNT = 1
@@ -146,7 +147,7 @@ def test_all_hyperparameters(sagemaker_session):
 
 def test_image(sagemaker_session):
     fm = FactorizationMachines(sagemaker_session=sagemaker_session, **ALL_REQ_ARGS)
-    assert fm.train_image() == registry(REGION) + "/factorization-machines:1"
+    assert image_uris.retrieve("factorization-machines", REGION) == fm.train_image()
 
 
 @pytest.mark.parametrize(
@@ -313,9 +314,7 @@ def test_model_image(sagemaker_session):
     fm.fit(data, MINI_BATCH_SIZE)
 
     model = fm.create_model()
-    assert (
-        model.image_uri == registry(REGION, "factorization-machines") + "/factorization-machines:1"
-    )
+    assert image_uris.retrieve("factorization-machines", REGION) == model.image_uri
 
 
 def test_predictor_type(sagemaker_session):

--- a/tests/unit/test_ipinsights.py
+++ b/tests/unit/test_ipinsights.py
@@ -15,8 +15,9 @@ from __future__ import absolute_import
 import pytest
 from mock import Mock, patch
 
+from sagemaker import image_uris
 from sagemaker.amazon.ipinsights import IPInsights, IPInsightsPredictor
-from sagemaker.amazon.amazon_estimator import registry, RecordSet
+from sagemaker.amazon.amazon_estimator import RecordSet
 
 # Mocked training config
 ROLE = "myrole"
@@ -119,7 +120,7 @@ def test_all_hyperparameters(sagemaker_session):
 
 def test_image(sagemaker_session):
     ipinsights = IPInsights(sagemaker_session=sagemaker_session, **ALL_REQ_ARGS)
-    assert ipinsights.train_image() == registry(REGION, "ipinsights") + "/ipinsights:1"
+    assert image_uris.retrieve("ipinsights", REGION) == ipinsights.train_image()
 
 
 @pytest.mark.parametrize(
@@ -288,7 +289,7 @@ def test_model_image(sagemaker_session):
     ipinsights.fit(data, MINI_BATCH_SIZE)
 
     model = ipinsights.create_model()
-    assert model.image_uri == registry(REGION, "ipinsights") + "/ipinsights:1"
+    assert image_uris.retrieve("ipinsights", REGION) == model.image_uri
 
 
 def test_predictor_type(sagemaker_session):

--- a/tests/unit/test_kmeans.py
+++ b/tests/unit/test_kmeans.py
@@ -15,8 +15,9 @@ from __future__ import absolute_import
 import pytest
 from mock import Mock, patch
 
+from sagemaker import image_uris
 from sagemaker.amazon.kmeans import KMeans, KMeansPredictor
-from sagemaker.amazon.amazon_estimator import registry, RecordSet
+from sagemaker.amazon.amazon_estimator import RecordSet
 
 ROLE = "myrole"
 INSTANCE_COUNT = 1
@@ -111,7 +112,7 @@ def test_all_hyperparameters(sagemaker_session):
 
 def test_image(sagemaker_session):
     kmeans = KMeans(sagemaker_session=sagemaker_session, **ALL_REQ_ARGS)
-    assert kmeans.train_image() == registry(REGION, "kmeans") + "/kmeans:1"
+    assert image_uris.retrieve("kmeans", REGION) == kmeans.train_image()
 
 
 @pytest.mark.parametrize("required_hyper_parameters, value", [("k", "string")])
@@ -255,7 +256,7 @@ def test_model_image(sagemaker_session):
     kmeans.fit(data, MINI_BATCH_SIZE)
 
     model = kmeans.create_model()
-    assert model.image_uri == registry(REGION, "kmeans") + "/kmeans:1"
+    assert image_uris.retrieve("kmeans", REGION) == model.image_uri
 
 
 def test_predictor_type(sagemaker_session):

--- a/tests/unit/test_knn.py
+++ b/tests/unit/test_knn.py
@@ -15,8 +15,9 @@ from __future__ import absolute_import
 import pytest
 from mock import Mock, patch
 
+from sagemaker import image_uris
 from sagemaker.amazon.knn import KNN, KNNPredictor
-from sagemaker.amazon.amazon_estimator import registry, RecordSet
+from sagemaker.amazon.amazon_estimator import RecordSet
 
 ROLE = "myrole"
 INSTANCE_COUNT = 1
@@ -145,7 +146,7 @@ def test_all_hyperparameters_classifier(sagemaker_session):
 
 def test_image(sagemaker_session):
     knn = KNN(sagemaker_session=sagemaker_session, **ALL_REQ_ARGS)
-    assert knn.train_image() == registry(REGION, "knn") + "/knn:1"
+    assert image_uris.retrieve("knn", REGION) == knn.train_image()
 
 
 @pytest.mark.parametrize(
@@ -279,7 +280,7 @@ def test_model_image(sagemaker_session):
     knn.fit(data, MINI_BATCH_SIZE)
 
     model = knn.create_model()
-    assert model.image_uri == registry(REGION, "knn") + "/knn:1"
+    assert image_uris.retrieve("knn", REGION) == model.image_uri
 
 
 def test_predictor_type(sagemaker_session):

--- a/tests/unit/test_lda.py
+++ b/tests/unit/test_lda.py
@@ -15,8 +15,9 @@ from __future__ import absolute_import
 import pytest
 from mock import Mock, patch
 
+from sagemaker import image_uris
 from sagemaker.amazon.lda import LDA, LDAPredictor
-from sagemaker.amazon.amazon_estimator import registry, RecordSet
+from sagemaker.amazon.amazon_estimator import RecordSet
 
 ROLE = "myrole"
 INSTANCE_COUNT = 1
@@ -95,7 +96,7 @@ def test_all_hyperparameters(sagemaker_session):
 
 def test_image(sagemaker_session):
     lda = LDA(sagemaker_session=sagemaker_session, **ALL_REQ_ARGS)
-    assert lda.train_image() == registry(REGION, "lda") + "/lda:1"
+    assert image_uris.retrieve("lda", REGION) == lda.train_image()
 
 
 @pytest.mark.parametrize("required_hyper_parameters, value", [("num_topics", "string")])
@@ -215,7 +216,7 @@ def test_model_image(sagemaker_session):
     lda.fit(data, MINI_BATCH_SZIE)
 
     model = lda.create_model()
-    assert model.image_uri == registry(REGION, "lda") + "/lda:1"
+    assert image_uris.retrieve("lda", REGION) == model.image_uri
 
 
 def test_predictor_type(sagemaker_session):

--- a/tests/unit/test_linear_learner.py
+++ b/tests/unit/test_linear_learner.py
@@ -15,8 +15,9 @@ from __future__ import absolute_import
 import pytest
 from mock import Mock, patch
 
+from sagemaker import image_uris
 from sagemaker.amazon.linear_learner import LinearLearner, LinearLearnerPredictor
-from sagemaker.amazon.amazon_estimator import registry, RecordSet
+from sagemaker.amazon.amazon_estimator import RecordSet
 
 ROLE = "myrole"
 INSTANCE_COUNT = 1
@@ -178,7 +179,7 @@ def test_all_hyperparameters(sagemaker_session):
 
 def test_image(sagemaker_session):
     lr = LinearLearner(sagemaker_session=sagemaker_session, **ALL_REQ_ARGS)
-    assert lr.train_image() == registry(REGION, "linear-learner") + "/linear-learner:1"
+    assert image_uris.retrieve("linear-learner", REGION) == lr.train_image()
 
 
 @pytest.mark.parametrize("required_hyper_parameters, value", [("predictor_type", 0)])
@@ -412,7 +413,7 @@ def test_model_image(sagemaker_session):
     lr.fit(data)
 
     model = lr.create_model()
-    assert model.image_uri == registry(REGION, "linear-learner") + "/linear-learner:1"
+    assert image_uris.retrieve("linear-learner", REGION) == model.image_uri
 
 
 def test_predictor_type(sagemaker_session):

--- a/tests/unit/test_ntm.py
+++ b/tests/unit/test_ntm.py
@@ -15,8 +15,9 @@ from __future__ import absolute_import
 import pytest
 from mock import Mock, patch
 
+from sagemaker import image_uris
 from sagemaker.amazon.ntm import NTM, NTMPredictor
-from sagemaker.amazon.amazon_estimator import registry, RecordSet
+from sagemaker.amazon.amazon_estimator import RecordSet
 
 ROLE = "myrole"
 INSTANCE_COUNT = 1
@@ -114,7 +115,7 @@ def test_all_hyperparameters(sagemaker_session):
 
 def test_image(sagemaker_session):
     ntm = NTM(sagemaker_session=sagemaker_session, **ALL_REQ_ARGS)
-    assert ntm.train_image() == registry(REGION, "ntm") + "/ntm:1"
+    assert image_uris.retrieve("ntm", REGION) == ntm.train_image()
 
 
 @pytest.mark.parametrize("required_hyper_parameters, value", [("num_topics", "string")])
@@ -278,7 +279,7 @@ def test_model_image(sagemaker_session):
     ntm.fit(data, MINI_BATCH_SIZE)
 
     model = ntm.create_model()
-    assert model.image_uri == registry(REGION, "ntm") + "/ntm:1"
+    assert image_uris.retrieve("ntm", REGION) == model.image_uri
 
 
 def test_predictor_type(sagemaker_session):

--- a/tests/unit/test_object2vec.py
+++ b/tests/unit/test_object2vec.py
@@ -15,9 +15,10 @@ from __future__ import absolute_import
 import pytest
 from mock import Mock, patch
 
+from sagemaker import image_uris
 from sagemaker.amazon.object2vec import Object2Vec
 from sagemaker.predictor import Predictor
-from sagemaker.amazon.amazon_estimator import registry, RecordSet
+from sagemaker.amazon.amazon_estimator import RecordSet
 
 ROLE = "myrole"
 INSTANCE_COUNT = 1
@@ -143,7 +144,7 @@ def test_all_hyperparameters(sagemaker_session):
 
 def test_image(sagemaker_session):
     object2vec = Object2Vec(sagemaker_session=sagemaker_session, **ALL_REQ_ARGS)
-    assert object2vec.train_image() == registry(REGION, "object2vec") + "/object2vec:1"
+    assert image_uris.retrieve("object2vec", REGION) == object2vec.train_image()
 
 
 @pytest.mark.parametrize("required_hyper_parameters, value", [("epochs", "string")])
@@ -308,7 +309,7 @@ def test_model_image(sagemaker_session):
     object2vec.fit(data, MINI_BATCH_SIZE)
 
     model = object2vec.create_model()
-    assert model.image_uri == registry(REGION, "object2vec") + "/object2vec:1"
+    assert image_uris.retrieve("object2vec", REGION) == model.image_uri
 
 
 def test_predictor_type(sagemaker_session):

--- a/tests/unit/test_pca.py
+++ b/tests/unit/test_pca.py
@@ -15,8 +15,9 @@ from __future__ import absolute_import
 import pytest
 from mock import Mock, patch
 
+from sagemaker import image_uris
 from sagemaker.amazon.pca import PCA, PCAPredictor
-from sagemaker.amazon.amazon_estimator import registry, RecordSet
+from sagemaker.amazon.amazon_estimator import RecordSet
 
 ROLE = "myrole"
 INSTANCE_COUNT = 1
@@ -100,7 +101,7 @@ def test_all_hyperparameters(sagemaker_session):
 
 def test_image(sagemaker_session):
     pca = PCA(sagemaker_session=sagemaker_session, **ALL_REQ_ARGS)
-    assert pca.train_image() == registry(REGION, "pca") + "/pca:1"
+    assert image_uris.retrieve("pca", REGION) == pca.train_image()
 
 
 @pytest.mark.parametrize("required_hyper_parameters, value", [("num_components", "string")])
@@ -231,7 +232,7 @@ def test_model_image(sagemaker_session):
     pca.fit(data, MINI_BATCH_SIZE)
 
     model = pca.create_model()
-    assert model.image_uri == registry(REGION, "pca") + "/pca:1"
+    assert image_uris.retrieve("pca", REGION) == model.image_uri
 
 
 def test_predictor_type(sagemaker_session):

--- a/tests/unit/test_randomcutforest.py
+++ b/tests/unit/test_randomcutforest.py
@@ -15,8 +15,9 @@ from __future__ import absolute_import
 import pytest
 from mock import Mock, patch
 
+from sagemaker import image_uris
 from sagemaker.amazon.randomcutforest import RandomCutForest, RandomCutForestPredictor
-from sagemaker.amazon.amazon_estimator import registry, RecordSet
+from sagemaker.amazon.amazon_estimator import RecordSet
 
 ROLE = "myrole"
 INSTANCE_COUNT = 1
@@ -106,9 +107,7 @@ def test_all_hyperparameters(sagemaker_session):
 
 def test_image(sagemaker_session):
     randomcutforest = RandomCutForest(sagemaker_session=sagemaker_session, **ALL_REQ_ARGS)
-    assert (
-        randomcutforest.train_image() == registry(REGION, "randomcutforest") + "/randomcutforest:1"
-    )
+    assert image_uris.retrieve("randomcutforest", REGION) == randomcutforest.train_image()
 
 
 @pytest.mark.parametrize("iterable_hyper_parameters, value", [("eval_metrics", 0)])
@@ -232,7 +231,7 @@ def test_model_image(sagemaker_session):
     randomcutforest.fit(data, MINI_BATCH_SIZE)
 
     model = randomcutforest.create_model()
-    assert model.image_uri == registry(REGION, "randomcutforest") + "/randomcutforest:1"
+    assert image_uris.retrieve("randomcutforest", REGION) == model.image_uri
 
 
 def test_predictor_type(sagemaker_session):


### PR DESCRIPTION
*Issue #, if available:*
#1464 

*Description of changes:*
This also deprecates sagemaker.amazon.amazon_estimator.registry()

*Testing done:*
unit tests

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
