### PR TITLE
fix: Nullable fields in processing_config

### DIFF
--- a/src/sagemaker/workflow/airflow.py
+++ b/src/sagemaker/workflow/airflow.py
@@ -1154,10 +1154,11 @@ def processing_config(
     )
     config["ProcessingResources"] = processing_resources
 
-    stopping_condition = sagemaker.processing.ProcessingJob.prepare_stopping_condition(
-        processor.max_runtime_in_seconds
-    )
-    config["StoppingCondition"] = stopping_condition
+    if processor.max_runtime_in_seconds is not None:
+        stopping_condition = sagemaker.processing.ProcessingJob.prepare_stopping_condition(
+            processor.max_runtime_in_seconds
+        )
+        config["StoppingCondition"] = stopping_condition
 
     if processor.tags is not None:
         config["Tags"] = processor.tags
@@ -1174,4 +1175,7 @@ def input_output_list_converter(object_list):
     Returns:
         List of dicts
     """
-    return [obj._to_request_dict() for obj in object_list]
+    if object_list is not None:
+        dict_list = [obj._to_request_dict() for obj in object_list]
+    else dict_list = object_list
+    return dict_list


### PR DESCRIPTION
*Description of changes:*
Allows for None values for processing inputs and stopping conditions.

*Testing done:*

Unit tests pass.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
