### PR TITLE
fix: convert network_config in processing_config to dict

### DIFF
--- a/src/sagemaker/workflow/airflow.py
+++ b/src/sagemaker/workflow/airflow.py
@@ -1144,7 +1144,7 @@ def processing_config(
         config["Environment"] = processor.env
 
     if processor.network_config is not None:
-        config["NetworkConfig"] = processor.network_config
+        config["NetworkConfig"] = processor.network_config._to_request_dict()
 
     processing_resources = sagemaker.processing.ProcessingJob.prepare_processing_resources(
         instance_count=processor.instance_count,

--- a/tests/unit/test_airflow.py
+++ b/tests/unit/test_airflow.py
@@ -16,6 +16,7 @@ import pytest
 from mock import Mock, MagicMock, patch
 
 from sagemaker import chainer, estimator, model, mxnet, tensorflow, transformer, tuner, processing
+from sagemaker.network import NetworkConfig
 from sagemaker.processing import ProcessingInput, ProcessingOutput
 from sagemaker.workflow import airflow
 from sagemaker.amazon import amazon_estimator
@@ -1598,6 +1599,13 @@ def test_deploy_config_from_amazon_alg_estimator(sagemaker_session):
 @patch("sagemaker.utils.sagemaker_timestamp", MagicMock(return_value=TIME_STAMP))
 def test_processing_config(sagemaker_session):
 
+    network_config = NetworkConfig(
+        encrypt_inter_container_traffic=False,
+        enable_network_isolation=True,
+        security_group_ids=["sg1"],
+        subnets=["subnet1"],
+    )
+
     processor = processing.Processor(
         role="arn:aws:iam::0122345678910:role/SageMakerPowerUser",
         image_uri="{{ image_uri }}",
@@ -1612,6 +1620,7 @@ def test_processing_config(sagemaker_session):
         sagemaker_session=sagemaker_session,
         tags=[{"{{ key }}": "{{ value }}"}],
         env={"{{ key }}": "{{ value }}"},
+        network_config=network_config,
     )
 
     outputs = [
@@ -1699,5 +1708,10 @@ def test_processing_config(sagemaker_session):
         "RoleArn": "arn:aws:iam::0122345678910:role/SageMakerPowerUser",
         "StoppingCondition": {"MaxRuntimeInSeconds": 3600},
         "Tags": [{"{{ key }}": "{{ value }}"}],
+        "NetworkConfig": {
+            "EnableInterContainerTrafficEncryption": False,
+            "EnableNetworkIsolation": True,
+            "VpcConfig": {"SecurityGroupIds": ["sg1"], "Subnets": ["subnet1"]},
+        },
     }
     assert config == expected_config


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Error "TypeError: Object of type 'NetworkConfig' is not JSON serializable" when using network_config with ScriptProcessor. Need to convert this to a dict. 

*Testing done:*

Unit tests pass. 

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
