### PR TITLE
Make files black compliant

### DIFF
--- a/ci-scripts/queue_build.py
+++ b/ci-scripts/queue_build.py
@@ -24,9 +24,9 @@ bucket_name = "sagemaker-us-west-2-%s" % account
 
 def queue_build():
     build_id = os.environ.get("CODEBUILD_BUILD_ID", "CODEBUILD-BUILD-ID")
-    source_version = os.environ.get("CODEBUILD_SOURCE_VERSION", "CODEBUILD-SOURCE-VERSION").replace(
-        "/", "-"
-    )
+    source_version = os.environ.get(
+        "CODEBUILD_SOURCE_VERSION", "CODEBUILD-SOURCE-VERSION"
+    ).replace("/", "-")
     ticket_number = int(1000 * time.time())
     filename = "%s_%s_%s" % (ticket_number, build_id, source_version)
 
@@ -54,7 +54,8 @@ def _wait_for_other_builds(files, ticket_number):
     for order, file in enumerate(sorted_files):
         file_ticket_number, build_id, source_version = _build_info_from_file(file)
         print(
-            "%s -> %s %s, ticket number: %s" % (order, build_id, source_version, file_ticket_number)
+            "%s -> %s %s, ticket number: %s"
+            % (order, build_id, source_version, file_ticket_number)
         )
 
     for file in sorted_files:
@@ -71,7 +72,8 @@ def _wait_for_other_builds(files, ticket_number):
 
                 if build_status == "IN_PROGRESS":
                     print(
-                        "waiting on build %s %s %s" % (build_id, source_version, file_ticket_number)
+                        "waiting on build %s %s %s"
+                        % (build_id, source_version, file_ticket_number)
                     )
                     time.sleep(30)
                 else:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -88,7 +88,10 @@ html_static_path = ["_static"]
 
 htmlhelp_basename = "%sdoc" % project
 
-html_js_files = ["https://a0.awsstatic.com/s_code/js/1.0/awshome_s_code.js", "js/analytics.js"]
+html_js_files = [
+    "https://a0.awsstatic.com/s_code/js/1.0/awshome_s_code.js",
+    "js/analytics.js",
+]
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {"http://docs.python.org/": None}

--- a/examples/cli/train/script.py
+++ b/examples/cli/train/script.py
@@ -42,7 +42,9 @@ def train(channel_input_dirs, hyperparameters, **kwargs):
     net.initialize(mx.init.Xavier(magnitude=2.24), ctx=ctx)
     # Trainer is for updating parameters with gradient.
     trainer = gluon.Trainer(
-        net.collect_params(), "sgd", {"learning_rate": learning_rate, "momentum": momentum}
+        net.collect_params(),
+        "sgd",
+        {"learning_rate": learning_rate, "momentum": momentum},
     )
     metric = mx.metric.Accuracy()
     loss = gluon.loss.SoftmaxCrossEntropyLoss()

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,9 @@ setup(
     description="Open source library for training and deploying models on Amazon SageMaker.",
     packages=find_packages("src"),
     package_dir={"": "src"},
-    py_modules=[os.path.splitext(os.path.basename(path))[0] for path in glob("src/*.py")],
+    py_modules=[
+        os.path.splitext(os.path.basename(path))[0] for path in glob("src/*.py")
+    ],
     long_description=read("README.rst"),
     author="Amazon Web Services",
     url="https://github.com/aws/sagemaker-python-sdk/",

--- a/src/sagemaker/__init__.py
+++ b/src/sagemaker/__init__.py
@@ -30,7 +30,9 @@ from sagemaker.amazon.factorization_machines import (  # noqa: F401
     FactorizationMachines,
     FactorizationMachinesModel,
 )
-from sagemaker.amazon.factorization_machines import FactorizationMachinesPredictor  # noqa: F401
+from sagemaker.amazon.factorization_machines import (
+    FactorizationMachinesPredictor,
+)  # noqa: F401
 from sagemaker.amazon.ntm import NTM, NTMModel, NTMPredictor  # noqa: F401
 from sagemaker.amazon.randomcutforest import (  # noqa: F401
     RandomCutForest,
@@ -46,7 +48,10 @@ from sagemaker.amazon.ipinsights import (  # noqa: F401
 )
 
 from sagemaker.algorithm import AlgorithmEstimator  # noqa: F401
-from sagemaker.analytics import TrainingJobAnalytics, HyperparameterTuningJobAnalytics  # noqa: F401
+from sagemaker.analytics import (
+    TrainingJobAnalytics,
+    HyperparameterTuningJobAnalytics,
+)  # noqa: F401
 from sagemaker.local.local_session import LocalSession  # noqa: F401
 
 from sagemaker.model import Model, ModelPackage  # noqa: F401
@@ -60,7 +65,10 @@ from sagemaker.session import s3_input  # noqa: F401
 from sagemaker.session import get_execution_role  # noqa: F401
 
 from sagemaker.automl.automl import AutoML, AutoMLJob, AutoMLInput  # noqa: F401
-from sagemaker.automl.candidate_estimator import CandidateEstimator, CandidateStep  # noqa: F401
+from sagemaker.automl.candidate_estimator import (
+    CandidateEstimator,
+    CandidateStep,
+)  # noqa: F401
 
 __version__ = importlib_metadata.version("sagemaker")
 

--- a/src/sagemaker/algorithm.py
+++ b/src/sagemaker/algorithm.py
@@ -182,7 +182,9 @@ class AlgorithmEstimator(EstimatorBase):
 
         # Check that the input mode provided is compatible with the training input modes for the
         # algorithm.
-        train_input_modes = self._algorithm_training_input_modes(train_spec["TrainingChannels"])
+        train_input_modes = self._algorithm_training_input_modes(
+            train_spec["TrainingChannels"]
+        )
         if self.input_mode not in train_input_modes:
             raise ValueError(
                 "Invalid input mode: %s. %s only supports: %s"
@@ -233,7 +235,9 @@ class AlgorithmEstimator(EstimatorBase):
         The fit() method, that does the model training, calls this method to
         find the image to use for model training.
         """
-        raise RuntimeError("train_image is never meant to be called on Algorithm Estimators")
+        raise RuntimeError(
+            "train_image is never meant to be called on Algorithm Estimators"
+        )
 
     def enable_network_isolation(self):
         """Return True if this Estimator will need network isolation to run.
@@ -384,7 +388,9 @@ class AlgorithmEstimator(EstimatorBase):
 
             tags = tags or self.tags
         else:
-            raise RuntimeError("No finished training job found associated with this estimator")
+            raise RuntimeError(
+                "No finished training job found associated with this estimator"
+            )
 
         return Transformer(
             model_name,
@@ -446,13 +452,20 @@ class AlgorithmEstimator(EstimatorBase):
         for c in channels:
             if c not in training_channels:
                 raise ValueError(
-                    "Unknown input channel: %s is not supported by: %s" % (c, algorithm_name)
+                    "Unknown input channel: %s is not supported by: %s"
+                    % (c, algorithm_name)
                 )
 
         # check for required channels that were not provided
         for name, channel in training_channels.items():
-            if name not in channels and "IsRequired" in channel and channel["IsRequired"]:
-                raise ValueError("Required input channel: %s Was not provided." % (name))
+            if (
+                name not in channels
+                and "IsRequired" in channel
+                and channel["IsRequired"]
+            ):
+                raise ValueError(
+                    "Required input channel: %s Was not provided." % (name)
+                )
 
     def _validate_and_cast_hyperparameter(self, name, v):
         """
@@ -464,7 +477,8 @@ class AlgorithmEstimator(EstimatorBase):
 
         if name not in self.hyperparameter_definitions:
             raise ValueError(
-                "Invalid hyperparameter: %s is not supported by %s" % (name, algorithm_name)
+                "Invalid hyperparameter: %s is not supported by %s"
+                % (name, algorithm_name)
             )
 
         definition = self.hyperparameter_definitions[name]
@@ -475,7 +489,9 @@ class AlgorithmEstimator(EstimatorBase):
 
         if "range" in definition and not definition["range"].is_valid(value):
             valid_range = definition["range"].as_tuning_range(name)
-            raise ValueError("Invalid value: %s Supported range: %s" % (value, valid_range))
+            raise ValueError(
+                "Invalid value: %s Supported range: %s" % (value, valid_range)
+            )
         return value
 
     def _validate_and_set_default_hyperparameters(self):
@@ -570,7 +586,9 @@ class AlgorithmEstimator(EstimatorBase):
         return current_input_modes
 
     @classmethod
-    def _prepare_init_params_from_job_description(cls, job_details, model_channel_name=None):
+    def _prepare_init_params_from_job_description(
+        cls, job_details, model_channel_name=None
+    ):
         """Convert the job description to init params that can be handled by the
         class constructor
 
@@ -583,9 +601,9 @@ class AlgorithmEstimator(EstimatorBase):
         Returns:
             dict: The transformed init_params
         """
-        init_params = super(AlgorithmEstimator, cls)._prepare_init_params_from_job_description(
-            job_details, model_channel_name
-        )
+        init_params = super(
+            AlgorithmEstimator, cls
+        )._prepare_init_params_from_job_description(job_details, model_channel_name)
 
         # This hyperparameter is added by Amazon SageMaker Automatic Model Tuning.
         # It cannot be set through instantiating an estimator.

--- a/src/sagemaker/amazon/amazon_estimator.py
+++ b/src/sagemaker/amazon/amazon_estimator.py
@@ -103,7 +103,9 @@ class AmazonAlgorithmEstimatorBase(EstimatorBase):
     def train_image(self):
         """Placeholder docstring"""
         return get_image_uri(
-            self.sagemaker_session.boto_region_name, type(self).repo_name, type(self).repo_version
+            self.sagemaker_session.boto_region_name,
+            type(self).repo_name,
+            type(self).repo_version,
         )
 
     def hyperparameters(self):
@@ -123,14 +125,18 @@ class AmazonAlgorithmEstimatorBase(EstimatorBase):
         """
         if not data_location.startswith("s3://"):
             raise ValueError(
-                'Expecting an S3 URL beginning with "s3://". Got "{}"'.format(data_location)
+                'Expecting an S3 URL beginning with "s3://". Got "{}"'.format(
+                    data_location
+                )
             )
         if data_location[-1] != "/":
             data_location = data_location + "/"
         self._data_location = data_location
 
     @classmethod
-    def _prepare_init_params_from_job_description(cls, job_details, model_channel_name=None):
+    def _prepare_init_params_from_job_description(
+        cls, job_details, model_channel_name=None
+    ):
         """Convert the job description to init params that can be handled by the
         class constructor
 
@@ -159,7 +165,9 @@ class AmazonAlgorithmEstimatorBase(EstimatorBase):
         del init_params["image"]
         return init_params
 
-    def prepare_workflow_for_training(self, records=None, mini_batch_size=None, job_name=None):
+    def prepare_workflow_for_training(
+        self, records=None, mini_batch_size=None, job_name=None
+    ):
         """Calls _prepare_for_training. Used when setting up a workflow.
 
         Args:
@@ -185,7 +193,9 @@ class AmazonAlgorithmEstimatorBase(EstimatorBase):
                 specified, one is generated, using the base name given to the
                 constructor if applicable.
         """
-        super(AmazonAlgorithmEstimatorBase, self)._prepare_for_training(job_name=job_name)
+        super(AmazonAlgorithmEstimatorBase, self)._prepare_for_training(
+            job_name=job_name
+        )
 
         feature_dim = None
 
@@ -243,7 +253,9 @@ class AmazonAlgorithmEstimatorBase(EstimatorBase):
                 'TrialName', and 'TrialComponentName'
                 (default: ``None``).
         """
-        self._prepare_for_training(records, job_name=job_name, mini_batch_size=mini_batch_size)
+        self._prepare_for_training(
+            records, job_name=job_name, mini_batch_size=mini_batch_size
+        )
 
         self.latest_training_job = _TrainingJob.start_new(
             self, records, experiment_config=experiment_config
@@ -287,7 +299,9 @@ class AmazonAlgorithmEstimatorBase(EstimatorBase):
         )
         parsed_s3_url = urlparse(self.data_location)
         bucket, key_prefix = parsed_s3_url.netloc, parsed_s3_url.path
-        key_prefix = key_prefix + "{}-{}/".format(type(self).__name__, sagemaker_timestamp())
+        key_prefix = key_prefix + "{}-{}/".format(
+            type(self).__name__, sagemaker_timestamp()
+        )
         key_prefix = key_prefix.lstrip("/")
         logger.debug("Uploading to bucket %s and key_prefix %s", bucket, key_prefix)
         manifest_s3_file = upload_numpy_to_s3_shards(
@@ -306,7 +320,12 @@ class RecordSet(object):
     """Placeholder docstring"""
 
     def __init__(
-        self, s3_data, num_records, feature_dim, s3_data_type="ManifestFile", channel="train"
+        self,
+        s3_data,
+        num_records,
+        feature_dim,
+        s3_data_type="ManifestFile",
+        channel="train",
     ):
         """A collection of Amazon :class:~`Record` objects serialized and stored
         in S3.
@@ -342,7 +361,9 @@ class RecordSet(object):
 
     def records_s3_input(self):
         """Return a s3_input to represent the training data"""
-        return s3_input(self.s3_data, distribution="ShardedByS3Key", s3_data_type=self.s3_data_type)
+        return s3_input(
+            self.s3_data, distribution="ShardedByS3Key", s3_data_type=self.s3_data_type
+        )
 
 
 class FileSystemRecordSet(object):
@@ -405,7 +426,10 @@ def _build_shards(num_shards, array):
     shard_size = int(array.shape[0] / num_shards)
     if shard_size == 0:
         raise ValueError("Array length is less than num shards")
-    shards = [array[i * shard_size : i * shard_size + shard_size] for i in range(num_shards - 1)]
+    shards = [
+        array[i * shard_size : i * shard_size + shard_size]
+        for i in range(num_shards - 1)
+    ]
     shards.append(array[(num_shards - 1) * shard_size :])
     return shards
 
@@ -451,7 +475,9 @@ def upload_numpy_to_s3_shards(
         manifest_str = json.dumps(
             [{"prefix": "s3://{}/{}".format(bucket, key_prefix)}] + uploaded_files
         )
-        s3.Object(bucket, manifest_key).put(Body=manifest_str.encode("utf-8"), **extra_put_kwargs)
+        s3.Object(bucket, manifest_key).put(
+            Body=manifest_str.encode("utf-8"), **extra_put_kwargs
+        )
         return "s3://{}/{}".format(bucket, manifest_key)
     except Exception as ex:  # pylint: disable=broad-except
         try:
@@ -593,7 +619,9 @@ def registry(region_name, algorithm=None):
         region_to_accounts = NEO_IMAGE_ACCOUNT
     else:
         raise ValueError(
-            "Algorithm class:{} does not have mapping to account_id with images".format(algorithm)
+            "Algorithm class:{} does not have mapping to account_id with images".format(
+                algorithm
+            )
         )
 
     if region_name in region_to_accounts:
@@ -627,7 +655,9 @@ def get_image_uri(region_name, repo_name, repo_version=1):
 
         if repo_version in XGBOOST_1P_VERSIONS:
             _warn_newer_xgboost_image()
-            return "{}/{}:{}".format(registry(region_name, repo_name), repo_name, repo_version)
+            return "{}/{}:{}".format(
+                registry(region_name, repo_name), repo_name, repo_version
+            )
 
         if "-" not in repo_version:
             xgboost_version_matches = [

--- a/src/sagemaker/amazon/factorization_machines.py
+++ b/src/sagemaker/amazon/factorization_machines.py
@@ -307,8 +307,12 @@ class FactorizationMachinesModel(Model):
             **kwargs:
         """
         sagemaker_session = sagemaker_session or Session()
-        repo = "{}:{}".format(FactorizationMachines.repo_name, FactorizationMachines.repo_version)
-        image = "{}/{}".format(registry(sagemaker_session.boto_session.region_name), repo)
+        repo = "{}:{}".format(
+            FactorizationMachines.repo_name, FactorizationMachines.repo_version
+        )
+        image = "{}/{}".format(
+            registry(sagemaker_session.boto_session.region_name), repo
+        )
         super(FactorizationMachinesModel, self).__init__(
             model_data,
             image,

--- a/src/sagemaker/amazon/hyperparameter.py
+++ b/src/sagemaker/amazon/hyperparameter.py
@@ -21,7 +21,9 @@ class Hyperparameter(object):
     python descriptor object.
     """
 
-    def __init__(self, name, validate=lambda _: True, validation_message="", data_type=str):
+    def __init__(
+        self, name, validate=lambda _: True, validation_message="", data_type=str
+    ):
         """Args: name (str): The name of this hyperparameter validate
         (callable[object]->[bool]): A validation function or list of validation
         functions.
@@ -52,14 +54,20 @@ class Hyperparameter(object):
         Args:
             value:
         """
-        if value is None:  # We allow assignment from None, but Nones are not sent to training.
+        if (
+            value is None
+        ):  # We allow assignment from None, but Nones are not sent to training.
             return
 
         for valid in self.validation:
             if not valid(value):
-                error_message = "Invalid hyperparameter value {} for {}".format(value, self.name)
+                error_message = "Invalid hyperparameter value {} for {}".format(
+                    value, self.name
+                )
                 if self.validation_message:
-                    error_message = error_message + ". Expecting: " + self.validation_message
+                    error_message = (
+                        error_message + ". Expecting: " + self.validation_message
+                    )
                 raise ValueError(error_message)
 
     def __get__(self, obj, objtype):

--- a/src/sagemaker/amazon/ipinsights.py
+++ b/src/sagemaker/amazon/ipinsights.py
@@ -30,7 +30,10 @@ class IPInsights(AmazonAlgorithmEstimatorBase):
     MINI_BATCH_SIZE = 10000
 
     num_entity_vectors = hp(
-        "num_entity_vectors", (ge(1), le(250000000)), "An integer in [1, 250000000]", int
+        "num_entity_vectors",
+        (ge(1), le(250000000)),
+        "An integer in [1, 250000000]",
+        int,
     )
     vector_dim = hp("vector_dim", (ge(4), le(4096)), "An integer in [4, 4096]", int)
 
@@ -38,7 +41,9 @@ class IPInsights(AmazonAlgorithmEstimatorBase):
         "batch_metrics_publish_interval", (ge(1)), "An integer greater than 0", int
     )
     epochs = hp("epochs", (ge(1)), "An integer greater than 0", int)
-    learning_rate = hp("learning_rate", (ge(1e-6), le(10.0)), "A float in [1e-6, 10.0]", float)
+    learning_rate = hp(
+        "learning_rate", (ge(1e-6), le(10.0)), "A float in [1e-6, 10.0]", float
+    )
     num_ip_encoder_layers = hp(
         "num_ip_encoder_layers", (ge(0), le(100)), "An integer in [0, 100]", int
     )
@@ -46,9 +51,14 @@ class IPInsights(AmazonAlgorithmEstimatorBase):
         "random_negative_sampling_rate", (ge(0), le(500)), "An integer in [0, 500]", int
     )
     shuffled_negative_sampling_rate = hp(
-        "shuffled_negative_sampling_rate", (ge(0), le(500)), "An integer in [0, 500]", int
+        "shuffled_negative_sampling_rate",
+        (ge(0), le(500)),
+        "An integer in [0, 500]",
+        int,
     )
-    weight_decay = hp("weight_decay", (ge(0.0), le(10.0)), "A float in [0.0, 10.0]", float)
+    weight_decay = hp(
+        "weight_decay", (ge(0.0), le(10.0)), "A float in [0.0, 10.0]", float
+    )
 
     def __init__(
         self,
@@ -126,7 +136,9 @@ class IPInsights(AmazonAlgorithmEstimatorBase):
             :class:`~sagemaker.estimator.amazon_estimator.AmazonAlgorithmEstimatorBase` and
             :class:`~sagemaker.estimator.EstimatorBase`.
         """
-        super(IPInsights, self).__init__(role, train_instance_count, train_instance_type, **kwargs)
+        super(IPInsights, self).__init__(
+            role, train_instance_count, train_instance_type, **kwargs
+        )
         self.num_entity_vectors = num_entity_vectors
         self.vector_dim = vector_dim
         self.batch_metrics_publish_interval = batch_metrics_publish_interval
@@ -166,7 +178,9 @@ class IPInsights(AmazonAlgorithmEstimatorBase):
             mini_batch_size:
             job_name:
         """
-        if mini_batch_size is not None and (mini_batch_size < 1 or mini_batch_size > 500000):
+        if mini_batch_size is not None and (
+            mini_batch_size < 1 or mini_batch_size > 500000
+        ):
             raise ValueError("mini_batch_size must be in [1, 500000]")
         super(IPInsights, self)._prepare_for_training(
             records, mini_batch_size=mini_batch_size, job_name=job_name
@@ -191,7 +205,10 @@ class IPInsightsPredictor(RealTimePredictor):
             sagemaker_session:
         """
         super(IPInsightsPredictor, self).__init__(
-            endpoint, sagemaker_session, serializer=csv_serializer, deserializer=json_deserializer
+            endpoint,
+            sagemaker_session,
+            serializer=csv_serializer,
+            deserializer=json_deserializer,
         )
 
 
@@ -212,7 +229,8 @@ class IPInsightsModel(Model):
         sagemaker_session = sagemaker_session or Session()
         repo = "{}:{}".format(IPInsights.repo_name, IPInsights.repo_version)
         image = "{}/{}".format(
-            registry(sagemaker_session.boto_session.region_name, IPInsights.repo_name), repo
+            registry(sagemaker_session.boto_session.region_name, IPInsights.repo_name),
+            repo,
         )
 
         super(IPInsightsModel, self).__init__(

--- a/src/sagemaker/amazon/kmeans.py
+++ b/src/sagemaker/amazon/kmeans.py
@@ -30,12 +30,17 @@ class KMeans(AmazonAlgorithmEstimatorBase):
     repo_version = 1
 
     k = hp("k", gt(1), "An integer greater-than 1", int)
-    init_method = hp("init_method", isin("random", "kmeans++"), 'One of "random", "kmeans++"', str)
+    init_method = hp(
+        "init_method", isin("random", "kmeans++"), 'One of "random", "kmeans++"', str
+    )
     max_iterations = hp("local_lloyd_max_iter", gt(0), "An integer greater-than 0", int)
     tol = hp("local_lloyd_tol", (ge(0), le(1)), "An float in [0, 1]", float)
     num_trials = hp("local_lloyd_num_trials", gt(0), "An integer greater-than 0", int)
     local_init_method = hp(
-        "local_lloyd_init_method", isin("random", "kmeans++"), 'One of "random", "kmeans++"', str
+        "local_lloyd_init_method",
+        isin("random", "kmeans++"),
+        'One of "random", "kmeans++"',
+        str,
     )
     half_life_time_size = hp(
         "half_life_time_size", ge(0), "An integer greater-than-or-equal-to 0", int
@@ -142,7 +147,9 @@ class KMeans(AmazonAlgorithmEstimatorBase):
             :class:`~sagemaker.estimator.amazon_estimator.AmazonAlgorithmEstimatorBase` and
             :class:`~sagemaker.estimator.EstimatorBase`.
         """
-        super(KMeans, self).__init__(role, train_instance_count, train_instance_type, **kwargs)
+        super(KMeans, self).__init__(
+            role, train_instance_count, train_instance_type, **kwargs
+        )
         self.k = k
         self.init_method = init_method
         self.max_iterations = max_iterations
@@ -189,7 +196,9 @@ class KMeans(AmazonAlgorithmEstimatorBase):
         """Return the SageMaker hyperparameters for training this KMeans
         Estimator
         """
-        hp_dict = dict(force_dense="True")  # KMeans requires this hp to fit on Record objects
+        hp_dict = dict(
+            force_dense="True"
+        )  # KMeans requires this hp to fit on Record objects
         hp_dict.update(super(KMeans, self).hyperparameters())
         return hp_dict
 
@@ -239,7 +248,9 @@ class KMeansModel(Model):
         """
         sagemaker_session = sagemaker_session or Session()
         repo = "{}:{}".format(KMeans.repo_name, KMeans.repo_version)
-        image = "{}/{}".format(registry(sagemaker_session.boto_session.region_name), repo)
+        image = "{}/{}".format(
+            registry(sagemaker_session.boto_session.region_name), repo
+        )
         super(KMeansModel, self).__init__(
             model_data,
             image,

--- a/src/sagemaker/amazon/knn.py
+++ b/src/sagemaker/amazon/knn.py
@@ -32,7 +32,10 @@ class KNN(AmazonAlgorithmEstimatorBase):
     k = hp("k", (ge(1)), "An integer greater than 0", int)
     sample_size = hp("sample_size", (ge(1)), "An integer greater than 0", int)
     predictor_type = hp(
-        "predictor_type", isin("classifier", "regressor"), 'One of "classifier" or "regressor"', str
+        "predictor_type",
+        isin("classifier", "regressor"),
+        'One of "classifier" or "regressor"',
+        str,
     )
     dimension_reduction_target = hp(
         "dimension_reduction_target",
@@ -136,7 +139,9 @@ class KNN(AmazonAlgorithmEstimatorBase):
             :class:`~sagemaker.estimator.EstimatorBase`.
         """
 
-        super(KNN, self).__init__(role, train_instance_count, train_instance_type, **kwargs)
+        super(KNN, self).__init__(
+            role, train_instance_count, train_instance_type, **kwargs
+        )
         self.k = k
         self.sample_size = sample_size
         self.predictor_type = predictor_type

--- a/src/sagemaker/amazon/linear_learner.py
+++ b/src/sagemaker/amazon/linear_learner.py
@@ -47,7 +47,10 @@ class LinearLearner(AmazonAlgorithmEstimatorBase):
     target_recall = hp("target_recall", (gt(0), lt(1)), "A float in (0,1)", float)
     target_precision = hp("target_precision", (gt(0), lt(1)), "A float in (0,1)", float)
     positive_example_weight_mult = hp(
-        "positive_example_weight_mult", (), "A float greater than 0 or 'auto' or 'balanced'", str
+        "positive_example_weight_mult",
+        (),
+        "A float greater than 0 or 'auto' or 'balanced'",
+        str,
     )
     epochs = hp("epochs", gt(0), "An integer greater-than 0", int)
     predictor_type = hp(
@@ -58,8 +61,12 @@ class LinearLearner(AmazonAlgorithmEstimatorBase):
     )
     use_bias = hp("use_bias", (), "Either True or False", bool)
     num_models = hp("num_models", gt(0), "An integer greater-than 0", int)
-    num_calibration_samples = hp("num_calibration_samples", gt(0), "An integer greater-than 0", int)
-    init_method = hp("init_method", isin("uniform", "normal"), 'One of "uniform" or "normal"', str)
+    num_calibration_samples = hp(
+        "num_calibration_samples", gt(0), "An integer greater-than 0", int
+    )
+    init_method = hp(
+        "init_method", isin("uniform", "normal"), 'One of "uniform" or "normal"', str
+    )
     init_scale = hp("init_scale", gt(0), "A float greater-than 0", float)
     init_sigma = hp("init_sigma", gt(0), "A float greater-than 0", float)
     init_bias = hp("init_bias", (), "A number", float)
@@ -94,26 +101,42 @@ class LinearLearner(AmazonAlgorithmEstimatorBase):
     beta_1 = hp("beta_1", (ge(0), lt(1)), "A float in [0,1)", float)
     beta_2 = hp("beta_2", (ge(0), lt(1)), "A float in [0,1)", float)
     bias_lr_mult = hp("bias_lr_mult", gt(0), "A float greater-than 0", float)
-    bias_wd_mult = hp("bias_wd_mult", ge(0), "A float greater-than or equal to 0", float)
+    bias_wd_mult = hp(
+        "bias_wd_mult", ge(0), "A float greater-than or equal to 0", float
+    )
     use_lr_scheduler = hp("use_lr_scheduler", (), "A boolean", bool)
     lr_scheduler_step = hp("lr_scheduler_step", gt(0), "An integer greater-than 0", int)
-    lr_scheduler_factor = hp("lr_scheduler_factor", (gt(0), lt(1)), "A float in (0,1)", float)
-    lr_scheduler_minimum_lr = hp("lr_scheduler_minimum_lr", gt(0), "A float greater-than 0", float)
+    lr_scheduler_factor = hp(
+        "lr_scheduler_factor", (gt(0), lt(1)), "A float in (0,1)", float
+    )
+    lr_scheduler_minimum_lr = hp(
+        "lr_scheduler_minimum_lr", gt(0), "A float greater-than 0", float
+    )
     normalize_data = hp("normalize_data", (), "A boolean", bool)
     normalize_label = hp("normalize_label", (), "A boolean", bool)
     unbias_data = hp("unbias_data", (), "A boolean", bool)
     unbias_label = hp("unbias_label", (), "A boolean", bool)
-    num_point_for_scaler = hp("num_point_for_scaler", gt(0), "An integer greater-than 0", int)
+    num_point_for_scaler = hp(
+        "num_point_for_scaler", gt(0), "An integer greater-than 0", int
+    )
     margin = hp("margin", ge(0), "A float greater-than or equal to 0", float)
     quantile = hp("quantile", (gt(0), lt(1)), "A float in (0,1)", float)
-    loss_insensitivity = hp("loss_insensitivity", gt(0), "A float greater-than 0", float)
+    loss_insensitivity = hp(
+        "loss_insensitivity", gt(0), "A float greater-than 0", float
+    )
     huber_delta = hp("huber_delta", ge(0), "A float greater-than or equal to 0", float)
-    early_stopping_patience = hp("early_stopping_patience", gt(0), "An integer greater-than 0", int)
+    early_stopping_patience = hp(
+        "early_stopping_patience", gt(0), "An integer greater-than 0", int
+    )
     early_stopping_tolerance = hp(
         "early_stopping_tolerance", gt(0), "A float greater-than 0", float
     )
-    num_classes = hp("num_classes", (gt(0), le(1000000)), "An integer in [1,1000000]", int)
-    accuracy_top_k = hp("accuracy_top_k", (gt(0), le(1000000)), "An integer in [1,1000000]", int)
+    num_classes = hp(
+        "num_classes", (gt(0), le(1000000)), "An integer in [1,1000000]", int
+    )
+    accuracy_top_k = hp(
+        "accuracy_top_k", (gt(0), le(1000000)), "An integer in [1,1000000]", int
+    )
     f_beta = hp("f_beta", gt(0), "A float greater-than 0", float)
     balance_multiclass_weights = hp("balance_multiclass_weights", (), "A boolean", bool)
 
@@ -329,7 +352,9 @@ class LinearLearner(AmazonAlgorithmEstimatorBase):
             role, train_instance_count, train_instance_type, **kwargs
         )
         self.predictor_type = predictor_type
-        self.binary_classifier_model_selection_criteria = binary_classifier_model_selection_criteria
+        self.binary_classifier_model_selection_criteria = (
+            binary_classifier_model_selection_criteria
+        )
         self.target_recall = target_recall
         self.target_precision = target_precision
         self.positive_example_weight_mult = positive_example_weight_mult
@@ -418,7 +443,8 @@ class LinearLearner(AmazonAlgorithmEstimatorBase):
 
         # mini_batch_size can't be greater than number of records or training job fails
         default_mini_batch_size = min(
-            self.DEFAULT_MINI_BATCH_SIZE, max(1, int(num_records / self.train_instance_count))
+            self.DEFAULT_MINI_BATCH_SIZE,
+            max(1, int(num_records / self.train_instance_count)),
         )
         mini_batch_size = mini_batch_size or default_mini_batch_size
         super(LinearLearner, self)._prepare_for_training(
@@ -472,7 +498,9 @@ class LinearLearnerModel(Model):
         """
         sagemaker_session = sagemaker_session or Session()
         repo = "{}:{}".format(LinearLearner.repo_name, LinearLearner.repo_version)
-        image = "{}/{}".format(registry(sagemaker_session.boto_session.region_name), repo)
+        image = "{}/{}".format(
+            registry(sagemaker_session.boto_session.region_name), repo
+        )
         super(LinearLearnerModel, self).__init__(
             model_data,
             image,

--- a/src/sagemaker/amazon/ntm.py
+++ b/src/sagemaker/amazon/ntm.py
@@ -49,12 +49,24 @@ class NTM(AmazonAlgorithmEstimatorBase):
         str,
     )
     tolerance = hp("tolerance", (ge(1e-6), le(0.1)), "A float in [1e-6, 0.1]", float)
-    num_patience_epochs = hp("num_patience_epochs", (ge(1), le(10)), "An integer in [1, 10]", int)
-    batch_norm = hp(name="batch_norm", validation_message="Value must be a boolean", data_type=bool)
-    rescale_gradient = hp("rescale_gradient", (ge(1e-3), le(1.0)), "A float in [1e-3, 1.0]", float)
-    clip_gradient = hp("clip_gradient", ge(1e-3), "A float greater equal to 1e-3", float)
-    weight_decay = hp("weight_decay", (ge(0.0), le(1.0)), "A float in [0.0, 1.0]", float)
-    learning_rate = hp("learning_rate", (ge(1e-6), le(1.0)), "A float in [1e-6, 1.0]", float)
+    num_patience_epochs = hp(
+        "num_patience_epochs", (ge(1), le(10)), "An integer in [1, 10]", int
+    )
+    batch_norm = hp(
+        name="batch_norm", validation_message="Value must be a boolean", data_type=bool
+    )
+    rescale_gradient = hp(
+        "rescale_gradient", (ge(1e-3), le(1.0)), "A float in [1e-3, 1.0]", float
+    )
+    clip_gradient = hp(
+        "clip_gradient", ge(1e-3), "A float greater equal to 1e-3", float
+    )
+    weight_decay = hp(
+        "weight_decay", (ge(0.0), le(1.0)), "A float in [0.0, 1.0]", float
+    )
+    learning_rate = hp(
+        "learning_rate", (ge(1e-6), le(1.0)), "A float in [1e-6, 1.0]", float
+    )
 
     def __init__(
         self,
@@ -147,7 +159,9 @@ class NTM(AmazonAlgorithmEstimatorBase):
             :class:`~sagemaker.estimator.EstimatorBase`.
         """
 
-        super(NTM, self).__init__(role, train_instance_count, train_instance_type, **kwargs)
+        super(NTM, self).__init__(
+            role, train_instance_count, train_instance_type, **kwargs
+        )
         self.num_topics = num_topics
         self.encoder_layers = encoder_layers
         self.epochs = epochs
@@ -189,7 +203,9 @@ class NTM(AmazonAlgorithmEstimatorBase):
             mini_batch_size:
             job_name:
         """
-        if mini_batch_size is not None and (mini_batch_size < 1 or mini_batch_size > 10000):
+        if mini_batch_size is not None and (
+            mini_batch_size < 1 or mini_batch_size > 10000
+        ):
             raise ValueError("mini_batch_size must be in [1, 10000]")
         super(NTM, self)._prepare_for_training(
             records, mini_batch_size=mini_batch_size, job_name=job_name

--- a/src/sagemaker/amazon/object2vec.py
+++ b/src/sagemaker/amazon/object2vec.py
@@ -47,22 +47,32 @@ class Object2Vec(AmazonAlgorithmEstimatorBase):
     MINI_BATCH_SIZE = 32
 
     enc_dim = hp("enc_dim", (ge(4), le(10000)), "An integer in [4, 10000]", int)
-    mini_batch_size = hp("mini_batch_size", (ge(1), le(10000)), "An integer in [1, 10000]", int)
+    mini_batch_size = hp(
+        "mini_batch_size", (ge(1), le(10000)), "An integer in [1, 10000]", int
+    )
     epochs = hp("epochs", (ge(1), le(100)), "An integer in [1, 100]", int)
     early_stopping_patience = hp(
         "early_stopping_patience", (ge(1), le(5)), "An integer in [1, 5]", int
     )
     early_stopping_tolerance = hp(
-        "early_stopping_tolerance", (ge(1e-06), le(0.1)), "A float in [1e-06, 0.1]", float
+        "early_stopping_tolerance",
+        (ge(1e-06), le(0.1)),
+        "A float in [1e-06, 0.1]",
+        float,
     )
     dropout = hp("dropout", (ge(0.0), le(1.0)), "A float in [0.0, 1.0]", float)
-    weight_decay = hp("weight_decay", (ge(0.0), le(10000.0)), "A float in [0.0, 10000.0]", float)
+    weight_decay = hp(
+        "weight_decay", (ge(0.0), le(10000.0)), "A float in [0.0, 10000.0]", float
+    )
     bucket_width = hp("bucket_width", (ge(0), le(100)), "An integer in [0, 100]", int)
     num_classes = hp("num_classes", (ge(2), le(30)), "An integer in [2, 30]", int)
     mlp_layers = hp("mlp_layers", (ge(1), le(10)), "An integer in [1, 10]", int)
     mlp_dim = hp("mlp_dim", (ge(2), le(10000)), "An integer in [2, 10000]", int)
     mlp_activation = hp(
-        "mlp_activation", isin("tanh", "relu", "linear"), 'One of "tanh", "relu", "linear"', str
+        "mlp_activation",
+        isin("tanh", "relu", "linear"),
+        'One of "tanh", "relu", "linear"',
+        str,
     )
     output_layer = hp(
         "output_layer",
@@ -76,7 +86,9 @@ class Object2Vec(AmazonAlgorithmEstimatorBase):
         'One of "adagrad", "adam", "rmsprop", "sgd", "adadelta"',
         str,
     )
-    learning_rate = hp("learning_rate", (ge(1e-06), le(1.0)), "A float in [1e-06, 1.0]", float)
+    learning_rate = hp(
+        "learning_rate", (ge(1e-06), le(1.0)), "A float in [1e-06, 1.0]", float
+    )
 
     negative_sampling_rate = hp(
         "negative_sampling_rate", (ge(0), le(100)), "An integer in [0, 100]", int
@@ -109,18 +121,30 @@ class Object2Vec(AmazonAlgorithmEstimatorBase):
         'One of "hcnn", "bilstm", "pooled_embedding", "enc0"',
         str,
     )
-    enc0_cnn_filter_width = hp("enc0_cnn_filter_width", (ge(1), le(9)), "An integer in [1, 9]", int)
-    enc1_cnn_filter_width = hp("enc1_cnn_filter_width", (ge(1), le(9)), "An integer in [1, 9]", int)
-    enc0_max_seq_len = hp("enc0_max_seq_len", (ge(1), le(5000)), "An integer in [1, 5000]", int)
-    enc1_max_seq_len = hp("enc1_max_seq_len", (ge(1), le(5000)), "An integer in [1, 5000]", int)
+    enc0_cnn_filter_width = hp(
+        "enc0_cnn_filter_width", (ge(1), le(9)), "An integer in [1, 9]", int
+    )
+    enc1_cnn_filter_width = hp(
+        "enc1_cnn_filter_width", (ge(1), le(9)), "An integer in [1, 9]", int
+    )
+    enc0_max_seq_len = hp(
+        "enc0_max_seq_len", (ge(1), le(5000)), "An integer in [1, 5000]", int
+    )
+    enc1_max_seq_len = hp(
+        "enc1_max_seq_len", (ge(1), le(5000)), "An integer in [1, 5000]", int
+    )
     enc0_token_embedding_dim = hp(
         "enc0_token_embedding_dim", (ge(2), le(1000)), "An integer in [2, 1000]", int
     )
     enc1_token_embedding_dim = hp(
         "enc1_token_embedding_dim", (ge(2), le(1000)), "An integer in [2, 1000]", int
     )
-    enc0_vocab_size = hp("enc0_vocab_size", (ge(2), le(3000000)), "An integer in [2, 3000000]", int)
-    enc1_vocab_size = hp("enc1_vocab_size", (ge(2), le(3000000)), "An integer in [2, 3000000]", int)
+    enc0_vocab_size = hp(
+        "enc0_vocab_size", (ge(2), le(3000000)), "An integer in [2, 3000000]", int
+    )
+    enc1_vocab_size = hp(
+        "enc1_vocab_size", (ge(2), le(3000000)), "An integer in [2, 3000000]", int
+    )
     enc0_layers = hp("enc0_layers", (ge(1), le(4)), "An integer in [1, 4]", int)
     enc1_layers = hp("enc1_layers", (ge(1), le(4)), "An integer in [1, 4]", int)
     enc0_freeze_pretrained_embedding = hp(
@@ -263,7 +287,9 @@ class Object2Vec(AmazonAlgorithmEstimatorBase):
             :class:`~sagemaker.estimator.EstimatorBase`.
         """
 
-        super(Object2Vec, self).__init__(role, train_instance_count, train_instance_type, **kwargs)
+        super(Object2Vec, self).__init__(
+            role, train_instance_count, train_instance_type, **kwargs
+        )
 
         self.enc_dim = enc_dim
         self.mini_batch_size = mini_batch_size
@@ -352,7 +378,8 @@ class Object2VecModel(Model):
         sagemaker_session = sagemaker_session or Session()
         repo = "{}:{}".format(Object2Vec.repo_name, Object2Vec.repo_version)
         image = "{}/{}".format(
-            registry(sagemaker_session.boto_session.region_name, Object2Vec.repo_name), repo
+            registry(sagemaker_session.boto_session.region_name, Object2Vec.repo_name),
+            repo,
         )
         super(Object2VecModel, self).__init__(
             model_data,

--- a/src/sagemaker/amazon/pca.py
+++ b/src/sagemaker/amazon/pca.py
@@ -31,7 +31,9 @@ class PCA(AmazonAlgorithmEstimatorBase):
 
     DEFAULT_MINI_BATCH_SIZE = 500
 
-    num_components = hp("num_components", gt(0), "Value must be an integer greater than zero", int)
+    num_components = hp(
+        "num_components", gt(0), "Value must be an integer greater than zero", int
+    )
     algorithm_mode = hp(
         "algorithm_mode",
         isin("regular", "randomized"),
@@ -39,7 +41,9 @@ class PCA(AmazonAlgorithmEstimatorBase):
         str,
     )
     subtract_mean = hp(
-        name="subtract_mean", validation_message="Value must be a boolean", data_type=bool
+        name="subtract_mean",
+        validation_message="Value must be a boolean",
+        data_type=bool,
     )
     extra_components = hp(
         name="extra_components",
@@ -120,7 +124,9 @@ class PCA(AmazonAlgorithmEstimatorBase):
             :class:`~sagemaker.estimator.amazon_estimator.AmazonAlgorithmEstimatorBase` and
             :class:`~sagemaker.estimator.EstimatorBase`.
         """
-        super(PCA, self).__init__(role, train_instance_count, train_instance_type, **kwargs)
+        super(PCA, self).__init__(
+            role, train_instance_count, train_instance_type, **kwargs
+        )
         self.num_components = num_components
         self.algorithm_mode = algorithm_mode
         self.subtract_mean = subtract_mean
@@ -169,7 +175,8 @@ class PCA(AmazonAlgorithmEstimatorBase):
 
         # mini_batch_size is a required parameter
         default_mini_batch_size = min(
-            self.DEFAULT_MINI_BATCH_SIZE, max(1, int(num_records / self.train_instance_count))
+            self.DEFAULT_MINI_BATCH_SIZE,
+            max(1, int(num_records / self.train_instance_count)),
         )
         use_mini_batch_size = mini_batch_size or default_mini_batch_size
 
@@ -223,7 +230,9 @@ class PCAModel(Model):
         """
         sagemaker_session = sagemaker_session or Session()
         repo = "{}:{}".format(PCA.repo_name, PCA.repo_version)
-        image = "{}/{}".format(registry(sagemaker_session.boto_session.region_name), repo)
+        image = "{}/{}".format(
+            registry(sagemaker_session.boto_session.region_name), repo
+        )
         super(PCAModel, self).__init__(
             model_data,
             image,

--- a/src/sagemaker/amazon/randomcutforest.py
+++ b/src/sagemaker/amazon/randomcutforest.py
@@ -149,7 +149,9 @@ class RandomCutForest(AmazonAlgorithmEstimatorBase):
             mini_batch_size = self.MINI_BATCH_SIZE
         elif mini_batch_size != self.MINI_BATCH_SIZE:
             raise ValueError(
-                "Random Cut Forest uses a fixed mini_batch_size of {}".format(self.MINI_BATCH_SIZE)
+                "Random Cut Forest uses a fixed mini_batch_size of {}".format(
+                    self.MINI_BATCH_SIZE
+                )
             )
 
         super(RandomCutForest, self)._prepare_for_training(
@@ -203,7 +205,10 @@ class RandomCutForestModel(Model):
         sagemaker_session = sagemaker_session or Session()
         repo = "{}:{}".format(RandomCutForest.repo_name, RandomCutForest.repo_version)
         image = "{}/{}".format(
-            registry(sagemaker_session.boto_session.region_name, RandomCutForest.repo_name), repo
+            registry(
+                sagemaker_session.boto_session.region_name, RandomCutForest.repo_name
+            ),
+            repo,
         )
         super(RandomCutForestModel, self).__init__(
             model_data,

--- a/src/sagemaker/amazon/record_pb2.py
+++ b/src/sagemaker/amazon/record_pb2.py
@@ -48,7 +48,9 @@ _FLOAT32TENSOR = _descriptor.Descriptor(
             containing_type=None,
             is_extension=False,
             extension_scope=None,
-            options=_descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b("\020\001")),
+            options=_descriptor._ParseOptions(
+                descriptor_pb2.FieldOptions(), _b("\020\001")
+            ),
             file=DESCRIPTOR,
         ),
         _descriptor.FieldDescriptor(
@@ -66,7 +68,9 @@ _FLOAT32TENSOR = _descriptor.Descriptor(
             containing_type=None,
             is_extension=False,
             extension_scope=None,
-            options=_descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b("\020\001")),
+            options=_descriptor._ParseOptions(
+                descriptor_pb2.FieldOptions(), _b("\020\001")
+            ),
             file=DESCRIPTOR,
         ),
         _descriptor.FieldDescriptor(
@@ -84,7 +88,9 @@ _FLOAT32TENSOR = _descriptor.Descriptor(
             containing_type=None,
             is_extension=False,
             extension_scope=None,
-            options=_descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b("\020\001")),
+            options=_descriptor._ParseOptions(
+                descriptor_pb2.FieldOptions(), _b("\020\001")
+            ),
             file=DESCRIPTOR,
         ),
     ],
@@ -123,7 +129,9 @@ _FLOAT64TENSOR = _descriptor.Descriptor(
             containing_type=None,
             is_extension=False,
             extension_scope=None,
-            options=_descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b("\020\001")),
+            options=_descriptor._ParseOptions(
+                descriptor_pb2.FieldOptions(), _b("\020\001")
+            ),
             file=DESCRIPTOR,
         ),
         _descriptor.FieldDescriptor(
@@ -141,7 +149,9 @@ _FLOAT64TENSOR = _descriptor.Descriptor(
             containing_type=None,
             is_extension=False,
             extension_scope=None,
-            options=_descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b("\020\001")),
+            options=_descriptor._ParseOptions(
+                descriptor_pb2.FieldOptions(), _b("\020\001")
+            ),
             file=DESCRIPTOR,
         ),
         _descriptor.FieldDescriptor(
@@ -159,7 +169,9 @@ _FLOAT64TENSOR = _descriptor.Descriptor(
             containing_type=None,
             is_extension=False,
             extension_scope=None,
-            options=_descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b("\020\001")),
+            options=_descriptor._ParseOptions(
+                descriptor_pb2.FieldOptions(), _b("\020\001")
+            ),
             file=DESCRIPTOR,
         ),
     ],
@@ -198,7 +210,9 @@ _INT32TENSOR = _descriptor.Descriptor(
             containing_type=None,
             is_extension=False,
             extension_scope=None,
-            options=_descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b("\020\001")),
+            options=_descriptor._ParseOptions(
+                descriptor_pb2.FieldOptions(), _b("\020\001")
+            ),
             file=DESCRIPTOR,
         ),
         _descriptor.FieldDescriptor(
@@ -216,7 +230,9 @@ _INT32TENSOR = _descriptor.Descriptor(
             containing_type=None,
             is_extension=False,
             extension_scope=None,
-            options=_descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b("\020\001")),
+            options=_descriptor._ParseOptions(
+                descriptor_pb2.FieldOptions(), _b("\020\001")
+            ),
             file=DESCRIPTOR,
         ),
         _descriptor.FieldDescriptor(
@@ -234,7 +250,9 @@ _INT32TENSOR = _descriptor.Descriptor(
             containing_type=None,
             is_extension=False,
             extension_scope=None,
-            options=_descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b("\020\001")),
+            options=_descriptor._ParseOptions(
+                descriptor_pb2.FieldOptions(), _b("\020\001")
+            ),
             file=DESCRIPTOR,
         ),
     ],
@@ -636,9 +654,13 @@ _VALUE.fields_by_name["float64_tensor"].message_type = _FLOAT64TENSOR
 _VALUE.fields_by_name["int32_tensor"].message_type = _INT32TENSOR
 _VALUE.fields_by_name["bytes"].message_type = _BYTES
 _VALUE.oneofs_by_name["value"].fields.append(_VALUE.fields_by_name["float32_tensor"])
-_VALUE.fields_by_name["float32_tensor"].containing_oneof = _VALUE.oneofs_by_name["value"]
+_VALUE.fields_by_name["float32_tensor"].containing_oneof = _VALUE.oneofs_by_name[
+    "value"
+]
 _VALUE.oneofs_by_name["value"].fields.append(_VALUE.fields_by_name["float64_tensor"])
-_VALUE.fields_by_name["float64_tensor"].containing_oneof = _VALUE.oneofs_by_name["value"]
+_VALUE.fields_by_name["float64_tensor"].containing_oneof = _VALUE.oneofs_by_name[
+    "value"
+]
 _VALUE.oneofs_by_name["value"].fields.append(_VALUE.fields_by_name["int32_tensor"])
 _VALUE.fields_by_name["int32_tensor"].containing_oneof = _VALUE.oneofs_by_name["value"]
 _VALUE.oneofs_by_name["value"].fields.append(_VALUE.fields_by_name["bytes"])
@@ -746,7 +768,8 @@ _sym_db.RegisterMessage(Record.LabelEntry)
 
 DESCRIPTOR.has_options = True
 DESCRIPTOR._options = _descriptor._ParseOptions(
-    descriptor_pb2.FileOptions(), _b("\n com.amazonaws.aialgorithms.protoB\014RecordProtos")
+    descriptor_pb2.FileOptions(),
+    _b("\n com.amazonaws.aialgorithms.protoB\014RecordProtos"),
 )
 _FLOAT32TENSOR.fields_by_name["values"].has_options = True
 _FLOAT32TENSOR.fields_by_name["values"]._options = _descriptor._ParseOptions(

--- a/src/sagemaker/analytics.py
+++ b/src/sagemaker/analytics.py
@@ -27,7 +27,9 @@ from sagemaker.utils import DeferredError
 try:
     import pandas as pd
 except ImportError as e:
-    logging.warning("pandas failed to import. Analytics features will be impaired or broken.")
+    logging.warning(
+        "pandas failed to import. Analytics features will be impaired or broken."
+    )
     # Any subsequent attempt to use pandas will raise the ImportError
     pd = DeferredError(e)
 
@@ -142,9 +144,13 @@ class HyperparameterTuningJobAnalytics(AnalyticsMetricsBase):
             out["TrainingStartTime"] = start_time
             out["TrainingEndTime"] = end_time
             if start_time and end_time:
-                out["TrainingElapsedTimeSeconds"] = (end_time - start_time).total_seconds()
+                out["TrainingElapsedTimeSeconds"] = (
+                    end_time - start_time
+                ).total_seconds()
             if "TrainingJobDefinitionName" in training_summary:
-                out["TrainingJobDefinitionName"] = training_summary["TrainingJobDefinitionName"]
+                out["TrainingJobDefinitionName"] = training_summary[
+                    "TrainingJobDefinitionName"
+                ]
             return out
 
         # Run that helper over all the summaries.
@@ -251,14 +257,18 @@ class HyperparameterTuningJobAnalytics(AnalyticsMetricsBase):
         output = []
         next_args = {}
         for count in range(100):
-            logging.debug("Calling list_training_jobs_for_hyper_parameter_tuning_job %d", count)
+            logging.debug(
+                "Calling list_training_jobs_for_hyper_parameter_tuning_job %d", count
+            )
             raw_result = self._sage_client.list_training_jobs_for_hyper_parameter_tuning_job(
                 HyperParameterTuningJobName=self.name, MaxResults=100, **next_args
             )
             new_output = raw_result["TrainingJobSummaries"]
             output.extend(new_output)
             logging.debug(
-                "Got %d more TrainingJobs. Total so far: %d", len(new_output), len(output)
+                "Got %d more TrainingJobs. Total so far: %d",
+                len(new_output),
+                len(output),
             )
             if ("NextToken" in raw_result) and (len(new_output) > 0):
                 next_args["NextToken"] = raw_result["NextToken"]
@@ -337,7 +347,9 @@ class TrainingJobAnalytics(AnalyticsMetricsBase):
         end_time, covering the interval of the training job
         """
         description = self._sage_client.describe_training_job(TrainingJobName=self.name)
-        start_time = self._start_time or description[u"TrainingStartTime"]  # datetime object
+        start_time = (
+            self._start_time or description[u"TrainingStartTime"]
+        )  # datetime object
         # Incrementing end time by 1 min since CloudWatch drops seconds before finding the logs.
         # This results in logs being searched in the time range in which the correct log line was
         # not present.
@@ -410,7 +422,9 @@ class TrainingJobAnalytics(AnalyticsMetricsBase):
             TrainingJobName=self._training_job_name
         )
 
-        metric_definitions = training_description["AlgorithmSpecification"]["MetricDefinitions"]
+        metric_definitions = training_description["AlgorithmSpecification"][
+            "MetricDefinitions"
+        ]
         metric_names = [md["Name"] for md in metric_definitions]
 
         return metric_names
@@ -462,7 +476,9 @@ class ExperimentAnalytics(AnalyticsMetricsBase):
         self._sage_client = sagemaker_session.sagemaker_client
 
         if not experiment_name and not search_expression:
-            raise ValueError("Either experiment_name or search_expression must be supplied.")
+            raise ValueError(
+                "Either experiment_name or search_expression must be supplied."
+            )
 
         self._experiment_name = experiment_name
         self._search_expression = search_expression
@@ -573,7 +589,9 @@ class ExperimentAnalytics(AnalyticsMetricsBase):
         """Return a pandas dataframe with all the trial_components,
             along with their parameters and metrics.
         """
-        df = pd.DataFrame([self._reshape(component) for component in self._get_trial_components()])
+        df = pd.DataFrame(
+            [self._reshape(component) for component in self._get_trial_components()]
+        )
         return df
 
     def _get_trial_components(self, force_refresh=False):
@@ -634,7 +652,9 @@ class ExperimentAnalytics(AnalyticsMetricsBase):
 
         while len(trial_components) < self.MAX_TRIAL_COMPONENTS:
             search_response = self._sage_client.search(**search_args)
-            components = [result["TrialComponent"] for result in search_response["Results"]]
+            components = [
+                result["TrialComponent"] for result in search_response["Results"]
+            ]
             trial_components.extend(components)
             if "NextToken" in search_response and len(components) > 0:
                 search_args["NextToken"] = search_response["NextToken"]

--- a/src/sagemaker/automl/automl.py
+++ b/src/sagemaker/automl/automl.py
@@ -59,7 +59,9 @@ class AutoML(object):
         self.vpc_config = vpc_config
         self.problem_type = problem_type
         self.max_candidate = max_candidates
-        self.max_runtime_per_training_job_in_seconds = max_runtime_per_training_job_in_seconds
+        self.max_runtime_per_training_job_in_seconds = (
+            max_runtime_per_training_job_in_seconds
+        )
         self.total_job_runtime_in_seconds = total_job_runtime_in_seconds
         self.target_attribute_name = target_attribute_name
         self.job_objective = job_objective
@@ -71,7 +73,9 @@ class AutoML(object):
         self._best_candidate = None
         self.sagemaker_session = sagemaker_session or Session()
 
-        self._check_problem_type_and_job_objective(self.problem_type, self.job_objective)
+        self._check_problem_type_and_job_objective(
+            self.problem_type, self.job_objective
+        )
 
     def fit(self, inputs=None, wait=True, logs=True, job_name=None):
         """Create an AutoML Job with the input dataset.
@@ -89,16 +93,22 @@ class AutoML(object):
         """
         if not wait and logs:
             logs = False
-            logger.warning("Setting logs to False. logs is only meaningful when wait is True.")
+            logger.warning(
+                "Setting logs to False. logs is only meaningful when wait is True."
+            )
 
         # upload data for users if provided local path
         # validations are done in _Job._format_inputs_to_input_config
         if isinstance(inputs, string_types):
             if not inputs.startswith("s3://"):
-                inputs = self.sagemaker_session.upload_data(inputs, key_prefix="auto-ml-input-data")
+                inputs = self.sagemaker_session.upload_data(
+                    inputs, key_prefix="auto-ml-input-data"
+                )
         self._prepare_for_auto_ml_job(job_name=job_name)
 
-        self.latest_auto_ml_job = AutoMLJob.start_new(self, inputs)  # pylint: disable=W0201
+        self.latest_auto_ml_job = AutoMLJob.start_new(
+            self, inputs
+        )  # pylint: disable=W0201
         if wait:
             self.latest_auto_ml_job.wait(logs=logs)
 
@@ -127,11 +137,15 @@ class AutoML(object):
 
         amlj = AutoML(
             role=auto_ml_job_desc["RoleArn"],
-            target_attribute_name=auto_ml_job_desc["InputDataConfig"][0]["TargetAttributeName"],
+            target_attribute_name=auto_ml_job_desc["InputDataConfig"][0][
+                "TargetAttributeName"
+            ],
             output_kms_key=auto_ml_job_desc["OutputDataConfig"].get("KmsKeyId"),
             output_path=auto_ml_job_desc["OutputDataConfig"]["S3OutputPath"],
             base_job_name=auto_ml_job_name,
-            compression_type=auto_ml_job_desc["InputDataConfig"][0].get("CompressionType"),
+            compression_type=auto_ml_job_desc["InputDataConfig"][0].get(
+                "CompressionType"
+            ),
             sagemaker_session=sagemaker_session,
             volume_kms_key=auto_ml_job_desc.get("AutoMLJobConfig", {})
             .get("SecurityConfig", {})
@@ -146,13 +160,17 @@ class AutoML(object):
             max_candidates=auto_ml_job_desc.get("AutoMLJobConfig", {})
             .get("CompletionCriteria", {})
             .get("MaxCandidates"),
-            max_runtime_per_training_job_in_seconds=auto_ml_job_desc.get("AutoMLJobConfig", {})
+            max_runtime_per_training_job_in_seconds=auto_ml_job_desc.get(
+                "AutoMLJobConfig", {}
+            )
             .get("CompletionCriteria", {})
             .get("MaxRuntimePerTrainingJobInSeconds"),
             total_job_runtime_in_seconds=auto_ml_job_desc.get("AutoMLJobConfig", {})
             .get("CompletionCriteria", {})
             .get("MaxAutoMLJobRuntimeInSeconds"),
-            job_objective=auto_ml_job_desc.get("AutoMLJobObjective", {}).get("MetricName"),
+            job_objective=auto_ml_job_desc.get("AutoMLJobObjective", {}).get(
+                "MetricName"
+            ),
             generate_candidate_definitions_only=auto_ml_job_desc.get(
                 "GenerateCandidateDefinitionsOnly", False
             ),
@@ -193,9 +211,13 @@ class AutoML(object):
         if job_name is None:
             job_name = self.current_job_name
         if self._auto_ml_job_desc is None:
-            self._auto_ml_job_desc = self.sagemaker_session.describe_auto_ml_job(job_name)
+            self._auto_ml_job_desc = self.sagemaker_session.describe_auto_ml_job(
+                job_name
+            )
         elif self._auto_ml_job_desc["AutoMLJobName"] != job_name:
-            self._auto_ml_job_desc = self.sagemaker_session.describe_auto_ml_job(job_name)
+            self._auto_ml_job_desc = self.sagemaker_session.describe_auto_ml_job(
+                job_name
+            )
 
         self._best_candidate = self._auto_ml_job_desc["BestCandidate"]
         return self._best_candidate
@@ -248,7 +270,9 @@ class AutoML(object):
         if max_results:
             list_candidates_args["max_results"] = max_results
 
-        return self.sagemaker_session.list_candidates(**list_candidates_args)["Candidates"]
+        return self.sagemaker_session.list_candidates(**list_candidates_args)[
+            "Candidates"
+        ]
 
     def create_model(
         self,
@@ -295,13 +319,19 @@ class AutoML(object):
 
         if candidate is None:
             candidate_dict = self.best_candidate()
-            candidate = CandidateEstimator(candidate_dict, sagemaker_session=sagemaker_session)
+            candidate = CandidateEstimator(
+                candidate_dict, sagemaker_session=sagemaker_session
+            )
         elif isinstance(candidate, dict):
-            candidate = CandidateEstimator(candidate, sagemaker_session=sagemaker_session)
+            candidate = CandidateEstimator(
+                candidate, sagemaker_session=sagemaker_session
+            )
 
         inference_containers = candidate.containers
 
-        self.validate_and_update_inference_response(inference_containers, inference_response_keys)
+        self.validate_and_update_inference_response(
+            inference_containers, inference_response_keys
+        )
 
         # construct Model objects
         models = []
@@ -454,7 +484,9 @@ class AutoML(object):
             self.current_job_name = name_from_base(base_name, max_length=32)
 
         if self.output_path is None:
-            self.output_path = "s3://{}/".format(self.sagemaker_session.default_bucket())
+            self.output_path = "s3://{}/".format(
+                self.sagemaker_session.default_bucket()
+            )
 
     @classmethod
     def _get_supported_inference_keys(cls, container, default=None):
@@ -475,7 +507,9 @@ class AutoML(object):
         try:
             return [
                 x.strip()
-                for x in container["Environment"]["SAGEMAKER_INFERENCE_SUPPORTED"].split(",")
+                for x in container["Environment"][
+                    "SAGEMAKER_INFERENCE_SUPPORTED"
+                ].split(",")
             ]
         except KeyError:
             if default is None:
@@ -499,7 +533,9 @@ class AutoML(object):
         if not inference_response_keys:
             return
         try:
-            supported_inference_keys = cls._get_supported_inference_keys(container=containers[-1])
+            supported_inference_keys = cls._get_supported_inference_keys(
+                container=containers[-1]
+            )
         except KeyError:
             raise ValueError(
                 "The inference model does not support selection of inference content beyond "
@@ -521,7 +557,9 @@ class AutoML(object):
             )
 
     @classmethod
-    def validate_and_update_inference_response(cls, inference_containers, inference_response_keys):
+    def validate_and_update_inference_response(
+        cls, inference_containers, inference_response_keys
+    ):
         """Validates the requested inference keys and updates inference containers to emit the
         requested content in the inference response.
 
@@ -551,7 +589,9 @@ class AutoML(object):
             for key in inference_response_keys:
                 if key in supported_inference_keys_container:
                     current_container_output = (
-                        current_container_output + "," + key if current_container_output else key
+                        current_container_output + "," + key
+                        if current_container_output
+                        else key
                     )
 
             if previous_container_output:
@@ -591,7 +631,9 @@ class AutoMLInput(object):
             self.inputs = [self.inputs]
         for entry in self.inputs:
             input_entry = {
-                "DataSource": {"S3DataSource": {"S3DataType": "S3Prefix", "S3Uri": entry}},
+                "DataSource": {
+                    "S3DataSource": {"S3DataType": "S3Prefix", "S3Uri": entry}
+                },
                 "TargetAttributeName": self.target_attribute_name,
             }
             if self.compression is not None:
@@ -606,7 +648,9 @@ class AutoMLJob(_Job):
     def __init__(self, sagemaker_session, job_name, inputs):
         self.inputs = inputs
         self.job_name = job_name
-        super(AutoMLJob, self).__init__(sagemaker_session=sagemaker_session, job_name=job_name)
+        super(AutoMLJob, self).__init__(
+            sagemaker_session=sagemaker_session, job_name=job_name
+        )
 
     @classmethod
     def start_new(cls, auto_ml, inputs):
@@ -656,11 +700,20 @@ class AutoMLJob(_Job):
             input_config = inputs.to_request_dict()
         else:
             input_config = cls._format_inputs_to_input_config(
-                inputs, validate_uri, auto_ml.compression_type, auto_ml.target_attribute_name
+                inputs,
+                validate_uri,
+                auto_ml.compression_type,
+                auto_ml.target_attribute_name,
             )
-        output_config = _Job._prepare_output_config(auto_ml.output_path, auto_ml.output_kms_key)
+        output_config = _Job._prepare_output_config(
+            auto_ml.output_path, auto_ml.output_kms_key
+        )
 
-        role = auto_ml.sagemaker_session.expand_role(auto_ml.role) if expand_role else auto_ml.role
+        role = (
+            auto_ml.sagemaker_session.expand_role(auto_ml.role)
+            if expand_role
+            else auto_ml.role
+        )
 
         stop_condition = cls._prepare_auto_ml_stop_condition(
             auto_ml.max_candidate,
@@ -676,7 +729,9 @@ class AutoMLJob(_Job):
         }
 
         if auto_ml.volume_kms_key:
-            auto_ml_job_config["SecurityConfig"]["VolumeKmsKeyId"] = auto_ml.volume_kms_key
+            auto_ml_job_config["SecurityConfig"][
+                "VolumeKmsKeyId"
+            ] = auto_ml.volume_kms_key
         if auto_ml.vpc_config:
             auto_ml_job_config["SecurityConfig"]["VpcConfig"] = auto_ml.vpc_config
 
@@ -740,7 +795,10 @@ class AutoMLJob(_Job):
 
     @classmethod
     def _prepare_auto_ml_stop_condition(
-        cls, max_candidates, max_runtime_per_training_job_in_seconds, total_job_runtime_in_seconds
+        cls,
+        max_candidates,
+        max_runtime_per_training_job_in_seconds,
+        total_job_runtime_in_seconds,
     ):
         """Defines the CompletionCriteria of an AutoMLJob.
 
@@ -761,7 +819,9 @@ class AutoMLJob(_Job):
                 "MaxRuntimePerTrainingJobInSeconds"
             ] = max_runtime_per_training_job_in_seconds
         if total_job_runtime_in_seconds is not None:
-            stopping_condition["MaxAutoMLJobRuntimeInSeconds"] = total_job_runtime_in_seconds
+            stopping_condition[
+                "MaxAutoMLJobRuntimeInSeconds"
+            ] = total_job_runtime_in_seconds
 
         return stopping_condition
 

--- a/src/sagemaker/automl/candidate_estimator.py
+++ b/src/sagemaker/automl/candidate_estimator.py
@@ -56,14 +56,18 @@ class CandidateEstimator(object):
                 )
 
                 inputs = training_job["InputDataConfig"]
-                candidate_step = CandidateStep(step_name, inputs, step_type, training_job)
+                candidate_step = CandidateStep(
+                    step_name, inputs, step_type, training_job
+                )
                 candidate_steps.append(candidate_step)
             elif step_type == "TransformJob":
                 transform_job = self.sagemaker_session.sagemaker_client.describe_transform_job(
                     TransformJobName=step_name
                 )
                 inputs = transform_job["TransformInput"]
-                candidate_step = CandidateStep(step_name, inputs, step_type, transform_job)
+                candidate_step = CandidateStep(
+                    step_name, inputs, step_type, transform_job
+                )
                 candidate_steps.append(candidate_step)
         return candidate_steps
 
@@ -106,7 +110,9 @@ class CandidateEstimator(object):
         # convert inputs to s3_input format
         if isinstance(inputs, string_types):
             if not inputs.startswith("s3://"):
-                inputs = self.sagemaker_session.upload_data(inputs, key_prefix="auto-ml-input-data")
+                inputs = self.sagemaker_session.upload_data(
+                    inputs, key_prefix="auto-ml-input-data"
+                )
 
         for step in self.steps:
             step_type = step["type"]
@@ -144,7 +150,9 @@ class CandidateEstimator(object):
 
             elif step_type == "TransformJob":
                 # prepare inputs
-                if not isinstance(inputs, string_types) or not inputs.startswith("s3://"):
+                if not isinstance(inputs, string_types) or not inputs.startswith(
+                    "s3://"
+                ):
                     msg = "Cannot format input {}. Expecting a string starts with file:// or s3://"
                     raise ValueError(msg.format(inputs))
 
@@ -154,7 +162,9 @@ class CandidateEstimator(object):
                 base_name = "sagemaker-automl-transform-rerun"
                 step_name = name_from_base(base_name)
                 step["name"] = step_name
-                transform_args = self._get_transform_args(desc, inputs, step_name, volume_kms_key)
+                transform_args = self._get_transform_args(
+                    desc, inputs, step_name, volume_kms_key
+                )
                 self.sagemaker_session.transform(**transform_args)
                 running_jobs[step_name] = True
 
@@ -167,11 +177,15 @@ class CandidateEstimator(object):
                     if step_type == "TrainingJob":
                         status = self.sagemaker_session.sagemaker_client.describe_training_job(
                             TrainingJobName=step_name
-                        )["TrainingJobStatus"]
+                        )[
+                            "TrainingJobStatus"
+                        ]
                     elif step_type == "TransformJob":
                         status = self.sagemaker_session.sagemaker_client.describe_transform_job(
                             TransformJobName=step_name
-                        )["TransformJobStatus"]
+                        )[
+                            "TransformJobStatus"
+                        ]
                     if status in ("Completed", "Failed", "Stopped"):
                         running_jobs[step_name] = False
                 if self._check_all_job_finished(running_jobs):
@@ -193,7 +207,13 @@ class CandidateEstimator(object):
         return True
 
     def _get_train_args(
-        self, desc, inputs, name, volume_kms_key, encrypt_inter_container_traffic, vpc_config
+        self,
+        desc,
+        inputs,
+        name,
+        volume_kms_key,
+        encrypt_inter_container_traffic,
+        vpc_config,
     ):
         """Format training args to pass in sagemaker_session.train.
 
@@ -280,7 +300,9 @@ class CandidateEstimator(object):
         if "BatchStrategy" in desc:
             transform_args["strategy"] = desc["BatchStrategy"]
         if "MaxConcurrentTransforms" in desc:
-            transform_args["max_concurrent_transforms"] = desc["MaxConcurrentTransforms"]
+            transform_args["max_concurrent_transforms"] = desc[
+                "MaxConcurrentTransforms"
+            ]
         if "MaxPayloadInMB" in desc:
             transform_args["max_payload"] = desc["MaxPayloadInMB"]
         if "Environment" in desc:

--- a/src/sagemaker/chainer/estimator.py
+++ b/src/sagemaker/chainer/estimator.py
@@ -127,7 +127,9 @@ class Chainer(Framework):
         """
         if framework_version is None:
             logger.warning(
-                empty_framework_version_warning(defaults.CHAINER_VERSION, self.LATEST_VERSION)
+                empty_framework_version_warning(
+                    defaults.CHAINER_VERSION, self.LATEST_VERSION
+                )
             )
         self.framework_version = framework_version or defaults.CHAINER_VERSION
 
@@ -137,7 +139,9 @@ class Chainer(Framework):
 
         if py_version == "py2":
             logger.warning(
-                python_deprecation_warning(self.__framework_name__, defaults.LATEST_PY2_VERSION)
+                python_deprecation_warning(
+                    self.__framework_name__, defaults.LATEST_PY2_VERSION
+                )
             )
 
         self.py_version = py_version
@@ -160,8 +164,12 @@ class Chainer(Framework):
         }
 
         # remove unset keys.
-        additional_hyperparameters = {k: v for k, v in additional_hyperparameters.items() if v}
-        hyperparameters.update(Framework._json_encode_hyperparameters(additional_hyperparameters))
+        additional_hyperparameters = {
+            k: v for k, v in additional_hyperparameters.items() if v
+        }
+        hyperparameters.update(
+            Framework._json_encode_hyperparameters(additional_hyperparameters)
+        )
         return hyperparameters
 
     def create_model(
@@ -231,7 +239,9 @@ class Chainer(Framework):
         )
 
     @classmethod
-    def _prepare_init_params_from_job_description(cls, job_details, model_channel_name=None):
+    def _prepare_init_params_from_job_description(
+        cls, job_details, model_channel_name=None
+    ):
         """Convert the job description to init params that can be handled by the
         class constructor
 

--- a/src/sagemaker/chainer/model.py
+++ b/src/sagemaker/chainer/model.py
@@ -112,12 +112,16 @@ class ChainerModel(FrameworkModel):
         )
         if py_version == "py2":
             logger.warning(
-                python_deprecation_warning(self.__framework_name__, defaults.LATEST_PY2_VERSION)
+                python_deprecation_warning(
+                    self.__framework_name__, defaults.LATEST_PY2_VERSION
+                )
             )
 
         if framework_version is None:
             logger.warning(
-                empty_framework_version_warning(defaults.CHAINER_VERSION, defaults.LATEST_VERSION)
+                empty_framework_version_warning(
+                    defaults.CHAINER_VERSION, defaults.LATEST_VERSION
+                )
             )
 
         self.py_version = py_version
@@ -151,13 +155,17 @@ class ChainerModel(FrameworkModel):
                 region_name, instance_type, accelerator_type=accelerator_type
             )
 
-        deploy_key_prefix = model_code_key_prefix(self.key_prefix, self.name, deploy_image)
+        deploy_key_prefix = model_code_key_prefix(
+            self.key_prefix, self.name, deploy_image
+        )
         self._upload_code(deploy_key_prefix)
         deploy_env = dict(self.env)
         deploy_env.update(self._framework_env_vars())
 
         if self.model_server_workers:
-            deploy_env[MODEL_SERVER_WORKERS_PARAM_NAME.upper()] = str(self.model_server_workers)
+            deploy_env[MODEL_SERVER_WORKERS_PARAM_NAME.upper()] = str(
+                self.model_server_workers
+            )
         return sagemaker.container_def(deploy_image, self.model_data, deploy_env)
 
     def serving_image_uri(self, region_name, instance_type, accelerator_type=None):

--- a/src/sagemaker/cli/common.py
+++ b/src/sagemaker/cli/common.py
@@ -50,7 +50,9 @@ class HostCommand(object):
         prefix = "{}/model".format(self.endpoint_name)
 
         archive = self.create_model_archive(self.data)
-        model_uri = self.session.upload_data(path=archive, bucket=self.bucket, key_prefix=prefix)
+        model_uri = self.session.upload_data(
+            path=archive, bucket=self.bucket, key_prefix=prefix
+        )
         shutil.rmtree(os.path.dirname(archive))
 
         return model_uri
@@ -126,7 +128,9 @@ class TrainCommand(object):
     def upload_training_data(self):
         """Placeholder docstring"""
         prefix = "{}/data".format(self.job_name)
-        data_url = self.session.upload_data(path=self.data, bucket=self.bucket, key_prefix=prefix)
+        data_url = self.session.upload_data(
+            path=self.data, bucket=self.bucket, key_prefix=prefix
+        )
         return data_url
 
     def create_estimator(self):

--- a/src/sagemaker/cli/main.py
+++ b/src/sagemaker/cli/main.py
@@ -43,23 +43,34 @@ def parse_arguments(args):
         "--role-name", help="SageMaker execution role name", type=str, required=True
     )
     common_parser.add_argument(
-        "--data", help="path to training data or model files", type=str, default="./data"
+        "--data",
+        help="path to training data or model files",
+        type=str,
+        default="./data",
     )
-    common_parser.add_argument("--script", help="path to script", type=str, default="./script.py")
-    common_parser.add_argument("--job-name", help="job or endpoint name", type=str, default=None)
+    common_parser.add_argument(
+        "--script", help="path to script", type=str, default="./script.py"
+    )
+    common_parser.add_argument(
+        "--job-name", help="job or endpoint name", type=str, default=None
+    )
     common_parser.add_argument(
         "--bucket-name",
         help="S3 bucket for training/model data and script files",
         type=str,
         default=None,
     )
-    common_parser.add_argument("--python", help="python version", type=str, default="py2")
+    common_parser.add_argument(
+        "--python", help="python version", type=str, default="py2"
+    )
 
     instance_group = common_parser.add_argument_group("instance settings")
     instance_group.add_argument(
         "--instance-type", type=str, help="instance type", default="ml.m4.xlarge"
     )
-    instance_group.add_argument("--instance-count", type=int, help="instance count", default=1)
+    instance_group.add_argument(
+        "--instance-count", type=int, help="instance count", default=1
+    )
 
     # common training args
     common_train_parser = argparse.ArgumentParser(add_help=False)
@@ -82,19 +93,27 @@ def parse_arguments(args):
     mxnet_parser = subparsers.add_parser("mxnet", help="use MXNet", parents=[])
     mxnet_subparsers = mxnet_parser.add_subparsers()
     mxnet_train_parser = mxnet_subparsers.add_parser(
-        "train", help="start a training job", parents=[common_parser, common_train_parser]
+        "train",
+        help="start a training job",
+        parents=[common_parser, common_train_parser],
     )
     mxnet_train_parser.set_defaults(func=sagemaker.cli.mxnet.train)
 
     mxnet_host_parser = mxnet_subparsers.add_parser(
-        "host", help="start a hosting endpoint", parents=[common_parser, common_host_parser]
+        "host",
+        help="start a hosting endpoint",
+        parents=[common_parser, common_host_parser],
     )
     mxnet_host_parser.set_defaults(func=sagemaker.cli.mxnet.host)
 
-    tensorflow_parser = subparsers.add_parser("tensorflow", help="use TensorFlow", parents=[])
+    tensorflow_parser = subparsers.add_parser(
+        "tensorflow", help="use TensorFlow", parents=[]
+    )
     tensorflow_subparsers = tensorflow_parser.add_subparsers()
     tensorflow_train_parser = tensorflow_subparsers.add_parser(
-        "train", help="start a training job", parents=[common_parser, common_train_parser]
+        "train",
+        help="start a training job",
+        parents=[common_parser, common_train_parser],
     )
     tensorflow_train_parser.add_argument(
         "--training-steps",
@@ -111,13 +130,18 @@ def parse_arguments(args):
     tensorflow_train_parser.set_defaults(func=sagemaker.cli.tensorflow.train)
 
     tensorflow_host_parser = tensorflow_subparsers.add_parser(
-        "host", help="start a hosting endpoint", parents=[common_parser, common_host_parser]
+        "host",
+        help="start a hosting endpoint",
+        parents=[common_parser, common_host_parser],
     )
     tensorflow_host_parser.set_defaults(func=sagemaker.cli.tensorflow.host)
 
     log_group = parser.add_argument_group("optional log settings")
     log_group.add_argument(
-        "--log-level", help="log level for this command", type=str, default=DEFAULT_LOG_LEVEL
+        "--log-level",
+        help="log level for this command",
+        type=str,
+        default=DEFAULT_LOG_LEVEL,
     )
     log_group.add_argument(
         "--botocore-log-level",

--- a/src/sagemaker/debugger.py
+++ b/src/sagemaker/debugger.py
@@ -61,7 +61,9 @@ def get_rule_container_image_uri(region):
     Returns:
         str: Formatted image uri for the given region and the rule container type
     """
-    registry_id = SAGEMAKER_RULE_CONTAINERS_ACCOUNTS_MAP.get(region).get(RULES_ECR_REPO_NAME)
+    registry_id = SAGEMAKER_RULE_CONTAINERS_ACCOUNTS_MAP.get(region).get(
+        RULES_ECR_REPO_NAME
+    )
     image_uri_prefix = get_ecr_image_uri_prefix(registry_id, region)
     return "{}/{}:latest".format(image_uri_prefix, RULES_ECR_REPO_NAME)
 
@@ -151,7 +153,10 @@ class Rule(object):
         """
         merged_rule_params = {}
 
-        if rule_parameters is not None and rule_parameters.get("rule_to_invoke") is not None:
+        if (
+            rule_parameters is not None
+            and rule_parameters.get("rule_to_invoke") is not None
+        ):
             raise RuntimeError(
                 """You cannot provide a 'rule_to_invoke' for SageMaker rules.
                 Please either remove the rule_to_invoke or use a custom rule.
@@ -162,7 +167,9 @@ class Rule(object):
             for index, s3_input_path in enumerate(other_trials_s3_input_paths):
                 merged_rule_params["other_trial_{}".format(str(index))] = s3_input_path
 
-        default_rule_params = base_config["DebugRuleConfiguration"].get("RuleParameters", {})
+        default_rule_params = base_config["DebugRuleConfiguration"].get(
+            "RuleParameters", {}
+        )
         merged_rule_params.update(default_rule_params)
         merged_rule_params.update(rule_parameters or {})
 
@@ -180,7 +187,8 @@ class Rule(object):
             )
 
         return cls(
-            name=name or base_config["DebugRuleConfiguration"].get("RuleConfigurationName"),
+            name=name
+            or base_config["DebugRuleConfiguration"].get("RuleConfigurationName"),
             image_uri="DEFAULT_RULE_EVALUATOR_IMAGE",
             instance_type=None,
             container_local_output_path=container_local_output_path,
@@ -370,7 +378,9 @@ class TensorBoardOutputConfig(object):
         tensorboard_output_config_request = {"S3OutputPath": self.s3_output_path}
 
         if self.container_local_output_path is not None:
-            tensorboard_output_config_request["LocalPath"] = self.container_local_output_path
+            tensorboard_output_config_request[
+                "LocalPath"
+            ] = self.container_local_output_path
 
         return tensorboard_output_config_request
 

--- a/src/sagemaker/fw_utils.py
+++ b/src/sagemaker/fw_utils.py
@@ -92,7 +92,10 @@ ASIMOV_VALID_ACCOUNTS_BY_REGION = {
     "cn-northwest-1": "727897471807",
 }
 OPT_IN_ACCOUNTS_BY_REGION = {"ap-east-1": "057415533634", "me-south-1": "724002660598"}
-ASIMOV_OPT_IN_ACCOUNTS_BY_REGION = {"ap-east-1": "871362719292", "me-south-1": "217643126080"}
+ASIMOV_OPT_IN_ACCOUNTS_BY_REGION = {
+    "ap-east-1": "871362719292",
+    "me-south-1": "217643126080",
+}
 DEFAULT_ACCOUNT = "520713654638"
 ASIMOV_PROD_ACCOUNT = "763104351884"
 ASIMOV_DEFAULT_ACCOUNT = ASIMOV_PROD_ACCOUNT
@@ -271,7 +274,9 @@ def create_image_uri(
         raise ValueError("invalid py_version argument: {}".format(py_version))
 
     if py_version == "py37" and framework not in PY37_SUPPORTED_FRAMEWORKS:
-        raise ValueError("{} does not support Python 3.7 at this time.".format(framework))
+        raise ValueError(
+            "{} does not support Python 3.7 at this time.".format(framework)
+        )
 
     if _accelerator_type_valid_for_framework(
         framework=framework,
@@ -297,7 +302,9 @@ def create_image_uri(
     elif not instance_type.startswith("ml."):
         raise ValueError(
             "{} is not a valid SageMaker instance type. See: "
-            "https://aws.amazon.com/sagemaker/pricing/instance-types/".format(instance_type)
+            "https://aws.amazon.com/sagemaker/pricing/instance-types/".format(
+                instance_type
+            )
         )
     else:
         family = instance_type.split(".")[1]
@@ -365,7 +372,9 @@ def _accelerator_type_valid_for_framework(
 
     if py_version == "py2" and framework in PY2_RESTRICTED_EIA_FRAMEWORKS:
         raise ValueError(
-            "{} is not supported with Amazon Elastic Inference in Python 2.".format(framework)
+            "{} is not supported with Amazon Elastic Inference in Python 2.".format(
+                framework
+            )
         )
 
     if framework not in VALID_EIA_FRAMEWORKS:
@@ -383,7 +392,9 @@ def _accelerator_type_valid_for_framework(
     ):
         raise ValueError(
             "{} is not a valid SageMaker Elastic Inference accelerator type. "
-            "See: https://docs.aws.amazon.com/sagemaker/latest/dg/ei.html".format(accelerator_type)
+            "See: https://docs.aws.amazon.com/sagemaker/latest/dg/ei.html".format(
+                accelerator_type
+            )
         )
 
     return True
@@ -401,7 +412,9 @@ def validate_source_dir(script, directory):
     if directory:
         if not os.path.isfile(os.path.join(directory, script)):
             raise ValueError(
-                'No file named "{}" was found in directory "{}".'.format(script, directory)
+                'No file named "{}" was found in directory "{}".'.format(
+                    script, directory
+                )
             )
 
     return True
@@ -517,7 +530,9 @@ def framework_name_from_image(image_name):
     name_pattern = re.compile(
         r"^(?:sagemaker(?:-rl)?-)?(tensorflow|mxnet|chainer|pytorch|scikit-learn|xgboost)(?:-)?(scriptmode|training)?:(.*)-(.*?)-(py2|py3)$"  # noqa: E501 # pylint: disable=line-too-long
     )
-    legacy_name_pattern = re.compile(r"^sagemaker-(tensorflow|mxnet)-(py2|py3)-(cpu|gpu):(.*)$")
+    legacy_name_pattern = re.compile(
+        r"^sagemaker-(tensorflow|mxnet)-(py2|py3)-(cpu|gpu):(.*)$"
+    )
 
     name_match = name_pattern.match(sagemaker_match.group(9))
     legacy_match = legacy_name_pattern.match(sagemaker_match.group(9))
@@ -532,7 +547,12 @@ def framework_name_from_image(image_name):
         )
         return fw, py, "{}-{}-{}".format(ver, device, py), scriptmode
     if legacy_match is not None:
-        return (legacy_match.group(1), legacy_match.group(2), legacy_match.group(4), None)
+        return (
+            legacy_match.group(1),
+            legacy_match.group(2),
+            legacy_match.group(4),
+            None,
+        )
     return None, None, None, None
 
 
@@ -576,7 +596,9 @@ def model_code_key_prefix(code_location_key_prefix, model_name, image):
         str: the key prefix to be used in uploading code
     """
     training_job_name = sagemaker.utils.name_from_image(image)
-    return "/".join(filter(None, [code_location_key_prefix, model_name or training_job_name]))
+    return "/".join(
+        filter(None, [code_location_key_prefix, model_name or training_job_name])
+    )
 
 
 def empty_framework_version_warning(default_version, latest_version):
@@ -629,9 +651,9 @@ def warn_if_parameter_server_with_multi_gpu(training_instance_type, distribution
         or training_instance_type.split(".")[1].startswith("p")
     ) and training_instance_type not in SINGLE_GPU_INSTANCE_TYPES
 
-    ps_enabled = "parameter_server" in distributions and distributions["parameter_server"].get(
-        "enabled", False
-    )
+    ps_enabled = "parameter_server" in distributions and distributions[
+        "parameter_server"
+    ].get("enabled", False)
 
     if is_multi_gpu_instance and ps_enabled:
         logger.warning(PARAMETER_SERVER_MULTI_GPU_WARNING)

--- a/src/sagemaker/git_utils.py
+++ b/src/sagemaker/git_utils.py
@@ -113,7 +113,9 @@ def git_clone_repo(git_config, entry_point, source_dir=None, dependencies=None):
             if os.path.exists(os.path.join(dest_dir, path)):
                 updated_paths["dependencies"].append(os.path.join(dest_dir, path))
             else:
-                raise ValueError("Dependency {} does not exist in the repo.".format(path))
+                raise ValueError(
+                    "Dependency {} does not exist in the repo.".format(path)
+                )
     return updated_paths
 
 
@@ -144,9 +146,9 @@ def _generate_and_run_clone_command(git_config, dest_dir):
     Raises:
         CalledProcessError: If failed to clone git repo.
     """
-    if git_config["repo"].startswith("https://git-codecommit") or git_config["repo"].startswith(
-        "ssh://git-codecommit"
-    ):
+    if git_config["repo"].startswith("https://git-codecommit") or git_config[
+        "repo"
+    ].startswith("ssh://git-codecommit"):
         _clone_command_for_codecommit(git_config, dest_dir)
     else:
         _clone_command_for_github_like(git_config, dest_dir)
@@ -184,7 +186,9 @@ def _clone_command_for_ssh(git_config, dest_dir):
         dest_dir:
     """
     if "username" in git_config or "password" in git_config or "token" in git_config:
-        warnings.warn("SSH cloning, authentication information in git config will be ignored.")
+        warnings.warn(
+            "SSH cloning, authentication information in git config will be ignored."
+        )
     _run_clone_command(git_config["repo"], dest_dir)
 
 
@@ -197,11 +201,17 @@ def _clone_command_for_github_like_https_2fa_disabled(git_config, dest_dir):
     updated_url = git_config["repo"]
     if "token" in git_config:
         if "username" in git_config or "password" in git_config:
-            warnings.warn("Using token for authentication, " "other credentials will be ignored.")
-        updated_url = _insert_token_to_repo_url(url=git_config["repo"], token=git_config["token"])
+            warnings.warn(
+                "Using token for authentication, " "other credentials will be ignored."
+            )
+        updated_url = _insert_token_to_repo_url(
+            url=git_config["repo"], token=git_config["token"]
+        )
     elif "username" in git_config and "password" in git_config:
         updated_url = _insert_username_and_password_to_repo_url(
-            url=git_config["repo"], username=git_config["username"], password=git_config["password"]
+            url=git_config["repo"],
+            username=git_config["username"],
+            password=git_config["password"],
         )
     elif "username" in git_config or "password" in git_config:
         warnings.warn("Credentials provided in git config will be ignored.")
@@ -217,8 +227,12 @@ def _clone_command_for_github_like_https_2fa_enabled(git_config, dest_dir):
     updated_url = git_config["repo"]
     if "token" in git_config:
         if "username" in git_config or "password" in git_config:
-            warnings.warn("Using token for authentication, " "other credentials will be ignored.")
-        updated_url = _insert_token_to_repo_url(url=git_config["repo"], token=git_config["token"])
+            warnings.warn(
+                "Using token for authentication, " "other credentials will be ignored."
+            )
+        updated_url = _insert_token_to_repo_url(
+            url=git_config["repo"], token=git_config["token"]
+        )
     _run_clone_command(updated_url, dest_dir)
 
 
@@ -242,7 +256,9 @@ def _clone_command_for_codecommit(git_config, dest_dir):
     if "2FA_enabled" in git_config:
         warnings.warn("CodeCommit does not support 2FA, '2FA_enabled' will be ignored.")
     if "token" in git_config:
-        warnings.warn("There are no tokens in CodeCommit, the token provided will be ignored.")
+        warnings.warn(
+            "There are no tokens in CodeCommit, the token provided will be ignored."
+        )
     if is_ssh:
         _clone_command_for_ssh(git_config, dest_dir)
     else:
@@ -258,7 +274,9 @@ def _clone_command_for_codecommit_https(git_config, dest_dir):
     updated_url = git_config["repo"]
     if "username" in git_config and "password" in git_config:
         updated_url = _insert_username_and_password_to_repo_url(
-            url=git_config["repo"], username=git_config["username"], password=git_config["password"]
+            url=git_config["repo"],
+            username=git_config["username"],
+            password=git_config["password"],
         )
     elif "username" in git_config or "password" in git_config:
         warnings.warn("Credentials provided in git config will be ignored.")
@@ -341,6 +359,10 @@ def _checkout_branch_and_commit(git_config, dest_dir):
             failed to checkout the required commit
     """
     if "branch" in git_config:
-        subprocess.check_call(args=["git", "checkout", git_config["branch"]], cwd=str(dest_dir))
+        subprocess.check_call(
+            args=["git", "checkout", git_config["branch"]], cwd=str(dest_dir)
+        )
     if "commit" in git_config:
-        subprocess.check_call(args=["git", "checkout", git_config["commit"]], cwd=str(dest_dir))
+        subprocess.check_call(
+            args=["git", "checkout", git_config["commit"]], cwd=str(dest_dir)
+        )

--- a/src/sagemaker/inputs.py
+++ b/src/sagemaker/inputs.py
@@ -85,14 +85,18 @@ class s3_input(object):
         )
 
         self.config = {
-            "DataSource": {"S3DataSource": {"S3DataType": s3_data_type, "S3Uri": s3_data}}
+            "DataSource": {
+                "S3DataSource": {"S3DataType": s3_data_type, "S3Uri": s3_data}
+            }
         }
 
         if not (target_attribute_name or distribution):
             distribution = "FullyReplicated"
 
         if distribution is not None:
-            self.config["DataSource"]["S3DataSource"]["S3DataDistributionType"] = distribution
+            self.config["DataSource"]["S3DataSource"][
+                "S3DataDistributionType"
+            ] = distribution
 
         if compression is not None:
             self.config["CompressionType"] = compression
@@ -103,7 +107,9 @@ class s3_input(object):
         if input_mode is not None:
             self.config["InputMode"] = input_mode
         if attribute_names is not None:
-            self.config["DataSource"]["S3DataSource"]["AttributeNames"] = attribute_names
+            self.config["DataSource"]["S3DataSource"][
+                "AttributeNames"
+            ] = attribute_names
         if target_attribute_name is not None:
             self.config["TargetAttributeName"] = target_attribute_name
         if shuffle_config is not None:

--- a/src/sagemaker/job.py
+++ b/src/sagemaker/job.py
@@ -82,7 +82,9 @@ class _Job(object):
             if expand_role
             else estimator.role
         )
-        output_config = _Job._prepare_output_config(estimator.output_path, estimator.output_kms_key)
+        output_config = _Job._prepare_output_config(
+            estimator.output_path, estimator.output_kms_key
+        )
         resource_config = _Job._prepare_resource_config(
             estimator.train_instance_count,
             estimator.train_instance_type,
@@ -108,7 +110,10 @@ class _Job(object):
 
         if estimator.enable_network_isolation():
             code_channel = _Job._prepare_channel(
-                input_config, estimator.code_uri, estimator.code_channel_name, validate_uri
+                input_config,
+                estimator.code_uri,
+                estimator.code_channel_name,
+                validate_uri,
             )
 
             if code_channel:
@@ -160,7 +165,8 @@ class _Job(object):
             raise ValueError(msg.format(inputs))
 
         channels = [
-            _Job._convert_input_to_channel(name, input) for name, input in input_dict.items()
+            _Job._convert_input_to_channel(name, input)
+            for name, input in input_dict.items()
         ]
 
         return channels
@@ -194,7 +200,11 @@ class _Job(object):
             compression:
             target_attribute_name:
         """
-        if isinstance(uri_input, str) and validate_uri and uri_input.startswith("s3://"):
+        if (
+            isinstance(uri_input, str)
+            and validate_uri
+            and uri_input.startswith("s3://")
+        ):
             s3_input_result = s3_input(
                 uri_input,
                 content_type=content_type,
@@ -203,7 +213,11 @@ class _Job(object):
                 target_attribute_name=target_attribute_name,
             )
             return s3_input_result
-        if isinstance(uri_input, str) and validate_uri and uri_input.startswith("file://"):
+        if (
+            isinstance(uri_input, str)
+            and validate_uri
+            and uri_input.startswith("file://")
+        ):
             return file_input(uri_input)
         if isinstance(uri_input, str) and validate_uri:
             raise ValueError(
@@ -249,13 +263,17 @@ class _Job(object):
             return None
         if not channel_name:
             raise ValueError(
-                "Expected a channel name if a channel URI {} is specified".format(channel_uri)
+                "Expected a channel name if a channel URI {} is specified".format(
+                    channel_uri
+                )
             )
 
         if input_config:
             for existing_channel in input_config:
                 if existing_channel["ChannelName"] == channel_name:
-                    raise ValueError("Duplicate channel {} not allowed.".format(channel_name))
+                    raise ValueError(
+                        "Duplicate channel {} not allowed.".format(channel_name)
+                    )
 
         channel_input = _Job._format_string_uri_input(
             channel_uri, validate_uri, content_type, input_mode
@@ -271,18 +289,27 @@ class _Job(object):
             model_uri:
             validate_uri:
         """
-        if isinstance(model_uri, string_types) and validate_uri and model_uri.startswith("s3://"):
+        if (
+            isinstance(model_uri, string_types)
+            and validate_uri
+            and model_uri.startswith("s3://")
+        ):
             return s3_input(
                 model_uri,
                 input_mode="File",
                 distribution="FullyReplicated",
                 content_type="application/x-sagemaker-model",
             )
-        if isinstance(model_uri, string_types) and validate_uri and model_uri.startswith("file://"):
+        if (
+            isinstance(model_uri, string_types)
+            and validate_uri
+            and model_uri.startswith("file://")
+        ):
             return file_input(model_uri)
         if isinstance(model_uri, string_types) and validate_uri:
             raise ValueError(
-                'Model URI must be a valid S3 or FILE URI: must start with "s3://" or ' '"file://'
+                'Model URI must be a valid S3 or FILE URI: must start with "s3://" or '
+                '"file://'
             )
         if isinstance(model_uri, string_types):
             return s3_input(
@@ -305,7 +332,9 @@ class _Job(object):
         input_dict = {}
         for record in inputs:
             if not isinstance(record, (RecordSet, FileSystemRecordSet)):
-                raise ValueError("List compatible only with RecordSets or FileSystemRecordSets.")
+                raise ValueError(
+                    "List compatible only with RecordSets or FileSystemRecordSets."
+                )
 
             if record.channel in input_dict:
                 raise ValueError("Duplicate channels not allowed.")
@@ -329,7 +358,9 @@ class _Job(object):
         return config
 
     @staticmethod
-    def _prepare_resource_config(instance_count, instance_type, volume_size, train_volume_kms_key):
+    def _prepare_resource_config(
+        instance_count, instance_type, volume_size, train_volume_kms_key
+    ):
         """
         Args:
             instance_count:

--- a/src/sagemaker/local/data.py
+++ b/src/sagemaker/local/data.py
@@ -52,7 +52,9 @@ def get_data_source_instance(data_source, sagemaker_session):
     if parsed_uri.scheme == "s3":
         return S3DataSource(parsed_uri.netloc, parsed_uri.path, sagemaker_session)
     raise ValueError(
-        "data_source must be either file or s3. parsed_uri.scheme: {}".format(parsed_uri.scheme)
+        "data_source must be either file or s3. parsed_uri.scheme: {}".format(
+            parsed_uri.scheme
+        )
     )
 
 
@@ -90,7 +92,9 @@ def get_batch_strategy_instance(strategy, splitter):
         return SingleRecordStrategy(splitter)
     if strategy == "MultiRecord":
         return MultiRecordStrategy(splitter)
-    raise ValueError('Invalid Batch Strategy: %s - Valid Strategies: "SingleRecord", "MultiRecord"')
+    raise ValueError(
+        'Invalid Batch Strategy: %s - Valid Strategies: "SingleRecord", "MultiRecord"'
+    )
 
 
 class DataSource(with_metaclass(ABCMeta, object)):
@@ -126,7 +130,9 @@ class LocalFileDataSource(DataSource):
 
         self.root_path = os.path.abspath(root_path)
         if not os.path.exists(self.root_path):
-            raise RuntimeError("Invalid data source: %s does not exist." % self.root_path)
+            raise RuntimeError(
+                "Invalid data source: %s does not exist." % self.root_path
+            )
 
     def get_file_list(self):
         """Retrieve the list of absolute paths to all the files in this data
@@ -414,4 +420,6 @@ def _validate_payload_size(payload, size):
 
     if _payload_size_within_limit(payload, size):
         return True
-    raise RuntimeError("Record is larger than %sMB. Please increase your max_payload" % size)
+    raise RuntimeError(
+        "Record is larger than %sMB. Please increase your max_payload" % size
+    )

--- a/src/sagemaker/local/local_session.py
+++ b/src/sagemaker/local/local_session.py
@@ -97,9 +97,13 @@ class LocalSagemakerClient(object):
             self.sagemaker_session,
         )
         training_job = _LocalTrainingJob(container)
-        hyperparameters = kwargs["HyperParameters"] if "HyperParameters" in kwargs else {}
+        hyperparameters = (
+            kwargs["HyperParameters"] if "HyperParameters" in kwargs else {}
+        )
         logger.info("Starting training job")
-        training_job.start(InputDataConfig, OutputDataConfig, hyperparameters, TrainingJobName)
+        training_job.start(
+            InputDataConfig, OutputDataConfig, hyperparameters, TrainingJobName
+        )
 
         LocalSagemakerClient._training_jobs[TrainingJobName] = training_job
 
@@ -145,9 +149,13 @@ class LocalSagemakerClient(object):
         Returns:
 
         """
-        transform_job = _LocalTransformJob(TransformJobName, ModelName, self.sagemaker_session)
+        transform_job = _LocalTransformJob(
+            TransformJobName, ModelName, self.sagemaker_session
+        )
         LocalSagemakerClient._transform_jobs[TransformJobName] = transform_job
-        transform_job.start(TransformInput, TransformOutput, TransformResources, **kwargs)
+        transform_job.start(
+            TransformInput, TransformOutput, TransformResources, **kwargs
+        )
 
     def describe_transform_job(self, TransformJobName):
         """
@@ -182,7 +190,9 @@ class LocalSagemakerClient(object):
 
         Returns:
         """
-        LocalSagemakerClient._models[ModelName] = _LocalModel(ModelName, PrimaryContainer)
+        LocalSagemakerClient._models[ModelName] = _LocalModel(
+            ModelName, PrimaryContainer
+        )
 
     def describe_model(self, ModelName):
         """
@@ -195,7 +205,10 @@ class LocalSagemakerClient(object):
         """
         if ModelName not in LocalSagemakerClient._models:
             error_response = {
-                "Error": {"Code": "ValidationException", "Message": "Could not find local model"}
+                "Error": {
+                    "Code": "ValidationException",
+                    "Message": "Could not find local model",
+                }
             }
             raise ClientError(error_response, "describe_model")
         return LocalSagemakerClient._models[ModelName].describe()
@@ -230,9 +243,9 @@ class LocalSagemakerClient(object):
         Returns:
 
         """
-        LocalSagemakerClient._endpoint_configs[EndpointConfigName] = _LocalEndpointConfig(
-            EndpointConfigName, ProductionVariants, Tags
-        )
+        LocalSagemakerClient._endpoint_configs[
+            EndpointConfigName
+        ] = _LocalEndpointConfig(EndpointConfigName, ProductionVariants, Tags)
 
     def describe_endpoint(self, EndpointName):
         """
@@ -245,7 +258,10 @@ class LocalSagemakerClient(object):
         """
         if EndpointName not in LocalSagemakerClient._endpoints:
             error_response = {
-                "Error": {"Code": "ValidationException", "Message": "Could not find local endpoint"}
+                "Error": {
+                    "Code": "ValidationException",
+                    "Message": "Could not find local endpoint",
+                }
             }
             raise ClientError(error_response, "describe_endpoint")
         return LocalSagemakerClient._endpoints[EndpointName].describe()
@@ -261,11 +277,15 @@ class LocalSagemakerClient(object):
         Returns:
 
         """
-        endpoint = _LocalEndpoint(EndpointName, EndpointConfigName, Tags, self.sagemaker_session)
+        endpoint = _LocalEndpoint(
+            EndpointName, EndpointConfigName, Tags, self.sagemaker_session
+        )
         LocalSagemakerClient._endpoints[EndpointName] = endpoint
         endpoint.serve()
 
-    def update_endpoint(self, EndpointName, EndpointConfigName):  # pylint: disable=unused-argument
+    def update_endpoint(
+        self, EndpointName, EndpointConfigName
+    ):  # pylint: disable=unused-argument
         """
 
         Args:
@@ -275,7 +295,9 @@ class LocalSagemakerClient(object):
         Returns:
 
         """
-        raise NotImplementedError("Update endpoint name is not supported in local session.")
+        raise NotImplementedError(
+            "Update endpoint name is not supported in local session."
+        )
 
     def delete_endpoint(self, EndpointName):
         """
@@ -374,7 +396,9 @@ class LocalSagemakerRuntimeClient(object):
         if TargetVariant is not None:
             headers["X-Amzn-SageMaker-Target-Variant"] = TargetVariant
 
-        r = self.http.request("POST", url, body=Body, preload_content=False, headers=headers)
+        r = self.http.request(
+            "POST", url, body=Body, preload_content=False, headers=headers
+        )
 
         return {"Body": r, "ContentType": Accept}
 
@@ -415,10 +439,16 @@ class LocalSession(Session):
         self.local_mode = True
 
         if self.s3_endpoint_url is not None:
-            self.s3_resource = boto_session.resource("s3", endpoint_url=self.s3_endpoint_url)
-            self.s3_client = boto_session.client("s3", endpoint_url=self.s3_endpoint_url)
+            self.s3_resource = boto_session.resource(
+                "s3", endpoint_url=self.s3_endpoint_url
+            )
+            self.s3_client = boto_session.client(
+                "s3", endpoint_url=self.s3_endpoint_url
+            )
 
-        sagemaker_config_file = os.path.join(os.path.expanduser("~"), ".sagemaker", "config.yaml")
+        sagemaker_config_file = os.path.join(
+            os.path.expanduser("~"), ".sagemaker", "config.yaml"
+        )
         if os.path.exists(sagemaker_config_file):
             try:
                 import yaml

--- a/src/sagemaker/local/utils.py
+++ b/src/sagemaker/local/utils.py
@@ -66,7 +66,9 @@ def move_to_destination(source, destination, job_name, sagemaker_session):
         final_uri = "s3://%s/%s" % (bucket, path)
         sagemaker_session.upload_data(source, bucket, path)
     else:
-        raise ValueError("Invalid destination URI, must be s3:// or file://, got: %s" % destination)
+        raise ValueError(
+            "Invalid destination URI, must be s3:// or file://, got: %s" % destination
+        )
 
     shutil.rmtree(source)
     return final_uri

--- a/src/sagemaker/logs.py
+++ b/src/sagemaker/logs.py
@@ -42,7 +42,9 @@ class ColorWrap(object):
             force (bool): If True, render colorizes output no matter where the
                 output is (default: False).
         """
-        self.colorize = force or sys.stdout.isatty() or os.environ.get("JPY_PARENT_PID", None)
+        self.colorize = (
+            force or sys.stdout.isatty() or os.environ.get("JPY_PARENT_PID", None)
+        )
 
     def __call__(self, index, s):
         """Print the output, colorized or not, depending on the environment.
@@ -62,7 +64,11 @@ class ColorWrap(object):
             index:
             s:
         """
-        print("\x1b[{}m{}\x1b[0m".format(self._stream_colors[index % len(self._stream_colors)], s))
+        print(
+            "\x1b[{}m{}\x1b[0m".format(
+                self._stream_colors[index % len(self._stream_colors)], s
+            )
+        )
 
 
 def argmin(arr, f):
@@ -113,7 +119,8 @@ def multi_stream_iter(client, log_group, streams, positions=None):
     """
     positions = positions or {s: Position(timestamp=0, skip=0) for s in streams}
     event_iters = [
-        log_stream(client, log_group, s, positions[s].timestamp, positions[s].skip) for s in streams
+        log_stream(client, log_group, s, positions[s].timestamp, positions[s].skip)
+        for s in streams
     ]
     events = []
     for s in event_iters:

--- a/src/sagemaker/model.py
+++ b/src/sagemaker/model.py
@@ -166,7 +166,9 @@ class Model(object):
         """
         return self._enable_network_isolation
 
-    def _create_sagemaker_model(self, instance_type=None, accelerator_type=None, tags=None):
+    def _create_sagemaker_model(
+        self, instance_type=None, accelerator_type=None, tags=None
+    ):
         """Create a SageMaker Model Entity
 
         Args:
@@ -183,7 +185,9 @@ class Model(object):
                 https://boto3.amazonaws.com/v1/documentation
                 /api/latest/reference/services/sagemaker.html#SageMaker.Client.add_tags
         """
-        container_def = self.prepare_container_def(instance_type, accelerator_type=accelerator_type)
+        container_def = self.prepare_container_def(
+            instance_type, accelerator_type=accelerator_type
+        )
         self.name = self.name or utils.name_from_image(container_def["Image"])
         enable_network_isolation = self.enable_network_isolation()
 
@@ -292,7 +296,9 @@ class Model(object):
             account=self._neo_image_account(region),
         )
 
-    def _inferentia_image(self, region, target_instance_type, framework, framework_version):
+    def _inferentia_image(
+        self, region, target_instance_type, framework, framework_version
+    ):
         """
                 Args:
                     region:
@@ -353,11 +359,15 @@ class Model(object):
         framework = self._framework() or framework
         if framework is None:
             raise ValueError(
-                "You must specify framework, allowed values {}".format(NEO_ALLOWED_FRAMEWORKS)
+                "You must specify framework, allowed values {}".format(
+                    NEO_ALLOWED_FRAMEWORKS
+                )
             )
         if framework not in NEO_ALLOWED_FRAMEWORKS:
             raise ValueError(
-                "You must provide valid framework, allowed values {}".format(NEO_ALLOWED_FRAMEWORKS)
+                "You must provide valid framework, allowed values {}".format(
+                    NEO_ALLOWED_FRAMEWORKS
+                )
             )
         if job_name is None:
             raise ValueError("You must provide a compilation job name")
@@ -480,13 +490,18 @@ class Model(object):
 
         self._create_sagemaker_model(instance_type, accelerator_type, tags)
         production_variant = sagemaker.production_variant(
-            self.name, instance_type, initial_instance_count, accelerator_type=accelerator_type
+            self.name,
+            instance_type,
+            initial_instance_count,
+            accelerator_type=accelerator_type,
         )
         if endpoint_name:
             self.endpoint_name = endpoint_name
         else:
             self.endpoint_name = self.name
-            if self._is_compiled_model and not self.endpoint_name.endswith(compiled_model_suffix):
+            if self._is_compiled_model and not self.endpoint_name.endswith(
+                compiled_model_suffix
+            ):
                 self.endpoint_name += compiled_model_suffix
 
         data_capture_config_dict = None
@@ -831,7 +846,9 @@ class FrameworkModel(Model):
             dict[str, str]: A container definition object usable with the
             CreateModel API.
         """
-        deploy_key_prefix = fw_utils.model_code_key_prefix(self.key_prefix, self.name, self.image)
+        deploy_key_prefix = fw_utils.model_code_key_prefix(
+            self.key_prefix, self.name, self.image
+        )
         self._upload_code(deploy_key_prefix)
         deploy_env = dict(self.env)
         deploy_env.update(self._framework_env_vars())
@@ -843,7 +860,9 @@ class FrameworkModel(Model):
             key_prefix:
             repack:
         """
-        local_code = utils.get_config_value("local.local_code", self.sagemaker_session.config)
+        local_code = utils.get_config_value(
+            "local.local_code", self.sagemaker_session.config
+        )
         if self.sagemaker_session.local_mode and local_code:
             self.uploaded_code = None
         elif not repack:
@@ -859,7 +878,9 @@ class FrameworkModel(Model):
 
         if repack:
             bucket = self.bucket or self.sagemaker_session.default_bucket()
-            repacked_model_data = "s3://" + "/".join([bucket, key_prefix, "model.tar.gz"])
+            repacked_model_data = "s3://" + "/".join(
+                [bucket, key_prefix, "model.tar.gz"]
+            )
 
             utils.repack_model(
                 inference_script=self.entry_point,
@@ -873,7 +894,8 @@ class FrameworkModel(Model):
 
             self.repacked_model_data = repacked_model_data
             self.uploaded_code = UploadedCode(
-                s3_prefix=self.repacked_model_data, script_name=os.path.basename(self.entry_point)
+                s3_prefix=self.repacked_model_data,
+                script_name=os.path.basename(self.entry_point),
             )
 
     def _framework_env_vars(self):
@@ -894,7 +916,9 @@ class FrameworkModel(Model):
         return {
             SCRIPT_PARAM_NAME.upper(): script_name,
             DIR_PARAM_NAME.upper(): dir_name,
-            CLOUDWATCH_METRICS_PARAM_NAME.upper(): str(self.enable_cloudwatch_metrics).lower(),
+            CLOUDWATCH_METRICS_PARAM_NAME.upper(): str(
+                self.enable_cloudwatch_metrics
+            ).lower(),
             CONTAINER_LOG_LEVEL_PARAM_NAME.upper(): str(self.container_log_level),
             SAGEMAKER_REGION_PARAM_NAME.upper(): self.sagemaker_session.boto_region_name,
         }
@@ -903,7 +927,14 @@ class FrameworkModel(Model):
 class ModelPackage(Model):
     """A SageMaker ``Model`` that can be deployed to an ``Endpoint``."""
 
-    def __init__(self, role, model_data=None, algorithm_arn=None, model_package_arn=None, **kwargs):
+    def __init__(
+        self,
+        role,
+        model_data=None,
+        algorithm_arn=None,
+        model_package_arn=None,
+        **kwargs
+    ):
         """Initialize a SageMaker ModelPackage.
 
         Args:
@@ -922,7 +953,9 @@ class ModelPackage(Model):
                 ``model_data`` is not required.
             **kwargs: Additional kwargs passed to the Model constructor.
         """
-        super(ModelPackage, self).__init__(role=role, model_data=model_data, image=None, **kwargs)
+        super(ModelPackage, self).__init__(
+            role=role, model_data=model_data, image=None, **kwargs
+        )
 
         if model_package_arn and algorithm_arn:
             raise ValueError(
@@ -933,7 +966,8 @@ class ModelPackage(Model):
 
         if model_package_arn is None and algorithm_arn is None:
             raise ValueError(
-                "either model_package_arn or algorithm_arn is required." " None was provided."
+                "either model_package_arn or algorithm_arn is required."
+                " None was provided."
             )
 
         self.algorithm_arn = algorithm_arn
@@ -948,7 +982,9 @@ class ModelPackage(Model):
     def _create_sagemaker_model_package(self):
         """Placeholder docstring"""
         if self.algorithm_arn is None:
-            raise ValueError("No algorithm_arn was provided to create a SageMaker Model Pacakge")
+            raise ValueError(
+                "No algorithm_arn was provided to create a SageMaker Model Pacakge"
+            )
 
         name = self.name or utils.name_from_base(self.algorithm_arn.split("/")[-1])
         description = "Model Package created from training with %s" % self.algorithm_arn
@@ -984,7 +1020,9 @@ class ModelPackage(Model):
                 return True
         return False
 
-    def _create_sagemaker_model(self, *args, **kwargs):  # pylint: disable=unused-argument
+    def _create_sagemaker_model(
+        self, *args, **kwargs
+    ):  # pylint: disable=unused-argument
         """Create a SageMaker Model Entity
 
         Args:

--- a/src/sagemaker/model_monitor/__init__.py
+++ b/src/sagemaker/model_monitor/__init__.py
@@ -25,7 +25,9 @@ from sagemaker.model_monitor.model_monitoring import MonitoringExecution  # noqa
 from sagemaker.model_monitor.model_monitoring import EndpointInput  # noqa: F401
 from sagemaker.model_monitor.model_monitoring import MonitoringOutput  # noqa: F401
 
-from sagemaker.model_monitor.cron_expression_generator import CronExpressionGenerator  # noqa: F401
+from sagemaker.model_monitor.cron_expression_generator import (
+    CronExpressionGenerator,
+)  # noqa: F401
 from sagemaker.model_monitor.monitoring_files import Statistics  # noqa: F401
 from sagemaker.model_monitor.monitoring_files import Constraints  # noqa: F401
 from sagemaker.model_monitor.monitoring_files import ConstraintViolations  # noqa: F401

--- a/src/sagemaker/model_monitor/data_capture_config.py
+++ b/src/sagemaker/model_monitor/data_capture_config.py
@@ -87,7 +87,11 @@ class DataCaptureConfig(object):
             "DestinationS3Uri": self.destination_s3_uri,
             "CaptureOptions": [
                 #  Convert to API values or pass value directly through if unable to convert.
-                {"CaptureMode": self.API_MAPPING.get(capture_option.upper(), capture_option)}
+                {
+                    "CaptureMode": self.API_MAPPING.get(
+                        capture_option.upper(), capture_option
+                    )
+                }
                 for capture_option in self.capture_options
             ],
         }
@@ -99,9 +103,13 @@ class DataCaptureConfig(object):
             request_dict["CaptureContentTypeHeader"] = {}
 
         if self.csv_content_types is not None:
-            request_dict["CaptureContentTypeHeader"]["CsvContentTypes"] = self.csv_content_types
+            request_dict["CaptureContentTypeHeader"][
+                "CsvContentTypes"
+            ] = self.csv_content_types
 
         if self.json_content_types is not None:
-            request_dict["CaptureContentTypeHeader"]["JsonContentTypes"] = self.json_content_types
+            request_dict["CaptureContentTypeHeader"][
+                "JsonContentTypes"
+            ] = self.json_content_types
 
         return request_dict

--- a/src/sagemaker/model_monitor/dataset_format.py
+++ b/src/sagemaker/model_monitor/dataset_format.py
@@ -35,7 +35,12 @@ class DatasetFormat(object):
             dict: JSON string containing DatasetFormat to be used by DefaultModelMonitor.
 
         """
-        return {"csv": {"header": header, "output_columns_position": output_columns_position}}
+        return {
+            "csv": {
+                "header": header,
+                "output_columns_position": output_columns_position,
+            }
+        }
 
     @staticmethod
     def json(lines=True):

--- a/src/sagemaker/model_monitor/model_monitoring.py
+++ b/src/sagemaker/model_monitor/model_monitoring.py
@@ -27,9 +27,18 @@ from six.moves.urllib.parse import urlparse
 from botocore.exceptions import ClientError
 
 from sagemaker.exceptions import UnexpectedStatusException
-from sagemaker.model_monitor.monitoring_files import Constraints, ConstraintViolations, Statistics
+from sagemaker.model_monitor.monitoring_files import (
+    Constraints,
+    ConstraintViolations,
+    Statistics,
+)
 from sagemaker.network import NetworkConfig
-from sagemaker.processing import Processor, ProcessingInput, ProcessingJob, ProcessingOutput
+from sagemaker.processing import (
+    Processor,
+    ProcessingInput,
+    ProcessingJob,
+    ProcessingOutput,
+)
 from sagemaker.s3 import S3Uploader
 from sagemaker.session import Session
 from sagemaker.utils import name_from_base, retries, get_ecr_image_uri_prefix
@@ -170,7 +179,13 @@ class ModelMonitor(object):
         self.monitoring_schedule_name = None
 
     def run_baseline(
-        self, baseline_inputs, output, arguments=None, wait=True, logs=True, job_name=None
+        self,
+        baseline_inputs,
+        output,
+        arguments=None,
+        wait=True,
+        logs=True,
+        job_name=None,
     ):
         """Run a processing job meant to baseline your dataset.
 
@@ -187,7 +202,9 @@ class ModelMonitor(object):
                 a default job name, based on the image name and current timestamp.
 
         """
-        self.latest_baselining_job_name = self._generate_baselining_job_name(job_name=job_name)
+        self.latest_baselining_job_name = self._generate_baselining_job_name(
+            job_name=job_name
+        )
         self.arguments = arguments
         normalized_baseline_inputs = self._normalize_baseline_inputs(
             baseline_inputs=baseline_inputs
@@ -274,12 +291,16 @@ class ModelMonitor(object):
             schedule_name=monitor_schedule_name
         )
 
-        normalized_endpoint_input = self._normalize_endpoint_input(endpoint_input=endpoint_input)
+        normalized_endpoint_input = self._normalize_endpoint_input(
+            endpoint_input=endpoint_input
+        )
 
         normalized_monitoring_output = self._normalize_monitoring_output(output=output)
 
         statistics_object, constraints_object = self._get_baseline_files(
-            statistics=statistics, constraints=constraints, sagemaker_session=self.sagemaker_session
+            statistics=statistics,
+            constraints=constraints,
+            sagemaker_session=self.sagemaker_session,
         )
 
         statistics_s3_uri = None
@@ -299,7 +320,9 @@ class ModelMonitor(object):
 
         self.monitoring_schedule_name = (
             monitor_schedule_name
-            or self._generate_monitoring_schedule_name(schedule_name=monitor_schedule_name)
+            or self._generate_monitoring_schedule_name(
+                schedule_name=monitor_schedule_name
+            )
         )
 
         network_config_dict = None
@@ -393,18 +416,24 @@ class ModelMonitor(object):
         monitoring_inputs = None
         if endpoint_input is not None:
             monitoring_inputs = [
-                self._normalize_endpoint_input(endpoint_input=endpoint_input)._to_request_dict()
+                self._normalize_endpoint_input(
+                    endpoint_input=endpoint_input
+                )._to_request_dict()
             ]
 
         monitoring_output_config = None
         if output is not None:
-            normalized_monitoring_output = self._normalize_monitoring_output(output=output)
+            normalized_monitoring_output = self._normalize_monitoring_output(
+                output=output
+            )
             monitoring_output_config = {
                 "MonitoringOutputs": [normalized_monitoring_output._to_request_dict()]
             }
 
         statistics_object, constraints_object = self._get_baseline_files(
-            statistics=statistics, constraints=constraints, sagemaker_session=self.sagemaker_session
+            statistics=statistics,
+            constraints=constraints,
+            sagemaker_session=self.sagemaker_session,
         )
 
         statistics_s3_uri = None
@@ -631,12 +660,15 @@ class ModelMonitor(object):
 
         processing_job_arns = [
             execution_dict["ProcessingJobArn"]
-            for execution_dict in monitoring_executions_dict["MonitoringExecutionSummaries"]
+            for execution_dict in monitoring_executions_dict[
+                "MonitoringExecutionSummaries"
+            ]
             if execution_dict.get("ProcessingJobArn") is not None
         ]
         monitoring_executions = [
             MonitoringExecution.from_processing_arn(
-                sagemaker_session=self.sagemaker_session, processing_job_arn=processing_job_arn
+                sagemaker_session=self.sagemaker_session,
+                processing_job_arn=processing_job_arn,
             )
             for processing_job_arn in processing_job_arns
         ]
@@ -663,28 +695,30 @@ class ModelMonitor(object):
             monitoring_schedule_name=monitor_schedule_name
         )
 
-        role = schedule_desc["MonitoringScheduleConfig"]["MonitoringJobDefinition"]["RoleArn"]
-        image_uri = schedule_desc["MonitoringScheduleConfig"]["MonitoringJobDefinition"][
-            "MonitoringAppSpecification"
-        ]["ImageUri"]
-        instance_count = schedule_desc["MonitoringScheduleConfig"]["MonitoringJobDefinition"][
-            "MonitoringResources"
-        ]["ClusterConfig"]["InstanceCount"]
-        instance_type = schedule_desc["MonitoringScheduleConfig"]["MonitoringJobDefinition"][
-            "MonitoringResources"
-        ]["ClusterConfig"]["InstanceType"]
-        entrypoint = schedule_desc["MonitoringScheduleConfig"]["MonitoringJobDefinition"][
-            "MonitoringAppSpecification"
-        ].get("ContainerEntrypoint")
-        volume_size_in_gb = schedule_desc["MonitoringScheduleConfig"]["MonitoringJobDefinition"][
-            "MonitoringResources"
-        ]["ClusterConfig"]["VolumeSizeInGB"]
-        volume_kms_key = schedule_desc["MonitoringScheduleConfig"]["MonitoringJobDefinition"][
-            "MonitoringResources"
-        ]["ClusterConfig"].get("VolumeKmsKeyId")
-        output_kms_key = schedule_desc["MonitoringScheduleConfig"]["MonitoringJobDefinition"][
-            "MonitoringOutputConfig"
-        ].get("KmsKeyId")
+        role = schedule_desc["MonitoringScheduleConfig"]["MonitoringJobDefinition"][
+            "RoleArn"
+        ]
+        image_uri = schedule_desc["MonitoringScheduleConfig"][
+            "MonitoringJobDefinition"
+        ]["MonitoringAppSpecification"]["ImageUri"]
+        instance_count = schedule_desc["MonitoringScheduleConfig"][
+            "MonitoringJobDefinition"
+        ]["MonitoringResources"]["ClusterConfig"]["InstanceCount"]
+        instance_type = schedule_desc["MonitoringScheduleConfig"][
+            "MonitoringJobDefinition"
+        ]["MonitoringResources"]["ClusterConfig"]["InstanceType"]
+        entrypoint = schedule_desc["MonitoringScheduleConfig"][
+            "MonitoringJobDefinition"
+        ]["MonitoringAppSpecification"].get("ContainerEntrypoint")
+        volume_size_in_gb = schedule_desc["MonitoringScheduleConfig"][
+            "MonitoringJobDefinition"
+        ]["MonitoringResources"]["ClusterConfig"]["VolumeSizeInGB"]
+        volume_kms_key = schedule_desc["MonitoringScheduleConfig"][
+            "MonitoringJobDefinition"
+        ]["MonitoringResources"]["ClusterConfig"].get("VolumeKmsKeyId")
+        output_kms_key = schedule_desc["MonitoringScheduleConfig"][
+            "MonitoringJobDefinition"
+        ]["MonitoringOutputConfig"].get("KmsKeyId")
 
         max_runtime_in_seconds = None
         if schedule_desc["MonitoringScheduleConfig"]["MonitoringJobDefinition"].get(
@@ -694,15 +728,17 @@ class ModelMonitor(object):
                 "MonitoringJobDefinition"
             ]["StoppingCondition"].get("MaxRuntimeInSeconds")
 
-        env = schedule_desc["MonitoringScheduleConfig"]["MonitoringJobDefinition"]["Environment"]
+        env = schedule_desc["MonitoringScheduleConfig"]["MonitoringJobDefinition"][
+            "Environment"
+        ]
 
         network_config_dict = schedule_desc["MonitoringScheduleConfig"][
             "MonitoringJobDefinition"
         ].get("NetworkConfig")
 
-        vpc_config = schedule_desc["MonitoringScheduleConfig"]["MonitoringJobDefinition"][
-            "NetworkConfig"
-        ].get("VpcConfig")
+        vpc_config = schedule_desc["MonitoringScheduleConfig"][
+            "MonitoringJobDefinition"
+        ]["NetworkConfig"].get("VpcConfig")
 
         security_group_ids = None
         if vpc_config is not None:
@@ -719,7 +755,9 @@ class ModelMonitor(object):
                 subnets=subnets,
             )
 
-        tags = sagemaker_session.list_tags(resource_arn=schedule_desc["MonitoringScheduleArn"])
+        tags = sagemaker_session.list_tags(
+            resource_arn=schedule_desc["MonitoringScheduleArn"]
+        )
 
         attached_monitor = cls(
             role=role,
@@ -831,7 +869,9 @@ class ModelMonitor(object):
             endpoint_input = EndpointInput(
                 endpoint_name=endpoint_input,
                 destination=os.path.join(
-                    _CONTAINER_BASE_PATH, _CONTAINER_INPUT_PATH, _CONTAINER_ENDPOINT_INPUT_PATH
+                    _CONTAINER_BASE_PATH,
+                    _CONTAINER_INPUT_PATH,
+                    _CONTAINER_ENDPOINT_INPUT_PATH,
                 ),
             )
 
@@ -855,7 +895,9 @@ class ModelMonitor(object):
             # Iterate through the provided list of inputs.
             for count, file_input in enumerate(baseline_inputs, 1):
                 if not isinstance(file_input, ProcessingInput):
-                    raise TypeError("Your inputs must be provided as ProcessingInput objects.")
+                    raise TypeError(
+                        "Your inputs must be provided as ProcessingInput objects."
+                    )
                 # Generate a name for the ProcessingInput if it doesn't have one.
                 if file_input.input_name is None:
                     file_input.input_name = "input-{}".format(count)
@@ -1042,7 +1084,9 @@ class DefaultModelMonitor(ModelMonitor):
         session = sagemaker_session or Session()
         super(DefaultModelMonitor, self).__init__(
             role=role,
-            image_uri=DefaultModelMonitor._get_default_image_uri(session.boto_session.region_name),
+            image_uri=DefaultModelMonitor._get_default_image_uri(
+                session.boto_session.region_name
+            ),
             instance_count=instance_count,
             instance_type=instance_type,
             volume_size_in_gb=volume_size_in_gb,
@@ -1091,12 +1135,16 @@ class DefaultModelMonitor(ModelMonitor):
                 baselining job.
 
         """
-        self.latest_baselining_job_name = self._generate_baselining_job_name(job_name=job_name)
+        self.latest_baselining_job_name = self._generate_baselining_job_name(
+            job_name=job_name
+        )
 
         normalized_baseline_dataset_input = self._upload_and_convert_to_processing_input(
             source=baseline_dataset,
             destination=os.path.join(
-                _CONTAINER_BASE_PATH, _CONTAINER_INPUT_PATH, _BASELINE_DATASET_INPUT_NAME
+                _CONTAINER_BASE_PATH,
+                _CONTAINER_INPUT_PATH,
+                _BASELINE_DATASET_INPUT_NAME,
             ),
             name=_BASELINE_DATASET_INPUT_NAME,
         )
@@ -1107,7 +1155,9 @@ class DefaultModelMonitor(ModelMonitor):
         normalized_record_preprocessor_script_input = self._upload_and_convert_to_processing_input(
             source=record_preprocessor_script,
             destination=os.path.join(
-                _CONTAINER_BASE_PATH, _CONTAINER_INPUT_PATH, _RECORD_PREPROCESSOR_SCRIPT_INPUT_NAME
+                _CONTAINER_BASE_PATH,
+                _CONTAINER_INPUT_PATH,
+                _RECORD_PREPROCESSOR_SCRIPT_INPUT_NAME,
             ),
             name=_RECORD_PREPROCESSOR_SCRIPT_INPUT_NAME,
         )
@@ -1136,7 +1186,9 @@ class DefaultModelMonitor(ModelMonitor):
                 os.path.basename(post_analytics_processor_script),
             )
 
-        normalized_baseline_output = self._normalize_baseline_output(output_s3_uri=output_s3_uri)
+        normalized_baseline_output = self._normalize_baseline_output(
+            output_s3_uri=output_s3_uri
+        )
 
         normalized_env = self._generate_env_map(
             env=self.env,
@@ -1252,9 +1304,15 @@ class DefaultModelMonitor(ModelMonitor):
         )
 
         print()
-        print("Creating Monitoring Schedule with name: {}".format(self.monitoring_schedule_name))
+        print(
+            "Creating Monitoring Schedule with name: {}".format(
+                self.monitoring_schedule_name
+            )
+        )
 
-        normalized_endpoint_input = self._normalize_endpoint_input(endpoint_input=endpoint_input)
+        normalized_endpoint_input = self._normalize_endpoint_input(
+            endpoint_input=endpoint_input
+        )
 
         record_preprocessor_script_s3_uri = None
         if record_preprocessor_script is not None:
@@ -1273,7 +1331,9 @@ class DefaultModelMonitor(ModelMonitor):
         )
 
         statistics_object, constraints_object = self._get_baseline_files(
-            statistics=statistics, constraints=constraints, sagemaker_session=self.sagemaker_session
+            statistics=statistics,
+            constraints=constraints,
+            sagemaker_session=self.sagemaker_session,
         )
 
         constraints_s3_uri = None
@@ -1298,7 +1358,9 @@ class DefaultModelMonitor(ModelMonitor):
         network_config_dict = None
         if self.network_config is not None:
             network_config_dict = self.network_config._to_request_dict()
-            super(DefaultModelMonitor, self)._validate_network_config(network_config_dict)
+            super(DefaultModelMonitor, self)._validate_network_config(
+                network_config_dict
+            )
 
         self.sagemaker_session.create_monitoring_schedule(
             monitoring_schedule_name=self.monitoring_schedule_name,
@@ -1387,7 +1449,9 @@ class DefaultModelMonitor(ModelMonitor):
         """
         monitoring_inputs = None
         if endpoint_input is not None:
-            monitoring_inputs = [self._normalize_endpoint_input(endpoint_input)._to_request_dict()]
+            monitoring_inputs = [
+                self._normalize_endpoint_input(endpoint_input)._to_request_dict()
+            ]
 
         record_preprocessor_script_s3_uri = None
         if record_preprocessor_script is not None:
@@ -1416,11 +1480,15 @@ class DefaultModelMonitor(ModelMonitor):
             self.env = env
 
         normalized_env = self._generate_env_map(
-            env=env, output_path=output_path, enable_cloudwatch_metrics=enable_cloudwatch_metrics
+            env=env,
+            output_path=output_path,
+            enable_cloudwatch_metrics=enable_cloudwatch_metrics,
         )
 
         statistics_object, constraints_object = self._get_baseline_files(
-            statistics=statistics, constraints=constraints, sagemaker_session=self.sagemaker_session
+            statistics=statistics,
+            constraints=constraints,
+            sagemaker_session=self.sagemaker_session,
         )
 
         statistics_s3_uri = None
@@ -1456,7 +1524,9 @@ class DefaultModelMonitor(ModelMonitor):
         network_config_dict = None
         if self.network_config is not None:
             network_config_dict = self.network_config._to_request_dict()
-            super(DefaultModelMonitor, self)._validate_network_config(network_config_dict)
+            super(DefaultModelMonitor, self)._validate_network_config(
+                network_config_dict
+            )
 
         if role is not None:
             self.role = role
@@ -1509,22 +1579,24 @@ class DefaultModelMonitor(ModelMonitor):
             monitoring_schedule_name=monitor_schedule_name
         )
 
-        role = schedule_desc["MonitoringScheduleConfig"]["MonitoringJobDefinition"]["RoleArn"]
-        instance_count = schedule_desc["MonitoringScheduleConfig"]["MonitoringJobDefinition"][
-            "MonitoringResources"
-        ]["ClusterConfig"]["InstanceCount"]
-        instance_type = schedule_desc["MonitoringScheduleConfig"]["MonitoringJobDefinition"][
-            "MonitoringResources"
-        ]["ClusterConfig"]["InstanceType"]
-        volume_size_in_gb = schedule_desc["MonitoringScheduleConfig"]["MonitoringJobDefinition"][
-            "MonitoringResources"
-        ]["ClusterConfig"]["VolumeSizeInGB"]
-        volume_kms_key = schedule_desc["MonitoringScheduleConfig"]["MonitoringJobDefinition"][
-            "MonitoringResources"
-        ]["ClusterConfig"].get("VolumeKmsKeyId")
-        output_kms_key = schedule_desc["MonitoringScheduleConfig"]["MonitoringJobDefinition"][
-            "MonitoringOutputConfig"
-        ].get("KmsKeyId")
+        role = schedule_desc["MonitoringScheduleConfig"]["MonitoringJobDefinition"][
+            "RoleArn"
+        ]
+        instance_count = schedule_desc["MonitoringScheduleConfig"][
+            "MonitoringJobDefinition"
+        ]["MonitoringResources"]["ClusterConfig"]["InstanceCount"]
+        instance_type = schedule_desc["MonitoringScheduleConfig"][
+            "MonitoringJobDefinition"
+        ]["MonitoringResources"]["ClusterConfig"]["InstanceType"]
+        volume_size_in_gb = schedule_desc["MonitoringScheduleConfig"][
+            "MonitoringJobDefinition"
+        ]["MonitoringResources"]["ClusterConfig"]["VolumeSizeInGB"]
+        volume_kms_key = schedule_desc["MonitoringScheduleConfig"][
+            "MonitoringJobDefinition"
+        ]["MonitoringResources"]["ClusterConfig"].get("VolumeKmsKeyId")
+        output_kms_key = schedule_desc["MonitoringScheduleConfig"][
+            "MonitoringJobDefinition"
+        ]["MonitoringOutputConfig"].get("KmsKeyId")
 
         max_runtime_in_seconds = None
         if schedule_desc["MonitoringScheduleConfig"]["MonitoringJobDefinition"].get(
@@ -1534,7 +1606,9 @@ class DefaultModelMonitor(ModelMonitor):
                 "MonitoringJobDefinition"
             ]["StoppingCondition"].get("MaxRuntimeInSeconds")
 
-        env = schedule_desc["MonitoringScheduleConfig"]["MonitoringJobDefinition"]["Environment"]
+        env = schedule_desc["MonitoringScheduleConfig"]["MonitoringJobDefinition"][
+            "Environment"
+        ]
 
         network_config_dict = schedule_desc["MonitoringScheduleConfig"][
             "MonitoringJobDefinition"
@@ -1547,9 +1621,9 @@ class DefaultModelMonitor(ModelMonitor):
             )
             is not None
         ):
-            vpc_config = schedule_desc["MonitoringScheduleConfig"]["MonitoringJobDefinition"][
-                "NetworkConfig"
-            ].get("VpcConfig")
+            vpc_config = schedule_desc["MonitoringScheduleConfig"][
+                "MonitoringJobDefinition"
+            ]["NetworkConfig"].get("VpcConfig")
 
         security_group_ids = None
         if vpc_config is not None:
@@ -1567,7 +1641,9 @@ class DefaultModelMonitor(ModelMonitor):
                 subnets=subnets,
             )
 
-        tags = sagemaker_session.list_tags(resource_arn=schedule_desc["MonitoringScheduleArn"])
+        tags = sagemaker_session.list_tags(
+            resource_arn=schedule_desc["MonitoringScheduleArn"]
+        )
 
         attached_monitor = cls(
             role=role,
@@ -1685,7 +1761,8 @@ class DefaultModelMonitor(ModelMonitor):
             _RESULTS_S3_PATH,
         )
         output = MonitoringOutput(
-            source=os.path.join(_CONTAINER_BASE_PATH, _CONTAINER_OUTPUT_PATH), destination=s3_uri
+            source=os.path.join(_CONTAINER_BASE_PATH, _CONTAINER_OUTPUT_PATH),
+            destination=s3_uri,
         )
 
         return output
@@ -1733,10 +1810,14 @@ class DefaultModelMonitor(ModelMonitor):
             env[_DATASET_FORMAT_ENV_NAME] = json.dumps(dataset_format)
 
         if record_preprocessor_script_container_path is not None:
-            env[_RECORD_PREPROCESSOR_SCRIPT_ENV_NAME] = record_preprocessor_script_container_path
+            env[
+                _RECORD_PREPROCESSOR_SCRIPT_ENV_NAME
+            ] = record_preprocessor_script_container_path
 
         if post_processor_script_container_path is not None:
-            env[_POST_ANALYTICS_PROCESSOR_SCRIPT_ENV_NAME] = post_processor_script_container_path
+            env[
+                _POST_ANALYTICS_PROCESSOR_SCRIPT_ENV_NAME
+            ] = post_processor_script_container_path
 
         if dataset_source_container_path is not None:
             env[_DATASET_SOURCE_PATH_ENV_NAME] = dataset_source_container_path
@@ -1789,14 +1870,18 @@ class DefaultModelMonitor(ModelMonitor):
             str: The Default Model Monitoring image uri based on the region.
         """
         return _DEFAULT_MONITOR_IMAGE_URI_WITH_PLACEHOLDERS.format(
-            get_ecr_image_uri_prefix(_DEFAULT_MONITOR_IMAGE_REGION_ACCOUNT_MAPPING[region], region)
+            get_ecr_image_uri_prefix(
+                _DEFAULT_MONITOR_IMAGE_REGION_ACCOUNT_MAPPING[region], region
+            )
         )
 
 
 class BaseliningJob(ProcessingJob):
     """Provides functionality to retrieve baseline-specific files output from baselining job."""
 
-    def __init__(self, sagemaker_session, job_name, inputs, outputs, output_kms_key=None):
+    def __init__(
+        self, sagemaker_session, job_name, inputs, outputs, output_kms_key=None
+    ):
         """Initializes a Baselining job that tracks a baselining job kicked off by the suggest
         workflow.
 
@@ -1843,7 +1928,9 @@ class BaseliningJob(ProcessingJob):
             processing_job.output_kms_key,
         )
 
-    def baseline_statistics(self, file_name=STATISTICS_JSON_DEFAULT_FILE_NAME, kms_key=None):
+    def baseline_statistics(
+        self, file_name=STATISTICS_JSON_DEFAULT_FILE_NAME, kms_key=None
+    ):
         """Returns a sagemaker.model_monitor.Statistics object representing the statistics
         JSON file generated by this baselining job.
 
@@ -1862,15 +1949,17 @@ class BaseliningJob(ProcessingJob):
         try:
             baselining_job_output_s3_path = self.outputs[0].destination
             return Statistics.from_s3_uri(
-                statistics_file_s3_uri=os.path.join(baselining_job_output_s3_path, file_name),
+                statistics_file_s3_uri=os.path.join(
+                    baselining_job_output_s3_path, file_name
+                ),
                 kms_key=kms_key,
                 sagemaker_session=self.sagemaker_session,
             )
         except ClientError as client_error:
             if client_error.response["Error"]["Code"] == "NoSuchKey":
-                status = self.sagemaker_session.describe_processing_job(job_name=self.job_name)[
-                    "ProcessingJobStatus"
-                ]
+                status = self.sagemaker_session.describe_processing_job(
+                    job_name=self.job_name
+                )["ProcessingJobStatus"]
                 if status != "Completed":
                     raise UnexpectedStatusException(
                         message="The underlying job is not in 'Completed' state. You may only "
@@ -1881,7 +1970,9 @@ class BaseliningJob(ProcessingJob):
             else:
                 raise client_error
 
-    def suggested_constraints(self, file_name=CONSTRAINTS_JSON_DEFAULT_FILE_NAME, kms_key=None):
+    def suggested_constraints(
+        self, file_name=CONSTRAINTS_JSON_DEFAULT_FILE_NAME, kms_key=None
+    ):
         """Returns a sagemaker.model_monitor.Constraints object representing the constraints
         JSON file generated by this baselining job.
 
@@ -1900,15 +1991,17 @@ class BaseliningJob(ProcessingJob):
         try:
             baselining_job_output_s3_path = self.outputs[0].destination
             return Constraints.from_s3_uri(
-                constraints_file_s3_uri=os.path.join(baselining_job_output_s3_path, file_name),
+                constraints_file_s3_uri=os.path.join(
+                    baselining_job_output_s3_path, file_name
+                ),
                 kms_key=kms_key,
                 sagemaker_session=self.sagemaker_session,
             )
         except ClientError as client_error:
             if client_error.response["Error"]["Code"] == "NoSuchKey":
-                status = self.sagemaker_session.describe_processing_job(job_name=self.job_name)[
-                    "ProcessingJobStatus"
-                ]
+                status = self.sagemaker_session.describe_processing_job(
+                    job_name=self.job_name
+                )["ProcessingJobStatus"]
                 if status != "Completed":
                     raise UnexpectedStatusException(
                         message="The underlying job is not in 'Completed' state. You may only "
@@ -1925,7 +2018,9 @@ class MonitoringExecution(ProcessingJob):
     executions
     """
 
-    def __init__(self, sagemaker_session, job_name, inputs, output, output_kms_key=None):
+    def __init__(
+        self, sagemaker_session, job_name, inputs, output, output_kms_key=None
+    ):
         """Initializes a MonitoringExecution job that tracks a monitoring execution kicked off by
         an Amazon SageMaker Model Monitoring Schedule.
 
@@ -1970,7 +2065,9 @@ class MonitoringExecution(ProcessingJob):
         processing_job_name = processing_job_arn.split(":")[5][
             len("processing-job/") :
         ]  # This is necessary while the API only vends an arn.
-        job_desc = sagemaker_session.describe_processing_job(job_name=processing_job_name)
+        job_desc = sagemaker_session.describe_processing_job(
+            job_name=processing_job_name
+        )
 
         return cls(
             sagemaker_session=sagemaker_session,
@@ -1985,14 +2082,22 @@ class MonitoringExecution(ProcessingJob):
                     s3_data_distribution_type=processing_input["S3Input"].get(
                         "S3DataDistributionType"
                     ),
-                    s3_compression_type=processing_input["S3Input"].get("S3CompressionType"),
+                    s3_compression_type=processing_input["S3Input"].get(
+                        "S3CompressionType"
+                    ),
                 )
                 for processing_input in job_desc["ProcessingInputs"]
             ],
             output=ProcessingOutput(
-                source=job_desc["ProcessingOutputConfig"]["Outputs"][0]["S3Output"]["LocalPath"],
-                destination=job_desc["ProcessingOutputConfig"]["Outputs"][0]["S3Output"]["S3Uri"],
-                output_name=job_desc["ProcessingOutputConfig"]["Outputs"][0]["OutputName"],
+                source=job_desc["ProcessingOutputConfig"]["Outputs"][0]["S3Output"][
+                    "LocalPath"
+                ],
+                destination=job_desc["ProcessingOutputConfig"]["Outputs"][0][
+                    "S3Output"
+                ]["S3Uri"],
+                output_name=job_desc["ProcessingOutputConfig"]["Outputs"][0][
+                    "OutputName"
+                ],
             ),
             output_kms_key=job_desc["ProcessingOutputConfig"].get("KmsKeyId"),
         )
@@ -2016,15 +2121,17 @@ class MonitoringExecution(ProcessingJob):
         try:
             baselining_job_output_s3_path = self.outputs[0].destination
             return Statistics.from_s3_uri(
-                statistics_file_s3_uri=os.path.join(baselining_job_output_s3_path, file_name),
+                statistics_file_s3_uri=os.path.join(
+                    baselining_job_output_s3_path, file_name
+                ),
                 kms_key=kms_key,
                 sagemaker_session=self.sagemaker_session,
             )
         except ClientError as client_error:
             if client_error.response["Error"]["Code"] == "NoSuchKey":
-                status = self.sagemaker_session.describe_processing_job(job_name=self.job_name)[
-                    "ProcessingJobStatus"
-                ]
+                status = self.sagemaker_session.describe_processing_job(
+                    job_name=self.job_name
+                )["ProcessingJobStatus"]
                 if status != "Completed":
                     raise UnexpectedStatusException(
                         message="The underlying job is not in 'Completed' state. You may only "
@@ -2064,9 +2171,9 @@ class MonitoringExecution(ProcessingJob):
             )
         except ClientError as client_error:
             if client_error.response["Error"]["Code"] == "NoSuchKey":
-                status = self.sagemaker_session.describe_processing_job(job_name=self.job_name)[
-                    "ProcessingJobStatus"
-                ]
+                status = self.sagemaker_session.describe_processing_job(
+                    job_name=self.job_name
+                )["ProcessingJobStatus"]
                 if status != "Completed":
                     raise UnexpectedStatusException(
                         message="The underlying job is not in 'Completed' state. You may only "

--- a/src/sagemaker/model_monitor/monitoring_files.py
+++ b/src/sagemaker/model_monitor/monitoring_files.py
@@ -80,7 +80,9 @@ class Statistics(ModelMonitoringFile):
     """Represents the statistics JSON file used in Amazon SageMaker Model Monitoring.
     """
 
-    def __init__(self, body_dict, statistics_file_s3_uri, kms_key=None, sagemaker_session=None):
+    def __init__(
+        self, body_dict, statistics_file_s3_uri, kms_key=None, sagemaker_session=None
+    ):
         """Initializes the Statistics object used in Amazon SageMaker Model Monitoring.
 
         Args:
@@ -119,7 +121,9 @@ class Statistics(ModelMonitoringFile):
         """
         try:
             body_dict = json.loads(
-                S3Downloader.read_file(s3_uri=statistics_file_s3_uri, session=sagemaker_session)
+                S3Downloader.read_file(
+                    s3_uri=statistics_file_s3_uri, session=sagemaker_session
+                )
             )
         except ClientError as error:
             print(
@@ -131,12 +135,18 @@ class Statistics(ModelMonitoringFile):
             raise error
 
         return cls(
-            body_dict=body_dict, statistics_file_s3_uri=statistics_file_s3_uri, kms_key=kms_key
+            body_dict=body_dict,
+            statistics_file_s3_uri=statistics_file_s3_uri,
+            kms_key=kms_key,
         )
 
     @classmethod
     def from_string(
-        cls, statistics_file_string, kms_key=None, file_name=None, sagemaker_session=None
+        cls,
+        statistics_file_string,
+        kms_key=None,
+        file_name=None,
+        sagemaker_session=None,
     ):
         """Generates a Statistics object from an s3 uri.
 
@@ -157,7 +167,11 @@ class Statistics(ModelMonitoringFile):
         sagemaker_session = sagemaker_session or Session()
         file_name = file_name or "statistics.json"
         desired_s3_uri = os.path.join(
-            "s3://", sagemaker_session.default_bucket(), "monitoring", str(uuid.uuid4()), file_name
+            "s3://",
+            sagemaker_session.default_bucket(),
+            "monitoring",
+            str(uuid.uuid4()),
+            file_name,
         )
         s3_uri = S3Uploader.upload_string_as_file_body(
             body=statistics_file_string,
@@ -167,7 +181,9 @@ class Statistics(ModelMonitoringFile):
         )
 
         return Statistics.from_s3_uri(
-            statistics_file_s3_uri=s3_uri, kms_key=kms_key, sagemaker_session=sagemaker_session
+            statistics_file_s3_uri=s3_uri,
+            kms_key=kms_key,
+            sagemaker_session=sagemaker_session,
         )
 
     @classmethod
@@ -204,7 +220,9 @@ class Constraints(ModelMonitoringFile):
     """Represents the constraints JSON file used in Amazon SageMaker Model Monitoring.
     """
 
-    def __init__(self, body_dict, constraints_file_s3_uri, kms_key=None, sagemaker_session=None):
+    def __init__(
+        self, body_dict, constraints_file_s3_uri, kms_key=None, sagemaker_session=None
+    ):
         """Initializes the Constraints object used in Amazon SageMaker Model Monitoring.
 
         Args:
@@ -243,7 +261,9 @@ class Constraints(ModelMonitoringFile):
         """
         try:
             body_dict = json.loads(
-                S3Downloader.read_file(s3_uri=constraints_file_s3_uri, session=sagemaker_session)
+                S3Downloader.read_file(
+                    s3_uri=constraints_file_s3_uri, session=sagemaker_session
+                )
             )
         except ClientError as error:
             print(
@@ -263,7 +283,11 @@ class Constraints(ModelMonitoringFile):
 
     @classmethod
     def from_string(
-        cls, constraints_file_string, kms_key=None, file_name=None, sagemaker_session=None
+        cls,
+        constraints_file_string,
+        kms_key=None,
+        file_name=None,
+        sagemaker_session=None,
     ):
         """Generates a Constraints object from an s3 uri.
 
@@ -284,7 +308,11 @@ class Constraints(ModelMonitoringFile):
         sagemaker_session = sagemaker_session or Session()
         file_name = file_name or "constraints.json"
         desired_s3_uri = os.path.join(
-            "s3://", sagemaker_session.default_bucket(), "monitoring", str(uuid.uuid4()), file_name
+            "s3://",
+            sagemaker_session.default_bucket(),
+            "monitoring",
+            str(uuid.uuid4()),
+            file_name,
         )
         s3_uri = S3Uploader.upload_string_as_file_body(
             body=constraints_file_string,
@@ -294,11 +322,15 @@ class Constraints(ModelMonitoringFile):
         )
 
         return Constraints.from_s3_uri(
-            constraints_file_s3_uri=s3_uri, kms_key=kms_key, sagemaker_session=sagemaker_session
+            constraints_file_s3_uri=s3_uri,
+            kms_key=kms_key,
+            sagemaker_session=sagemaker_session,
         )
 
     @classmethod
-    def from_file_path(cls, constraints_file_path, kms_key=None, sagemaker_session=None):
+    def from_file_path(
+        cls, constraints_file_path, kms_key=None, sagemaker_session=None
+    ):
         """Initializes a Constraints object from a file path.
 
         Args:
@@ -347,7 +379,9 @@ class Constraints(ModelMonitoringFile):
                     string_constraints = feature["string_constraints"]
                     if string_constraints.get("monitoring_config_overrides") is None:
                         string_constraints["monitoring_config_overrides"] = {}
-                    string_constraints["monitoring_config_overrides"]["evaluate_constraints"] = flag
+                    string_constraints["monitoring_config_overrides"][
+                        "evaluate_constraints"
+                    ] = flag
 
 
 class ConstraintViolations(ModelMonitoringFile):
@@ -355,7 +389,11 @@ class ConstraintViolations(ModelMonitoringFile):
     """
 
     def __init__(
-        self, body_dict, constraint_violations_file_s3_uri, kms_key=None, sagemaker_session=None
+        self,
+        body_dict,
+        constraint_violations_file_s3_uri,
+        kms_key=None,
+        sagemaker_session=None,
     ):
         """Initializes the ConstraintViolations object used in Amazon SageMaker Model Monitoring.
 
@@ -377,7 +415,9 @@ class ConstraintViolations(ModelMonitoringFile):
         )
 
     @classmethod
-    def from_s3_uri(cls, constraint_violations_file_s3_uri, kms_key=None, sagemaker_session=None):
+    def from_s3_uri(
+        cls, constraint_violations_file_s3_uri, kms_key=None, sagemaker_session=None
+    ):
         """Generates a ConstraintViolations object from an s3 uri.
 
         Args:
@@ -418,7 +458,11 @@ class ConstraintViolations(ModelMonitoringFile):
 
     @classmethod
     def from_string(
-        cls, constraint_violations_file_string, kms_key=None, file_name=None, sagemaker_session=None
+        cls,
+        constraint_violations_file_string,
+        kms_key=None,
+        file_name=None,
+        sagemaker_session=None,
     ):
         """Generates a ConstraintViolations object from an s3 uri.
 
@@ -439,7 +483,11 @@ class ConstraintViolations(ModelMonitoringFile):
         sagemaker_session = sagemaker_session or Session()
         file_name = file_name or "constraint_violations.json"
         desired_s3_uri = os.path.join(
-            "s3://", sagemaker_session.default_bucket(), "monitoring", str(uuid.uuid4()), file_name
+            "s3://",
+            sagemaker_session.default_bucket(),
+            "monitoring",
+            str(uuid.uuid4()),
+            file_name,
         )
         s3_uri = S3Uploader.upload_string_as_file_body(
             body=constraint_violations_file_string,
@@ -455,7 +503,9 @@ class ConstraintViolations(ModelMonitoringFile):
         )
 
     @classmethod
-    def from_file_path(cls, constraint_violations_file_path, kms_key=None, sagemaker_session=None):
+    def from_file_path(
+        cls, constraint_violations_file_path, kms_key=None, sagemaker_session=None
+    ):
         """Initializes a ConstraintViolations object from a file path.
 
         Args:

--- a/src/sagemaker/multidatamodel.py
+++ b/src/sagemaker/multidatamodel.py
@@ -125,7 +125,9 @@ class MultiDataModel(Model):
         # with FrameworkEstimator set framework specific environment variables which need to be
         # copied over
         if self.model:
-            container_definition = self.model.prepare_container_def(instance_type, accelerator_type)
+            container_definition = self.model.prepare_container_def(
+                instance_type, accelerator_type
+            )
             image = container_definition["Image"]
             environment = container_definition["Environment"]
         else:
@@ -216,10 +218,14 @@ class MultiDataModel(Model):
         if role is None:
             raise ValueError("Role can not be null for deploying a model")
 
-        if instance_type == "local" and not isinstance(self.sagemaker_session, local.LocalSession):
+        if instance_type == "local" and not isinstance(
+            self.sagemaker_session, local.LocalSession
+        ):
             self.sagemaker_session = local.LocalSession()
 
-        container_def = self.prepare_container_def(instance_type, accelerator_type=accelerator_type)
+        container_def = self.prepare_container_def(
+            instance_type, accelerator_type=accelerator_type
+        )
         self.sagemaker_session.create_model(
             self.name,
             role,
@@ -230,7 +236,10 @@ class MultiDataModel(Model):
         )
 
         production_variant = sagemaker.production_variant(
-            self.name, instance_type, initial_instance_count, accelerator_type=accelerator_type
+            self.name,
+            instance_type,
+            initial_instance_count,
+            accelerator_type=accelerator_type,
         )
         if endpoint_name:
             self.endpoint_name = endpoint_name
@@ -297,8 +306,12 @@ class MultiDataModel(Model):
             destination_bucket, destination_model_data_path = s3.parse_s3_url(dst_url)
 
             # Copy the model artifact
-            self.s3_client.copy(copy_source, destination_bucket, destination_model_data_path)
-            return os.path.join("s3://", destination_bucket, destination_model_data_path)
+            self.s3_client.copy(
+                copy_source, destination_bucket, destination_model_data_path
+            )
+            return os.path.join(
+                "s3://", destination_bucket, destination_model_data_path
+            )
 
         # If the model source is a local path, upload the local model artifact to the destination
         #  s3 path
@@ -307,8 +320,12 @@ class MultiDataModel(Model):
             if model_data_path:
                 dst_s3_uri = os.path.join(dst_prefix, model_data_path)
             else:
-                dst_s3_uri = os.path.join(dst_prefix, os.path.basename(model_data_source))
-            self.s3_client.upload_file(model_data_source, destination_bucket, dst_s3_uri)
+                dst_s3_uri = os.path.join(
+                    dst_prefix, os.path.basename(model_data_source)
+                )
+            self.s3_client.upload_file(
+                model_data_source, destination_bucket, dst_s3_uri
+            )
             # return upload_path
             return os.path.join("s3://", destination_bucket, dst_s3_uri)
 
@@ -325,7 +342,9 @@ class MultiDataModel(Model):
         Yields: Paths to model archives relative to model_data_prefix path.
         """
         bucket, url_prefix = s3.parse_s3_url(self.model_data_prefix)
-        file_keys = self.sagemaker_session.list_s3_files(bucket=bucket, key_prefix=url_prefix)
+        file_keys = self.sagemaker_session.list_s3_files(
+            bucket=bucket, key_prefix=url_prefix
+        )
         for file_key in file_keys:
             # Return the model paths relative to the model_data_prefix
             # Ex: "a/b/c.tar.gz" -> "b/c.tar.gz" where url_prefix = "a/"

--- a/src/sagemaker/mxnet/estimator.py
+++ b/src/sagemaker/mxnet/estimator.py
@@ -112,7 +112,9 @@ class MXNet(Framework):
         """
         if framework_version is None:
             logger.warning(
-                empty_framework_version_warning(defaults.MXNET_VERSION, self.LATEST_VERSION)
+                empty_framework_version_warning(
+                    defaults.MXNET_VERSION, self.LATEST_VERSION
+                )
             )
         self.framework_version = framework_version or defaults.MXNET_VERSION
 
@@ -127,7 +129,9 @@ class MXNet(Framework):
 
         if py_version == "py2":
             logger.warning(
-                python_deprecation_warning(self.__framework_name__, defaults.LATEST_PY2_VERSION)
+                python_deprecation_warning(
+                    self.__framework_name__, defaults.LATEST_PY2_VERSION
+                )
             )
 
         if distributions is not None:
@@ -236,7 +240,9 @@ class MXNet(Framework):
         )
 
     @classmethod
-    def _prepare_init_params_from_job_description(cls, job_details, model_channel_name=None):
+    def _prepare_init_params_from_job_description(
+        cls, job_details, model_channel_name=None
+    ):
         """Convert the job description to init params that can be handled by the
         class constructor
 

--- a/src/sagemaker/mxnet/model.py
+++ b/src/sagemaker/mxnet/model.py
@@ -114,12 +114,16 @@ class MXNetModel(FrameworkModel):
 
         if py_version == "py2":
             logger.warning(
-                python_deprecation_warning(self.__framework_name__, defaults.LATEST_PY2_VERSION)
+                python_deprecation_warning(
+                    self.__framework_name__, defaults.LATEST_PY2_VERSION
+                )
             )
 
         if framework_version is None:
             logger.warning(
-                empty_framework_version_warning(defaults.MXNET_VERSION, defaults.LATEST_VERSION)
+                empty_framework_version_warning(
+                    defaults.MXNET_VERSION, defaults.LATEST_VERSION
+                )
             )
 
         self.py_version = py_version
@@ -153,13 +157,17 @@ class MXNetModel(FrameworkModel):
                 region_name, instance_type, accelerator_type=accelerator_type
             )
 
-        deploy_key_prefix = model_code_key_prefix(self.key_prefix, self.name, deploy_image)
+        deploy_key_prefix = model_code_key_prefix(
+            self.key_prefix, self.name, deploy_image
+        )
         self._upload_code(deploy_key_prefix, self._is_mms_version())
         deploy_env = dict(self.env)
         deploy_env.update(self._framework_env_vars())
 
         if self.model_server_workers:
-            deploy_env[MODEL_SERVER_WORKERS_PARAM_NAME.upper()] = str(self.model_server_workers)
+            deploy_env[MODEL_SERVER_WORKERS_PARAM_NAME.upper()] = str(
+                self.model_server_workers
+            )
         return sagemaker.container_def(
             deploy_image, self.repacked_model_data or self.model_data, deploy_env
         )

--- a/src/sagemaker/network.py
+++ b/src/sagemaker/network.py
@@ -45,7 +45,9 @@ class NetworkConfig(object):
 
     def _to_request_dict(self):
         """Generates a request dictionary using the parameters provided to the class."""
-        network_config_request = {"EnableNetworkIsolation": self.enable_network_isolation}
+        network_config_request = {
+            "EnableNetworkIsolation": self.enable_network_isolation
+        }
 
         if self.encrypt_inter_container_traffic is not None:
             network_config_request[
@@ -56,7 +58,9 @@ class NetworkConfig(object):
             network_config_request["VpcConfig"] = {}
 
         if self.security_group_ids is not None:
-            network_config_request["VpcConfig"]["SecurityGroupIds"] = self.security_group_ids
+            network_config_request["VpcConfig"][
+                "SecurityGroupIds"
+            ] = self.security_group_ids
 
         if self.subnets is not None:
             network_config_request["VpcConfig"]["Subnets"] = self.subnets

--- a/src/sagemaker/pipeline.py
+++ b/src/sagemaker/pipeline.py
@@ -25,7 +25,13 @@ class PipelineModel(object):
     """
 
     def __init__(
-        self, models, role, predictor_cls=None, name=None, vpc_config=None, sagemaker_session=None
+        self,
+        models,
+        role,
+        predictor_cls=None,
+        name=None,
+        vpc_config=None,
+        sagemaker_session=None,
     ):
         """Initialize an SageMaker ``Model`` which can be used to build an
         Inference Pipeline comprising of multiple model containers.
@@ -265,6 +271,8 @@ class PipelineModel(object):
         """
 
         if self.name is None:
-            raise ValueError("The SageMaker model must be created before attempting to delete.")
+            raise ValueError(
+                "The SageMaker model must be created before attempting to delete."
+            )
 
         self.sagemaker_session.delete_model(self.name)

--- a/src/sagemaker/predictor.py
+++ b/src/sagemaker/predictor.py
@@ -20,7 +20,11 @@ import six
 from six import StringIO, BytesIO
 import numpy as np
 
-from sagemaker.content_types import CONTENT_TYPE_JSON, CONTENT_TYPE_CSV, CONTENT_TYPE_NPY
+from sagemaker.content_types import (
+    CONTENT_TYPE_JSON,
+    CONTENT_TYPE_CSV,
+    CONTENT_TYPE_NPY,
+)
 from sagemaker.model_monitor import DataCaptureConfig
 from sagemaker.session import Session
 from sagemaker.utils import name_from_base
@@ -109,8 +113,12 @@ class RealTimePredictor(object):
                 as is.
         """
 
-        request_args = self._create_request_args(data, initial_args, target_model, target_variant)
-        response = self.sagemaker_session.sagemaker_runtime_client.invoke_endpoint(**request_args)
+        request_args = self._create_request_args(
+            data, initial_args, target_model, target_variant
+        )
+        response = self.sagemaker_session.sagemaker_runtime_client.invoke_endpoint(
+            **request_args
+        )
         return self._handle_response(response)
 
     def _handle_response(self, response):
@@ -126,7 +134,9 @@ class RealTimePredictor(object):
         response_body.close()
         return data
 
-    def _create_request_args(self, data, initial_args=None, target_model=None, target_variant=None):
+    def _create_request_args(
+        self, data, initial_args=None, target_model=None, target_variant=None
+    ):
         """
         Args:
             data:
@@ -269,9 +279,13 @@ class RealTimePredictor(object):
             image_uri = schedule["MonitoringScheduleConfig"]["MonitoringJobDefinition"][
                 "MonitoringAppSpecification"
             ]["ImageUri"]
-            index_after_placeholders = _DEFAULT_MONITOR_IMAGE_URI_WITH_PLACEHOLDERS.rfind("{}")
+            index_after_placeholders = _DEFAULT_MONITOR_IMAGE_URI_WITH_PLACEHOLDERS.rfind(
+                "{}"
+            )
             if image_uri.endswith(
-                _DEFAULT_MONITOR_IMAGE_URI_WITH_PLACEHOLDERS[index_after_placeholders + len("{}") :]
+                _DEFAULT_MONITOR_IMAGE_URI_WITH_PLACEHOLDERS[
+                    index_after_placeholders + len("{}") :
+                ]
             ):
                 monitors.append(
                     DefaultModelMonitor.attach(
@@ -324,7 +338,11 @@ class _CsvSerializer(object):
         """
         # For inputs which represent multiple "rows", the result should be newline-separated CSV
         # rows
-        if _is_mutable_sequence_like(data) and len(data) > 0 and _is_sequence_like(data[0]):
+        if (
+            _is_mutable_sequence_like(data)
+            and len(data) > 0
+            and _is_sequence_like(data[0])
+        ):
             return "\n".join([_CsvSerializer._serialize_row(row) for row in data])
         return _CsvSerializer._serialize_row(data)
 
@@ -621,7 +639,9 @@ class _NumpyDeserializer(object):
                     codecs.getreader("utf-8")(stream), delimiter=",", dtype=self.dtype
                 )
             if content_type == CONTENT_TYPE_JSON:
-                return np.array(json.load(codecs.getreader("utf-8")(stream)), dtype=self.dtype)
+                return np.array(
+                    json.load(codecs.getreader("utf-8")(stream)), dtype=self.dtype
+                )
             if content_type == CONTENT_TYPE_NPY:
                 return np.load(BytesIO(stream.read()))
         finally:

--- a/src/sagemaker/processing.py
+++ b/src/sagemaker/processing.py
@@ -25,7 +25,9 @@ from sagemaker.job import _Job
 from sagemaker.utils import base_name_from_image, name_from_base
 from sagemaker.session import Session
 from sagemaker.s3 import S3Uploader
-from sagemaker.network import NetworkConfig  # noqa: F401 # pylint: disable=unused-import
+from sagemaker.network import (
+    NetworkConfig,
+)  # noqa: F401 # pylint: disable=unused-import
 
 
 class Processor(object):
@@ -206,7 +208,9 @@ class Processor(object):
             # Iterate through the provided list of inputs.
             for count, file_input in enumerate(inputs, 1):
                 if not isinstance(file_input, ProcessingInput):
-                    raise TypeError("Your inputs must be provided as ProcessingInput objects.")
+                    raise TypeError(
+                        "Your inputs must be provided as ProcessingInput objects."
+                    )
                 # Generate a name for the ProcessingInput if it doesn't have one.
                 if file_input.input_name is None:
                     file_input.input_name = "input-{}".format(count)
@@ -251,7 +255,9 @@ class Processor(object):
             # Iterate through the provided list of outputs.
             for count, output in enumerate(outputs, 1):
                 if not isinstance(output, ProcessingOutput):
-                    raise TypeError("Your outputs must be provided as ProcessingOutput objects.")
+                    raise TypeError(
+                        "Your outputs must be provided as ProcessingOutput objects."
+                    )
                 # Generate a name for the ProcessingOutput if it doesn't have one.
                 if output.output_name is None:
                     output.output_name = "output-{}".format(count)
@@ -388,7 +394,9 @@ class ScriptProcessor(Processor):
         user_code_s3_uri = self._handle_user_code_url(code)
         user_script_name = self._get_user_code_name(code)
 
-        inputs_with_code = self._convert_code_and_add_to_inputs(inputs, user_code_s3_uri)
+        inputs_with_code = self._convert_code_and_add_to_inputs(
+            inputs, user_code_s3_uri
+        )
 
         self._set_entrypoint(self.command, user_script_name)
 
@@ -480,7 +488,9 @@ class ScriptProcessor(Processor):
             self._CODE_CONTAINER_INPUT_NAME,
         )
         return S3Uploader.upload(
-            local_path=code, desired_s3_uri=desired_s3_uri, session=self.sagemaker_session
+            local_path=code,
+            desired_s3_uri=desired_s3_uri,
+            session=self.sagemaker_session,
         )
 
     def _convert_code_and_add_to_inputs(self, inputs, s3_uri):
@@ -512,7 +522,9 @@ class ScriptProcessor(Processor):
             user_script_name (str): A filename with an extension.
         """
         user_script_location = "{}{}/{}".format(
-            self._CODE_CONTAINER_BASE_PATH, self._CODE_CONTAINER_INPUT_NAME, user_script_name
+            self._CODE_CONTAINER_BASE_PATH,
+            self._CODE_CONTAINER_INPUT_NAME,
+            user_script_name,
         )
         self.entrypoint = command + [user_script_location]
 
@@ -520,7 +532,9 @@ class ScriptProcessor(Processor):
 class ProcessingJob(_Job):
     """Provides functionality to start, describe, and stop processing jobs."""
 
-    def __init__(self, sagemaker_session, job_name, inputs, outputs, output_kms_key=None):
+    def __init__(
+        self, sagemaker_session, job_name, inputs, outputs, output_kms_key=None
+    ):
         """Initializes a Processing job.
 
         Args:
@@ -538,7 +552,9 @@ class ProcessingJob(_Job):
         self.inputs = inputs
         self.outputs = outputs
         self.output_kms_key = output_kms_key
-        super(ProcessingJob, self).__init__(sagemaker_session=sagemaker_session, job_name=job_name)
+        super(ProcessingJob, self).__init__(
+            sagemaker_session=sagemaker_session, job_name=job_name
+        )
 
     @classmethod
     def start_new(cls, processor, inputs, outputs, experiment_config):
@@ -596,18 +612,26 @@ class ProcessingJob(_Job):
 
         process_request_args["app_specification"] = {"ImageUri": processor.image_uri}
         if processor.arguments is not None:
-            process_request_args["app_specification"]["ContainerArguments"] = processor.arguments
+            process_request_args["app_specification"][
+                "ContainerArguments"
+            ] = processor.arguments
         if processor.entrypoint is not None:
-            process_request_args["app_specification"]["ContainerEntrypoint"] = processor.entrypoint
+            process_request_args["app_specification"][
+                "ContainerEntrypoint"
+            ] = processor.entrypoint
 
         process_request_args["environment"] = processor.env
 
         if processor.network_config is not None:
-            process_request_args["network_config"] = processor.network_config._to_request_dict()
+            process_request_args[
+                "network_config"
+            ] = processor.network_config._to_request_dict()
         else:
             process_request_args["network_config"] = None
 
-        process_request_args["role_arn"] = processor.sagemaker_session.expand_role(processor.role)
+        process_request_args["role_arn"] = processor.sagemaker_session.expand_role(
+            processor.role
+        )
 
         process_request_args["tags"] = processor.tags
 
@@ -643,7 +667,9 @@ class ProcessingJob(_Job):
             :class:`~sagemaker.processing.ProcessingJob`: The instance of ``ProcessingJob`` created
                 from the job name.
         """
-        job_desc = sagemaker_session.describe_processing_job(job_name=processing_job_name)
+        job_desc = sagemaker_session.describe_processing_job(
+            job_name=processing_job_name
+        )
 
         inputs = None
         if job_desc.get("ProcessingInputs"):
@@ -657,15 +683,17 @@ class ProcessingJob(_Job):
                     s3_data_distribution_type=processing_input["S3Input"].get(
                         "S3DataDistributionType"
                     ),
-                    s3_compression_type=processing_input["S3Input"].get("S3CompressionType"),
+                    s3_compression_type=processing_input["S3Input"].get(
+                        "S3CompressionType"
+                    ),
                 )
                 for processing_input in job_desc["ProcessingInputs"]
             ]
 
         outputs = None
-        if job_desc.get("ProcessingOutputConfig") and job_desc["ProcessingOutputConfig"].get(
-            "Outputs"
-        ):
+        if job_desc.get("ProcessingOutputConfig") and job_desc[
+            "ProcessingOutputConfig"
+        ].get("Outputs"):
             outputs = [
                 ProcessingOutput(
                     source=processing_output["S3Output"]["LocalPath"],
@@ -895,7 +923,9 @@ class ProcessingOutput(object):
     """Accepts parameters that specify an Amazon S3 output for a processing job and provides
     a method to turn those parameters into a dictionary."""
 
-    def __init__(self, source, destination=None, output_name=None, s3_upload_mode="EndOfJob"):
+    def __init__(
+        self, source, destination=None, output_name=None, s3_upload_mode="EndOfJob"
+    ):
         """Initializes a ``ProcessingOutput`` instance. ``ProcessingOutput`` accepts parameters that
         specify an Amazon S3 output for a processing job and provides a method to turn
         those parameters into a dictionary.

--- a/src/sagemaker/pytorch/estimator.py
+++ b/src/sagemaker/pytorch/estimator.py
@@ -105,7 +105,9 @@ class PyTorch(Framework):
         """
         if framework_version is None:
             logger.warning(
-                empty_framework_version_warning(defaults.PYTORCH_VERSION, self.LATEST_VERSION)
+                empty_framework_version_warning(
+                    defaults.PYTORCH_VERSION, self.LATEST_VERSION
+                )
             )
         self.framework_version = framework_version or defaults.PYTORCH_VERSION
 
@@ -120,7 +122,9 @@ class PyTorch(Framework):
 
         if py_version == "py2":
             logger.warning(
-                python_deprecation_warning(self.__framework_name__, defaults.LATEST_PY2_VERSION)
+                python_deprecation_warning(
+                    self.__framework_name__, defaults.LATEST_PY2_VERSION
+                )
             )
 
         self.py_version = py_version
@@ -191,7 +195,9 @@ class PyTorch(Framework):
         )
 
     @classmethod
-    def _prepare_init_params_from_job_description(cls, job_details, model_channel_name=None):
+    def _prepare_init_params_from_job_description(
+        cls, job_details, model_channel_name=None
+    ):
         """Convert the job description to init params that can be handled by the
         class constructor
 

--- a/src/sagemaker/pytorch/model.py
+++ b/src/sagemaker/pytorch/model.py
@@ -115,12 +115,16 @@ class PyTorchModel(FrameworkModel):
 
         if py_version == "py2":
             logger.warning(
-                python_deprecation_warning(self.__framework_name__, defaults.LATEST_PY2_VERSION)
+                python_deprecation_warning(
+                    self.__framework_name__, defaults.LATEST_PY2_VERSION
+                )
             )
 
         if framework_version is None:
             logger.warning(
-                empty_framework_version_warning(defaults.PYTORCH_VERSION, defaults.LATEST_VERSION)
+                empty_framework_version_warning(
+                    defaults.PYTORCH_VERSION, defaults.LATEST_VERSION
+                )
             )
 
         self.py_version = py_version
@@ -154,13 +158,17 @@ class PyTorchModel(FrameworkModel):
                 region_name, instance_type, accelerator_type=accelerator_type
             )
 
-        deploy_key_prefix = model_code_key_prefix(self.key_prefix, self.name, deploy_image)
+        deploy_key_prefix = model_code_key_prefix(
+            self.key_prefix, self.name, deploy_image
+        )
         self._upload_code(deploy_key_prefix, repack=self._is_mms_version())
         deploy_env = dict(self.env)
         deploy_env.update(self._framework_env_vars())
 
         if self.model_server_workers:
-            deploy_env[MODEL_SERVER_WORKERS_PARAM_NAME.upper()] = str(self.model_server_workers)
+            deploy_env[MODEL_SERVER_WORKERS_PARAM_NAME.upper()] = str(
+                self.model_server_workers
+            )
         return sagemaker.container_def(
             deploy_image, self.repacked_model_data or self.model_data, deploy_env
         )

--- a/src/sagemaker/rl/estimator.py
+++ b/src/sagemaker/rl/estimator.py
@@ -142,7 +142,9 @@ class RLEstimator(Framework):
         self._validate_images_args(toolkit, toolkit_version, framework, image_name)
 
         if not image_name:
-            self._validate_toolkit_support(toolkit.value, toolkit_version, framework.value)
+            self._validate_toolkit_support(
+                toolkit.value, toolkit_version, framework.value
+            )
             self.toolkit = toolkit.value
             self.toolkit_version = toolkit_version
             self.framework = framework.value
@@ -259,10 +261,14 @@ class RLEstimator(Framework):
             return tfsModel(framework_version=self.framework_version, **base_args)
         if self.framework == RLFramework.MXNET.value:
             return MXNetModel(
-                framework_version=self.framework_version, py_version=PYTHON_VERSION, **extended_args
+                framework_version=self.framework_version,
+                py_version=PYTHON_VERSION,
+                **extended_args
             )
         raise ValueError(
-            "An unknown RLFramework enum was passed in. framework: {}".format(self.framework)
+            "An unknown RLFramework enum was passed in. framework: {}".format(
+                self.framework
+            )
         )
 
     def train_image(self):
@@ -286,7 +292,9 @@ class RLEstimator(Framework):
         )
 
     @classmethod
-    def _prepare_init_params_from_job_description(cls, job_details, model_channel_name=None):
+    def _prepare_init_params_from_job_description(
+        cls, job_details, model_channel_name=None
+    ):
         """Convert the job description to init params that can be handled by the
         class constructor
 
@@ -340,7 +348,9 @@ class RLEstimator(Framework):
             SAGEMAKER_ESTIMATOR: SAGEMAKER_ESTIMATOR_VALUE,
         }
 
-        hyperparameters.update(Framework._json_encode_hyperparameters(additional_hyperparameters))
+        hyperparameters.update(
+            Framework._json_encode_hyperparameters(additional_hyperparameters)
+        )
         return hyperparameters
 
     @classmethod
@@ -378,7 +388,9 @@ class RLEstimator(Framework):
         """
         if toolkit and toolkit not in list(RLToolkit):
             raise ValueError(
-                "Invalid type: {}, valid RL toolkits types are: {}".format(toolkit, list(RLToolkit))
+                "Invalid type: {}, valid RL toolkits types are: {}".format(
+                    toolkit, list(RLToolkit)
+                )
             )
 
     @classmethod
@@ -483,7 +495,15 @@ class RLEstimator(Framework):
             float_regex = "[-+]?[0-9]*[.]?[0-9]+([eE][-+]?[0-9]+)?"  # noqa: W605, E501
 
             return [
-                {"Name": "episode_reward_mean", "Regex": "episode_reward_mean: (%s)" % float_regex},
-                {"Name": "episode_reward_max", "Regex": "episode_reward_max: (%s)" % float_regex},
+                {
+                    "Name": "episode_reward_mean",
+                    "Regex": "episode_reward_mean: (%s)" % float_regex,
+                },
+                {
+                    "Name": "episode_reward_max",
+                    "Regex": "episode_reward_max: (%s)" % float_regex,
+                },
             ]
-        raise ValueError("An unknown RLToolkit enum was passed in. toolkit: {}".format(toolkit))
+        raise ValueError(
+            "An unknown RLToolkit enum was passed in. toolkit: {}".format(toolkit)
+        )

--- a/src/sagemaker/s3.py
+++ b/src/sagemaker/s3.py
@@ -20,9 +20,7 @@ from sagemaker.session import Session
 
 logger = logging.getLogger("sagemaker")
 
-SESSION_V2_RENAME_MESSAGE = (
-    "Parameter 'session' will be renamed to 'sagemaker_session' in SageMaker Python SDK v2."
-)
+SESSION_V2_RENAME_MESSAGE = "Parameter 'session' will be renamed to 'sagemaker_session' in SageMaker Python SDK v2."
 
 
 def _session_v2_rename_warning(session):
@@ -45,7 +43,9 @@ def parse_s3_url(url):
     """
     parsed_url = urlparse(url)
     if parsed_url.scheme != "s3":
-        raise ValueError("Expecting 's3' scheme, got: {} in {}.".format(parsed_url.scheme, url))
+        raise ValueError(
+            "Expecting 's3' scheme, got: {} in {}.".format(parsed_url.scheme, url)
+        )
     return parsed_url.netloc, parsed_url.path.lstrip("/")
 
 
@@ -85,7 +85,9 @@ class S3Uploader(object):
         )
 
     @staticmethod
-    def upload_string_as_file_body(body, desired_s3_uri=None, kms_key=None, session=None):
+    def upload_string_as_file_body(
+        body, desired_s3_uri=None, kms_key=None, session=None
+    ):
         """Static method that uploads a given file or directory to S3.
 
         Args:
@@ -183,5 +185,7 @@ class S3Downloader(object):
         sagemaker_session = session or Session()
         bucket, key_prefix = parse_s3_url(url=s3_uri)
 
-        file_keys = sagemaker_session.list_s3_files(bucket=bucket, key_prefix=key_prefix)
+        file_keys = sagemaker_session.list_s3_files(
+            bucket=bucket, key_prefix=key_prefix
+        )
         return ["s3://{}/{}".format(bucket, file_key) for file_key in file_keys]

--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -131,7 +131,9 @@ class Session(object):  # pylint: disable=too-many-public-methods
                 "Must setup local AWS configuration with a region supported by SageMaker."
             )
 
-        self.sagemaker_client = sagemaker_client or self.boto_session.client("sagemaker")
+        self.sagemaker_client = sagemaker_client or self.boto_session.client(
+            "sagemaker"
+        )
         prepend_user_agent(self.sagemaker_client)
 
         if sagemaker_runtime_client is not None:
@@ -188,7 +190,9 @@ class Session(object):  # pylint: disable=too-many-public-methods
                 for name in filenames:
                     local_path = os.path.join(dirpath, name)
                     s3_relative_prefix = (
-                        "" if path == dirpath else os.path.relpath(dirpath, start=path) + "/"
+                        ""
+                        if path == dirpath
+                        else os.path.relpath(dirpath, start=path) + "/"
                     )
                     s3_key = "{}/{}{}".format(key_prefix, s3_relative_prefix, name)
                     files.append((local_path, s3_key))
@@ -238,7 +242,9 @@ class Session(object):  # pylint: disable=too-many-public-methods
         s3_object = s3.Object(bucket_name=bucket, key=key)
 
         if kms_key is not None:
-            s3_object.put(Body=body, SSEKMSKeyId=kms_key, ServerSideEncryption="aws:kms")
+            s3_object.put(
+                Body=body, SSEKMSKeyId=kms_key, ServerSideEncryption="aws:kms"
+            )
         else:
             s3_object.put(Body=body)
 
@@ -359,7 +365,9 @@ class Session(object):  # pylint: disable=too-many-public-methods
             ).get_caller_identity()["Account"]
             default_bucket = "sagemaker-{}-{}".format(region, account)
 
-        self._create_s3_bucket_if_it_does_not_exist(bucket_name=default_bucket, region=region)
+        self._create_s3_bucket_if_it_does_not_exist(
+            bucket_name=default_bucket, region=region
+        )
 
         self._default_bucket = default_bucket
 
@@ -395,7 +403,8 @@ class Session(object):  # pylint: disable=too-many-public-methods
                     s3.create_bucket(Bucket=bucket_name)
                 else:
                     s3.create_bucket(
-                        Bucket=bucket_name, CreateBucketConfiguration={"LocationConstraint": region}
+                        Bucket=bucket_name,
+                        CreateBucketConfiguration={"LocationConstraint": region},
                     )
 
                 LOGGER.info("Created S3 bucket: %s", bucket_name)
@@ -526,11 +535,14 @@ class Session(object):  # pylint: disable=too-many-public-methods
         if image and algorithm_arn:
             raise ValueError(
                 "image and algorithm_arn are mutually exclusive."
-                "Both were provided: image: %s algorithm_arn: %s" % (image, algorithm_arn)
+                "Both were provided: image: %s algorithm_arn: %s"
+                % (image, algorithm_arn)
             )
 
         if image is None and algorithm_arn is None:
-            raise ValueError("either image or algorithm_arn is required. None was provided.")
+            raise ValueError(
+                "either image or algorithm_arn is required. None was provided."
+            )
 
         if image is not None:
             train_request["AlgorithmSpecification"]["TrainingImage"] = image
@@ -542,7 +554,9 @@ class Session(object):  # pylint: disable=too-many-public-methods
             train_request["InputDataConfig"] = input_config
 
         if metric_definitions is not None:
-            train_request["AlgorithmSpecification"]["MetricDefinitions"] = metric_definitions
+            train_request["AlgorithmSpecification"][
+                "MetricDefinitions"
+            ] = metric_definitions
 
         if enable_sagemaker_metrics is not None:
             train_request["AlgorithmSpecification"][
@@ -565,7 +579,9 @@ class Session(object):  # pylint: disable=too-many-public-methods
             train_request["EnableNetworkIsolation"] = enable_network_isolation
 
         if encrypt_inter_container_traffic:
-            train_request["EnableInterContainerTrafficEncryption"] = encrypt_inter_container_traffic
+            train_request[
+                "EnableInterContainerTrafficEncryption"
+            ] = encrypt_inter_container_traffic
 
         if train_use_spot_instances:
             train_request["EnableManagedSpotTraining"] = train_use_spot_instances
@@ -747,76 +763,81 @@ class Session(object):  # pylint: disable=too-many-public-methods
         }
 
         if schedule_expression is not None:
-            monitoring_schedule_request["MonitoringScheduleConfig"]["ScheduleConfig"] = {
-                "ScheduleExpression": schedule_expression
-            }
+            monitoring_schedule_request["MonitoringScheduleConfig"][
+                "ScheduleConfig"
+            ] = {"ScheduleExpression": schedule_expression}
 
         if monitoring_output_config is not None:
-            monitoring_schedule_request["MonitoringScheduleConfig"]["MonitoringJobDefinition"][
-                "MonitoringOutputConfig"
-            ] = monitoring_output_config
+            monitoring_schedule_request["MonitoringScheduleConfig"][
+                "MonitoringJobDefinition"
+            ]["MonitoringOutputConfig"] = monitoring_output_config
 
         if statistics_s3_uri is not None or constraints_s3_uri is not None:
-            monitoring_schedule_request["MonitoringScheduleConfig"]["MonitoringJobDefinition"][
-                "BaselineConfig"
-            ] = {}
+            monitoring_schedule_request["MonitoringScheduleConfig"][
+                "MonitoringJobDefinition"
+            ]["BaselineConfig"] = {}
 
         if statistics_s3_uri is not None:
-            monitoring_schedule_request["MonitoringScheduleConfig"]["MonitoringJobDefinition"][
-                "BaselineConfig"
-            ]["StatisticsResource"] = {"S3Uri": statistics_s3_uri}
+            monitoring_schedule_request["MonitoringScheduleConfig"][
+                "MonitoringJobDefinition"
+            ]["BaselineConfig"]["StatisticsResource"] = {"S3Uri": statistics_s3_uri}
 
         if constraints_s3_uri is not None:
-            monitoring_schedule_request["MonitoringScheduleConfig"]["MonitoringJobDefinition"][
-                "BaselineConfig"
-            ]["ConstraintsResource"] = {"S3Uri": constraints_s3_uri}
+            monitoring_schedule_request["MonitoringScheduleConfig"][
+                "MonitoringJobDefinition"
+            ]["BaselineConfig"]["ConstraintsResource"] = {"S3Uri": constraints_s3_uri}
 
         if record_preprocessor_source_uri is not None:
-            monitoring_schedule_request["MonitoringScheduleConfig"]["MonitoringJobDefinition"][
-                "MonitoringAppSpecification"
-            ]["RecordPreprocessorSourceUri"] = record_preprocessor_source_uri
+            monitoring_schedule_request["MonitoringScheduleConfig"][
+                "MonitoringJobDefinition"
+            ]["MonitoringAppSpecification"][
+                "RecordPreprocessorSourceUri"
+            ] = record_preprocessor_source_uri
 
         if post_analytics_processor_source_uri is not None:
-            monitoring_schedule_request["MonitoringScheduleConfig"]["MonitoringJobDefinition"][
-                "MonitoringAppSpecification"
-            ]["PostAnalyticsProcessorSourceUri"] = post_analytics_processor_source_uri
+            monitoring_schedule_request["MonitoringScheduleConfig"][
+                "MonitoringJobDefinition"
+            ]["MonitoringAppSpecification"][
+                "PostAnalyticsProcessorSourceUri"
+            ] = post_analytics_processor_source_uri
 
         if entrypoint is not None:
-            monitoring_schedule_request["MonitoringScheduleConfig"]["MonitoringJobDefinition"][
-                "MonitoringAppSpecification"
-            ]["ContainerEntrypoint"] = entrypoint
+            monitoring_schedule_request["MonitoringScheduleConfig"][
+                "MonitoringJobDefinition"
+            ]["MonitoringAppSpecification"]["ContainerEntrypoint"] = entrypoint
 
         if arguments is not None:
-            monitoring_schedule_request["MonitoringScheduleConfig"]["MonitoringJobDefinition"][
-                "MonitoringAppSpecification"
-            ]["ContainerArguments"] = arguments
+            monitoring_schedule_request["MonitoringScheduleConfig"][
+                "MonitoringJobDefinition"
+            ]["MonitoringAppSpecification"]["ContainerArguments"] = arguments
 
         if volume_kms_key is not None:
-            monitoring_schedule_request["MonitoringScheduleConfig"]["MonitoringJobDefinition"][
-                "MonitoringResources"
-            ]["ClusterConfig"]["VolumeKmsKeyId"] = volume_kms_key
+            monitoring_schedule_request["MonitoringScheduleConfig"][
+                "MonitoringJobDefinition"
+            ]["MonitoringResources"]["ClusterConfig"]["VolumeKmsKeyId"] = volume_kms_key
 
         if max_runtime_in_seconds is not None:
-            monitoring_schedule_request["MonitoringScheduleConfig"]["MonitoringJobDefinition"][
-                "StoppingCondition"
-            ] = {"MaxRuntimeInSeconds": max_runtime_in_seconds}
+            monitoring_schedule_request["MonitoringScheduleConfig"][
+                "MonitoringJobDefinition"
+            ]["StoppingCondition"] = {"MaxRuntimeInSeconds": max_runtime_in_seconds}
 
         if environment is not None:
-            monitoring_schedule_request["MonitoringScheduleConfig"]["MonitoringJobDefinition"][
-                "Environment"
-            ] = environment
+            monitoring_schedule_request["MonitoringScheduleConfig"][
+                "MonitoringJobDefinition"
+            ]["Environment"] = environment
 
         if network_config is not None:
-            monitoring_schedule_request["MonitoringScheduleConfig"]["MonitoringJobDefinition"][
-                "NetworkConfig"
-            ] = network_config
+            monitoring_schedule_request["MonitoringScheduleConfig"][
+                "MonitoringJobDefinition"
+            ]["NetworkConfig"] = network_config
 
         if tags is not None:
             monitoring_schedule_request["Tags"] = tags
 
         LOGGER.info("Creating monitoring schedule name %s.", monitoring_schedule_name)
         LOGGER.debug(
-            "monitoring_schedule_request= %s", json.dumps(monitoring_schedule_request, indent=4)
+            "monitoring_schedule_request= %s",
+            json.dumps(monitoring_schedule_request, indent=4),
         )
         self.sagemaker_client.create_monitoring_schedule(**monitoring_schedule_request)
 
@@ -888,13 +909,16 @@ class Session(object):  # pylint: disable=too-many-public-methods
         existing_schedule_config = None
         if (
             existing_desc.get("MonitoringScheduleConfig") is not None
-            and existing_desc["MonitoringScheduleConfig"].get("ScheduleConfig") is not None
-            and existing_desc["MonitoringScheduleConfig"]["ScheduleConfig"]["ScheduleExpression"]
+            and existing_desc["MonitoringScheduleConfig"].get("ScheduleConfig")
             is not None
-        ):
-            existing_schedule_config = existing_desc["MonitoringScheduleConfig"]["ScheduleConfig"][
+            and existing_desc["MonitoringScheduleConfig"]["ScheduleConfig"][
                 "ScheduleExpression"
             ]
+            is not None
+        ):
+            existing_schedule_config = existing_desc["MonitoringScheduleConfig"][
+                "ScheduleConfig"
+            ]["ScheduleExpression"]
 
         request_schedule_expression = schedule_expression or existing_schedule_config
         request_monitoring_inputs = (
@@ -929,7 +953,9 @@ class Session(object):  # pylint: disable=too-many-public-methods
         )
         request_role_arn = (
             role_arn
-            or existing_desc["MonitoringScheduleConfig"]["MonitoringJobDefinition"]["RoleArn"]
+            or existing_desc["MonitoringScheduleConfig"]["MonitoringJobDefinition"][
+                "RoleArn"
+            ]
         )
 
         monitoring_schedule_request = {
@@ -951,17 +977,22 @@ class Session(object):  # pylint: disable=too-many-public-methods
         }
 
         if existing_schedule_config is not None:
-            monitoring_schedule_request["MonitoringScheduleConfig"]["ScheduleConfig"] = {
-                "ScheduleExpression": request_schedule_expression
-            }
+            monitoring_schedule_request["MonitoringScheduleConfig"][
+                "ScheduleConfig"
+            ] = {"ScheduleExpression": request_schedule_expression}
 
         existing_monitoring_output_config = existing_desc["MonitoringScheduleConfig"][
             "MonitoringJobDefinition"
         ].get("MonitoringOutputConfig")
-        if monitoring_output_config is not None or existing_monitoring_output_config is not None:
-            monitoring_schedule_request["MonitoringScheduleConfig"]["MonitoringJobDefinition"][
-                "MonitoringOutputConfig"
-            ] = (monitoring_output_config or existing_monitoring_output_config)
+        if (
+            monitoring_output_config is not None
+            or existing_monitoring_output_config is not None
+        ):
+            monitoring_schedule_request["MonitoringScheduleConfig"][
+                "MonitoringJobDefinition"
+            ]["MonitoringOutputConfig"] = (
+                monitoring_output_config or existing_monitoring_output_config
+            )
 
         existing_statistics_s3_uri = None
         existing_constraints_s3_uri = None
@@ -997,70 +1028,86 @@ class Session(object):  # pylint: disable=too-many-public-methods
             or existing_statistics_s3_uri is not None
             or existing_constraints_s3_uri is not None
         ):
-            monitoring_schedule_request["MonitoringScheduleConfig"]["MonitoringJobDefinition"][
-                "BaselineConfig"
-            ] = {}
+            monitoring_schedule_request["MonitoringScheduleConfig"][
+                "MonitoringJobDefinition"
+            ]["BaselineConfig"] = {}
 
         if statistics_s3_uri is not None or existing_statistics_s3_uri is not None:
-            monitoring_schedule_request["MonitoringScheduleConfig"]["MonitoringJobDefinition"][
-                "BaselineConfig"
-            ]["StatisticsResource"] = {"S3Uri": statistics_s3_uri or existing_statistics_s3_uri}
+            monitoring_schedule_request["MonitoringScheduleConfig"][
+                "MonitoringJobDefinition"
+            ]["BaselineConfig"]["StatisticsResource"] = {
+                "S3Uri": statistics_s3_uri or existing_statistics_s3_uri
+            }
 
         if constraints_s3_uri is not None or existing_constraints_s3_uri is not None:
-            monitoring_schedule_request["MonitoringScheduleConfig"]["MonitoringJobDefinition"][
-                "BaselineConfig"
-            ]["ConstraintsResource"] = {"S3Uri": constraints_s3_uri or existing_constraints_s3_uri}
+            monitoring_schedule_request["MonitoringScheduleConfig"][
+                "MonitoringJobDefinition"
+            ]["BaselineConfig"]["ConstraintsResource"] = {
+                "S3Uri": constraints_s3_uri or existing_constraints_s3_uri
+            }
 
-        existing_record_preprocessor_source_uri = existing_desc["MonitoringScheduleConfig"][
-            "MonitoringJobDefinition"
-        ]["MonitoringAppSpecification"].get("RecordPreprocessorSourceUri")
+        existing_record_preprocessor_source_uri = existing_desc[
+            "MonitoringScheduleConfig"
+        ]["MonitoringJobDefinition"]["MonitoringAppSpecification"].get(
+            "RecordPreprocessorSourceUri"
+        )
         if (
             record_preprocessor_source_uri is not None
             or existing_record_preprocessor_source_uri is not None
         ):
-            monitoring_schedule_request["MonitoringScheduleConfig"]["MonitoringJobDefinition"][
-                "MonitoringAppSpecification"
-            ]["RecordPreprocessorSourceUri"] = (
-                record_preprocessor_source_uri or existing_record_preprocessor_source_uri
+            monitoring_schedule_request["MonitoringScheduleConfig"][
+                "MonitoringJobDefinition"
+            ]["MonitoringAppSpecification"]["RecordPreprocessorSourceUri"] = (
+                record_preprocessor_source_uri
+                or existing_record_preprocessor_source_uri
             )
 
-        existing_post_analytics_processor_source_uri = existing_desc["MonitoringScheduleConfig"][
-            "MonitoringJobDefinition"
-        ]["MonitoringAppSpecification"].get("PostAnalyticsProcessorSourceUri")
+        existing_post_analytics_processor_source_uri = existing_desc[
+            "MonitoringScheduleConfig"
+        ]["MonitoringJobDefinition"]["MonitoringAppSpecification"].get(
+            "PostAnalyticsProcessorSourceUri"
+        )
         if (
             post_analytics_processor_source_uri is not None
             or existing_post_analytics_processor_source_uri is not None
         ):
-            monitoring_schedule_request["MonitoringScheduleConfig"]["MonitoringJobDefinition"][
-                "MonitoringAppSpecification"
-            ]["PostAnalyticsProcessorSourceUri"] = (
-                post_analytics_processor_source_uri or existing_post_analytics_processor_source_uri
+            monitoring_schedule_request["MonitoringScheduleConfig"][
+                "MonitoringJobDefinition"
+            ]["MonitoringAppSpecification"]["PostAnalyticsProcessorSourceUri"] = (
+                post_analytics_processor_source_uri
+                or existing_post_analytics_processor_source_uri
             )
 
-        existing_entrypoint = existing_desc["MonitoringScheduleConfig"]["MonitoringJobDefinition"][
-            "MonitoringAppSpecification"
-        ].get("ContainerEntrypoint")
+        existing_entrypoint = existing_desc["MonitoringScheduleConfig"][
+            "MonitoringJobDefinition"
+        ]["MonitoringAppSpecification"].get("ContainerEntrypoint")
         if entrypoint is not None or existing_entrypoint is not None:
-            monitoring_schedule_request["MonitoringScheduleConfig"]["MonitoringJobDefinition"][
-                "MonitoringAppSpecification"
-            ]["ContainerEntrypoint"] = (entrypoint or existing_entrypoint)
+            monitoring_schedule_request["MonitoringScheduleConfig"][
+                "MonitoringJobDefinition"
+            ]["MonitoringAppSpecification"]["ContainerEntrypoint"] = (
+                entrypoint or existing_entrypoint
+            )
 
-        existing_arguments = existing_desc["MonitoringScheduleConfig"]["MonitoringJobDefinition"][
-            "MonitoringAppSpecification"
-        ].get("ContainerArguments")
+        existing_arguments = existing_desc["MonitoringScheduleConfig"][
+            "MonitoringJobDefinition"
+        ]["MonitoringAppSpecification"].get("ContainerArguments")
         if arguments is not None or existing_arguments is not None:
-            monitoring_schedule_request["MonitoringScheduleConfig"]["MonitoringJobDefinition"][
-                "MonitoringAppSpecification"
-            ]["ContainerArguments"] = (arguments or existing_arguments)
+            monitoring_schedule_request["MonitoringScheduleConfig"][
+                "MonitoringJobDefinition"
+            ]["MonitoringAppSpecification"]["ContainerArguments"] = (
+                arguments or existing_arguments
+            )
 
         existing_volume_kms_key = existing_desc["MonitoringScheduleConfig"][
             "MonitoringJobDefinition"
         ]["MonitoringResources"]["ClusterConfig"].get("VolumeKmsKeyId")
 
         if volume_kms_key is not None or existing_volume_kms_key is not None:
-            monitoring_schedule_request["MonitoringScheduleConfig"]["MonitoringJobDefinition"][
-                "MonitoringResources"
-            ]["ClusterConfig"]["VolumeKmsKeyId"] = (volume_kms_key or existing_volume_kms_key)
+            monitoring_schedule_request["MonitoringScheduleConfig"][
+                "MonitoringJobDefinition"
+            ]["MonitoringResources"]["ClusterConfig"]["VolumeKmsKeyId"] = (
+                volume_kms_key or existing_volume_kms_key
+            )
 
         existing_max_runtime_in_seconds = None
         if existing_desc["MonitoringScheduleConfig"]["MonitoringJobDefinition"].get(
@@ -1070,30 +1117,39 @@ class Session(object):  # pylint: disable=too-many-public-methods
                 "MonitoringJobDefinition"
             ]["StoppingCondition"].get("MaxRuntimeInSeconds")
 
-        if max_runtime_in_seconds is not None or existing_max_runtime_in_seconds is not None:
-            monitoring_schedule_request["MonitoringScheduleConfig"]["MonitoringJobDefinition"][
-                "StoppingCondition"
-            ] = {"MaxRuntimeInSeconds": max_runtime_in_seconds or existing_max_runtime_in_seconds}
+        if (
+            max_runtime_in_seconds is not None
+            or existing_max_runtime_in_seconds is not None
+        ):
+            monitoring_schedule_request["MonitoringScheduleConfig"][
+                "MonitoringJobDefinition"
+            ]["StoppingCondition"] = {
+                "MaxRuntimeInSeconds": max_runtime_in_seconds
+                or existing_max_runtime_in_seconds
+            }
 
         existing_environment = existing_desc["MonitoringScheduleConfig"][
             "MonitoringJobDefinition"
         ].get("Environment")
         if environment is not None or existing_environment is not None:
-            monitoring_schedule_request["MonitoringScheduleConfig"]["MonitoringJobDefinition"][
-                "Environment"
-            ] = (environment or existing_environment)
+            monitoring_schedule_request["MonitoringScheduleConfig"][
+                "MonitoringJobDefinition"
+            ]["Environment"] = (environment or existing_environment)
 
         existing_network_config = existing_desc["MonitoringScheduleConfig"][
             "MonitoringJobDefinition"
         ].get("NetworkConfig")
         if network_config is not None or existing_network_config is not None:
-            monitoring_schedule_request["MonitoringScheduleConfig"]["MonitoringJobDefinition"][
-                "NetworkConfig"
-            ] = (network_config or existing_network_config)
+            monitoring_schedule_request["MonitoringScheduleConfig"][
+                "MonitoringJobDefinition"
+            ]["NetworkConfig"] = (network_config or existing_network_config)
 
-        LOGGER.info("Updating monitoring schedule with name: %s .", monitoring_schedule_name)
+        LOGGER.info(
+            "Updating monitoring schedule with name: %s .", monitoring_schedule_name
+        )
         LOGGER.debug(
-            "monitoring_schedule_request= %s", json.dumps(monitoring_schedule_request, indent=4)
+            "monitoring_schedule_request= %s",
+            json.dumps(monitoring_schedule_request, indent=4),
         )
         self.sagemaker_client.update_monitoring_schedule(**monitoring_schedule_request)
 
@@ -1106,7 +1162,11 @@ class Session(object):  # pylint: disable=too-many-public-methods
 
         """
         print()
-        print("Starting Monitoring Schedule with name: {}".format(monitoring_schedule_name))
+        print(
+            "Starting Monitoring Schedule with name: {}".format(
+                monitoring_schedule_name
+            )
+        )
         self.sagemaker_client.start_monitoring_schedule(
             MonitoringScheduleName=monitoring_schedule_name
         )
@@ -1120,7 +1180,11 @@ class Session(object):  # pylint: disable=too-many-public-methods
 
         """
         print()
-        print("Stopping Monitoring Schedule with name: {}".format(monitoring_schedule_name))
+        print(
+            "Stopping Monitoring Schedule with name: {}".format(
+                monitoring_schedule_name
+            )
+        )
         self.sagemaker_client.stop_monitoring_schedule(
             MonitoringScheduleName=monitoring_schedule_name
         )
@@ -1134,7 +1198,11 @@ class Session(object):  # pylint: disable=too-many-public-methods
 
         """
         print()
-        print("Deleting Monitoring Schedule with name: {}".format(monitoring_schedule_name))
+        print(
+            "Deleting Monitoring Schedule with name: {}".format(
+                monitoring_schedule_name
+            )
+        )
         self.sagemaker_client.delete_monitoring_schedule(
             MonitoringScheduleName=monitoring_schedule_name
         )
@@ -1184,7 +1252,11 @@ class Session(object):  # pylint: disable=too-many-public-methods
         return response
 
     def list_monitoring_schedules(
-        self, endpoint_name=None, sort_by="CreationTime", sort_order="Descending", max_results=100
+        self,
+        endpoint_name=None,
+        sort_by="CreationTime",
+        sort_order="Descending",
+        max_results=100,
     ):
         """Lists the monitoring executions associated with the given monitoring_schedule_name.
 
@@ -1224,7 +1296,9 @@ class Session(object):  # pylint: disable=too-many-public-methods
         Returns:
             bool: Whether the processing job was successful.
         """
-        job_desc = self.sagemaker_client.describe_processing_job(ProcessingJobName=job_name)
+        job_desc = self.sagemaker_client.describe_processing_job(
+            ProcessingJobName=job_name
+        )
         return job_desc["ProcessingJobStatus"] == "Completed"
 
     def describe_processing_job(self, job_name):
@@ -1381,7 +1455,9 @@ class Session(object):  # pylint: disable=too-many-public-methods
         if max_results:
             list_candidates_args["MaxResults"] = max_results
 
-        return self.sagemaker_client.list_candidates_for_auto_ml_job(**list_candidates_args)
+        return self.sagemaker_client.list_candidates_for_auto_ml_job(
+            **list_candidates_args
+        )
 
     def wait_for_auto_ml_job(self, job, poll=5):
         """Wait for an Amazon SageMaker AutoML job to complete.
@@ -1394,7 +1470,9 @@ class Session(object):  # pylint: disable=too-many-public-methods
         Raises:
             exceptions.UnexpectedStatusException: If the auto ml job fails.
         """
-        desc = _wait_until(lambda: _auto_ml_job_status(self.sagemaker_client, job), poll)
+        desc = _wait_until(
+            lambda: _auto_ml_job_status(self.sagemaker_client, job), poll
+        )
         self._check_job_status(job, desc, "AutoMLJobStatus")
         return desc
 
@@ -1418,9 +1496,15 @@ class Session(object):  # pylint: disable=too-many-public-methods
 
         description = self.sagemaker_client.describe_auto_ml_job(AutoMLJobName=job_name)
 
-        instance_count, stream_names, positions, client, log_group, dot, color_wrap = _logs_init(
-            self, description, job="AutoML"
-        )
+        (
+            instance_count,
+            stream_names,
+            positions,
+            client,
+            log_group,
+            dot,
+            color_wrap,
+        ) = _logs_init(self, description, job="AutoML")
 
         state = _get_initial_job_state(description, "AutoMLJobStatus", wait)
 
@@ -1464,7 +1548,9 @@ class Session(object):  # pylint: disable=too-many-public-methods
             if state == LogState.JOB_COMPLETE:
                 state = LogState.COMPLETE
             elif time.time() - last_describe_job_call >= 30:
-                description = self.sagemaker_client.describe_auto_ml_job(AutoMLJobName=job_name)
+                description = self.sagemaker_client.describe_auto_ml_job(
+                    AutoMLJobName=job_name
+                )
                 last_describe_job_call = time.time()
 
                 status = description["AutoMLJobStatus"]
@@ -1479,7 +1565,13 @@ class Session(object):  # pylint: disable=too-many-public-methods
                 print()
 
     def compile_model(
-        self, input_model_config, output_model_config, role, job_name, stop_condition, tags
+        self,
+        input_model_config,
+        output_model_config,
+        role,
+        job_name,
+        stop_condition,
+        tags,
     ):
         """Create an Amazon SageMaker Neo compilation job.
 
@@ -1693,7 +1785,9 @@ class Session(object):  # pylint: disable=too-many-public-methods
         """
 
         if training_config is None and training_config_list is None:
-            raise ValueError("Either training_config or training_config_list should be provided.")
+            raise ValueError(
+                "Either training_config or training_config_list should be provided."
+            )
         if training_config is not None and training_config_list is not None:
             raise ValueError(
                 "Only one of training_config and training_config_list should be provided."
@@ -1705,11 +1799,14 @@ class Session(object):  # pylint: disable=too-many-public-methods
         }
 
         if training_config is not None:
-            tune_request["TrainingJobDefinition"] = self._map_training_config(**training_config)
+            tune_request["TrainingJobDefinition"] = self._map_training_config(
+                **training_config
+            )
 
         if training_config_list is not None:
             tune_request["TrainingJobDefinitions"] = [
-                self._map_training_config(**training_cfg) for training_cfg in training_config_list
+                self._map_training_config(**training_cfg)
+                for training_cfg in training_config_list
             ]
 
         if warm_start_config is not None:
@@ -1780,7 +1877,9 @@ class Session(object):  # pylint: disable=too-many-public-methods
             "TrainingJobEarlyStoppingType": early_stopping_type,
         }
 
-        tuning_objective = cls._map_tuning_objective(objective_type, objective_metric_name)
+        tuning_objective = cls._map_tuning_objective(
+            objective_type, objective_metric_name
+        )
         if tuning_objective is not None:
             tuning_config["HyperParameterTuningJobObjective"] = tuning_objective
 
@@ -1949,7 +2048,9 @@ class Session(object):  # pylint: disable=too-many-public-methods
         if estimator_name is not None:
             training_job_definition["DefinitionName"] = estimator_name
 
-        tuning_objective = cls._map_tuning_objective(objective_type, objective_metric_name)
+        tuning_objective = cls._map_tuning_objective(
+            objective_type, objective_metric_name
+        )
         if tuning_objective is not None:
             training_job_definition["TuningObjective"] = tuning_objective
 
@@ -1969,7 +2070,9 @@ class Session(object):  # pylint: disable=too-many-public-methods
         """
         try:
             LOGGER.info("Stopping tuning job: %s", name)
-            self.sagemaker_client.stop_hyper_parameter_tuning_job(HyperParameterTuningJobName=name)
+            self.sagemaker_client.stop_hyper_parameter_tuning_job(
+                HyperParameterTuningJobName=name
+            )
         except ClientError as e:
             error_code = e.response["Error"]["Code"]
             # allow to pass if the job already stopped
@@ -2112,7 +2215,9 @@ class Session(object):  # pylint: disable=too-many-public-methods
             str: Name of the Amazon SageMaker ``Model`` created.
         """
         if container_defs and primary_container:
-            raise ValueError("Both container_defs and primary_container can not be passed as input")
+            raise ValueError(
+                "Both container_defs and primary_container can not be passed as input"
+            )
 
         if primary_container:
             msg = (
@@ -2140,7 +2245,9 @@ class Session(object):  # pylint: disable=too-many-public-methods
             create_model_request["EnableNetworkIsolation"] = True
 
         LOGGER.info("Creating model with name: %s", name)
-        LOGGER.debug("CreateModel request: %s", json.dumps(create_model_request, indent=4))
+        LOGGER.debug(
+            "CreateModel request: %s", json.dumps(create_model_request, indent=4)
+        )
 
         try:
             self.sagemaker_client.create_model(**create_model_request)
@@ -2201,14 +2308,20 @@ class Session(object):  # pylint: disable=too-many-public-methods
         role = role or training_job["RoleArn"]
         env = env or {}
         primary_container = container_def(
-            primary_container_image or training_job["AlgorithmSpecification"]["TrainingImage"],
-            model_data_url=model_data_url or training_job["ModelArtifacts"]["S3ModelArtifacts"],
+            primary_container_image
+            or training_job["AlgorithmSpecification"]["TrainingImage"],
+            model_data_url=model_data_url
+            or training_job["ModelArtifacts"]["S3ModelArtifacts"],
             env=env,
         )
         vpc_config = _vpc_config_from_training_job(training_job, vpc_config_override)
-        return self.create_model(name, role, primary_container, vpc_config=vpc_config, tags=tags)
+        return self.create_model(
+            name, role, primary_container, vpc_config=vpc_config, tags=tags
+        )
 
-    def create_model_package_from_algorithm(self, name, description, algorithm_arn, model_data):
+    def create_model_package_from_algorithm(
+        self, name, description, algorithm_arn, model_data
+    ):
         """Create a SageMaker Model Package from the results of training with an Algorithm Package
 
         Args:
@@ -2221,7 +2334,9 @@ class Session(object):  # pylint: disable=too-many-public-methods
             "ModelPackageName": name,
             "ModelPackageDescription": description,
             "SourceAlgorithmSpecification": {
-                "SourceAlgorithms": [{"AlgorithmName": algorithm_arn, "ModelDataUrl": model_data}]
+                "SourceAlgorithms": [
+                    {"AlgorithmName": algorithm_arn, "ModelDataUrl": model_data}
+                ]
             },
         }
         try:
@@ -2231,7 +2346,10 @@ class Session(object):  # pylint: disable=too-many-public-methods
             error_code = e.response["Error"]["Code"]
             message = e.response["Error"]["Message"]
 
-            if error_code == "ValidationException" and "ModelPackage already exists" in message:
+            if (
+                error_code == "ValidationException"
+                and "ModelPackage already exists" in message
+            ):
                 LOGGER.warning("Using already existing model package: %s", name)
             else:
                 raise
@@ -2247,7 +2365,10 @@ class Session(object):  # pylint: disable=too-many-public-methods
             dict: Return value from the ``DescribeEndpoint`` API.
         """
         desc = _wait_until(
-            lambda: _create_model_package_status(self.sagemaker_client, model_package_name), poll
+            lambda: _create_model_package_status(
+                self.sagemaker_client, model_package_name
+            ),
+            poll,
         )
         status = desc["ModelPackageStatus"]
 
@@ -2386,11 +2507,17 @@ class Session(object):  # pylint: disable=too-many-public-methods
         if request_tags:
             request["Tags"] = request_tags
 
-        if new_kms_key is not None or existing_endpoint_config_desc.get("KmsKeyId") is not None:
-            request["KmsKeyId"] = new_kms_key or existing_endpoint_config_desc.get("KmsKeyId")
+        if (
+            new_kms_key is not None
+            or existing_endpoint_config_desc.get("KmsKeyId") is not None
+        ):
+            request["KmsKeyId"] = new_kms_key or existing_endpoint_config_desc.get(
+                "KmsKeyId"
+            )
 
         request_data_capture_config_dict = (
-            new_data_capture_config_dict or existing_endpoint_config_desc.get("DataCaptureConfig")
+            new_data_capture_config_dict
+            or existing_endpoint_config_desc.get("DataCaptureConfig")
         )
 
         if request_data_capture_config_dict is not None:
@@ -2476,8 +2603,12 @@ class Session(object):  # pylint: disable=too-many-public-methods
             endpoint_config_name (str): Name of the Amazon SageMaker endpoint configuration to
                 delete.
         """
-        LOGGER.info("Deleting endpoint configuration with name: %s", endpoint_config_name)
-        self.sagemaker_client.delete_endpoint_config(EndpointConfigName=endpoint_config_name)
+        LOGGER.info(
+            "Deleting endpoint configuration with name: %s", endpoint_config_name
+        )
+        self.sagemaker_client.delete_endpoint_config(
+            EndpointConfigName=endpoint_config_name
+        )
 
     def delete_model(self, model_name):
         """Delete an Amazon SageMaker Model.
@@ -2509,7 +2640,9 @@ class Session(object):  # pylint: disable=too-many-public-methods
             next_token = list_tags_response.get("nextToken")
             while next_token is not None:
                 list_tags_response = self.sagemaker_client.list_tags(
-                    ResourceArn=resource_arn, MaxResults=max_results, NextToken=next_token
+                    ResourceArn=resource_arn,
+                    MaxResults=max_results,
+                    NextToken=next_token,
                 )
                 tags_list = tags_list + list_tags_response["Tags"]
                 next_token = list_tags_response.get("nextToken")
@@ -2538,7 +2671,9 @@ class Session(object):  # pylint: disable=too-many-public-methods
 
         """
         desc = _wait_until_training_done(
-            lambda last_desc: _train_done(self.sagemaker_client, job, last_desc), None, poll
+            lambda last_desc: _train_done(self.sagemaker_client, job, last_desc),
+            None,
+            poll,
         )
         self._check_job_status(job, desc, "TrainingJobStatus")
         return desc
@@ -2556,7 +2691,9 @@ class Session(object):  # pylint: disable=too-many-public-methods
         Raises:
             exceptions.UnexpectedStatusException: If the compilation job fails.
         """
-        desc = _wait_until(lambda: _processing_job_status(self.sagemaker_client, job), poll)
+        desc = _wait_until(
+            lambda: _processing_job_status(self.sagemaker_client, job), poll
+        )
         self._check_job_status(job, desc, "ProcessingJobStatus")
         return desc
 
@@ -2573,7 +2710,9 @@ class Session(object):  # pylint: disable=too-many-public-methods
         Raises:
             exceptions.UnexpectedStatusException: If the compilation job fails.
         """
-        desc = _wait_until(lambda: _compilation_job_status(self.sagemaker_client, job), poll)
+        desc = _wait_until(
+            lambda: _compilation_job_status(self.sagemaker_client, job), poll
+        )
         self._check_job_status(job, desc, "CompilationJobStatus")
         return desc
 
@@ -2619,7 +2758,9 @@ class Session(object):  # pylint: disable=too-many-public-methods
         Raises:
             exceptions.UnexpectedStatusException: If the transform job fails.
         """
-        desc = _wait_until(lambda: _transform_job_status(self.sagemaker_client, job), poll)
+        desc = _wait_until(
+            lambda: _transform_job_status(self.sagemaker_client, job), poll
+        )
         self._check_job_status(job, desc, "TransformJobStatus")
         return desc
 
@@ -2639,9 +2780,13 @@ class Session(object):  # pylint: disable=too-many-public-methods
             error_code = e.response["Error"]["Code"]
             # allow to pass if the job already stopped
             if error_code == "ValidationException":
-                LOGGER.info("Transform job: %s is already stopped or not running.", name)
+                LOGGER.info(
+                    "Transform job: %s is already stopped or not running.", name
+                )
             else:
-                LOGGER.error("Error occurred while attempting to stop transform job: %s.", name)
+                LOGGER.error(
+                    "Error occurred while attempting to stop transform job: %s.", name
+                )
                 raise
 
     def _check_job_status(self, job, desc, status_key_name):
@@ -2755,10 +2900,14 @@ class Session(object):  # pylint: disable=too-many-public-methods
         """
         job_desc = self.sagemaker_client.describe_training_job(TrainingJobName=job_name)
         output_url = job_desc["ModelArtifacts"]["S3ModelArtifacts"]
-        deployment_image = deployment_image or job_desc["AlgorithmSpecification"]["TrainingImage"]
+        deployment_image = (
+            deployment_image or job_desc["AlgorithmSpecification"]["TrainingImage"]
+        )
         role = role or job_desc["RoleArn"]
         name = name or job_name
-        vpc_config_override = _vpc_config_from_training_job(job_desc, vpc_config_override)
+        vpc_config_override = _vpc_config_from_training_job(
+            job_desc, vpc_config_override
+        )
 
         return self.endpoint_from_model_data(
             model_s3_location=output_url,
@@ -2831,17 +2980,24 @@ class Session(object):  # pylint: disable=too-many-public-methods
             lambda: self.sagemaker_client.describe_endpoint(EndpointName=name)
         ):
             raise ValueError(
-                'Endpoint with name "{}" already exists; please pick a different name.'.format(name)
+                'Endpoint with name "{}" already exists; please pick a different name.'.format(
+                    name
+                )
             )
 
         if not _deployment_entity_exists(
             lambda: self.sagemaker_client.describe_model(ModelName=name)
         ):
             primary_container = container_def(
-                image=deployment_image, model_data_url=model_s3_location, env=model_environment_vars
+                image=deployment_image,
+                model_data_url=model_s3_location,
+                env=model_environment_vars,
             )
             self.create_model(
-                name=name, role=role, container_defs=primary_container, vpc_config=model_vpc_config
+                name=name,
+                role=role,
+                container_defs=primary_container,
+                vpc_config=model_vpc_config,
             )
 
         data_capture_config_dict = None
@@ -2849,7 +3005,9 @@ class Session(object):  # pylint: disable=too-many-public-methods
             data_capture_config_dict = data_capture_config._to_request_dict()
 
         if not _deployment_entity_exists(
-            lambda: self.sagemaker_client.describe_endpoint_config(EndpointConfigName=name)
+            lambda: self.sagemaker_client.describe_endpoint_config(
+                EndpointConfigName=name
+            )
         ):
             self.create_endpoint_config(
                 name=name,
@@ -2891,9 +3049,14 @@ class Session(object):  # pylint: disable=too-many-public-methods
 
         """
         if not _deployment_entity_exists(
-            lambda: self.sagemaker_client.describe_endpoint_config(EndpointConfigName=name)
+            lambda: self.sagemaker_client.describe_endpoint_config(
+                EndpointConfigName=name
+            )
         ):
-            config_options = {"EndpointConfigName": name, "ProductionVariants": production_variants}
+            config_options = {
+                "EndpointConfigName": name,
+                "ProductionVariants": production_variants,
+            }
             if tags:
                 config_options["Tags"] = tags
             if kms_key:
@@ -2902,7 +3065,9 @@ class Session(object):  # pylint: disable=too-many-public-methods
                 config_options["DataCaptureConfig"] = data_capture_config_dict
 
             self.sagemaker_client.create_endpoint_config(**config_options)
-        return self.create_endpoint(endpoint_name=name, config_name=name, tags=tags, wait=wait)
+        return self.create_endpoint(
+            endpoint_name=name, config_name=name, tags=tags, wait=wait
+        )
 
     def expand_role(self, role):
         """Expand an IAM role name into an ARN.
@@ -2955,12 +3120,18 @@ class Session(object):  # pylint: disable=too-many-public-methods
             )
             return role
 
-        role = re.sub(r"^(.+)sts::(\d+):assumed-role/(.+?)/.*$", r"\1iam::\2:role/\3", assumed_role)
+        role = re.sub(
+            r"^(.+)sts::(\d+):assumed-role/(.+?)/.*$",
+            r"\1iam::\2:role/\3",
+            assumed_role,
+        )
 
         # Call IAM to get the role's path
         role_name = role[role.rfind("/") + 1 :]
         try:
-            role = self.boto_session.client("iam").get_role(RoleName=role_name)["Role"]["Arn"]
+            role = self.boto_session.client("iam").get_role(RoleName=role_name)["Role"][
+                "Arn"
+            ]
         except ClientError:
             LOGGER.warning(
                 "Couldn't call 'get_role' to get Role ARN from role name %s to get Role path.",
@@ -2987,12 +3158,20 @@ class Session(object):  # pylint: disable=too-many-public-methods
             exceptions.UnexpectedStatusException: If waiting and the training job fails.
         """
 
-        description = self.sagemaker_client.describe_training_job(TrainingJobName=job_name)
+        description = self.sagemaker_client.describe_training_job(
+            TrainingJobName=job_name
+        )
         print(secondary_training_status_message(description, None), end="")
 
-        instance_count, stream_names, positions, client, log_group, dot, color_wrap = _logs_init(
-            self, description, job="Training"
-        )
+        (
+            instance_count,
+            stream_names,
+            positions,
+            client,
+            log_group,
+            dot,
+            color_wrap,
+        ) = _logs_init(self, description, job="Training")
 
         state = _get_initial_job_state(description, "TrainingJobStatus", wait)
 
@@ -3039,12 +3218,19 @@ class Session(object):  # pylint: disable=too-many-public-methods
             if state == LogState.JOB_COMPLETE:
                 state = LogState.COMPLETE
             elif time.time() - last_describe_job_call >= 30:
-                description = self.sagemaker_client.describe_training_job(TrainingJobName=job_name)
+                description = self.sagemaker_client.describe_training_job(
+                    TrainingJobName=job_name
+                )
                 last_describe_job_call = time.time()
 
                 if secondary_training_status_changed(description, last_description):
                     print()
-                    print(secondary_training_status_message(description, last_description), end="")
+                    print(
+                        secondary_training_status_message(
+                            description, last_description
+                        ),
+                        end="",
+                    )
                     last_description = description
 
                 status = description["TrainingJobStatus"]
@@ -3057,7 +3243,9 @@ class Session(object):  # pylint: disable=too-many-public-methods
                 debug_rule_statuses = description.get("DebugRuleEvaluationStatuses", {})
                 if (
                     debug_rule_statuses
-                    and _debug_rule_statuses_changed(debug_rule_statuses, last_debug_rule_statuses)
+                    and _debug_rule_statuses_changed(
+                        debug_rule_statuses, last_debug_rule_statuses
+                    )
                     and (log_type in {"All", "Rules"})
                 ):
                     print()
@@ -3065,7 +3253,8 @@ class Session(object):  # pylint: disable=too-many-public-methods
                     print("*")
                     for status in debug_rule_statuses:
                         rule_log = "* {:>18}: {:<18}".format(
-                            status["RuleConfigurationName"], status["RuleEvaluationStatus"]
+                            status["RuleConfigurationName"],
+                            status["RuleEvaluationStatus"],
                         )
                         print(rule_log)
                     print("*")
@@ -3104,11 +3293,19 @@ class Session(object):  # pylint: disable=too-many-public-methods
             ValueError: If the processing job fails.
         """
 
-        description = self.sagemaker_client.describe_processing_job(ProcessingJobName=job_name)
-
-        instance_count, stream_names, positions, client, log_group, dot, color_wrap = _logs_init(
-            self, description, job="Processing"
+        description = self.sagemaker_client.describe_processing_job(
+            ProcessingJobName=job_name
         )
+
+        (
+            instance_count,
+            stream_names,
+            positions,
+            client,
+            log_group,
+            dot,
+            color_wrap,
+        ) = _logs_init(self, description, job="Processing")
 
         state = _get_initial_job_state(description, "ProcessingJobStatus", wait)
 
@@ -3184,11 +3381,19 @@ class Session(object):  # pylint: disable=too-many-public-methods
             ValueError: If the transform job fails.
         """
 
-        description = self.sagemaker_client.describe_transform_job(TransformJobName=job_name)
-
-        instance_count, stream_names, positions, client, log_group, dot, color_wrap = _logs_init(
-            self, description, job="Transform"
+        description = self.sagemaker_client.describe_transform_job(
+            TransformJobName=job_name
         )
+
+        (
+            instance_count,
+            stream_names,
+            positions,
+            client,
+            log_group,
+            dot,
+            color_wrap,
+        ) = _logs_init(self, description, job="Transform")
 
         state = _get_initial_job_state(description, "TransformJobStatus", wait)
 
@@ -3288,7 +3493,9 @@ def pipeline_container_def(models, instance_type=None):
         list[dict[str, str]]: list of container definition objects usable with with the
             CreateModel API for inference pipelines if passed via `Containers` field.
     """
-    c_defs = []  # should contain list of container definitions in the same order customer passed
+    c_defs = (
+        []
+    )  # should contain list of container definitions in the same order customer passed
     for model in models:
         c_defs.append(model.prepare_container_def(instance_type))
     return c_defs
@@ -3681,12 +3888,16 @@ def _logs_init(sagemaker_session, description, job):
     elif job == "Transform":
         instance_count = description["TransformResources"]["InstanceCount"]
     elif job == "Processing":
-        instance_count = description["ProcessingResources"]["ClusterConfig"]["InstanceCount"]
+        instance_count = description["ProcessingResources"]["ClusterConfig"][
+            "InstanceCount"
+        ]
     elif job == "AutoML":
         instance_count = 0
 
     stream_names = []  # The list of log streams
-    positions = {}  # The current position in each stream, map of stream name -> position
+    positions = (
+        {}
+    )  # The current position in each stream, map of stream name -> position
 
     # Increase retries allowed (from default of 4), as we don't want waiting for a training job
     # to be interrupted by a transient exception.
@@ -3702,7 +3913,14 @@ def _logs_init(sagemaker_session, description, job):
 
 
 def _flush_log_streams(
-    stream_names, instance_count, client, log_group, job_name, positions, dot, color_wrap
+    stream_names,
+    instance_count,
+    client,
+    log_group,
+    job_name,
+    positions,
+    dot,
+    color_wrap,
 ):
     """Placeholder docstring"""
     if len(stream_names) < instance_count:
@@ -3751,7 +3969,9 @@ def _flush_log_streams(
             color_wrap(idx, event["message"])
             ts, count = positions[stream_names[idx]]
             if event["timestamp"] == ts:
-                positions[stream_names[idx]] = sagemaker.logs.Position(timestamp=ts, skip=count + 1)
+                positions[stream_names[idx]] = sagemaker.logs.Position(
+                    timestamp=ts, skip=count + 1
+                )
             else:
                 positions[stream_names[idx]] = sagemaker.logs.Position(
                     timestamp=event["timestamp"], skip=1

--- a/src/sagemaker/sklearn/estimator.py
+++ b/src/sagemaker/sklearn/estimator.py
@@ -122,7 +122,9 @@ class SKLearn(Framework):
 
         if py_version == "py2":
             logger.warning(
-                python_deprecation_warning(self.__framework_name__, defaults.LATEST_PY2_VERSION)
+                python_deprecation_warning(
+                    self.__framework_name__, defaults.LATEST_PY2_VERSION
+                )
             )
 
         self.py_version = py_version
@@ -132,17 +134,23 @@ class SKLearn(Framework):
         else:
             raise ValueError(
                 get_unsupported_framework_version_error(
-                    self.__framework_name__, framework_version, defaults.SKLEARN_SUPPORTED_VERSIONS
+                    self.__framework_name__,
+                    framework_version,
+                    defaults.SKLEARN_SUPPORTED_VERSIONS,
                 )
             )
 
         if framework_version != defaults.SKLEARN_LATEST_VERSION:
-            logger.warning(later_framework_version_warning(defaults.SKLEARN_LATEST_VERSION))
+            logger.warning(
+                later_framework_version_warning(defaults.SKLEARN_LATEST_VERSION)
+            )
 
         if image_name is None:
             image_tag = "{}-{}-{}".format(framework_version, "cpu", py_version)
             self.image_name = default_framework_uri(
-                SKLearn.__framework_name__, self.sagemaker_session.boto_region_name, image_tag
+                SKLearn.__framework_name__,
+                self.sagemaker_session.boto_region_name,
+                image_tag,
             )
 
     def create_model(
@@ -216,7 +224,9 @@ class SKLearn(Framework):
         )
 
     @classmethod
-    def _prepare_init_params_from_job_description(cls, job_details, model_channel_name=None):
+    def _prepare_init_params_from_job_description(
+        cls, job_details, model_channel_name=None
+    ):
         """Convert the job description to init params that can be handled by the
         class constructor
 
@@ -228,7 +238,9 @@ class SKLearn(Framework):
         Returns:
             dictionary: The transformed init_params
         """
-        init_params = super(SKLearn, cls)._prepare_init_params_from_job_description(job_details)
+        init_params = super(SKLearn, cls)._prepare_init_params_from_job_description(
+            job_details
+        )
 
         image_name = init_params.pop("image")
         framework, py_version, _, _ = framework_name_from_image(image_name)

--- a/src/sagemaker/sklearn/model.py
+++ b/src/sagemaker/sklearn/model.py
@@ -109,7 +109,9 @@ class SKLearnModel(FrameworkModel):
 
         if py_version == "py2":
             logger.warning(
-                python_deprecation_warning(self.__framework_name__, defaults.LATEST_PY2_VERSION)
+                python_deprecation_warning(
+                    self.__framework_name__, defaults.LATEST_PY2_VERSION
+                )
             )
 
         self.py_version = py_version
@@ -141,19 +143,29 @@ class SKLearnModel(FrameworkModel):
                 self.sagemaker_session.boto_region_name, instance_type
             )
 
-        deploy_key_prefix = model_code_key_prefix(self.key_prefix, self.name, deploy_image)
-        self._upload_code(key_prefix=deploy_key_prefix, repack=self.enable_network_isolation())
+        deploy_key_prefix = model_code_key_prefix(
+            self.key_prefix, self.name, deploy_image
+        )
+        self._upload_code(
+            key_prefix=deploy_key_prefix, repack=self.enable_network_isolation()
+        )
         deploy_env = dict(self.env)
         deploy_env.update(self._framework_env_vars())
 
         if self.model_server_workers:
-            deploy_env[MODEL_SERVER_WORKERS_PARAM_NAME.upper()] = str(self.model_server_workers)
+            deploy_env[MODEL_SERVER_WORKERS_PARAM_NAME.upper()] = str(
+                self.model_server_workers
+            )
         model_data_uri = (
-            self.repacked_model_data if self.enable_network_isolation() else self.model_data
+            self.repacked_model_data
+            if self.enable_network_isolation()
+            else self.model_data
         )
         return sagemaker.container_def(deploy_image, model_data_uri, deploy_env)
 
-    def serving_image_uri(self, region_name, instance_type):  # pylint: disable=unused-argument
+    def serving_image_uri(
+        self, region_name, instance_type
+    ):  # pylint: disable=unused-argument
         """Create a URI for the serving image.
 
         Args:

--- a/src/sagemaker/sparkml/model.py
+++ b/src/sagemaker/sparkml/model.py
@@ -63,7 +63,9 @@ class SparkMLModel(Model):
     model .
     """
 
-    def __init__(self, model_data, role=None, spark_version=2.2, sagemaker_session=None, **kwargs):
+    def __init__(
+        self, model_data, role=None, spark_version=2.2, sagemaker_session=None, **kwargs
+    ):
         """Initialize a SparkMLModel.
 
         Args:
@@ -94,7 +96,9 @@ class SparkMLModel(Model):
         # For local mode, sagemaker_session should be passed as None but we need a session to get
         # boto_region_name
         region_name = (sagemaker_session or Session()).boto_region_name
-        image = "{}/{}:{}".format(registry(region_name, framework_name), repo_name, spark_version)
+        image = "{}/{}:{}".format(
+            registry(region_name, framework_name), repo_name, spark_version
+        )
         super(SparkMLModel, self).__init__(
             model_data,
             image,

--- a/src/sagemaker/tensorflow/model.py
+++ b/src/sagemaker/tensorflow/model.py
@@ -112,12 +112,16 @@ class TensorFlowModel(FrameworkModel):
 
         if py_version == "py2":
             logger.warning(
-                python_deprecation_warning(self.__framework_name__, defaults.LATEST_PY2_VERSION)
+                python_deprecation_warning(
+                    self.__framework_name__, defaults.LATEST_PY2_VERSION
+                )
             )
 
         if framework_version is None:
             logger.warning(
-                empty_framework_version_warning(defaults.TF_VERSION, defaults.LATEST_VERSION)
+                empty_framework_version_warning(
+                    defaults.TF_VERSION, defaults.LATEST_VERSION
+                )
             )
 
         self.py_version = py_version
@@ -153,13 +157,17 @@ class TensorFlowModel(FrameworkModel):
                 region_name, instance_type, accelerator_type=accelerator_type
             )
 
-        deploy_key_prefix = model_code_key_prefix(self.key_prefix, self.name, deploy_image)
+        deploy_key_prefix = model_code_key_prefix(
+            self.key_prefix, self.name, deploy_image
+        )
         self._upload_code(deploy_key_prefix)
         deploy_env = dict(self.env)
         deploy_env.update(self._framework_env_vars())
 
         if self.model_server_workers:
-            deploy_env[MODEL_SERVER_WORKERS_PARAM_NAME.upper()] = str(self.model_server_workers)
+            deploy_env[MODEL_SERVER_WORKERS_PARAM_NAME.upper()] = str(
+                self.model_server_workers
+            )
 
         return sagemaker.container_def(deploy_image, self.model_data, deploy_env)
 

--- a/src/sagemaker/tensorflow/predictor.py
+++ b/src/sagemaker/tensorflow/predictor.py
@@ -18,7 +18,11 @@ import json
 import google.protobuf.json_format as json_format
 from google.protobuf.message import DecodeError
 from protobuf_to_dict import protobuf_to_dict
-from sagemaker.content_types import CONTENT_TYPE_JSON, CONTENT_TYPE_OCTET_STREAM, CONTENT_TYPE_CSV
+from sagemaker.content_types import (
+    CONTENT_TYPE_JSON,
+    CONTENT_TYPE_OCTET_STREAM,
+    CONTENT_TYPE_CSV,
+)
 from sagemaker.predictor import json_serializer, csv_serializer
 
 
@@ -26,7 +30,9 @@ def _possible_responses():
     """
     Returns: Possible available request types.
     """
-    from tensorflow.core.framework import tensor_pb2  # pylint: disable=no-name-in-module
+    from tensorflow.core.framework import (
+        tensor_pb2,
+    )  # pylint: disable=no-name-in-module
     from tensorflow_serving.apis import (
         predict_pb2,
         classification_pb2,
@@ -125,7 +131,9 @@ class _TFJsonSerializer(object):
             data:
         """
 
-        from tensorflow.core.framework import tensor_pb2  # pylint: disable=no-name-in-module
+        from tensorflow.core.framework import (
+            tensor_pb2,
+        )  # pylint: disable=no-name-in-module
 
         if isinstance(data, tensor_pb2.TensorProto):
             return json_format.MessageToJson(data)
@@ -178,8 +186,12 @@ class _TFCsvSerializer(object):
         """
         to_serialize = data
 
-        from tensorflow.core.framework import tensor_pb2  # pylint: disable=no-name-in-module
-        from tensorflow.python.framework import tensor_util  # pylint: disable=no-name-in-module
+        from tensorflow.core.framework import (
+            tensor_pb2,
+        )  # pylint: disable=no-name-in-module
+        from tensorflow.python.framework import (
+            tensor_util,
+        )  # pylint: disable=no-name-in-module
 
         if isinstance(data, tensor_pb2.TensorProto):
             to_serialize = tensor_util.MakeNdarray(data)

--- a/src/sagemaker/tensorflow/serving.py
+++ b/src/sagemaker/tensorflow/serving.py
@@ -196,7 +196,10 @@ class Model(sagemaker.model.FrameworkModel):
     ):
 
         if accelerator_type and not self._eia_supported():
-            msg = "The TensorFlow version %s doesn't support EIA." % self._framework_version
+            msg = (
+                "The TensorFlow version %s doesn't support EIA."
+                % self._framework_version
+            )
 
             raise AttributeError(msg)
         return super(Model, self).deploy(
@@ -213,7 +216,9 @@ class Model(sagemaker.model.FrameworkModel):
 
     def _eia_supported(self):
         """Return true if TF version is EIA enabled"""
-        return [int(s) for s in self._framework_version.split(".")][:2] <= self.LATEST_EIA_VERSION
+        return [int(s) for s in self._framework_version.split(".")][
+            :2
+        ] <= self.LATEST_EIA_VERSION
 
     def prepare_container_def(self, instance_type=None, accelerator_type=None):
         """
@@ -230,7 +235,9 @@ class Model(sagemaker.model.FrameworkModel):
         env = self._get_container_env()
 
         if self.entry_point:
-            key_prefix = sagemaker.fw_utils.model_code_key_prefix(self.key_prefix, self.name, image)
+            key_prefix = sagemaker.fw_utils.model_code_key_prefix(
+                self.key_prefix, self.name, image
+            )
 
             bucket = self.bucket or self.sagemaker_session.default_bucket()
             model_data = "s3://{}/{}/model.tar.gz".format(bucket, key_prefix)
@@ -255,7 +262,9 @@ class Model(sagemaker.model.FrameworkModel):
             return self.env
 
         if self._container_log_level not in Model.LOG_LEVEL_MAP:
-            logging.warning("ignoring invalid container log level: %s", self._container_log_level)
+            logging.warning(
+                "ignoring invalid container log level: %s", self._container_log_level
+            )
             return self.env
 
         env = dict(self.env)
@@ -297,4 +306,6 @@ class Model(sagemaker.model.FrameworkModel):
             str: The appropriate image URI based on the given parameters.
 
         """
-        return self._get_image_uri(instance_type=instance_type, accelerator_type=accelerator_type)
+        return self._get_image_uri(
+            instance_type=instance_type, accelerator_type=accelerator_type
+        )

--- a/src/sagemaker/tensorflow/tensorflow_serving/apis/classification_pb2.py
+++ b/src/sagemaker/tensorflow/tensorflow_serving/apis/classification_pb2.py
@@ -15,8 +15,12 @@ from google.protobuf import descriptor_pb2
 _sym_db = _symbol_database.Default()
 
 
-from tensorflow_serving.apis import input_pb2 as tensorflow__serving_dot_apis_dot_input__pb2
-from tensorflow_serving.apis import model_pb2 as tensorflow__serving_dot_apis_dot_model__pb2
+from tensorflow_serving.apis import (
+    input_pb2 as tensorflow__serving_dot_apis_dot_input__pb2,
+)
+from tensorflow_serving.apis import (
+    model_pb2 as tensorflow__serving_dot_apis_dot_model__pb2,
+)
 
 
 DESCRIPTOR = _descriptor.FileDescriptor(
@@ -357,5 +361,7 @@ _sym_db.RegisterMessage(ClassificationResponse)
 
 
 DESCRIPTOR.has_options = True
-DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), _b("\370\001\001"))
+DESCRIPTOR._options = _descriptor._ParseOptions(
+    descriptor_pb2.FileOptions(), _b("\370\001\001")
+)
 # @@protoc_insertion_point(module_scope)

--- a/src/sagemaker/tensorflow/tensorflow_serving/apis/get_model_metadata_pb2.py
+++ b/src/sagemaker/tensorflow/tensorflow_serving/apis/get_model_metadata_pb2.py
@@ -19,7 +19,9 @@ from google.protobuf import any_pb2 as google_dot_protobuf_dot_any__pb2
 from tensorflow.core.protobuf import (
     meta_graph_pb2 as tensorflow_dot_core_dot_protobuf_dot_meta__graph__pb2,
 )
-from tensorflow_serving.apis import model_pb2 as tensorflow__serving_dot_apis_dot_model__pb2
+from tensorflow_serving.apis import (
+    model_pb2 as tensorflow__serving_dot_apis_dot_model__pb2,
+)
 
 
 DESCRIPTOR = _descriptor.FileDescriptor(
@@ -305,7 +307,9 @@ _SIGNATUREDEFMAP_SIGNATUREDEFENTRY.fields_by_name[
     "value"
 ].message_type = tensorflow_dot_core_dot_protobuf_dot_meta__graph__pb2._SIGNATUREDEF
 _SIGNATUREDEFMAP_SIGNATUREDEFENTRY.containing_type = _SIGNATUREDEFMAP
-_SIGNATUREDEFMAP.fields_by_name["signature_def"].message_type = _SIGNATUREDEFMAP_SIGNATUREDEFENTRY
+_SIGNATUREDEFMAP.fields_by_name[
+    "signature_def"
+].message_type = _SIGNATUREDEFMAP_SIGNATUREDEFENTRY
 _GETMODELMETADATAREQUEST.fields_by_name[
     "model_spec"
 ].message_type = tensorflow__serving_dot_apis_dot_model__pb2._MODELSPEC
@@ -379,7 +383,9 @@ _sym_db.RegisterMessage(GetModelMetadataResponse.MetadataEntry)
 
 
 DESCRIPTOR.has_options = True
-DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), _b("\370\001\001"))
+DESCRIPTOR._options = _descriptor._ParseOptions(
+    descriptor_pb2.FileOptions(), _b("\370\001\001")
+)
 _SIGNATUREDEFMAP_SIGNATUREDEFENTRY.has_options = True
 _SIGNATUREDEFMAP_SIGNATUREDEFENTRY._options = _descriptor._ParseOptions(
     descriptor_pb2.MessageOptions(), _b("8\001")

--- a/src/sagemaker/tensorflow/tensorflow_serving/apis/inference_pb2.py
+++ b/src/sagemaker/tensorflow/tensorflow_serving/apis/inference_pb2.py
@@ -18,8 +18,12 @@ _sym_db = _symbol_database.Default()
 from tensorflow_serving.apis import (
     classification_pb2 as tensorflow__serving_dot_apis_dot_classification__pb2,
 )
-from tensorflow_serving.apis import input_pb2 as tensorflow__serving_dot_apis_dot_input__pb2
-from tensorflow_serving.apis import model_pb2 as tensorflow__serving_dot_apis_dot_model__pb2
+from tensorflow_serving.apis import (
+    input_pb2 as tensorflow__serving_dot_apis_dot_input__pb2,
+)
+from tensorflow_serving.apis import (
+    model_pb2 as tensorflow__serving_dot_apis_dot_model__pb2,
+)
 from tensorflow_serving.apis import (
     regression_pb2 as tensorflow__serving_dot_apis_dot_regression__pb2,
 )
@@ -284,7 +288,9 @@ _INFERENCERESULT.fields_by_name[
 ].message_type = tensorflow__serving_dot_apis_dot_model__pb2._MODELSPEC
 _INFERENCERESULT.fields_by_name[
     "classification_result"
-].message_type = tensorflow__serving_dot_apis_dot_classification__pb2._CLASSIFICATIONRESULT
+].message_type = (
+    tensorflow__serving_dot_apis_dot_classification__pb2._CLASSIFICATIONRESULT
+)
 _INFERENCERESULT.fields_by_name[
     "regression_result"
 ].message_type = tensorflow__serving_dot_apis_dot_regression__pb2._REGRESSIONRESULT
@@ -357,5 +363,7 @@ _sym_db.RegisterMessage(MultiInferenceResponse)
 
 
 DESCRIPTOR.has_options = True
-DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), _b("\370\001\001"))
+DESCRIPTOR._options = _descriptor._ParseOptions(
+    descriptor_pb2.FileOptions(), _b("\370\001\001")
+)
 # @@protoc_insertion_point(module_scope)

--- a/src/sagemaker/tensorflow/tensorflow_serving/apis/input_pb2.py
+++ b/src/sagemaker/tensorflow/tensorflow_serving/apis/input_pb2.py
@@ -15,7 +15,9 @@ from google.protobuf import descriptor_pb2
 _sym_db = _symbol_database.Default()
 
 
-from tensorflow.core.example import example_pb2 as tensorflow_dot_core_dot_example_dot_example__pb2
+from tensorflow.core.example import (
+    example_pb2 as tensorflow_dot_core_dot_example_dot_example__pb2,
+)
 
 
 DESCRIPTOR = _descriptor.FileDescriptor(
@@ -147,7 +149,9 @@ _INPUT = _descriptor.Descriptor(
             containing_type=None,
             is_extension=False,
             extension_scope=None,
-            options=_descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b("(\001")),
+            options=_descriptor._ParseOptions(
+                descriptor_pb2.FieldOptions(), _b("(\001")
+            ),
             file=DESCRIPTOR,
         ),
         _descriptor.FieldDescriptor(
@@ -165,7 +169,9 @@ _INPUT = _descriptor.Descriptor(
             containing_type=None,
             is_extension=False,
             extension_scope=None,
-            options=_descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b("(\001")),
+            options=_descriptor._ParseOptions(
+                descriptor_pb2.FieldOptions(), _b("(\001")
+            ),
             file=DESCRIPTOR,
         ),
     ],
@@ -199,11 +205,17 @@ _EXAMPLELISTWITHCONTEXT.fields_by_name[
     "context"
 ].message_type = tensorflow_dot_core_dot_example_dot_example__pb2._EXAMPLE
 _INPUT.fields_by_name["example_list"].message_type = _EXAMPLELIST
-_INPUT.fields_by_name["example_list_with_context"].message_type = _EXAMPLELISTWITHCONTEXT
+_INPUT.fields_by_name[
+    "example_list_with_context"
+].message_type = _EXAMPLELISTWITHCONTEXT
 _INPUT.oneofs_by_name["kind"].fields.append(_INPUT.fields_by_name["example_list"])
 _INPUT.fields_by_name["example_list"].containing_oneof = _INPUT.oneofs_by_name["kind"]
-_INPUT.oneofs_by_name["kind"].fields.append(_INPUT.fields_by_name["example_list_with_context"])
-_INPUT.fields_by_name["example_list_with_context"].containing_oneof = _INPUT.oneofs_by_name["kind"]
+_INPUT.oneofs_by_name["kind"].fields.append(
+    _INPUT.fields_by_name["example_list_with_context"]
+)
+_INPUT.fields_by_name[
+    "example_list_with_context"
+].containing_oneof = _INPUT.oneofs_by_name["kind"]
 DESCRIPTOR.message_types_by_name["ExampleList"] = _EXAMPLELIST
 DESCRIPTOR.message_types_by_name["ExampleListWithContext"] = _EXAMPLELISTWITHCONTEXT
 DESCRIPTOR.message_types_by_name["Input"] = _INPUT
@@ -244,7 +256,9 @@ _sym_db.RegisterMessage(Input)
 
 
 DESCRIPTOR.has_options = True
-DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), _b("\370\001\001"))
+DESCRIPTOR._options = _descriptor._ParseOptions(
+    descriptor_pb2.FileOptions(), _b("\370\001\001")
+)
 _INPUT.fields_by_name["example_list"].has_options = True
 _INPUT.fields_by_name["example_list"]._options = _descriptor._ParseOptions(
     descriptor_pb2.FieldOptions(), _b("(\001")

--- a/src/sagemaker/tensorflow/tensorflow_serving/apis/model_pb2.py
+++ b/src/sagemaker/tensorflow/tensorflow_serving/apis/model_pb2.py
@@ -122,5 +122,7 @@ _sym_db.RegisterMessage(ModelSpec)
 
 
 DESCRIPTOR.has_options = True
-DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), _b("\370\001\001"))
+DESCRIPTOR._options = _descriptor._ParseOptions(
+    descriptor_pb2.FileOptions(), _b("\370\001\001")
+)
 # @@protoc_insertion_point(module_scope)

--- a/src/sagemaker/tensorflow/tensorflow_serving/apis/model_service_pb2.py
+++ b/src/sagemaker/tensorflow/tensorflow_serving/apis/model_service_pb2.py
@@ -49,7 +49,9 @@ _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
 
 DESCRIPTOR.has_options = True
-DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), _b("\370\001\001"))
+DESCRIPTOR._options = _descriptor._ParseOptions(
+    descriptor_pb2.FileOptions(), _b("\370\001\001")
+)
 try:
     # THESE ELEMENTS WILL BE DEPRECATED.
     # Please use the generated *_pb2_grpc.py files instead.
@@ -135,7 +137,12 @@ try:
     """
 
         def GetModelStatus(
-            self, request, timeout, metadata=None, with_call=False, protocol_options=None
+            self,
+            request,
+            timeout,
+            metadata=None,
+            with_call=False,
+            protocol_options=None,
         ):
             """Gets status of model. If the ModelSpec in the request does not specify
       version, information about all versions of the model will be returned. If
@@ -180,7 +187,9 @@ try:
             default_timeout=default_timeout,
             maximum_timeout=maximum_timeout,
         )
-        return beta_implementations.server(method_implementations, options=server_options)
+        return beta_implementations.server(
+            method_implementations, options=server_options
+        )
 
     def beta_create_ModelService_stub(
         channel, host=None, metadata_transformer=None, pool=None, pool_size=None
@@ -212,7 +221,10 @@ try:
             thread_pool_size=pool_size,
         )
         return beta_implementations.dynamic_stub(
-            channel, "tensorflow.serving.ModelService", cardinalities, options=stub_options
+            channel,
+            "tensorflow.serving.ModelService",
+            cardinalities,
+            options=stub_options,
         )
 
 

--- a/src/sagemaker/tensorflow/tensorflow_serving/apis/predict_pb2.py
+++ b/src/sagemaker/tensorflow/tensorflow_serving/apis/predict_pb2.py
@@ -18,7 +18,9 @@ _sym_db = _symbol_database.Default()
 from tensorflow.core.framework import (
     tensor_pb2 as tensorflow_dot_core_dot_framework_dot_tensor__pb2,
 )
-from tensorflow_serving.apis import model_pb2 as tensorflow__serving_dot_apis_dot_model__pb2
+from tensorflow_serving.apis import (
+    model_pb2 as tensorflow__serving_dot_apis_dot_model__pb2,
+)
 
 
 DESCRIPTOR = _descriptor.FileDescriptor(
@@ -342,7 +344,9 @@ _sym_db.RegisterMessage(PredictResponse.OutputsEntry)
 
 
 DESCRIPTOR.has_options = True
-DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), _b("\370\001\001"))
+DESCRIPTOR._options = _descriptor._ParseOptions(
+    descriptor_pb2.FileOptions(), _b("\370\001\001")
+)
 _PREDICTREQUEST_INPUTSENTRY.has_options = True
 _PREDICTREQUEST_INPUTSENTRY._options = _descriptor._ParseOptions(
     descriptor_pb2.MessageOptions(), _b("8\001")

--- a/src/sagemaker/tensorflow/tensorflow_serving/apis/prediction_service_pb2.py
+++ b/src/sagemaker/tensorflow/tensorflow_serving/apis/prediction_service_pb2.py
@@ -37,8 +37,12 @@ from tensorflow_serving.apis import (
 from tensorflow_serving.apis import (
     get_model_metadata_pb2 as tensorflow__serving_dot_apis_dot_get__model__metadata__pb2,
 )
-from tensorflow_serving.apis import inference_pb2 as tensorflow__serving_dot_apis_dot_inference__pb2
-from tensorflow_serving.apis import predict_pb2 as tensorflow__serving_dot_apis_dot_predict__pb2
+from tensorflow_serving.apis import (
+    inference_pb2 as tensorflow__serving_dot_apis_dot_inference__pb2,
+)
+from tensorflow_serving.apis import (
+    predict_pb2 as tensorflow__serving_dot_apis_dot_predict__pb2,
+)
 from tensorflow_serving.apis import (
     regression_pb2 as tensorflow__serving_dot_apis_dot_regression__pb2,
 )
@@ -63,7 +67,9 @@ _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
 
 DESCRIPTOR.has_options = True
-DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), _b("\370\001\001"))
+DESCRIPTOR._options = _descriptor._ParseOptions(
+    descriptor_pb2.FileOptions(), _b("\370\001\001")
+)
 try:
     # THESE ELEMENTS WILL BE DEPRECATED.
     # Please use the generated *_pb2_grpc.py files instead.
@@ -234,21 +240,42 @@ try:
     model_servers.
     """
 
-        def Classify(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
+        def Classify(
+            self,
+            request,
+            timeout,
+            metadata=None,
+            with_call=False,
+            protocol_options=None,
+        ):
             """Classify.
       """
             raise NotImplementedError()
 
         Classify.future = None
 
-        def Regress(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
+        def Regress(
+            self,
+            request,
+            timeout,
+            metadata=None,
+            with_call=False,
+            protocol_options=None,
+        ):
             """Regress.
       """
             raise NotImplementedError()
 
         Regress.future = None
 
-        def Predict(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
+        def Predict(
+            self,
+            request,
+            timeout,
+            metadata=None,
+            with_call=False,
+            protocol_options=None,
+        ):
             """Predict -- provides access to loaded TensorFlow model.
       """
             raise NotImplementedError()
@@ -256,7 +283,12 @@ try:
         Predict.future = None
 
         def MultiInference(
-            self, request, timeout, metadata=None, with_call=False, protocol_options=None
+            self,
+            request,
+            timeout,
+            metadata=None,
+            with_call=False,
+            protocol_options=None,
         ):
             """MultiInference API for multi-headed models.
       """
@@ -265,7 +297,12 @@ try:
         MultiInference.future = None
 
         def GetModelMetadata(
-            self, request, timeout, metadata=None, with_call=False, protocol_options=None
+            self,
+            request,
+            timeout,
+            metadata=None,
+            with_call=False,
+            protocol_options=None,
         ):
             """GetModelMetadata - provides access to metadata for loaded models.
       """
@@ -326,9 +363,10 @@ try:
             ): tensorflow__serving_dot_apis_dot_regression__pb2.RegressionResponse.SerializeToString,
         }
         method_implementations = {
-            ("tensorflow.serving.PredictionService", "Classify"): face_utilities.unary_unary_inline(
-                servicer.Classify
-            ),
+            (
+                "tensorflow.serving.PredictionService",
+                "Classify",
+            ): face_utilities.unary_unary_inline(servicer.Classify),
             (
                 "tensorflow.serving.PredictionService",
                 "GetModelMetadata",
@@ -337,12 +375,14 @@ try:
                 "tensorflow.serving.PredictionService",
                 "MultiInference",
             ): face_utilities.unary_unary_inline(servicer.MultiInference),
-            ("tensorflow.serving.PredictionService", "Predict"): face_utilities.unary_unary_inline(
-                servicer.Predict
-            ),
-            ("tensorflow.serving.PredictionService", "Regress"): face_utilities.unary_unary_inline(
-                servicer.Regress
-            ),
+            (
+                "tensorflow.serving.PredictionService",
+                "Predict",
+            ): face_utilities.unary_unary_inline(servicer.Predict),
+            (
+                "tensorflow.serving.PredictionService",
+                "Regress",
+            ): face_utilities.unary_unary_inline(servicer.Regress),
         }
         server_options = beta_implementations.server_options(
             request_deserializers=request_deserializers,
@@ -352,7 +392,9 @@ try:
             default_timeout=default_timeout,
             maximum_timeout=maximum_timeout,
         )
-        return beta_implementations.server(method_implementations, options=server_options)
+        return beta_implementations.server(
+            method_implementations, options=server_options
+        )
 
     def beta_create_PredictionService_stub(
         channel, host=None, metadata_transformer=None, pool=None, pool_size=None
@@ -422,7 +464,10 @@ try:
             thread_pool_size=pool_size,
         )
         return beta_implementations.dynamic_stub(
-            channel, "tensorflow.serving.PredictionService", cardinalities, options=stub_options
+            channel,
+            "tensorflow.serving.PredictionService",
+            cardinalities,
+            options=stub_options,
         )
 
 

--- a/src/sagemaker/tensorflow/tensorflow_serving/apis/regression_pb2.py
+++ b/src/sagemaker/tensorflow/tensorflow_serving/apis/regression_pb2.py
@@ -15,8 +15,12 @@ from google.protobuf import descriptor_pb2
 _sym_db = _symbol_database.Default()
 
 
-from tensorflow_serving.apis import input_pb2 as tensorflow__serving_dot_apis_dot_input__pb2
-from tensorflow_serving.apis import model_pb2 as tensorflow__serving_dot_apis_dot_model__pb2
+from tensorflow_serving.apis import (
+    input_pb2 as tensorflow__serving_dot_apis_dot_input__pb2,
+)
+from tensorflow_serving.apis import (
+    model_pb2 as tensorflow__serving_dot_apis_dot_model__pb2,
+)
 
 
 DESCRIPTOR = _descriptor.FileDescriptor(
@@ -287,5 +291,7 @@ _sym_db.RegisterMessage(RegressionResponse)
 
 
 DESCRIPTOR.has_options = True
-DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), _b("\370\001\001"))
+DESCRIPTOR._options = _descriptor._ParseOptions(
+    descriptor_pb2.FileOptions(), _b("\370\001\001")
+)
 # @@protoc_insertion_point(module_scope)

--- a/src/sagemaker/transformer.py
+++ b/src/sagemaker/transformer.py
@@ -297,7 +297,8 @@ class Transformer(object):
         init_params = cls._prepare_init_params_from_job_description(job_details)
         transformer = cls(sagemaker_session=sagemaker_session, **init_params)
         transformer.latest_transform_job = _TransformJob(
-            sagemaker_session=sagemaker_session, job_name=init_params["base_transform_job_name"]
+            sagemaker_session=sagemaker_session,
+            job_name=init_params["base_transform_job_name"],
         )
 
         return transformer
@@ -317,15 +318,23 @@ class Transformer(object):
         init_params = dict()
 
         init_params["model_name"] = job_details["ModelName"]
-        init_params["instance_count"] = job_details["TransformResources"]["InstanceCount"]
+        init_params["instance_count"] = job_details["TransformResources"][
+            "InstanceCount"
+        ]
         init_params["instance_type"] = job_details["TransformResources"]["InstanceType"]
-        init_params["volume_kms_key"] = job_details["TransformResources"].get("VolumeKmsKeyId")
+        init_params["volume_kms_key"] = job_details["TransformResources"].get(
+            "VolumeKmsKeyId"
+        )
         init_params["strategy"] = job_details.get("BatchStrategy")
-        init_params["assemble_with"] = job_details["TransformOutput"].get("AssembleWith")
+        init_params["assemble_with"] = job_details["TransformOutput"].get(
+            "AssembleWith"
+        )
         init_params["output_path"] = job_details["TransformOutput"]["S3OutputPath"]
         init_params["output_kms_key"] = job_details["TransformOutput"].get("KmsKeyId")
         init_params["accept"] = job_details["TransformOutput"].get("Accept")
-        init_params["max_concurrent_transforms"] = job_details.get("MaxConcurrentTransforms")
+        init_params["max_concurrent_transforms"] = job_details.get(
+            "MaxConcurrentTransforms"
+        )
         init_params["max_payload"] = job_details.get("MaxPayloadInMB")
         init_params["base_transform_job_name"] = job_details["TransformJobName"]
 
@@ -400,7 +409,9 @@ class _TransformJob(_Job):
         self.sagemaker_session.stop_transform_job(name=self.job_name)
 
     @staticmethod
-    def _load_config(data, data_type, content_type, compression_type, split_type, transformer):
+    def _load_config(
+        data, data_type, content_type, compression_type, split_type, transformer
+    ):
         """
         Args:
             data:
@@ -422,7 +433,9 @@ class _TransformJob(_Job):
         )
 
         resource_config = _TransformJob._prepare_resource_config(
-            transformer.instance_count, transformer.instance_type, transformer.volume_kms_key
+            transformer.instance_count,
+            transformer.instance_type,
+            transformer.volume_kms_key,
         )
 
         return {
@@ -432,7 +445,9 @@ class _TransformJob(_Job):
         }
 
     @staticmethod
-    def _format_inputs_to_input_config(data, data_type, content_type, compression_type, split_type):
+    def _format_inputs_to_input_config(
+        data, data_type, content_type, compression_type, split_type
+    ):
         """
         Args:
             data:
@@ -441,7 +456,9 @@ class _TransformJob(_Job):
             compression_type:
             split_type:
         """
-        config = {"DataSource": {"S3DataSource": {"S3DataType": data_type, "S3Uri": data}}}
+        config = {
+            "DataSource": {"S3DataSource": {"S3DataType": data_type, "S3Uri": data}}
+        }
 
         if content_type is not None:
             config["ContentType"] = content_type
@@ -463,7 +480,9 @@ class _TransformJob(_Job):
             assemble_with:
             accept:
         """
-        config = super(_TransformJob, _TransformJob)._prepare_output_config(s3_path, kms_key_id)
+        config = super(_TransformJob, _TransformJob)._prepare_output_config(
+            s3_path, kms_key_id
+        )
 
         if assemble_with is not None:
             config["AssembleWith"] = assemble_with

--- a/src/sagemaker/user_agent.py
+++ b/src/sagemaker/user_agent.py
@@ -31,11 +31,18 @@ PYTHON_VERSION = "{}.{}.{}".format(
 def determine_prefix():
     """Placeholder docstring"""
     prefix = "AWS-SageMaker-Python-SDK/{} Python/{} {}/{} Boto3/{} Botocore/{}".format(
-        SDK_VERSION, PYTHON_VERSION, OS_NAME, OS_VERSION, boto3.__version__, botocore.__version__
+        SDK_VERSION,
+        PYTHON_VERSION,
+        OS_NAME,
+        OS_VERSION,
+        boto3.__version__,
+        botocore.__version__,
     )
 
     try:
-        with open("/etc/opt/ml/sagemaker-notebook-instance-version.txt") as sagemaker_nbi_file:
+        with open(
+            "/etc/opt/ml/sagemaker-notebook-instance-version.txt"
+        ) as sagemaker_nbi_file:
             prefix = "AWS-SageMaker-Notebook-Instance/{} {}".format(
                 sagemaker_nbi_file.read().strip(), prefix
             )
@@ -56,4 +63,6 @@ def prepend_user_agent(client):
     if client._client_config.user_agent is None:
         client._client_config.user_agent = prefix
     else:
-        client._client_config.user_agent = "{} {}".format(prefix, client._client_config.user_agent)
+        client._client_config.user_agent = "{} {}".format(
+            prefix, client._client_config.user_agent
+        )

--- a/src/sagemaker/utils.py
+++ b/src/sagemaker/utils.py
@@ -205,7 +205,9 @@ def secondary_training_status_changed(current_job_description, prev_job_descript
         boolean: Whether the secondary status message of a training job changed
         or not.
     """
-    current_secondary_status_transitions = current_job_description.get("SecondaryStatusTransitions")
+    current_secondary_status_transitions = current_job_description.get(
+        "SecondaryStatusTransitions"
+    )
     if (
         current_secondary_status_transitions is None
         or len(current_secondary_status_transitions) == 0
@@ -250,7 +252,9 @@ def secondary_training_status_message(job_description, prev_description):
         return ""
 
     prev_description_secondary_transitions = (
-        prev_description.get("SecondaryStatusTransitions") if prev_description is not None else None
+        prev_description.get("SecondaryStatusTransitions")
+        if prev_description is not None
+        else None
     )
     prev_transitions_num = (
         len(prev_description["SecondaryStatusTransitions"])
@@ -488,14 +492,21 @@ def repack_model(
         model_dir = _extract_model(model_uri, sagemaker_session, tmp)
 
         _create_or_update_code_dir(
-            model_dir, inference_script, source_directory, dependencies, sagemaker_session, tmp
+            model_dir,
+            inference_script,
+            source_directory,
+            dependencies,
+            sagemaker_session,
+            tmp,
         )
 
         tmp_model_path = os.path.join(tmp, "temp-model.tar.gz")
         with tarfile.open(tmp_model_path, mode="w:gz") as t:
             t.add(model_dir, arcname=os.path.sep)
 
-        _save_model(repacked_model_uri, tmp_model_path, sagemaker_session, kms_key=kms_key)
+        _save_model(
+            repacked_model_uri, tmp_model_path, sagemaker_session, kms_key=kms_key
+        )
 
 
 def _save_model(repacked_model_uri, tmp_model_path, sagemaker_session, kms_key):
@@ -508,7 +519,9 @@ def _save_model(repacked_model_uri, tmp_model_path, sagemaker_session, kms_key):
     if repacked_model_uri.lower().startswith("s3://"):
         url = parse.urlparse(repacked_model_uri)
         bucket, key = url.netloc, url.path.lstrip("/")
-        new_key = key.replace(os.path.basename(key), os.path.basename(repacked_model_uri))
+        new_key = key.replace(
+            os.path.basename(key), os.path.basename(repacked_model_uri)
+        )
 
         if kms_key:
             extra_args = {"ServerSideEncryption": "aws:kms", "SSEKMSKeyId": kms_key}
@@ -559,7 +572,9 @@ def _create_or_update_code_dir(
     for dependency in dependencies:
         lib_dir = os.path.join(code_dir, "lib")
         if os.path.isdir(dependency):
-            shutil.copytree(dependency, os.path.join(lib_dir, os.path.basename(dependency)))
+            shutil.copytree(
+                dependency, os.path.join(lib_dir, os.path.basename(dependency))
+            )
         else:
             if not os.path.exists(lib_dir):
                 os.mkdir(lib_dir)
@@ -649,7 +664,11 @@ def sts_regional_endpoint(region):
     return "https://{}".format(endpoint_data["hostname"])
 
 
-def retries(max_retry_count, exception_message_prefix, seconds_to_sleep=DEFAULT_SLEEP_TIME_SECONDS):
+def retries(
+    max_retry_count,
+    exception_message_prefix,
+    seconds_to_sleep=DEFAULT_SLEEP_TIME_SECONDS,
+):
     """Retries until max retry count is reached.
 
     Args:

--- a/src/sagemaker/vpc_utils.py
+++ b/src/sagemaker/vpc_utils.py
@@ -99,7 +99,9 @@ def sanitize(vpc_config):
     if subnets is None:
         raise ValueError("vpc_config is missing key: {}".format(SUBNETS_KEY))
     if not isinstance(subnets, list):
-        raise ValueError("vpc_config value for {} is not a list: {}".format(SUBNETS_KEY, subnets))
+        raise ValueError(
+            "vpc_config value for {} is not a list: {}".format(SUBNETS_KEY, subnets)
+        )
     if not subnets:
         raise ValueError("vpc_config value for {} is empty".format(SUBNETS_KEY))
 
@@ -113,6 +115,8 @@ def sanitize(vpc_config):
             )
         )
     if not security_group_ids:
-        raise ValueError("vpc_config value for {} is empty".format(SECURITY_GROUP_IDS_KEY))
+        raise ValueError(
+            "vpc_config value for {} is empty".format(SECURITY_GROUP_IDS_KEY)
+        )
 
     return to_dict(subnets, security_group_ids)

--- a/src/sagemaker/xgboost/__init__.py
+++ b/src/sagemaker/xgboost/__init__.py
@@ -11,6 +11,9 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 """Placeholder docstring"""
-from sagemaker.xgboost.defaults import XGBOOST_NAME, XGBOOST_LATEST_VERSION  # noqa: F401
+from sagemaker.xgboost.defaults import (
+    XGBOOST_NAME,
+    XGBOOST_LATEST_VERSION,
+)  # noqa: F401
 from sagemaker.xgboost.estimator import XGBoost  # noqa: F401
 from sagemaker.xgboost.model import XGBoostModel, XGBoostPredictor  # noqa: F401

--- a/src/sagemaker/xgboost/estimator.py
+++ b/src/sagemaker/xgboost/estimator.py
@@ -106,7 +106,9 @@ class XGBoost(Framework):
         )
 
         if py_version == "py2":
-            raise AttributeError("XGBoost container does not support Python 2, please use Python 3")
+            raise AttributeError(
+                "XGBoost container does not support Python 2, please use Python 3"
+            )
         self.py_version = py_version
 
         if framework_version in defaults.XGBOOST_SUPPORTED_VERSIONS:
@@ -114,7 +116,9 @@ class XGBoost(Framework):
         else:
             raise ValueError(
                 get_unsupported_framework_version_error(
-                    self.__framework_name__, framework_version, defaults.XGBOOST_SUPPORTED_VERSIONS
+                    self.__framework_name__,
+                    framework_version,
+                    defaults.XGBOOST_SUPPORTED_VERSIONS,
                 )
             )
 
@@ -189,7 +193,9 @@ class XGBoost(Framework):
         )
 
     @classmethod
-    def attach(cls, training_job_name, sagemaker_session=None, model_channel_name="model"):
+    def attach(
+        cls, training_job_name, sagemaker_session=None, model_channel_name="model"
+    ):
         """Attach to an existing training job.
 
         Create an Estimator bound to an existing training job, each subclass
@@ -230,7 +236,9 @@ class XGBoost(Framework):
         job_details = sagemaker_session.sagemaker_client.describe_training_job(
             TrainingJobName=training_job_name
         )
-        init_params = cls._prepare_init_params_from_job_description(job_details, model_channel_name)
+        init_params = cls._prepare_init_params_from_job_description(
+            job_details, model_channel_name
+        )
         tags = sagemaker_session.sagemaker_client.list_tags(
             ResourceArn=job_details["TrainingJobArn"]
         )["Tags"]
@@ -251,7 +259,9 @@ class XGBoost(Framework):
         return estimator
 
     @classmethod
-    def _prepare_init_params_from_job_description(cls, job_details, model_channel_name=None):
+    def _prepare_init_params_from_job_description(
+        cls, job_details, model_channel_name=None
+    ):
         """Convert the job description to init params that can be handled by the class constructor
 
         Args:
@@ -261,7 +271,9 @@ class XGBoost(Framework):
              dictionary: The transformed init_params
 
         """
-        init_params = super(XGBoost, cls)._prepare_init_params_from_job_description(job_details)
+        init_params = super(XGBoost, cls)._prepare_init_params_from_job_description(
+            job_details
+        )
 
         image_name = init_params.pop("image")
         framework, py_version, tag, _ = framework_name_from_image(image_name)

--- a/src/sagemaker/xgboost/model.py
+++ b/src/sagemaker/xgboost/model.py
@@ -99,7 +99,9 @@ class XGBoostModel(FrameworkModel):
         )
 
         if py_version == "py2":
-            raise AttributeError("XGBoost container does not support Python 2, please use Python 3")
+            raise AttributeError(
+                "XGBoost container does not support Python 2, please use Python 3"
+            )
 
         self.py_version = py_version
         self.framework_version = framework_version
@@ -125,16 +127,22 @@ class XGBoostModel(FrameworkModel):
                 self.sagemaker_session.boto_region_name, instance_type
             )
 
-        deploy_key_prefix = model_code_key_prefix(self.key_prefix, self.name, deploy_image)
+        deploy_key_prefix = model_code_key_prefix(
+            self.key_prefix, self.name, deploy_image
+        )
         self._upload_code(deploy_key_prefix)
         deploy_env = dict(self.env)
         deploy_env.update(self._framework_env_vars())
 
         if self.model_server_workers:
-            deploy_env[MODEL_SERVER_WORKERS_PARAM_NAME.upper()] = str(self.model_server_workers)
+            deploy_env[MODEL_SERVER_WORKERS_PARAM_NAME.upper()] = str(
+                self.model_server_workers
+            )
         return sagemaker.container_def(deploy_image, self.model_data, deploy_env)
 
-    def serving_image_uri(self, region_name, instance_type):  # pylint: disable=unused-argument
+    def serving_image_uri(
+        self, region_name, instance_type
+    ):  # pylint: disable=unused-argument
         """Create a URI for the serving image.
 
         Args:

--- a/tests/component/test_mxnet_estimator.py
+++ b/tests/component/test_mxnet_estimator.py
@@ -69,7 +69,9 @@ def test_deploy(sagemaker_session, tf_version):
     print("job succeeded: {}".format(estimator.latest_training_job.name))
 
     estimator.deploy(initial_instance_count=1, instance_type=INSTANCE_TYPE_CPU)
-    image = IMAGE_URI_FORMAT_STRING.format(REGION, CPU_IMAGE_NAME, tf_version, "cpu", "py2")
+    image = IMAGE_URI_FORMAT_STRING.format(
+        REGION, CPU_IMAGE_NAME, tf_version, "cpu", "py2"
+    )
     sagemaker_session.create_model.assert_called_with(
         estimator._current_job_name,
         ROLE,

--- a/tests/component/test_tf_estimator.py
+++ b/tests/component/test_tf_estimator.py
@@ -68,7 +68,9 @@ def test_deploy(sagemaker_session, tf_version):
     print("job succeeded: {}".format(estimator.latest_training_job.name))
 
     estimator.deploy(initial_instance_count=1, instance_type=INSTANCE_TYPE_CPU)
-    image = IMAGE_URI_FORMAT_STRING.format(REGION, CPU_IMAGE_NAME, tf_version, "cpu", "py2")
+    image = IMAGE_URI_FORMAT_STRING.format(
+        REGION, CPU_IMAGE_NAME, tf_version, "cpu", "py2"
+    )
     sagemaker_session.create_model.assert_called_with(
         estimator._current_job_name,
         ROLE,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,17 +49,25 @@ def pytest_addoption(parser):
     parser.addoption("--sagemaker-client-config", action="store", default=None)
     parser.addoption("--sagemaker-runtime-config", action="store", default=None)
     parser.addoption("--boto-config", action="store", default=None)
-    parser.addoption("--chainer-full-version", action="store", default=Chainer.LATEST_VERSION)
-    parser.addoption("--mxnet-full-version", action="store", default=MXNet.LATEST_VERSION)
+    parser.addoption(
+        "--chainer-full-version", action="store", default=Chainer.LATEST_VERSION
+    )
+    parser.addoption(
+        "--mxnet-full-version", action="store", default=MXNet.LATEST_VERSION
+    )
     parser.addoption("--ei-mxnet-full-version", action="store", default="1.5.1")
-    parser.addoption("--pytorch-full-version", action="store", default=PyTorch.LATEST_VERSION)
+    parser.addoption(
+        "--pytorch-full-version", action="store", default=PyTorch.LATEST_VERSION
+    )
     parser.addoption(
         "--rl-coach-mxnet-full-version",
         action="store",
         default=RLEstimator.COACH_LATEST_VERSION_MXNET,
     )
     parser.addoption(
-        "--rl-coach-tf-full-version", action="store", default=RLEstimator.COACH_LATEST_VERSION_TF
+        "--rl-coach-tf-full-version",
+        action="store",
+        default=RLEstimator.COACH_LATEST_VERSION_TF,
     )
     parser.addoption(
         "--rl-ray-full-version", action="store", default=RLEstimator.RAY_LATEST_VERSION
@@ -322,7 +330,9 @@ def pytest_generate_tests(metafunc):
         boto_config = metafunc.config.getoption("--boto-config")
         parsed_config = json.loads(boto_config) if boto_config else {}
         region = parsed_config.get("region_name", DEFAULT_REGION)
-        cpu_instance_type = "ml.m5.xlarge" if region in NO_M4_REGIONS else "ml.m4.xlarge"
+        cpu_instance_type = (
+            "ml.m5.xlarge" if region in NO_M4_REGIONS else "ml.m4.xlarge"
+        )
 
         params = [cpu_instance_type]
         if not (

--- a/tests/data/chainer_mnist/distributed_mnist.py
+++ b/tests/data/chainer_mnist/distributed_mnist.py
@@ -45,7 +45,9 @@ class MLP(chainer.Chain):
         return self.l3(h2)
 
 
-def _preprocess_mnist(raw, withlabel, ndim, scale, image_dtype, label_dtype, rgb_format):
+def _preprocess_mnist(
+    raw, withlabel, ndim, scale, image_dtype, label_dtype, rgb_format
+):
     images = raw["x"][-100:]
     if ndim == 2:
         images = images.reshape(-1, 28, 28)
@@ -129,7 +131,9 @@ if __name__ == "__main__":
     )
 
     updater = training.StandardUpdater(train_iter, optimizer, device=device)
-    trainer = training.Trainer(updater, (args.epochs, "epoch"), out=args.output_data_dir)
+    trainer = training.Trainer(
+        updater, (args.epochs, "epoch"), out=args.output_data_dir
+    )
 
     # Create a multi node evaluator from a standard Chainer evaluator.
     evaluator = extensions.Evaluator(test_iter, model, device=device)
@@ -147,7 +151,9 @@ if __name__ == "__main__":
             )
             trainer.extend(
                 extensions.PlotReport(
-                    ["main/accuracy", "validation/main/accuracy"], "epoch", file_name="accuracy.png"
+                    ["main/accuracy", "validation/main/accuracy"],
+                    "epoch",
+                    file_name="accuracy.png",
                 )
             )
         trainer.extend(extensions.snapshot(), trigger=(args.frequency, "epoch"))

--- a/tests/data/chainer_mnist/mnist.py
+++ b/tests/data/chainer_mnist/mnist.py
@@ -41,7 +41,9 @@ class MLP(chainer.Chain):
         return self.l3(h2)
 
 
-def _preprocess_mnist(raw, withlabel, ndim, scale, image_dtype, label_dtype, rgb_format):
+def _preprocess_mnist(
+    raw, withlabel, ndim, scale, image_dtype, label_dtype, rgb_format
+):
     images = raw["x"][-100:]
     if ndim == 2:
         images = images.reshape(-1, 28, 28)
@@ -110,10 +112,14 @@ if __name__ == "__main__":
 
     # Load the MNIST dataset
     train_iter = chainer.iterators.SerialIterator(train, args.batch_size)
-    test_iter = chainer.iterators.SerialIterator(test, args.batch_size, repeat=False, shuffle=False)
+    test_iter = chainer.iterators.SerialIterator(
+        test, args.batch_size, repeat=False, shuffle=False
+    )
 
     # Set up a trainer
-    device = 0 if chainer.cuda.available else -1  # -1 indicates CPU, 0 indicates first GPU device.
+    device = (
+        0 if chainer.cuda.available else -1
+    )  # -1 indicates CPU, 0 indicates first GPU device.
     if chainer.cuda.available:
 
         def device_name(device_intra_rank):
@@ -157,7 +163,9 @@ if __name__ == "__main__":
         )
         trainer.extend(
             extensions.PlotReport(
-                ["main/accuracy", "validation/main/accuracy"], "epoch", file_name="accuracy.png"
+                ["main/accuracy", "validation/main/accuracy"],
+                "epoch",
+                file_name="accuracy.png",
             )
         )
 

--- a/tests/data/coach_cartpole/preset_cartpole_clippedppo.py
+++ b/tests/data/coach_cartpole/preset_cartpole_clippedppo.py
@@ -5,7 +5,12 @@ from rl_coach.base_parameters import (
     PresetValidationParameters,
     DistributedCoachSynchronizationType,
 )
-from rl_coach.core_types import TrainingSteps, EnvironmentEpisodes, EnvironmentSteps, RunPhase
+from rl_coach.core_types import (
+    TrainingSteps,
+    EnvironmentEpisodes,
+    EnvironmentSteps,
+    RunPhase,
+)
 from rl_coach.environments.gym_environment import GymVectorEnvironment, mujoco_v2
 from rl_coach.exploration_policies.additive_noise import AdditiveNoiseParameters
 from rl_coach.exploration_policies.e_greedy import EGreedyParameters
@@ -41,7 +46,9 @@ agent_params.network_wrappers["main"].learning_rate = 0.0003
 agent_params.network_wrappers["main"].input_embedders_parameters[
     "observation"
 ].activation_function = "tanh"
-agent_params.network_wrappers["main"].input_embedders_parameters["observation"].scheme = [Dense(64)]
+agent_params.network_wrappers["main"].input_embedders_parameters[
+    "observation"
+].scheme = [Dense(64)]
 agent_params.network_wrappers["main"].middleware_parameters.scheme = [Dense(64)]
 agent_params.network_wrappers["main"].middleware_parameters.activation_function = "tanh"
 agent_params.network_wrappers["main"].batch_size = 64
@@ -55,7 +62,9 @@ agent_params.algorithm.gae_lambda = 0.95
 agent_params.algorithm.discount = 0.99
 agent_params.algorithm.optimization_epochs = 10
 agent_params.algorithm.estimate_state_value_using_gae = True
-agent_params.algorithm.num_steps_between_copying_online_weights_to_target = EnvironmentSteps(2048)
+agent_params.algorithm.num_steps_between_copying_online_weights_to_target = EnvironmentSteps(
+    2048
+)
 
 # Distributed Coach synchronization type.
 agent_params.algorithm.distributed_coach_synchronization_type = (

--- a/tests/data/multimodel/container/dockerd-entrypoint.py
+++ b/tests/data/multimodel/container/dockerd-entrypoint.py
@@ -30,7 +30,9 @@ def _start_mms():
     # by default the number of workers per model is 1, but we can configure it through the
     # environment variable below if desired.
     # os.environ['SAGEMAKER_MODEL_SERVER_WORKERS'] = '2'
-    model_server.start_model_server(handler_service="/home/model-server/model_handler.py:handle")
+    model_server.start_model_server(
+        handler_service="/home/model-server/model_handler.py:handle"
+    )
 
 
 def main():

--- a/tests/data/multimodel/container/model_handler.py
+++ b/tests/data/multimodel/container/model_handler.py
@@ -50,7 +50,9 @@ class ModelHandler(object):
         self.error = None  # reset earlier errors
 
         try:
-            target_model = context.get_request_header(0, "X-Amzn-SageMaker-Target-Model")
+            target_model = context.get_request_header(
+                0, "X-Amzn-SageMaker-Target-Model"
+            )
             return ["Invoked model: {}".format(target_model)]
         except Exception as e:
             logging.error(e, exc_info=True)

--- a/tests/data/mxnet_mnist/mnist.py
+++ b/tests/data/mxnet_mnist/mnist.py
@@ -27,7 +27,9 @@ def load_data(path):
         labels = np.fromstring(flbl.read(), dtype=np.int8)
     with gzip.open(find_file(path, "images.gz")) as fimg:
         _, _, rows, cols = struct.unpack(">IIII", fimg.read(16))
-        images = np.fromstring(fimg.read(), dtype=np.uint8).reshape(len(labels), rows, cols)
+        images = np.fromstring(fimg.read(), dtype=np.uint8).reshape(
+            len(labels), rows, cols
+        )
         images = images.reshape(images.shape[0], 1, 28, 28).astype(np.float32) / 255
     return labels, images
 
@@ -127,8 +129,12 @@ if __name__ == "__main__":
     parser.add_argument("--train", type=str, default=os.environ["SM_CHANNEL_TRAIN"])
     parser.add_argument("--test", type=str, default=os.environ["SM_CHANNEL_TEST"])
 
-    parser.add_argument("--current-host", type=str, default=os.environ["SM_CURRENT_HOST"])
-    parser.add_argument("--hosts", type=list, default=json.loads(os.environ["SM_HOSTS"]))
+    parser.add_argument(
+        "--current-host", type=str, default=os.environ["SM_CURRENT_HOST"]
+    )
+    parser.add_argument(
+        "--hosts", type=list, default=json.loads(os.environ["SM_HOSTS"])
+    )
 
     args = parser.parse_args()
 

--- a/tests/data/mxnet_mnist/mnist_gluon.py
+++ b/tests/data/mxnet_mnist/mnist_gluon.py
@@ -20,7 +20,10 @@ def parse_args():
         "--context", type=str, default="cpu", help="Context can be either cpu or gpu"
     )
     parser.add_argument(
-        "--validate", type=bool, default=True, help="Run validation if running with smdebug"
+        "--validate",
+        type=bool,
+        default=True,
+        help="Run validation if running with smdebug",
     )
 
     opt = parser.parse_args()
@@ -43,7 +46,9 @@ def train_model(net, epochs, ctx, learning_rate, momentum, train_data, val_data)
     net.initialize(mx.init.Xavier(magnitude=2.24), ctx=ctx)
     # Trainer is for updating parameters with gradient.
     trainer = gluon.Trainer(
-        net.collect_params(), "sgd", {"learning_rate": learning_rate, "momentum": momentum}
+        net.collect_params(),
+        "sgd",
+        {"learning_rate": learning_rate, "momentum": momentum},
     )
     metric = mx.metric.Accuracy()
     loss = gluon.loss.SoftmaxCrossEntropyLoss()

--- a/tests/data/mxnet_mnist/mnist_hosting_with_custom_handlers.py
+++ b/tests/data/mxnet_mnist/mnist_hosting_with_custom_handlers.py
@@ -37,7 +37,9 @@ def model_fn(path_to_model_files):
 # --- Option 1 - provide just 1 entry point for end2end prediction ---
 # if this function is specified, no other overwriting described in Option 2 will have effect
 # returns serialized data and content type it has used
-def transform_fn(model, request_data, input_content_type, requested_output_content_type):
+def transform_fn(
+    model, request_data, input_content_type, requested_output_content_type
+):
     # for demonstration purposes we will be calling handlers from Option2
     return (
         output_fn(
@@ -93,7 +95,10 @@ def handle_s3_file_path(path):
         data = obj.get()["Body"]
     except ClientError as ce:
         raise ValueError(
-            "Can't download from S3 path: " + path + " : " + ce.response["Error"]["Message"]
+            "Can't download from S3 path: "
+            + path
+            + " : "
+            + ce.response["Error"]["Message"]
         )
 
     import StringIO

--- a/tests/data/mxnet_mnist/mnist_neo.py
+++ b/tests/data/mxnet_mnist/mnist_neo.py
@@ -27,7 +27,9 @@ def load_data(path):
         labels = np.fromstring(flbl.read(), dtype=np.int8)
     with gzip.open(find_file(path, "images.gz")) as fimg:
         _, _, rows, cols = struct.unpack(">IIII", fimg.read(16))
-        images = np.fromstring(fimg.read(), dtype=np.uint8).reshape(len(labels), rows, cols)
+        images = np.fromstring(fimg.read(), dtype=np.uint8).reshape(
+            len(labels), rows, cols
+        )
         images = images.reshape(images.shape[0], 1, 28, 28).astype(np.float32) / 255
     return labels, images
 
@@ -142,8 +144,12 @@ if __name__ == "__main__":
     parser.add_argument("--train", type=str, default=os.environ["SM_CHANNEL_TRAIN"])
     parser.add_argument("--test", type=str, default=os.environ["SM_CHANNEL_TEST"])
 
-    parser.add_argument("--current-host", type=str, default=os.environ["SM_CURRENT_HOST"])
-    parser.add_argument("--hosts", type=list, default=json.loads(os.environ["SM_HOSTS"]))
+    parser.add_argument(
+        "--current-host", type=str, default=os.environ["SM_CURRENT_HOST"]
+    )
+    parser.add_argument(
+        "--hosts", type=list, default=json.loads(os.environ["SM_HOSTS"])
+    )
 
     args = parser.parse_args()
 

--- a/tests/data/pytorch_mnist/mnist.py
+++ b/tests/data/pytorch_mnist/mnist.py
@@ -50,7 +50,9 @@ def _get_train_data_loader(training_dir, is_distributed, batch_size, **kwargs):
         download=False,  # True sets a dependency on an external site for our canaries.
     )
     train_sampler = (
-        torch.utils.data.distributed.DistributedSampler(dataset) if is_distributed else None
+        torch.utils.data.distributed.DistributedSampler(dataset)
+        if is_distributed
+        else None
     )
     train_loader = torch.utils.data.DataLoader(
         dataset,
@@ -90,7 +92,11 @@ def _average_gradients(model):
 def train(args):
     world_size = len(args.hosts)
     is_distributed = world_size > 1
-    logger.debug("Number of hosts {}. Distributed training - {}".format(world_size, is_distributed))
+    logger.debug(
+        "Number of hosts {}. Distributed training - {}".format(
+            world_size, is_distributed
+        )
+    )
     use_cuda = args.num_gpus > 0
     logger.debug("Number of gpus available - {}".format(args.num_gpus))
     kwargs = {"num_workers": 1, "pin_memory": True} if use_cuda else {}
@@ -193,8 +199,12 @@ def test(model, test_loader, device):
         for data, target in test_loader:
             data, target = data.to(device), target.to(device)
             output = model(data)
-            test_loss += F.nll_loss(output, target, size_average=False).item()  # sum up batch loss
-            pred = output.max(1, keepdim=True)[1]  # get the index of the max log-probability
+            test_loss += F.nll_loss(
+                output, target, size_average=False
+            ).item()  # sum up batch loss
+            pred = output.max(1, keepdim=True)[
+                1
+            ]  # get the index of the max log-probability
             correct += pred.eq(target.view_as(pred)).sum().item()
 
     test_loss /= len(test_loader.dataset)
@@ -229,10 +239,16 @@ if __name__ == "__main__":
     parser.add_argument("--batch-size", type=int, default=64, metavar="N")
 
     # Container environment
-    parser.add_argument("--hosts", type=list, default=json.loads(os.environ["SM_HOSTS"]))
-    parser.add_argument("--current-host", type=str, default=os.environ["SM_CURRENT_HOST"])
+    parser.add_argument(
+        "--hosts", type=list, default=json.loads(os.environ["SM_HOSTS"])
+    )
+    parser.add_argument(
+        "--current-host", type=str, default=os.environ["SM_CURRENT_HOST"]
+    )
     parser.add_argument("--model-dir", type=str, default=os.environ["SM_MODEL_DIR"])
-    parser.add_argument("--data-dir", type=str, default=os.environ["SM_CHANNEL_TRAINING"])
+    parser.add_argument(
+        "--data-dir", type=str, default=os.environ["SM_CHANNEL_TRAINING"]
+    )
     parser.add_argument("--num-gpus", type=int, default=os.environ["SM_NUM_GPUS"])
     parser.add_argument("--num-cpus", type=int, default=os.environ["SM_NUM_CPUS"])
 

--- a/tests/data/sagemaker_rl/coach_launcher.py
+++ b/tests/data/sagemaker_rl/coach_launcher.py
@@ -66,7 +66,9 @@ class SageMakerCoachPresetLauncher(CoachLauncher):
         args, _ = parser.parse_known_args(args=empty_arg_list)
 
         # Now fill in the args that we care about.
-        sagemaker_job_name = os.environ.get("sagemaker_job_name", "sagemaker-experiment")
+        sagemaker_job_name = os.environ.get(
+            "sagemaker_job_name", "sagemaker-experiment"
+        )
         args.experiment_name = logger.get_experiment_name(sagemaker_job_name)
 
         # Override experiment_path used for outputs
@@ -89,7 +91,9 @@ class SageMakerCoachPresetLauncher(CoachLauncher):
 
         self.hyperparameters = CoachConfigurationList()
         if len(unknown) % 2 == 1:
-            raise ValueError("Odd number of command-line arguments specified. Key without value.")
+            raise ValueError(
+                "Odd number of command-line arguments specified. Key without value."
+            )
 
         for i in range(0, len(unknown), 2):
             name = unknown[i]
@@ -189,7 +193,10 @@ class SageMakerCoachPresetLauncher(CoachLauncher):
     def preset_from_name(self, preset_name):
         preset_path = self.path_of_main_launcher()
         print("Loading preset %s from %s" % (preset_name, preset_path))
-        preset_path = os.path.join(self.path_of_main_launcher(), preset_name) + ".py:graph_manager"
+        preset_path = (
+            os.path.join(self.path_of_main_launcher(), preset_name)
+            + ".py:graph_manager"
+        )
         graph_manager = short_dynamic_import(preset_path, ignore_module_case=True)
         return graph_manager
 
@@ -201,7 +208,9 @@ class SageMakerCoachPresetLauncher(CoachLauncher):
         # Set framework
         # Note: Some graph managers (e.g. HAC preset) create multiple agents and the attribute is called agents_params
         if hasattr(graph_manager, "agent_params"):
-            for network_parameters in graph_manager.agent_params.network_wrappers.values():
+            for (
+                network_parameters
+            ) in graph_manager.agent_params.network_wrappers.values():
                 network_parameters.framework = args.framework
         elif hasattr(graph_manager, "agents_params"):
             for ap in graph_manager.agents_params:
@@ -217,10 +226,12 @@ class SageMakerCoachPresetLauncher(CoachLauncher):
 
         # Re-Initialize from the checkpoint so that you will have the latest models up.
         tf.train.init_from_checkpoint(
-            ckpt_dir, {"main_level/agent/online/network_0/": "main_level/agent/online/network_0"}
+            ckpt_dir,
+            {"main_level/agent/online/network_0/": "main_level/agent/online/network_0"},
         )
         tf.train.init_from_checkpoint(
-            ckpt_dir, {"main_level/agent/online/network_1/": "main_level/agent/online/network_1"}
+            ckpt_dir,
+            {"main_level/agent/online/network_1/": "main_level/agent/online/network_1"},
         )
 
         # Create a new session with a new tf graph.
@@ -294,7 +305,9 @@ class SageMakerCoachLauncher(SageMakerCoachPresetLauncher):
 
     def __init__(self):
         super().__init__()
-        screen.warning("DEPRECATION WARNING: Please switch to SageMakerCoachPresetLauncher")
+        screen.warning(
+            "DEPRECATION WARNING: Please switch to SageMakerCoachPresetLauncher"
+        )
         # TODO: Remove this whole class when nobody's using it any more.
 
     def define_environment(self):

--- a/tests/data/sagemaker_rl/configuration_list.py
+++ b/tests/data/sagemaker_rl/configuration_list.py
@@ -52,7 +52,9 @@ class ConfigurationList(object):
             else:
                 sub_obj = obj.__dict__[top_key]
             # Recurse
-            return self._set_rl_property_value(sub_obj, sub_keys, val, "%s.%s" % (path, top_key))
+            return self._set_rl_property_value(
+                sub_obj, sub_keys, val, "%s.%s" % (path, top_key)
+            )
         else:
             key, val = self._parse_type(key, val)
             if key.startswith("__"):

--- a/tests/data/sklearn_mnist/mnist.py
+++ b/tests/data/sklearn_mnist/mnist.py
@@ -45,7 +45,9 @@ if __name__ == "__main__":
 
     # Data and model checkpoints directories
     parser.add_argument("--epochs", type=int, default=-1)
-    parser.add_argument("--output-data-dir", type=str, default=os.environ["SM_OUTPUT_DATA_DIR"])
+    parser.add_argument(
+        "--output-data-dir", type=str, default=os.environ["SM_OUTPUT_DATA_DIR"]
+    )
     parser.add_argument("--model-dir", type=str, default=os.environ["SM_MODEL_DIR"])
     parser.add_argument("--train", type=str, default=os.environ["SM_CHANNEL_TRAIN"])
     parser.add_argument("--test", type=str, default=os.environ["SM_CHANNEL_TEST"])
@@ -65,7 +67,9 @@ if __name__ == "__main__":
     }
 
     # Preprocess MNIST data
-    train_images, train_labels = preprocess_mnist(train_file, **preprocess_mnist_options)
+    train_images, train_labels = preprocess_mnist(
+        train_file, **preprocess_mnist_options
+    )
     test_images, test_labels = preprocess_mnist(test_file, **preprocess_mnist_options)
 
     # Set up a Support Vector Machine classifier to predict digit from images

--- a/tests/data/tensorflow_mnist/mnist.py
+++ b/tests/data/tensorflow_mnist/mnist.py
@@ -34,7 +34,11 @@ def cnn_model_fn(features, labels, mode):
     # Input Tensor Shape: [batch_size, 28, 28, 1]
     # Output Tensor Shape: [batch_size, 28, 28, 32]
     conv1 = tf.compat.v1.layers.conv2d(
-        inputs=input_layer, filters=32, kernel_size=[5, 5], padding="same", activation=tf.nn.relu
+        inputs=input_layer,
+        filters=32,
+        kernel_size=[5, 5],
+        padding="same",
+        activation=tf.nn.relu,
     )
 
     # Pooling Layer #1
@@ -49,7 +53,11 @@ def cnn_model_fn(features, labels, mode):
     # Input Tensor Shape: [batch_size, 14, 14, 32]
     # Output Tensor Shape: [batch_size, 14, 14, 64]
     conv2 = tf.compat.v1.layers.conv2d(
-        inputs=pool1, filters=64, kernel_size=[5, 5], padding="same", activation=tf.nn.relu
+        inputs=pool1,
+        filters=64,
+        kernel_size=[5, 5],
+        padding="same",
+        activation=tf.nn.relu,
     )
 
     # Pooling Layer #2
@@ -67,7 +75,9 @@ def cnn_model_fn(features, labels, mode):
     # Densely connected layer with 1024 neurons
     # Input Tensor Shape: [batch_size, 7 * 7 * 64]
     # Output Tensor Shape: [batch_size, 1024]
-    dense = tf.compat.v1.layers.dense(inputs=pool2_flat, units=1024, activation=tf.nn.relu)
+    dense = tf.compat.v1.layers.dense(
+        inputs=pool2_flat, units=1024, activation=tf.nn.relu
+    )
 
     # Add dropout operation; 0.6 probability that element will be kept
     dropout = tf.compat.v1.layers.dropout(
@@ -90,19 +100,27 @@ def cnn_model_fn(features, labels, mode):
         return tf.estimator.EstimatorSpec(mode=mode, predictions=predictions)
 
     # Calculate Loss (for both TRAIN and EVAL modes)
-    loss = tf.compat.v1.losses.sparse_softmax_cross_entropy(labels=labels, logits=logits)
+    loss = tf.compat.v1.losses.sparse_softmax_cross_entropy(
+        labels=labels, logits=logits
+    )
 
     # Configure the Training Op (for TRAIN mode)
     if mode == tf.estimator.ModeKeys.TRAIN:
         optimizer = tf.compat.v1.train.GradientDescentOptimizer(learning_rate=0.001)
-        train_op = optimizer.minimize(loss=loss, global_step=tf.compat.v1.train.get_global_step())
+        train_op = optimizer.minimize(
+            loss=loss, global_step=tf.compat.v1.train.get_global_step()
+        )
         return tf.estimator.EstimatorSpec(mode=mode, loss=loss, train_op=train_op)
 
     # Add evaluation metrics (for EVAL mode)
     eval_metric_ops = {
-        "accuracy": tf.compat.v1.metrics.accuracy(labels=labels, predictions=predictions["classes"])
+        "accuracy": tf.compat.v1.metrics.accuracy(
+            labels=labels, predictions=predictions["classes"]
+        )
     }
-    return tf.estimator.EstimatorSpec(mode=mode, loss=loss, eval_metric_ops=eval_metric_ops)
+    return tf.estimator.EstimatorSpec(
+        mode=mode, loss=loss, eval_metric_ops=eval_metric_ops
+    )
 
 
 def _load_training_data(base_dir):
@@ -124,11 +142,19 @@ def _parse_args():
     # hyperparameters sent by the client are passed as command-line arguments to the script.
     parser.add_argument("--epochs", type=int, default=1)
     # Data, model, and output directories
-    parser.add_argument("--output-data-dir", type=str, default=os.environ.get("SM_OUTPUT_DATA_DIR"))
+    parser.add_argument(
+        "--output-data-dir", type=str, default=os.environ.get("SM_OUTPUT_DATA_DIR")
+    )
     parser.add_argument("--model_dir", type=str)
-    parser.add_argument("--train", type=str, default=os.environ.get("SM_CHANNEL_TRAINING"))
-    parser.add_argument("--hosts", type=list, default=json.loads(os.environ.get("SM_HOSTS")))
-    parser.add_argument("--current-host", type=str, default=os.environ.get("SM_CURRENT_HOST"))
+    parser.add_argument(
+        "--train", type=str, default=os.environ.get("SM_CHANNEL_TRAINING")
+    )
+    parser.add_argument(
+        "--hosts", type=list, default=json.loads(os.environ.get("SM_HOSTS"))
+    )
+    parser.add_argument(
+        "--current-host", type=str, default=os.environ.get("SM_CURRENT_HOST")
+    )
 
     return parser.parse_known_args()
 
@@ -150,16 +176,24 @@ if __name__ == "__main__":
     eval_data, eval_labels = _load_testing_data(args.train)
 
     # Create the Estimator
-    mnist_classifier = tf.estimator.Estimator(model_fn=cnn_model_fn, model_dir=args.model_dir)
+    mnist_classifier = tf.estimator.Estimator(
+        model_fn=cnn_model_fn, model_dir=args.model_dir
+    )
 
     # Set up logging for predictions
     # Log the values in the "Softmax" tensor with label "probabilities"
     tensors_to_log = {"probabilities": "softmax_tensor"}
-    logging_hook = tf.estimator.LoggingTensorHook(tensors=tensors_to_log, every_n_iter=50)
+    logging_hook = tf.estimator.LoggingTensorHook(
+        tensors=tensors_to_log, every_n_iter=50
+    )
 
     # Train the model
     train_input_fn = tf.compat.v1.estimator.inputs.numpy_input_fn(
-        x={"x": train_data}, y=train_labels, batch_size=50, num_epochs=None, shuffle=True
+        x={"x": train_data},
+        y=train_labels,
+        batch_size=50,
+        num_epochs=None,
+        shuffle=True,
     )
 
     # Evaluate the model and print results

--- a/tests/integ/__init__.py
+++ b/tests/integ/__init__.py
@@ -75,7 +75,13 @@ EI_SUPPORTED_REGIONS = [
 ]
 
 NO_LDA_REGIONS = ["eu-west-3", "eu-north-1", "sa-east-1", "ap-east-1", "me-south-1"]
-NO_MARKET_PLACE_REGIONS = ["eu-west-3", "eu-north-1", "sa-east-1", "ap-east-1", "me-south-1"]
+NO_MARKET_PLACE_REGIONS = [
+    "eu-west-3",
+    "eu-north-1",
+    "sa-east-1",
+    "ap-east-1",
+    "me-south-1",
+]
 NO_AUTO_ML_REGIONS = ["sa-east-1", "me-south-1", "ap-east-1", "eu-west-3"]
 NO_MODEL_MONITORING_REGIONS = ["me-south-1"]
 

--- a/tests/integ/auto_ml_utils.py
+++ b/tests/integ/auto_ml_utils.py
@@ -37,6 +37,8 @@ def create_auto_ml_job_if_not_exist(sagemaker_session):
             sagemaker_session=sagemaker_session,
             max_candidates=3,
         )
-        inputs = sagemaker_session.upload_data(path=TRAINING_DATA, key_prefix=PREFIX + "/input")
+        inputs = sagemaker_session.upload_data(
+            path=TRAINING_DATA, key_prefix=PREFIX + "/input"
+        )
         with timeout(minutes=AUTO_ML_DEFAULT_TIMEMOUT_MINUTES):
             auto_ml.fit(inputs, job_name=auto_ml_job_name, wait=True)

--- a/tests/integ/kms_utils.py
+++ b/tests/integ/kms_utils.py
@@ -18,7 +18,8 @@ import json
 from sagemaker import utils
 
 PRINCIPAL_TEMPLATE = (
-    '["{account_id}", "{role_arn}", ' '"arn:{partition}:iam::{account_id}:role/{sagemaker_role}"] '
+    '["{account_id}", "{role_arn}", '
+    '"arn:{partition}:iam::{account_id}:role/{sagemaker_role}"] '
 )
 
 KEY_ALIAS = "SageMakerTestKMSKey"
@@ -60,7 +61,12 @@ def _get_kms_key_id(kms_client, alias):
 
 
 def _create_kms_key(
-    kms_client, account_id, region, role_arn=None, sagemaker_role="SageMakerRole", alias=KEY_ALIAS
+    kms_client,
+    account_id,
+    region,
+    role_arn=None,
+    sagemaker_role="SageMakerRole",
+    alias=KEY_ALIAS,
 ):
     if role_arn:
         principal = PRINCIPAL_TEMPLATE.format(
@@ -86,7 +92,12 @@ def _create_kms_key(
 
 
 def _add_role_to_policy(
-    kms_client, account_id, role_arn, region, alias=KEY_ALIAS, sagemaker_role="SageMakerRole"
+    kms_client,
+    account_id,
+    role_arn,
+    region,
+    alias=KEY_ALIAS,
+    sagemaker_role="SageMakerRole",
 ):
     key_id = _get_kms_key_id(kms_client, alias)
     policy = kms_client.get_key_policy(KeyId=key_id, PolicyName=POLICY_NAME)
@@ -121,10 +132,14 @@ def get_or_create_kms_key(
     account_id = sts_client.get_caller_identity()["Account"]
 
     if kms_key_arn is None:
-        return _create_kms_key(kms_client, account_id, region, role_arn, sagemaker_role, alias)
+        return _create_kms_key(
+            kms_client, account_id, region, role_arn, sagemaker_role, alias
+        )
 
     if role_arn:
-        _add_role_to_policy(kms_client, account_id, role_arn, region, alias, sagemaker_role)
+        _add_role_to_policy(
+            kms_client, account_id, role_arn, region, alias, sagemaker_role
+        )
 
     return kms_key_arn
 
@@ -173,12 +188,16 @@ def bucket_with_encryption(sagemaker_session, sagemaker_role):
     role_arn = sts_client.get_caller_identity()["Arn"]
 
     kms_client = boto_session.client("kms", region_name=region)
-    kms_key_arn = _create_kms_key(kms_client, account, region, role_arn, sagemaker_role, None)
+    kms_key_arn = _create_kms_key(
+        kms_client, account, region, role_arn, sagemaker_role, None
+    )
 
     region = boto_session.region_name
     bucket_name = "sagemaker-{}-{}-with-kms".format(region, account)
 
-    sagemaker_session._create_s3_bucket_if_it_does_not_exist(bucket_name=bucket_name, region=region)
+    sagemaker_session._create_s3_bucket_if_it_does_not_exist(
+        bucket_name=bucket_name, region=region
+    )
 
     s3_client = boto_session.client("s3", region_name=region)
     s3_client.put_bucket_encryption(

--- a/tests/integ/record_set.py
+++ b/tests/integ/record_set.py
@@ -35,5 +35,9 @@ def prepare_record_set_from_local_files(
     key_prefix = urlparse(destination).path
     key_prefix = key_prefix + "{}-{}".format("testfiles", sagemaker_timestamp())
     key_prefix = key_prefix.lstrip("/")
-    uploaded_location = sagemaker_session.upload_data(path=dir_path, key_prefix=key_prefix)
-    return RecordSet(uploaded_location, num_records, feature_dim, s3_data_type="S3Prefix")
+    uploaded_location = sagemaker_session.upload_data(
+        path=dir_path, key_prefix=key_prefix
+    )
+    return RecordSet(
+        uploaded_location, num_records, feature_dim, s3_data_type="S3Prefix"
+    )

--- a/tests/integ/retry.py
+++ b/tests/integ/retry.py
@@ -17,7 +17,11 @@ import time
 DEFAULT_SLEEP_TIME_SECONDS = 10
 
 
-def retries(max_retry_count, exception_message_prefix, seconds_to_sleep=DEFAULT_SLEEP_TIME_SECONDS):
+def retries(
+    max_retry_count,
+    exception_message_prefix,
+    seconds_to_sleep=DEFAULT_SLEEP_TIME_SECONDS,
+):
     for i in range(max_retry_count):
         yield i
         time.sleep(seconds_to_sleep)

--- a/tests/integ/s3_utils.py
+++ b/tests/integ/s3_utils.py
@@ -20,9 +20,9 @@ def assert_s3_files_exist(sagemaker_session, s3_url, files):
     parsed_url = urlparse(s3_url)
     region = sagemaker_session.boto_region_name
     s3 = boto3.client("s3", region_name=region)
-    contents = s3.list_objects_v2(Bucket=parsed_url.netloc, Prefix=parsed_url.path.lstrip("/"))[
-        "Contents"
-    ]
+    contents = s3.list_objects_v2(
+        Bucket=parsed_url.netloc, Prefix=parsed_url.path.lstrip("/")
+    )["Contents"]
     for f in files:
         found = [x["Key"] for x in contents if x["Key"].endswith(f)]
         if not found:

--- a/tests/integ/test_airflow_config.py
+++ b/tests/integ/test_airflow_config.py
@@ -46,8 +46,12 @@ from sagemaker.utils import sagemaker_timestamp
 
 import airflow
 from airflow import DAG
-from airflow.contrib.operators.sagemaker_training_operator import SageMakerTrainingOperator
-from airflow.contrib.operators.sagemaker_transform_operator import SageMakerTransformOperator
+from airflow.contrib.operators.sagemaker_training_operator import (
+    SageMakerTrainingOperator,
+)
+from airflow.contrib.operators.sagemaker_transform_operator import (
+    SageMakerTransformOperator,
+)
 
 from sagemaker.xgboost import XGBoost
 from tests.integ import DATA_DIR, PYTHON_VERSION
@@ -76,7 +80,8 @@ def test_byo_airflow_config_uploads_data_source_to_s3_when_inputs_provided(
 
         data_source_location = "test-airflow-config-{}".format(sagemaker_timestamp())
         inputs = sagemaker_session.upload_data(
-            path=training_data_path, key_prefix=os.path.join(data_source_location, "train")
+            path=training_data_path,
+            key_prefix=os.path.join(data_source_location, "train"),
         )
 
         estimator = Estimator(
@@ -95,12 +100,16 @@ def test_byo_airflow_config_uploads_data_source_to_s3_when_inputs_provided(
 
         _assert_that_s3_url_contains_data(
             sagemaker_session,
-            training_config["InputDataConfig"][0]["DataSource"]["S3DataSource"]["S3Uri"],
+            training_config["InputDataConfig"][0]["DataSource"]["S3DataSource"][
+                "S3Uri"
+            ],
         )
 
 
 @pytest.mark.canary_quick
-def test_kmeans_airflow_config_uploads_data_source_to_s3(sagemaker_session, cpu_instance_type):
+def test_kmeans_airflow_config_uploads_data_source_to_s3(
+    sagemaker_session, cpu_instance_type
+):
     with timeout(seconds=AIRFLOW_CONFIG_TIMEOUT_IN_SECONDS):
         data_path = os.path.join(DATA_DIR, "one_p_mnist", "mnist.pkl.gz")
         pickle_args = {} if sys.version_info.major == 2 else {"encoding": "latin1"}
@@ -135,11 +144,15 @@ def test_kmeans_airflow_config_uploads_data_source_to_s3(sagemaker_session, cpu_
 
         _assert_that_s3_url_contains_data(
             sagemaker_session,
-            training_config["InputDataConfig"][0]["DataSource"]["S3DataSource"]["S3Uri"],
+            training_config["InputDataConfig"][0]["DataSource"]["S3DataSource"][
+                "S3Uri"
+            ],
         )
 
 
-def test_fm_airflow_config_uploads_data_source_to_s3(sagemaker_session, cpu_instance_type):
+def test_fm_airflow_config_uploads_data_source_to_s3(
+    sagemaker_session, cpu_instance_type
+):
     with timeout(seconds=AIRFLOW_CONFIG_TIMEOUT_IN_SECONDS):
         data_path = os.path.join(DATA_DIR, "one_p_mnist", "mnist.pkl.gz")
         pickle_args = {} if sys.version_info.major == 2 else {"encoding": "latin1"}
@@ -161,7 +174,9 @@ def test_fm_airflow_config_uploads_data_source_to_s3(sagemaker_session, cpu_inst
             sagemaker_session=sagemaker_session,
         )
 
-        records = fm.record_set(train_set[0][:200], train_set[1][:200].astype("float32"))
+        records = fm.record_set(
+            train_set[0][:200], train_set[1][:200].astype("float32")
+        )
 
         training_config = _build_airflow_workflow(
             estimator=fm, instance_type=cpu_instance_type, inputs=records
@@ -169,12 +184,16 @@ def test_fm_airflow_config_uploads_data_source_to_s3(sagemaker_session, cpu_inst
 
         _assert_that_s3_url_contains_data(
             sagemaker_session,
-            training_config["InputDataConfig"][0]["DataSource"]["S3DataSource"]["S3Uri"],
+            training_config["InputDataConfig"][0]["DataSource"]["S3DataSource"][
+                "S3Uri"
+            ],
         )
 
 
 @pytest.mark.canary_quick
-def test_ipinsights_airflow_config_uploads_data_source_to_s3(sagemaker_session, cpu_instance_type):
+def test_ipinsights_airflow_config_uploads_data_source_to_s3(
+    sagemaker_session, cpu_instance_type
+):
     with timeout(seconds=AIRFLOW_CONFIG_TIMEOUT_IN_SECONDS):
         data_path = os.path.join(DATA_DIR, "ipinsights")
         data_filename = "train.csv"
@@ -201,11 +220,15 @@ def test_ipinsights_airflow_config_uploads_data_source_to_s3(sagemaker_session, 
 
         _assert_that_s3_url_contains_data(
             sagemaker_session,
-            training_config["InputDataConfig"][0]["DataSource"]["S3DataSource"]["S3Uri"],
+            training_config["InputDataConfig"][0]["DataSource"]["S3DataSource"][
+                "S3Uri"
+            ],
         )
 
 
-def test_knn_airflow_config_uploads_data_source_to_s3(sagemaker_session, cpu_instance_type):
+def test_knn_airflow_config_uploads_data_source_to_s3(
+    sagemaker_session, cpu_instance_type
+):
     with timeout(seconds=AIRFLOW_CONFIG_TIMEOUT_IN_SECONDS):
         data_path = os.path.join(DATA_DIR, "one_p_mnist", "mnist.pkl.gz")
         pickle_args = {} if sys.version_info.major == 2 else {"encoding": "latin1"}
@@ -224,7 +247,9 @@ def test_knn_airflow_config_uploads_data_source_to_s3(sagemaker_session, cpu_ins
             sagemaker_session=sagemaker_session,
         )
 
-        records = knn.record_set(train_set[0][:200], train_set[1][:200].astype("float32"))
+        records = knn.record_set(
+            train_set[0][:200], train_set[1][:200].astype("float32")
+        )
 
         training_config = _build_airflow_workflow(
             estimator=knn, instance_type=cpu_instance_type, inputs=records
@@ -232,7 +257,9 @@ def test_knn_airflow_config_uploads_data_source_to_s3(sagemaker_session, cpu_ins
 
         _assert_that_s3_url_contains_data(
             sagemaker_session,
-            training_config["InputDataConfig"][0]["DataSource"]["S3DataSource"]["S3Uri"],
+            training_config["InputDataConfig"][0]["DataSource"]["S3DataSource"][
+                "S3Uri"
+            ],
         )
 
 
@@ -241,7 +268,9 @@ def test_knn_airflow_config_uploads_data_source_to_s3(sagemaker_session, cpu_ins
     reason="LDA image is not supported in certain regions",
 )
 @pytest.mark.canary_quick
-def test_lda_airflow_config_uploads_data_source_to_s3(sagemaker_session, cpu_instance_type):
+def test_lda_airflow_config_uploads_data_source_to_s3(
+    sagemaker_session, cpu_instance_type
+):
     with timeout(seconds=AIRFLOW_CONFIG_TIMEOUT_IN_SECONDS):
         data_path = os.path.join(DATA_DIR, "lda")
         data_filename = "nips-train_1.pbr"
@@ -260,16 +289,25 @@ def test_lda_airflow_config_uploads_data_source_to_s3(sagemaker_session, cpu_ins
         )
 
         records = prepare_record_set_from_local_files(
-            data_path, lda.data_location, len(all_records), feature_num, sagemaker_session
+            data_path,
+            lda.data_location,
+            len(all_records),
+            feature_num,
+            sagemaker_session,
         )
 
         training_config = _build_airflow_workflow(
-            estimator=lda, instance_type=cpu_instance_type, inputs=records, mini_batch_size=100
+            estimator=lda,
+            instance_type=cpu_instance_type,
+            inputs=records,
+            mini_batch_size=100,
         )
 
         _assert_that_s3_url_contains_data(
             sagemaker_session,
-            training_config["InputDataConfig"][0]["DataSource"]["S3DataSource"]["S3Uri"],
+            training_config["InputDataConfig"][0]["DataSource"]["S3DataSource"][
+                "S3Uri"
+            ],
         )
 
 
@@ -340,12 +378,16 @@ def test_linearlearner_airflow_config_uploads_data_source_to_s3(
 
         _assert_that_s3_url_contains_data(
             sagemaker_session,
-            training_config["InputDataConfig"][0]["DataSource"]["S3DataSource"]["S3Uri"],
+            training_config["InputDataConfig"][0]["DataSource"]["S3DataSource"][
+                "S3Uri"
+            ],
         )
 
 
 @pytest.mark.canary_quick
-def test_ntm_airflow_config_uploads_data_source_to_s3(sagemaker_session, cpu_instance_type):
+def test_ntm_airflow_config_uploads_data_source_to_s3(
+    sagemaker_session, cpu_instance_type
+):
     with timeout(seconds=AIRFLOW_CONFIG_TIMEOUT_IN_SECONDS):
         data_path = os.path.join(DATA_DIR, "ntm")
         data_filename = "nips-train_1.pbr"
@@ -365,7 +407,11 @@ def test_ntm_airflow_config_uploads_data_source_to_s3(sagemaker_session, cpu_ins
         )
 
         records = prepare_record_set_from_local_files(
-            data_path, ntm.data_location, len(all_records), feature_num, sagemaker_session
+            data_path,
+            ntm.data_location,
+            len(all_records),
+            feature_num,
+            sagemaker_session,
         )
 
         training_config = _build_airflow_workflow(
@@ -374,12 +420,16 @@ def test_ntm_airflow_config_uploads_data_source_to_s3(sagemaker_session, cpu_ins
 
         _assert_that_s3_url_contains_data(
             sagemaker_session,
-            training_config["InputDataConfig"][0]["DataSource"]["S3DataSource"]["S3Uri"],
+            training_config["InputDataConfig"][0]["DataSource"]["S3DataSource"][
+                "S3Uri"
+            ],
         )
 
 
 @pytest.mark.canary_quick
-def test_pca_airflow_config_uploads_data_source_to_s3(sagemaker_session, cpu_instance_type):
+def test_pca_airflow_config_uploads_data_source_to_s3(
+    sagemaker_session, cpu_instance_type
+):
     with timeout(seconds=AIRFLOW_CONFIG_TIMEOUT_IN_SECONDS):
         data_path = os.path.join(DATA_DIR, "one_p_mnist", "mnist.pkl.gz")
         pickle_args = {} if sys.version_info.major == 2 else {"encoding": "latin1"}
@@ -408,12 +458,16 @@ def test_pca_airflow_config_uploads_data_source_to_s3(sagemaker_session, cpu_ins
 
         _assert_that_s3_url_contains_data(
             sagemaker_session,
-            training_config["InputDataConfig"][0]["DataSource"]["S3DataSource"]["S3Uri"],
+            training_config["InputDataConfig"][0]["DataSource"]["S3DataSource"][
+                "S3Uri"
+            ],
         )
 
 
 @pytest.mark.canary_quick
-def test_rcf_airflow_config_uploads_data_source_to_s3(sagemaker_session, cpu_instance_type):
+def test_rcf_airflow_config_uploads_data_source_to_s3(
+    sagemaker_session, cpu_instance_type
+):
     with timeout(seconds=AIRFLOW_CONFIG_TIMEOUT_IN_SECONDS):
         # Generate a thousand 14-dimensional datapoints.
         feature_num = 14
@@ -437,7 +491,9 @@ def test_rcf_airflow_config_uploads_data_source_to_s3(sagemaker_session, cpu_ins
 
         _assert_that_s3_url_contains_data(
             sagemaker_session,
-            training_config["InputDataConfig"][0]["DataSource"]["S3DataSource"]["S3Uri"],
+            training_config["InputDataConfig"][0]["DataSource"]["S3DataSource"][
+                "S3Uri"
+            ],
         )
 
 
@@ -531,10 +587,12 @@ def test_sklearn_airflow_config_uploads_data_source_to_s3(
         )
 
         train_input = sklearn.sagemaker_session.upload_data(
-            path=os.path.join(data_path, "train"), key_prefix="integ-test-data/sklearn_mnist/train"
+            path=os.path.join(data_path, "train"),
+            key_prefix="integ-test-data/sklearn_mnist/train",
         )
         test_input = sklearn.sagemaker_session.upload_data(
-            path=os.path.join(data_path, "test"), key_prefix="integ-test-data/sklearn_mnist/test"
+            path=os.path.join(data_path, "test"),
+            key_prefix="integ-test-data/sklearn_mnist/test",
         )
 
         training_config = _build_airflow_workflow(
@@ -550,7 +608,9 @@ def test_sklearn_airflow_config_uploads_data_source_to_s3(
 
 
 @pytest.mark.canary_quick
-def test_tf_airflow_config_uploads_data_source_to_s3(sagemaker_session, cpu_instance_type):
+def test_tf_airflow_config_uploads_data_source_to_s3(
+    sagemaker_session, cpu_instance_type
+):
     with timeout(seconds=AIRFLOW_CONFIG_TIMEOUT_IN_SECONDS):
         tf = TensorFlow(
             image_name=get_image_uri(
@@ -569,7 +629,8 @@ def test_tf_airflow_config_uploads_data_source_to_s3(sagemaker_session, cpu_inst
             ],
         )
         inputs = tf.sagemaker_session.upload_data(
-            path=os.path.join(TF_MNIST_RESOURCE_PATH, "data"), key_prefix="scriptmode/mnist"
+            path=os.path.join(TF_MNIST_RESOURCE_PATH, "data"),
+            key_prefix="scriptmode/mnist",
         )
 
         training_config = _build_airflow_workflow(
@@ -583,7 +644,9 @@ def test_tf_airflow_config_uploads_data_source_to_s3(sagemaker_session, cpu_inst
 
 
 @pytest.mark.canary_quick
-def test_xgboost_airflow_config_uploads_data_source_to_s3(sagemaker_session, cpu_instance_type):
+def test_xgboost_airflow_config_uploads_data_source_to_s3(
+    sagemaker_session, cpu_instance_type
+):
     with timeout(seconds=AIRFLOW_CONFIG_TIMEOUT_IN_SECONDS):
         xgboost = XGBoost(
             entry_point=os.path.join(DATA_DIR, "dummy_script.py"),
@@ -663,7 +726,9 @@ def _assert_that_s3_url_contains_data(sagemaker_session, s3_url):
     assert s3_request["KeyCount"] > 0
 
 
-def _build_airflow_workflow(estimator, instance_type, inputs=None, mini_batch_size=None):
+def _build_airflow_workflow(
+    estimator, instance_type, inputs=None, mini_batch_size=None
+):
     training_config = sm_airflow.training_config(
         estimator=estimator, inputs=inputs, mini_batch_size=mini_batch_size
     )
@@ -692,14 +757,19 @@ def _build_airflow_workflow(estimator, instance_type, inputs=None, mini_batch_si
         "provide_context": True,
     }
 
-    dag = DAG("tensorflow_example", default_args=default_args, schedule_interval="@once")
+    dag = DAG(
+        "tensorflow_example", default_args=default_args, schedule_interval="@once"
+    )
 
     train_op = SageMakerTrainingOperator(
         task_id="tf_training", config=training_config, wait_for_completion=True, dag=dag
     )
 
     transform_op = SageMakerTransformOperator(
-        task_id="transform_operator", config=transform_config, wait_for_completion=True, dag=dag
+        task_id="transform_operator",
+        config=transform_config,
+        wait_for_completion=True,
+        dag=dag,
     )
 
     transform_op.set_upstream(train_op)

--- a/tests/integ/test_auto_ml.py
+++ b/tests/integ/test_auto_ml.py
@@ -61,7 +61,9 @@ def test_auto_ml_fit(sagemaker_session):
     )
 
     job_name = unique_name_from_base("auto-ml", max_length=32)
-    inputs = sagemaker_session.upload_data(path=TRAINING_DATA, key_prefix=PREFIX + "/input")
+    inputs = sagemaker_session.upload_data(
+        path=TRAINING_DATA, key_prefix=PREFIX + "/input"
+    )
     with timeout(minutes=AUTO_ML_DEFAULT_TIMEMOUT_MINUTES):
         auto_ml.fit(inputs, job_name=job_name)
 
@@ -96,7 +98,9 @@ def test_auto_ml_input_object_fit(sagemaker_session):
         max_candidates=1,
     )
     job_name = unique_name_from_base("auto-ml", max_length=32)
-    s3_input = sagemaker_session.upload_data(path=TRAINING_DATA, key_prefix=PREFIX + "/input")
+    s3_input = sagemaker_session.upload_data(
+        path=TRAINING_DATA, key_prefix=PREFIX + "/input"
+    )
     inputs = AutoMLInput(inputs=s3_input, target_attribute_name=TARGET_ATTRIBUTE_NAME)
     with timeout(minutes=AUTO_ML_DEFAULT_TIMEMOUT_MINUTES):
         auto_ml.fit(inputs, job_name=job_name)
@@ -107,7 +111,9 @@ def test_auto_ml_input_object_fit(sagemaker_session):
     reason="AutoML is not supported in the region yet.",
 )
 def test_auto_ml_fit_optional_args(sagemaker_session):
-    output_path = "s3://{}/{}".format(sagemaker_session.default_bucket(), "specified_ouput_path")
+    output_path = "s3://{}/{}".format(
+        sagemaker_session.default_bucket(), "specified_ouput_path"
+    )
     problem_type = "MulticlassClassification"
     job_objective = {"MetricName": "Accuracy"}
     auto_ml = AutoML(
@@ -123,7 +129,9 @@ def test_auto_ml_fit_optional_args(sagemaker_session):
     with timeout(minutes=AUTO_ML_DEFAULT_TIMEMOUT_MINUTES):
         auto_ml.fit(inputs, job_name=unique_name_from_base(BASE_JOB_NAME))
 
-    auto_ml_desc = auto_ml.describe_auto_ml_job(job_name=auto_ml.latest_auto_ml_job.job_name)
+    auto_ml_desc = auto_ml.describe_auto_ml_job(
+        job_name=auto_ml.latest_auto_ml_job.job_name
+    )
     assert auto_ml_desc["AutoMLJobStatus"] == "Completed"
     assert auto_ml_desc["AutoMLJobName"] == auto_ml.latest_auto_ml_job.job_name
     assert auto_ml_desc["AutoMLJobObjective"] == job_objective
@@ -137,12 +145,18 @@ def test_auto_ml_fit_optional_args(sagemaker_session):
 )
 def test_auto_ml_invalid_target_attribute(sagemaker_session):
     auto_ml = AutoML(
-        role=ROLE, target_attribute_name="y", sagemaker_session=sagemaker_session, max_candidates=1
+        role=ROLE,
+        target_attribute_name="y",
+        sagemaker_session=sagemaker_session,
+        max_candidates=1,
     )
     job_name = unique_name_from_base("auto-ml", max_length=32)
-    inputs = sagemaker_session.upload_data(path=TRAINING_DATA, key_prefix=PREFIX + "/input")
+    inputs = sagemaker_session.upload_data(
+        path=TRAINING_DATA, key_prefix=PREFIX + "/input"
+    )
     with pytest.raises(
-        UnexpectedStatusException, match="Could not complete the data builder processing job."
+        UnexpectedStatusException,
+        match="Could not complete the data builder processing job.",
     ):
         auto_ml.fit(inputs, job_name=job_name)
 
@@ -171,7 +185,9 @@ def test_auto_ml_describe_auto_ml_job(sagemaker_session):
 
     auto_ml_utils.create_auto_ml_job_if_not_exist(sagemaker_session)
     auto_ml = AutoML(
-        role=ROLE, target_attribute_name=TARGET_ATTRIBUTE_NAME, sagemaker_session=sagemaker_session
+        role=ROLE,
+        target_attribute_name=TARGET_ATTRIBUTE_NAME,
+        sagemaker_session=sagemaker_session,
     )
 
     desc = auto_ml.describe_auto_ml_job(job_name=AUTO_ML_JOB_NAME)
@@ -227,7 +243,9 @@ def test_list_candidates(sagemaker_session):
     auto_ml_utils.create_auto_ml_job_if_not_exist(sagemaker_session)
 
     auto_ml = AutoML(
-        role=ROLE, target_attribute_name=TARGET_ATTRIBUTE_NAME, sagemaker_session=sagemaker_session
+        role=ROLE,
+        target_attribute_name=TARGET_ATTRIBUTE_NAME,
+        sagemaker_session=sagemaker_session,
     )
 
     candidates = auto_ml.list_candidates(job_name=AUTO_ML_JOB_NAME)
@@ -242,7 +260,9 @@ def test_best_candidate(sagemaker_session):
     auto_ml_utils.create_auto_ml_job_if_not_exist(sagemaker_session)
 
     auto_ml = AutoML(
-        role=ROLE, target_attribute_name=TARGET_ATTRIBUTE_NAME, sagemaker_session=sagemaker_session
+        role=ROLE,
+        target_attribute_name=TARGET_ATTRIBUTE_NAME,
+        sagemaker_session=sagemaker_session,
     )
     best_candidate = auto_ml.best_candidate(job_name=AUTO_ML_JOB_NAME)
     assert len(best_candidate["InferenceContainers"]) == 3
@@ -259,7 +279,9 @@ def test_deploy_best_candidate(sagemaker_session, cpu_instance_type):
     auto_ml_utils.create_auto_ml_job_if_not_exist(sagemaker_session)
 
     auto_ml = AutoML(
-        role=ROLE, target_attribute_name=TARGET_ATTRIBUTE_NAME, sagemaker_session=sagemaker_session
+        role=ROLE,
+        target_attribute_name=TARGET_ATTRIBUTE_NAME,
+        sagemaker_session=sagemaker_session,
     )
     best_candidate = auto_ml.best_candidate(job_name=AUTO_ML_JOB_NAME)
     endpoint_name = unique_name_from_base("sagemaker-auto-ml-best-candidate-test")
@@ -286,7 +308,9 @@ def test_deploy_best_candidate(sagemaker_session, cpu_instance_type):
 def test_create_model_best_candidate(sagemaker_session, cpu_instance_type):
     auto_ml_utils.create_auto_ml_job_if_not_exist(sagemaker_session)
 
-    auto_ml = AutoML.attach(auto_ml_job_name=AUTO_ML_JOB_NAME, sagemaker_session=sagemaker_session)
+    auto_ml = AutoML.attach(
+        auto_ml_job_name=AUTO_ML_JOB_NAME, sagemaker_session=sagemaker_session
+    )
     best_candidate = auto_ml.best_candidate()
 
     with timeout(minutes=5):
@@ -306,20 +330,28 @@ def test_create_model_best_candidate(sagemaker_session, cpu_instance_type):
         instance_count=1,
         instance_type=cpu_instance_type,
         assemble_with="Line",
-        output_path="s3://{}/{}".format(sagemaker_session.default_bucket(), "transform_test"),
+        output_path="s3://{}/{}".format(
+            sagemaker_session.default_bucket(), "transform_test"
+        ),
         accept="text/csv",
-    ).transform(data=inputs, content_type="text/csv", split_type="Line", join_source="Input")
+    ).transform(
+        data=inputs, content_type="text/csv", split_type="Line", join_source="Input"
+    )
 
 
 @pytest.mark.skipif(
     tests.integ.test_region() in tests.integ.NO_AUTO_ML_REGIONS,
     reason="AutoML is not supported in the region yet.",
 )
-def test_candidate_estimator_default_rerun_and_deploy(sagemaker_session, cpu_instance_type):
+def test_candidate_estimator_default_rerun_and_deploy(
+    sagemaker_session, cpu_instance_type
+):
     auto_ml_utils.create_auto_ml_job_if_not_exist(sagemaker_session)
 
     auto_ml = AutoML(
-        role=ROLE, target_attribute_name=TARGET_ATTRIBUTE_NAME, sagemaker_session=sagemaker_session
+        role=ROLE,
+        target_attribute_name=TARGET_ATTRIBUTE_NAME,
+        sagemaker_session=sagemaker_session,
     )
 
     candidates = auto_ml.list_candidates(job_name=AUTO_ML_JOB_NAME)
@@ -348,11 +380,15 @@ def test_candidate_estimator_default_rerun_and_deploy(sagemaker_session, cpu_ins
     tests.integ.test_region() in tests.integ.NO_AUTO_ML_REGIONS,
     reason="AutoML is not supported in the region yet.",
 )
-def test_candidate_estimator_rerun_with_optional_args(sagemaker_session, cpu_instance_type):
+def test_candidate_estimator_rerun_with_optional_args(
+    sagemaker_session, cpu_instance_type
+):
     auto_ml_utils.create_auto_ml_job_if_not_exist(sagemaker_session)
 
     auto_ml = AutoML(
-        role=ROLE, target_attribute_name=TARGET_ATTRIBUTE_NAME, sagemaker_session=sagemaker_session
+        role=ROLE,
+        target_attribute_name=TARGET_ATTRIBUTE_NAME,
+        sagemaker_session=sagemaker_session,
     )
 
     candidates = auto_ml.list_candidates(job_name=AUTO_ML_JOB_NAME)
@@ -385,7 +421,9 @@ def test_candidate_estimator_get_steps(sagemaker_session):
     auto_ml_utils.create_auto_ml_job_if_not_exist(sagemaker_session)
 
     auto_ml = AutoML(
-        role=ROLE, target_attribute_name=TARGET_ATTRIBUTE_NAME, sagemaker_session=sagemaker_session
+        role=ROLE,
+        target_attribute_name=TARGET_ATTRIBUTE_NAME,
+        sagemaker_session=sagemaker_session,
     )
     candidates = auto_ml.list_candidates(job_name=AUTO_ML_JOB_NAME)
     candidate = candidates[1]

--- a/tests/integ/test_byo_estimator.py
+++ b/tests/integ/test_byo_estimator.py
@@ -79,7 +79,10 @@ def test_byo_estimator(sagemaker_session, region, cpu_instance_type):
         )
 
         estimator.set_hyperparameters(
-            num_factors=10, feature_dim=784, mini_batch_size=100, predictor_type="binary_classifier"
+            num_factors=10,
+            feature_dim=784,
+            mini_batch_size=100,
+            predictor_type="binary_classifier",
         )
 
         # training labels must be 'float32'
@@ -128,7 +131,10 @@ def test_async_byo_estimator(sagemaker_session, region, cpu_instance_type):
         )
 
         estimator.set_hyperparameters(
-            num_factors=10, feature_dim=784, mini_batch_size=100, predictor_type="binary_classifier"
+            num_factors=10,
+            feature_dim=784,
+            mini_batch_size=100,
+            predictor_type="binary_classifier",
         )
 
         # training labels must be 'float32'

--- a/tests/integ/test_chainer_train.py
+++ b/tests/integ/test_chainer_train.py
@@ -26,7 +26,9 @@ from tests.integ.timeout import timeout, timeout_and_delete_endpoint_by_name
 
 @pytest.fixture(scope="module")
 def chainer_local_training_job(sagemaker_local_session, chainer_full_version):
-    return _run_mnist_training_job(sagemaker_local_session, "local", 1, chainer_full_version)
+    return _run_mnist_training_job(
+        sagemaker_local_session, "local", 1, chainer_full_version
+    )
 
 
 @pytest.mark.local_mode
@@ -35,7 +37,9 @@ def test_distributed_cpu_training(sagemaker_local_session, chainer_full_version)
 
 
 @pytest.mark.local_mode
-def test_training_with_additional_hyperparameters(sagemaker_local_session, chainer_full_version):
+def test_training_with_additional_hyperparameters(
+    sagemaker_local_session, chainer_full_version
+):
     script_path = os.path.join(DATA_DIR, "chainer_mnist", "mnist.py")
     data_path = os.path.join(DATA_DIR, "chainer_mnist")
 
@@ -78,15 +82,19 @@ def test_attach_deploy(sagemaker_session, chainer_full_version, cpu_instance_typ
         )
 
         train_input = sagemaker_session.upload_data(
-            path=os.path.join(data_path, "train"), key_prefix="integ-test-data/chainer_mnist/train"
+            path=os.path.join(data_path, "train"),
+            key_prefix="integ-test-data/chainer_mnist/train",
         )
 
         test_input = sagemaker_session.upload_data(
-            path=os.path.join(data_path, "test"), key_prefix="integ-test-data/chainer_mnist/test"
+            path=os.path.join(data_path, "test"),
+            key_prefix="integ-test-data/chainer_mnist/test",
         )
 
         job_name = unique_name_from_base("test-chainer-training")
-        chainer.fit({"train": train_input, "test": test_input}, wait=False, job_name=job_name)
+        chainer.fit(
+            {"train": train_input, "test": test_input}, wait=False, job_name=job_name
+        )
 
     endpoint_name = unique_name_from_base("test-chainer-attach-deploy")
 
@@ -144,7 +152,9 @@ def _run_mnist_training_job(
     test_input = "file://" + os.path.join(data_path, "test")
 
     job_name = unique_name_from_base("test-chainer-training")
-    chainer.fit({"train": train_input, "test": test_input}, wait=wait, job_name=job_name)
+    chainer.fit(
+        {"train": train_input, "test": test_input}, wait=wait, job_name=job_name
+    )
     return chainer
 
 

--- a/tests/integ/test_data_capture_config.py
+++ b/tests/integ/test_data_capture_config.py
@@ -48,7 +48,9 @@ def test_enabling_data_capture_on_endpoint_shows_correct_data_capture_status(
         path=os.path.join(tests.integ.DATA_DIR, "tensorflow-serving-test-model.tar.gz"),
         key_prefix="tensorflow-serving/models",
     )
-    with tests.integ.timeout.timeout_and_delete_endpoint_by_name(endpoint_name, sagemaker_session):
+    with tests.integ.timeout.timeout_and_delete_endpoint_by_name(
+        endpoint_name, sagemaker_session
+    ):
         model = Model(
             model_data=model_data,
             role=ROLE,
@@ -105,7 +107,9 @@ def test_disabling_data_capture_on_endpoint_shows_correct_data_capture_status(
         path=os.path.join(tests.integ.DATA_DIR, "tensorflow-serving-test-model.tar.gz"),
         key_prefix="tensorflow-serving/models",
     )
-    with tests.integ.timeout.timeout_and_delete_endpoint_by_name(endpoint_name, sagemaker_session):
+    with tests.integ.timeout.timeout_and_delete_endpoint_by_name(
+        endpoint_name, sagemaker_session
+    ):
         model = Model(
             model_data=model_data,
             role=ROLE,
@@ -147,7 +151,9 @@ def test_disabling_data_capture_on_endpoint_shows_correct_data_capture_status(
             {"CaptureMode": "Input"}
         ]
         assert (
-            endpoint_config_desc["DataCaptureConfig"]["CaptureContentTypeHeader"]["CsvContentTypes"]
+            endpoint_config_desc["DataCaptureConfig"]["CaptureContentTypeHeader"][
+                "CsvContentTypes"
+            ]
             == CUSTOM_CSV_CONTENT_TYPES
         )
         assert (
@@ -186,12 +192,16 @@ def test_disabling_data_capture_on_endpoint_shows_correct_data_capture_status(
 def test_updating_data_capture_on_endpoint_shows_correct_data_capture_status(
     sagemaker_session, tf_full_version
 ):
-    endpoint_name = sagemaker.utils.unique_name_from_base("sagemaker-tensorflow-serving")
+    endpoint_name = sagemaker.utils.unique_name_from_base(
+        "sagemaker-tensorflow-serving"
+    )
     model_data = sagemaker_session.upload_data(
         path=os.path.join(tests.integ.DATA_DIR, "tensorflow-serving-test-model.tar.gz"),
         key_prefix="tensorflow-serving/models",
     )
-    with tests.integ.timeout.timeout_and_delete_endpoint_by_name(endpoint_name, sagemaker_session):
+    with tests.integ.timeout.timeout_and_delete_endpoint_by_name(
+        endpoint_name, sagemaker_session
+    ):
         model = Model(
             model_data=model_data,
             role=ROLE,
@@ -259,7 +269,9 @@ def test_updating_data_capture_on_endpoint_shows_correct_data_capture_status(
             {"CaptureMode": "Input"}
         ]
         assert (
-            endpoint_config_desc["DataCaptureConfig"]["CaptureContentTypeHeader"]["CsvContentTypes"]
+            endpoint_config_desc["DataCaptureConfig"]["CaptureContentTypeHeader"][
+                "CsvContentTypes"
+            ]
             == CUSTOM_CSV_CONTENT_TYPES
         )
         assert (

--- a/tests/integ/test_data_upload.py
+++ b/tests/integ/test_data_upload.py
@@ -24,17 +24,23 @@ AES_ENCRYPTION_ENABLED = {"ServerSideEncryption": "AES256"}
 def test_upload_data_absolute_file(sagemaker_session):
     """Test the method ``Session.upload_data`` can upload one encrypted file to S3 bucket"""
     data_path = os.path.join(DATA_DIR, "upload_data_tests", "file1.py")
-    uploaded_file = sagemaker_session.upload_data(data_path, extra_args=AES_ENCRYPTION_ENABLED)
+    uploaded_file = sagemaker_session.upload_data(
+        data_path, extra_args=AES_ENCRYPTION_ENABLED
+    )
     parsed_url = urlparse(uploaded_file)
     s3_client = sagemaker_session.boto_session.client("s3")
-    head = s3_client.head_object(Bucket=parsed_url.netloc, Key=parsed_url.path.lstrip("/"))
+    head = s3_client.head_object(
+        Bucket=parsed_url.netloc, Key=parsed_url.path.lstrip("/")
+    )
     assert head["ServerSideEncryption"] == "AES256"
 
 
 def test_upload_data_absolute_dir(sagemaker_session):
     """Test the method ``Session.upload_data`` can upload encrypted objects to S3 bucket"""
     data_path = os.path.join(DATA_DIR, "upload_data_tests", "nested_dir")
-    uploaded_dir = sagemaker_session.upload_data(data_path, extra_args=AES_ENCRYPTION_ENABLED)
+    uploaded_dir = sagemaker_session.upload_data(
+        data_path, extra_args=AES_ENCRYPTION_ENABLED
+    )
     parsed_url = urlparse(uploaded_dir)
     s3_bucket = parsed_url.netloc
     s3_prefix = parsed_url.path.lstrip("/")

--- a/tests/integ/test_debugger.py
+++ b/tests/integ/test_debugger.py
@@ -65,7 +65,8 @@ def test_mxnet_with_rules(sagemaker_session, mxnet_full_version, cpu_instance_ty
         rules = [
             Rule.sagemaker(rule_configs.vanishing_gradient()),
             Rule.sagemaker(
-                base_config=rule_configs.all_zero(), rule_parameters={"tensor_regex": ".*"}
+                base_config=rule_configs.all_zero(),
+                rule_parameters={"tensor_regex": ".*"},
             ),
             Rule.sagemaker(rule_configs.loss_not_decreasing()),
         ]
@@ -85,10 +86,12 @@ def test_mxnet_with_rules(sagemaker_session, mxnet_full_version, cpu_instance_ty
         )
 
         train_input = mx.sagemaker_session.upload_data(
-            path=os.path.join(data_path, "train"), key_prefix="integ-test-data/mxnet_mnist/train"
+            path=os.path.join(data_path, "train"),
+            key_prefix="integ-test-data/mxnet_mnist/train",
         )
         test_input = mx.sagemaker_session.upload_data(
-            path=os.path.join(data_path, "test"), key_prefix="integ-test-data/mxnet_mnist/test"
+            path=os.path.join(data_path, "test"),
+            key_prefix="integ-test-data/mxnet_mnist/test",
         )
 
         mx.fit({"train": train_input, "test": test_input})
@@ -97,14 +100,18 @@ def test_mxnet_with_rules(sagemaker_session, mxnet_full_version, cpu_instance_ty
 
         for index, rule in enumerate(rules):
             assert (
-                job_description["DebugRuleConfigurations"][index]["RuleConfigurationName"]
+                job_description["DebugRuleConfigurations"][index][
+                    "RuleConfigurationName"
+                ]
                 == rule.name
             )
             assert (
                 job_description["DebugRuleConfigurations"][index]["RuleEvaluatorImage"]
                 == rule.image_uri
             )
-            assert job_description["DebugRuleConfigurations"][index]["VolumeSizeInGB"] == 0
+            assert (
+                job_description["DebugRuleConfigurations"][index]["VolumeSizeInGB"] == 0
+            )
             assert (
                 job_description["DebugRuleConfigurations"][index]["RuleParameters"][
                     "rule_to_invoke"
@@ -119,7 +126,9 @@ def test_mxnet_with_rules(sagemaker_session, mxnet_full_version, cpu_instance_ty
         _wait_and_assert_that_no_rule_jobs_errored(training_job=mx.latest_training_job)
 
 
-def test_mxnet_with_custom_rule(sagemaker_session, mxnet_full_version, cpu_instance_type):
+def test_mxnet_with_custom_rule(
+    sagemaker_session, mxnet_full_version, cpu_instance_type
+):
     with timeout(minutes=TRAINING_DEFAULT_TIMEOUT_MINUTES):
         rules = [_get_custom_rule(sagemaker_session)]
 
@@ -138,10 +147,12 @@ def test_mxnet_with_custom_rule(sagemaker_session, mxnet_full_version, cpu_insta
         )
 
         train_input = mx.sagemaker_session.upload_data(
-            path=os.path.join(data_path, "train"), key_prefix="integ-test-data/mxnet_mnist/train"
+            path=os.path.join(data_path, "train"),
+            key_prefix="integ-test-data/mxnet_mnist/train",
         )
         test_input = mx.sagemaker_session.upload_data(
-            path=os.path.join(data_path, "test"), key_prefix="integ-test-data/mxnet_mnist/test"
+            path=os.path.join(data_path, "test"),
+            key_prefix="integ-test-data/mxnet_mnist/test",
         )
 
         mx.fit({"train": train_input, "test": test_input})
@@ -150,14 +161,19 @@ def test_mxnet_with_custom_rule(sagemaker_session, mxnet_full_version, cpu_insta
 
         for index, rule in enumerate(rules):
             assert (
-                job_description["DebugRuleConfigurations"][index]["RuleConfigurationName"]
+                job_description["DebugRuleConfigurations"][index][
+                    "RuleConfigurationName"
+                ]
                 == rule.name
             )
             assert (
                 job_description["DebugRuleConfigurations"][index]["RuleEvaluatorImage"]
                 == rule.image_uri
             )
-            assert job_description["DebugRuleConfigurations"][index]["VolumeSizeInGB"] == 30
+            assert (
+                job_description["DebugRuleConfigurations"][index]["VolumeSizeInGB"]
+                == 30
+            )
         assert (
             job_description["DebugRuleEvaluationStatuses"]
             == mx.latest_training_job.rule_job_summary()
@@ -166,11 +182,16 @@ def test_mxnet_with_custom_rule(sagemaker_session, mxnet_full_version, cpu_insta
         _wait_and_assert_that_no_rule_jobs_errored(training_job=mx.latest_training_job)
 
 
-def test_mxnet_with_debugger_hook_config(sagemaker_session, mxnet_full_version, cpu_instance_type):
+def test_mxnet_with_debugger_hook_config(
+    sagemaker_session, mxnet_full_version, cpu_instance_type
+):
     with timeout(minutes=TRAINING_DEFAULT_TIMEOUT_MINUTES):
         debugger_hook_config = DebuggerHookConfig(
             s3_output_path=os.path.join(
-                "s3://", sagemaker_session.default_bucket(), str(uuid.uuid4()), "tensors"
+                "s3://",
+                sagemaker_session.default_bucket(),
+                str(uuid.uuid4()),
+                "tensors",
             )
         )
 
@@ -189,16 +210,21 @@ def test_mxnet_with_debugger_hook_config(sagemaker_session, mxnet_full_version, 
         )
 
         train_input = mx.sagemaker_session.upload_data(
-            path=os.path.join(data_path, "train"), key_prefix="integ-test-data/mxnet_mnist/train"
+            path=os.path.join(data_path, "train"),
+            key_prefix="integ-test-data/mxnet_mnist/train",
         )
         test_input = mx.sagemaker_session.upload_data(
-            path=os.path.join(data_path, "test"), key_prefix="integ-test-data/mxnet_mnist/test"
+            path=os.path.join(data_path, "test"),
+            key_prefix="integ-test-data/mxnet_mnist/test",
         )
 
         mx.fit({"train": train_input, "test": test_input})
 
         job_description = mx.latest_training_job.describe()
-        assert job_description["DebugHookConfig"] == debugger_hook_config._to_request_dict()
+        assert (
+            job_description["DebugHookConfig"]
+            == debugger_hook_config._to_request_dict()
+        )
 
         _wait_and_assert_that_no_rule_jobs_errored(training_job=mx.latest_training_job)
 
@@ -210,13 +236,17 @@ def test_mxnet_with_rules_and_debugger_hook_config(
         rules = [
             Rule.sagemaker(rule_configs.vanishing_gradient()),
             Rule.sagemaker(
-                base_config=rule_configs.all_zero(), rule_parameters={"tensor_regex": ".*"}
+                base_config=rule_configs.all_zero(),
+                rule_parameters={"tensor_regex": ".*"},
             ),
             Rule.sagemaker(rule_configs.loss_not_decreasing()),
         ]
         debugger_hook_config = DebuggerHookConfig(
             s3_output_path=os.path.join(
-                "s3://", sagemaker_session.default_bucket(), str(uuid.uuid4()), "tensors"
+                "s3://",
+                sagemaker_session.default_bucket(),
+                str(uuid.uuid4()),
+                "tensors",
             )
         )
 
@@ -236,10 +266,12 @@ def test_mxnet_with_rules_and_debugger_hook_config(
         )
 
         train_input = mx.sagemaker_session.upload_data(
-            path=os.path.join(data_path, "train"), key_prefix="integ-test-data/mxnet_mnist/train"
+            path=os.path.join(data_path, "train"),
+            key_prefix="integ-test-data/mxnet_mnist/train",
         )
         test_input = mx.sagemaker_session.upload_data(
-            path=os.path.join(data_path, "test"), key_prefix="integ-test-data/mxnet_mnist/test"
+            path=os.path.join(data_path, "test"),
+            key_prefix="integ-test-data/mxnet_mnist/test",
         )
 
         mx.fit({"train": train_input, "test": test_input})
@@ -248,21 +280,28 @@ def test_mxnet_with_rules_and_debugger_hook_config(
 
         for index, rule in enumerate(rules):
             assert (
-                job_description["DebugRuleConfigurations"][index]["RuleConfigurationName"]
+                job_description["DebugRuleConfigurations"][index][
+                    "RuleConfigurationName"
+                ]
                 == rule.name
             )
             assert (
                 job_description["DebugRuleConfigurations"][index]["RuleEvaluatorImage"]
                 == rule.image_uri
             )
-            assert job_description["DebugRuleConfigurations"][index]["VolumeSizeInGB"] == 0
+            assert (
+                job_description["DebugRuleConfigurations"][index]["VolumeSizeInGB"] == 0
+            )
             assert (
                 job_description["DebugRuleConfigurations"][index]["RuleParameters"][
                     "rule_to_invoke"
                 ]
                 == rule.rule_parameters["rule_to_invoke"]
             )
-        assert job_description["DebugHookConfig"] == debugger_hook_config._to_request_dict()
+        assert (
+            job_description["DebugHookConfig"]
+            == debugger_hook_config._to_request_dict()
+        )
         assert (
             job_description["DebugRuleEvaluationStatuses"]
             == mx.latest_training_job.rule_job_summary()
@@ -278,7 +317,10 @@ def test_mxnet_with_custom_rule_and_debugger_hook_config(
         rules = [_get_custom_rule(sagemaker_session)]
         debugger_hook_config = DebuggerHookConfig(
             s3_output_path=os.path.join(
-                "s3://", sagemaker_session.default_bucket(), str(uuid.uuid4()), "tensors"
+                "s3://",
+                sagemaker_session.default_bucket(),
+                str(uuid.uuid4()),
+                "tensors",
             )
         )
 
@@ -298,10 +340,12 @@ def test_mxnet_with_custom_rule_and_debugger_hook_config(
         )
 
         train_input = mx.sagemaker_session.upload_data(
-            path=os.path.join(data_path, "train"), key_prefix="integ-test-data/mxnet_mnist/train"
+            path=os.path.join(data_path, "train"),
+            key_prefix="integ-test-data/mxnet_mnist/train",
         )
         test_input = mx.sagemaker_session.upload_data(
-            path=os.path.join(data_path, "test"), key_prefix="integ-test-data/mxnet_mnist/test"
+            path=os.path.join(data_path, "test"),
+            key_prefix="integ-test-data/mxnet_mnist/test",
         )
 
         mx.fit({"train": train_input, "test": test_input})
@@ -310,15 +354,23 @@ def test_mxnet_with_custom_rule_and_debugger_hook_config(
 
         for index, rule in enumerate(rules):
             assert (
-                job_description["DebugRuleConfigurations"][index]["RuleConfigurationName"]
+                job_description["DebugRuleConfigurations"][index][
+                    "RuleConfigurationName"
+                ]
                 == rule.name
             )
             assert (
                 job_description["DebugRuleConfigurations"][index]["RuleEvaluatorImage"]
                 == rule.image_uri
             )
-            assert job_description["DebugRuleConfigurations"][index]["VolumeSizeInGB"] == 30
-        assert job_description["DebugHookConfig"] == debugger_hook_config._to_request_dict()
+            assert (
+                job_description["DebugRuleConfigurations"][index]["VolumeSizeInGB"]
+                == 30
+            )
+        assert (
+            job_description["DebugHookConfig"]
+            == debugger_hook_config._to_request_dict()
+        )
         assert (
             job_description["DebugRuleEvaluationStatuses"]
             == mx.latest_training_job.rule_job_summary()
@@ -333,7 +385,10 @@ def test_mxnet_with_tensorboard_output_config(
     with timeout(minutes=TRAINING_DEFAULT_TIMEOUT_MINUTES):
         tensorboard_output_config = TensorBoardOutputConfig(
             s3_output_path=os.path.join(
-                "s3://", sagemaker_session.default_bucket(), str(uuid.uuid4()), "tensorboard"
+                "s3://",
+                sagemaker_session.default_bucket(),
+                str(uuid.uuid4()),
+                "tensorboard",
             )
         )
 
@@ -352,10 +407,12 @@ def test_mxnet_with_tensorboard_output_config(
         )
 
         train_input = mx.sagemaker_session.upload_data(
-            path=os.path.join(data_path, "train"), key_prefix="integ-test-data/mxnet_mnist/train"
+            path=os.path.join(data_path, "train"),
+            key_prefix="integ-test-data/mxnet_mnist/train",
         )
         test_input = mx.sagemaker_session.upload_data(
-            path=os.path.join(data_path, "test"), key_prefix="integ-test-data/mxnet_mnist/test"
+            path=os.path.join(data_path, "test"),
+            key_prefix="integ-test-data/mxnet_mnist/test",
         )
 
         mx.fit({"train": train_input, "test": test_input})
@@ -370,24 +427,33 @@ def test_mxnet_with_tensorboard_output_config(
 
 
 @pytest.mark.canary_quick
-def test_mxnet_with_all_rules_and_configs(sagemaker_session, mxnet_full_version, cpu_instance_type):
+def test_mxnet_with_all_rules_and_configs(
+    sagemaker_session, mxnet_full_version, cpu_instance_type
+):
     with timeout(minutes=TRAINING_DEFAULT_TIMEOUT_MINUTES):
         rules = [
             Rule.sagemaker(rule_configs.vanishing_gradient()),
             Rule.sagemaker(
-                base_config=rule_configs.all_zero(), rule_parameters={"tensor_regex": ".*"}
+                base_config=rule_configs.all_zero(),
+                rule_parameters={"tensor_regex": ".*"},
             ),
             Rule.sagemaker(rule_configs.loss_not_decreasing()),
             _get_custom_rule(sagemaker_session),
         ]
         debugger_hook_config = DebuggerHookConfig(
             s3_output_path=os.path.join(
-                "s3://", sagemaker_session.default_bucket(), str(uuid.uuid4()), "tensors"
+                "s3://",
+                sagemaker_session.default_bucket(),
+                str(uuid.uuid4()),
+                "tensors",
             )
         )
         tensorboard_output_config = TensorBoardOutputConfig(
             s3_output_path=os.path.join(
-                "s3://", sagemaker_session.default_bucket(), str(uuid.uuid4()), "tensorboard"
+                "s3://",
+                sagemaker_session.default_bucket(),
+                str(uuid.uuid4()),
+                "tensorboard",
             )
         )
 
@@ -408,10 +474,12 @@ def test_mxnet_with_all_rules_and_configs(sagemaker_session, mxnet_full_version,
         )
 
         train_input = mx.sagemaker_session.upload_data(
-            path=os.path.join(data_path, "train"), key_prefix="integ-test-data/mxnet_mnist/train"
+            path=os.path.join(data_path, "train"),
+            key_prefix="integ-test-data/mxnet_mnist/train",
         )
         test_input = mx.sagemaker_session.upload_data(
-            path=os.path.join(data_path, "test"), key_prefix="integ-test-data/mxnet_mnist/test"
+            path=os.path.join(data_path, "test"),
+            key_prefix="integ-test-data/mxnet_mnist/test",
         )
 
         mx.fit({"train": train_input, "test": test_input})
@@ -420,14 +488,19 @@ def test_mxnet_with_all_rules_and_configs(sagemaker_session, mxnet_full_version,
 
         for index, rule in enumerate(rules):
             assert (
-                job_description["DebugRuleConfigurations"][index]["RuleConfigurationName"]
+                job_description["DebugRuleConfigurations"][index][
+                    "RuleConfigurationName"
+                ]
                 == rule.name
             )
             assert (
                 job_description["DebugRuleConfigurations"][index]["RuleEvaluatorImage"]
                 == rule.image_uri
             )
-        assert job_description["DebugHookConfig"] == debugger_hook_config._to_request_dict()
+        assert (
+            job_description["DebugHookConfig"]
+            == debugger_hook_config._to_request_dict()
+        )
         assert (
             job_description["TensorBoardOutputConfig"]
             == tensorboard_output_config._to_request_dict()
@@ -459,10 +532,12 @@ def test_mxnet_with_debugger_hook_config_disabled(
         )
 
         train_input = mx.sagemaker_session.upload_data(
-            path=os.path.join(data_path, "train"), key_prefix="integ-test-data/mxnet_mnist/train"
+            path=os.path.join(data_path, "train"),
+            key_prefix="integ-test-data/mxnet_mnist/train",
         )
         test_input = mx.sagemaker_session.upload_data(
-            path=os.path.join(data_path, "test"), key_prefix="integ-test-data/mxnet_mnist/test"
+            path=os.path.join(data_path, "test"),
+            key_prefix="integ-test-data/mxnet_mnist/test",
         )
 
         mx.fit({"train": train_input, "test": test_input})
@@ -482,7 +557,8 @@ def _get_custom_rule(session):
         instance_type="ml.m5.xlarge",
         volume_size_in_gb=30,
         image_uri=CUSTOM_RULE_REPO_WITH_PLACEHOLDERS.format(
-            CUSTOM_RULE_CONTAINERS_ACCOUNTS_MAP[session.boto_region_name], session.boto_region_name
+            CUSTOM_RULE_CONTAINERS_ACCOUNTS_MAP[session.boto_region_name],
+            session.boto_region_name,
         ),
     )
 
@@ -497,7 +573,9 @@ def _wait_and_assert_that_no_rule_jobs_errored(training_job):
         seconds_to_sleep=10,
     ):
         job_description = training_job.describe()
-        debug_rule_evaluation_statuses = job_description.get("DebugRuleEvaluationStatuses")
+        debug_rule_evaluation_statuses = job_description.get(
+            "DebugRuleEvaluationStatuses"
+        )
         if not debug_rule_evaluation_statuses:
             break
         incomplete_rule_job_found = False

--- a/tests/integ/test_experiments_analytics.py
+++ b/tests/integ/test_experiments_analytics.py
@@ -30,7 +30,8 @@ def experiment(sagemaker_session):
                 TrialComponentName=trial_component_name, DisplayName="Training"
             )
             sm.update_trial_component(
-                TrialComponentName=trial_component_name, Parameters={"hp1": {"NumberValue": i}}
+                TrialComponentName=trial_component_name,
+                Parameters={"hp1": {"NumberValue": i}},
             )
             sm.associate_trial_component(
                 TrialComponentName=trial_component_name, TrialName=trial_name
@@ -67,10 +68,16 @@ def experiment_with_artifacts(sagemaker_session):
                 TrialComponentName=trial_component_name,
                 Parameters={"hp1": {"NumberValue": i}},
                 InputArtifacts={
-                    "inputArtifacts1": {"MediaType": "text/csv", "Value": "s3:/foo/bar1"}
+                    "inputArtifacts1": {
+                        "MediaType": "text/csv",
+                        "Value": "s3:/foo/bar1",
+                    }
                 },
                 OutputArtifacts={
-                    "outputArtifacts1": {"MediaType": "text/plain", "Value": "s3:/foo/bar2"}
+                    "outputArtifacts1": {
+                        "MediaType": "text/plain",
+                        "Value": "s3:/foo/bar2",
+                    }
                 },
             )
             sm.associate_trial_component(
@@ -109,7 +116,11 @@ def test_experiment_analytics(sagemaker_session):
             experiment_name=experiment_name, sagemaker_session=sagemaker_session
         )
 
-        assert list(analytics.dataframe().columns) == ["TrialComponentName", "DisplayName", "hp1"]
+        assert list(analytics.dataframe().columns) == [
+            "TrialComponentName",
+            "DisplayName",
+            "hp1",
+        ]
 
 
 def test_experiment_analytics_pagination(sagemaker_session):
@@ -118,7 +129,11 @@ def test_experiment_analytics_pagination(sagemaker_session):
             experiment_name=experiment_name, sagemaker_session=sagemaker_session
         )
 
-        assert list(analytics.dataframe().columns) == ["TrialComponentName", "DisplayName", "hp1"]
+        assert list(analytics.dataframe().columns) == [
+            "TrialComponentName",
+            "DisplayName",
+            "hp1",
+        ]
         assert (
             len(analytics.dataframe()) > 10
         )  # TODO [owen-t] Replace with == 20 and put test in retry block
@@ -128,8 +143,16 @@ def test_experiment_analytics_search_by_nested_filter(sagemaker_session):
     with experiment(sagemaker_session) as experiment_name:
         search_exp = {
             "Filters": [
-                {"Name": "Parents.ExperimentName", "Operator": "Equals", "Value": experiment_name},
-                {"Name": "Parameters.hp1", "Operator": "GreaterThanOrEqualTo", "Value": "10"},
+                {
+                    "Name": "Parents.ExperimentName",
+                    "Operator": "Equals",
+                    "Value": experiment_name,
+                },
+                {
+                    "Name": "Parameters.hp1",
+                    "Operator": "GreaterThanOrEqualTo",
+                    "Value": "10",
+                },
             ]
         }
 
@@ -137,7 +160,11 @@ def test_experiment_analytics_search_by_nested_filter(sagemaker_session):
             sagemaker_session=sagemaker_session, search_expression=search_exp
         )
 
-        assert list(analytics.dataframe().columns) == ["TrialComponentName", "DisplayName", "hp1"]
+        assert list(analytics.dataframe().columns) == [
+            "TrialComponentName",
+            "DisplayName",
+            "hp1",
+        ]
         assert (
             len(analytics.dataframe()) > 5
         )  # TODO [owen-t] Replace with == 10 and put test in retry block
@@ -147,8 +174,16 @@ def test_experiment_analytics_search_by_nested_filter_sort_ascending(sagemaker_s
     with experiment(sagemaker_session) as experiment_name:
         search_exp = {
             "Filters": [
-                {"Name": "Parents.ExperimentName", "Operator": "Equals", "Value": experiment_name},
-                {"Name": "Parameters.hp1", "Operator": "GreaterThanOrEqualTo", "Value": "10"},
+                {
+                    "Name": "Parents.ExperimentName",
+                    "Operator": "Equals",
+                    "Value": experiment_name,
+                },
+                {
+                    "Name": "Parameters.hp1",
+                    "Operator": "GreaterThanOrEqualTo",
+                    "Value": "10",
+                },
             ]
         }
 
@@ -159,7 +194,11 @@ def test_experiment_analytics_search_by_nested_filter_sort_ascending(sagemaker_s
             sort_order="Ascending",
         )
 
-        assert list(analytics.dataframe().columns) == ["TrialComponentName", "DisplayName", "hp1"]
+        assert list(analytics.dataframe().columns) == [
+            "TrialComponentName",
+            "DisplayName",
+            "hp1",
+        ]
         assert (
             len(analytics.dataframe()) > 5
         )  # TODO [owen-t] Replace with == 10 and put test in retry block
@@ -168,12 +207,22 @@ def test_experiment_analytics_search_by_nested_filter_sort_ascending(sagemaker_s
         )
 
 
-def test_experiment_analytics_search_by_nested_filter_sort_descending(sagemaker_session):
+def test_experiment_analytics_search_by_nested_filter_sort_descending(
+    sagemaker_session,
+):
     with experiment(sagemaker_session) as experiment_name:
         search_exp = {
             "Filters": [
-                {"Name": "Parents.ExperimentName", "Operator": "Equals", "Value": experiment_name},
-                {"Name": "Parameters.hp1", "Operator": "GreaterThanOrEqualTo", "Value": "10"},
+                {
+                    "Name": "Parents.ExperimentName",
+                    "Operator": "Equals",
+                    "Value": experiment_name,
+                },
+                {
+                    "Name": "Parameters.hp1",
+                    "Operator": "GreaterThanOrEqualTo",
+                    "Value": "10",
+                },
             ]
         }
 
@@ -183,7 +232,11 @@ def test_experiment_analytics_search_by_nested_filter_sort_descending(sagemaker_
             sort_by="Parameters.hp1",
         )
 
-        assert list(analytics.dataframe().columns) == ["TrialComponentName", "DisplayName", "hp1"]
+        assert list(analytics.dataframe().columns) == [
+            "TrialComponentName",
+            "DisplayName",
+            "hp1",
+        ]
         assert (
             len(analytics.dataframe()) > 5
         )  # TODO [owen-t] Replace with == 10 and put test in retry block
@@ -196,7 +249,9 @@ def test_experiment_analytics_search_by_nested_filter_sort_descending(sagemaker_
 def _delete_resources(sagemaker_client, experiment_name, trials):
     for trial, tc in trials.items():
         with _ignore_resource_not_found(sagemaker_client):
-            sagemaker_client.disassociate_trial_component(TrialName=trial, TrialComponentName=tc)
+            sagemaker_client.disassociate_trial_component(
+                TrialName=trial, TrialComponentName=tc
+            )
             _wait_for_trial_component_disassociation(sagemaker_client, tc)
 
         with _ignore_resource_not_found(sagemaker_client):

--- a/tests/integ/test_factorization_machines.py
+++ b/tests/integ/test_factorization_machines.py
@@ -106,7 +106,9 @@ def test_async_factorization_machines(sagemaker_session, cpu_instance_type):
             training_job_name=job_name, sagemaker_session=sagemaker_session
         )
         model = FactorizationMachinesModel(
-            estimator.model_data, role="SageMakerRole", sagemaker_session=sagemaker_session
+            estimator.model_data,
+            role="SageMakerRole",
+            sagemaker_session=sagemaker_session,
         )
         predictor = model.deploy(1, cpu_instance_type, endpoint_name=job_name)
         result = predictor.predict(train_set[0][:10])

--- a/tests/integ/test_git.py
+++ b/tests/integ/test_git.py
@@ -42,9 +42,7 @@ PRIVATE_GIT_REPO_2FA_SSH = "git@github.com:git-support-test-2fa/test-git.git"
 PRIVATE_BRANCH_2FA = "master"
 PRIVATE_COMMIT_2FA = "52381dee030eb332a7e42d9992878d7261eb21d4"
 
-CODECOMMIT_REPO = (
-    "https://git-codecommit.us-west-2.amazonaws.com/v1/repos/sagemaker-python-sdk-git-testing-repo/"
-)
+CODECOMMIT_REPO = "https://git-codecommit.us-west-2.amazonaws.com/v1/repos/sagemaker-python-sdk-git-testing-repo/"
 CODECOMMIT_BRANCH = "master"
 
 # endpoint tests all use the same port, so we use this lock to prevent concurrent execution
@@ -68,7 +66,9 @@ def test_github(sagemaker_local_session):
         git_config=git_config,
     )
 
-    pytorch.fit({"training": "file://" + os.path.join(data_path, "training", MNIST_FOLDER_NAME)})
+    pytorch.fit(
+        {"training": "file://" + os.path.join(data_path, "training", MNIST_FOLDER_NAME)}
+    )
 
     with lock.lock(LOCK_PATH):
         try:
@@ -167,7 +167,9 @@ def test_private_github_with_2fa(sagemaker_local_session, sklearn_full_version):
     with lock.lock(LOCK_PATH):
         try:
             client = sagemaker_local_session.sagemaker_client
-            desc = client.describe_training_job(TrainingJobName=sklearn.latest_training_job.name)
+            desc = client.describe_training_job(
+                TrainingJobName=sklearn.latest_training_job.name
+            )
             model_data = desc["ModelArtifacts"]["S3ModelArtifacts"]
             model = SKLearnModel(
                 model_data,
@@ -187,7 +189,9 @@ def test_private_github_with_2fa(sagemaker_local_session, sklearn_full_version):
 
 
 @pytest.mark.local_mode
-def test_github_with_ssh_passphrase_not_configured(sagemaker_local_session, sklearn_full_version):
+def test_github_with_ssh_passphrase_not_configured(
+    sagemaker_local_session, sklearn_full_version
+):
     script_path = "mnist.py"
     data_path = os.path.join(DATA_DIR, "sklearn_mnist")
     git_config = {

--- a/tests/integ/test_horovod.py
+++ b/tests/integ/test_horovod.py
@@ -40,7 +40,8 @@ def test_hvd_cpu(sagemaker_session, cpu_instance_type, tmpdir):
 
 @pytest.mark.canary_quick
 @pytest.mark.skipif(
-    integ.test_region() in integ.TRAINING_NO_P2_REGIONS, reason="no ml.p2 instances in this region"
+    integ.test_region() in integ.TRAINING_NO_P2_REGIONS,
+    reason="no ml.p2 instances in this region",
 )
 def test_hvd_gpu(sagemaker_session, gpu_instance_type, tmpdir):
     _create_and_fit_estimator(sagemaker_session, gpu_instance_type, tmpdir)

--- a/tests/integ/test_inference_pipeline.py
+++ b/tests/integ/test_inference_pipeline.py
@@ -35,7 +35,9 @@ SPARKML_DATA_PATH = os.path.join(DATA_DIR, "sparkml_model")
 XGBOOST_DATA_PATH = os.path.join(DATA_DIR, "xgboost_model")
 SPARKML_XGBOOST_DATA_DIR = "sparkml_xgboost_pipeline"
 VALID_DATA_PATH = os.path.join(DATA_DIR, SPARKML_XGBOOST_DATA_DIR, "valid_input.csv")
-INVALID_DATA_PATH = os.path.join(DATA_DIR, SPARKML_XGBOOST_DATA_DIR, "invalid_input.csv")
+INVALID_DATA_PATH = os.path.join(
+    DATA_DIR, SPARKML_XGBOOST_DATA_DIR, "invalid_input.csv"
+)
 SCHEMA = json.dumps(
     {
         "input": [
@@ -117,7 +119,9 @@ def test_inference_pipeline_model_deploy(sagemaker_session, cpu_instance_type):
         )
         xgb_image = get_image_uri(sagemaker_session.boto_region_name, "xgboost")
         xgb_model = Model(
-            model_data=xgb_model_data, image=xgb_image, sagemaker_session=sagemaker_session
+            model_data=xgb_model_data,
+            image=xgb_image,
+            sagemaker_session=sagemaker_session,
         )
         model = PipelineModel(
             models=[sparkml_model, xgb_model],
@@ -171,7 +175,9 @@ def test_inference_pipeline_model_deploy_with_update_endpoint(
         )
         xgb_image = get_image_uri(sagemaker_session.boto_region_name, "xgboost")
         xgb_model = Model(
-            model_data=xgb_model_data, image=xgb_image, sagemaker_session=sagemaker_session
+            model_data=xgb_model_data,
+            image=xgb_image,
+            sagemaker_session=sagemaker_session,
         )
         model = PipelineModel(
             models=[sparkml_model, xgb_model],
@@ -184,11 +190,15 @@ def test_inference_pipeline_model_deploy_with_update_endpoint(
         )
         old_config_name = old_endpoint["EndpointConfigName"]
 
-        model.deploy(1, cpu_instance_type, update_endpoint=True, endpoint_name=endpoint_name)
+        model.deploy(
+            1, cpu_instance_type, update_endpoint=True, endpoint_name=endpoint_name
+        )
 
         # Wait for endpoint to finish updating
         # Endpoint update takes ~7min. 40 retries * 30s sleeps = 20min timeout
-        for _ in retries(40, "Waiting for 'InService' endpoint status", seconds_to_sleep=30):
+        for _ in retries(
+            40, "Waiting for 'InService' endpoint status", seconds_to_sleep=30
+        ):
             new_endpoint = sagemaker_session.sagemaker_client.describe_endpoint(
                 EndpointName=endpoint_name
             )

--- a/tests/integ/test_ipinsights.py
+++ b/tests/integ/test_ipinsights.py
@@ -44,13 +44,19 @@ def test_ipinsights(sagemaker_session, cpu_instance_type):
             )
 
         record_set = prepare_record_set_from_local_files(
-            data_path, ipinsights.data_location, num_records, FEATURE_DIM, sagemaker_session
+            data_path,
+            ipinsights.data_location,
+            num_records,
+            FEATURE_DIM,
+            sagemaker_session,
         )
         ipinsights.fit(records=record_set, job_name=job_name)
 
     with timeout_and_delete_endpoint_by_name(job_name, sagemaker_session):
         model = IPInsightsModel(
-            ipinsights.model_data, role="SageMakerRole", sagemaker_session=sagemaker_session
+            ipinsights.model_data,
+            role="SageMakerRole",
+            sagemaker_session=sagemaker_session,
         )
         predictor = model.deploy(1, cpu_instance_type, endpoint_name=job_name)
         assert isinstance(predictor, RealTimePredictor)

--- a/tests/integ/test_kmeans.py
+++ b/tests/integ/test_kmeans.py
@@ -137,9 +137,13 @@ def test_async_kmeans(sagemaker_session, cpu_instance_type):
         print("attaching now...")
 
     with timeout_and_delete_endpoint_by_name(job_name, sagemaker_session):
-        estimator = KMeans.attach(training_job_name=job_name, sagemaker_session=sagemaker_session)
+        estimator = KMeans.attach(
+            training_job_name=job_name, sagemaker_session=sagemaker_session
+        )
         model = KMeansModel(
-            estimator.model_data, role="SageMakerRole", sagemaker_session=sagemaker_session
+            estimator.model_data,
+            role="SageMakerRole",
+            sagemaker_session=sagemaker_session,
         )
         predictor = model.deploy(1, cpu_instance_type, endpoint_name=job_name)
         result = predictor.predict(train_set[0][:10])

--- a/tests/integ/test_knn.py
+++ b/tests/integ/test_knn.py
@@ -52,7 +52,9 @@ def test_knn_regressor(sagemaker_session, cpu_instance_type):
         )
 
     with timeout_and_delete_endpoint_by_name(job_name, sagemaker_session):
-        model = KNNModel(knn.model_data, role="SageMakerRole", sagemaker_session=sagemaker_session)
+        model = KNNModel(
+            knn.model_data, role="SageMakerRole", sagemaker_session=sagemaker_session
+        )
         predictor = model.deploy(1, cpu_instance_type, endpoint_name=job_name)
         result = predictor.predict(train_set[0][:10])
 
@@ -96,9 +98,13 @@ def test_async_knn_classifier(sagemaker_session, cpu_instance_type):
         print("attaching now...")
 
     with timeout_and_delete_endpoint_by_name(job_name, sagemaker_session):
-        estimator = KNN.attach(training_job_name=job_name, sagemaker_session=sagemaker_session)
+        estimator = KNN.attach(
+            training_job_name=job_name, sagemaker_session=sagemaker_session
+        )
         model = KNNModel(
-            estimator.model_data, role="SageMakerRole", sagemaker_session=sagemaker_session
+            estimator.model_data,
+            role="SageMakerRole",
+            sagemaker_session=sagemaker_session,
         )
         predictor = model.deploy(1, cpu_instance_type, endpoint_name=job_name)
         result = predictor.predict(train_set[0][:10])

--- a/tests/integ/test_lda.py
+++ b/tests/integ/test_lda.py
@@ -51,12 +51,18 @@ def test_lda(sagemaker_session, cpu_instance_type):
         )
 
         record_set = prepare_record_set_from_local_files(
-            data_path, lda.data_location, len(all_records), feature_num, sagemaker_session
+            data_path,
+            lda.data_location,
+            len(all_records),
+            feature_num,
+            sagemaker_session,
         )
         lda.fit(records=record_set, mini_batch_size=100, job_name=job_name)
 
     with timeout_and_delete_endpoint_by_name(job_name, sagemaker_session):
-        model = LDAModel(lda.model_data, role="SageMakerRole", sagemaker_session=sagemaker_session)
+        model = LDAModel(
+            lda.model_data, role="SageMakerRole", sagemaker_session=sagemaker_session
+        )
         predictor = model.deploy(1, cpu_instance_type, endpoint_name=job_name)
 
         predict_input = np.random.rand(1, feature_num)

--- a/tests/integ/test_linear_learner.py
+++ b/tests/integ/test_linear_learner.py
@@ -189,7 +189,11 @@ def test_async_linear_learner(sagemaker_session, cpu_instance_type):
         ll.huber_delta = 0.1
         ll.early_stopping_tolerance = 0.0001
         ll.early_stopping_patience = 3
-        ll.fit(ll.record_set(train_set[0][:200], train_set[1][:200]), wait=False, job_name=job_name)
+        ll.fit(
+            ll.record_set(train_set[0][:200], train_set[1][:200]),
+            wait=False,
+            job_name=job_name,
+        )
 
         print("Waiting to re-attach to the training job: %s" % job_name)
         time.sleep(20)
@@ -199,7 +203,9 @@ def test_async_linear_learner(sagemaker_session, cpu_instance_type):
             training_job_name=job_name, sagemaker_session=sagemaker_session
         )
         model = LinearLearnerModel(
-            estimator.model_data, role="SageMakerRole", sagemaker_session=sagemaker_session
+            estimator.model_data,
+            role="SageMakerRole",
+            sagemaker_session=sagemaker_session,
         )
         predictor = model.deploy(1, cpu_instance_type, endpoint_name=job_name)
 

--- a/tests/integ/test_local_mode.py
+++ b/tests/integ/test_local_mode.py
@@ -25,7 +25,11 @@ import stopit
 import tests.integ.lock as lock
 from tests.integ import DATA_DIR, PYTHON_VERSION
 
-from sagemaker.local import LocalSession, LocalSagemakerRuntimeClient, LocalSagemakerClient
+from sagemaker.local import (
+    LocalSession,
+    LocalSagemakerRuntimeClient,
+    LocalSagemakerClient,
+)
 from sagemaker.mxnet import MXNet
 from sagemaker.tensorflow import TensorFlow
 
@@ -71,10 +75,12 @@ def mxnet_model(sagemaker_local_session, mxnet_full_version):
         )
 
         train_input = mx.sagemaker_session.upload_data(
-            path=os.path.join(data_path, "train"), key_prefix="integ-test-data/mxnet_mnist/train"
+            path=os.path.join(data_path, "train"),
+            key_prefix="integ-test-data/mxnet_mnist/train",
         )
         test_input = mx.sagemaker_session.upload_data(
-            path=os.path.join(data_path, "test"), key_prefix="integ-test-data/mxnet_mnist/test"
+            path=os.path.join(data_path, "test"),
+            key_prefix="integ-test-data/mxnet_mnist/test",
         )
 
         mx.fit({"train": train_input, "test": test_input})
@@ -85,7 +91,9 @@ def mxnet_model(sagemaker_local_session, mxnet_full_version):
 
 
 @pytest.mark.local_mode
-@pytest.mark.skipif(PYTHON_VERSION != "py2", reason="TensorFlow image supports only python 2.")
+@pytest.mark.skipif(
+    PYTHON_VERSION != "py2", reason="TensorFlow image supports only python 2."
+)
 def test_tf_local_mode(sagemaker_local_session):
     with stopit.ThreadingTimeout(5 * 60, swallow_exc=False):
         script_path = os.path.join(DATA_DIR, "iris", "iris-dnn-classifier.py")
@@ -113,7 +121,9 @@ def test_tf_local_mode(sagemaker_local_session):
     with lock.lock(LOCK_PATH):
         try:
             json_predictor = estimator.deploy(
-                initial_instance_count=1, instance_type="local", endpoint_name=endpoint_name
+                initial_instance_count=1,
+                instance_type="local",
+                endpoint_name=endpoint_name,
             )
 
             features = [6.4, 3.2, 4.5, 1.5]
@@ -128,7 +138,9 @@ def test_tf_local_mode(sagemaker_local_session):
 
 
 @pytest.mark.local_mode
-@pytest.mark.skipif(PYTHON_VERSION != "py2", reason="TensorFlow image supports only python 2.")
+@pytest.mark.skipif(
+    PYTHON_VERSION != "py2", reason="TensorFlow image supports only python 2."
+)
 def test_tf_distributed_local_mode(sagemaker_local_session):
     with stopit.ThreadingTimeout(5 * 60, swallow_exc=False):
         script_path = os.path.join(DATA_DIR, "iris", "iris-dnn-classifier.py")
@@ -155,7 +167,9 @@ def test_tf_distributed_local_mode(sagemaker_local_session):
     with lock.lock(LOCK_PATH):
         try:
             json_predictor = estimator.deploy(
-                initial_instance_count=1, instance_type="local", endpoint_name=endpoint_name
+                initial_instance_count=1,
+                instance_type="local",
+                endpoint_name=endpoint_name,
             )
 
             features = [6.4, 3.2, 4.5, 1.5]
@@ -170,7 +184,9 @@ def test_tf_distributed_local_mode(sagemaker_local_session):
 
 
 @pytest.mark.local_mode
-@pytest.mark.skipif(PYTHON_VERSION != "py2", reason="TensorFlow image supports only python 2.")
+@pytest.mark.skipif(
+    PYTHON_VERSION != "py2", reason="TensorFlow image supports only python 2."
+)
 def test_tf_local_data(sagemaker_local_session):
     with stopit.ThreadingTimeout(5 * 60, swallow_exc=False):
         script_path = os.path.join(DATA_DIR, "iris", "iris-dnn-classifier.py")
@@ -196,7 +212,9 @@ def test_tf_local_data(sagemaker_local_session):
     with lock.lock(LOCK_PATH):
         try:
             json_predictor = estimator.deploy(
-                initial_instance_count=1, instance_type="local", endpoint_name=endpoint_name
+                initial_instance_count=1,
+                instance_type="local",
+                endpoint_name=endpoint_name,
             )
 
             features = [6.4, 3.2, 4.5, 1.5]
@@ -211,7 +229,9 @@ def test_tf_local_data(sagemaker_local_session):
 
 
 @pytest.mark.local_mode
-@pytest.mark.skipif(PYTHON_VERSION != "py2", reason="TensorFlow image supports only python 2.")
+@pytest.mark.skipif(
+    PYTHON_VERSION != "py2", reason="TensorFlow image supports only python 2."
+)
 def test_tf_local_data_local_script():
     with stopit.ThreadingTimeout(5 * 60, swallow_exc=False):
         script_path = os.path.join(DATA_DIR, "iris", "iris-dnn-classifier.py")
@@ -238,7 +258,9 @@ def test_tf_local_data_local_script():
     with lock.lock(LOCK_PATH):
         try:
             json_predictor = estimator.deploy(
-                initial_instance_count=1, instance_type="local", endpoint_name=endpoint_name
+                initial_instance_count=1,
+                instance_type="local",
+                endpoint_name=endpoint_name,
             )
 
             features = [6.4, 3.2, 4.5, 1.5]
@@ -253,7 +275,9 @@ def test_tf_local_data_local_script():
 
 
 @pytest.mark.local_mode
-def test_local_mode_serving_from_s3_model(sagemaker_local_session, mxnet_model, mxnet_full_version):
+def test_local_mode_serving_from_s3_model(
+    sagemaker_local_session, mxnet_model, mxnet_full_version
+):
     path = "s3://%s" % sagemaker_local_session.default_bucket()
     s3_model = mxnet_model(path)
     s3_model.sagemaker_session = sagemaker_local_session
@@ -270,7 +294,9 @@ def test_local_mode_serving_from_s3_model(sagemaker_local_session, mxnet_model, 
 
 
 @pytest.mark.local_mode
-def test_local_mode_serving_from_local_model(tmpdir, sagemaker_local_session, mxnet_model):
+def test_local_mode_serving_from_local_model(
+    tmpdir, sagemaker_local_session, mxnet_model
+):
     predictor = None
 
     with lock.lock(LOCK_PATH):
@@ -302,10 +328,12 @@ def test_mxnet_local_mode(sagemaker_local_session, mxnet_full_version):
     )
 
     train_input = mx.sagemaker_session.upload_data(
-        path=os.path.join(data_path, "train"), key_prefix="integ-test-data/mxnet_mnist/train"
+        path=os.path.join(data_path, "train"),
+        key_prefix="integ-test-data/mxnet_mnist/train",
     )
     test_input = mx.sagemaker_session.upload_data(
-        path=os.path.join(data_path, "test"), key_prefix="integ-test-data/mxnet_mnist/test"
+        path=os.path.join(data_path, "test"),
+        key_prefix="integ-test-data/mxnet_mnist/test",
     )
 
     mx.fit({"train": train_input, "test": test_input})
@@ -389,10 +417,12 @@ def test_local_transform_mxnet(
     )
 
     train_input = mx.sagemaker_session.upload_data(
-        path=os.path.join(data_path, "train"), key_prefix="integ-test-data/mxnet_mnist/train"
+        path=os.path.join(data_path, "train"),
+        key_prefix="integ-test-data/mxnet_mnist/train",
     )
     test_input = mx.sagemaker_session.upload_data(
-        path=os.path.join(data_path, "test"), key_prefix="integ-test-data/mxnet_mnist/test"
+        path=os.path.join(data_path, "test"),
+        key_prefix="integ-test-data/mxnet_mnist/test",
     )
 
     with stopit.ThreadingTimeout(5 * 60, swallow_exc=False):
@@ -415,7 +445,9 @@ def test_local_transform_mxnet(
     )
 
     with lock.lock(LOCK_PATH):
-        transformer.transform(transform_input, content_type="text/csv", split_type="Line")
+        transformer.transform(
+            transform_input, content_type="text/csv", split_type="Line"
+        )
         transformer.wait()
 
     assert os.path.exists(os.path.join(str(tmpdir), "data.csv.out"))

--- a/tests/integ/test_marketplace.py
+++ b/tests/integ/test_marketplace.py
@@ -83,7 +83,9 @@ def test_marketplace_estimator(sagemaker_session, cpu_instance_type):
         algo.fit({"training": train_input})
 
     endpoint_name = "test-marketplace-estimator{}".format(sagemaker_timestamp())
-    with timeout_and_delete_endpoint_by_name(endpoint_name, sagemaker_session, minutes=20):
+    with timeout_and_delete_endpoint_by_name(
+        endpoint_name, sagemaker_session, minutes=20
+    ):
         predictor = algo.deploy(1, cpu_instance_type, endpoint_name=endpoint_name)
         shape = pandas.read_csv(os.path.join(data_path, "iris.csv"), header=None)
 
@@ -130,7 +132,9 @@ def test_marketplace_attach(sagemaker_session, cpu_instance_type):
         time.sleep(20)
         endpoint_name = "test-marketplace-estimator{}".format(sagemaker_timestamp())
 
-    with timeout_and_delete_endpoint_by_name(endpoint_name, sagemaker_session, minutes=20):
+    with timeout_and_delete_endpoint_by_name(
+        endpoint_name, sagemaker_session, minutes=20
+    ):
         print("Re-attaching now to: %s" % training_job_name)
         estimator = AlgorithmEstimator.attach(
             training_job_name=training_job_name, sagemaker_session=sagemaker_session
@@ -177,7 +181,9 @@ def test_marketplace_model(sagemaker_session, cpu_instance_type):
     )
 
     endpoint_name = "test-marketplace-model-endpoint{}".format(sagemaker_timestamp())
-    with timeout_and_delete_endpoint_by_name(endpoint_name, sagemaker_session, minutes=20):
+    with timeout_and_delete_endpoint_by_name(
+        endpoint_name, sagemaker_session, minutes=20
+    ):
         predictor = model.deploy(1, cpu_instance_type, endpoint_name=endpoint_name)
         data_path = os.path.join(DATA_DIR, "marketplace", "training")
         shape = pandas.read_csv(os.path.join(data_path, "iris.csv"), header=None)
@@ -262,7 +268,9 @@ def test_marketplace_transform_job(sagemaker_session, cpu_instance_type):
     shape = pandas.read_csv(data_path + "/iris.csv", header=None).drop([0], axis=1)
 
     transform_workdir = DATA_DIR + "/marketplace/transform"
-    shape.to_csv(transform_workdir + "/batchtransform_test.csv", index=False, header=False)
+    shape.to_csv(
+        transform_workdir + "/batchtransform_test.csv", index=False, header=False
+    )
     transform_input = algo.sagemaker_session.upload_data(
         transform_workdir, key_prefix="integ-test-data/marketplace/transform"
     )
@@ -278,12 +286,16 @@ def test_marketplace_transform_job(sagemaker_session, cpu_instance_type):
     tests.integ.test_region() in tests.integ.NO_MARKET_PLACE_REGIONS,
     reason="Marketplace is not available in {}".format(tests.integ.test_region()),
 )
-def test_marketplace_transform_job_from_model_package(sagemaker_session, cpu_instance_type):
+def test_marketplace_transform_job_from_model_package(
+    sagemaker_session, cpu_instance_type
+):
     data_path = os.path.join(DATA_DIR, "marketplace", "training")
     shape = pandas.read_csv(data_path + "/iris.csv", header=None).drop([0], axis=1)
 
     TRANSFORM_WORKDIR = DATA_DIR + "/marketplace/transform"
-    shape.to_csv(TRANSFORM_WORKDIR + "/batchtransform_test.csv", index=False, header=False)
+    shape.to_csv(
+        TRANSFORM_WORKDIR + "/batchtransform_test.csv", index=False, header=False
+    )
     transform_input = sagemaker_session.upload_data(
         TRANSFORM_WORKDIR, key_prefix="integ-test-data/marketplace/transform"
     )

--- a/tests/integ/test_monitoring_files.py
+++ b/tests/integ/test_monitoring_files.py
@@ -33,7 +33,9 @@ def test_statistics_object_creation_from_file_path_with_customizations(
     sagemaker_session, monitoring_files_kms_key
 ):
     statistics = Statistics.from_file_path(
-        statistics_file_path=os.path.join(tests.integ.DATA_DIR, "monitor/statistics.json"),
+        statistics_file_path=os.path.join(
+            tests.integ.DATA_DIR, "monitor/statistics.json"
+        ),
         kms_key=monitoring_files_kms_key,
         sagemaker_session=sagemaker_session,
     )
@@ -44,9 +46,13 @@ def test_statistics_object_creation_from_file_path_with_customizations(
     assert statistics.body_dict["dataset"]["item_count"] == 418
 
 
-def test_statistics_object_creation_from_file_path_without_customizations(sagemaker_session):
+def test_statistics_object_creation_from_file_path_without_customizations(
+    sagemaker_session,
+):
     statistics = Statistics.from_file_path(
-        statistics_file_path=os.path.join(tests.integ.DATA_DIR, "monitor/statistics.json"),
+        statistics_file_path=os.path.join(
+            tests.integ.DATA_DIR, "monitor/statistics.json"
+        ),
         sagemaker_session=sagemaker_session,
     )
 
@@ -75,7 +81,9 @@ def test_statistics_object_creation_from_string_with_customizations(
     assert statistics.body_dict["dataset"]["item_count"] == 418
 
 
-def test_statistics_object_creation_from_string_without_customizations(sagemaker_session):
+def test_statistics_object_creation_from_string_without_customizations(
+    sagemaker_session,
+):
     with open(os.path.join(tests.integ.DATA_DIR, "monitor/statistics.json"), "r") as f:
         file_body = f.read()
 
@@ -123,7 +131,9 @@ def test_statistics_object_creation_from_s3_uri_with_customizations(
     assert statistics.body_dict["dataset"]["item_count"] == 418
 
 
-def test_statistics_object_creation_from_s3_uri_without_customizations(sagemaker_session):
+def test_statistics_object_creation_from_s3_uri_without_customizations(
+    sagemaker_session,
+):
     with open(os.path.join(tests.integ.DATA_DIR, "monitor/statistics.json"), "r") as f:
         file_body = f.read()
 
@@ -154,7 +164,9 @@ def test_constraints_object_creation_from_file_path_with_customizations(
     sagemaker_session, monitoring_files_kms_key
 ):
     constraints = Constraints.from_file_path(
-        constraints_file_path=os.path.join(tests.integ.DATA_DIR, "monitor/constraints.json"),
+        constraints_file_path=os.path.join(
+            tests.integ.DATA_DIR, "monitor/constraints.json"
+        ),
         kms_key=monitoring_files_kms_key,
         sagemaker_session=sagemaker_session,
     )
@@ -162,27 +174,31 @@ def test_constraints_object_creation_from_file_path_with_customizations(
     assert constraints.file_s3_uri.startswith("s3://")
     assert constraints.file_s3_uri.endswith("constraints.json")
 
-    assert constraints.body_dict["monitoring_config"]["evaluate_constraints"] == "Enabled"
+    assert (
+        constraints.body_dict["monitoring_config"]["evaluate_constraints"] == "Enabled"
+    )
 
     constraints.set_monitoring(False)
 
-    assert constraints.body_dict["monitoring_config"]["evaluate_constraints"] == "Disabled"
+    assert (
+        constraints.body_dict["monitoring_config"]["evaluate_constraints"] == "Disabled"
+    )
 
     constraints.set_monitoring(True, "message")
 
     assert (
-        constraints.body_dict["features"][0]["string_constraints"]["monitoring_config_overrides"][
-            "evaluate_constraints"
-        ]
+        constraints.body_dict["features"][0]["string_constraints"][
+            "monitoring_config_overrides"
+        ]["evaluate_constraints"]
         == "Enabled"
     )
 
     constraints.set_monitoring(True, "second_message")
 
     assert (
-        constraints.body_dict["features"][0]["string_constraints"]["monitoring_config_overrides"][
-            "evaluate_constraints"
-        ]
+        constraints.body_dict["features"][0]["string_constraints"][
+            "monitoring_config_overrides"
+        ]["evaluate_constraints"]
         == "Enabled"
     )
 
@@ -192,19 +208,28 @@ def test_constraints_object_creation_from_file_path_with_customizations(
         constraints.file_s3_uri, sagemaker_session=sagemaker_session
     )
 
-    assert new_constraints.body_dict["monitoring_config"]["evaluate_constraints"] == "Disabled"
+    assert (
+        new_constraints.body_dict["monitoring_config"]["evaluate_constraints"]
+        == "Disabled"
+    )
 
 
-def test_constraints_object_creation_from_file_path_without_customizations(sagemaker_session):
+def test_constraints_object_creation_from_file_path_without_customizations(
+    sagemaker_session,
+):
     constraints = Constraints.from_file_path(
-        constraints_file_path=os.path.join(tests.integ.DATA_DIR, "monitor/constraints.json"),
+        constraints_file_path=os.path.join(
+            tests.integ.DATA_DIR, "monitor/constraints.json"
+        ),
         sagemaker_session=sagemaker_session,
     )
 
     assert constraints.file_s3_uri.startswith("s3://")
     assert constraints.file_s3_uri.endswith("constraints.json")
 
-    assert constraints.body_dict["monitoring_config"]["evaluate_constraints"] == "Enabled"
+    assert (
+        constraints.body_dict["monitoring_config"]["evaluate_constraints"] == "Enabled"
+    )
 
 
 def test_constraints_object_creation_from_string_with_customizations(
@@ -223,10 +248,14 @@ def test_constraints_object_creation_from_string_with_customizations(
     assert constraints.file_s3_uri.startswith("s3://")
     assert constraints.file_s3_uri.endswith("constraints.json")
 
-    assert constraints.body_dict["monitoring_config"]["evaluate_constraints"] == "Enabled"
+    assert (
+        constraints.body_dict["monitoring_config"]["evaluate_constraints"] == "Enabled"
+    )
 
 
-def test_constraints_object_creation_from_string_without_customizations(sagemaker_session):
+def test_constraints_object_creation_from_string_without_customizations(
+    sagemaker_session,
+):
     with open(os.path.join(tests.integ.DATA_DIR, "monitor/constraints.json"), "r") as f:
         file_body = f.read()
 
@@ -237,7 +266,9 @@ def test_constraints_object_creation_from_string_without_customizations(sagemake
     assert constraints.file_s3_uri.startswith("s3://")
     assert constraints.file_s3_uri.endswith("constraints.json")
 
-    assert constraints.body_dict["monitoring_config"]["evaluate_constraints"] == "Enabled"
+    assert (
+        constraints.body_dict["monitoring_config"]["evaluate_constraints"] == "Enabled"
+    )
 
 
 def test_constraints_object_creation_from_s3_uri_with_customizations(
@@ -271,10 +302,14 @@ def test_constraints_object_creation_from_s3_uri_with_customizations(
     assert constraints.file_s3_uri.startswith("s3://")
     assert constraints.file_s3_uri.endswith("constraints.json")
 
-    assert constraints.body_dict["monitoring_config"]["evaluate_constraints"] == "Enabled"
+    assert (
+        constraints.body_dict["monitoring_config"]["evaluate_constraints"] == "Enabled"
+    )
 
 
-def test_constraints_object_creation_from_s3_uri_without_customizations(sagemaker_session):
+def test_constraints_object_creation_from_s3_uri_without_customizations(
+    sagemaker_session,
+):
     with open(os.path.join(tests.integ.DATA_DIR, "monitor/constraints.json"), "r") as f:
         file_body = f.read()
 
@@ -298,7 +333,9 @@ def test_constraints_object_creation_from_s3_uri_without_customizations(sagemake
     assert constraints.file_s3_uri.startswith("s3://")
     assert constraints.file_s3_uri.endswith("constraints.json")
 
-    assert constraints.body_dict["monitoring_config"]["evaluate_constraints"] == "Enabled"
+    assert (
+        constraints.body_dict["monitoring_config"]["evaluate_constraints"] == "Enabled"
+    )
 
 
 def test_constraint_violations_object_creation_from_file_path_with_customizations(
@@ -315,7 +352,10 @@ def test_constraint_violations_object_creation_from_file_path_with_customization
     assert constraint_violations.file_s3_uri.startswith("s3://")
     assert constraint_violations.file_s3_uri.endswith("constraint_violations.json")
 
-    assert constraint_violations.body_dict["violations"][0]["feature_name"] == "store_and_fwd_flag"
+    assert (
+        constraint_violations.body_dict["violations"][0]["feature_name"]
+        == "store_and_fwd_flag"
+    )
 
 
 def test_constraint_violations_object_creation_from_file_path_without_customizations(
@@ -331,13 +371,18 @@ def test_constraint_violations_object_creation_from_file_path_without_customizat
     assert constraint_violations.file_s3_uri.startswith("s3://")
     assert constraint_violations.file_s3_uri.endswith("constraint_violations.json")
 
-    assert constraint_violations.body_dict["violations"][0]["feature_name"] == "store_and_fwd_flag"
+    assert (
+        constraint_violations.body_dict["violations"][0]["feature_name"]
+        == "store_and_fwd_flag"
+    )
 
 
 def test_constraint_violations_object_creation_from_string_with_customizations(
     sagemaker_session, monitoring_files_kms_key
 ):
-    with open(os.path.join(tests.integ.DATA_DIR, "monitor/constraint_violations.json"), "r") as f:
+    with open(
+        os.path.join(tests.integ.DATA_DIR, "monitor/constraint_violations.json"), "r"
+    ) as f:
         file_body = f.read()
 
     constraint_violations = ConstraintViolations.from_string(
@@ -350,13 +395,18 @@ def test_constraint_violations_object_creation_from_string_with_customizations(
     assert constraint_violations.file_s3_uri.startswith("s3://")
     assert constraint_violations.file_s3_uri.endswith("constraint_violations.json")
 
-    assert constraint_violations.body_dict["violations"][0]["feature_name"] == "store_and_fwd_flag"
+    assert (
+        constraint_violations.body_dict["violations"][0]["feature_name"]
+        == "store_and_fwd_flag"
+    )
 
 
 def test_constraint_violations_object_creation_from_string_without_customizations(
     sagemaker_session,
 ):
-    with open(os.path.join(tests.integ.DATA_DIR, "monitor/constraint_violations.json"), "r") as f:
+    with open(
+        os.path.join(tests.integ.DATA_DIR, "monitor/constraint_violations.json"), "r"
+    ) as f:
         file_body = f.read()
 
     constraint_violations = ConstraintViolations.from_string(
@@ -366,13 +416,18 @@ def test_constraint_violations_object_creation_from_string_without_customization
     assert constraint_violations.file_s3_uri.startswith("s3://")
     assert constraint_violations.file_s3_uri.endswith("constraint_violations.json")
 
-    assert constraint_violations.body_dict["violations"][0]["feature_name"] == "store_and_fwd_flag"
+    assert (
+        constraint_violations.body_dict["violations"][0]["feature_name"]
+        == "store_and_fwd_flag"
+    )
 
 
 def test_constraint_violations_object_creation_from_s3_uri_with_customizations(
     sagemaker_session, monitoring_files_kms_key
 ):
-    with open(os.path.join(tests.integ.DATA_DIR, "monitor/constraint_violations.json"), "r") as f:
+    with open(
+        os.path.join(tests.integ.DATA_DIR, "monitor/constraint_violations.json"), "r"
+    ) as f:
         file_body = f.read()
 
     file_name = "constraint_violations.json"
@@ -400,13 +455,18 @@ def test_constraint_violations_object_creation_from_s3_uri_with_customizations(
     assert constraint_violations.file_s3_uri.startswith("s3://")
     assert constraint_violations.file_s3_uri.endswith("constraint_violations.json")
 
-    assert constraint_violations.body_dict["violations"][0]["feature_name"] == "store_and_fwd_flag"
+    assert (
+        constraint_violations.body_dict["violations"][0]["feature_name"]
+        == "store_and_fwd_flag"
+    )
 
 
 def test_constraint_violations_object_creation_from_s3_uri_without_customizations(
     sagemaker_session,
 ):
-    with open(os.path.join(tests.integ.DATA_DIR, "monitor/constraint_violations.json"), "r") as f:
+    with open(
+        os.path.join(tests.integ.DATA_DIR, "monitor/constraint_violations.json"), "r"
+    ) as f:
         file_body = f.read()
 
     file_name = "constraint_violations.json"
@@ -429,4 +489,7 @@ def test_constraint_violations_object_creation_from_s3_uri_without_customization
     assert constraint_violations.file_s3_uri.startswith("s3://")
     assert constraint_violations.file_s3_uri.endswith("constraint_violations.json")
 
-    assert constraint_violations.body_dict["violations"][0]["feature_name"] == "store_and_fwd_flag"
+    assert (
+        constraint_violations.body_dict["violations"][0]["feature_name"]
+        == "store_and_fwd_flag"
+    )

--- a/tests/integ/test_multi_variant_endpoint.py
+++ b/tests/integ/test_multi_variant_endpoint.py
@@ -36,7 +36,9 @@ MODEL_NAME = "test-xgboost-model-{}".format(sagemaker_timestamp())
 DEFAULT_REGION = "us-west-2"
 DEFAULT_INSTANCE_TYPE = "ml.m5.xlarge"
 DEFAULT_INSTANCE_COUNT = 1
-XG_BOOST_MODEL_LOCAL_PATH = os.path.join(tests.integ.DATA_DIR, "xgboost_model", "xgb_model.tar.gz")
+XG_BOOST_MODEL_LOCAL_PATH = os.path.join(
+    tests.integ.DATA_DIR, "xgboost_model", "xgb_model.tar.gz"
+)
 
 TEST_VARIANT_1 = "Variant1"
 TEST_VARIANT_1_WEIGHT = 0.3
@@ -96,7 +98,9 @@ def multi_variant_endpoint(sagemaker_session):
             session=sagemaker_session,
         )
 
-        image_uri = get_image_uri(sagemaker_session.boto_session.region_name, "xgboost", "0.90-1")
+        image_uri = get_image_uri(
+            sagemaker_session.boto_session.region_name, "xgboost", "0.90-1"
+        )
 
         multi_variant_endpoint_model = sagemaker_session.create_model(
             name=MODEL_NAME,
@@ -120,7 +124,8 @@ def multi_variant_endpoint(sagemaker_session):
             initial_weight=TEST_VARIANT_2_WEIGHT,
         )
         sagemaker_session.endpoint_from_production_variants(
-            name=multi_variant_endpoint.endpoint_name, production_variants=[variant1, variant2]
+            name=multi_variant_endpoint.endpoint_name,
+            production_variants=[variant1, variant2],
         )
 
         # Yield to run the integration tests
@@ -165,7 +170,9 @@ def test_target_variant_invocation(sagemaker_session, multi_variant_endpoint):
     assert response["InvokedProductionVariant"] == TEST_VARIANT_2
 
 
-def test_predict_invocation_with_target_variant(sagemaker_session, multi_variant_endpoint):
+def test_predict_invocation_with_target_variant(
+    sagemaker_session, multi_variant_endpoint
+):
     predictor = RealTimePredictor(
         endpoint=multi_variant_endpoint.endpoint_name,
         sagemaker_session=sagemaker_session,
@@ -195,26 +202,47 @@ def test_variant_traffic_distribution(sagemaker_session, multi_variant_endpoint)
         elif response["InvokedProductionVariant"] == TEST_VARIANT_2:
             variant_2_invocation_count += 1
 
-    assert variant_1_invocation_count + variant_2_invocation_count == VARIANT_TRAFFIC_SAMPLING_COUNT
+    assert (
+        variant_1_invocation_count + variant_2_invocation_count
+        == VARIANT_TRAFFIC_SAMPLING_COUNT
+    )
 
     variant_1_invocation_percentage = float(variant_1_invocation_count) / float(
         VARIANT_TRAFFIC_SAMPLING_COUNT
     )
-    variant_1_margin_of_error = _compute_and_retrieve_margin_of_error(TEST_VARIANT_1_WEIGHT)
-    assert variant_1_invocation_percentage < TEST_VARIANT_1_WEIGHT + variant_1_margin_of_error
-    assert variant_1_invocation_percentage > TEST_VARIANT_1_WEIGHT - variant_1_margin_of_error
+    variant_1_margin_of_error = _compute_and_retrieve_margin_of_error(
+        TEST_VARIANT_1_WEIGHT
+    )
+    assert (
+        variant_1_invocation_percentage
+        < TEST_VARIANT_1_WEIGHT + variant_1_margin_of_error
+    )
+    assert (
+        variant_1_invocation_percentage
+        > TEST_VARIANT_1_WEIGHT - variant_1_margin_of_error
+    )
 
     variant_2_invocation_percentage = float(variant_2_invocation_count) / float(
         VARIANT_TRAFFIC_SAMPLING_COUNT
     )
-    variant_2_margin_of_error = _compute_and_retrieve_margin_of_error(TEST_VARIANT_2_WEIGHT)
-    assert variant_2_invocation_percentage < TEST_VARIANT_2_WEIGHT + variant_2_margin_of_error
-    assert variant_2_invocation_percentage > TEST_VARIANT_2_WEIGHT - variant_2_margin_of_error
+    variant_2_margin_of_error = _compute_and_retrieve_margin_of_error(
+        TEST_VARIANT_2_WEIGHT
+    )
+    assert (
+        variant_2_invocation_percentage
+        < TEST_VARIANT_2_WEIGHT + variant_2_margin_of_error
+    )
+    assert (
+        variant_2_invocation_percentage
+        > TEST_VARIANT_2_WEIGHT - variant_2_margin_of_error
+    )
 
 
 def test_spark_ml_predict_invocation_with_target_variant(sagemaker_session):
 
-    spark_ml_model_endpoint_name = unique_name_from_base("integ-test-target-variant-sparkml")
+    spark_ml_model_endpoint_name = unique_name_from_base(
+        "integ-test-target-variant-sparkml"
+    )
 
     model_data = sagemaker_session.upload_data(
         path=SPARK_ML_MODEL_LOCAL_PATH, key_prefix="integ-test-data/sparkml/model"
@@ -237,10 +265,14 @@ def test_spark_ml_predict_invocation_with_target_variant(sagemaker_session):
         )
 
         # Validate that no exception is raised when the target_variant is specified.
-        predictor.predict(SPARK_ML_TEST_DATA, target_variant=SPARK_ML_DEFAULT_VARIANT_NAME)
+        predictor.predict(
+            SPARK_ML_TEST_DATA, target_variant=SPARK_ML_DEFAULT_VARIANT_NAME
+        )
 
         with pytest.raises(Exception) as exception_info:
-            predictor.predict(SPARK_ML_TEST_DATA, target_variant=SPARK_ML_WRONG_VARIANT_NAME)
+            predictor.predict(
+                SPARK_ML_TEST_DATA, target_variant=SPARK_ML_WRONG_VARIANT_NAME
+            )
 
         assert "ValidationError" in str(exception_info.value)
         assert SPARK_ML_WRONG_VARIANT_NAME in str(exception_info.value)
@@ -262,7 +294,9 @@ def test_spark_ml_predict_invocation_with_target_variant(sagemaker_session):
 
 
 @pytest.mark.local_mode
-def test_target_variant_invocation_local_mode(sagemaker_session, multi_variant_endpoint):
+def test_target_variant_invocation_local_mode(
+    sagemaker_session, multi_variant_endpoint
+):
 
     if sagemaker_session._region_name is None:
         sagemaker_session._region_name = DEFAULT_REGION
@@ -313,6 +347,8 @@ def _compute_and_retrieve_margin_of_error(variant_weight):
     intervals of a binomial distribution.
     """
     z_value = st.norm.ppf(DESIRED_CONFIDENCE_FOR_VARIANT_TRAFFIC_DISTRIBUTION)
-    margin_of_error = (variant_weight * (1 - variant_weight)) / VARIANT_TRAFFIC_SAMPLING_COUNT
+    margin_of_error = (
+        variant_weight * (1 - variant_weight)
+    ) / VARIANT_TRAFFIC_SAMPLING_COUNT
     margin_of_error = z_value * math.sqrt(margin_of_error)
     return margin_of_error

--- a/tests/integ/test_mxnet_train.py
+++ b/tests/integ/test_mxnet_train.py
@@ -45,10 +45,12 @@ def mxnet_training_job(sagemaker_session, mxnet_full_version, cpu_instance_type)
         )
 
         train_input = mx.sagemaker_session.upload_data(
-            path=os.path.join(data_path, "train"), key_prefix="integ-test-data/mxnet_mnist/train"
+            path=os.path.join(data_path, "train"),
+            key_prefix="integ-test-data/mxnet_mnist/train",
         )
         test_input = mx.sagemaker_session.upload_data(
-            path=os.path.join(data_path, "test"), key_prefix="integ-test-data/mxnet_mnist/test"
+            path=os.path.join(data_path, "test"),
+            key_prefix="integ-test-data/mxnet_mnist/test",
         )
 
         mx.fit({"train": train_input, "test": test_input})
@@ -60,14 +62,18 @@ def test_attach_deploy(mxnet_training_job, sagemaker_session, cpu_instance_type)
     endpoint_name = "test-mxnet-attach-deploy-{}".format(sagemaker_timestamp())
 
     with timeout_and_delete_endpoint_by_name(endpoint_name, sagemaker_session):
-        estimator = MXNet.attach(mxnet_training_job, sagemaker_session=sagemaker_session)
+        estimator = MXNet.attach(
+            mxnet_training_job, sagemaker_session=sagemaker_session
+        )
         predictor = estimator.deploy(1, cpu_instance_type, endpoint_name=endpoint_name)
         data = numpy.zeros(shape=(1, 1, 28, 28))
         result = predictor.predict(data)
         assert result is not None
 
 
-def test_deploy_model(mxnet_training_job, sagemaker_session, mxnet_full_version, cpu_instance_type):
+def test_deploy_model(
+    mxnet_training_job, sagemaker_session, mxnet_full_version, cpu_instance_type
+):
     endpoint_name = "test-mxnet-deploy-model-{}".format(sagemaker_timestamp())
 
     with timeout_and_delete_endpoint_by_name(endpoint_name, sagemaker_session):
@@ -120,15 +126,23 @@ def test_deploy_model_with_tags_and_kms(
         kms_key_arn = get_or_create_kms_key(sagemaker_session)
 
         model.deploy(
-            1, cpu_instance_type, endpoint_name=endpoint_name, tags=tags, kms_key=kms_key_arn
+            1,
+            cpu_instance_type,
+            endpoint_name=endpoint_name,
+            tags=tags,
+            kms_key=kms_key_arn,
         )
 
-        returned_model = sagemaker_session.sagemaker_client.describe_model(ModelName=model.name)
+        returned_model = sagemaker_session.sagemaker_client.describe_model(
+            ModelName=model.name
+        )
         returned_model_tags = sagemaker_session.sagemaker_client.list_tags(
             ResourceArn=returned_model["ModelArn"]
         )["Tags"]
 
-        endpoint = sagemaker_session.sagemaker_client.describe_endpoint(EndpointName=endpoint_name)
+        endpoint = sagemaker_session.sagemaker_client.describe_endpoint(
+            EndpointName=endpoint_name
+        )
         endpoint_tags = sagemaker_session.sagemaker_client.list_tags(
             ResourceArn=endpoint["EndpointArn"]
         )["Tags"]
@@ -179,11 +193,15 @@ def test_deploy_model_with_update_endpoint(
         )
         old_config_name = old_endpoint["EndpointConfigName"]
 
-        model.deploy(1, cpu_instance_type, update_endpoint=True, endpoint_name=endpoint_name)
+        model.deploy(
+            1, cpu_instance_type, update_endpoint=True, endpoint_name=endpoint_name
+        )
 
         # Wait for endpoint to finish updating
         # Endpoint update takes ~7min. 40 retries * 30s sleeps = 20min timeout
-        for _ in retries(40, "Waiting for 'InService' endpoint status", seconds_to_sleep=30):
+        for _ in retries(
+            40, "Waiting for 'InService' endpoint status", seconds_to_sleep=30
+        ):
             new_endpoint = sagemaker_session.sagemaker_client.describe_endpoint(
                 EndpointName=endpoint_name
             )
@@ -232,7 +250,10 @@ def test_deploy_model_with_update_non_existing_endpoint(
 
         with pytest.raises(ValueError, message=expected_error_message):
             model.deploy(
-                1, cpu_instance_type, update_endpoint=True, endpoint_name="non-existing-endpoint"
+                1,
+                cpu_instance_type,
+                update_endpoint=True,
+                endpoint_name="non-existing-endpoint",
             )
 
 
@@ -261,7 +282,10 @@ def test_deploy_model_with_accelerator(
             sagemaker_session=sagemaker_session,
         )
         predictor = model.deploy(
-            1, cpu_instance_type, endpoint_name=endpoint_name, accelerator_type="ml.eia1.medium"
+            1,
+            cpu_instance_type,
+            endpoint_name=endpoint_name,
+            accelerator_type="ml.eia1.medium",
         )
 
         data = numpy.zeros(shape=(1, 1, 28, 28))
@@ -288,10 +312,12 @@ def test_async_fit(sagemaker_session, mxnet_full_version, cpu_instance_type):
         )
 
         train_input = mx.sagemaker_session.upload_data(
-            path=os.path.join(data_path, "train"), key_prefix="integ-test-data/mxnet_mnist/train"
+            path=os.path.join(data_path, "train"),
+            key_prefix="integ-test-data/mxnet_mnist/train",
         )
         test_input = mx.sagemaker_session.upload_data(
-            path=os.path.join(data_path, "test"), key_prefix="integ-test-data/mxnet_mnist/test"
+            path=os.path.join(data_path, "test"),
+            key_prefix="integ-test-data/mxnet_mnist/test",
         )
 
         mx.fit({"train": train_input, "test": test_input}, wait=False)

--- a/tests/integ/test_neo_mxnet.py
+++ b/tests/integ/test_neo_mxnet.py
@@ -44,10 +44,12 @@ def mxnet_training_job(sagemaker_session, cpu_instance_type):
         )
 
         train_input = mx.sagemaker_session.upload_data(
-            path=os.path.join(data_path, "train"), key_prefix="integ-test-data/mxnet_mnist/train"
+            path=os.path.join(data_path, "train"),
+            key_prefix="integ-test-data/mxnet_mnist/train",
         )
         test_input = mx.sagemaker_session.upload_data(
-            path=os.path.join(data_path, "test"), key_prefix="integ-test-data/mxnet_mnist/test"
+            path=os.path.join(data_path, "test"),
+            key_prefix="integ-test-data/mxnet_mnist/test",
         )
 
         mx.fit({"train": train_input, "test": test_input})
@@ -61,7 +63,9 @@ def test_attach_deploy(
     endpoint_name = unique_name_from_base("test-neo-attach-deploy")
 
     with timeout_and_delete_endpoint_by_name(endpoint_name, sagemaker_session):
-        estimator = MXNet.attach(mxnet_training_job, sagemaker_session=sagemaker_session)
+        estimator = MXNet.attach(
+            mxnet_training_job, sagemaker_session=sagemaker_session
+        )
 
         estimator.compile_model(
             target_instance_family=cpu_instance_family,

--- a/tests/integ/test_ntm.py
+++ b/tests/integ/test_ntm.py
@@ -52,12 +52,18 @@ def test_ntm(sagemaker_session, cpu_instance_type):
         )
 
         record_set = prepare_record_set_from_local_files(
-            data_path, ntm.data_location, len(all_records), feature_num, sagemaker_session
+            data_path,
+            ntm.data_location,
+            len(all_records),
+            feature_num,
+            sagemaker_session,
         )
         ntm.fit(records=record_set, job_name=job_name)
 
     with timeout_and_delete_endpoint_by_name(job_name, sagemaker_session):
-        model = NTMModel(ntm.model_data, role="SageMakerRole", sagemaker_session=sagemaker_session)
+        model = NTMModel(
+            ntm.model_data, role="SageMakerRole", sagemaker_session=sagemaker_session
+        )
         predictor = model.deploy(1, cpu_instance_type, endpoint_name=job_name)
 
         predict_input = np.random.rand(1, feature_num)

--- a/tests/integ/test_object2vec.py
+++ b/tests/integ/test_object2vec.py
@@ -57,14 +57,20 @@ def test_object2vec(sagemaker_session, cpu_instance_type):
         )
 
         record_set = prepare_record_set_from_local_files(
-            data_path, object2vec.data_location, num_records, FEATURE_NUM, sagemaker_session
+            data_path,
+            object2vec.data_location,
+            num_records,
+            FEATURE_NUM,
+            sagemaker_session,
         )
 
         object2vec.fit(records=record_set, job_name=job_name)
 
     with timeout_and_delete_endpoint_by_name(job_name, sagemaker_session):
         model = Object2VecModel(
-            object2vec.model_data, role="SageMakerRole", sagemaker_session=sagemaker_session
+            object2vec.model_data,
+            role="SageMakerRole",
+            sagemaker_session=sagemaker_session,
         )
         predictor = model.deploy(1, cpu_instance_type, endpoint_name=job_name)
         assert isinstance(predictor, RealTimePredictor)

--- a/tests/integ/test_pca.py
+++ b/tests/integ/test_pca.py
@@ -57,7 +57,9 @@ def test_pca(sagemaker_session, cpu_instance_type):
             enable_network_isolation=True,
         )
         predictor = pca_model.deploy(
-            initial_instance_count=1, instance_type=cpu_instance_type, endpoint_name=job_name
+            initial_instance_count=1,
+            instance_type=cpu_instance_type,
+            endpoint_name=job_name,
         )
 
         result = predictor.predict(train_set[0][:5])
@@ -101,10 +103,14 @@ def test_async_pca(sagemaker_session, cpu_instance_type):
         )
 
         model = sagemaker.amazon.pca.PCAModel(
-            estimator.model_data, role="SageMakerRole", sagemaker_session=sagemaker_session
+            estimator.model_data,
+            role="SageMakerRole",
+            sagemaker_session=sagemaker_session,
         )
         predictor = model.deploy(
-            initial_instance_count=1, instance_type=cpu_instance_type, endpoint_name=job_name
+            initial_instance_count=1,
+            instance_type=cpu_instance_type,
+            endpoint_name=job_name,
         )
 
         result = predictor.predict(train_set[0][:5])

--- a/tests/integ/test_processing.py
+++ b/tests/integ/test_processing.py
@@ -106,7 +106,11 @@ def test_sklearn(sagemaker_session, sklearn_full_version, cpu_instance_type):
 
     sklearn_processor.run(
         code=script_path,
-        inputs=[ProcessingInput(source=input_file_path, destination="/opt/ml/processing/inputs/")],
+        inputs=[
+            ProcessingInput(
+                source=input_file_path, destination="/opt/ml/processing/inputs/"
+            )
+        ],
         wait=False,
         logs=False,
     )
@@ -116,9 +120,12 @@ def test_sklearn(sagemaker_session, sklearn_full_version, cpu_instance_type):
     assert len(job_description["ProcessingInputs"]) == 2
     assert job_description["ProcessingResources"]["ClusterConfig"]["InstanceCount"] == 1
     assert (
-        job_description["ProcessingResources"]["ClusterConfig"]["InstanceType"] == cpu_instance_type
+        job_description["ProcessingResources"]["ClusterConfig"]["InstanceType"]
+        == cpu_instance_type
     )
-    assert job_description["ProcessingResources"]["ClusterConfig"]["VolumeSizeInGB"] == 30
+    assert (
+        job_description["ProcessingResources"]["ClusterConfig"]["VolumeSizeInGB"] == 30
+    )
     assert job_description["StoppingCondition"] == {"MaxRuntimeInSeconds": 86400}
     assert job_description["AppSpecification"]["ContainerEntrypoint"] == [
         "python3",
@@ -129,7 +136,11 @@ def test_sklearn(sagemaker_session, sklearn_full_version, cpu_instance_type):
 
 @pytest.mark.canary_quick
 def test_sklearn_with_customizations(
-    sagemaker_session, image_uri, sklearn_full_version, cpu_instance_type, output_kms_key
+    sagemaker_session,
+    image_uri,
+    sklearn_full_version,
+    cpu_instance_type,
+    output_kms_key,
 ):
     input_file_path = os.path.join(DATA_DIR, "dummy_input.txt")
 
@@ -180,18 +191,26 @@ def test_sklearn_with_customizations(
 
     assert job_description["ProcessingInputs"][1]["InputName"] == "code"
 
-    assert job_description["ProcessingJobName"].startswith("test-sklearn-with-customizations")
+    assert job_description["ProcessingJobName"].startswith(
+        "test-sklearn-with-customizations"
+    )
 
     assert job_description["ProcessingJobStatus"] == "Completed"
 
     assert job_description["ProcessingOutputConfig"]["KmsKeyId"] == output_kms_key
-    assert job_description["ProcessingOutputConfig"]["Outputs"][0]["OutputName"] == "dummy_output"
+    assert (
+        job_description["ProcessingOutputConfig"]["Outputs"][0]["OutputName"]
+        == "dummy_output"
+    )
 
     assert job_description["ProcessingResources"]["ClusterConfig"]["InstanceCount"] == 1
     assert (
-        job_description["ProcessingResources"]["ClusterConfig"]["InstanceType"] == cpu_instance_type
+        job_description["ProcessingResources"]["ClusterConfig"]["InstanceType"]
+        == cpu_instance_type
     )
-    assert job_description["ProcessingResources"]["ClusterConfig"]["VolumeSizeInGB"] == 100
+    assert (
+        job_description["ProcessingResources"]["ClusterConfig"]["VolumeSizeInGB"] == 100
+    )
 
     assert job_description["AppSpecification"]["ContainerArguments"] == ["-v"]
     assert job_description["AppSpecification"]["ContainerEntrypoint"] == [
@@ -200,7 +219,9 @@ def test_sklearn_with_customizations(
     ]
     assert job_description["AppSpecification"]["ImageUri"] == image_uri
 
-    assert job_description["Environment"] == {"DUMMY_ENVIRONMENT_VARIABLE": "dummy-value"}
+    assert job_description["Environment"] == {
+        "DUMMY_ENVIRONMENT_VARIABLE": "dummy-value"
+    }
 
     assert ROLE in job_description["RoleArn"]
 
@@ -261,23 +282,35 @@ def test_sklearn_with_custom_default_bucket(
     job_description = sklearn_processor.latest_job.describe()
 
     assert job_description["ProcessingInputs"][0]["InputName"] == "dummy_input"
-    assert custom_bucket_name in job_description["ProcessingInputs"][0]["S3Input"]["S3Uri"]
+    assert (
+        custom_bucket_name in job_description["ProcessingInputs"][0]["S3Input"]["S3Uri"]
+    )
 
     assert job_description["ProcessingInputs"][1]["InputName"] == "code"
-    assert custom_bucket_name in job_description["ProcessingInputs"][1]["S3Input"]["S3Uri"]
+    assert (
+        custom_bucket_name in job_description["ProcessingInputs"][1]["S3Input"]["S3Uri"]
+    )
 
-    assert job_description["ProcessingJobName"].startswith("test-sklearn-with-customizations")
+    assert job_description["ProcessingJobName"].startswith(
+        "test-sklearn-with-customizations"
+    )
 
     assert job_description["ProcessingJobStatus"] == "Completed"
 
     assert job_description["ProcessingOutputConfig"]["KmsKeyId"] == output_kms_key
-    assert job_description["ProcessingOutputConfig"]["Outputs"][0]["OutputName"] == "dummy_output"
+    assert (
+        job_description["ProcessingOutputConfig"]["Outputs"][0]["OutputName"]
+        == "dummy_output"
+    )
 
     assert job_description["ProcessingResources"]["ClusterConfig"]["InstanceCount"] == 1
     assert (
-        job_description["ProcessingResources"]["ClusterConfig"]["InstanceType"] == cpu_instance_type
+        job_description["ProcessingResources"]["ClusterConfig"]["InstanceType"]
+        == cpu_instance_type
     )
-    assert job_description["ProcessingResources"]["ClusterConfig"]["VolumeSizeInGB"] == 100
+    assert (
+        job_description["ProcessingResources"]["ClusterConfig"]["VolumeSizeInGB"] == 100
+    )
 
     assert job_description["AppSpecification"]["ContainerArguments"] == ["-v"]
     assert job_description["AppSpecification"]["ContainerEntrypoint"] == [
@@ -286,7 +319,9 @@ def test_sklearn_with_custom_default_bucket(
     ]
     assert job_description["AppSpecification"]["ImageUri"] == image_uri
 
-    assert job_description["Environment"] == {"DUMMY_ENVIRONMENT_VARIABLE": "dummy-value"}
+    assert job_description["Environment"] == {
+        "DUMMY_ENVIRONMENT_VARIABLE": "dummy-value"
+    }
 
     assert ROLE in job_description["RoleArn"]
 
@@ -312,22 +347,30 @@ def test_sklearn_with_no_inputs_or_outputs(
     )
 
     sklearn_processor.run(
-        code=os.path.join(DATA_DIR, "dummy_script.py"), arguments=["-v"], wait=True, logs=True
+        code=os.path.join(DATA_DIR, "dummy_script.py"),
+        arguments=["-v"],
+        wait=True,
+        logs=True,
     )
 
     job_description = sklearn_processor.latest_job.describe()
 
     assert job_description["ProcessingInputs"][0]["InputName"] == "code"
 
-    assert job_description["ProcessingJobName"].startswith("test-sklearn-with-no-inputs")
+    assert job_description["ProcessingJobName"].startswith(
+        "test-sklearn-with-no-inputs"
+    )
 
     assert job_description["ProcessingJobStatus"] == "Completed"
 
     assert job_description["ProcessingResources"]["ClusterConfig"]["InstanceCount"] == 1
     assert (
-        job_description["ProcessingResources"]["ClusterConfig"]["InstanceType"] == cpu_instance_type
+        job_description["ProcessingResources"]["ClusterConfig"]["InstanceType"]
+        == cpu_instance_type
     )
-    assert job_description["ProcessingResources"]["ClusterConfig"]["VolumeSizeInGB"] == 100
+    assert (
+        job_description["ProcessingResources"]["ClusterConfig"]["VolumeSizeInGB"] == 100
+    )
 
     assert job_description["AppSpecification"]["ContainerArguments"] == ["-v"]
     assert job_description["AppSpecification"]["ContainerEntrypoint"] == [
@@ -336,7 +379,9 @@ def test_sklearn_with_no_inputs_or_outputs(
     ]
     assert job_description["AppSpecification"]["ImageUri"] == image_uri
 
-    assert job_description["Environment"] == {"DUMMY_ENVIRONMENT_VARIABLE": "dummy-value"}
+    assert job_description["Environment"] == {
+        "DUMMY_ENVIRONMENT_VARIABLE": "dummy-value"
+    }
 
     assert ROLE in job_description["RoleArn"]
 
@@ -344,7 +389,9 @@ def test_sklearn_with_no_inputs_or_outputs(
 
 
 @pytest.mark.canary_quick
-def test_script_processor(sagemaker_session, image_uri, cpu_instance_type, output_kms_key):
+def test_script_processor(
+    sagemaker_session, image_uri, cpu_instance_type, output_kms_key
+):
     input_file_path = os.path.join(DATA_DIR, "dummy_input.txt")
 
     script_processor = ScriptProcessor(
@@ -399,13 +446,19 @@ def test_script_processor(sagemaker_session, image_uri, cpu_instance_type, outpu
     assert job_description["ProcessingJobStatus"] == "Completed"
 
     assert job_description["ProcessingOutputConfig"]["KmsKeyId"] == output_kms_key
-    assert job_description["ProcessingOutputConfig"]["Outputs"][0]["OutputName"] == "dummy_output"
+    assert (
+        job_description["ProcessingOutputConfig"]["Outputs"][0]["OutputName"]
+        == "dummy_output"
+    )
 
     assert job_description["ProcessingResources"]["ClusterConfig"]["InstanceCount"] == 1
     assert (
-        job_description["ProcessingResources"]["ClusterConfig"]["InstanceType"] == cpu_instance_type
+        job_description["ProcessingResources"]["ClusterConfig"]["InstanceType"]
+        == cpu_instance_type
     )
-    assert job_description["ProcessingResources"]["ClusterConfig"]["VolumeSizeInGB"] == 100
+    assert (
+        job_description["ProcessingResources"]["ClusterConfig"]["VolumeSizeInGB"] == 100
+    )
 
     assert job_description["AppSpecification"]["ContainerArguments"] == ["-v"]
     assert job_description["AppSpecification"]["ContainerEntrypoint"] == [
@@ -414,7 +467,9 @@ def test_script_processor(sagemaker_session, image_uri, cpu_instance_type, outpu
     ]
     assert job_description["AppSpecification"]["ImageUri"] == image_uri
 
-    assert job_description["Environment"] == {"DUMMY_ENVIRONMENT_VARIABLE": "dummy-value"}
+    assert job_description["Environment"] == {
+        "DUMMY_ENVIRONMENT_VARIABLE": "dummy-value"
+    }
 
     assert ROLE in job_description["RoleArn"]
 
@@ -440,22 +495,30 @@ def test_script_processor_with_no_inputs_or_outputs(
     )
 
     script_processor.run(
-        code=os.path.join(DATA_DIR, "dummy_script.py"), arguments=["-v"], wait=True, logs=True
+        code=os.path.join(DATA_DIR, "dummy_script.py"),
+        arguments=["-v"],
+        wait=True,
+        logs=True,
     )
 
     job_description = script_processor.latest_job.describe()
 
     assert job_description["ProcessingInputs"][0]["InputName"] == "code"
 
-    assert job_description["ProcessingJobName"].startswith("test-script-processor-with-no-inputs")
+    assert job_description["ProcessingJobName"].startswith(
+        "test-script-processor-with-no-inputs"
+    )
 
     assert job_description["ProcessingJobStatus"] == "Completed"
 
     assert job_description["ProcessingResources"]["ClusterConfig"]["InstanceCount"] == 1
     assert (
-        job_description["ProcessingResources"]["ClusterConfig"]["InstanceType"] == cpu_instance_type
+        job_description["ProcessingResources"]["ClusterConfig"]["InstanceType"]
+        == cpu_instance_type
     )
-    assert job_description["ProcessingResources"]["ClusterConfig"]["VolumeSizeInGB"] == 100
+    assert (
+        job_description["ProcessingResources"]["ClusterConfig"]["VolumeSizeInGB"] == 100
+    )
 
     assert job_description["AppSpecification"]["ContainerArguments"] == ["-v"]
     assert job_description["AppSpecification"]["ContainerEntrypoint"] == [
@@ -464,7 +527,9 @@ def test_script_processor_with_no_inputs_or_outputs(
     ]
     assert job_description["AppSpecification"]["ImageUri"] == image_uri
 
-    assert job_description["Environment"] == {"DUMMY_ENVIRONMENT_VARIABLE": "dummy-value"}
+    assert job_description["Environment"] == {
+        "DUMMY_ENVIRONMENT_VARIABLE": "dummy-value"
+    }
 
     assert ROLE in job_description["RoleArn"]
 
@@ -478,15 +543,20 @@ def test_script_processor_with_no_inputs_or_outputs(
 
     assert job_description["ProcessingInputs"][0]["InputName"] == "code"
 
-    assert job_description["ProcessingJobName"].startswith("test-script-processor-with-no-inputs")
+    assert job_description["ProcessingJobName"].startswith(
+        "test-script-processor-with-no-inputs"
+    )
 
     assert job_description["ProcessingJobStatus"] == "Completed"
 
     assert job_description["ProcessingResources"]["ClusterConfig"]["InstanceCount"] == 1
     assert (
-        job_description["ProcessingResources"]["ClusterConfig"]["InstanceType"] == cpu_instance_type
+        job_description["ProcessingResources"]["ClusterConfig"]["InstanceType"]
+        == cpu_instance_type
     )
-    assert job_description["ProcessingResources"]["ClusterConfig"]["VolumeSizeInGB"] == 100
+    assert (
+        job_description["ProcessingResources"]["ClusterConfig"]["VolumeSizeInGB"] == 100
+    )
 
     assert job_description["AppSpecification"]["ContainerArguments"] == ["-v"]
     assert job_description["AppSpecification"]["ContainerEntrypoint"] == [
@@ -495,7 +565,9 @@ def test_script_processor_with_no_inputs_or_outputs(
     ]
     assert job_description["AppSpecification"]["ImageUri"] == image_uri
 
-    assert job_description["Environment"] == {"DUMMY_ENVIRONMENT_VARIABLE": "dummy-value"}
+    assert job_description["Environment"] == {
+        "DUMMY_ENVIRONMENT_VARIABLE": "dummy-value"
+    }
 
     assert ROLE in job_description["RoleArn"]
 
@@ -525,7 +597,9 @@ def test_processor(sagemaker_session, image_uri, cpu_instance_type, output_kms_k
     processor.run(
         inputs=[
             ProcessingInput(
-                source=script_path, destination="/opt/ml/processing/input/code/", input_name="code"
+                source=script_path,
+                destination="/opt/ml/processing/input/code/",
+                input_name="code",
             )
         ],
         outputs=[
@@ -549,13 +623,19 @@ def test_processor(sagemaker_session, image_uri, cpu_instance_type, output_kms_k
     assert job_description["ProcessingJobStatus"] == "Completed"
 
     assert job_description["ProcessingOutputConfig"]["KmsKeyId"] == output_kms_key
-    assert job_description["ProcessingOutputConfig"]["Outputs"][0]["OutputName"] == "dummy_output"
+    assert (
+        job_description["ProcessingOutputConfig"]["Outputs"][0]["OutputName"]
+        == "dummy_output"
+    )
 
     assert job_description["ProcessingResources"]["ClusterConfig"]["InstanceCount"] == 1
     assert (
-        job_description["ProcessingResources"]["ClusterConfig"]["InstanceType"] == cpu_instance_type
+        job_description["ProcessingResources"]["ClusterConfig"]["InstanceType"]
+        == cpu_instance_type
     )
-    assert job_description["ProcessingResources"]["ClusterConfig"]["VolumeSizeInGB"] == 100
+    assert (
+        job_description["ProcessingResources"]["ClusterConfig"]["VolumeSizeInGB"] == 100
+    )
 
     assert job_description["AppSpecification"]["ContainerArguments"] == ["-v"]
     assert job_description["AppSpecification"]["ContainerEntrypoint"] == [
@@ -564,7 +644,9 @@ def test_processor(sagemaker_session, image_uri, cpu_instance_type, output_kms_k
     ]
     assert job_description["AppSpecification"]["ImageUri"] == image_uri
 
-    assert job_description["Environment"] == {"DUMMY_ENVIRONMENT_VARIABLE": "dummy-value"}
+    assert job_description["Environment"] == {
+        "DUMMY_ENVIRONMENT_VARIABLE": "dummy-value"
+    }
 
     assert ROLE in job_description["RoleArn"]
 
@@ -599,7 +681,9 @@ def test_processor_with_custom_bucket(
     processor.run(
         inputs=[
             ProcessingInput(
-                source=script_path, destination="/opt/ml/processing/input/code/", input_name="code"
+                source=script_path,
+                destination="/opt/ml/processing/input/code/",
+                input_name="code",
             )
         ],
         outputs=[
@@ -617,20 +701,28 @@ def test_processor_with_custom_bucket(
     job_description = processor.latest_job.describe()
 
     assert job_description["ProcessingInputs"][0]["InputName"] == "code"
-    assert custom_bucket_name in job_description["ProcessingInputs"][0]["S3Input"]["S3Uri"]
+    assert (
+        custom_bucket_name in job_description["ProcessingInputs"][0]["S3Input"]["S3Uri"]
+    )
 
     assert job_description["ProcessingJobName"].startswith("test-processor")
 
     assert job_description["ProcessingJobStatus"] == "Completed"
 
     assert job_description["ProcessingOutputConfig"]["KmsKeyId"] == output_kms_key
-    assert job_description["ProcessingOutputConfig"]["Outputs"][0]["OutputName"] == "dummy_output"
+    assert (
+        job_description["ProcessingOutputConfig"]["Outputs"][0]["OutputName"]
+        == "dummy_output"
+    )
 
     assert job_description["ProcessingResources"]["ClusterConfig"]["InstanceCount"] == 1
     assert (
-        job_description["ProcessingResources"]["ClusterConfig"]["InstanceType"] == cpu_instance_type
+        job_description["ProcessingResources"]["ClusterConfig"]["InstanceType"]
+        == cpu_instance_type
     )
-    assert job_description["ProcessingResources"]["ClusterConfig"]["VolumeSizeInGB"] == 100
+    assert (
+        job_description["ProcessingResources"]["ClusterConfig"]["VolumeSizeInGB"] == 100
+    )
 
     assert job_description["AppSpecification"]["ContainerArguments"] == ["-v"]
     assert job_description["AppSpecification"]["ContainerEntrypoint"] == [
@@ -639,14 +731,18 @@ def test_processor_with_custom_bucket(
     ]
     assert job_description["AppSpecification"]["ImageUri"] == image_uri
 
-    assert job_description["Environment"] == {"DUMMY_ENVIRONMENT_VARIABLE": "dummy-value"}
+    assert job_description["Environment"] == {
+        "DUMMY_ENVIRONMENT_VARIABLE": "dummy-value"
+    }
 
     assert ROLE in job_description["RoleArn"]
 
     assert job_description["StoppingCondition"] == {"MaxRuntimeInSeconds": 3600}
 
 
-def test_sklearn_with_network_config(sagemaker_session, sklearn_full_version, cpu_instance_type):
+def test_sklearn_with_network_config(
+    sagemaker_session, sklearn_full_version, cpu_instance_type
+):
     script_path = os.path.join(DATA_DIR, "dummy_script.py")
     input_file_path = os.path.join(DATA_DIR, "dummy_input.txt")
 
@@ -665,7 +761,11 @@ def test_sklearn_with_network_config(sagemaker_session, sklearn_full_version, cp
 
     sklearn_processor.run(
         code=script_path,
-        inputs=[ProcessingInput(source=input_file_path, destination="/opt/ml/processing/inputs/")],
+        inputs=[
+            ProcessingInput(
+                source=input_file_path, destination="/opt/ml/processing/inputs/"
+            )
+        ],
         wait=False,
         logs=False,
     )

--- a/tests/integ/test_pytorch_train.py
+++ b/tests/integ/test_pytorch_train.py
@@ -41,7 +41,9 @@ EIA_SCRIPT = os.path.join(EIA_DIR, "empty_inference_script.py")
 @pytest.fixture(scope="module", name="pytorch_training_job")
 def fixture_training_job(sagemaker_session, pytorch_full_version, cpu_instance_type):
     with timeout(minutes=TRAINING_DEFAULT_TIMEOUT_MINUTES):
-        pytorch = _get_pytorch_estimator(sagemaker_session, pytorch_full_version, cpu_instance_type)
+        pytorch = _get_pytorch_estimator(
+            sagemaker_session, pytorch_full_version, cpu_instance_type
+        )
 
         pytorch.fit({"training": _upload_training_data(pytorch)})
         return pytorch.latest_training_job.name
@@ -50,13 +52,19 @@ def fixture_training_job(sagemaker_session, pytorch_full_version, cpu_instance_t
 @pytest.mark.canary_quick
 @pytest.mark.skipif(
     PYTHON_VERSION == "py2",
-    reason="Python 2 is supported by PyTorch {} and lower versions.".format(LATEST_PY2_VERSION),
+    reason="Python 2 is supported by PyTorch {} and lower versions.".format(
+        LATEST_PY2_VERSION
+    ),
 )
 def test_sync_fit_deploy(pytorch_training_job, sagemaker_session, cpu_instance_type):
     # TODO: add tests against local mode when it's ready to be used
-    endpoint_name = "test-pytorch-sync-fit-attach-deploy{}".format(sagemaker_timestamp())
+    endpoint_name = "test-pytorch-sync-fit-attach-deploy{}".format(
+        sagemaker_timestamp()
+    )
     with timeout_and_delete_endpoint_by_name(endpoint_name, sagemaker_session):
-        estimator = PyTorch.attach(pytorch_training_job, sagemaker_session=sagemaker_session)
+        estimator = PyTorch.attach(
+            pytorch_training_job, sagemaker_session=sagemaker_session
+        )
         predictor = estimator.deploy(1, cpu_instance_type, endpoint_name=endpoint_name)
         data = numpy.zeros(shape=(1, 1, 28, 28), dtype=numpy.float32)
         predictor.predict(data)
@@ -71,7 +79,9 @@ def test_sync_fit_deploy(pytorch_training_job, sagemaker_session, cpu_instance_t
 @pytest.mark.local_mode
 @pytest.mark.skipif(
     PYTHON_VERSION == "py2",
-    reason="Python 2 is supported by PyTorch {} and lower versions.".format(LATEST_PY2_VERSION),
+    reason="Python 2 is supported by PyTorch {} and lower versions.".format(
+        LATEST_PY2_VERSION
+    ),
 )
 def test_fit_deploy(sagemaker_local_session, pytorch_full_version):
     pytorch = PyTorch(
@@ -99,7 +109,9 @@ def test_fit_deploy(sagemaker_local_session, pytorch_full_version):
 
 @pytest.mark.skipif(
     PYTHON_VERSION == "py2",
-    reason="Python 2 is supported by PyTorch {} and lower versions.".format(LATEST_PY2_VERSION),
+    reason="Python 2 is supported by PyTorch {} and lower versions.".format(
+        LATEST_PY2_VERSION
+    ),
 )
 def test_deploy_model(pytorch_training_job, sagemaker_session, cpu_instance_type):
     endpoint_name = "test-pytorch-deploy-model-{}".format(sagemaker_timestamp())
@@ -126,9 +138,13 @@ def test_deploy_model(pytorch_training_job, sagemaker_session, cpu_instance_type
 
 @pytest.mark.skipif(
     PYTHON_VERSION == "py2",
-    reason="Python 2 is supported by PyTorch {} and lower versions.".format(LATEST_PY2_VERSION),
+    reason="Python 2 is supported by PyTorch {} and lower versions.".format(
+        LATEST_PY2_VERSION
+    ),
 )
-def test_deploy_packed_model_with_entry_point_name(sagemaker_session, cpu_instance_type):
+def test_deploy_packed_model_with_entry_point_name(
+    sagemaker_session, cpu_instance_type
+):
     endpoint_name = "test-pytorch-deploy-model-{}".format(sagemaker_timestamp())
 
     with timeout_and_delete_endpoint_by_name(endpoint_name, sagemaker_session):
@@ -149,9 +165,12 @@ def test_deploy_packed_model_with_entry_point_name(sagemaker_session, cpu_instan
         assert output.shape == (batch_size, 10)
 
 
-@pytest.mark.skipif(PYTHON_VERSION == "py2", reason="PyTorch EIA does not support Python 2.")
 @pytest.mark.skipif(
-    test_region() not in EI_SUPPORTED_REGIONS, reason="EI isn't supported in that specific region."
+    PYTHON_VERSION == "py2", reason="PyTorch EIA does not support Python 2."
+)
+@pytest.mark.skipif(
+    test_region() not in EI_SUPPORTED_REGIONS,
+    reason="EI isn't supported in that specific region.",
 )
 def test_deploy_model_with_accelerator(sagemaker_session, cpu_instance_type):
     endpoint_name = "test-pytorch-deploy-eia-{}".format(sagemaker_timestamp())

--- a/tests/integ/test_record_set.py
+++ b/tests/integ/test_record_set.py
@@ -42,5 +42,7 @@ def test_record_set(sagemaker_session, cpu_instance_type):
     record_set = kmeans.record_set(train_set[0][:100], encrypt=True)
     parsed_url = urlparse(record_set.s3_data)
     s3_client = sagemaker_session.boto_session.client("s3")
-    head = s3_client.head_object(Bucket=parsed_url.netloc, Key=parsed_url.path.lstrip("/"))
+    head = s3_client.head_object(
+        Bucket=parsed_url.netloc, Key=parsed_url.path.lstrip("/")
+    )
     assert head["ServerSideEncryption"] == "AES256"

--- a/tests/integ/test_rl.py
+++ b/tests/integ/test_rl.py
@@ -27,7 +27,10 @@ from tests.integ.timeout import timeout, timeout_and_delete_endpoint_by_name
 @pytest.mark.skipif(PYTHON_VERSION != "py3", reason="RL images supports only Python 3.")
 def test_coach_mxnet(sagemaker_session, rl_coach_mxnet_full_version, cpu_instance_type):
     estimator = _test_coach(
-        sagemaker_session, RLFramework.MXNET, rl_coach_mxnet_full_version, cpu_instance_type
+        sagemaker_session,
+        RLFramework.MXNET,
+        rl_coach_mxnet_full_version,
+        cpu_instance_type,
     )
     job_name = unique_name_from_base("test-coach-mxnet")
 
@@ -42,7 +45,10 @@ def test_coach_mxnet(sagemaker_session, rl_coach_mxnet_full_version, cpu_instanc
 
     with timeout_and_delete_endpoint_by_name(endpoint_name, sagemaker_session):
         predictor = estimator.deploy(
-            1, cpu_instance_type, entry_point="mxnet_deploy.py", endpoint_name=endpoint_name
+            1,
+            cpu_instance_type,
+            entry_point="mxnet_deploy.py",
+            endpoint_name=endpoint_name,
         )
 
         observation = numpy.asarray([0, 0, 0, 0])
@@ -55,7 +61,10 @@ def test_coach_mxnet(sagemaker_session, rl_coach_mxnet_full_version, cpu_instanc
 @pytest.mark.skipif(PYTHON_VERSION != "py3", reason="RL images supports only Python 3.")
 def test_coach_tf(sagemaker_session, rl_coach_tf_full_version, cpu_instance_type):
     estimator = _test_coach(
-        sagemaker_session, RLFramework.TENSORFLOW, rl_coach_tf_full_version, cpu_instance_type
+        sagemaker_session,
+        RLFramework.TENSORFLOW,
+        rl_coach_tf_full_version,
+        cpu_instance_type,
     )
     job_name = unique_name_from_base("test-coach-tf")
 
@@ -121,4 +130,6 @@ def test_ray_tf(sagemaker_session, rl_ray_full_version, cpu_instance_type):
 
     with pytest.raises(NotImplementedError) as e:
         estimator.deploy(1, cpu_instance_type)
-    assert "Automatic deployment of Ray models is not currently available" in str(e.value)
+    assert "Automatic deployment of Ray models is not currently available" in str(
+        e.value
+    )

--- a/tests/integ/test_s3.py
+++ b/tests/integ/test_s3.py
@@ -66,8 +66,12 @@ def test_s3_uploader_and_downloader_reads_files_when_given_file_name_uris(
     assert file_1_name in s3_uris[0]
     assert file_2_name in s3_uris[1]
 
-    assert file_1_body == S3Downloader.read_file(s3_uri=s3_uris[0], session=sagemaker_session)
-    assert file_2_body == S3Downloader.read_file(s3_uri=s3_uris[1], session=sagemaker_session)
+    assert file_1_body == S3Downloader.read_file(
+        s3_uri=s3_uris[0], session=sagemaker_session
+    )
+    assert file_2_body == S3Downloader.read_file(
+        s3_uri=s3_uris[1], session=sagemaker_session
+    )
 
 
 def test_s3_uploader_and_downloader_downloads_files_when_given_file_name_uris(
@@ -105,8 +109,12 @@ def test_s3_uploader_and_downloader_downloads_files_when_given_file_name_uris(
     assert file_1_name in s3_uris[0]
     assert file_2_name in s3_uris[1]
 
-    S3Downloader.download(s3_uri=s3_uris[0], local_path=TMP_BASE_PATH, session=sagemaker_session)
-    S3Downloader.download(s3_uri=s3_uris[1], local_path=TMP_BASE_PATH, session=sagemaker_session)
+    S3Downloader.download(
+        s3_uri=s3_uris[0], local_path=TMP_BASE_PATH, session=sagemaker_session
+    )
+    S3Downloader.download(
+        s3_uri=s3_uris[1], local_path=TMP_BASE_PATH, session=sagemaker_session
+    )
 
     with open(os.path.join(TMP_BASE_PATH, file_1_name), "r") as f:
         assert file_1_body == f.read()
@@ -150,10 +158,16 @@ def test_s3_uploader_and_downloader_downloads_files_when_given_directory_uris_wi
     assert file_1_name in s3_uris[0]
     assert file_2_name in s3_uris[1]
 
-    assert file_1_body == S3Downloader.read_file(s3_uri=s3_uris[0], session=sagemaker_session)
-    assert file_2_body == S3Downloader.read_file(s3_uri=s3_uris[1], session=sagemaker_session)
+    assert file_1_body == S3Downloader.read_file(
+        s3_uri=s3_uris[0], session=sagemaker_session
+    )
+    assert file_2_body == S3Downloader.read_file(
+        s3_uri=s3_uris[1], session=sagemaker_session
+    )
 
-    S3Downloader.download(s3_uri=base_s3_uri, local_path=TMP_BASE_PATH, session=sagemaker_session)
+    S3Downloader.download(
+        s3_uri=base_s3_uri, local_path=TMP_BASE_PATH, session=sagemaker_session
+    )
 
     with open(os.path.join(TMP_BASE_PATH, file_1_name), "r") as f:
         assert file_1_body == f.read()
@@ -202,8 +216,12 @@ def test_s3_uploader_and_downloader_downloads_files_when_given_directory_uris_wi
     assert file_1_name in s3_uris[0]
     assert file_2_name in s3_uris[1]
 
-    assert file_1_body == S3Downloader.read_file(s3_uri=s3_uris[0], session=sagemaker_session)
-    assert file_2_body == S3Downloader.read_file(s3_uri=s3_uris[1], session=sagemaker_session)
+    assert file_1_body == S3Downloader.read_file(
+        s3_uri=s3_uris[0], session=sagemaker_session
+    )
+    assert file_2_body == S3Downloader.read_file(
+        s3_uri=s3_uris[1], session=sagemaker_session
+    )
 
     s3_directory_with_directory_underneath = os.path.join(
         "s3://", sagemaker_session.default_bucket(), "integ-test-test-s3-list", my_uuid
@@ -215,8 +233,12 @@ def test_s3_uploader_and_downloader_downloads_files_when_given_directory_uris_wi
         session=sagemaker_session,
     )
 
-    with open(os.path.join(TMP_BASE_PATH, my_inner_directory_uuid, file_1_name), "r") as f:
+    with open(
+        os.path.join(TMP_BASE_PATH, my_inner_directory_uuid, file_1_name), "r"
+    ) as f:
         assert file_1_body == f.read()
 
-    with open(os.path.join(TMP_BASE_PATH, my_inner_directory_uuid, file_2_name), "r") as f:
+    with open(
+        os.path.join(TMP_BASE_PATH, my_inner_directory_uuid, file_2_name), "r"
+    ) as f:
         assert file_2_body == f.read()

--- a/tests/integ/test_sklearn_train.py
+++ b/tests/integ/test_sklearn_train.py
@@ -32,11 +32,15 @@ from tests.integ.timeout import timeout, timeout_and_delete_endpoint_by_name
     "This test should be fixed. Details in https://github.com/aws/sagemaker-python-sdk/pull/968"
 )
 def sklearn_training_job(sagemaker_session, sklearn_full_version, cpu_instance_type):
-    return _run_mnist_training_job(sagemaker_session, cpu_instance_type, sklearn_full_version)
+    return _run_mnist_training_job(
+        sagemaker_session, cpu_instance_type, sklearn_full_version
+    )
     sagemaker_session.boto_region_name
 
 
-@pytest.mark.skipif(PYTHON_VERSION != "py3", reason="Scikit-learn image supports only python 3.")
+@pytest.mark.skipif(
+    PYTHON_VERSION != "py3", reason="Scikit-learn image supports only python 3."
+)
 def test_training_with_additional_hyperparameters(
     sagemaker_session, sklearn_full_version, cpu_instance_type
 ):
@@ -55,10 +59,12 @@ def test_training_with_additional_hyperparameters(
         )
 
         train_input = sklearn.sagemaker_session.upload_data(
-            path=os.path.join(data_path, "train"), key_prefix="integ-test-data/sklearn_mnist/train"
+            path=os.path.join(data_path, "train"),
+            key_prefix="integ-test-data/sklearn_mnist/train",
         )
         test_input = sklearn.sagemaker_session.upload_data(
-            path=os.path.join(data_path, "test"), key_prefix="integ-test-data/sklearn_mnist/test"
+            path=os.path.join(data_path, "test"),
+            key_prefix="integ-test-data/sklearn_mnist/test",
         )
         job_name = unique_name_from_base("test-sklearn-hp")
 
@@ -66,7 +72,9 @@ def test_training_with_additional_hyperparameters(
         return sklearn.latest_training_job.name
 
 
-@pytest.mark.skipif(PYTHON_VERSION != "py3", reason="Scikit-learn image supports only python 3.")
+@pytest.mark.skipif(
+    PYTHON_VERSION != "py3", reason="Scikit-learn image supports only python 3."
+)
 def test_training_with_network_isolation(
     sagemaker_session, sklearn_full_version, cpu_instance_type
 ):
@@ -86,22 +94,26 @@ def test_training_with_network_isolation(
         )
 
         train_input = sklearn.sagemaker_session.upload_data(
-            path=os.path.join(data_path, "train"), key_prefix="integ-test-data/sklearn_mnist/train"
+            path=os.path.join(data_path, "train"),
+            key_prefix="integ-test-data/sklearn_mnist/train",
         )
         test_input = sklearn.sagemaker_session.upload_data(
-            path=os.path.join(data_path, "test"), key_prefix="integ-test-data/sklearn_mnist/test"
+            path=os.path.join(data_path, "test"),
+            key_prefix="integ-test-data/sklearn_mnist/test",
         )
         job_name = unique_name_from_base("test-sklearn-hp")
 
         sklearn.fit({"train": train_input, "test": test_input}, job_name=job_name)
-        assert sagemaker_session.sagemaker_client.describe_training_job(TrainingJobName=job_name)[
-            "EnableNetworkIsolation"
-        ]
+        assert sagemaker_session.sagemaker_client.describe_training_job(
+            TrainingJobName=job_name
+        )["EnableNetworkIsolation"]
         return sklearn.latest_training_job.name
 
 
 @pytest.mark.canary_quick
-@pytest.mark.skipif(PYTHON_VERSION != "py3", reason="Scikit-learn image supports only python 3.")
+@pytest.mark.skipif(
+    PYTHON_VERSION != "py3", reason="Scikit-learn image supports only python 3."
+)
 @pytest.mark.skip(
     reason="This test has always failed, but the failure was masked by a bug. "
     "This test should be fixed. Details in https://github.com/aws/sagemaker-python-sdk/pull/968"
@@ -110,12 +122,16 @@ def test_attach_deploy(sklearn_training_job, sagemaker_session, cpu_instance_typ
     endpoint_name = "test-sklearn-attach-deploy-{}".format(sagemaker_timestamp())
 
     with timeout_and_delete_endpoint_by_name(endpoint_name, sagemaker_session):
-        estimator = SKLearn.attach(sklearn_training_job, sagemaker_session=sagemaker_session)
+        estimator = SKLearn.attach(
+            sklearn_training_job, sagemaker_session=sagemaker_session
+        )
         predictor = estimator.deploy(1, cpu_instance_type, endpoint_name=endpoint_name)
         _predict_and_assert(predictor)
 
 
-@pytest.mark.skipif(PYTHON_VERSION != "py3", reason="Scikit-learn image supports only python 3.")
+@pytest.mark.skipif(
+    PYTHON_VERSION != "py3", reason="Scikit-learn image supports only python 3."
+)
 @pytest.mark.skip(
     reason="This test has always failed, but the failure was masked by a bug. "
     "This test should be fixed. Details in https://github.com/aws/sagemaker-python-sdk/pull/968"
@@ -138,7 +154,9 @@ def test_deploy_model(sklearn_training_job, sagemaker_session, cpu_instance_type
         _predict_and_assert(predictor)
 
 
-@pytest.mark.skipif(PYTHON_VERSION != "py3", reason="Scikit-learn image supports only python 3.")
+@pytest.mark.skipif(
+    PYTHON_VERSION != "py3", reason="Scikit-learn image supports only python 3."
+)
 @pytest.mark.skip(
     reason="This test has always failed, but the failure was masked by a bug. "
     "This test should be fixed. Details in https://github.com/aws/sagemaker-python-sdk/pull/968"
@@ -148,7 +166,10 @@ def test_async_fit(sagemaker_session, cpu_instance_type):
 
     with timeout(minutes=5):
         training_job_name = _run_mnist_training_job(
-            sagemaker_session, cpu_instance_type, sklearn_full_version=SKLEARN_VERSION, wait=False
+            sagemaker_session,
+            cpu_instance_type,
+            sklearn_full_version=SKLEARN_VERSION,
+            wait=False,
         )
 
         print("Waiting to re-attach to the training job: %s" % training_job_name)
@@ -163,8 +184,12 @@ def test_async_fit(sagemaker_session, cpu_instance_type):
         _predict_and_assert(predictor)
 
 
-@pytest.mark.skipif(PYTHON_VERSION != "py3", reason="Scikit-learn image supports only python 3.")
-def test_failed_training_job(sagemaker_session, sklearn_full_version, cpu_instance_type):
+@pytest.mark.skipif(
+    PYTHON_VERSION != "py3", reason="Scikit-learn image supports only python 3."
+)
+def test_failed_training_job(
+    sagemaker_session, sklearn_full_version, cpu_instance_type
+):
     with timeout(minutes=TRAINING_DEFAULT_TIMEOUT_MINUTES):
         script_path = os.path.join(DATA_DIR, "sklearn_mnist", "failure_script.py")
         data_path = os.path.join(DATA_DIR, "sklearn_mnist")
@@ -180,7 +205,8 @@ def test_failed_training_job(sagemaker_session, sklearn_full_version, cpu_instan
         )
 
         train_input = sklearn.sagemaker_session.upload_data(
-            path=os.path.join(data_path, "train"), key_prefix="integ-test-data/sklearn_mnist/train"
+            path=os.path.join(data_path, "train"),
+            key_prefix="integ-test-data/sklearn_mnist/train",
         )
         job_name = unique_name_from_base("test-sklearn-failed")
 
@@ -188,7 +214,9 @@ def test_failed_training_job(sagemaker_session, sklearn_full_version, cpu_instan
             sklearn.fit(train_input, job_name=job_name)
 
 
-def _run_mnist_training_job(sagemaker_session, instance_type, sklearn_full_version, wait=True):
+def _run_mnist_training_job(
+    sagemaker_session, instance_type, sklearn_full_version, wait=True
+):
     with timeout(minutes=TRAINING_DEFAULT_TIMEOUT_MINUTES):
 
         script_path = os.path.join(DATA_DIR, "sklearn_mnist", "mnist.py")
@@ -206,14 +234,18 @@ def _run_mnist_training_job(sagemaker_session, instance_type, sklearn_full_versi
         )
 
         train_input = sklearn.sagemaker_session.upload_data(
-            path=os.path.join(data_path, "train"), key_prefix="integ-test-data/sklearn_mnist/train"
+            path=os.path.join(data_path, "train"),
+            key_prefix="integ-test-data/sklearn_mnist/train",
         )
         test_input = sklearn.sagemaker_session.upload_data(
-            path=os.path.join(data_path, "test"), key_prefix="integ-test-data/sklearn_mnist/test"
+            path=os.path.join(data_path, "test"),
+            key_prefix="integ-test-data/sklearn_mnist/test",
         )
         job_name = unique_name_from_base("test-sklearn-mnist")
 
-        sklearn.fit({"train": train_input, "test": test_input}, wait=wait, job_name=job_name)
+        sklearn.fit(
+            {"train": train_input, "test": test_input}, wait=wait, job_name=job_name
+        )
         return sklearn.latest_training_job.name
 
 

--- a/tests/integ/test_source_dirs.py
+++ b/tests/integ/test_source_dirs.py
@@ -45,7 +45,9 @@ def test_source_dirs(tmpdir, sagemaker_local_session):
     # endpoint tests all use the same port, so we use this lock to prevent concurrent execution
     with lock.lock():
         try:
-            predictor = estimator.deploy(initial_instance_count=1, instance_type="local")
+            predictor = estimator.deploy(
+                initial_instance_count=1, instance_type="local"
+            )
             predict_response = predictor.predict([7])
             assert predict_response == [49]
         finally:

--- a/tests/integ/test_tf_efs_fsx.py
+++ b/tests/integ/test_tf_efs_fsx.py
@@ -31,7 +31,9 @@ from tests.integ.timeout import timeout
 RESOURCE_PATH = os.path.join(os.path.dirname(__file__), "..", "data")
 MNIST_RESOURCE_PATH = os.path.join(RESOURCE_PATH, "tensorflow_mnist")
 SCRIPT = os.path.join(MNIST_RESOURCE_PATH, "mnist.py")
-TFS_RESOURCE_PATH = os.path.join(RESOURCE_PATH, "tfs", "tfs-test-entrypoint-with-handler")
+TFS_RESOURCE_PATH = os.path.join(
+    RESOURCE_PATH, "tfs", "tfs-test-entrypoint-with-handler"
+)
 EFS_DIR_PATH = "/tensorflow"
 FSX_DIR_PATH = "/fsx/tensorflow"
 MAX_JOBS = 2
@@ -81,7 +83,9 @@ def test_mnist_efs(efs_fsx_setup, sagemaker_session, cpu_instance_type):
         content_type=content_type,
     )
     with timeout(minutes=TRAINING_DEFAULT_TIMEOUT_MINUTES):
-        estimator.fit(inputs=file_system_input, job_name=unique_name_from_base("test-mnist-efs"))
+        estimator.fit(
+            inputs=file_system_input, job_name=unique_name_from_base("test-mnist-efs")
+        )
 
     assert_s3_files_exist(
         sagemaker_session,
@@ -114,11 +118,16 @@ def test_mnist_lustre(efs_fsx_setup, sagemaker_session, cpu_instance_type):
 
     file_system_fsx_id = efs_fsx_setup["file_system_fsx_id"]
     file_system_input = FileSystemInput(
-        file_system_id=file_system_fsx_id, file_system_type="FSxLustre", directory_path=FSX_DIR_PATH
+        file_system_id=file_system_fsx_id,
+        file_system_type="FSxLustre",
+        directory_path=FSX_DIR_PATH,
     )
 
     with timeout(minutes=TRAINING_DEFAULT_TIMEOUT_MINUTES):
-        estimator.fit(inputs=file_system_input, job_name=unique_name_from_base("test-mnist-lustre"))
+        estimator.fit(
+            inputs=file_system_input,
+            job_name=unique_name_from_base("test-mnist-lustre"),
+        )
     assert_s3_files_exist(
         sagemaker_session,
         estimator.model_dir,
@@ -150,7 +159,9 @@ def test_tuning_tf_script_mode_efs(efs_fsx_setup, sagemaker_session, cpu_instanc
 
     hyperparameter_ranges = {"epochs": IntegerParameter(1, 2)}
     objective_metric_name = "accuracy"
-    metric_definitions = [{"Name": objective_metric_name, "Regex": "accuracy = ([0-9\\.]+)"}]
+    metric_definitions = [
+        {"Name": objective_metric_name, "Regex": "accuracy = ([0-9\\.]+)"}
+    ]
     tuner = HyperparameterTuner(
         estimator,
         objective_metric_name,
@@ -162,11 +173,15 @@ def test_tuning_tf_script_mode_efs(efs_fsx_setup, sagemaker_session, cpu_instanc
 
     file_system_efs_id = efs_fsx_setup["file_system_efs_id"]
     file_system_input = FileSystemInput(
-        file_system_id=file_system_efs_id, file_system_type="EFS", directory_path=EFS_DIR_PATH
+        file_system_id=file_system_efs_id,
+        file_system_type="EFS",
+        directory_path=EFS_DIR_PATH,
     )
 
     with timeout(minutes=TUNING_DEFAULT_TIMEOUT_MINUTES):
-        tuning_job_name = unique_name_from_base("test-tuning-tf-script-mode-efs", max_length=32)
+        tuning_job_name = unique_name_from_base(
+            "test-tuning-tf-script-mode-efs", max_length=32
+        )
         tuner.fit(file_system_input, job_name=tuning_job_name)
         time.sleep(15)
         tuner.wait()
@@ -178,7 +193,9 @@ def test_tuning_tf_script_mode_efs(efs_fsx_setup, sagemaker_session, cpu_instanc
     tests.integ.test_region() not in tests.integ.EFS_TEST_ENABLED_REGION,
     reason="EFS integration tests need to be fixed before running in all regions.",
 )
-def test_tuning_tf_script_mode_lustre(efs_fsx_setup, sagemaker_session, cpu_instance_type):
+def test_tuning_tf_script_mode_lustre(
+    efs_fsx_setup, sagemaker_session, cpu_instance_type
+):
     role = efs_fsx_setup["role_name"]
     subnets = [efs_fsx_setup["subnet_id"]]
     security_group_ids = efs_fsx_setup["security_group_ids"]
@@ -198,7 +215,9 @@ def test_tuning_tf_script_mode_lustre(efs_fsx_setup, sagemaker_session, cpu_inst
 
     hyperparameter_ranges = {"epochs": IntegerParameter(1, 2)}
     objective_metric_name = "accuracy"
-    metric_definitions = [{"Name": objective_metric_name, "Regex": "accuracy = ([0-9\\.]+)"}]
+    metric_definitions = [
+        {"Name": objective_metric_name, "Regex": "accuracy = ([0-9\\.]+)"}
+    ]
     tuner = HyperparameterTuner(
         estimator,
         objective_metric_name,
@@ -210,11 +229,15 @@ def test_tuning_tf_script_mode_lustre(efs_fsx_setup, sagemaker_session, cpu_inst
 
     file_system_fsx_id = efs_fsx_setup["file_system_fsx_id"]
     file_system_input = FileSystemInput(
-        file_system_id=file_system_fsx_id, file_system_type="FSxLustre", directory_path=FSX_DIR_PATH
+        file_system_id=file_system_fsx_id,
+        file_system_type="FSxLustre",
+        directory_path=FSX_DIR_PATH,
     )
 
     with timeout(minutes=TUNING_DEFAULT_TIMEOUT_MINUTES):
-        tuning_job_name = unique_name_from_base("test-tuning-tf-script-mode-lustre", max_length=32)
+        tuning_job_name = unique_name_from_base(
+            "test-tuning-tf-script-mode-lustre", max_length=32
+        )
         tuner.fit(file_system_input, job_name=tuning_job_name)
         time.sleep(15)
         tuner.wait()

--- a/tests/integ/test_tf_script_mode.py
+++ b/tests/integ/test_tf_script_mode.py
@@ -32,7 +32,9 @@ ROLE = "SageMakerRole"
 
 RESOURCE_PATH = os.path.join(os.path.dirname(__file__), "..", "data")
 MNIST_RESOURCE_PATH = os.path.join(RESOURCE_PATH, "tensorflow_mnist")
-TFS_RESOURCE_PATH = os.path.join(RESOURCE_PATH, "tfs", "tfs-test-entrypoint-with-handler")
+TFS_RESOURCE_PATH = os.path.join(
+    RESOURCE_PATH, "tfs", "tfs-test-entrypoint-with-handler"
+)
 
 SCRIPT = os.path.join(MNIST_RESOURCE_PATH, "mnist.py")
 PARAMETER_SERVER_DISTRIBUTION = {"parameter_server": {"enabled": True}}
@@ -61,7 +63,9 @@ def test_mnist_with_checkpoint_config(
         script_mode=True,
         framework_version=tf_full_version,
         py_version=py_version,
-        metric_definitions=[{"Name": "train:global_steps", "Regex": r"global_step\/sec:\s(.*)"}],
+        metric_definitions=[
+            {"Name": "train:global_steps", "Regex": r"global_step\/sec:\s(.*)"}
+        ],
         checkpoint_s3_uri=checkpoint_s3_uri,
         checkpoint_local_path=checkpoint_local_path,
     )
@@ -70,7 +74,9 @@ def test_mnist_with_checkpoint_config(
     )
 
     training_job_name = unique_name_from_base("test-tf-sm-mnist")
-    with tests.integ.timeout.timeout(minutes=tests.integ.TRAINING_DEFAULT_TIMEOUT_MINUTES):
+    with tests.integ.timeout.timeout(
+        minutes=tests.integ.TRAINING_DEFAULT_TIMEOUT_MINUTES
+    ):
         estimator.fit(inputs=inputs, job_name=training_job_name)
     assert_s3_files_exist(
         sagemaker_session,
@@ -86,12 +92,17 @@ def test_mnist_with_checkpoint_config(
     }
     actual_training_checkpoint_config = sagemaker_session.sagemaker_client.describe_training_job(
         TrainingJobName=training_job_name
-    )["CheckpointConfig"]
+    )[
+        "CheckpointConfig"
+    ]
     assert actual_training_checkpoint_config == expected_training_checkpoint_config
 
 
 def test_server_side_encryption(sagemaker_session, tf_full_version, py_version):
-    with kms_utils.bucket_with_encryption(sagemaker_session, ROLE) as (bucket_with_kms, kms_key):
+    with kms_utils.bucket_with_encryption(sagemaker_session, ROLE) as (
+        bucket_with_kms,
+        kms_key,
+    ):
         output_path = os.path.join(
             bucket_with_kms, "test-server-side-encryption", time.strftime("%y%m%d-%H%M")
         )
@@ -113,16 +124,22 @@ def test_server_side_encryption(sagemaker_session, tf_full_version, py_version):
         )
 
         inputs = estimator.sagemaker_session.upload_data(
-            path=os.path.join(MNIST_RESOURCE_PATH, "data"), key_prefix="scriptmode/mnist"
+            path=os.path.join(MNIST_RESOURCE_PATH, "data"),
+            key_prefix="scriptmode/mnist",
         )
 
-        with tests.integ.timeout.timeout(minutes=tests.integ.TRAINING_DEFAULT_TIMEOUT_MINUTES):
+        with tests.integ.timeout.timeout(
+            minutes=tests.integ.TRAINING_DEFAULT_TIMEOUT_MINUTES
+        ):
             estimator.fit(
-                inputs=inputs, job_name=unique_name_from_base("test-server-side-encryption")
+                inputs=inputs,
+                job_name=unique_name_from_base("test-server-side-encryption"),
             )
 
         endpoint_name = unique_name_from_base("test-server-side-encryption")
-        with timeout.timeout_and_delete_endpoint_by_name(endpoint_name, sagemaker_session):
+        with timeout.timeout_and_delete_endpoint_by_name(
+            endpoint_name, sagemaker_session
+        ):
             estimator.deploy(
                 initial_instance_count=1,
                 instance_type="ml.c5.xlarge",
@@ -132,7 +149,9 @@ def test_server_side_encryption(sagemaker_session, tf_full_version, py_version):
 
 
 @pytest.mark.canary_quick
-def test_mnist_distributed(sagemaker_session, instance_type, tf_full_version, py_version):
+def test_mnist_distributed(
+    sagemaker_session, instance_type, tf_full_version, py_version
+):
     estimator = TensorFlow(
         entry_point=SCRIPT,
         role=ROLE,
@@ -145,11 +164,16 @@ def test_mnist_distributed(sagemaker_session, instance_type, tf_full_version, py
         distributions=PARAMETER_SERVER_DISTRIBUTION,
     )
     inputs = estimator.sagemaker_session.upload_data(
-        path=os.path.join(MNIST_RESOURCE_PATH, "data"), key_prefix="scriptmode/distributed_mnist"
+        path=os.path.join(MNIST_RESOURCE_PATH, "data"),
+        key_prefix="scriptmode/distributed_mnist",
     )
 
-    with tests.integ.timeout.timeout(minutes=tests.integ.TRAINING_DEFAULT_TIMEOUT_MINUTES):
-        estimator.fit(inputs=inputs, job_name=unique_name_from_base("test-tf-sm-distributed"))
+    with tests.integ.timeout.timeout(
+        minutes=tests.integ.TRAINING_DEFAULT_TIMEOUT_MINUTES
+    ):
+        estimator.fit(
+            inputs=inputs, job_name=unique_name_from_base("test-tf-sm-distributed")
+        )
     assert_s3_files_exist(
         sagemaker_session,
         estimator.model_dir,
@@ -173,14 +197,18 @@ def test_mnist_async(sagemaker_session, cpu_instance_type, tf_full_version, py_v
     inputs = estimator.sagemaker_session.upload_data(
         path=os.path.join(MNIST_RESOURCE_PATH, "data"), key_prefix="scriptmode/mnist"
     )
-    estimator.fit(inputs=inputs, wait=False, job_name=unique_name_from_base("test-tf-sm-async"))
+    estimator.fit(
+        inputs=inputs, wait=False, job_name=unique_name_from_base("test-tf-sm-async")
+    )
     training_job_name = estimator.latest_training_job.name
     time.sleep(20)
     endpoint_name = training_job_name
     _assert_training_job_tags_match(
         sagemaker_session.sagemaker_client, estimator.latest_training_job.name, TAGS
     )
-    with tests.integ.timeout.timeout_and_delete_endpoint_by_name(endpoint_name, sagemaker_session):
+    with tests.integ.timeout.timeout_and_delete_endpoint_by_name(
+        endpoint_name, sagemaker_session
+    ):
         estimator = TensorFlow.attach(
             training_job_name=training_job_name, sagemaker_session=sagemaker_session
         )
@@ -194,12 +222,18 @@ def test_mnist_async(sagemaker_session, cpu_instance_type, tf_full_version, py_v
 
         result = predictor.predict(np.zeros(784))
         print("predict result: {}".format(result))
-        _assert_endpoint_tags_match(sagemaker_session.sagemaker_client, predictor.endpoint, TAGS)
+        _assert_endpoint_tags_match(
+            sagemaker_session.sagemaker_client, predictor.endpoint, TAGS
+        )
         _assert_model_tags_match(sagemaker_session.sagemaker_client, model_name, TAGS)
-        _assert_model_name_match(sagemaker_session.sagemaker_client, endpoint_name, model_name)
+        _assert_model_name_match(
+            sagemaker_session.sagemaker_client, endpoint_name, model_name
+        )
 
 
-def test_deploy_with_input_handlers(sagemaker_session, instance_type, tf_full_version, py_version):
+def test_deploy_with_input_handlers(
+    sagemaker_session, instance_type, tf_full_version, py_version
+):
     estimator = TensorFlow(
         entry_point="training.py",
         source_dir=TFS_RESOURCE_PATH,
@@ -248,7 +282,9 @@ def _assert_model_tags_match(sagemaker_client, model_name, tags):
 
 
 def _assert_endpoint_tags_match(sagemaker_client, endpoint_name, tags):
-    endpoint_description = sagemaker_client.describe_endpoint(EndpointName=endpoint_name)
+    endpoint_description = sagemaker_client.describe_endpoint(
+        EndpointName=endpoint_name
+    )
 
     _assert_tags_match(sagemaker_client, endpoint_description["EndpointArn"], tags)
 
@@ -257,11 +293,15 @@ def _assert_training_job_tags_match(sagemaker_client, training_job_name, tags):
     training_job_description = sagemaker_client.describe_training_job(
         TrainingJobName=training_job_name
     )
-    _assert_tags_match(sagemaker_client, training_job_description["TrainingJobArn"], tags)
+    _assert_tags_match(
+        sagemaker_client, training_job_description["TrainingJobArn"], tags
+    )
 
 
 def _assert_model_name_match(sagemaker_client, endpoint_config_name, model_name):
     endpoint_config_description = sagemaker_client.describe_endpoint_config(
         EndpointConfigName=endpoint_config_name
     )
-    assert model_name == endpoint_config_description["ProductionVariants"][0]["ModelName"]
+    assert (
+        model_name == endpoint_config_description["ProductionVariants"][0]["ModelName"]
+    )

--- a/tests/integ/test_tfs.py
+++ b/tests/integ/test_tfs.py
@@ -28,12 +28,16 @@ from sagemaker.tensorflow.serving import Model, Predictor
 
 @pytest.fixture(scope="module")
 def tfs_predictor(sagemaker_session, tf_full_version):
-    endpoint_name = sagemaker.utils.unique_name_from_base("sagemaker-tensorflow-serving")
+    endpoint_name = sagemaker.utils.unique_name_from_base(
+        "sagemaker-tensorflow-serving"
+    )
     model_data = sagemaker_session.upload_data(
         path=os.path.join(tests.integ.DATA_DIR, "tensorflow-serving-test-model.tar.gz"),
         key_prefix="tensorflow-serving/models",
     )
-    with tests.integ.timeout.timeout_and_delete_endpoint_by_name(endpoint_name, sagemaker_session):
+    with tests.integ.timeout.timeout_and_delete_endpoint_by_name(
+        endpoint_name, sagemaker_session
+    ):
         model = Model(
             model_data=model_data,
             role="SageMakerRole",
@@ -56,7 +60,9 @@ def tar_dir(directory, tmpdir):
 def tfs_predictor_with_model_and_entry_point_same_tar(
     sagemaker_local_session, tf_full_version, tmpdir
 ):
-    endpoint_name = sagemaker.utils.unique_name_from_base("sagemaker-tensorflow-serving")
+    endpoint_name = sagemaker.utils.unique_name_from_base(
+        "sagemaker-tensorflow-serving"
+    )
 
     model_tar = tar_dir(
         os.path.join(tests.integ.DATA_DIR, "tfs/tfs-test-model-with-inference"), tmpdir
@@ -80,13 +86,18 @@ def tfs_predictor_with_model_and_entry_point_same_tar(
 def tfs_predictor_with_model_and_entry_point_and_dependencies(
     sagemaker_local_session, tf_full_version
 ):
-    endpoint_name = sagemaker.utils.unique_name_from_base("sagemaker-tensorflow-serving")
+    endpoint_name = sagemaker.utils.unique_name_from_base(
+        "sagemaker-tensorflow-serving"
+    )
 
     entry_point = os.path.join(
         tests.integ.DATA_DIR, "tfs/tfs-test-entrypoint-and-dependencies/inference.py"
     )
     dependencies = [
-        os.path.join(tests.integ.DATA_DIR, "tfs/tfs-test-entrypoint-and-dependencies/dependency.py")
+        os.path.join(
+            tests.integ.DATA_DIR,
+            "tfs/tfs-test-entrypoint-and-dependencies/dependency.py",
+        )
     ]
 
     model_data = "file://" + os.path.join(
@@ -111,13 +122,19 @@ def tfs_predictor_with_model_and_entry_point_and_dependencies(
 
 
 @pytest.fixture(scope="module")
-def tfs_predictor_with_accelerator(sagemaker_session, ei_tf_full_version, cpu_instance_type):
-    endpoint_name = sagemaker.utils.unique_name_from_base("sagemaker-tensorflow-serving")
+def tfs_predictor_with_accelerator(
+    sagemaker_session, ei_tf_full_version, cpu_instance_type
+):
+    endpoint_name = sagemaker.utils.unique_name_from_base(
+        "sagemaker-tensorflow-serving"
+    )
     model_data = sagemaker_session.upload_data(
         path=os.path.join(tests.integ.DATA_DIR, "tensorflow-serving-test-model.tar.gz"),
         key_prefix="tensorflow-serving/models",
     )
-    with tests.integ.timeout.timeout_and_delete_endpoint_by_name(endpoint_name, sagemaker_session):
+    with tests.integ.timeout.timeout_and_delete_endpoint_by_name(
+        endpoint_name, sagemaker_session
+    ):
         model = Model(
             model_data=model_data,
             role="SageMakerRole",
@@ -125,7 +142,10 @@ def tfs_predictor_with_accelerator(sagemaker_session, ei_tf_full_version, cpu_in
             sagemaker_session=sagemaker_session,
         )
         predictor = model.deploy(
-            1, cpu_instance_type, endpoint_name=endpoint_name, accelerator_type="ml.eia1.medium"
+            1,
+            cpu_instance_type,
+            endpoint_name=endpoint_name,
+            accelerator_type="ml.eia1.medium",
         )
         yield predictor
 
@@ -168,7 +188,9 @@ def test_predict_with_model_and_entry_point_and_dependencies_separated(
     input_data = {"instances": [1.0, 2.0, 5.0]}
     expected_result = {"predictions": [4.0, 4.5, 6.0]}
 
-    result = tfs_predictor_with_model_and_entry_point_and_dependencies.predict(input_data)
+    result = tfs_predictor_with_model_and_entry_point_and_dependencies.predict(
+        input_data
+    )
     assert expected_result == result
 
 

--- a/tests/integ/test_transformer.py
+++ b/tests/integ/test_transformer.py
@@ -59,10 +59,12 @@ def mxnet_estimator(sagemaker_session, mxnet_full_version, cpu_instance_type):
     )
 
     train_input = mx.sagemaker_session.upload_data(
-        path=os.path.join(MXNET_MNIST_PATH, "train"), key_prefix="integ-test-data/mxnet_mnist/train"
+        path=os.path.join(MXNET_MNIST_PATH, "train"),
+        key_prefix="integ-test-data/mxnet_mnist/train",
     )
     test_input = mx.sagemaker_session.upload_data(
-        path=os.path.join(MXNET_MNIST_PATH, "test"), key_prefix="integ-test-data/mxnet_mnist/test"
+        path=os.path.join(MXNET_MNIST_PATH, "test"),
+        key_prefix="integ-test-data/mxnet_mnist/test",
     )
 
     job_name = unique_name_from_base("test-mxnet-transform")
@@ -152,7 +154,9 @@ def test_attach_transform_kmeans(sagemaker_session, cpu_instance_type):
         path=transform_input_path, key_prefix=transform_input_key_prefix
     )
 
-    transformer = _create_transformer_and_transform_job(kmeans, transform_input, cpu_instance_type)
+    transformer = _create_transformer_and_transform_job(
+        kmeans, transform_input, cpu_instance_type
+    )
 
     attached_transformer = Transformer.attach(
         transformer.latest_transform_job.name, sagemaker_session=sagemaker_session
@@ -210,7 +214,9 @@ def test_transform_pytorch_vpc_custom_model_bucket(
         assert set(subnet_ids) == set(model_desc["VpcConfig"]["Subnets"])
         assert [security_group_id] == model_desc["VpcConfig"]["SecurityGroupIds"]
 
-        model_bucket, _ = s3.parse_s3_url(model_desc["PrimaryContainer"]["ModelDataUrl"])
+        model_bucket, _ = s3.parse_s3_url(
+            model_desc["PrimaryContainer"]["ModelDataUrl"]
+        )
         assert custom_bucket_name == model_bucket
 
 
@@ -238,10 +244,15 @@ def test_transform_mxnet_tags(
 def test_transform_model_client_config(
     mxnet_estimator, mxnet_transform_input, sagemaker_session, cpu_instance_type
 ):
-    model_client_config = {"InvocationsTimeoutInSeconds": 60, "InvocationsMaxRetries": 2}
+    model_client_config = {
+        "InvocationsTimeoutInSeconds": 60,
+        "InvocationsMaxRetries": 2,
+    }
     transformer = mxnet_estimator.transformer(1, cpu_instance_type)
     transformer.transform(
-        mxnet_transform_input, content_type="text/csv", model_client_config=model_client_config
+        mxnet_transform_input,
+        content_type="text/csv",
+        model_client_config=model_client_config,
     )
 
     with timeout_and_delete_model_with_transformer(
@@ -290,7 +301,9 @@ def test_transform_byo_estimator(sagemaker_session, cpu_instance_type):
     with timeout(minutes=TRAINING_DEFAULT_TIMEOUT_MINUTES):
         kmeans.fit(records, job_name=job_name)
 
-    estimator = Estimator.attach(training_job_name=job_name, sagemaker_session=sagemaker_session)
+    estimator = Estimator.attach(
+        training_job_name=job_name, sagemaker_session=sagemaker_session
+    )
     estimator._enable_network_isolation = True
 
     transform_input_path = os.path.join(data_path, "transform_input.csv")
@@ -323,7 +336,9 @@ def test_single_transformer_multiple_jobs(
     transformer = mxnet_estimator.transformer(1, cpu_instance_type)
 
     job_name = unique_name_from_base("test-mxnet-transform")
-    transformer.transform(mxnet_transform_input, content_type="text/csv", job_name=job_name)
+    transformer.transform(
+        mxnet_transform_input, content_type="text/csv", job_name=job_name
+    )
     with timeout_and_delete_model_with_transformer(
         transformer, sagemaker_session, minutes=TRANSFORM_DEFAULT_TIMEOUT_MINUTES
     ):
@@ -331,7 +346,9 @@ def test_single_transformer_multiple_jobs(
             sagemaker_session.default_bucket(), job_name
         )
         job_name = unique_name_from_base("test-mxnet-transform")
-        transformer.transform(mxnet_transform_input, content_type="text/csv", job_name=job_name)
+        transformer.transform(
+            mxnet_transform_input, content_type="text/csv", job_name=job_name
+        )
         assert transformer.output_path == "s3://{}/{}".format(
             sagemaker_session.default_bucket(), job_name
         )
@@ -360,7 +377,11 @@ def test_transform_mxnet_logs(
 ):
     with timeout(minutes=45):
         transformer = _create_transformer_and_transform_job(
-            mxnet_estimator, mxnet_transform_input, cpu_instance_type, wait=True, logs=True
+            mxnet_estimator,
+            mxnet_transform_input,
+            cpu_instance_type,
+            wait=True,
+            logs=True,
         )
 
     with timeout_and_delete_model_with_transformer(
@@ -394,10 +415,14 @@ def test_transform_tf_kms_network_isolation(
     tf.fit(inputs=training_input, job_name=job_name)
 
     transform_input = sagemaker_session.upload_data(
-        path=os.path.join(data_path, "transform"), key_prefix="{}/transform".format(s3_prefix)
+        path=os.path.join(data_path, "transform"),
+        key_prefix="{}/transform".format(s3_prefix),
     )
 
-    with bucket_with_encryption(sagemaker_session, "SageMakerRole") as (bucket_with_kms, kms_key):
+    with bucket_with_encryption(sagemaker_session, "SageMakerRole") as (
+        bucket_with_kms,
+        kms_key,
+    ):
         output_path = "{}/{}/output".format(bucket_with_kms, job_name)
 
         transformer = tf.transformer(

--- a/tests/integ/test_tuner.py
+++ b/tests/integ/test_tuner.py
@@ -57,7 +57,11 @@ PY37_SUPPORTED_FRAMEWORK_VERSION = [TensorFlow._LATEST_1X_VERSION, LATEST_VERSIO
 
 @pytest.fixture(scope="module")
 def py_version(tf_full_version):
-    return "py37" if tf_full_version in PY37_SUPPORTED_FRAMEWORK_VERSION else PYTHON_VERSION
+    return (
+        "py37"
+        if tf_full_version in PY37_SUPPORTED_FRAMEWORK_VERSION
+        else PYTHON_VERSION
+    )
 
 
 @pytest.fixture(scope="module")
@@ -121,10 +125,18 @@ def _tune_and_deploy(
         job_name=job_name,
         early_stopping_type=early_stopping_type,
     )
-    _deploy(kmeans_train_set, sagemaker_session, tuner, early_stopping_type, cpu_instance_type)
+    _deploy(
+        kmeans_train_set,
+        sagemaker_session,
+        tuner,
+        early_stopping_type,
+        cpu_instance_type,
+    )
 
 
-def _deploy(kmeans_train_set, sagemaker_session, tuner, early_stopping_type, cpu_instance_type):
+def _deploy(
+    kmeans_train_set, sagemaker_session, tuner, early_stopping_type, cpu_instance_type
+):
     best_training_job = tuner.best_training_job()
     assert tuner.early_stopping_type == early_stopping_type
     with timeout_and_delete_endpoint_by_name(best_training_job, sagemaker_session):
@@ -165,10 +177,15 @@ def _tune(
             )
 
         records = kmeans_estimator.record_set(kmeans_train_set[0][:100])
-        test_record_set = kmeans_estimator.record_set(kmeans_train_set[0][:100], channel="test")
+        test_record_set = kmeans_estimator.record_set(
+            kmeans_train_set[0][:100], channel="test"
+        )
 
         tuner.fit([records, test_record_set], job_name=job_name)
-        print("Started hyperparameter tuning job with name:" + tuner.latest_tuning_job.name)
+        print(
+            "Started hyperparameter tuning job with name:"
+            + tuner.latest_tuning_job.name
+        )
 
         if wait_till_terminal:
             tuner.wait()
@@ -178,7 +195,11 @@ def _tune(
 
 @pytest.mark.canary_quick
 def test_tuning_kmeans(
-    sagemaker_session, kmeans_train_set, kmeans_estimator, hyperparameter_ranges, cpu_instance_type
+    sagemaker_session,
+    kmeans_train_set,
+    kmeans_estimator,
+    hyperparameter_ranges,
+    cpu_instance_type,
 ):
     job_name = unique_name_from_base("test-tune-kmeans")
     _tune_and_deploy(
@@ -224,7 +245,10 @@ def test_tuning_kmeans_identical_dataset_algorithm_tuner_raw(
     )
 
     assert child_warm_start_config_response.type == child_tuner.warm_start_config.type
-    assert child_warm_start_config_response.parents == child_tuner.warm_start_config.parents
+    assert (
+        child_warm_start_config_response.parents
+        == child_tuner.warm_start_config.parents
+    )
 
 
 def test_tuning_kmeans_identical_dataset_algorithm_tuner(
@@ -260,7 +284,10 @@ def test_tuning_kmeans_identical_dataset_algorithm_tuner(
     )
 
     assert child_warm_start_config_response.type == child_tuner.warm_start_config.type
-    assert child_warm_start_config_response.parents == child_tuner.warm_start_config.parents
+    assert (
+        child_warm_start_config_response.parents
+        == child_tuner.warm_start_config.parents
+    )
 
 
 def test_create_tuning_kmeans_identical_dataset_algorithm_tuner(
@@ -301,7 +328,10 @@ def test_create_tuning_kmeans_identical_dataset_algorithm_tuner(
     )
 
     assert child_warm_start_config_response.type == child_tuner.warm_start_config.type
-    assert child_warm_start_config_response.parents == child_tuner.warm_start_config.parents
+    assert (
+        child_warm_start_config_response.parents
+        == child_tuner.warm_start_config.parents
+    )
 
 
 def test_transfer_learning_tuner(
@@ -339,7 +369,10 @@ def test_transfer_learning_tuner(
     )
 
     assert child_warm_start_config_response.type == child_tuner.warm_start_config.type
-    assert child_warm_start_config_response.parents == child_tuner.warm_start_config.parents
+    assert (
+        child_warm_start_config_response.parents
+        == child_tuner.warm_start_config.parents
+    )
 
 
 def test_create_transfer_learning_tuner(
@@ -376,7 +409,12 @@ def test_create_transfer_learning_tuner(
         additional_parents={parent_tuner_2.latest_tuning_job.name},
     )
 
-    _tune(kmeans_estimator, kmeans_train_set, job_name=child_tuning_job_name, tuner=child_tuner)
+    _tune(
+        kmeans_estimator,
+        kmeans_train_set,
+        job_name=child_tuning_job_name,
+        tuner=child_tuner,
+    )
 
     child_warm_start_config_response = WarmStartConfig.from_job_desc(
         sagemaker_session.sagemaker_client.describe_hyper_parameter_tuning_job(
@@ -385,7 +423,10 @@ def test_create_transfer_learning_tuner(
     )
 
     assert child_warm_start_config_response.type == child_tuner.warm_start_config.type
-    assert child_warm_start_config_response.parents == child_tuner.warm_start_config.parents
+    assert (
+        child_warm_start_config_response.parents
+        == child_tuner.warm_start_config.parents
+    )
 
 
 def test_tuning_kmeans_identical_dataset_algorithm_tuner_from_non_terminal_parent(
@@ -441,10 +482,18 @@ def test_tuning_lda(sagemaker_session, cpu_instance_type):
         )
 
         record_set = prepare_record_set_from_local_files(
-            data_path, lda.data_location, len(all_records), feature_num, sagemaker_session
+            data_path,
+            lda.data_location,
+            len(all_records),
+            feature_num,
+            sagemaker_session,
         )
         test_record_set = prepare_record_set_from_local_files(
-            data_path, lda.data_location, len(all_records), feature_num, sagemaker_session
+            data_path,
+            lda.data_location,
+            len(all_records),
+            feature_num,
+            sagemaker_session,
         )
         test_record_set.channel = "test"
 
@@ -466,7 +515,9 @@ def test_tuning_lda(sagemaker_session, cpu_instance_type):
         )
 
         tuning_job_name = unique_name_from_base("test-lda", max_length=32)
-        tuner.fit([record_set, test_record_set], mini_batch_size=1, job_name=tuning_job_name)
+        tuner.fit(
+            [record_set, test_record_set], mini_batch_size=1, job_name=tuning_job_name
+        )
 
         latest_tuning_job_name = tuner.latest_tuning_job.name
 
@@ -576,10 +627,12 @@ def test_tuning_mxnet(sagemaker_session, mxnet_full_version, cpu_instance_type):
         )
 
         train_input = estimator.sagemaker_session.upload_data(
-            path=os.path.join(data_path, "train"), key_prefix="integ-test-data/mxnet_mnist/train"
+            path=os.path.join(data_path, "train"),
+            key_prefix="integ-test-data/mxnet_mnist/train",
         )
         test_input = estimator.sagemaker_session.upload_data(
-            path=os.path.join(data_path, "test"), key_prefix="integ-test-data/mxnet_mnist/test"
+            path=os.path.join(data_path, "test"),
+            key_prefix="integ-test-data/mxnet_mnist/test",
         )
 
         tuning_job_name = unique_name_from_base("tune-mxnet", max_length=32)
@@ -598,7 +651,9 @@ def test_tuning_mxnet(sagemaker_session, mxnet_full_version, cpu_instance_type):
 
 
 @pytest.mark.canary_quick
-def test_tuning_tf_script_mode(sagemaker_session, cpu_instance_type, tf_full_version, py_version):
+def test_tuning_tf_script_mode(
+    sagemaker_session, cpu_instance_type, tf_full_version, py_version
+):
     resource_path = os.path.join(DATA_DIR, "tensorflow_mnist")
     script_path = os.path.join(resource_path, "mnist.py")
 
@@ -615,7 +670,9 @@ def test_tuning_tf_script_mode(sagemaker_session, cpu_instance_type, tf_full_ver
 
     hyperparameter_ranges = {"epochs": IntegerParameter(1, 2)}
     objective_metric_name = "accuracy"
-    metric_definitions = [{"Name": objective_metric_name, "Regex": "accuracy = ([0-9\\.]+)"}]
+    metric_definitions = [
+        {"Name": objective_metric_name, "Regex": "accuracy = ([0-9\\.]+)"}
+    ]
 
     tuner = HyperparameterTuner(
         estimator,
@@ -641,7 +698,9 @@ def test_tuning_tf_script_mode(sagemaker_session, cpu_instance_type, tf_full_ver
 
 
 @pytest.mark.canary_quick
-@pytest.mark.skipif(PYTHON_VERSION != "py2", reason="TensorFlow image supports only python 2.")
+@pytest.mark.skipif(
+    PYTHON_VERSION != "py2", reason="TensorFlow image supports only python 2."
+)
 def test_tuning_tf(sagemaker_session, cpu_instance_type):
     with timeout(minutes=TUNING_DEFAULT_TIMEOUT_MINUTES):
         script_path = os.path.join(DATA_DIR, "iris", "iris-dnn-classifier.py")
@@ -657,7 +716,9 @@ def test_tuning_tf(sagemaker_session, cpu_instance_type):
             sagemaker_session=sagemaker_session,
         )
 
-        inputs = sagemaker_session.upload_data(path=DATA_PATH, key_prefix="integ-test-data/tf_iris")
+        inputs = sagemaker_session.upload_data(
+            path=DATA_PATH, key_prefix="integ-test-data/tf_iris"
+        )
         hyperparameter_ranges = {"learning_rate": ContinuousParameter(0.05, 0.2)}
 
         objective_metric_name = "loss"
@@ -694,7 +755,9 @@ def test_tuning_tf(sagemaker_session, cpu_instance_type):
         assert dict_result == list_result
 
 
-@pytest.mark.skipif(PYTHON_VERSION != "py2", reason="TensorFlow image supports only python 2.")
+@pytest.mark.skipif(
+    PYTHON_VERSION != "py2", reason="TensorFlow image supports only python 2."
+)
 def test_tuning_tf_vpc_multi(sagemaker_session, cpu_instance_type):
     """Test Tensorflow multi-instance using the same VpcConfig for training and inference"""
     instance_type = cpu_instance_type
@@ -703,7 +766,9 @@ def test_tuning_tf_vpc_multi(sagemaker_session, cpu_instance_type):
     script_path = os.path.join(DATA_DIR, "iris", "iris-dnn-classifier.py")
 
     ec2_client = sagemaker_session.boto_session.client("ec2")
-    subnet_ids, security_group_id = vpc_test_utils.get_or_create_vpc_resources(ec2_client)
+    subnet_ids, security_group_id = vpc_test_utils.get_or_create_vpc_resources(
+        ec2_client
+    )
     vpc_test_utils.setup_security_group_for_encryption(ec2_client, security_group_id)
 
     estimator = TensorFlow(
@@ -721,7 +786,9 @@ def test_tuning_tf_vpc_multi(sagemaker_session, cpu_instance_type):
         encrypt_inter_container_traffic=True,
     )
 
-    inputs = sagemaker_session.upload_data(path=DATA_PATH, key_prefix="integ-test-data/tf_iris")
+    inputs = sagemaker_session.upload_data(
+        path=DATA_PATH, key_prefix="integ-test-data/tf_iris"
+    )
     hyperparameter_ranges = {"learning_rate": ContinuousParameter(0.05, 0.2)}
 
     objective_metric_name = "loss"
@@ -764,10 +831,12 @@ def test_tuning_chainer(sagemaker_session, cpu_instance_type):
         )
 
         train_input = estimator.sagemaker_session.upload_data(
-            path=os.path.join(data_path, "train"), key_prefix="integ-test-data/chainer_mnist/train"
+            path=os.path.join(data_path, "train"),
+            key_prefix="integ-test-data/chainer_mnist/train",
         )
         test_input = estimator.sagemaker_session.upload_data(
-            path=os.path.join(data_path, "test"), key_prefix="integ-test-data/chainer_mnist/test"
+            path=os.path.join(data_path, "test"),
+            key_prefix="integ-test-data/chainer_mnist/test",
         )
 
         hyperparameter_ranges = {"alpha": ContinuousParameter(0.001, 0.005)}
@@ -885,7 +954,9 @@ def test_attach_tuning_pytorch(sagemaker_session, cpu_instance_type):
         output = predictor.predict(data)
 
         assert output.shape == (batch_size, 10)
-        _assert_model_name_match(sagemaker_session.sagemaker_client, endpoint_name, model_name)
+        _assert_model_name_match(
+            sagemaker_session.sagemaker_client, endpoint_name, model_name
+        )
 
 
 @pytest.mark.canary_quick
@@ -899,7 +970,9 @@ def test_tuning_byo_estimator(sagemaker_session, cpu_instance_type):
     Later the trained model is deployed and prediction is called against the endpoint.
     Default predictor is updated with json serializer and deserializer.
     """
-    image_name = get_image_uri(sagemaker_session.boto_session.region_name, "factorization-machines")
+    image_name = get_image_uri(
+        sagemaker_session.boto_session.region_name, "factorization-machines"
+    )
     training_data_path = os.path.join(DATA_DIR, "dummy_tensor")
 
     with timeout(minutes=TUNING_DEFAULT_TIMEOUT_MINUTES):
@@ -924,7 +997,10 @@ def test_tuning_byo_estimator(sagemaker_session, cpu_instance_type):
         )
 
         estimator.set_hyperparameters(
-            num_factors=10, feature_dim=784, mini_batch_size=100, predictor_type="binary_classifier"
+            num_factors=10,
+            feature_dim=784,
+            mini_batch_size=100,
+            predictor_type="binary_classifier",
         )
 
         hyperparameter_ranges = {"mini_batch_size": IntegerParameter(100, 200)}
@@ -943,7 +1019,10 @@ def test_tuning_byo_estimator(sagemaker_session, cpu_instance_type):
             job_name=unique_name_from_base("byo", 32),
         )
 
-        print("Started hyperparameter tuning job with name:" + tuner.latest_tuning_job.name)
+        print(
+            "Started hyperparameter tuning job with name:"
+            + tuner.latest_tuning_job.name
+        )
 
         time.sleep(15)
         tuner.wait()
@@ -974,4 +1053,6 @@ def _assert_model_name_match(sagemaker_client, endpoint_config_name, model_name)
     endpoint_config_description = sagemaker_client.describe_endpoint_config(
         EndpointConfigName=endpoint_config_name
     )
-    assert model_name == endpoint_config_description["ProductionVariants"][0]["ModelName"]
+    assert (
+        model_name == endpoint_config_description["ProductionVariants"][0]["ModelName"]
+    )

--- a/tests/integ/test_tuner_multi_algo.py
+++ b/tests/integ/test_tuner_multi_algo.py
@@ -72,7 +72,9 @@ def data_set():
 @pytest.fixture(scope="function")
 def estimator_fm(sagemaker_session, cpu_instance_type):
     fm_image = get_image_uri(
-        sagemaker_session.boto_session.region_name, "factorization-machines", repo_version="1"
+        sagemaker_session.boto_session.region_name,
+        "factorization-machines",
+        repo_version="1",
     )
 
     estimator = Estimator(
@@ -92,7 +94,9 @@ def estimator_fm(sagemaker_session, cpu_instance_type):
 
 @pytest.fixture(scope="function")
 def estimator_knn(sagemaker_session, cpu_instance_type):
-    knn_image = get_image_uri(sagemaker_session.boto_session.region_name, "knn", repo_version="1")
+    knn_image = get_image_uri(
+        sagemaker_session.boto_session.region_name, "knn", repo_version="1"
+    )
 
     estimator = Estimator(
         image_name=knn_image,
@@ -103,7 +107,11 @@ def estimator_knn(sagemaker_session, cpu_instance_type):
     )
 
     estimator.set_hyperparameters(
-        k=10, sample_size=500, feature_dim=784, mini_batch_size=100, predictor_type="regressor"
+        k=10,
+        sample_size=500,
+        feature_dim=784,
+        mini_batch_size=100,
+        predictor_type="regressor",
     )
     return estimator
 
@@ -154,7 +162,8 @@ def _fit_tuner(sagemaker_session, tuner):
 
 def _retrieve_analytics(sagemaker_session, tuning_job_name):
     tuner_analytics = HyperparameterTuningJobAnalytics(
-        hyperparameter_tuning_job_name=tuning_job_name, sagemaker_session=sagemaker_session
+        hyperparameter_tuning_job_name=tuning_job_name,
+        sagemaker_session=sagemaker_session,
     )
     _verify_analytics_dataframe(tuner_analytics)
     _verify_analytics_tuning_ranges(tuner_analytics)
@@ -170,18 +179,24 @@ def _verify_analytics_tuning_ranges(tuner_analytics):
     assert len(analytics_tuning_ranges) == 2
 
     expected_tuning_ranges_fm = {
-        key: value.as_tuning_range(key) for key, value in HYPER_PARAMETER_RANGES_FM.items()
+        key: value.as_tuning_range(key)
+        for key, value in HYPER_PARAMETER_RANGES_FM.items()
     }
     assert expected_tuning_ranges_fm == analytics_tuning_ranges[ESTIMATOR_FM]
 
     expected_tuning_ranges_knn = {
-        key: value.as_tuning_range(key) for key, value in HYPER_PARAMETER_RANGES_KNN.items()
+        key: value.as_tuning_range(key)
+        for key, value in HYPER_PARAMETER_RANGES_KNN.items()
     }
     assert expected_tuning_ranges_knn == analytics_tuning_ranges[ESTIMATOR_KNN]
 
 
 def _attach_tuner(sagemaker_session, tuning_job_name):
-    print("Attaching hyperparameter tuning job {} to a new tuner instance".format(tuning_job_name))
+    print(
+        "Attaching hyperparameter tuning job {} to a new tuner instance".format(
+            tuning_job_name
+        )
+    )
     return HyperparameterTuner.attach(
         tuning_job_name,
         sagemaker_session=sagemaker_session,

--- a/tests/integ/timeout.py
+++ b/tests/integ/timeout.py
@@ -88,7 +88,12 @@ def timeout_and_delete_endpoint_by_name(
 
 @contextmanager
 def timeout_and_delete_model_with_transformer(
-    transformer, sagemaker_session, seconds=0, minutes=0, hours=0, sleep_between_cleanup_attempts=10
+    transformer,
+    sagemaker_session,
+    seconds=0,
+    minutes=0,
+    hours=0,
+    sleep_between_cleanup_attempts=10,
 ):
     limit = seconds + 60 * minutes + 3600 * hours
 
@@ -104,11 +109,15 @@ def timeout_and_delete_model_with_transformer(
                 attempts -= 1
                 try:
                     transformer.delete_model()
-                    LOGGER.info("deleted SageMaker model {}".format(transformer.model_name))
+                    LOGGER.info(
+                        "deleted SageMaker model {}".format(transformer.model_name)
+                    )
 
                     _show_logs(transformer.model_name, "Models", sagemaker_session)
                     if no_errors:
-                        _cleanup_logs(transformer.model_name, "Models", sagemaker_session)
+                        _cleanup_logs(
+                            transformer.model_name, "Models", sagemaker_session
+                        )
                     break
                 except ClientError as ce:
                     if ce.response["Error"]["Code"] == "ValidationException":
@@ -129,7 +138,9 @@ def _delete_schedules_associated_with_endpoint(sagemaker_session, endpoint_name)
         endpoint_name (str): The name of the endpoint to delete schedules from.
 
     """
-    predictor = RealTimePredictor(endpoint=endpoint_name, sagemaker_session=sagemaker_session)
+    predictor = RealTimePredictor(
+        endpoint=endpoint_name, sagemaker_session=sagemaker_session
+    )
     monitors = predictor.list_monitors()
     for monitor in monitors:
         try:
@@ -142,7 +153,9 @@ def _delete_schedules_associated_with_endpoint(sagemaker_session, endpoint_name)
             # Wait for all executions to completely stop.
             # Schedules can't be deleted with running executions.
             for execution in executions:
-                for _ in retries(60, "Waiting for executions to stop", seconds_to_sleep=5):
+                for _ in retries(
+                    60, "Waiting for executions to stop", seconds_to_sleep=5
+                ):
                     status = execution.describe()["ProcessingJobStatus"]
                     if status == "Stopped":
                         break
@@ -150,7 +163,8 @@ def _delete_schedules_associated_with_endpoint(sagemaker_session, endpoint_name)
             monitor.delete_monitoring_schedule()
         except Exception as e:
             LOGGER.warning(
-                "Failed to delete monitor {}".format(monitor.monitoring_schedule_name), e
+                "Failed to delete monitor {}".format(monitor.monitoring_schedule_name),
+                e,
             )
 
 

--- a/tests/unit/sagemaker/automl/test_auto_ml.py
+++ b/tests/unit/sagemaker/automl/test_auto_ml.py
@@ -193,7 +193,9 @@ TRANSFORM_JOB = {
     "MaxConcurrentTransforms": 1,
     "MaxPayloadInMB": 2000,
     "ModelName": "string",
-    "TransformInput": {"DataSource": {"S3DataSource": {"S3DataType": "string", "S3Uri": "string"}}},
+    "TransformInput": {
+        "DataSource": {"S3DataSource": {"S3DataType": "string", "S3Uri": "string"}}
+    },
     "TransformJobStatus": "string",
     "TransformJobArn": "string",
     "TransformJobName": "string",
@@ -234,7 +236,9 @@ def sagemaker_session():
         name="describe_transform_job", return_value=TRANSFORM_JOB
     )
     sms.list_candidates = Mock(name="list_candidates", return_value={"Candidates": []})
-    sms.sagemaker_client.list_tags = Mock(name="list_tags", return_value=LIST_TAGS_RESULT)
+    sms.sagemaker_client.list_tags = Mock(
+        name="list_tags", return_value=LIST_TAGS_RESULT
+    )
     return sms
 
 
@@ -251,7 +255,9 @@ def candidate_mock(sagemaker_session):
 
 def test_auto_ml_default_channel_name(sagemaker_session):
     auto_ml = AutoML(
-        role=ROLE, target_attribute_name=TARGET_ATTRIBUTE_NAME, sagemaker_session=sagemaker_session
+        role=ROLE,
+        target_attribute_name=TARGET_ATTRIBUTE_NAME,
+        sagemaker_session=sagemaker_session,
     )
     inputs = DEFAULT_S3_INPUT_DATA
     AutoMLJob.start_new(auto_ml, inputs)
@@ -260,7 +266,10 @@ def test_auto_ml_default_channel_name(sagemaker_session):
     assert args["input_config"] == [
         {
             "DataSource": {
-                "S3DataSource": {"S3DataType": "S3Prefix", "S3Uri": DEFAULT_S3_INPUT_DATA}
+                "S3DataSource": {
+                    "S3DataType": "S3Prefix",
+                    "S3Uri": DEFAULT_S3_INPUT_DATA,
+                }
             },
             "TargetAttributeName": TARGET_ATTRIBUTE_NAME,
         }
@@ -269,14 +278,18 @@ def test_auto_ml_default_channel_name(sagemaker_session):
 
 def test_auto_ml_invalid_input_data_format(sagemaker_session):
     auto_ml = AutoML(
-        role=ROLE, target_attribute_name=TARGET_ATTRIBUTE_NAME, sagemaker_session=sagemaker_session
+        role=ROLE,
+        target_attribute_name=TARGET_ATTRIBUTE_NAME,
+        sagemaker_session=sagemaker_session,
     )
     inputs = {}
 
     with pytest.raises(ValueError) as excinfo:
         AutoMLJob.start_new(auto_ml, inputs)
 
-    expected_error_msg = "Cannot format input {}. Expecting a string or a list of strings."
+    expected_error_msg = (
+        "Cannot format input {}. Expecting a string or a list of strings."
+    )
     assert expected_error_msg.format(inputs) in str(excinfo.value)
 
     sagemaker_session.auto_ml.assert_not_called()
@@ -301,12 +314,17 @@ def test_auto_ml_only_one_of_problem_type_and_job_objective_provided(sagemaker_s
 @patch("sagemaker.automl.automl.AutoMLJob.start_new")
 def test_auto_ml_fit_set_logs_to_false(start_new, sagemaker_session, caplog):
     auto_ml = AutoML(
-        role=ROLE, target_attribute_name=TARGET_ATTRIBUTE_NAME, sagemaker_session=sagemaker_session
+        role=ROLE,
+        target_attribute_name=TARGET_ATTRIBUTE_NAME,
+        sagemaker_session=sagemaker_session,
     )
     inputs = DEFAULT_S3_INPUT_DATA
     auto_ml.fit(inputs, job_name=JOB_NAME, wait=False, logs=True)
     start_new.wait.assert_not_called()
-    assert "Setting logs to False. logs is only meaningful when wait is True." in caplog.text
+    assert (
+        "Setting logs to False. logs is only meaningful when wait is True."
+        in caplog.text
+    )
 
 
 def test_auto_ml_additional_optional_params(sagemaker_session):
@@ -338,7 +356,10 @@ def test_auto_ml_additional_optional_params(sagemaker_session):
             {
                 "CompressionType": COMPRESSION_TYPE,
                 "DataSource": {
-                    "S3DataSource": {"S3DataType": "S3Prefix", "S3Uri": DEFAULT_S3_INPUT_DATA}
+                    "S3DataSource": {
+                        "S3DataType": "S3Prefix",
+                        "S3Uri": DEFAULT_S3_INPUT_DATA,
+                    }
                 },
                 "TargetAttributeName": TARGET_ATTRIBUTE_NAME,
             }
@@ -368,7 +389,9 @@ def test_auto_ml_additional_optional_params(sagemaker_session):
 @patch("time.strftime", return_value=TIMESTAMP)
 def test_auto_ml_default_fit(strftime, sagemaker_session):
     auto_ml = AutoML(
-        role=ROLE, target_attribute_name=TARGET_ATTRIBUTE_NAME, sagemaker_session=sagemaker_session
+        role=ROLE,
+        target_attribute_name=TARGET_ATTRIBUTE_NAME,
+        sagemaker_session=sagemaker_session,
     )
     inputs = DEFAULT_S3_INPUT_DATA
     auto_ml.fit(inputs)
@@ -378,7 +401,10 @@ def test_auto_ml_default_fit(strftime, sagemaker_session):
         "input_config": [
             {
                 "DataSource": {
-                    "S3DataSource": {"S3DataType": "S3Prefix", "S3Uri": DEFAULT_S3_INPUT_DATA}
+                    "S3DataSource": {
+                        "S3DataType": "S3Prefix",
+                        "S3Uri": DEFAULT_S3_INPUT_DATA,
+                    }
                 },
                 "TargetAttributeName": TARGET_ATTRIBUTE_NAME,
             }
@@ -401,13 +427,18 @@ def test_auto_ml_default_fit(strftime, sagemaker_session):
 
 def test_auto_ml_local_input(sagemaker_session):
     auto_ml = AutoML(
-        role=ROLE, target_attribute_name=TARGET_ATTRIBUTE_NAME, sagemaker_session=sagemaker_session
+        role=ROLE,
+        target_attribute_name=TARGET_ATTRIBUTE_NAME,
+        sagemaker_session=sagemaker_session,
     )
     inputs = DEFAULT_S3_INPUT_DATA
     auto_ml.fit(inputs)
     sagemaker_session.auto_ml.assert_called_once()
     _, args = sagemaker_session.auto_ml.call_args
-    assert args["input_config"][0]["DataSource"]["S3DataSource"]["S3Uri"] == DEFAULT_S3_INPUT_DATA
+    assert (
+        args["input_config"][0]["DataSource"]["S3DataSource"]["S3Uri"]
+        == DEFAULT_S3_INPUT_DATA
+    )
 
 
 def test_auto_ml_input(sagemaker_session):
@@ -415,7 +446,9 @@ def test_auto_ml_input(sagemaker_session):
         inputs=DEFAULT_S3_INPUT_DATA, target_attribute_name="target", compression="Gzip"
     )
     auto_ml = AutoML(
-        role=ROLE, target_attribute_name=TARGET_ATTRIBUTE_NAME, sagemaker_session=sagemaker_session
+        role=ROLE,
+        target_attribute_name=TARGET_ATTRIBUTE_NAME,
+        sagemaker_session=sagemaker_session,
     )
     auto_ml.fit(inputs)
     _, args = sagemaker_session.auto_ml.call_args
@@ -423,7 +456,10 @@ def test_auto_ml_input(sagemaker_session):
         {
             "CompressionType": "Gzip",
             "DataSource": {
-                "S3DataSource": {"S3DataType": "S3Prefix", "S3Uri": DEFAULT_S3_INPUT_DATA}
+                "S3DataSource": {
+                    "S3DataType": "S3Prefix",
+                    "S3Uri": DEFAULT_S3_INPUT_DATA,
+                }
             },
             "TargetAttributeName": TARGET_ATTRIBUTE_NAME,
         }
@@ -432,7 +468,9 @@ def test_auto_ml_input(sagemaker_session):
 
 def test_describe_auto_ml_job(sagemaker_session):
     auto_ml = AutoML(
-        role=ROLE, target_attribute_name=TARGET_ATTRIBUTE_NAME, sagemaker_session=sagemaker_session
+        role=ROLE,
+        target_attribute_name=TARGET_ATTRIBUTE_NAME,
+        sagemaker_session=sagemaker_session,
     )
     auto_ml.describe_auto_ml_job(job_name=JOB_NAME)
     sagemaker_session.describe_auto_ml_job.assert_called_once()
@@ -441,17 +479,23 @@ def test_describe_auto_ml_job(sagemaker_session):
 
 def test_list_candidates_default(sagemaker_session):
     auto_ml = AutoML(
-        role=ROLE, target_attribute_name=TARGET_ATTRIBUTE_NAME, sagemaker_session=sagemaker_session
+        role=ROLE,
+        target_attribute_name=TARGET_ATTRIBUTE_NAME,
+        sagemaker_session=sagemaker_session,
     )
     auto_ml.current_job_name = "current_job_name"
     auto_ml.list_candidates()
     sagemaker_session.list_candidates.assert_called_once()
-    sagemaker_session.list_candidates.assert_called_with(job_name=auto_ml.current_job_name)
+    sagemaker_session.list_candidates.assert_called_with(
+        job_name=auto_ml.current_job_name
+    )
 
 
 def test_list_candidates_with_optional_args(sagemaker_session):
     auto_ml = AutoML(
-        role=ROLE, target_attribute_name=TARGET_ATTRIBUTE_NAME, sagemaker_session=sagemaker_session
+        role=ROLE,
+        target_attribute_name=TARGET_ATTRIBUTE_NAME,
+        sagemaker_session=sagemaker_session,
     )
     auto_ml.list_candidates(
         job_name=JOB_NAME,
@@ -477,7 +521,9 @@ def test_list_candidates_with_optional_args(sagemaker_session):
 
 def test_best_candidate_with_existing_best_candidate(sagemaker_session):
     auto_ml = AutoML(
-        role=ROLE, target_attribute_name=TARGET_ATTRIBUTE_NAME, sagemaker_session=sagemaker_session
+        role=ROLE,
+        target_attribute_name=TARGET_ATTRIBUTE_NAME,
+        sagemaker_session=sagemaker_session,
     )
     auto_ml._best_candidate = BEST_CANDIDATE
     best_candidate = auto_ml.best_candidate()
@@ -487,7 +533,9 @@ def test_best_candidate_with_existing_best_candidate(sagemaker_session):
 
 def test_best_candidate_default_job_name(sagemaker_session):
     auto_ml = AutoML(
-        role=ROLE, target_attribute_name=TARGET_ATTRIBUTE_NAME, sagemaker_session=sagemaker_session
+        role=ROLE,
+        target_attribute_name=TARGET_ATTRIBUTE_NAME,
+        sagemaker_session=sagemaker_session,
     )
     auto_ml.current_job_name = JOB_NAME
     auto_ml._auto_ml_job_desc = AUTO_ML_DESC
@@ -498,7 +546,9 @@ def test_best_candidate_default_job_name(sagemaker_session):
 
 def test_best_candidate_job_no_desc(sagemaker_session):
     auto_ml = AutoML(
-        role=ROLE, target_attribute_name=TARGET_ATTRIBUTE_NAME, sagemaker_session=sagemaker_session
+        role=ROLE,
+        target_attribute_name=TARGET_ATTRIBUTE_NAME,
+        sagemaker_session=sagemaker_session,
     )
     auto_ml.current_job_name = JOB_NAME
     best_candidate = auto_ml.best_candidate()
@@ -509,7 +559,9 @@ def test_best_candidate_job_no_desc(sagemaker_session):
 
 def test_best_candidate_no_desc_no_job_name(sagemaker_session):
     auto_ml = AutoML(
-        role=ROLE, target_attribute_name=TARGET_ATTRIBUTE_NAME, sagemaker_session=sagemaker_session
+        role=ROLE,
+        target_attribute_name=TARGET_ATTRIBUTE_NAME,
+        sagemaker_session=sagemaker_session,
     )
     best_candidate = auto_ml.best_candidate(job_name=JOB_NAME)
     sagemaker_session.describe_auto_ml_job.assert_called_once()
@@ -519,7 +571,9 @@ def test_best_candidate_no_desc_no_job_name(sagemaker_session):
 
 def test_best_candidate_job_name_not_match(sagemaker_session):
     auto_ml = AutoML(
-        role=ROLE, target_attribute_name=TARGET_ATTRIBUTE_NAME, sagemaker_session=sagemaker_session
+        role=ROLE,
+        target_attribute_name=TARGET_ATTRIBUTE_NAME,
+        sagemaker_session=sagemaker_session,
     )
     auto_ml.current_job_name = JOB_NAME
     auto_ml._auto_ml_job_desc = AUTO_ML_DESC
@@ -531,7 +585,9 @@ def test_best_candidate_job_name_not_match(sagemaker_session):
 
 def test_deploy(sagemaker_session, candidate_mock):
     auto_ml = AutoML(
-        role=ROLE, target_attribute_name=TARGET_ATTRIBUTE_NAME, sagemaker_session=sagemaker_session
+        role=ROLE,
+        target_attribute_name=TARGET_ATTRIBUTE_NAME,
+        sagemaker_session=sagemaker_session,
     )
     mock_pipeline = Mock(name="pipeline_model")
     mock_pipeline.deploy = Mock(name="model_deploy")
@@ -551,7 +607,9 @@ def test_deploy_optional_args(candidate_estimator, sagemaker_session, candidate_
     candidate_estimator.return_value = candidate_mock
 
     auto_ml = AutoML(
-        role=ROLE, target_attribute_name=TARGET_ATTRIBUTE_NAME, sagemaker_session=sagemaker_session
+        role=ROLE,
+        target_attribute_name=TARGET_ATTRIBUTE_NAME,
+        sagemaker_session=sagemaker_session,
     )
     mock_pipeline = Mock(name="pipeline_model")
     mock_pipeline.deploy = Mock(name="model_deploy")
@@ -600,13 +658,17 @@ def test_deploy_optional_args(candidate_estimator, sagemaker_session, candidate_
 
 
 def test_candidate_estimator_get_steps(sagemaker_session):
-    candidate_estimator = CandidateEstimator(CANDIDATE_DICT, sagemaker_session=sagemaker_session)
+    candidate_estimator = CandidateEstimator(
+        CANDIDATE_DICT, sagemaker_session=sagemaker_session
+    )
     steps = candidate_estimator.get_steps()
     assert len(steps) == 3
 
 
 def test_candidate_estimator_fit(sagemaker_session):
-    candidate_estimator = CandidateEstimator(CANDIDATE_DICT, sagemaker_session=sagemaker_session)
+    candidate_estimator = CandidateEstimator(
+        CANDIDATE_DICT, sagemaker_session=sagemaker_session
+    )
     candidate_estimator._check_all_job_finished = Mock(
         name="_check_all_job_finished", return_value=True
     )
@@ -621,7 +683,12 @@ def test_validate_and_update_inference_response():
 
     AutoML.validate_and_update_inference_response(
         inference_containers=cic,
-        inference_response_keys=["predicted_label", "labels", "probabilities", "probability"],
+        inference_response_keys=[
+            "predicted_label",
+            "labels",
+            "probabilities",
+            "probability",
+        ],
     )
 
     assert (
@@ -644,7 +711,12 @@ def test_validate_and_update_inference_response_wrong_input():
     with pytest.raises(ValueError) as excinfo:
         AutoML.validate_and_update_inference_response(
             inference_containers=cic,
-            inference_response_keys=["wrong_key", "wrong_label", "probabilities", "probability"],
+            inference_response_keys=[
+                "wrong_key",
+                "wrong_label",
+                "probabilities",
+                "probability",
+            ],
         )
     message = (
         "Requested inference output keys [wrong_key, wrong_label] are unsupported. "
@@ -655,7 +727,9 @@ def test_validate_and_update_inference_response_wrong_input():
 
 def test_create_model(sagemaker_session):
     auto_ml = AutoML(
-        role=ROLE, target_attribute_name=TARGET_ATTRIBUTE_NAME, sagemaker_session=sagemaker_session
+        role=ROLE,
+        target_attribute_name=TARGET_ATTRIBUTE_NAME,
+        sagemaker_session=sagemaker_session,
     )
 
     pipeline_model = auto_ml.create_model(
@@ -673,7 +747,9 @@ def test_create_model(sagemaker_session):
 
 
 def test_attach(sagemaker_session):
-    aml = AutoML.attach(auto_ml_job_name=JOB_NAME_3, sagemaker_session=sagemaker_session)
+    aml = AutoML.attach(
+        auto_ml_job_name=JOB_NAME_3, sagemaker_session=sagemaker_session
+    )
     assert aml.current_job_name == JOB_NAME_3
     assert aml.role == "mock_role_arn"
     assert aml.target_attribute_name == "y"

--- a/tests/unit/sagemaker/model/test_deploy.py
+++ b/tests/unit/sagemaker/model/test_deploy.py
@@ -47,14 +47,22 @@ def sagemaker_session():
 @patch("sagemaker.production_variant")
 @patch("sagemaker.model.Model.prepare_container_def")
 @patch("sagemaker.utils.name_from_image")
-def test_deploy(name_from_image, prepare_container_def, production_variant, sagemaker_session):
+def test_deploy(
+    name_from_image, prepare_container_def, production_variant, sagemaker_session
+):
     name_from_image.return_value = MODEL_NAME
     production_variant.return_value = BASE_PRODUCTION_VARIANT
 
-    container_def = {"Image": MODEL_IMAGE, "Environment": {}, "ModelDataUrl": MODEL_DATA}
+    container_def = {
+        "Image": MODEL_IMAGE,
+        "Environment": {},
+        "ModelDataUrl": MODEL_DATA,
+    }
     prepare_container_def.return_value = container_def
 
-    model = Model(MODEL_DATA, MODEL_IMAGE, role=ROLE, sagemaker_session=sagemaker_session)
+    model = Model(
+        MODEL_DATA, MODEL_IMAGE, role=ROLE, sagemaker_session=sagemaker_session
+    )
     model.deploy(instance_type=INSTANCE_TYPE, initial_instance_count=INSTANCE_COUNT)
 
     name_from_image.assert_called_with(MODEL_IMAGE)
@@ -64,7 +72,12 @@ def test_deploy(name_from_image, prepare_container_def, production_variant, sage
     )
 
     sagemaker_session.create_model.assert_called_with(
-        MODEL_NAME, ROLE, container_def, vpc_config=None, enable_network_isolation=False, tags=None
+        MODEL_NAME,
+        ROLE,
+        container_def,
+        vpc_config=None,
+        enable_network_isolation=False,
+        tags=None,
     )
 
     sagemaker_session.endpoint_from_production_variants.assert_called_with(
@@ -79,9 +92,15 @@ def test_deploy(name_from_image, prepare_container_def, production_variant, sage
 
 @patch("sagemaker.model.Model._create_sagemaker_model")
 @patch("sagemaker.production_variant")
-def test_deploy_accelerator_type(production_variant, create_sagemaker_model, sagemaker_session):
+def test_deploy_accelerator_type(
+    production_variant, create_sagemaker_model, sagemaker_session
+):
     model = Model(
-        MODEL_DATA, MODEL_IMAGE, role=ROLE, name=MODEL_NAME, sagemaker_session=sagemaker_session
+        MODEL_DATA,
+        MODEL_IMAGE,
+        role=ROLE,
+        name=MODEL_NAME,
+        sagemaker_session=sagemaker_session,
     )
 
     production_variant_result = copy.deepcopy(BASE_PRODUCTION_VARIANT)
@@ -113,7 +132,9 @@ def test_deploy_accelerator_type(production_variant, create_sagemaker_model, sag
 @patch("sagemaker.model.Model._create_sagemaker_model", Mock())
 @patch("sagemaker.production_variant", return_value=BASE_PRODUCTION_VARIANT)
 def test_deploy_endpoint_name(sagemaker_session):
-    model = Model(MODEL_DATA, MODEL_IMAGE, role=ROLE, sagemaker_session=sagemaker_session)
+    model = Model(
+        MODEL_DATA, MODEL_IMAGE, role=ROLE, sagemaker_session=sagemaker_session
+    )
 
     endpoint_name = "blah"
     model.deploy(
@@ -136,11 +157,17 @@ def test_deploy_endpoint_name(sagemaker_session):
 @patch("sagemaker.model.Model._create_sagemaker_model")
 def test_deploy_tags(create_sagemaker_model, production_variant, sagemaker_session):
     model = Model(
-        MODEL_DATA, MODEL_IMAGE, role=ROLE, name=MODEL_NAME, sagemaker_session=sagemaker_session
+        MODEL_DATA,
+        MODEL_IMAGE,
+        role=ROLE,
+        name=MODEL_NAME,
+        sagemaker_session=sagemaker_session,
     )
 
     tags = [{"Key": "ModelName", "Value": "TestModel"}]
-    model.deploy(instance_type=INSTANCE_TYPE, initial_instance_count=INSTANCE_COUNT, tags=tags)
+    model.deploy(
+        instance_type=INSTANCE_TYPE, initial_instance_count=INSTANCE_COUNT, tags=tags
+    )
 
     create_sagemaker_model.assert_called_with(INSTANCE_TYPE, None, tags)
     sagemaker_session.endpoint_from_production_variants.assert_called_with(
@@ -157,11 +184,17 @@ def test_deploy_tags(create_sagemaker_model, production_variant, sagemaker_sessi
 @patch("sagemaker.production_variant", return_value=BASE_PRODUCTION_VARIANT)
 def test_deploy_kms_key(production_variant, sagemaker_session):
     model = Model(
-        MODEL_DATA, MODEL_IMAGE, role=ROLE, name=MODEL_NAME, sagemaker_session=sagemaker_session
+        MODEL_DATA,
+        MODEL_IMAGE,
+        role=ROLE,
+        name=MODEL_NAME,
+        sagemaker_session=sagemaker_session,
     )
 
     key = "some-key-arn"
-    model.deploy(instance_type=INSTANCE_TYPE, initial_instance_count=INSTANCE_COUNT, kms_key=key)
+    model.deploy(
+        instance_type=INSTANCE_TYPE, initial_instance_count=INSTANCE_COUNT, kms_key=key
+    )
 
     sagemaker_session.endpoint_from_production_variants.assert_called_with(
         name=MODEL_NAME,
@@ -177,10 +210,16 @@ def test_deploy_kms_key(production_variant, sagemaker_session):
 @patch("sagemaker.production_variant", return_value=BASE_PRODUCTION_VARIANT)
 def test_deploy_async(production_variant, sagemaker_session):
     model = Model(
-        MODEL_DATA, MODEL_IMAGE, role=ROLE, name=MODEL_NAME, sagemaker_session=sagemaker_session
+        MODEL_DATA,
+        MODEL_IMAGE,
+        role=ROLE,
+        name=MODEL_NAME,
+        sagemaker_session=sagemaker_session,
     )
 
-    model.deploy(instance_type=INSTANCE_TYPE, initial_instance_count=INSTANCE_COUNT, wait=False)
+    model.deploy(
+        instance_type=INSTANCE_TYPE, initial_instance_count=INSTANCE_COUNT, wait=False
+    )
 
     sagemaker_session.endpoint_from_production_variants.assert_called_with(
         name=MODEL_NAME,
@@ -196,7 +235,11 @@ def test_deploy_async(production_variant, sagemaker_session):
 @patch("sagemaker.production_variant", return_value=BASE_PRODUCTION_VARIANT)
 def test_deploy_data_capture_config(production_variant, sagemaker_session):
     model = Model(
-        MODEL_DATA, MODEL_IMAGE, role=ROLE, name=MODEL_NAME, sagemaker_session=sagemaker_session
+        MODEL_DATA,
+        MODEL_IMAGE,
+        role=ROLE,
+        name=MODEL_NAME,
+        sagemaker_session=sagemaker_session,
     )
 
     data_capture_config = Mock()
@@ -230,7 +273,9 @@ def test_deploy_creates_correct_session(local_session, session):
     # We expect a real Session when deploying to instance_type != local/local_gpu
     model = Model(MODEL_DATA, MODEL_IMAGE, role=ROLE)
     model.deploy(
-        endpoint_name="remote_endpoint", instance_type="ml.m4.4xlarge", initial_instance_count=2
+        endpoint_name="remote_endpoint",
+        instance_type="ml.m4.4xlarge",
+        initial_instance_count=2,
     )
     assert model.sagemaker_session == session.return_value
 
@@ -269,9 +314,13 @@ def test_deploy_predictor_cls(production_variant, sagemaker_session):
 
 
 def test_deploy_update_endpoint(sagemaker_session):
-    model = Model(MODEL_DATA, MODEL_IMAGE, role=ROLE, sagemaker_session=sagemaker_session)
+    model = Model(
+        MODEL_DATA, MODEL_IMAGE, role=ROLE, sagemaker_session=sagemaker_session
+    )
     model.deploy(
-        instance_type=INSTANCE_TYPE, initial_instance_count=INSTANCE_COUNT, update_endpoint=True
+        instance_type=INSTANCE_TYPE,
+        initial_instance_count=INSTANCE_COUNT,
+        update_endpoint=True,
     )
     sagemaker_session.create_endpoint_config.assert_called_with(
         name=model.name,
@@ -290,7 +339,9 @@ def test_deploy_update_endpoint(sagemaker_session):
         instance_type=INSTANCE_TYPE,
         accelerator_type=ACCELERATOR_TYPE,
     )
-    sagemaker_session.update_endpoint.assert_called_with(model.name, config_name, wait=True)
+    sagemaker_session.update_endpoint.assert_called_with(
+        model.name, config_name, wait=True
+    )
     sagemaker_session.create_endpoint.assert_not_called()
 
 
@@ -300,7 +351,9 @@ def test_deploy_update_endpoint_optional_args(sagemaker_session):
     kms_key = "foo"
     data_capture_config = Mock()
 
-    model = Model(MODEL_DATA, MODEL_IMAGE, role=ROLE, sagemaker_session=sagemaker_session)
+    model = Model(
+        MODEL_DATA, MODEL_IMAGE, role=ROLE, sagemaker_session=sagemaker_session
+    )
     model.deploy(
         instance_type=INSTANCE_TYPE,
         initial_instance_count=INSTANCE_COUNT,
@@ -330,5 +383,7 @@ def test_deploy_update_endpoint_optional_args(sagemaker_session):
         accelerator_type=ACCELERATOR_TYPE,
         wait=False,
     )
-    sagemaker_session.update_endpoint.assert_called_with(endpoint_name, config_name, wait=False)
+    sagemaker_session.update_endpoint.assert_called_with(
+        endpoint_name, config_name, wait=False
+    )
     sagemaker_session.create_endpoint.assert_not_called()

--- a/tests/unit/sagemaker/model/test_framework_model.py
+++ b/tests/unit/sagemaker/model/test_framework_model.py
@@ -60,7 +60,9 @@ class DummyFrameworkModel(FrameworkModel):
         )
 
     def create_predictor(self, endpoint_name):
-        return RealTimePredictor(endpoint_name, sagemaker_session=self.sagemaker_session)
+        return RealTimePredictor(
+            endpoint_name, sagemaker_session=self.sagemaker_session
+        )
 
 
 class DummyFrameworkModelForGit(FrameworkModel):
@@ -75,7 +77,9 @@ class DummyFrameworkModelForGit(FrameworkModel):
         )
 
     def create_predictor(self, endpoint_name):
-        return RealTimePredictor(endpoint_name, sagemaker_session=self.sagemaker_session)
+        return RealTimePredictor(
+            endpoint_name, sagemaker_session=self.sagemaker_session
+        )
 
 
 @pytest.fixture()
@@ -194,7 +198,9 @@ def test_git_support_repo_not_provided(sagemaker_session):
     git_config = {"branch": BRANCH, "commit": COMMIT}
     with pytest.raises(ValueError) as error:
         model = DummyFrameworkModelForGit(
-            sagemaker_session=sagemaker_session, entry_point=entry_point, git_config=git_config
+            sagemaker_session=sagemaker_session,
+            entry_point=entry_point,
+            git_config=git_config,
         )
         model.prepare_container_def(instance_type=INSTANCE_TYPE)
     assert "Please provide a repo for git_config." in str(error)
@@ -203,7 +209,8 @@ def test_git_support_repo_not_provided(sagemaker_session):
 @patch(
     "sagemaker.git_utils.git_clone_repo",
     side_effect=subprocess.CalledProcessError(
-        returncode=1, cmd="git clone https://github.com/aws/no-such-repo.git /tmp/repo_dir"
+        returncode=1,
+        cmd="git clone https://github.com/aws/no-such-repo.git /tmp/repo_dir",
     ),
 )
 def test_git_support_git_clone_fail(sagemaker_session):
@@ -211,7 +218,9 @@ def test_git_support_git_clone_fail(sagemaker_session):
     git_config = {"repo": "https://github.com/aws/no-such-repo.git", "branch": BRANCH}
     with pytest.raises(subprocess.CalledProcessError) as error:
         model = DummyFrameworkModelForGit(
-            sagemaker_session=sagemaker_session, entry_point=entry_point, git_config=git_config
+            sagemaker_session=sagemaker_session,
+            entry_point=entry_point,
+            git_config=git_config,
         )
         model.prepare_container_def(instance_type=INSTANCE_TYPE)
     assert "returned non-zero exit status" in str(error)
@@ -225,10 +234,16 @@ def test_git_support_git_clone_fail(sagemaker_session):
 )
 def test_git_support_branch_not_exist(git_clone_repo, sagemaker_session):
     entry_point = "source_dir/entry_point"
-    git_config = {"repo": GIT_REPO, "branch": "branch-that-does-not-exist", "commit": COMMIT}
+    git_config = {
+        "repo": GIT_REPO,
+        "branch": "branch-that-does-not-exist",
+        "commit": COMMIT,
+    }
     with pytest.raises(subprocess.CalledProcessError) as error:
         model = DummyFrameworkModelForGit(
-            sagemaker_session=sagemaker_session, entry_point=entry_point, git_config=git_config
+            sagemaker_session=sagemaker_session,
+            entry_point=entry_point,
+            git_config=git_config,
         )
         model.prepare_container_def(instance_type=INSTANCE_TYPE)
     assert "returned non-zero exit status" in str(error)
@@ -242,10 +257,16 @@ def test_git_support_branch_not_exist(git_clone_repo, sagemaker_session):
 )
 def test_git_support_commit_not_exist(git_clone_repo, sagemaker_session):
     entry_point = "source_dir/entry_point"
-    git_config = {"repo": GIT_REPO, "branch": BRANCH, "commit": "commit-sha-that-does-not-exist"}
+    git_config = {
+        "repo": GIT_REPO,
+        "branch": BRANCH,
+        "commit": "commit-sha-that-does-not-exist",
+    }
     with pytest.raises(subprocess.CalledProcessError) as error:
         model = DummyFrameworkModelForGit(
-            sagemaker_session=sagemaker_session, entry_point=entry_point, git_config=git_config
+            sagemaker_session=sagemaker_session,
+            entry_point=entry_point,
+            git_config=git_config,
         )
         model.prepare_container_def(instance_type=INSTANCE_TYPE)
     assert "returned non-zero exit status" in str(error)
@@ -260,7 +281,9 @@ def test_git_support_entry_point_not_exist(sagemaker_session):
     git_config = {"repo": GIT_REPO, "branch": BRANCH, "commit": COMMIT}
     with pytest.raises(ValueError) as error:
         model = DummyFrameworkModelForGit(
-            sagemaker_session=sagemaker_session, entry_point=entry_point, git_config=git_config
+            sagemaker_session=sagemaker_session,
+            entry_point=entry_point,
+            git_config=git_config,
         )
         model.prepare_container_def(instance_type=INSTANCE_TYPE)
     assert "Entry point does not exist in the repo." in str(error)
@@ -325,7 +348,9 @@ def test_git_support_with_username_password_no_2fa(
         "password": "passw0rd!",
     }
     model = DummyFrameworkModelForGit(
-        sagemaker_session=sagemaker_session, entry_point=entry_point, git_config=git_config
+        sagemaker_session=sagemaker_session,
+        entry_point=entry_point,
+        git_config=git_config,
     )
     model.prepare_container_def(instance_type=INSTANCE_TYPE)
     git_clone_repo.assert_called_with(git_config, entry_point, None, [])
@@ -341,7 +366,9 @@ def test_git_support_with_username_password_no_2fa(
     },
 )
 @patch("sagemaker.model.fw_utils.tar_and_upload_dir")
-def test_git_support_with_token_2fa(tar_and_upload_dir, git_clone_repo, sagemaker_session):
+def test_git_support_with_token_2fa(
+    tar_and_upload_dir, git_clone_repo, sagemaker_session
+):
     entry_point = "entry_point"
     git_config = {
         "repo": PRIVATE_GIT_REPO,
@@ -351,7 +378,9 @@ def test_git_support_with_token_2fa(tar_and_upload_dir, git_clone_repo, sagemake
         "2FA_enabled": True,
     }
     model = DummyFrameworkModelForGit(
-        sagemaker_session=sagemaker_session, entry_point=entry_point, git_config=git_config
+        sagemaker_session=sagemaker_session,
+        entry_point=entry_point,
+        git_config=git_config,
     )
     model.prepare_container_def(instance_type=INSTANCE_TYPE)
     git_clone_repo.assert_called_with(git_config, entry_point, None, [])
@@ -371,9 +400,15 @@ def test_git_support_ssh_no_passphrase_needed(
     tar_and_upload_dir, git_clone_repo, sagemaker_session
 ):
     entry_point = "entry_point"
-    git_config = {"repo": PRIVATE_GIT_REPO_SSH, "branch": PRIVATE_BRANCH, "commit": PRIVATE_COMMIT}
+    git_config = {
+        "repo": PRIVATE_GIT_REPO_SSH,
+        "branch": PRIVATE_BRANCH,
+        "commit": PRIVATE_COMMIT,
+    }
     model = DummyFrameworkModelForGit(
-        sagemaker_session=sagemaker_session, entry_point=entry_point, git_config=git_config
+        sagemaker_session=sagemaker_session,
+        entry_point=entry_point,
+        git_config=git_config,
     )
     model.prepare_container_def(instance_type=INSTANCE_TYPE)
     git_clone_repo.assert_called_with(git_config, entry_point, None, [])
@@ -387,12 +422,20 @@ def test_git_support_ssh_no_passphrase_needed(
     ),
 )
 @patch("sagemaker.model.fw_utils.tar_and_upload_dir")
-def test_git_support_ssh_passphrase_required(tar_and_upload_dir, git_clone_repo, sagemaker_session):
+def test_git_support_ssh_passphrase_required(
+    tar_and_upload_dir, git_clone_repo, sagemaker_session
+):
     entry_point = "entry_point"
-    git_config = {"repo": PRIVATE_GIT_REPO_SSH, "branch": PRIVATE_BRANCH, "commit": PRIVATE_COMMIT}
+    git_config = {
+        "repo": PRIVATE_GIT_REPO_SSH,
+        "branch": PRIVATE_BRANCH,
+        "commit": PRIVATE_COMMIT,
+    }
     with pytest.raises(subprocess.CalledProcessError) as error:
         model = DummyFrameworkModelForGit(
-            sagemaker_session=sagemaker_session, entry_point=entry_point, git_config=git_config
+            sagemaker_session=sagemaker_session,
+            entry_point=entry_point,
+            git_config=git_config,
         )
         model.prepare_container_def(instance_type=INSTANCE_TYPE)
     assert "returned non-zero exit status" in str(error)
@@ -418,7 +461,9 @@ def test_git_support_codecommit_with_username_and_password_succeed(
         "password": "passw0rd!",
     }
     model = DummyFrameworkModelForGit(
-        sagemaker_session=sagemaker_session, entry_point=entry_point, git_config=git_config
+        sagemaker_session=sagemaker_session,
+        entry_point=entry_point,
+        git_config=git_config,
     )
     model.prepare_container_def(instance_type=INSTANCE_TYPE)
     git_clone_repo.assert_called_with(git_config, entry_point, None, [])
@@ -440,7 +485,9 @@ def test_git_support_codecommit_ssh_no_passphrase_needed(
     entry_point = "entry_point"
     git_config = {"repo": CODECOMMIT_REPO_SSH, "branch": CODECOMMIT_BRANCH}
     model = DummyFrameworkModelForGit(
-        sagemaker_session=sagemaker_session, entry_point=entry_point, git_config=git_config
+        sagemaker_session=sagemaker_session,
+        entry_point=entry_point,
+        git_config=git_config,
     )
     model.prepare_container_def(instance_type=INSTANCE_TYPE)
     git_clone_repo.assert_called_with(git_config, entry_point, None, [])
@@ -461,7 +508,9 @@ def test_git_support_codecommit_ssh_passphrase_required(
     git_config = {"repo": CODECOMMIT_REPO_SSH, "branch": CODECOMMIT_BRANCH}
     with pytest.raises(subprocess.CalledProcessError) as error:
         model = DummyFrameworkModelForGit(
-            sagemaker_session=sagemaker_session, entry_point=entry_point, git_config=git_config
+            sagemaker_session=sagemaker_session,
+            entry_point=entry_point,
+            git_config=git_config,
         )
         model.prepare_container_def(instance_type=INSTANCE_TYPE)
     assert "returned non-zero exit status" in str(error)

--- a/tests/unit/sagemaker/model/test_model.py
+++ b/tests/unit/sagemaker/model/test_model.py
@@ -56,10 +56,16 @@ def test_model_enable_network_isolation():
 
 @patch("sagemaker.model.Model.prepare_container_def")
 @patch("sagemaker.utils.name_from_image")
-def test_create_sagemaker_model(name_from_image, prepare_container_def, sagemaker_session):
+def test_create_sagemaker_model(
+    name_from_image, prepare_container_def, sagemaker_session
+):
     name_from_image.return_value = MODEL_NAME
 
-    container_def = {"Image": MODEL_IMAGE, "Environment": {}, "ModelDataUrl": MODEL_DATA}
+    container_def = {
+        "Image": MODEL_IMAGE,
+        "Environment": {},
+        "ModelDataUrl": MODEL_DATA,
+    }
     prepare_container_def.return_value = container_def
 
     model = Model(MODEL_DATA, MODEL_IMAGE, sagemaker_session=sagemaker_session)
@@ -69,7 +75,12 @@ def test_create_sagemaker_model(name_from_image, prepare_container_def, sagemake
     name_from_image.assert_called_with(MODEL_IMAGE)
 
     sagemaker_session.create_model.assert_called_with(
-        MODEL_NAME, None, container_def, vpc_config=None, enable_network_isolation=False, tags=None
+        MODEL_NAME,
+        None,
+        container_def,
+        vpc_config=None,
+        enable_network_isolation=False,
+        tags=None,
     )
 
 
@@ -84,19 +95,29 @@ def test_create_sagemaker_model_instance_type(prepare_container_def, sagemaker_s
 
 @patch("sagemaker.utils.name_from_image", Mock())
 @patch("sagemaker.model.Model.prepare_container_def")
-def test_create_sagemaker_model_accelerator_type(prepare_container_def, sagemaker_session):
+def test_create_sagemaker_model_accelerator_type(
+    prepare_container_def, sagemaker_session
+):
     model = Model(MODEL_DATA, MODEL_IMAGE, sagemaker_session=sagemaker_session)
 
     accelerator_type = "ml.eia.medium"
     model._create_sagemaker_model(INSTANCE_TYPE, accelerator_type=accelerator_type)
 
-    prepare_container_def.assert_called_with(INSTANCE_TYPE, accelerator_type=accelerator_type)
+    prepare_container_def.assert_called_with(
+        INSTANCE_TYPE, accelerator_type=accelerator_type
+    )
 
 
 @patch("sagemaker.model.Model.prepare_container_def")
 @patch("sagemaker.utils.name_from_image")
-def test_create_sagemaker_model_tags(name_from_image, prepare_container_def, sagemaker_session):
-    container_def = {"Image": MODEL_IMAGE, "Environment": {}, "ModelDataUrl": MODEL_DATA}
+def test_create_sagemaker_model_tags(
+    name_from_image, prepare_container_def, sagemaker_session
+):
+    container_def = {
+        "Image": MODEL_IMAGE,
+        "Environment": {},
+        "ModelDataUrl": MODEL_DATA,
+    }
     prepare_container_def.return_value = container_def
 
     name_from_image.return_value = MODEL_NAME
@@ -107,7 +128,12 @@ def test_create_sagemaker_model_tags(name_from_image, prepare_container_def, sag
     model._create_sagemaker_model(INSTANCE_TYPE, tags=tags)
 
     sagemaker_session.create_model.assert_called_with(
-        MODEL_NAME, None, container_def, vpc_config=None, enable_network_isolation=False, tags=tags
+        MODEL_NAME,
+        None,
+        container_def,
+        vpc_config=None,
+        enable_network_isolation=False,
+        tags=tags,
     )
 
 
@@ -116,7 +142,11 @@ def test_create_sagemaker_model_tags(name_from_image, prepare_container_def, sag
 def test_create_sagemaker_model_optional_model_params(
     name_from_image, prepare_container_def, sagemaker_session
 ):
-    container_def = {"Image": MODEL_IMAGE, "Environment": {}, "ModelDataUrl": MODEL_DATA}
+    container_def = {
+        "Image": MODEL_IMAGE,
+        "Environment": {},
+        "ModelDataUrl": MODEL_DATA,
+    }
     prepare_container_def.return_value = container_def
 
     vpc_config = {"Subnets": ["123"], "SecurityGroupIds": ["456", "789"]}
@@ -159,7 +189,9 @@ def test_create_sagemaker_model_creates_correct_session(local_session, session):
 @patch("sagemaker.model.Model._create_sagemaker_model")
 def test_model_create_transformer(create_sagemaker_model, sagemaker_session):
     model_name = "auto-generated-model"
-    model = Model(MODEL_DATA, MODEL_IMAGE, name=model_name, sagemaker_session=sagemaker_session)
+    model = Model(
+        MODEL_DATA, MODEL_IMAGE, name=model_name, sagemaker_session=sagemaker_session
+    )
 
     instance_type = "ml.m4.xlarge"
     transformer = model.transformer(instance_count=1, instance_type=instance_type)
@@ -186,7 +218,9 @@ def test_model_create_transformer(create_sagemaker_model, sagemaker_session):
 
 
 @patch("sagemaker.model.Model._create_sagemaker_model")
-def test_model_create_transformer_optional_params(create_sagemaker_model, sagemaker_session):
+def test_model_create_transformer_optional_params(
+    create_sagemaker_model, sagemaker_session
+):
     model = Model(MODEL_DATA, MODEL_IMAGE, sagemaker_session=sagemaker_session)
 
     instance_type = "ml.m4.xlarge"
@@ -231,9 +265,14 @@ def test_model_create_transformer_optional_params(create_sagemaker_model, sagema
 
 
 @patch("sagemaker.model.Model._create_sagemaker_model")
-def test_model_create_transformer_network_isolation(create_sagemaker_model, sagemaker_session):
+def test_model_create_transformer_network_isolation(
+    create_sagemaker_model, sagemaker_session
+):
     model = Model(
-        MODEL_DATA, MODEL_IMAGE, sagemaker_session=sagemaker_session, enable_network_isolation=True
+        MODEL_DATA,
+        MODEL_IMAGE,
+        sagemaker_session=sagemaker_session,
+        enable_network_isolation=True,
     )
 
     transformer = model.transformer(1, "ml.m4.xlarge", env={"should_be": "overwritten"})
@@ -255,7 +294,9 @@ def test_transformer_creates_correct_session(local_session, session):
 
 
 def test_delete_model(sagemaker_session):
-    model = Model(MODEL_DATA, MODEL_IMAGE, name=MODEL_NAME, sagemaker_session=sagemaker_session)
+    model = Model(
+        MODEL_DATA, MODEL_IMAGE, name=MODEL_NAME, sagemaker_session=sagemaker_session
+    )
 
     model.delete_model()
     sagemaker_session.delete_model.assert_called_with(model.name)
@@ -265,7 +306,8 @@ def test_delete_model_no_name(sagemaker_session):
     model = Model(MODEL_DATA, MODEL_IMAGE, sagemaker_session=sagemaker_session)
 
     with pytest.raises(
-        ValueError, match="The SageMaker model must be created first before attempting to delete."
+        ValueError,
+        match="The SageMaker model must be created first before attempting to delete.",
     ):
         model.delete_model()
     sagemaker_session.delete_model.assert_not_called()

--- a/tests/unit/sagemaker/model/test_model_package.py
+++ b/tests/unit/sagemaker/model/test_model_package.py
@@ -64,7 +64,9 @@ def test_model_package_enable_network_isolation_with_no_product_id(sagemaker_ses
     )
 
     model_package = ModelPackage(
-        role="role", model_package_arn="my-model-package", sagemaker_session=sagemaker_session
+        role="role",
+        model_package_arn="my-model-package",
+        sagemaker_session=sagemaker_session,
     )
     assert model_package.enable_network_isolation() is False
 
@@ -83,7 +85,9 @@ def test_model_package_enable_network_isolation_with_product_id(sagemaker_sessio
     )
 
     model_package = ModelPackage(
-        role="role", model_package_arn="my-model-package", sagemaker_session=sagemaker_session
+        role="role",
+        model_package_arn="my-model-package",
+        sagemaker_session=sagemaker_session,
     )
     assert model_package.enable_network_isolation() is True
 
@@ -95,7 +99,9 @@ def test_model_package_create_transformer(sagemaker_session):
     )
 
     model_package = ModelPackage(
-        role="role", model_package_arn="my-model-package", sagemaker_session=sagemaker_session
+        role="role",
+        model_package_arn="my-model-package",
+        sagemaker_session=sagemaker_session,
     )
     model_package.name = "auto-generated-model"
     transformer = model_package.transformer(
@@ -122,7 +128,9 @@ def test_model_package_create_transformer_with_product_id(sagemaker_session):
     )
 
     model_package = ModelPackage(
-        role="role", model_package_arn="my-model-package", sagemaker_session=sagemaker_session
+        role="role",
+        model_package_arn="my-model-package",
+        sagemaker_session=sagemaker_session,
     )
     model_package.name = "auto-generated-model"
     transformer = model_package.transformer(

--- a/tests/unit/sagemaker/model/test_neo.py
+++ b/tests/unit/sagemaker/model/test_neo.py
@@ -152,5 +152,9 @@ def test_check_neo_region(sagemaker_session):
 
     boto_session = boto3.Session()
     for partition in boto_session.get_available_partitions():
-        for region_name in boto_session.get_available_regions("ec2", partition_name=partition):
-            assert (region_name in NEO_REGION_LIST) is model.check_neo_region(region_name)
+        for region_name in boto_session.get_available_regions(
+            "ec2", partition_name=partition
+        ):
+            assert (region_name in NEO_REGION_LIST) is model.check_neo_region(
+                region_name
+            )

--- a/tests/unit/sagemaker/monitor/test_cron_expression_generator.py
+++ b/tests/unit/sagemaker/monitor/test_cron_expression_generator.py
@@ -28,7 +28,10 @@ def test_cron_expression_generator_daily_returns_expected_value_when_called_with
 
 
 def test_cron_expression_generator_daily_every_x_hours_returns_expected_value_when_called_without_customizations():
-    assert CronExpressionGenerator.daily_every_x_hours(hour_interval=6) == "cron(0 0/6 ? * * *)"
+    assert (
+        CronExpressionGenerator.daily_every_x_hours(hour_interval=6)
+        == "cron(0 0/6 ? * * *)"
+    )
 
 
 def test_cron_expression_generator_daily_every_x_hours_returns_expected_value_when_called_with_customizations():

--- a/tests/unit/sagemaker/monitor/test_data_capture_config.py
+++ b/tests/unit/sagemaker/monitor/test_data_capture_config.py
@@ -19,7 +19,9 @@ from sagemaker.model_monitor import DataCaptureConfig
 DEFAULT_ENABLE_CAPTURE = True
 DEFAULT_SAMPLING_PERCENTAGE = 20
 DEFAULT_BUCKET_NAME = "default-bucket"
-DEFAULT_DESTINATION_S3_URI = "s3://{}/model-monitor/data-capture".format(DEFAULT_BUCKET_NAME)
+DEFAULT_DESTINATION_S3_URI = "s3://{}/model-monitor/data-capture".format(
+    DEFAULT_BUCKET_NAME
+)
 DEFAULT_KMS_KEY_ID = None
 DEFAULT_CAPTURE_MODES = ["REQUEST", "RESPONSE"]
 DEFAULT_CSV_CONTENT_TYPES = ["text/csv"]

--- a/tests/unit/sagemaker/monitor/test_model_monitoring.py
+++ b/tests/unit/sagemaker/monitor/test_model_monitoring.py
@@ -57,9 +57,7 @@ OUTPUT_S3_URI = "s3://output-s3-uri/"
 
 CUSTOM_IMAGE_URI = "012345678901.dkr.ecr.us-west-2.amazonaws.com/my-custom-image-uri"
 
-INTER_CONTAINER_ENCRYPTION_EXCEPTION_MSG = (
-    "EnableInterContainerTrafficEncryption is not supported in Model Monitor. Please ensure that "
-)
+INTER_CONTAINER_ENCRYPTION_EXCEPTION_MSG = "EnableInterContainerTrafficEncryption is not supported in Model Monitor. Please ensure that "
 "encrypt_inter_container_traffic=None when creating your NetworkConfig object."
 
 
@@ -140,7 +138,9 @@ def test_default_model_monitor_suggest_baseline(sagemaker_session):
 def test_default_model_monitor_with_invalid_network_config(sagemaker_session):
     invalid_network_config = NetworkConfig(encrypt_inter_container_traffic=False)
     my_default_monitor = DefaultModelMonitor(
-        role=ROLE, sagemaker_session=sagemaker_session, network_config=invalid_network_config
+        role=ROLE,
+        sagemaker_session=sagemaker_session,
+        network_config=invalid_network_config,
     )
     with pytest.raises(ValueError) as exception:
         my_default_monitor.create_monitoring_schedule(endpoint_input="test_endpoint")
@@ -163,7 +163,8 @@ def test_model_monitor_with_invalid_network_config(sagemaker_session):
         my_model_monitor.create_monitoring_schedule(
             endpoint_input="test_endpoint",
             output=MonitoringOutput(
-                source="/opt/ml/processing/output", destination="/opt/ml/processing/output"
+                source="/opt/ml/processing/output",
+                destination="/opt/ml/processing/output",
             ),
         )
     assert INTER_CONTAINER_ENCRYPTION_EXCEPTION_MSG in str(exception.value)

--- a/tests/unit/test_airflow.py
+++ b/tests/unit/test_airflow.py
@@ -15,7 +15,16 @@ from __future__ import absolute_import
 import pytest
 from mock import Mock, MagicMock, patch
 
-from sagemaker import chainer, estimator, model, mxnet, tensorflow, transformer, tuner, processing
+from sagemaker import (
+    chainer,
+    estimator,
+    model,
+    mxnet,
+    tensorflow,
+    transformer,
+    tuner,
+    processing,
+)
 from sagemaker.network import NetworkConfig
 from sagemaker.processing import ProcessingInput, ProcessingOutput
 from sagemaker.workflow import airflow
@@ -82,7 +91,11 @@ def test_byo_training_config_required_args(sagemaker_session):
                 "ChannelName": "train",
             }
         ],
-        "HyperParameters": {"epochs": "32", "feature_dim": "1024", "mini_batch_size": "256"},
+        "HyperParameters": {
+            "epochs": "32",
+            "feature_dim": "1024",
+            "mini_batch_size": "256",
+        },
     }
     assert config == expected_config
 
@@ -159,7 +172,11 @@ def test_byo_training_config_all_args(sagemaker_session):
             "SecurityGroupIds": ["{{ security_group_ids }}"],
         },
         "EnableManagedSpotTraining": True,
-        "HyperParameters": {"epochs": "32", "feature_dim": "1024", "mini_batch_size": "256"},
+        "HyperParameters": {
+            "epochs": "32",
+            "feature_dim": "1024",
+            "mini_batch_size": "256",
+        },
         "Tags": [{"{{ key }}": "{{ value }}"}],
     }
     assert config == expected_config
@@ -230,7 +247,8 @@ def test_framework_training_config_required_args(ecr_prefix, sagemaker_session):
             "sagemaker_container_log_level": "20",
             "sagemaker_job_name": '"sagemaker-tensorflow-%s"' % TIME_STAMP,
             "sagemaker_region": '"us-west-2"',
-            "checkpoint_path": '"s3://output/sagemaker-tensorflow-%s/checkpoints"' % TIME_STAMP,
+            "checkpoint_path": '"s3://output/sagemaker-tensorflow-%s/checkpoints"'
+            % TIME_STAMP,
             "training_steps": "1000",
             "evaluation_steps": "100",
             "sagemaker_requirements": '""',
@@ -240,7 +258,8 @@ def test_framework_training_config_required_args(ecr_prefix, sagemaker_session):
                 {
                     "Path": "/some/script.py",
                     "Bucket": "output",
-                    "Key": "sagemaker-tensorflow-%s/source/sourcedir.tar.gz" % TIME_STAMP,
+                    "Key": "sagemaker-tensorflow-%s/source/sourcedir.tar.gz"
+                    % TIME_STAMP,
                     "Tar": True,
                 }
             ]
@@ -561,7 +580,12 @@ def test_framework_tuning_config(ecr_prefix, sagemaker_session):
                     {"Name": "optimizer", "Values": ['"sgd"', '"Adam"']}
                 ],
                 "IntegerParameterRanges": [
-                    {"Name": "num_epoch", "MinValue": "10", "MaxValue": "50", "ScalingType": "Auto"}
+                    {
+                        "Name": "num_epoch",
+                        "MinValue": "10",
+                        "MaxValue": "50",
+                        "ScalingType": "Auto",
+                    }
                 ],
             },
             "TrainingJobEarlyStoppingType": "Off",
@@ -571,7 +595,10 @@ def test_framework_tuning_config(ecr_prefix, sagemaker_session):
                 "TrainingImage": "520713654638.dkr.ecr.us-west-2.amazonaws.com/sagemaker-mxnet:1.3.0-cpu-py3",
                 "TrainingInputMode": "File",
                 "MetricDefinitions": [
-                    {"Name": "Validation-accuracy", "Regex": "Validation-accuracy=([0-9\\.]+)"}
+                    {
+                        "Name": "Validation-accuracy",
+                        "Regex": "Validation-accuracy=([0-9\\.]+)",
+                    }
                 ],
             },
             "OutputDataConfig": {"S3OutputPath": "s3://output/"},
@@ -613,7 +640,8 @@ def test_framework_tuning_config(ecr_prefix, sagemaker_session):
                 {
                     "Path": "{{ source_dir }}",
                     "Bucket": "output",
-                    "Key": "{{ base_job_name }}-%s/source/sourcedir.tar.gz" % TIME_STAMP,
+                    "Key": "{{ base_job_name }}-%s/source/sourcedir.tar.gz"
+                    % TIME_STAMP,
                     "Tar": True,
                 }
             ]
@@ -643,7 +671,9 @@ def test_framework_tuning_config(ecr_prefix, sagemaker_session):
     "sagemaker.amazon.amazon_estimator.get_ecr_image_uri_prefix",
     return_value="174872318107.dkr.ecr.us-west-2.amazonaws.com",
 )
-def test_multi_estimator_tuning_config(algo_ecr_prefix, fw_ecr_prefix, sagemaker_session):
+def test_multi_estimator_tuning_config(
+    algo_ecr_prefix, fw_ecr_prefix, sagemaker_session
+):
     estimator_dict = {}
     hyperparameter_ranges_dict = {}
     objective_metric_name_dict = {}
@@ -684,7 +714,9 @@ def test_multi_estimator_tuning_config(algo_ecr_prefix, fw_ecr_prefix, sagemaker
         "learning_rate": tuner.ContinuousParameter(0.2, 0.5),
         "use_bias": tuner.CategoricalParameter([True, False]),
     }
-    objective_metric_name_dict[ll_estimator_name] = "validation:binary_classification_accuracy"
+    objective_metric_name_dict[
+        ll_estimator_name
+    ] = "validation:binary_classification_accuracy"
 
     multi_estimator_tuner = tuner.HyperparameterTuner.create(
         estimator_dict=estimator_dict,
@@ -701,10 +733,14 @@ def test_multi_estimator_tuning_config(algo_ecr_prefix, fw_ecr_prefix, sagemaker
 
     data = {
         mxnet_estimator_name: "{{ training_data_mxnet }}",
-        ll_estimator_name: amazon_estimator.RecordSet("{{ record }}", 10000, 100, "S3Prefix"),
+        ll_estimator_name: amazon_estimator.RecordSet(
+            "{{ record }}", 10000, 100, "S3Prefix"
+        ),
     }
 
-    config = airflow.tuning_config(multi_estimator_tuner, inputs=data, include_cls_metadata={})
+    config = airflow.tuning_config(
+        multi_estimator_tuner, inputs=data, include_cls_metadata={}
+    )
 
     expected_config = {
         "HyperParameterTuningJobName": "{{ base_job_name }}-%s" % TIME_STAMP,
@@ -769,7 +805,10 @@ def test_multi_estimator_tuning_config(algo_ecr_prefix, fw_ecr_prefix, sagemaker
             },
             {
                 "DefinitionName": "mxnet",
-                "TuningObjective": {"MetricName": "Validation-accuracy", "Type": "Maximize"},
+                "TuningObjective": {
+                    "MetricName": "Validation-accuracy",
+                    "Type": "Maximize",
+                },
                 "HyperParameterRanges": {
                     "CategoricalParameterRanges": [
                         {"Name": "optimizer", "Values": ['"sgd"', '"Adam"']}
@@ -805,7 +844,10 @@ def test_multi_estimator_tuning_config(algo_ecr_prefix, fw_ecr_prefix, sagemaker
                 },
                 "AlgorithmSpecification": {
                     "MetricDefinitions": [
-                        {"Name": "Validation-accuracy", "Regex": "Validation-accuracy=([0-9\\.]+)"}
+                        {
+                            "Name": "Validation-accuracy",
+                            "Regex": "Validation-accuracy=([0-9\\.]+)",
+                        }
                     ],
                     "TrainingImage": "520713654638.dkr.ecr.us-west-2.amazonaws.com/sagemaker-mxnet:1.3.0-cpu-py3",
                     "TrainingInputMode": "File",
@@ -836,7 +878,8 @@ def test_multi_estimator_tuning_config(algo_ecr_prefix, fw_ecr_prefix, sagemaker
             "S3Upload": [
                 {
                     "Bucket": "output",
-                    "Key": "{{ base_job_name }}-%s/source/sourcedir.tar.gz" % TIME_STAMP,
+                    "Key": "{{ base_job_name }}-%s/source/sourcedir.tar.gz"
+                    % TIME_STAMP,
                     "Path": "{{ source_dir }}",
                     "Tar": True,
                 }
@@ -1022,7 +1065,9 @@ def test_framework_model_config(sagemaker_session):
 @patch("sagemaker.utils.sagemaker_timestamp", MagicMock(return_value=TIME_STAMP))
 def test_amazon_alg_model_config(sagemaker_session):
     pca_model = pca.PCAModel(
-        model_data="{{ model_data }}", role="{{ role }}", sagemaker_session=sagemaker_session
+        model_data="{{ model_data }}",
+        role="{{ role }}",
+        sagemaker_session=sagemaker_session,
     )
 
     config = airflow.model_config(instance_type="ml.c4.xlarge", model=pca_model)
@@ -1119,7 +1164,10 @@ def test_model_config_from_amazon_alg_estimator(sagemaker_session):
     airflow.training_config(knn_estimator, record, mini_batch_size=256)
 
     config = airflow.model_config_from_estimator(
-        instance_type="ml.c4.xlarge", estimator=knn_estimator, task_id="task_id", task_type="tuning"
+        instance_type="ml.c4.xlarge",
+        estimator=knn_estimator,
+        task_id="task_id",
+        task_type="tuning",
     )
     expected_config = {
         "ModelName": "knn-%s" % TIME_STAMP,
@@ -1173,7 +1221,10 @@ def test_transform_config(sagemaker_session):
         "ModelName": "tensorflow-model",
         "TransformInput": {
             "DataSource": {
-                "S3DataSource": {"S3DataType": "S3Prefix", "S3Uri": "{{ transform_data }}"}
+                "S3DataSource": {
+                    "S3DataType": "S3Prefix",
+                    "S3Uri": "{{ transform_data }}",
+                }
             },
             "ContentType": "{{ content_type }}",
             "CompressionType": "{{ compression_type }}",
@@ -1276,10 +1327,15 @@ def test_transform_config_from_framework_estimator(ecr_prefix, sagemaker_session
             "ModelName": "mxnet-inference-%s" % TIME_STAMP,
             "TransformInput": {
                 "DataSource": {
-                    "S3DataSource": {"S3DataType": "S3Prefix", "S3Uri": "{{ transform_data }}"}
+                    "S3DataSource": {
+                        "S3DataType": "S3Prefix",
+                        "S3Uri": "{{ transform_data }}",
+                    }
                 }
             },
-            "TransformOutput": {"S3OutputPath": "s3://output/{{ base_job_name }}-%s" % TIME_STAMP},
+            "TransformOutput": {
+                "S3OutputPath": "s3://output/{{ base_job_name }}-%s" % TIME_STAMP
+            },
             "TransformResources": {
                 "InstanceCount": "{{ instance_count }}",
                 "InstanceType": "ml.p2.xlarge",
@@ -1338,7 +1394,10 @@ def test_transform_config_from_amazon_alg_estimator(sagemaker_session):
             "ModelName": "knn-%s" % TIME_STAMP,
             "TransformInput": {
                 "DataSource": {
-                    "S3DataSource": {"S3DataType": "S3Prefix", "S3Uri": "{{ transform_data }}"}
+                    "S3DataSource": {
+                        "S3DataType": "S3Prefix",
+                        "S3Uri": "{{ transform_data }}",
+                    }
                 }
             },
             "TransformOutput": {"S3OutputPath": "s3://output/knn-%s" % TIME_STAMP},
@@ -1367,7 +1426,9 @@ def test_deploy_framework_model_config(sagemaker_session):
     )
 
     config = airflow.deploy_config(
-        chainer_model, initial_instance_count="{{ instance_count }}", instance_type="ml.m4.xlarge"
+        chainer_model,
+        initial_instance_count="{{ instance_count }}",
+        instance_type="ml.m4.xlarge",
     )
     expected_config = {
         "Model": {
@@ -1421,11 +1482,15 @@ def test_deploy_framework_model_config(sagemaker_session):
 @patch("sagemaker.utils.sagemaker_timestamp", MagicMock(return_value=TIME_STAMP))
 def test_deploy_amazon_alg_model_config(sagemaker_session):
     pca_model = pca.PCAModel(
-        model_data="{{ model_data }}", role="{{ role }}", sagemaker_session=sagemaker_session
+        model_data="{{ model_data }}",
+        role="{{ role }}",
+        sagemaker_session=sagemaker_session,
     )
 
     config = airflow.deploy_config(
-        pca_model, initial_instance_count="{{ instance_count }}", instance_type="ml.c4.xlarge"
+        pca_model,
+        initial_instance_count="{{ instance_count }}",
+        instance_type="ml.c4.xlarge",
     )
     expected_config = {
         "Model": {

--- a/tests/unit/test_algorithm.py
+++ b/tests/unit/test_algorithm.py
@@ -36,7 +36,10 @@ DESCRIBE_ALGORITHM_RESPONSE = {
                 "Description": "Grow a tree with max_leaf_nodes in best-first fashion.",
                 "Type": "Integer",
                 "Range": {
-                    "IntegerParameterRangeSpecification": {"MinValue": "1", "MaxValue": "100000"}
+                    "IntegerParameterRangeSpecification": {
+                        "MinValue": "1",
+                        "MaxValue": "100000",
+                    }
                 },
                 "IsTunable": True,
                 "IsRequired": False,
@@ -50,7 +53,11 @@ DESCRIBE_ALGORITHM_RESPONSE = {
                 "IsRequired": True,
             },
         ],
-        "SupportedTrainingInstanceTypes": ["ml.m4.xlarge", "ml.m4.2xlarge", "ml.m4.4xlarge"],
+        "SupportedTrainingInstanceTypes": [
+            "ml.m4.xlarge",
+            "ml.m4.2xlarge",
+            "ml.m4.4xlarge",
+        ],
         "SupportsDistributedTraining": False,
         "MetricDefinitions": [
             {"Name": "validation:accuracy", "Regex": "validation-accuracy: (\\S+)"}
@@ -129,7 +136,10 @@ DESCRIBE_ALGORITHM_RESPONSE = {
                         "AssembleWith": "Line",
                         "KmsKeyId": "",
                     },
-                    "TransformResources": {"InstanceType": "ml.c4.xlarge", "InstanceCount": 1},
+                    "TransformResources": {
+                        "InstanceType": "ml.c4.xlarge",
+                        "InstanceCount": 1,
+                    },
                 },
             }
         ],
@@ -138,7 +148,9 @@ DESCRIBE_ALGORITHM_RESPONSE = {
     },
     "AlgorithmStatus": "Completed",
     "AlgorithmStatusDetails": {
-        "ValidationStatuses": [{"ProfileName": "ValidationProfile1", "Status": "Completed"}]
+        "ValidationStatuses": [
+            {"ProfileName": "ValidationProfile1", "Status": "Completed"}
+        ]
     },
     "ResponseMetadata": {
         "RequestId": "e04bc28b-61b6-4486-9106-0edf07f5649c",
@@ -407,7 +419,9 @@ def test_algorithm_trainining_channels_with_invalid_channels(session):
 
     # Passing an unknown channel should fail???
     with pytest.raises(ValueError):
-        estimator.fit({"training": "s3://some/data", "training2": "s3://some/other/data"})
+        estimator.fit(
+            {"training": "s3://some/data", "training2": "s3://some/other/data"}
+        )
 
 
 @patch("sagemaker.Session")
@@ -419,7 +433,9 @@ def test_algorithm_train_instance_types_valid_instance_types(session):
         "SupportedTrainingInstanceTypes"
     ] = train_instance_types
 
-    session.sagemaker_client.describe_algorithm = Mock(return_value=describe_algo_response)
+    session.sagemaker_client.describe_algorithm = Mock(
+        return_value=describe_algo_response
+    )
 
     AlgorithmEstimator(
         algorithm_arn="arn:aws:sagemaker:us-east-2:1234:algorithm/scikit-decision-trees",
@@ -447,7 +463,9 @@ def test_algorithm_train_instance_types_invalid_instance_types(session):
         "SupportedTrainingInstanceTypes"
     ] = train_instance_types
 
-    session.sagemaker_client.describe_algorithm = Mock(return_value=describe_algo_response)
+    session.sagemaker_client.describe_algorithm = Mock(
+        return_value=describe_algo_response
+    )
 
     # invalid instance type, should fail
     with pytest.raises(ValueError):
@@ -487,7 +505,9 @@ def test_algorithm_distributed_training_validation(session):
         sagemaker_session=session,
     )
 
-    session.sagemaker_client.describe_algorithm = Mock(return_value=single_instance_algo)
+    session.sagemaker_client.describe_algorithm = Mock(
+        return_value=single_instance_algo
+    )
 
     # distributed training on a single instance algorithm should fail.
     with pytest.raises(ValueError):
@@ -508,7 +528,10 @@ def test_algorithm_hyperparameter_integer_range_valid_range(session):
             "Type": "Integer",
             "Name": "max_leaf_nodes",
             "Range": {
-                "IntegerParameterRangeSpecification": {"MinValue": "1", "MaxValue": "100000"}
+                "IntegerParameterRangeSpecification": {
+                    "MinValue": "1",
+                    "MaxValue": "100000",
+                }
             },
             "IsTunable": True,
             "IsRequired": False,
@@ -541,7 +564,10 @@ def test_algorithm_hyperparameter_integer_range_invalid_range(session):
             "Type": "Integer",
             "Name": "max_leaf_nodes",
             "Range": {
-                "IntegerParameterRangeSpecification": {"MinValue": "1", "MaxValue": "100000"}
+                "IntegerParameterRangeSpecification": {
+                    "MinValue": "1",
+                    "MaxValue": "100000",
+                }
             },
             "IsTunable": True,
             "IsRequired": False,
@@ -577,7 +603,10 @@ def test_algorithm_hyperparameter_continuous_range_valid_range(session):
             "Type": "Continuous",
             "Name": "max_leaf_nodes",
             "Range": {
-                "ContinuousParameterRangeSpecification": {"MinValue": "0.0", "MaxValue": "1.0"}
+                "ContinuousParameterRangeSpecification": {
+                    "MinValue": "0.0",
+                    "MaxValue": "1.0",
+                }
             },
             "IsTunable": True,
             "IsRequired": False,
@@ -612,7 +641,10 @@ def test_algorithm_hyperparameter_continuous_range_invalid_range(session):
             "Type": "Continuous",
             "Name": "max_leaf_nodes",
             "Range": {
-                "ContinuousParameterRangeSpecification": {"MinValue": "0.0", "MaxValue": "1.0"}
+                "ContinuousParameterRangeSpecification": {
+                    "MinValue": "0.0",
+                    "MaxValue": "1.0",
+                }
             },
             "IsTunable": True,
             "IsRequired": False,
@@ -647,7 +679,9 @@ def test_algorithm_hyperparameter_categorical_range(session):
             "Description": "A continuous hyperparameter",
             "Type": "Categorical",
             "Name": "hp1",
-            "Range": {"CategoricalParameterRangeSpecification": {"Values": ["TF", "MXNet"]}},
+            "Range": {
+                "CategoricalParameterRangeSpecification": {"Values": ["TF", "MXNet"]}
+            },
             "IsTunable": True,
             "IsRequired": False,
             "DefaultValue": "100",
@@ -684,7 +718,9 @@ def test_algorithm_required_hyperparameters_not_provided(session):
             "Description": "A continuous hyperparameter",
             "Type": "Categorical",
             "Name": "hp1",
-            "Range": {"CategoricalParameterRangeSpecification": {"Values": ["TF", "MXNet"]}},
+            "Range": {
+                "CategoricalParameterRangeSpecification": {"Values": ["TF", "MXNet"]}
+            },
             "IsTunable": True,
             "IsRequired": True,
         },
@@ -728,7 +764,9 @@ def test_algorithm_required_hyperparameters_are_provided(session):
             "Description": "A categorical hyperparameter",
             "Type": "Categorical",
             "Name": "hp1",
-            "Range": {"CategoricalParameterRangeSpecification": {"Values": ["TF", "MXNet"]}},
+            "Range": {
+                "CategoricalParameterRangeSpecification": {"Values": ["TF", "MXNet"]}
+            },
             "IsTunable": True,
             "IsRequired": True,
         },
@@ -810,7 +848,9 @@ def test_algorithm_required_free_text_hyperparameter_not_provided(session):
 @patch("sagemaker.Session")
 @patch("sagemaker.algorithm.AlgorithmEstimator.create_model")
 def test_algorithm_create_transformer(create_model, session):
-    session.sagemaker_client.describe_algorithm = Mock(return_value=DESCRIBE_ALGORITHM_RESPONSE)
+    session.sagemaker_client.describe_algorithm = Mock(
+        return_value=DESCRIBE_ALGORITHM_RESPONSE
+    )
 
     estimator = AlgorithmEstimator(
         algorithm_arn="arn:aws:sagemaker:us-east-2:1234:algorithm/scikit-decision-trees",
@@ -834,7 +874,9 @@ def test_algorithm_create_transformer(create_model, session):
 
 @patch("sagemaker.Session")
 def test_algorithm_create_transformer_without_completed_training_job(session):
-    session.sagemaker_client.describe_algorithm = Mock(return_value=DESCRIBE_ALGORITHM_RESPONSE)
+    session.sagemaker_client.describe_algorithm = Mock(
+        return_value=DESCRIBE_ALGORITHM_RESPONSE
+    )
 
     estimator = AlgorithmEstimator(
         algorithm_arn="arn:aws:sagemaker:us-east-2:1234:algorithm/scikit-decision-trees",
@@ -846,7 +888,9 @@ def test_algorithm_create_transformer_without_completed_training_job(session):
 
     with pytest.raises(RuntimeError) as error:
         estimator.transformer(instance_count=1, instance_type="ml.m4.xlarge")
-        assert "No finished training job found associated with this estimator" in str(error)
+        assert "No finished training job found associated with this estimator" in str(
+            error
+        )
 
 
 @patch("sagemaker.algorithm.AlgorithmEstimator.create_model")
@@ -875,7 +919,9 @@ def test_algorithm_create_transformer_with_product_id(create_model, session):
 
 @patch("sagemaker.Session")
 def test_algorithm_enable_network_isolation_no_product_id(session):
-    session.sagemaker_client.describe_algorithm = Mock(return_value=DESCRIBE_ALGORITHM_RESPONSE)
+    session.sagemaker_client.describe_algorithm = Mock(
+        return_value=DESCRIBE_ALGORITHM_RESPONSE
+    )
 
     estimator = AlgorithmEstimator(
         algorithm_arn="arn:aws:sagemaker:us-east-2:1234:algorithm/scikit-decision-trees",
@@ -948,7 +994,9 @@ def test_algorithm_no_required_hyperparameters(session):
 def test_algorithm_attach_from_hyperparameter_tuning():
     session = Mock()
     job_name = "training-job-that-is-part-of-a-tuning-job"
-    algo_arn = "arn:aws:sagemaker:us-east-2:000000000000:algorithm/scikit-decision-trees"
+    algo_arn = (
+        "arn:aws:sagemaker:us-east-2:000000000000:algorithm/scikit-decision-trees"
+    )
     role_arn = "arn:aws:iam::123412341234:role/SageMakerRole"
     instance_count = 1
     instance_type = "ml.m4.xlarge"
@@ -956,10 +1004,13 @@ def test_algorithm_attach_from_hyperparameter_tuning():
     input_mode = "File"
 
     session.sagemaker_client.list_tags.return_value = {"Tags": []}
-    session.sagemaker_client.describe_algorithm.return_value = DESCRIBE_ALGORITHM_RESPONSE
+    session.sagemaker_client.describe_algorithm.return_value = (
+        DESCRIBE_ALGORITHM_RESPONSE
+    )
     session.sagemaker_client.describe_training_job.return_value = {
         "TrainingJobName": job_name,
-        "TrainingJobArn": "arn:aws:sagemaker:us-east-2:123412341234:training-job/%s" % job_name,
+        "TrainingJobArn": "arn:aws:sagemaker:us-east-2:123412341234:training-job/%s"
+        % job_name,
         "TuningJobArn": "arn:aws:sagemaker:us-east-2:123412341234:hyper-parameter-tuning-job/%s"
         % job_name,
         "ModelArtifacts": {
@@ -974,7 +1025,10 @@ def test_algorithm_attach_from_hyperparameter_tuning():
             "max_leaf_nodes": 1,
             "free_text_hp1": "foo",
         },
-        "AlgorithmSpecification": {"AlgorithmName": algo_arn, "TrainingInputMode": input_mode},
+        "AlgorithmSpecification": {
+            "AlgorithmName": algo_arn,
+            "TrainingInputMode": input_mode,
+        },
         "MetricDefinitions": [
             {"Name": "validation:accuracy", "Regex": "validation-accuracy: (\\S+)"}
         ],
@@ -1019,7 +1073,9 @@ def test_algorithm_attach_from_hyperparameter_tuning():
 
 @patch("sagemaker.Session")
 def test_algorithm_supported_with_spot_instances(session):
-    session.sagemaker_client.describe_algorithm = Mock(return_value=DESCRIBE_ALGORITHM_RESPONSE)
+    session.sagemaker_client.describe_algorithm = Mock(
+        return_value=DESCRIBE_ALGORITHM_RESPONSE
+    )
 
     assert AlgorithmEstimator(
         algorithm_arn="arn:aws:sagemaker:us-east-2:1234:algorithm/scikit-decision-trees",

--- a/tests/unit/test_amazon_estimator.py
+++ b/tests/unit/test_amazon_estimator.py
@@ -26,9 +26,16 @@ from sagemaker.amazon.amazon_estimator import (
     FileSystemRecordSet,
     _is_latest_xgboost_version,
 )
-from sagemaker.xgboost.defaults import XGBOOST_LATEST_VERSION, XGBOOST_SUPPORTED_VERSIONS
+from sagemaker.xgboost.defaults import (
+    XGBOOST_LATEST_VERSION,
+    XGBOOST_SUPPORTED_VERSIONS,
+)
 
-COMMON_ARGS = {"role": "myrole", "train_instance_count": 1, "train_instance_type": "ml.c4.xlarge"}
+COMMON_ARGS = {
+    "role": "myrole",
+    "train_instance_count": 1,
+    "train_instance_type": "ml.c4.xlarge",
+}
 
 REGION = "us-west-2"
 BUCKET_NAME = "Some-Bucket"
@@ -199,7 +206,8 @@ def test_prepare_for_training_encrypt(sagemaker_session):
     train = [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 8.0], [44.0, 55.0, 66.0]]
     labels = [99, 85, 87, 2]
     with patch(
-        "sagemaker.amazon.amazon_estimator.upload_numpy_to_s3_shards", return_value="manfiest_file"
+        "sagemaker.amazon.amazon_estimator.upload_numpy_to_s3_shards",
+        return_value="manfiest_file",
     ) as mock_upload:
         pca.record_set(np.array(train), np.array(labels))
         pca.record_set(np.array(train), np.array(labels), encrypt=True)
@@ -290,14 +298,18 @@ def test_upload_numpy_to_s3_shards():
     def make_all_put_calls(**kwargs):
         return [call(Body=ANY, **kwargs) for i in range(num_objects)]
 
-    upload_numpy_to_s3_shards(num_shards, mock_s3, BUCKET_NAME, "key-prefix", array, labels)
+    upload_numpy_to_s3_shards(
+        num_shards, mock_s3, BUCKET_NAME, "key-prefix", array, labels
+    )
     mock_s3.Object.assert_has_calls([call(BUCKET_NAME, "key-prefix/matrix_0.pbr")])
     mock_s3.Object.assert_has_calls([call(BUCKET_NAME, "key-prefix/matrix_1.pbr")])
     mock_s3.Object.assert_has_calls([call(BUCKET_NAME, "key-prefix/matrix_2.pbr")])
     mock_put.assert_has_calls(make_all_put_calls())
 
     mock_put.reset()
-    upload_numpy_to_s3_shards(3, mock_s3, BUCKET_NAME, "key-prefix", array, labels, encrypt=True)
+    upload_numpy_to_s3_shards(
+        3, mock_s3, BUCKET_NAME, "key-prefix", array, labels, encrypt=True
+    )
     mock_put.assert_has_calls(make_all_put_calls(ServerSideEncryption="AES256"))
 
 
@@ -451,11 +463,18 @@ def test_file_system_record_set_data_channel():
 
 def test_get_xgboost_image_uri():
     legacy_xgb_image_uri = get_image_uri(REGION, "xgboost")
-    assert legacy_xgb_image_uri == "433757028032.dkr.ecr.us-west-2.amazonaws.com/xgboost:1"
+    assert (
+        legacy_xgb_image_uri == "433757028032.dkr.ecr.us-west-2.amazonaws.com/xgboost:1"
+    )
     legacy_xgb_image_uri = get_image_uri(REGION, "xgboost", 1)
-    assert legacy_xgb_image_uri == "433757028032.dkr.ecr.us-west-2.amazonaws.com/xgboost:1"
+    assert (
+        legacy_xgb_image_uri == "433757028032.dkr.ecr.us-west-2.amazonaws.com/xgboost:1"
+    )
     legacy_xgb_image_uri = get_image_uri(REGION, "xgboost", "latest")
-    assert legacy_xgb_image_uri == "433757028032.dkr.ecr.us-west-2.amazonaws.com/xgboost:latest"
+    assert (
+        legacy_xgb_image_uri
+        == "433757028032.dkr.ecr.us-west-2.amazonaws.com/xgboost:latest"
+    )
 
     updated_xgb_image_uri = get_image_uri(REGION, "xgboost", "0.90-1")
     assert (
@@ -525,7 +544,9 @@ def test_regitry_throws_error_if_mapping_does_not_exist_for_lda():
 def test_regitry_throws_error_if_mapping_does_not_exist_for_default_algorithm():
     with pytest.raises(ValueError) as error:
         registry("broken_region_name")
-    assert "Algorithm (None) is unsupported for region (broken_region_name)." in str(error)
+    assert "Algorithm (None) is unsupported for region (broken_region_name)." in str(
+        error
+    )
 
 
 def test_is_latest_xgboost_version():

--- a/tests/unit/test_chainer.py
+++ b/tests/unit/test_chainer.py
@@ -49,7 +49,9 @@ CPU = "ml.c4.xlarge"
 
 ENDPOINT_DESC = {"EndpointConfigName": "test-endpoint"}
 
-ENDPOINT_CONFIG_DESC = {"ProductionVariants": [{"ModelName": "model-1"}, {"ModelName": "model-2"}]}
+ENDPOINT_CONFIG_DESC = {
+    "ProductionVariants": [{"ModelName": "model-1"}, {"ModelName": "model-2"}]
+}
 
 LIST_TAGS_RESULT = {"Tags": [{"Key": "TagtestKey", "Value": "TagtestValue"}]}
 
@@ -70,7 +72,9 @@ def sagemaker_session():
     describe = {"ModelArtifacts": {"S3ModelArtifacts": "s3://m/m.tar.gz"}}
     session.sagemaker_client.describe_training_job = Mock(return_value=describe)
     session.sagemaker_client.describe_endpoint = Mock(return_value=ENDPOINT_DESC)
-    session.sagemaker_client.describe_endpoint_config = Mock(return_value=ENDPOINT_CONFIG_DESC)
+    session.sagemaker_client.describe_endpoint_config = Mock(
+        return_value=ENDPOINT_CONFIG_DESC
+    )
     session.sagemaker_client.list_tags = Mock(return_value=LIST_TAGS_RESULT)
     session.default_bucket = Mock(name="default_bucket", return_value=BUCKET_NAME)
     session.expand_role = Mock(name="expand_role", return_value=ROLE)
@@ -78,11 +82,15 @@ def sagemaker_session():
 
 
 def _get_full_cpu_image_uri(version, py_version=PYTHON_VERSION):
-    return IMAGE_URI_FORMAT_STRING.format(REGION, IMAGE_NAME, version, "cpu", py_version)
+    return IMAGE_URI_FORMAT_STRING.format(
+        REGION, IMAGE_NAME, version, "cpu", py_version
+    )
 
 
 def _get_full_gpu_image_uri(version, py_version=PYTHON_VERSION):
-    return IMAGE_URI_FORMAT_STRING.format(REGION, IMAGE_NAME, version, "gpu", py_version)
+    return IMAGE_URI_FORMAT_STRING.format(
+        REGION, IMAGE_NAME, version, "gpu", py_version
+    )
 
 
 def _get_full_cpu_image_uri_with_ei(version, py_version=PYTHON_VERSION):
@@ -106,7 +114,9 @@ def _chainer_estimator(
         role=ROLE,
         sagemaker_session=sagemaker_session,
         train_instance_count=INSTANCE_COUNT,
-        train_instance_type=train_instance_type if train_instance_type else INSTANCE_TYPE,
+        train_instance_type=train_instance_type
+        if train_instance_type
+        else INSTANCE_TYPE,
         base_job_name=base_job_name,
         use_mpi=use_mpi,
         num_processes=num_processes,
@@ -224,7 +234,10 @@ def test_attach_with_additional_hyperparameters(sagemaker_session, chainer_versi
         chainer_version, PYTHON_VERSION
     )
     returned_job_description = {
-        "AlgorithmSpecification": {"TrainingInputMode": "File", "TrainingImage": training_image},
+        "AlgorithmSpecification": {
+            "TrainingInputMode": "File",
+            "TrainingImage": training_image,
+        },
         "HyperParameters": {
             "sagemaker_submit_directory": '"s3://some/sourcedir.tar.gz"',
             "sagemaker_program": '"iris-dnn-classifier.py"',
@@ -255,7 +268,9 @@ def test_attach_with_additional_hyperparameters(sagemaker_session, chainer_versi
         name="describe_training_job", return_value=returned_job_description
     )
 
-    estimator = Chainer.attach(training_job_name="neo", sagemaker_session=sagemaker_session)
+    estimator = Chainer.attach(
+        training_job_name="neo", sagemaker_session=sagemaker_session
+    )
     assert bool(estimator.hyperparameters()["sagemaker_use_mpi"])
     assert int(estimator.hyperparameters()["sagemaker_num_processes"]) == 4
     assert int(estimator.hyperparameters()["sagemaker_process_slots_per_host"]) == 10
@@ -386,14 +401,18 @@ def test_chainer(strftime, sagemaker_session, chainer_version):
     assert boto_call_names == ["resource"]
 
     expected_train_args = _create_train_job(chainer_version)
-    expected_train_args["input_config"][0]["DataSource"]["S3DataSource"]["S3Uri"] = inputs
+    expected_train_args["input_config"][0]["DataSource"]["S3DataSource"][
+        "S3Uri"
+    ] = inputs
 
     actual_train_args = sagemaker_session.method_calls[0][2]
     assert actual_train_args == expected_train_args
 
     model = chainer.create_model()
 
-    expected_image_base = "520713654638.dkr.ecr.us-west-2.amazonaws.com/sagemaker-chainer:{}-gpu-{}"
+    expected_image_base = (
+        "520713654638.dkr.ecr.us-west-2.amazonaws.com/sagemaker-chainer:{}-gpu-{}"
+    )
     assert {
         "Environment": {
             "SAGEMAKER_SUBMIT_DIRECTORY": "s3://mybucket/sagemaker-chainer-{}/source/sourcedir.tar.gz".format(
@@ -428,7 +447,10 @@ def test_model(sagemaker_session):
 @patch("sagemaker.fw_utils.tar_and_upload_dir", MagicMock())
 def test_model_prepare_container_def_accelerator_error(sagemaker_session):
     model = ChainerModel(
-        MODEL_DATA, role=ROLE, entry_point=SCRIPT_PATH, sagemaker_session=sagemaker_session
+        MODEL_DATA,
+        role=ROLE,
+        entry_point=SCRIPT_PATH,
+        sagemaker_session=sagemaker_session,
     )
     with pytest.raises(ValueError):
         model.prepare_container_def(INSTANCE_TYPE, accelerator_type=ACCELERATOR_TYPE)
@@ -440,7 +462,9 @@ def test_model_prepare_container_def_no_instance_type_or_image():
     with pytest.raises(ValueError) as e:
         model.prepare_container_def()
 
-    expected_msg = "Must supply either an instance type (for choosing CPU vs GPU) or an image URI."
+    expected_msg = (
+        "Must supply either an instance type (for choosing CPU vs GPU) or an image URI."
+    )
     assert expected_msg in str(e)
 
 
@@ -468,7 +492,9 @@ def test_train_image_cpu_instances(sagemaker_session, chainer_version):
     )
     assert chainer.train_image() == _get_full_cpu_image_uri(chainer_version)
 
-    chainer = _chainer_estimator(sagemaker_session, chainer_version, train_instance_type="ml.m16")
+    chainer = _chainer_estimator(
+        sagemaker_session, chainer_version, train_instance_type="ml.m16"
+    )
     assert chainer.train_image() == _get_full_cpu_image_uri(chainer_version)
 
 
@@ -489,7 +515,10 @@ def test_attach(sagemaker_session, chainer_version):
         chainer_version, PYTHON_VERSION
     )
     returned_job_description = {
-        "AlgorithmSpecification": {"TrainingInputMode": "File", "TrainingImage": training_image},
+        "AlgorithmSpecification": {
+            "TrainingInputMode": "File",
+            "TrainingImage": training_image,
+        },
         "HyperParameters": {
             "sagemaker_submit_directory": '"s3://some/sourcedir.tar.gz"',
             "sagemaker_program": '"iris-dnn-classifier.py"',
@@ -517,7 +546,9 @@ def test_attach(sagemaker_session, chainer_version):
         name="describe_training_job", return_value=returned_job_description
     )
 
-    estimator = Chainer.attach(training_job_name="neo", sagemaker_session=sagemaker_session)
+    estimator = Chainer.attach(
+        training_job_name="neo", sagemaker_session=sagemaker_session
+    )
     assert estimator.latest_training_job.job_name == "neo"
     assert estimator.py_version == PYTHON_VERSION
     assert estimator.framework_version == chainer_version
@@ -573,7 +604,10 @@ def test_attach_wrong_framework(sagemaker_session):
 def test_attach_custom_image(sagemaker_session):
     training_image = "1.dkr.ecr.us-west-2.amazonaws.com/my_custom_chainer_image:latest"
     returned_job_description = {
-        "AlgorithmSpecification": {"TrainingInputMode": "File", "TrainingImage": training_image},
+        "AlgorithmSpecification": {
+            "TrainingInputMode": "File",
+            "TrainingImage": training_image,
+        },
         "HyperParameters": {
             "sagemaker_submit_directory": '"s3://some/sourcedir.tar.gz"',
             "sagemaker_program": '"iris-dnn-classifier.py"',
@@ -601,7 +635,9 @@ def test_attach_custom_image(sagemaker_session):
         name="describe_training_job", return_value=returned_job_description
     )
 
-    estimator = Chainer.attach(training_job_name="neo", sagemaker_session=sagemaker_session)
+    estimator = Chainer.attach(
+        training_job_name="neo", sagemaker_session=sagemaker_session
+    )
     assert estimator.image_name == training_image
     assert estimator.train_image() == training_image
 
@@ -618,7 +654,9 @@ def test_estimator_py2_warning(warning, sagemaker_session):
     )
 
     assert estimator.py_version == "py2"
-    warning.assert_called_with(estimator.__framework_name__, defaults.LATEST_PY2_VERSION)
+    warning.assert_called_with(
+        estimator.__framework_name__, defaults.LATEST_PY2_VERSION
+    )
 
 
 @patch("sagemaker.chainer.model.python_deprecation_warning")

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -79,7 +79,9 @@ def test_args_mxnet_train_defaults():
 
 def test_args_mxnet_train_non_defaults():
     args = cli.parse_arguments(
-        "{} mxnet train --role-name role {} {}".format(LOG_ARGS, COMMON_ARGS, TRAIN_ARGS).split()
+        "{} mxnet train --role-name role {} {}".format(
+            LOG_ARGS, COMMON_ARGS, TRAIN_ARGS
+        ).split()
     )
     assert_common_non_defaults(args)
     assert_train_non_defaults(args)
@@ -97,7 +99,9 @@ def test_args_mxnet_host_defaults():
 
 def test_args_mxnet_host_non_defaults():
     args = cli.parse_arguments(
-        "{} mxnet host --role-name role {} {}".format(LOG_ARGS, COMMON_ARGS, HOST_ARGS).split()
+        "{} mxnet host --role-name role {} {}".format(
+            LOG_ARGS, COMMON_ARGS, HOST_ARGS
+        ).split()
     )
     assert_common_non_defaults(args)
     assert_host_non_defaults(args)
@@ -139,7 +143,9 @@ def test_args_tensorflow_host_defaults():
 
 def test_args_tensorflow_host_non_defaults():
     args = cli.parse_arguments(
-        "{} tensorflow host --role-name role {} {}".format(LOG_ARGS, COMMON_ARGS, HOST_ARGS).split()
+        "{} tensorflow host --role-name role {} {}".format(
+            LOG_ARGS, COMMON_ARGS, HOST_ARGS
+        ).split()
     )
     assert_common_non_defaults(args)
     assert_host_non_defaults(args)
@@ -174,7 +180,9 @@ def test_args_invalid_host_args_in_train():
 
 def test_args_invalid_train_args_in_host():
     with pytest.raises(SystemExit):
-        cli.parse_arguments("tensorflow host --role-name role --hyperparameters foo.json".split())
+        cli.parse_arguments(
+            "tensorflow host --role-name role --hyperparameters foo.json".split()
+        )
 
 
 @patch("sagemaker.mxnet.estimator.MXNet")

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -99,7 +99,9 @@ def test_int_label():
     with tempfile.TemporaryFile() as f:
         write_numpy_to_dense_tensor(f, array, label_data)
         f.seek(0)
-        for record_data, expected, label in zip(read_recordio(f), array_data, label_data):
+        for record_data, expected, label in zip(
+            read_recordio(f), array_data, label_data
+        ):
             record = Record()
             record.ParseFromString(record_data)
             assert record.features["values"].int32_tensor.values == expected
@@ -113,7 +115,9 @@ def test_float32_label():
     with tempfile.TemporaryFile() as f:
         write_numpy_to_dense_tensor(f, array, label_data)
         f.seek(0)
-        for record_data, expected, label in zip(read_recordio(f), array_data, label_data):
+        for record_data, expected, label in zip(
+            read_recordio(f), array_data, label_data
+        ):
             record = Record()
             record.ParseFromString(record_data)
             assert record.features["values"].int32_tensor.values == expected
@@ -127,7 +131,9 @@ def test_float_label():
     with tempfile.TemporaryFile() as f:
         write_numpy_to_dense_tensor(f, array, label_data)
         f.seek(0)
-        for record_data, expected, label in zip(read_recordio(f), array_data, label_data):
+        for record_data, expected, label in zip(
+            read_recordio(f), array_data, label_data
+        ):
             record = Record()
             record.ParseFromString(record_data)
             assert record.features["values"].int32_tensor.values == expected
@@ -166,7 +172,9 @@ def test_dense_float_write_spmatrix_to_sparse_tensor():
             record.ParseFromString(record_data)
             assert record.features["values"].float64_tensor.values == expected_data
             assert record.features["values"].float64_tensor.keys == expected_keys
-            assert record.features["values"].float64_tensor.shape == [len(expected_data)]
+            assert record.features["values"].float64_tensor.shape == [
+                len(expected_data)
+            ]
 
 
 def test_dense_float32_write_spmatrix_to_sparse_tensor():
@@ -183,7 +191,9 @@ def test_dense_float32_write_spmatrix_to_sparse_tensor():
             record.ParseFromString(record_data)
             assert record.features["values"].float32_tensor.values == expected_data
             assert record.features["values"].float32_tensor.keys == expected_keys
-            assert record.features["values"].float32_tensor.shape == [len(expected_data)]
+            assert record.features["values"].float32_tensor.shape == [
+                len(expected_data)
+            ]
 
 
 def test_dense_int_write_spmatrix_to_sparse_tensor():
@@ -238,7 +248,9 @@ def test_dense_float32_spmatrix_to_sparse_label():
             assert record.features["values"].float32_tensor.values == expected_data
             assert record.features["values"].float32_tensor.keys == expected_keys
             assert record.label["values"].int32_tensor.values == [label]
-            assert record.features["values"].float32_tensor.shape == [len(expected_data)]
+            assert record.features["values"].float32_tensor.shape == [
+                len(expected_data)
+            ]
 
 
 def test_dense_float64_spmatrix_to_sparse_label():
@@ -257,7 +269,9 @@ def test_dense_float64_spmatrix_to_sparse_label():
             assert record.features["values"].float64_tensor.values == expected_data
             assert record.features["values"].float64_tensor.keys == expected_keys
             assert record.label["values"].int32_tensor.values == [label]
-            assert record.features["values"].float64_tensor.shape == [len(expected_data)]
+            assert record.features["values"].float64_tensor.shape == [
+                len(expected_data)
+            ]
 
 
 def test_invalid_sparse_label():
@@ -271,7 +285,12 @@ def test_invalid_sparse_label():
 
 def test_sparse_float_write_spmatrix_to_sparse_tensor():
     n = 4
-    array_data = [[1.0, 2.0], [10.0, 30.0], [100.0, 200.0, 300.0, 400.0], [1000.0, 2000.0, 3000.0]]
+    array_data = [
+        [1.0, 2.0],
+        [10.0, 30.0],
+        [100.0, 200.0, 300.0, 400.0],
+        [1000.0, 2000.0, 3000.0],
+    ]
     keys_data = [[0, 1], [1, 2], [0, 1, 2, 3], [0, 2, 3]]
 
     flatten_data = list(itertools.chain.from_iterable(array_data))
@@ -295,7 +314,12 @@ def test_sparse_float_write_spmatrix_to_sparse_tensor():
 
 def test_sparse_float32_write_spmatrix_to_sparse_tensor():
     n = 4
-    array_data = [[1.0, 2.0], [10.0, 30.0], [100.0, 200.0, 300.0, 400.0], [1000.0, 2000.0, 3000.0]]
+    array_data = [
+        [1.0, 2.0],
+        [10.0, 30.0],
+        [100.0, 200.0, 300.0, 400.0],
+        [1000.0, 2000.0, 3000.0],
+    ]
     keys_data = [[0, 1], [1, 2], [0, 1, 2, 3], [0, 2, 3]]
 
     flatten_data = list(itertools.chain.from_iterable(array_data))
@@ -319,7 +343,12 @@ def test_sparse_float32_write_spmatrix_to_sparse_tensor():
 
 def test_sparse_int_write_spmatrix_to_sparse_tensor():
     n = 4
-    array_data = [[1.0, 2.0], [10.0, 30.0], [100.0, 200.0, 300.0, 400.0], [1000.0, 2000.0, 3000.0]]
+    array_data = [
+        [1.0, 2.0],
+        [10.0, 30.0],
+        [100.0, 200.0, 300.0, 400.0],
+        [1000.0, 2000.0, 3000.0],
+    ]
     keys_data = [[0, 1], [1, 2], [0, 1, 2, 3], [0, 2, 3]]
 
     flatten_data = list(itertools.chain.from_iterable(array_data))

--- a/tests/unit/test_create_deploy_entities.py
+++ b/tests/unit/test_create_deploy_entities.py
@@ -23,7 +23,11 @@ ENDPOINT_NAME = "myendpointname"
 ROLE = "myimrole"
 EXPANDED_ROLE = "arn:aws:iam::111111111111:role/ExpandedRole"
 IMAGE = "myimage"
-FULL_CONTAINER_DEF = {"Environment": {}, "Image": IMAGE, "ModelDataUrl": "s3://mybucket/mymodel"}
+FULL_CONTAINER_DEF = {
+    "Environment": {},
+    "Image": IMAGE,
+    "ModelDataUrl": "s3://mybucket/mymodel",
+}
 VPC_CONFIG = {"Subnets": ["subnet-foo"], "SecurityGroups": ["sg-foo"]}
 INITIAL_INSTANCE_COUNT = 1
 INSTANCE_TYPE = "ml.c4.xlarge"
@@ -41,7 +45,10 @@ def sagemaker_session():
 
 def test_create_model(sagemaker_session):
     returned_name = sagemaker_session.create_model(
-        name=MODEL_NAME, role=ROLE, container_defs=FULL_CONTAINER_DEF, vpc_config=VPC_CONFIG
+        name=MODEL_NAME,
+        role=ROLE,
+        container_defs=FULL_CONTAINER_DEF,
+        vpc_config=VPC_CONFIG,
     )
 
     assert returned_name == MODEL_NAME
@@ -56,8 +63,15 @@ def test_create_model(sagemaker_session):
 def test_create_model_expand_primary_container(sagemaker_session):
     sagemaker_session.create_model(name=MODEL_NAME, role=ROLE, container_defs=IMAGE)
 
-    _1, _2, create_model_kwargs = sagemaker_session.sagemaker_client.create_model.mock_calls[0]
-    assert create_model_kwargs["PrimaryContainer"] == {"Environment": {}, "Image": IMAGE}
+    (
+        _1,
+        _2,
+        create_model_kwargs,
+    ) = sagemaker_session.sagemaker_client.create_model.mock_calls[0]
+    assert create_model_kwargs["PrimaryContainer"] == {
+        "Environment": {},
+        "Image": IMAGE,
+    }
 
 
 def test_create_endpoint_config(sagemaker_session):
@@ -79,7 +93,9 @@ def test_create_endpoint_config(sagemaker_session):
         }
     ]
     sagemaker_session.sagemaker_client.create_endpoint_config.assert_called_once_with(
-        EndpointConfigName=ENDPOINT_CONFIG_NAME, ProductionVariants=expected_pvs, Tags=[]
+        EndpointConfigName=ENDPOINT_CONFIG_NAME,
+        ProductionVariants=expected_pvs,
+        Tags=[],
     )
 
 
@@ -104,7 +120,9 @@ def test_create_endpoint_config_with_accelerator(sagemaker_session):
         }
     ]
     sagemaker_session.sagemaker_client.create_endpoint_config.assert_called_once_with(
-        EndpointConfigName=ENDPOINT_CONFIG_NAME, ProductionVariants=expected_pvs, Tags=[]
+        EndpointConfigName=ENDPOINT_CONFIG_NAME,
+        ProductionVariants=expected_pvs,
+        Tags=[],
     )
 
 

--- a/tests/unit/test_default_bucket.py
+++ b/tests/unit/test_default_bucket.py
@@ -58,7 +58,9 @@ def test_default_already_cached(sagemaker_session):
 
 def test_default_bucket_exists(sagemaker_session):
     error = ClientError(
-        error_response={"Error": {"Code": "BucketAlreadyOwnedByYou", "Message": "message"}},
+        error_response={
+            "Error": {"Code": "BucketAlreadyOwnedByYou", "Message": "message"}
+        },
         operation_name="foo",
     )
     sagemaker_session.boto_session.resource().create_bucket.side_effect = error
@@ -70,7 +72,9 @@ def test_default_bucket_exists(sagemaker_session):
 def test_concurrent_bucket_modification(sagemaker_session):
     message = "A conflicting conditional operation is currently in progress against this resource. Please try again"
     error = ClientError(
-        error_response={"Error": {"Code": "BucketAlreadyOwnedByYou", "Message": message}},
+        error_response={
+            "Error": {"Code": "BucketAlreadyOwnedByYou", "Message": message}
+        },
         operation_name="foo",
     )
     sagemaker_session.boto_session.resource().create_bucket.side_effect = error

--- a/tests/unit/test_endpoint_from_job.py
+++ b/tests/unit/test_endpoint_from_job.py
@@ -31,7 +31,11 @@ TRAINING_JOB_RESPONSE = {
     "RoleArn": TRAIN_ROLE,
     "VpcConfig": VPC_CONFIG,
 }
-FULL_CONTAINER_DEF = {"Environment": {}, "Image": IMAGE, "ModelDataUrl": S3_MODEL_ARTIFACTS}
+FULL_CONTAINER_DEF = {
+    "Environment": {},
+    "Image": IMAGE,
+    "ModelDataUrl": S3_MODEL_ARTIFACTS,
+}
 DEPLOY_IMAGE = "mydeployimage"
 DEPLOY_ROLE = "mydeployrole"
 NEW_ENTITY_NAME = "mynewendpoint"
@@ -43,7 +47,9 @@ REGION = "us-west-2"
 @pytest.fixture()
 def sagemaker_session():
     boto_mock = Mock(name="boto_session", region_name=REGION)
-    ims = sagemaker.Session(sagemaker_client=Mock(name="sagemaker_client"), boto_session=boto_mock)
+    ims = sagemaker.Session(
+        sagemaker_client=Mock(name="sagemaker_client"), boto_session=boto_mock
+    )
     ims.sagemaker_client.describe_training_job = Mock(
         name="describe_training_job", return_value=TRAINING_JOB_RESPONSE
     )

--- a/tests/unit/test_endpoint_from_model_data.py
+++ b/tests/unit/test_endpoint_from_model_data.py
@@ -25,7 +25,11 @@ INSTANCE_TYPE = "ml.c4.xlarge"
 ACCELERATOR_TYPE = "ml.eia.medium"
 S3_MODEL_ARTIFACTS = "s3://mybucket/mymodel"
 DEPLOY_IMAGE = "mydeployimage"
-CONTAINER_DEF = {"Environment": {}, "Image": DEPLOY_IMAGE, "ModelDataUrl": S3_MODEL_ARTIFACTS}
+CONTAINER_DEF = {
+    "Environment": {},
+    "Image": DEPLOY_IMAGE,
+    "ModelDataUrl": S3_MODEL_ARTIFACTS,
+}
 VPC_CONFIG = {"Subnets": ["foo"], "SecurityGroupIds": ["bar"]}
 DEPLOY_ROLE = "mydeployrole"
 ENV_VARS = {"PYTHONUNBUFFERED": "TRUE", "some": "nonsense"}
@@ -36,7 +40,9 @@ REGION = "us-west-2"
 @pytest.fixture()
 def sagemaker_session():
     boto_mock = Mock(name="boto_session", region_name=REGION)
-    ims = sagemaker.Session(sagemaker_client=Mock(name="sagemaker_client"), boto_session=boto_mock)
+    ims = sagemaker.Session(
+        sagemaker_client=Mock(name="sagemaker_client"), boto_session=boto_mock
+    )
     ims.sagemaker_client.describe_model = Mock(
         name="describe_model", side_effect=_raise_does_not_exist_client_error
     )
@@ -73,7 +79,10 @@ def test_all_defaults_no_existing_entities(name_from_image_mock, sagemaker_sessi
         EndpointConfigName=NAME_FROM_IMAGE
     )
     sagemaker_session.create_model.assert_called_once_with(
-        name=NAME_FROM_IMAGE, role=DEPLOY_ROLE, container_defs=CONTAINER_DEF, vpc_config=None
+        name=NAME_FROM_IMAGE,
+        role=DEPLOY_ROLE,
+        container_defs=CONTAINER_DEF,
+        vpc_config=None,
     )
     sagemaker_session.create_endpoint_config.assert_called_once_with(
         name=NAME_FROM_IMAGE,
@@ -163,13 +172,18 @@ def test_entity_exists():
 
 
 def test_entity_doesnt_exist():
-    assert not sagemaker.session._deployment_entity_exists(_raise_does_not_exist_client_error)
+    assert not sagemaker.session._deployment_entity_exists(
+        _raise_does_not_exist_client_error
+    )
 
 
 def test_describe_failure():
     def _raise_unexpected_client_error():
         response = {
-            "Error": {"Code": "ValidationException", "Message": "Name does not satisfy expression."}
+            "Error": {
+                "Code": "ValidationException",
+                "Message": "Name does not satisfy expression.",
+            }
         }
         raise ClientError(error_response=response, operation_name="foo")
 
@@ -178,5 +192,7 @@ def test_describe_failure():
 
 
 def _raise_does_not_exist_client_error(**kwargs):
-    response = {"Error": {"Code": "ValidationException", "Message": "Could not find entity."}}
+    response = {
+        "Error": {"Code": "ValidationException", "Message": "Could not find entity."}
+    }
     raise ClientError(error_response=response, operation_name="foo")

--- a/tests/unit/test_estimator.py
+++ b/tests/unit/test_estimator.py
@@ -79,7 +79,11 @@ RETURNED_JOB_DESCRIPTION = {
         "training_steps": "100",
     },
     "RoleArn": "arn:aws:iam::366:role/SageMakerRole",
-    "ResourceConfig": {"VolumeSizeInGB": 30, "InstanceCount": 1, "InstanceType": "ml.c4.xlarge"},
+    "ResourceConfig": {
+        "VolumeSizeInGB": 30,
+        "InstanceCount": 1,
+        "InstanceType": "ml.c4.xlarge",
+    },
     "EnableNetworkIsolation": False,
     "StoppingCondition": {"MaxRuntimeInSeconds": 24 * 60 * 60},
     "TrainingJobName": "neo",
@@ -104,7 +108,9 @@ MODEL_CONTAINER_DEF = {
 
 ENDPOINT_DESC = {"EndpointConfigName": "test-endpoint"}
 
-ENDPOINT_CONFIG_DESC = {"ProductionVariants": [{"ModelName": "model-1"}, {"ModelName": "model-2"}]}
+ENDPOINT_CONFIG_DESC = {
+    "ProductionVariants": [{"ModelName": "model-1"}, {"ModelName": "model-2"}]
+}
 
 LIST_TAGS_RESULT = {"Tags": [{"Key": "TagtestKey", "Value": "TagtestValue"}]}
 
@@ -137,10 +143,12 @@ class DummyFramework(Framework):
         )
 
     @classmethod
-    def _prepare_init_params_from_job_description(cls, job_details, model_channel_name=None):
-        init_params = super(DummyFramework, cls)._prepare_init_params_from_job_description(
-            job_details, model_channel_name
-        )
+    def _prepare_init_params_from_job_description(
+        cls, job_details, model_channel_name=None
+    ):
+        init_params = super(
+            DummyFramework, cls
+        )._prepare_init_params_from_job_description(job_details, model_channel_name)
         init_params.pop("image", None)
         return init_params
 
@@ -186,7 +194,9 @@ def sagemaker_session():
         name="describe_training_job", return_value=DESCRIBE_TRAINING_JOB_RESULT
     )
     sms.sagemaker_client.describe_endpoint = Mock(return_value=ENDPOINT_DESC)
-    sms.sagemaker_client.describe_endpoint_config = Mock(return_value=ENDPOINT_CONFIG_DESC)
+    sms.sagemaker_client.describe_endpoint_config = Mock(
+        return_value=ENDPOINT_CONFIG_DESC
+    )
     sms.sagemaker_client.list_tags = Mock(return_value=LIST_TAGS_RESULT)
     return sms
 
@@ -208,7 +218,9 @@ def test_framework_all_init_args(sagemaker_session):
         tags=[{"foo": "bar"}],
         subnets=["123", "456"],
         security_group_ids=["789", "012"],
-        metric_definitions=[{"Name": "validation-rmse", "Regex": "validation-rmse=(\\d+)"}],
+        metric_definitions=[
+            {"Name": "validation-rmse", "Regex": "validation-rmse=(\\d+)"}
+        ],
         encrypt_inter_container_traffic=True,
         checkpoint_s3_uri="s3://bucket/checkpoint",
         checkpoint_local_path="file://local/checkpoint",
@@ -246,7 +258,9 @@ def test_framework_all_init_args(sagemaker_session):
             "VolumeKmsKeyId": "volumekms",
             "InstanceType": "ml.m4.xlarge",
         },
-        "metric_definitions": [{"Name": "validation-rmse", "Regex": "validation-rmse=(\\d+)"}],
+        "metric_definitions": [
+            {"Name": "validation-rmse", "Regex": "validation-rmse=(\\d+)"}
+        ],
         "encrypt_inter_container_traffic": True,
         "experiment_config": None,
         "checkpoint_s3_uri": "s3://bucket/checkpoint",
@@ -273,7 +287,9 @@ def test_framework_with_spot_and_checkpoints(sagemaker_session):
         tags=[{"foo": "bar"}],
         subnets=["123", "456"],
         security_group_ids=["789", "012"],
-        metric_definitions=[{"Name": "validation-rmse", "Regex": "validation-rmse=(\\d+)"}],
+        metric_definitions=[
+            {"Name": "validation-rmse", "Regex": "validation-rmse=(\\d+)"}
+        ],
         encrypt_inter_container_traffic=True,
         train_use_spot_instances=True,
         train_max_wait=500,
@@ -311,7 +327,9 @@ def test_framework_with_spot_and_checkpoints(sagemaker_session):
             "VolumeKmsKeyId": "volumekms",
             "InstanceType": "ml.m4.xlarge",
         },
-        "metric_definitions": [{"Name": "validation-rmse", "Regex": "validation-rmse=(\\d+)"}],
+        "metric_definitions": [
+            {"Name": "validation-rmse", "Regex": "validation-rmse=(\\d+)"}
+        ],
         "encrypt_inter_container_traffic": True,
         "train_use_spot_instances": True,
         "checkpoint_s3_uri": "s3://mybucket/checkpoints/",
@@ -531,7 +549,9 @@ def test_s3_input_mode(sagemaker_session):
         train_instance_type=INSTANCE_TYPE,
         enable_cloudwatch_metrics=True,
     )
-    fw.fit(inputs=s3_input("s3://mybucket/train_manifest", input_mode=expected_input_mode))
+    fw.fit(
+        inputs=s3_input("s3://mybucket/train_manifest", input_mode=expected_input_mode)
+    )
 
     actual_input_mode = sagemaker_session.method_calls[1][2]["input_mode"]
     assert actual_input_mode == expected_input_mode
@@ -546,7 +566,11 @@ def test_shuffle_config(sagemaker_session):
         train_instance_type=INSTANCE_TYPE,
         enable_cloudwatch_metrics=True,
     )
-    fw.fit(inputs=s3_input("s3://mybucket/train_manifest", shuffle_config=ShuffleConfig(100)))
+    fw.fit(
+        inputs=s3_input(
+            "s3://mybucket/train_manifest", shuffle_config=ShuffleConfig(100)
+        )
+    )
     _, _, train_kwargs = sagemaker_session.train.mock_calls[0]
     channel = train_kwargs["input_config"][0]
     assert channel["ShuffleConfig"]["Seed"] == 100
@@ -708,7 +732,10 @@ def test_enable_cloudwatch_metrics(sagemaker_session):
 
 def test_attach_framework(sagemaker_session):
     returned_job_description = RETURNED_JOB_DESCRIPTION.copy()
-    returned_job_description["VpcConfig"] = {"Subnets": ["foo"], "SecurityGroupIds": ["bar"]}
+    returned_job_description["VpcConfig"] = {
+        "Subnets": ["foo"],
+        "SecurityGroupIds": ["bar"],
+    }
     returned_job_description["EnableNetworkIsolation"] = True
     sagemaker_session.sagemaker_client.describe_training_job = Mock(
         name="describe_training_job", return_value=returned_job_description
@@ -743,21 +770,29 @@ def test_attach_without_hyperparameters(sagemaker_session):
     mock_describe_training_job = Mock(
         name="describe_training_job", return_value=returned_job_description
     )
-    sagemaker_session.sagemaker_client.describe_training_job = mock_describe_training_job
+    sagemaker_session.sagemaker_client.describe_training_job = (
+        mock_describe_training_job
+    )
 
-    estimator = Estimator.attach(training_job_name="job", sagemaker_session=sagemaker_session)
+    estimator = Estimator.attach(
+        training_job_name="job", sagemaker_session=sagemaker_session
+    )
 
     assert estimator.hyperparameters() == {}
 
 
 def test_attach_framework_with_tuning(sagemaker_session):
     returned_job_description = RETURNED_JOB_DESCRIPTION.copy()
-    returned_job_description["HyperParameters"]["_tuning_objective_metric"] = "Validation-accuracy"
+    returned_job_description["HyperParameters"][
+        "_tuning_objective_metric"
+    ] = "Validation-accuracy"
 
     mock_describe_training_job = Mock(
         name="describe_training_job", return_value=returned_job_description
     )
-    sagemaker_session.sagemaker_client.describe_training_job = mock_describe_training_job
+    sagemaker_session.sagemaker_client.describe_training_job = (
+        mock_describe_training_job
+    )
 
     framework_estimator = DummyFramework.attach(
         training_job_name="neo", sagemaker_session=sagemaker_session
@@ -800,7 +835,9 @@ def test_attach_framework_with_model_channel(sagemaker_session):
     assert framework_estimator.encrypt_inter_container_traffic is False
 
 
-def test_attach_framework_with_inter_container_traffic_encryption_flag(sagemaker_session):
+def test_attach_framework_with_inter_container_traffic_encryption_flag(
+    sagemaker_session,
+):
     returned_job_description = RETURNED_JOB_DESCRIPTION.copy()
     returned_job_description["EnableInterContainerTrafficEncryption"] = True
 
@@ -953,11 +990,15 @@ def test_git_support_with_dependencies_succeed(git_clone_repo, sagemaker_session
         enable_cloudwatch_metrics=True,
     )
     fw.fit()
-    git_clone_repo.assert_called_once_with(git_config, entry_point, None, ["foo", "foo/bar"])
+    git_clone_repo.assert_called_once_with(
+        git_config, entry_point, None, ["foo", "foo/bar"]
+    )
 
 
 @patch("sagemaker.git_utils.git_clone_repo")
-def test_git_support_without_branch_and_commit_succeed(git_clone_repo, sagemaker_session):
+def test_git_support_without_branch_and_commit_succeed(
+    git_clone_repo, sagemaker_session
+):
     git_clone_repo.side_effect = lambda gitconfig, entrypoint, source_dir, dependencies=None: {
         "entry_point": "/tmp/repo_dir/source_dir/entry_point",
         "source_dir": None,
@@ -1015,7 +1056,8 @@ def test_git_support_bad_repo_url_format(sagemaker_session):
 @patch(
     "sagemaker.git_utils.git_clone_repo",
     side_effect=subprocess.CalledProcessError(
-        returncode=1, cmd="git clone https://github.com/aws/no-such-repo.git /tmp/repo_dir"
+        returncode=1,
+        cmd="git clone https://github.com/aws/no-such-repo.git /tmp/repo_dir",
     ),
 )
 def test_git_support_git_clone_fail(sagemaker_session):
@@ -1041,7 +1083,11 @@ def test_git_support_git_clone_fail(sagemaker_session):
     ),
 )
 def test_git_support_branch_not_exist(sagemaker_session):
-    git_config = {"repo": GIT_REPO, "branch": "branch-that-does-not-exist", "commit": COMMIT}
+    git_config = {
+        "repo": GIT_REPO,
+        "branch": "branch-that-does-not-exist",
+        "commit": COMMIT,
+    }
     fw = DummyFramework(
         entry_point="entry_point",
         git_config=git_config,
@@ -1063,7 +1109,11 @@ def test_git_support_branch_not_exist(sagemaker_session):
     ),
 )
 def test_git_support_commit_not_exist(sagemaker_session):
-    git_config = {"repo": GIT_REPO, "branch": BRANCH, "commit": "commit-sha-that-does-not-exist"}
+    git_config = {
+        "repo": GIT_REPO,
+        "branch": BRANCH,
+        "commit": "commit-sha-that-does-not-exist",
+    }
     fw = DummyFramework(
         entry_point="entry_point",
         git_config=git_config,
@@ -1212,7 +1262,11 @@ def test_git_support_with_token_2fa(git_clone_repo, sagemaker_session):
     },
 )
 def test_git_support_ssh_no_passphrase_needed(git_clone_repo, sagemaker_session):
-    git_config = {"repo": PRIVATE_GIT_REPO_SSH, "branch": PRIVATE_BRANCH, "commit": PRIVATE_COMMIT}
+    git_config = {
+        "repo": PRIVATE_GIT_REPO_SSH,
+        "branch": PRIVATE_BRANCH,
+        "commit": PRIVATE_COMMIT,
+    }
     entry_point = "entry_point"
     fw = DummyFramework(
         entry_point=entry_point,
@@ -1235,7 +1289,11 @@ def test_git_support_ssh_no_passphrase_needed(git_clone_repo, sagemaker_session)
     ),
 )
 def test_git_support_ssh_passphrase_required(git_clone_repo, sagemaker_session):
-    git_config = {"repo": PRIVATE_GIT_REPO_SSH, "branch": PRIVATE_BRANCH, "commit": PRIVATE_COMMIT}
+    git_config = {
+        "repo": PRIVATE_GIT_REPO_SSH,
+        "branch": PRIVATE_BRANCH,
+        "commit": PRIVATE_COMMIT,
+    }
     entry_point = "entry_point"
     fw = DummyFramework(
         entry_point=entry_point,
@@ -1291,7 +1349,9 @@ def test_git_support_codecommit_with_username_and_password_succeed(
         "dependencies": None,
     },
 )
-def test_git_support_codecommit_with_ssh_no_passphrase_needed(git_clone_repo, sagemaker_session):
+def test_git_support_codecommit_with_ssh_no_passphrase_needed(
+    git_clone_repo, sagemaker_session
+):
     git_config = {"repo": CODECOMMIT_REPO_SSH, "branch": CODECOMMIT_BRANCH}
     entry_point = "entry_point"
     fw = DummyFramework(
@@ -1368,7 +1428,9 @@ def test_framework_transformer_creation(name_from_image, sagemaker_session):
 
 
 @patch("sagemaker.model.utils.name_from_image", return_value=MODEL_IMAGE)
-def test_framework_transformer_creation_with_optional_params(name_from_image, sagemaker_session):
+def test_framework_transformer_creation_with_optional_params(
+    name_from_image, sagemaker_session
+):
     base_name = "foo"
     vpc_config = {"Subnets": ["foo"], "SecurityGroupIds": ["bar"]}
     fw = DummyFramework(
@@ -1492,7 +1554,9 @@ def test_estimator_transformer_creation(create_model, sagemaker_session):
 
 
 @patch("sagemaker.estimator.Estimator.create_model")
-def test_estimator_transformer_creation_with_optional_params(create_model, sagemaker_session):
+def test_estimator_transformer_creation_with_optional_params(
+    create_model, sagemaker_session
+):
     base_name = "foo"
     kms_key = "key"
 
@@ -1535,7 +1599,9 @@ def test_estimator_transformer_creation_with_optional_params(create_model, sagem
     )
 
     create_model.assert_called_with(
-        vpc_config_override=new_vpc_config, model_kms_key=kms_key, enable_network_isolation=True
+        vpc_config_override=new_vpc_config,
+        model_kms_key=kms_key,
+        enable_network_isolation=True,
     )
 
     assert transformer.strategy == strategy
@@ -1567,9 +1633,15 @@ def test_start_new(sagemaker_session):
         hyperparameters=hyperparameters,
     )
 
-    exp_config = {"ExperimentName": "exp", "TrialName": "t", "TrialComponentDisplayName": "tc"}
+    exp_config = {
+        "ExperimentName": "exp",
+        "TrialName": "t",
+        "TrialComponentDisplayName": "tc",
+    }
 
-    started_training_job = training_job.start_new(estimator, inputs, experiment_config=exp_config)
+    started_training_job = training_job.start_new(
+        estimator, inputs, experiment_config=exp_config
+    )
     called_args = sagemaker_session.train.call_args
 
     assert started_training_job.sagemaker_session == sagemaker_session
@@ -1592,8 +1664,9 @@ def test_start_new_not_local_mode_error(sagemaker_session):
     )
     with pytest.raises(ValueError) as error:
         training_job.start_new(estimator, inputs, None)
-        assert "File URIs are supported in local mode only. Please use a S3 URI instead." == str(
-            error
+        assert (
+            "File URIs are supported in local mode only. Please use a S3 URI instead."
+            == str(error)
         )
 
 
@@ -1628,7 +1701,9 @@ def test_same_code_location_keeps_kms_key(utils, sagemaker_session):
     extra_args = {"ServerSideEncryption": "aws:kms", "SSEKMSKeyId": "kms-key"}
     obj = sagemaker_session.boto_session.resource("s3").Object
 
-    obj.assert_called_with("mybucket", "%s/source/sourcedir.tar.gz" % fw._current_job_name)
+    obj.assert_called_with(
+        "mybucket", "%s/source/sourcedir.tar.gz" % fw._current_job_name
+    )
 
     obj().upload_file.assert_called_with(utils.create_tar_file(), ExtraArgs=extra_args)
 
@@ -1649,7 +1724,9 @@ def test_different_code_location_kms_key(utils, sagemaker_session):
 
     obj = sagemaker_session.boto_session.resource("s3").Object
 
-    obj.assert_called_with("another-location", "%s/source/sourcedir.tar.gz" % fw._current_job_name)
+    obj.assert_called_with(
+        "another-location", "%s/source/sourcedir.tar.gz" % fw._current_job_name
+    )
 
     obj().upload_file.assert_called_with(utils.create_tar_file(), ExtraArgs=None)
 
@@ -1670,7 +1747,9 @@ def test_default_code_location_uses_output_path(utils, sagemaker_session):
 
     obj = sagemaker_session.boto_session.resource("s3").Object
 
-    obj.assert_called_with("output_path", "%s/source/sourcedir.tar.gz" % fw._current_job_name)
+    obj.assert_called_with(
+        "output_path", "%s/source/sourcedir.tar.gz" % fw._current_job_name
+    )
 
     extra_args = {"ServerSideEncryption": "aws:kms", "SSEKMSKeyId": "kms-key"}
     obj().upload_file.assert_called_with(utils.create_tar_file(), ExtraArgs=extra_args)
@@ -1791,7 +1870,11 @@ def test_fit_deploy_tags_in_estimator(sagemaker_session):
     sagemaker_session.create_model.assert_called_with(
         ANY,
         "DummyRole",
-        {"ModelDataUrl": "s3://bucket/model.tar.gz", "Environment": {}, "Image": "fakeimage"},
+        {
+            "ModelDataUrl": "s3://bucket/model.tar.gz",
+            "Environment": {},
+            "Image": "fakeimage",
+        },
         enable_network_isolation=False,
         vpc_config=None,
         tags=tags,
@@ -1800,7 +1883,11 @@ def test_fit_deploy_tags_in_estimator(sagemaker_session):
 
 def test_fit_deploy_tags(sagemaker_session):
     estimator = Estimator(
-        IMAGE_NAME, ROLE, INSTANCE_COUNT, INSTANCE_TYPE, sagemaker_session=sagemaker_session
+        IMAGE_NAME,
+        ROLE,
+        INSTANCE_COUNT,
+        INSTANCE_TYPE,
+        sagemaker_session=sagemaker_session,
     )
 
     estimator.fit()
@@ -1831,7 +1918,11 @@ def test_fit_deploy_tags(sagemaker_session):
     sagemaker_session.create_model.assert_called_with(
         ANY,
         "DummyRole",
-        {"ModelDataUrl": "s3://bucket/model.tar.gz", "Environment": {}, "Image": "fakeimage"},
+        {
+            "ModelDataUrl": "s3://bucket/model.tar.gz",
+            "Environment": {},
+            "Image": "fakeimage",
+        },
         enable_network_isolation=False,
         vpc_config=None,
         tags=tags,
@@ -2103,7 +2194,9 @@ def test_generic_to_deploy_kms(create_model, sagemaker_session):
 
     endpoint_name = "foo"
     kms_key = "key"
-    e.deploy(INSTANCE_COUNT, INSTANCE_TYPE, endpoint_name=endpoint_name, kms_key=kms_key)
+    e.deploy(
+        INSTANCE_COUNT, INSTANCE_TYPE, endpoint_name=endpoint_name, kms_key=kms_key
+    )
 
     model.deploy.assert_called_with(
         instance_type=INSTANCE_TYPE,
@@ -2129,7 +2222,10 @@ def test_generic_training_job_analytics(sagemaker_session):
                 "TrainingInputMode": "File",
                 "MetricDefinitions": [
                     {"Name": "train:loss", "Regex": "train_loss=([0-9]+\\.[0-9]+)"},
-                    {"Name": "validation:loss", "Regex": "valid_loss=([0-9]+\\.[0-9]+)"},
+                    {
+                        "Name": "validation:loss",
+                        "Regex": "valid_loss=([0-9]+\\.[0-9]+)",
+                    },
                 ],
             },
         },
@@ -2160,7 +2256,11 @@ def test_generic_create_model_vpc_config_override(sagemaker_session):
     vpc_config_b = {"Subnets": ["foo", "bar"], "SecurityGroupIds": ["baz"]}
 
     e = Estimator(
-        IMAGE_NAME, ROLE, INSTANCE_COUNT, INSTANCE_TYPE, sagemaker_session=sagemaker_session
+        IMAGE_NAME,
+        ROLE,
+        INSTANCE_COUNT,
+        INSTANCE_TYPE,
+        sagemaker_session=sagemaker_session,
     )
     e.fit({"train": "s3://bucket/training-prefix"})
     assert e.get_vpc_config() is None
@@ -2186,7 +2286,11 @@ def test_generic_deploy_vpc_config_override(sagemaker_session):
     vpc_config_b = {"Subnets": ["foo", "bar"], "SecurityGroupIds": ["baz"]}
 
     e = Estimator(
-        IMAGE_NAME, ROLE, INSTANCE_COUNT, INSTANCE_TYPE, sagemaker_session=sagemaker_session
+        IMAGE_NAME,
+        ROLE,
+        INSTANCE_COUNT,
+        INSTANCE_TYPE,
+        sagemaker_session=sagemaker_session,
     )
     e.fit({"train": "s3://bucket/training-prefix"})
     e.deploy(INSTANCE_COUNT, INSTANCE_TYPE)
@@ -2195,10 +2299,16 @@ def test_generic_deploy_vpc_config_override(sagemaker_session):
     e.subnets = vpc_config_a["Subnets"]
     e.security_group_ids = vpc_config_a["SecurityGroupIds"]
     e.deploy(INSTANCE_COUNT, INSTANCE_TYPE)
-    assert sagemaker_session.create_model.call_args_list[1][1]["vpc_config"] == vpc_config_a
+    assert (
+        sagemaker_session.create_model.call_args_list[1][1]["vpc_config"]
+        == vpc_config_a
+    )
 
     e.deploy(INSTANCE_COUNT, INSTANCE_TYPE, vpc_config_override=vpc_config_b)
-    assert sagemaker_session.create_model.call_args_list[2][1]["vpc_config"] == vpc_config_b
+    assert (
+        sagemaker_session.create_model.call_args_list[2][1]["vpc_config"]
+        == vpc_config_b
+    )
 
     e.deploy(INSTANCE_COUNT, INSTANCE_TYPE, vpc_config_override=None)
     assert sagemaker_session.create_model.call_args_list[3][1]["vpc_config"] is None
@@ -2206,7 +2316,11 @@ def test_generic_deploy_vpc_config_override(sagemaker_session):
 
 def test_generic_deploy_accelerator_type(sagemaker_session):
     e = Estimator(
-        IMAGE_NAME, ROLE, INSTANCE_COUNT, INSTANCE_TYPE, sagemaker_session=sagemaker_session
+        IMAGE_NAME,
+        ROLE,
+        INSTANCE_COUNT,
+        INSTANCE_TYPE,
+        sagemaker_session=sagemaker_session,
     )
     e.fit({"train": "s3://bucket/training-prefix"})
     e.deploy(INSTANCE_COUNT, INSTANCE_TYPE, ACCELERATOR_TYPE)
@@ -2314,7 +2428,9 @@ def test_local_mode_file_output_path(local_session_class):
     local_session.local_mode = True
     local_session_class.return_value = local_session
 
-    e = Estimator(IMAGE_NAME, ROLE, INSTANCE_COUNT, "local", output_path="file:///tmp/model/")
+    e = Estimator(
+        IMAGE_NAME, ROLE, INSTANCE_COUNT, "local", output_path="file:///tmp/model/"
+    )
     assert e.output_path == "file:///tmp/model/"
 
 
@@ -2325,7 +2441,13 @@ def test_file_output_path_not_supported_outside_local_mode(session_class):
     session_class.return_value = session
 
     with pytest.raises(RuntimeError):
-        Estimator(IMAGE_NAME, ROLE, INSTANCE_COUNT, INSTANCE_TYPE, output_path="file:///tmp/model")
+        Estimator(
+            IMAGE_NAME,
+            ROLE,
+            INSTANCE_COUNT,
+            INSTANCE_TYPE,
+            output_path="file:///tmp/model",
+        )
 
 
 def test_prepare_init_params_from_job_description_with_image_training_job():
@@ -2336,7 +2458,10 @@ def test_prepare_init_params_from_job_description_with_image_training_job():
 
     assert init_params["role"] == "arn:aws:iam::366:role/SageMakerRole"
     assert init_params["train_instance_count"] == 1
-    assert init_params["image"] == "1.dkr.ecr.us-west-2.amazonaws.com/sagemaker-other-py2-cpu:1.0.4"
+    assert (
+        init_params["image"]
+        == "1.dkr.ecr.us-west-2.amazonaws.com/sagemaker-other-py2-cpu:1.0.4"
+    )
 
 
 def test_prepare_init_params_from_job_description_with_algorithm_training_job():
@@ -2365,7 +2490,9 @@ def test_prepare_init_params_from_job_description_with_invalid_training_job():
     invalid_job_description["AlgorithmSpecification"] = {"TrainingInputMode": "File"}
 
     with pytest.raises(RuntimeError) as error:
-        EstimatorBase._prepare_init_params_from_job_description(job_details=invalid_job_description)
+        EstimatorBase._prepare_init_params_from_job_description(
+            job_details=invalid_job_description
+        )
         assert "Invalid AlgorithmSpecification" in str(error)
 
 
@@ -2397,7 +2524,10 @@ def test_prepare_for_training_with_name_based_on_image(sagemaker_session):
 
 
 @patch("sagemaker.algorithm.AlgorithmEstimator.validate_train_spec", Mock())
-@patch("sagemaker.algorithm.AlgorithmEstimator._parse_hyperparameters", Mock(return_value={}))
+@patch(
+    "sagemaker.algorithm.AlgorithmEstimator._parse_hyperparameters",
+    Mock(return_value={}),
+)
 def test_prepare_for_training_with_name_based_on_algorithm(sagemaker_session):
     estimator = AlgorithmEstimator(
         algorithm_arn="arn:aws:sagemaker:us-west-2:1234:algorithm/scikit-decision-trees-1542410022",

--- a/tests/unit/test_exception_on_bad_status.py
+++ b/tests/unit/test_exception_on_bad_status.py
@@ -29,7 +29,9 @@ def get_sagemaker_session(returns_status):
     client_mock.describe_model_package = MagicMock(
         return_value={"ModelPackageStatus": returns_status}
     )
-    client_mock.describe_endpoint = MagicMock(return_value={"EndpointStatus": returns_status})
+    client_mock.describe_endpoint = MagicMock(
+        return_value={"EndpointStatus": returns_status}
+    )
     ims = sagemaker.Session(boto_session=boto_mock, sagemaker_client=client_mock)
     ims.expand_role = Mock(return_value=EXPANDED_ROLE)
     return ims

--- a/tests/unit/test_experiments_analytics.py
+++ b/tests/unit/test_experiments_analytics.py
@@ -58,7 +58,9 @@ def test_trial_analytics_dataframe_all_metrics_hyperparams(mock_session):
             {"TrialComponent": trial_component("trial-2")},
         ]
     }
-    analytics = ExperimentAnalytics(experiment_name="experiment1", sagemaker_session=mock_session)
+    analytics = ExperimentAnalytics(
+        experiment_name="experiment1", sagemaker_session=mock_session
+    )
 
     expected_dataframe = pd.DataFrame.from_dict(
         OrderedDict(
@@ -95,7 +97,11 @@ def test_trial_analytics_dataframe_all_metrics_hyperparams(mock_session):
     pd.testing.assert_frame_equal(expected_dataframe, analytics.dataframe())
     expected_search_exp = {
         "Filters": [
-            {"Name": "Parents.ExperimentName", "Operator": "Equals", "Value": "experiment1"}
+            {
+                "Name": "Parents.ExperimentName",
+                "Operator": "Equals",
+                "Value": "experiment1",
+            }
         ]
     }
     mock_session.sagemaker_client.search.assert_called_with(
@@ -111,7 +117,9 @@ def test_trial_analytics_dataframe_selected_hyperparams(mock_session):
         ]
     }
     analytics = ExperimentAnalytics(
-        experiment_name="experiment1", parameter_names=["hp2"], sagemaker_session=mock_session
+        experiment_name="experiment1",
+        parameter_names=["hp2"],
+        sagemaker_session=mock_session,
     )
 
     expected_dataframe = pd.DataFrame.from_dict(
@@ -148,7 +156,11 @@ def test_trial_analytics_dataframe_selected_hyperparams(mock_session):
     pd.testing.assert_frame_equal(expected_dataframe, analytics.dataframe())
     expected_search_exp = {
         "Filters": [
-            {"Name": "Parents.ExperimentName", "Operator": "Equals", "Value": "experiment1"}
+            {
+                "Name": "Parents.ExperimentName",
+                "Operator": "Equals",
+                "Value": "experiment1",
+            }
         ]
     }
     mock_session.sagemaker_client.search.assert_called_with(
@@ -164,7 +176,9 @@ def test_trial_analytics_dataframe_selected_metrics(mock_session):
         ]
     }
     analytics = ExperimentAnalytics(
-        experiment_name="experiment1", metric_names=["metric1"], sagemaker_session=mock_session
+        experiment_name="experiment1",
+        metric_names=["metric1"],
+        sagemaker_session=mock_session,
     )
 
     expected_dataframe = pd.DataFrame.from_dict(
@@ -196,7 +210,11 @@ def test_trial_analytics_dataframe_selected_metrics(mock_session):
     pd.testing.assert_frame_equal(expected_dataframe, analytics.dataframe())
     expected_search_exp = {
         "Filters": [
-            {"Name": "Parents.ExperimentName", "Operator": "Equals", "Value": "experiment1"}
+            {
+                "Name": "Parents.ExperimentName",
+                "Operator": "Equals",
+                "Value": "experiment1",
+            }
         ]
     }
     mock_session.sagemaker_client.search.assert_called_with(
@@ -213,7 +231,9 @@ def test_trial_analytics_dataframe_search_pagination(mock_session):
     result_page_2 = {"Results": [{"TrialComponent": trial_component("trial-2")}]}
 
     mock_session.sagemaker_client.search.side_effect = [result_page_1, result_page_2]
-    analytics = ExperimentAnalytics(experiment_name="experiment1", sagemaker_session=mock_session)
+    analytics = ExperimentAnalytics(
+        experiment_name="experiment1", sagemaker_session=mock_session
+    )
 
     expected_dataframe = pd.DataFrame.from_dict(
         OrderedDict(
@@ -250,12 +270,19 @@ def test_trial_analytics_dataframe_search_pagination(mock_session):
     pd.testing.assert_frame_equal(expected_dataframe, analytics.dataframe())
     expected_search_exp = {
         "Filters": [
-            {"Name": "Parents.ExperimentName", "Operator": "Equals", "Value": "experiment1"}
+            {
+                "Name": "Parents.ExperimentName",
+                "Operator": "Equals",
+                "Value": "experiment1",
+            }
         ]
     }
     mock_session.sagemaker_client.search.assert_has_calls(
         [
-            mock.call(Resource="ExperimentTrialComponent", SearchExpression=expected_search_exp),
+            mock.call(
+                Resource="ExperimentTrialComponent",
+                SearchExpression=expected_search_exp,
+            ),
             mock.call(
                 Resource="ExperimentTrialComponent",
                 SearchExpression=expected_search_exp,
@@ -268,8 +295,14 @@ def test_trial_analytics_dataframe_search_pagination(mock_session):
 def test_trial_analytics_dataframe_filter_trials_search_exp_only(mock_session):
     mock_session.sagemaker_client.search.return_value = {"Results": []}
 
-    search_exp = {"Filters": [{"Name": "Tags.someTag", "Operator": "Equals", "Value": "someValue"}]}
-    analytics = ExperimentAnalytics(search_expression=search_exp, sagemaker_session=mock_session)
+    search_exp = {
+        "Filters": [
+            {"Name": "Tags.someTag", "Operator": "Equals", "Value": "someValue"}
+        ]
+    }
+    analytics = ExperimentAnalytics(
+        search_expression=search_exp, sagemaker_session=mock_session
+    )
 
     analytics.dataframe()
 
@@ -278,10 +311,16 @@ def test_trial_analytics_dataframe_filter_trials_search_exp_only(mock_session):
     )
 
 
-def test_trial_analytics_dataframe_filter_trials_search_exp_with_experiment(mock_session):
+def test_trial_analytics_dataframe_filter_trials_search_exp_with_experiment(
+    mock_session,
+):
     mock_session.sagemaker_client.search.return_value = {"Results": []}
 
-    search_exp = {"Filters": [{"Name": "Tags.someTag", "Operator": "Equals", "Value": "someValue"}]}
+    search_exp = {
+        "Filters": [
+            {"Name": "Tags.someTag", "Operator": "Equals", "Value": "someValue"}
+        ]
+    }
     analytics = ExperimentAnalytics(
         experiment_name="someExperiment",
         search_expression=search_exp,
@@ -293,7 +332,11 @@ def test_trial_analytics_dataframe_filter_trials_search_exp_with_experiment(mock
     expected_search_exp = {
         "Filters": [
             {"Name": "Tags.someTag", "Operator": "Equals", "Value": "someValue"},
-            {"Name": "Parents.ExperimentName", "Operator": "Equals", "Value": "someExperiment"},
+            {
+                "Name": "Parents.ExperimentName",
+                "Operator": "Equals",
+                "Value": "someExperiment",
+            },
         ]
     }
 
@@ -310,7 +353,11 @@ def test_trial_analytics_dataframe_throws_error_if_no_filter_specified(mock_sess
 def test_trial_analytics_dataframe_filter_trials_search_exp_with_sort(mock_session):
     mock_session.sagemaker_client.search.return_value = {"Results": []}
 
-    search_exp = {"Filters": [{"Name": "Tags.someTag", "Operator": "Equals", "Value": "someValue"}]}
+    search_exp = {
+        "Filters": [
+            {"Name": "Tags.someTag", "Operator": "Equals", "Value": "someValue"}
+        ]
+    }
     analytics = ExperimentAnalytics(
         experiment_name="someExperiment",
         search_expression=search_exp,
@@ -324,7 +371,11 @@ def test_trial_analytics_dataframe_filter_trials_search_exp_with_sort(mock_sessi
     expected_search_exp = {
         "Filters": [
             {"Name": "Tags.someTag", "Operator": "Equals", "Value": "someValue"},
-            {"Name": "Parents.ExperimentName", "Operator": "Equals", "Value": "someExperiment"},
+            {
+                "Name": "Parents.ExperimentName",
+                "Operator": "Equals",
+                "Value": "someExperiment",
+            },
         ]
     }
 

--- a/tests/unit/test_fm.py
+++ b/tests/unit/test_fm.py
@@ -39,11 +39,15 @@ ALL_REQ_ARGS = dict(
 REGION = "us-west-2"
 BUCKET_NAME = "Some-Bucket"
 
-DESCRIBE_TRAINING_JOB_RESULT = {"ModelArtifacts": {"S3ModelArtifacts": "s3://bucket/model.tar.gz"}}
+DESCRIBE_TRAINING_JOB_RESULT = {
+    "ModelArtifacts": {"S3ModelArtifacts": "s3://bucket/model.tar.gz"}
+}
 
 ENDPOINT_DESC = {"EndpointConfigName": "test-endpoint"}
 
-ENDPOINT_CONFIG_DESC = {"ProductionVariants": [{"ModelName": "model-1"}, {"ModelName": "model-2"}]}
+ENDPOINT_CONFIG_DESC = {
+    "ProductionVariants": [{"ModelName": "model-1"}, {"ModelName": "model-2"}]
+}
 
 
 @pytest.fixture()
@@ -64,7 +68,9 @@ def sagemaker_session():
         name="describe_training_job", return_value=DESCRIBE_TRAINING_JOB_RESULT
     )
     sms.sagemaker_client.describe_endpoint = Mock(return_value=ENDPOINT_DESC)
-    sms.sagemaker_client.describe_endpoint_config = Mock(return_value=ENDPOINT_CONFIG_DESC)
+    sms.sagemaker_client.describe_endpoint_config = Mock(
+        return_value=ENDPOINT_CONFIG_DESC
+    )
     return sms
 
 
@@ -150,9 +156,12 @@ def test_image(sagemaker_session):
 
 
 @pytest.mark.parametrize(
-    "required_hyper_parameters, value", [("num_factors", "string"), ("predictor_type", 0)]
+    "required_hyper_parameters, value",
+    [("num_factors", "string"), ("predictor_type", 0)],
 )
-def test_required_hyper_parameters_type(sagemaker_session, required_hyper_parameters, value):
+def test_required_hyper_parameters_type(
+    sagemaker_session, required_hyper_parameters, value
+):
     with pytest.raises(ValueError):
         test_params = ALL_REQ_ARGS.copy()
         test_params[required_hyper_parameters] = value
@@ -160,9 +169,12 @@ def test_required_hyper_parameters_type(sagemaker_session, required_hyper_parame
 
 
 @pytest.mark.parametrize(
-    "required_hyper_parameters, value", [("num_factors", 0), ("predictor_type", "string")]
+    "required_hyper_parameters, value",
+    [("num_factors", 0), ("predictor_type", "string")],
 )
-def test_required_hyper_parameters_value(sagemaker_session, required_hyper_parameters, value):
+def test_required_hyper_parameters_value(
+    sagemaker_session, required_hyper_parameters, value
+):
     with pytest.raises(ValueError):
         test_params = ALL_REQ_ARGS.copy()
         test_params[required_hyper_parameters] = value
@@ -196,7 +208,9 @@ def test_required_hyper_parameters_value(sagemaker_session, required_hyper_param
         ("factors_init_value", "string"),
     ],
 )
-def test_optional_hyper_parameters_type(sagemaker_session, optional_hyper_parameters, value):
+def test_optional_hyper_parameters_type(
+    sagemaker_session, optional_hyper_parameters, value
+):
     with pytest.raises(ValueError):
         test_params = ALL_REQ_ARGS.copy()
         test_params.update({optional_hyper_parameters: value})
@@ -224,7 +238,9 @@ def test_optional_hyper_parameters_type(sagemaker_session, optional_hyper_parame
         ("factors_init_sigma", -1),
     ],
 )
-def test_optional_hyper_parameters_value(sagemaker_session, optional_hyper_parameters, value):
+def test_optional_hyper_parameters_value(
+    sagemaker_session, optional_hyper_parameters, value
+):
     with pytest.raises(ValueError):
         test_params = ALL_REQ_ARGS.copy()
         test_params.update({optional_hyper_parameters: value})
@@ -313,7 +329,10 @@ def test_model_image(sagemaker_session):
     fm.fit(data, MINI_BATCH_SIZE)
 
     model = fm.create_model()
-    assert model.image == registry(REGION, "factorization-machines") + "/factorization-machines:1"
+    assert (
+        model.image
+        == registry(REGION, "factorization-machines") + "/factorization-machines:1"
+    )
 
 
 def test_predictor_type(sagemaker_session):

--- a/tests/unit/test_fw_registry.py
+++ b/tests/unit/test_fw_registry.py
@@ -23,16 +23,20 @@ scikit_learn_framework_name = SKLearn.__framework_name__
 
 def test_registry_sparkml_serving():
     assert (
-        registry("us-west-1", "sparkml-serving") == "746614075791.dkr.ecr.us-west-1.amazonaws.com"
+        registry("us-west-1", "sparkml-serving")
+        == "746614075791.dkr.ecr.us-west-1.amazonaws.com"
     )
     assert (
-        registry("us-west-2", "sparkml-serving") == "246618743249.dkr.ecr.us-west-2.amazonaws.com"
+        registry("us-west-2", "sparkml-serving")
+        == "246618743249.dkr.ecr.us-west-2.amazonaws.com"
     )
     assert (
-        registry("us-east-1", "sparkml-serving") == "683313688378.dkr.ecr.us-east-1.amazonaws.com"
+        registry("us-east-1", "sparkml-serving")
+        == "683313688378.dkr.ecr.us-east-1.amazonaws.com"
     )
     assert (
-        registry("us-east-2", "sparkml-serving") == "257758044811.dkr.ecr.us-east-2.amazonaws.com"
+        registry("us-east-2", "sparkml-serving")
+        == "257758044811.dkr.ecr.us-east-2.amazonaws.com"
     )
     assert (
         registry("ap-northeast-1", "sparkml-serving")
@@ -51,13 +55,16 @@ def test_registry_sparkml_serving():
         == "783357654285.dkr.ecr.ap-southeast-2.amazonaws.com"
     )
     assert (
-        registry("ap-south-1", "sparkml-serving") == "720646828776.dkr.ecr.ap-south-1.amazonaws.com"
+        registry("ap-south-1", "sparkml-serving")
+        == "720646828776.dkr.ecr.ap-south-1.amazonaws.com"
     )
     assert (
-        registry("eu-west-1", "sparkml-serving") == "141502667606.dkr.ecr.eu-west-1.amazonaws.com"
+        registry("eu-west-1", "sparkml-serving")
+        == "141502667606.dkr.ecr.eu-west-1.amazonaws.com"
     )
     assert (
-        registry("eu-west-2", "sparkml-serving") == "764974769150.dkr.ecr.eu-west-2.amazonaws.com"
+        registry("eu-west-2", "sparkml-serving")
+        == "764974769150.dkr.ecr.eu-west-2.amazonaws.com"
     )
     assert (
         registry("eu-central-1", "sparkml-serving")
@@ -142,7 +149,9 @@ def test_registry_sklearn():
 
 def test_default_sklearn_image_uri():
     image_tag = "0.20.0-cpu-py3"
-    sklearn_image_uri = default_framework_uri(scikit_learn_framework_name, "us-west-1", image_tag)
+    sklearn_image_uri = default_framework_uri(
+        scikit_learn_framework_name, "us-west-1", image_tag
+    )
     assert (
         sklearn_image_uri
         == "746614075791.dkr.ecr.us-west-1.amazonaws.com/sagemaker-scikit-learn:0.20.0-cpu-py3"

--- a/tests/unit/test_fw_utils.py
+++ b/tests/unit/test_fw_utils.py
@@ -95,7 +95,10 @@ def get_repo_name(framework, framework_version, is_serving=False, py_version="py
             ecr_repo = "sagemaker-{}-serving"
         else:
             ecr_repo = "sagemaker-{}"
-            if framework == "tensorflow" and framework_version in SERVING_FW_VERSIONS[framework]:
+            if (
+                framework == "tensorflow"
+                and framework_version in SERVING_FW_VERSIONS[framework]
+            ):
                 framework = framework + "-scriptmode"
     elif is_serving:
         ecr_repo = "{}-inference"
@@ -105,12 +108,27 @@ def get_repo_name(framework, framework_version, is_serving=False, py_version="py
 
 
 def is_mxnet_1_4_py2(framework, framework_version, py_version):
-    return framework == "mxnet" and py_version == "py2" and framework_version in ["1.4", "1.4.1"]
+    return (
+        framework == "mxnet"
+        and py_version == "py2"
+        and framework_version in ["1.4", "1.4.1"]
+    )
 
 
 @pytest.fixture(
     scope="module",
-    params=["1.11", "1.11.0", "1.12", "1.12.0", "1.14", "1.14.0", "1.15", "1.15.0", "2.0", "2.2.0"],
+    params=[
+        "1.11",
+        "1.11.0",
+        "1.12",
+        "1.12.0",
+        "1.14",
+        "1.14.0",
+        "1.15",
+        "1.15.0",
+        "2.0",
+        "2.2.0",
+    ],
 )
 def tf_version(request):
     return request.param
@@ -118,7 +136,18 @@ def tf_version(request):
 
 @pytest.fixture(
     scope="module",
-    params=["0.4", "0.4.0", "1.0", "1.0.0", "1.1", "1.1.0", "1.2", "1.2.0", "1.3", "1.3.1"],
+    params=[
+        "0.4",
+        "0.4.0",
+        "1.0",
+        "1.0.0",
+        "1.1",
+        "1.1.0",
+        "1.2",
+        "1.2.0",
+        "1.3",
+        "1.3.1",
+    ],
 )
 def pytorch_version(request):
     return request.param
@@ -160,7 +189,10 @@ def cd(path):
 def sagemaker_session():
     boto_mock = Mock(name="boto_session", region_name=REGION)
     session_mock = Mock(
-        name="sagemaker_session", boto_session=boto_mock, s3_client=None, s3_resource=None
+        name="sagemaker_session",
+        boto_session=boto_mock,
+        s3_client=None,
+        s3_resource=None,
     )
     session_mock.default_bucket = Mock(name="default_bucket", return_value=BUCKET_NAME)
     session_mock.expand_role = Mock(name="expand_role", return_value=ROLE)
@@ -176,29 +208,42 @@ def test_create_image_uri_cpu(ecr_prefix):
     image_uri = fw_utils.create_image_uri(
         MOCK_REGION, MOCK_FRAMEWORK, "ml.c4.large", "1.0rc", "py2", "23"
     )
-    assert image_uri == "23.dkr.ecr.mars-south-3.amazonaws.com/sagemaker-mlfw:1.0rc-cpu-py2"
+    assert (
+        image_uri
+        == "23.dkr.ecr.mars-south-3.amazonaws.com/sagemaker-mlfw:1.0rc-cpu-py2"
+    )
 
     image_uri = fw_utils.create_image_uri(
         MOCK_REGION, MOCK_FRAMEWORK, "local", "1.0rc", "py2", "23"
     )
-    assert image_uri == "23.dkr.ecr.mars-south-3.amazonaws.com/sagemaker-mlfw:1.0rc-cpu-py2"
+    assert (
+        image_uri
+        == "23.dkr.ecr.mars-south-3.amazonaws.com/sagemaker-mlfw:1.0rc-cpu-py2"
+    )
 
     ecr_prefix.return_value = "246785580436.dkr.ecr.us-gov-west-1.amazonaws.com"
     image_uri = fw_utils.create_image_uri(
         "us-gov-west-1", MOCK_FRAMEWORK, "ml.c4.large", "1.0rc", "py2"
     )
     assert (
-        image_uri == "246785580436.dkr.ecr.us-gov-west-1.amazonaws.com/sagemaker-mlfw:1.0rc-cpu-py2"
+        image_uri
+        == "246785580436.dkr.ecr.us-gov-west-1.amazonaws.com/sagemaker-mlfw:1.0rc-cpu-py2"
     )
 
     ecr_prefix.return_value = "744548109606.dkr.ecr.us-iso-east-1.c2s.ic.gov"
     image_uri = fw_utils.create_image_uri(
         "us-iso-east-1", MOCK_FRAMEWORK, "ml.c4.large", "1.0rc", "py2"
     )
-    assert image_uri == "744548109606.dkr.ecr.us-iso-east-1.c2s.ic.gov/sagemaker-mlfw:1.0rc-cpu-py2"
+    assert (
+        image_uri
+        == "744548109606.dkr.ecr.us-iso-east-1.c2s.ic.gov/sagemaker-mlfw:1.0rc-cpu-py2"
+    )
 
 
-@patch("sagemaker.fw_utils.get_ecr_image_uri_prefix", return_value=ECR_PREFIX_FORMAT.format("23"))
+@patch(
+    "sagemaker.fw_utils.get_ecr_image_uri_prefix",
+    return_value=ECR_PREFIX_FORMAT.format("23"),
+)
 def test_create_image_uri_no_python(ecr_prefix):
     image_uri = fw_utils.create_image_uri(
         MOCK_REGION, MOCK_FRAMEWORK, "ml.c4.large", "1.0rc", account="23"
@@ -208,23 +253,37 @@ def test_create_image_uri_no_python(ecr_prefix):
 
 def test_create_image_uri_bad_python():
     with pytest.raises(ValueError):
-        fw_utils.create_image_uri(MOCK_REGION, MOCK_FRAMEWORK, "ml.c4.large", "1.0rc", "py0")
+        fw_utils.create_image_uri(
+            MOCK_REGION, MOCK_FRAMEWORK, "ml.c4.large", "1.0rc", "py0"
+        )
 
 
-@patch("sagemaker.fw_utils.get_ecr_image_uri_prefix", return_value=ECR_PREFIX_FORMAT.format("23"))
+@patch(
+    "sagemaker.fw_utils.get_ecr_image_uri_prefix",
+    return_value=ECR_PREFIX_FORMAT.format("23"),
+)
 def test_create_image_uri_gpu(ecr_prefix):
     image_uri = fw_utils.create_image_uri(
         MOCK_REGION, MOCK_FRAMEWORK, "ml.p3.2xlarge", "1.0rc", "py3", "23"
     )
-    assert image_uri == "23.dkr.ecr.mars-south-3.amazonaws.com/sagemaker-mlfw:1.0rc-gpu-py3"
+    assert (
+        image_uri
+        == "23.dkr.ecr.mars-south-3.amazonaws.com/sagemaker-mlfw:1.0rc-gpu-py3"
+    )
 
     image_uri = fw_utils.create_image_uri(
         MOCK_REGION, MOCK_FRAMEWORK, "local_gpu", "1.0rc", "py3", "23"
     )
-    assert image_uri == "23.dkr.ecr.mars-south-3.amazonaws.com/sagemaker-mlfw:1.0rc-gpu-py3"
+    assert (
+        image_uri
+        == "23.dkr.ecr.mars-south-3.amazonaws.com/sagemaker-mlfw:1.0rc-gpu-py3"
+    )
 
 
-@patch("sagemaker.fw_utils.get_ecr_image_uri_prefix", return_value=ECR_PREFIX_FORMAT.format("23"))
+@patch(
+    "sagemaker.fw_utils.get_ecr_image_uri_prefix",
+    return_value=ECR_PREFIX_FORMAT.format("23"),
+)
 def test_create_image_uri_accelerator_tfs(ecr_prefix):
     image_uri = fw_utils.create_image_uri(
         MOCK_REGION,
@@ -249,7 +308,8 @@ def test_create_image_uri_default_account(ecr_prefix):
         MOCK_REGION, MOCK_FRAMEWORK, "ml.p3.2xlarge", "1.0rc", "py3"
     )
     assert (
-        image_uri == "520713654638.dkr.ecr.mars-south-3.amazonaws.com/sagemaker-mlfw:1.0rc-gpu-py3"
+        image_uri
+        == "520713654638.dkr.ecr.mars-south-3.amazonaws.com/sagemaker-mlfw:1.0rc-gpu-py3"
     )
 
 
@@ -258,7 +318,8 @@ def test_create_image_uri_gov_cloud():
         "us-gov-west-1", MOCK_FRAMEWORK, "ml.p3.2xlarge", "1.0rc", "py3"
     )
     assert (
-        image_uri == "246785580436.dkr.ecr.us-gov-west-1.amazonaws.com/sagemaker-mlfw:1.0rc-gpu-py3"
+        image_uri
+        == "246785580436.dkr.ecr.us-gov-west-1.amazonaws.com/sagemaker-mlfw:1.0rc-gpu-py3"
     )
 
 
@@ -267,7 +328,8 @@ def test_create_image_uri_hkg():
         MOCK_HKG_REGION, MOCK_FRAMEWORK, "ml.p3.2xlarge", "1.0rc", "py3"
     )
     assert {
-        image_uri == "871362719292.dkr.ecr.ap-east-1.amazonaws.com/sagemaker-mlfw:1.0rc-gpu-py3"
+        image_uri
+        == "871362719292.dkr.ecr.ap-east-1.amazonaws.com/sagemaker-mlfw:1.0rc-gpu-py3"
     }
 
 
@@ -276,7 +338,8 @@ def test_create_image_uri_bah():
         MOCK_BAH_REGION, MOCK_FRAMEWORK, "ml.p3.2xlarge", "1.0rc", "py3"
     )
     assert {
-        image_uri == "217643126080.dkr.ecr.me-south-1.amazonaws.com/sagemaker-mlfw:1.0rc-gpu-py3"
+        image_uri
+        == "217643126080.dkr.ecr.me-south-1.amazonaws.com/sagemaker-mlfw:1.0rc-gpu-py3"
     }
 
 
@@ -285,7 +348,8 @@ def test_create_image_uri_cn_north_1():
         "cn-north-1", MOCK_FRAMEWORK, "ml.p3.2xlarge", "1.0rc", "py3"
     )
     assert {
-        image_uri == "727897471807.dkr.ecr.me-south-1.amazonaws.com/sagemaker-mlfw:1.0rc-gpu-py3"
+        image_uri
+        == "727897471807.dkr.ecr.me-south-1.amazonaws.com/sagemaker-mlfw:1.0rc-gpu-py3"
     }
 
 
@@ -294,15 +358,20 @@ def test_create_image_uri_cn_northwest_1():
         "cn-northwest-1", MOCK_FRAMEWORK, "ml.p3.2xlarge", "1.0rc", "py3"
     )
     assert {
-        image_uri == "727897471807.dkr.ecr.me-south-1.amazonaws.com/sagemaker-mlfw:1.0rc-gpu-py3"
+        image_uri
+        == "727897471807.dkr.ecr.me-south-1.amazonaws.com/sagemaker-mlfw:1.0rc-gpu-py3"
     }
 
 
 def test_create_image_uri_py37_invalid_framework():
-    error_message = "{} does not support Python 3.7 at this time.".format(MOCK_FRAMEWORK)
+    error_message = "{} does not support Python 3.7 at this time.".format(
+        MOCK_FRAMEWORK
+    )
 
     with pytest.raises(ValueError) as error:
-        fw_utils.create_image_uri(REGION, MOCK_FRAMEWORK, "ml.m4.xlarge", "1.4.0", "py37")
+        fw_utils.create_image_uri(
+            REGION, MOCK_FRAMEWORK, "ml.m4.xlarge", "1.4.0", "py37"
+        )
     assert error_message in str(error)
 
 
@@ -368,7 +437,9 @@ def test_pytorch_eia_images():
 
 
 def test_pytorch_eia_py2_error():
-    error_message = "pytorch-serving is not supported with Amazon Elastic Inference in Python 2."
+    error_message = (
+        "pytorch-serving is not supported with Amazon Elastic Inference in Python 2."
+    )
     with pytest.raises(ValueError) as error:
         fw_utils.create_image_uri(
             "us-east-1",
@@ -385,21 +456,28 @@ def test_create_image_uri_override_account():
     image_uri = fw_utils.create_image_uri(
         "us-west-1", MOCK_FRAMEWORK, "ml.p3.2xlarge", "1.0rc", "py3", account="fake"
     )
-    assert image_uri == "fake.dkr.ecr.us-west-1.amazonaws.com/sagemaker-mlfw:1.0rc-gpu-py3"
+    assert (
+        image_uri == "fake.dkr.ecr.us-west-1.amazonaws.com/sagemaker-mlfw:1.0rc-gpu-py3"
+    )
 
 
 def test_create_image_uri_gov_cloud_override_account():
     image_uri = fw_utils.create_image_uri(
         "us-gov-west-1", MOCK_FRAMEWORK, "ml.p3.2xlarge", "1.0rc", "py3", account="fake"
     )
-    assert image_uri == "fake.dkr.ecr.us-gov-west-1.amazonaws.com/sagemaker-mlfw:1.0rc-gpu-py3"
+    assert (
+        image_uri
+        == "fake.dkr.ecr.us-gov-west-1.amazonaws.com/sagemaker-mlfw:1.0rc-gpu-py3"
+    )
 
 
 def test_create_image_uri_hkg_override_account():
     image_uri = fw_utils.create_image_uri(
         MOCK_HKG_REGION, MOCK_FRAMEWORK, "ml.p3.2xlarge", "1.0rc", "py3", account="fake"
     )
-    assert {image_uri == "fake.dkr.ecr.ap-east-1.amazonaws.com/sagemaker-mlfw:1.0rc-gpu-py3"}
+    assert {
+        image_uri == "fake.dkr.ecr.ap-east-1.amazonaws.com/sagemaker-mlfw:1.0rc-gpu-py3"
+    }
 
 
 def test_create_dlc_image_uri():
@@ -426,20 +504,31 @@ def test_create_dlc_image_uri():
     image_uri = fw_utils.create_image_uri(
         "us-west-2", "tensorflow-serving", "ml.c4.2xlarge", "1.13.1"
     )
-    assert image_uri == "{}.dkr.ecr.us-west-2.amazonaws.com/tensorflow-inference:1.13.1-cpu".format(
-        fw_utils.ASIMOV_DEFAULT_ACCOUNT
+    assert (
+        image_uri
+        == "{}.dkr.ecr.us-west-2.amazonaws.com/tensorflow-inference:1.13.1-cpu".format(
+            fw_utils.ASIMOV_DEFAULT_ACCOUNT
+        )
     )
 
-    image_uri = fw_utils.create_image_uri("us-west-2", "mxnet", "ml.p3.2xlarge", "1.4.1", "py3")
-    assert image_uri == "{}.dkr.ecr.us-west-2.amazonaws.com/mxnet-training:1.4.1-gpu-py3".format(
-        fw_utils.ASIMOV_DEFAULT_ACCOUNT
+    image_uri = fw_utils.create_image_uri(
+        "us-west-2", "mxnet", "ml.p3.2xlarge", "1.4.1", "py3"
+    )
+    assert (
+        image_uri
+        == "{}.dkr.ecr.us-west-2.amazonaws.com/mxnet-training:1.4.1-gpu-py3".format(
+            fw_utils.ASIMOV_DEFAULT_ACCOUNT
+        )
     )
 
     image_uri = fw_utils.create_image_uri(
         "us-west-2", "mxnet-serving", "ml.c4.2xlarge", "1.4.1", "py3"
     )
-    assert image_uri == "{}.dkr.ecr.us-west-2.amazonaws.com/mxnet-inference:1.4.1-cpu-py3".format(
-        fw_utils.ASIMOV_DEFAULT_ACCOUNT
+    assert (
+        image_uri
+        == "{}.dkr.ecr.us-west-2.amazonaws.com/mxnet-inference:1.4.1-cpu-py3".format(
+            fw_utils.ASIMOV_DEFAULT_ACCOUNT
+        )
     )
 
     image_uri = fw_utils.create_image_uri(
@@ -477,8 +566,13 @@ def test_create_dlc_image_uri_py2():
         )
     )
 
-    image_uri = fw_utils.create_image_uri("us-west-2", "mxnet", "ml.p3.2xlarge", "1.4.1", "py2")
-    assert image_uri == "520713654638.dkr.ecr.us-west-2.amazonaws.com/sagemaker-mxnet:1.4.1-gpu-py2"
+    image_uri = fw_utils.create_image_uri(
+        "us-west-2", "mxnet", "ml.p3.2xlarge", "1.4.1", "py2"
+    )
+    assert (
+        image_uri
+        == "520713654638.dkr.ecr.us-west-2.amazonaws.com/sagemaker-mxnet:1.4.1-gpu-py2"
+    )
 
     image_uri = fw_utils.create_image_uri(
         "us-west-2", "mxnet-serving", "ml.c4.2xlarge", "1.3.1", "py2"
@@ -510,17 +604,24 @@ def test_create_dlc_image_uri_iso_east_1():
         "us-iso-east-1", "tensorflow-serving", "ml.m4.xlarge", "1.13.0"
     )
     assert (
-        image_uri == "886529160074.dkr.ecr.us-iso-east-1.c2s.ic.gov/tensorflow-inference:1.13.0-cpu"
+        image_uri
+        == "886529160074.dkr.ecr.us-iso-east-1.c2s.ic.gov/tensorflow-inference:1.13.0-cpu"
     )
 
-    image_uri = fw_utils.create_image_uri("us-iso-east-1", "mxnet", "ml.p3.2xlarge", "1.4.1", "py3")
-    assert image_uri == "886529160074.dkr.ecr.us-iso-east-1.c2s.ic.gov/mxnet-training:1.4.1-gpu-py3"
+    image_uri = fw_utils.create_image_uri(
+        "us-iso-east-1", "mxnet", "ml.p3.2xlarge", "1.4.1", "py3"
+    )
+    assert (
+        image_uri
+        == "886529160074.dkr.ecr.us-iso-east-1.c2s.ic.gov/mxnet-training:1.4.1-gpu-py3"
+    )
 
     image_uri = fw_utils.create_image_uri(
         "us-iso-east-1", "mxnet-serving", "ml.c4.2xlarge", "1.4.1", "py3"
     )
     assert (
-        image_uri == "886529160074.dkr.ecr.us-iso-east-1.c2s.ic.gov/mxnet-inference:1.4.1-cpu-py3"
+        image_uri
+        == "886529160074.dkr.ecr.us-iso-east-1.c2s.ic.gov/mxnet-inference:1.4.1-cpu-py3"
     )
 
     image_uri = fw_utils.create_image_uri(
@@ -557,9 +658,12 @@ def test_create_dlc_image_uri_gov_west_1():
         == "442386744353.dkr.ecr.us-gov-west-1.amazonaws.com/tensorflow-inference:1.13.0-cpu"
     )
 
-    image_uri = fw_utils.create_image_uri("us-gov-west-1", "mxnet", "ml.p3.2xlarge", "1.4.1", "py3")
+    image_uri = fw_utils.create_image_uri(
+        "us-gov-west-1", "mxnet", "ml.p3.2xlarge", "1.4.1", "py3"
+    )
     assert (
-        image_uri == "442386744353.dkr.ecr.us-gov-west-1.amazonaws.com/mxnet-training:1.4.1-gpu-py3"
+        image_uri
+        == "442386744353.dkr.ecr.us-gov-west-1.amazonaws.com/mxnet-training:1.4.1-gpu-py3"
     )
 
     image_uri = fw_utils.create_image_uri(
@@ -614,7 +718,9 @@ def test_create_image_uri_mxnet(mxnet_version):
         "us-west-2", "mxnet", "ml.p3.2xlarge", mxnet_version, "py3"
     )
     assert image_uri == "{}.dkr.ecr.us-west-2.amazonaws.com/{}:{}-gpu-py3".format(
-        get_account("mxnet", mxnet_version), get_repo_name("mxnet", mxnet_version), mxnet_version
+        get_account("mxnet", mxnet_version),
+        get_repo_name("mxnet", mxnet_version),
+        mxnet_version,
     )
 
     if mxnet_version not in ORIGINAL_FW_VERSIONS:
@@ -635,7 +741,9 @@ def test_create_image_uri_tensorflow(tf_version):
         "us-west-2", "tensorflow-scriptmode", "ml.p3.2xlarge", tf_version, "py3"
     )
     assert image_uri == "{}.dkr.ecr.us-west-2.amazonaws.com/{}:{}-gpu-py3".format(
-        get_account("tensorflow", tf_version), get_repo_name("tensorflow", tf_version), tf_version
+        get_account("tensorflow", tf_version),
+        get_repo_name("tensorflow", tf_version),
+        tf_version,
     )
 
     if tf_version not in ORIGINAL_FW_VERSIONS:
@@ -655,7 +763,12 @@ def test_create_image_uri_tensorflow(tf_version):
 )
 def test_create_image_uri_accelerator_tf(ecr_prefix):
     image_uri = fw_utils.create_image_uri(
-        MOCK_REGION, "tensorflow", "ml.p3.2xlarge", "1.0", "py3", accelerator_type="ml.eia1.medium"
+        MOCK_REGION,
+        "tensorflow",
+        "ml.p3.2xlarge",
+        "1.0",
+        "py3",
+        accelerator_type="ml.eia1.medium",
     )
     assert (
         image_uri
@@ -720,7 +833,9 @@ def test_invalid_accelerator():
 
 
 def test_invalid_framework_accelerator():
-    error_message = "{} is not supported with Amazon Elastic Inference.".format(MOCK_FRAMEWORK)
+    error_message = "{} is not supported with Amazon Elastic Inference.".format(
+        MOCK_FRAMEWORK
+    )
     # accelerator was chosen for unsupported framework
     with pytest.raises(ValueError) as error:
         fw_utils.create_image_uri(
@@ -755,7 +870,9 @@ def test_invalid_framework_accelerator_with_neo():
 def test_invalid_instance_type():
     # instance type is missing 'ml.' prefix
     with pytest.raises(ValueError):
-        fw_utils.create_image_uri(MOCK_REGION, MOCK_FRAMEWORK, "p3.2xlarge", "1.0.0", "py3")
+        fw_utils.create_image_uri(
+            MOCK_REGION, MOCK_FRAMEWORK, "p3.2xlarge", "1.0.0", "py3"
+        )
 
 
 def test_valid_inferentia_image():
@@ -828,7 +945,8 @@ def test_optimized_family(ecr_prefix):
         optimized_families=["c5", "p3"],
     )
     assert (
-        image_uri == "520713654638.dkr.ecr.mars-south-3.amazonaws.com/sagemaker-mlfw:1.0.0-p3-py3"
+        image_uri
+        == "520713654638.dkr.ecr.mars-south-3.amazonaws.com/sagemaker-mlfw:1.0.0-p3-py3"
     )
 
 
@@ -838,10 +956,16 @@ def test_optimized_family(ecr_prefix):
 )
 def test_unoptimized_cpu_family(ecr_prefix):
     image_uri = fw_utils.create_image_uri(
-        MOCK_REGION, MOCK_FRAMEWORK, "ml.m4.xlarge", "1.0.0", "py3", optimized_families=["c5", "p3"]
+        MOCK_REGION,
+        MOCK_FRAMEWORK,
+        "ml.m4.xlarge",
+        "1.0.0",
+        "py3",
+        optimized_families=["c5", "p3"],
     )
     assert (
-        image_uri == "520713654638.dkr.ecr.mars-south-3.amazonaws.com/sagemaker-mlfw:1.0.0-cpu-py3"
+        image_uri
+        == "520713654638.dkr.ecr.mars-south-3.amazonaws.com/sagemaker-mlfw:1.0.0-cpu-py3"
     )
 
 
@@ -851,10 +975,16 @@ def test_unoptimized_cpu_family(ecr_prefix):
 )
 def test_unoptimized_gpu_family(ecr_prefix):
     image_uri = fw_utils.create_image_uri(
-        MOCK_REGION, MOCK_FRAMEWORK, "ml.p2.xlarge", "1.0.0", "py3", optimized_families=["c5", "p3"]
+        MOCK_REGION,
+        MOCK_FRAMEWORK,
+        "ml.p2.xlarge",
+        "1.0.0",
+        "py3",
+        optimized_families=["c5", "p3"],
     )
     assert (
-        image_uri == "520713654638.dkr.ecr.mars-south-3.amazonaws.com/sagemaker-mlfw:1.0.0-gpu-py3"
+        image_uri
+        == "520713654638.dkr.ecr.mars-south-3.amazonaws.com/sagemaker-mlfw:1.0.0-gpu-py3"
     )
 
 
@@ -914,7 +1044,9 @@ def test_tar_and_upload_dir_not_s3(sagemaker_session):
     bucket = "mybucket"
     s3_key_prefix = "something/source"
     script = os.path.basename(__file__)
-    directory = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
+    directory = os.path.dirname(
+        os.path.abspath(inspect.getfile(inspect.currentframe()))
+    )
     result = fw_utils.tar_and_upload_dir(
         sagemaker_session, bucket, s3_key_prefix, script, directory
     )
@@ -1017,7 +1149,9 @@ def test_tar_and_upload_dir_with_subdirectory(sagemaker_session, tmpdir):
 
 
 def test_tar_and_upload_dir_with_directory_and_files(sagemaker_session, tmpdir):
-    file_tree(tmpdir, ["src-dir/train.py", "src-dir/laucher", "src-dir/module/__init__.py"])
+    file_tree(
+        tmpdir, ["src-dir/train.py", "src-dir/laucher", "src-dir/module/__init__.py"]
+    )
     source_dir = os.path.join(str(tmpdir), "src-dir")
 
     with patch("shutil.rmtree"):
@@ -1035,7 +1169,10 @@ def test_tar_and_upload_dir_with_directory_and_files(sagemaker_session, tmpdir):
 
 
 def test_tar_and_upload_dir_with_directories_and_files(sagemaker_session, tmpdir):
-    file_tree(tmpdir, ["src-dir/a/b", "src-dir/a/b2", "src-dir/x/y", "src-dir/x/y2", "src-dir/z"])
+    file_tree(
+        tmpdir,
+        ["src-dir/a/b", "src-dir/a/b2", "src-dir/x/y", "src-dir/x/y2", "src-dir/z"],
+    )
     source_dir = os.path.join(str(tmpdir), "src-dir")
 
     with patch("shutil.rmtree"):
@@ -1053,22 +1190,36 @@ def test_tar_and_upload_dir_with_directories_and_files(sagemaker_session, tmpdir
 
 
 def test_tar_and_upload_dir_with_many_folders(sagemaker_session, tmpdir):
-    file_tree(tmpdir, ["src-dir/a/b", "src-dir/a/b2", "common/x/y", "common/x/y2", "t/y/z"])
+    file_tree(
+        tmpdir, ["src-dir/a/b", "src-dir/a/b2", "common/x/y", "common/x/y2", "t/y/z"]
+    )
     source_dir = os.path.join(str(tmpdir), "src-dir")
-    dependencies = [os.path.join(str(tmpdir), "common"), os.path.join(str(tmpdir), "t", "y", "z")]
+    dependencies = [
+        os.path.join(str(tmpdir), "common"),
+        os.path.join(str(tmpdir), "t", "y", "z"),
+    ]
 
     with patch("shutil.rmtree"):
         result = fw_utils.tar_and_upload_dir(
-            sagemaker_session, "bucket", "prefix", "pipeline.py", source_dir, dependencies
+            sagemaker_session,
+            "bucket",
+            "prefix",
+            "pipeline.py",
+            source_dir,
+            dependencies,
         )
 
     assert result == fw_utils.UploadedCode(
         s3_prefix="s3://bucket/prefix/sourcedir.tar.gz", script_name="pipeline.py"
     )
 
-    assert {"/a/b", "/a/b2", "/common/x/y", "/common/x/y2", "/z"} == list_source_dir_files(
-        sagemaker_session, tmpdir
-    )
+    assert {
+        "/a/b",
+        "/a/b2",
+        "/common/x/y",
+        "/common/x/y2",
+        "/z",
+    } == list_source_dir_files(sagemaker_session, tmpdir)
 
 
 def test_test_tar_and_upload_dir_with_subfolders(sagemaker_session, tmpdir):
@@ -1095,7 +1246,9 @@ def test_test_tar_and_upload_dir_with_subfolders(sagemaker_session, tmpdir):
 
 
 def list_source_dir_files(sagemaker_session, tmpdir):
-    source_dir_tar = sagemaker_session.resource("s3").Object().upload_file.call_args[0][0]
+    source_dir_tar = (
+        sagemaker_session.resource("s3").Object().upload_file.call_args[0][0]
+    )
 
     source_dir_files = list_tar_files("/opt/ml/code/", source_dir_tar, tmpdir)
     return source_dir_files
@@ -1119,19 +1272,26 @@ def list_tar_files(folder, tar_ball, tmpdir):
 
 def test_framework_name_from_image_mxnet():
     image_name = "123.dkr.ecr.us-west-2.amazonaws.com/sagemaker-mxnet:1.1-gpu-py3"
-    assert ("mxnet", "py3", "1.1-gpu-py3", None) == fw_utils.framework_name_from_image(image_name)
+    assert ("mxnet", "py3", "1.1-gpu-py3", None) == fw_utils.framework_name_from_image(
+        image_name
+    )
 
 
 def test_framework_name_from_image_mxnet_in_gov():
     image_name = "123.dkr.ecr.region-name.c2s.ic.gov/sagemaker-mxnet:1.1-gpu-py3"
-    assert ("mxnet", "py3", "1.1-gpu-py3", None) == fw_utils.framework_name_from_image(image_name)
+    assert ("mxnet", "py3", "1.1-gpu-py3", None) == fw_utils.framework_name_from_image(
+        image_name
+    )
 
 
 def test_framework_name_from_image_tf():
     image_name = "123.dkr.ecr.us-west-2.amazonaws.com/sagemaker-tensorflow:1.6-cpu-py2"
-    assert ("tensorflow", "py2", "1.6-cpu-py2", None) == fw_utils.framework_name_from_image(
-        image_name
-    )
+    assert (
+        "tensorflow",
+        "py2",
+        "1.6-cpu-py2",
+        None,
+    ) == fw_utils.framework_name_from_image(image_name)
 
 
 def test_framework_name_from_image_tf_scriptmode():
@@ -1144,20 +1304,30 @@ def test_framework_name_from_image_tf_scriptmode():
     ) == fw_utils.framework_name_from_image(image_name)
 
     image_name = "123.dkr.ecr.us-west-2.amazonaws.com/tensorflow-training:1.13-cpu-py3"
-    assert ("tensorflow", "py3", "1.13-cpu-py3", "training") == fw_utils.framework_name_from_image(
-        image_name
-    )
+    assert (
+        "tensorflow",
+        "py3",
+        "1.13-cpu-py3",
+        "training",
+    ) == fw_utils.framework_name_from_image(image_name)
 
 
 def test_framework_name_from_image_rl():
-    image_name = "123.dkr.ecr.us-west-2.amazonaws.com/sagemaker-rl-mxnet:toolkit1.1-gpu-py3"
-    assert ("mxnet", "py3", "toolkit1.1-gpu-py3", None) == fw_utils.framework_name_from_image(
-        image_name
+    image_name = (
+        "123.dkr.ecr.us-west-2.amazonaws.com/sagemaker-rl-mxnet:toolkit1.1-gpu-py3"
     )
+    assert (
+        "mxnet",
+        "py3",
+        "toolkit1.1-gpu-py3",
+        None,
+    ) == fw_utils.framework_name_from_image(image_name)
 
 
 def test_legacy_name_from_framework_image():
-    image_name = "123.dkr.ecr.us-west-2.amazonaws.com/sagemaker-mxnet-py3-gpu:2.5.6-gpu-py2"
+    image_name = (
+        "123.dkr.ecr.us-west-2.amazonaws.com/sagemaker-mxnet-py3-gpu:2.5.6-gpu-py2"
+    )
     framework, py_ver, tag, _ = fw_utils.framework_name_from_image(image_name)
     assert framework == "mxnet"
     assert py_ver == "py3"
@@ -1192,7 +1362,9 @@ def test_legacy_name_from_wrong_device():
 
 
 def test_legacy_name_from_image_any_tag():
-    image_name = "123.dkr.ecr.us-west-2.amazonaws.com/sagemaker-tensorflow-py2-cpu:any-tag"
+    image_name = (
+        "123.dkr.ecr.us-west-2.amazonaws.com/sagemaker-tensorflow-py2-cpu:any-tag"
+    )
     framework, py_ver, tag, _ = fw_utils.framework_name_from_image(image_name)
     assert framework == "tensorflow"
     assert py_ver == "py2"

--- a/tests/unit/test_git_utils.py
+++ b/tests/unit/test_git_utils.py
@@ -38,7 +38,11 @@ CODECOMMIT_BRANCH = "master"
 @patch("os.path.isdir", return_value=True)
 @patch("os.path.exists", return_value=True)
 def test_git_clone_repo_succeed(exists, isdir, isfile, mkdtemp, check_call):
-    git_config = {"repo": PUBLIC_GIT_REPO, "branch": PUBLIC_BRANCH, "commit": PUBLIC_COMMIT}
+    git_config = {
+        "repo": PUBLIC_GIT_REPO,
+        "branch": PUBLIC_BRANCH,
+        "commit": PUBLIC_COMMIT,
+    }
     entry_point = "entry_point"
     source_dir = "source_dir"
     dependencies = ["foo", "bar"]
@@ -89,7 +93,11 @@ def test_git_clone_repo_git_argument_wrong_format():
 )
 @patch("tempfile.mkdtemp", return_value=REPO_DIR)
 def test_git_clone_repo_clone_fail(mkdtemp, check_call):
-    git_config = {"repo": PUBLIC_GIT_REPO, "branch": PUBLIC_BRANCH, "commit": PUBLIC_COMMIT}
+    git_config = {
+        "repo": PUBLIC_GIT_REPO,
+        "branch": PUBLIC_BRANCH,
+        "commit": PUBLIC_COMMIT,
+    }
     entry_point = "entry_point"
     source_dir = "source_dir"
     dependencies = ["foo", "bar"]
@@ -100,11 +108,18 @@ def test_git_clone_repo_clone_fail(mkdtemp, check_call):
 
 @patch(
     "subprocess.check_call",
-    side_effect=[True, subprocess.CalledProcessError(returncode=1, cmd="git checkout banana")],
+    side_effect=[
+        True,
+        subprocess.CalledProcessError(returncode=1, cmd="git checkout banana"),
+    ],
 )
 @patch("tempfile.mkdtemp", return_value=REPO_DIR)
 def test_git_clone_repo_branch_not_exist(mkdtemp, check_call):
-    git_config = {"repo": PUBLIC_GIT_REPO, "branch": PUBLIC_BRANCH, "commit": PUBLIC_COMMIT}
+    git_config = {
+        "repo": PUBLIC_GIT_REPO,
+        "branch": PUBLIC_BRANCH,
+        "commit": PUBLIC_COMMIT,
+    }
     entry_point = "entry_point"
     source_dir = "source_dir"
     dependencies = ["foo", "bar"]
@@ -118,12 +133,18 @@ def test_git_clone_repo_branch_not_exist(mkdtemp, check_call):
     side_effect=[
         True,
         True,
-        subprocess.CalledProcessError(returncode=1, cmd="git checkout {}".format(PUBLIC_COMMIT)),
+        subprocess.CalledProcessError(
+            returncode=1, cmd="git checkout {}".format(PUBLIC_COMMIT)
+        ),
     ],
 )
 @patch("tempfile.mkdtemp", return_value=REPO_DIR)
 def test_git_clone_repo_commit_not_exist(mkdtemp, check_call):
-    git_config = {"repo": PUBLIC_GIT_REPO, "branch": PUBLIC_BRANCH, "commit": PUBLIC_COMMIT}
+    git_config = {
+        "repo": PUBLIC_GIT_REPO,
+        "branch": PUBLIC_BRANCH,
+        "commit": PUBLIC_COMMIT,
+    }
     entry_point = "entry_point"
     source_dir = "source_dir"
     dependencies = ["foo", "bar"]
@@ -137,8 +158,14 @@ def test_git_clone_repo_commit_not_exist(mkdtemp, check_call):
 @patch("os.path.isfile", return_value=False)
 @patch("os.path.isdir", return_value=True)
 @patch("os.path.exists", return_value=True)
-def test_git_clone_repo_entry_point_not_exist(exists, isdir, isfile, mkdtemp, heck_call):
-    git_config = {"repo": PUBLIC_GIT_REPO, "branch": PUBLIC_BRANCH, "commit": PUBLIC_COMMIT}
+def test_git_clone_repo_entry_point_not_exist(
+    exists, isdir, isfile, mkdtemp, heck_call
+):
+    git_config = {
+        "repo": PUBLIC_GIT_REPO,
+        "branch": PUBLIC_BRANCH,
+        "commit": PUBLIC_COMMIT,
+    }
     entry_point = "entry_point_that_does_not_exist"
     source_dir = "source_dir"
     dependencies = ["foo", "bar"]
@@ -152,8 +179,14 @@ def test_git_clone_repo_entry_point_not_exist(exists, isdir, isfile, mkdtemp, he
 @patch("os.path.isfile", return_value=True)
 @patch("os.path.isdir", return_value=False)
 @patch("os.path.exists", return_value=True)
-def test_git_clone_repo_source_dir_not_exist(exists, isdir, isfile, mkdtemp, check_call):
-    git_config = {"repo": PUBLIC_GIT_REPO, "branch": PUBLIC_BRANCH, "commit": PUBLIC_COMMIT}
+def test_git_clone_repo_source_dir_not_exist(
+    exists, isdir, isfile, mkdtemp, check_call
+):
+    git_config = {
+        "repo": PUBLIC_GIT_REPO,
+        "branch": PUBLIC_BRANCH,
+        "commit": PUBLIC_COMMIT,
+    }
     entry_point = "entry_point"
     source_dir = "source_dir_that_does_not_exist"
     dependencies = ["foo", "bar"]
@@ -167,8 +200,14 @@ def test_git_clone_repo_source_dir_not_exist(exists, isdir, isfile, mkdtemp, che
 @patch("os.path.isfile", return_value=True)
 @patch("os.path.isdir", return_value=True)
 @patch("os.path.exists", side_effect=[True, False])
-def test_git_clone_repo_dependencies_not_exist(exists, isdir, isfile, mkdtemp, check_call):
-    git_config = {"repo": PUBLIC_GIT_REPO, "branch": PUBLIC_BRANCH, "commit": PUBLIC_COMMIT}
+def test_git_clone_repo_dependencies_not_exist(
+    exists, isdir, isfile, mkdtemp, check_call
+):
+    git_config = {
+        "repo": PUBLIC_GIT_REPO,
+        "branch": PUBLIC_BRANCH,
+        "commit": PUBLIC_COMMIT,
+    }
     entry_point = "entry_point"
     source_dir = "source_dir"
     dependencies = ["foo", "dep_that_does_not_exist"]
@@ -224,7 +263,12 @@ def test_git_clone_repo_with_token_no_2fa(isfile, mkdtemp, check_call):
     env["GIT_TERMINAL_PROMPT"] = "0"
     ret = git_utils.git_clone_repo(git_config=git_config, entry_point=entry_point)
     check_call.assert_any_call(
-        ["git", "clone", "https://my-token@github.com/testAccount/private-repo.git", REPO_DIR],
+        [
+            "git",
+            "clone",
+            "https://my-token@github.com/testAccount/private-repo.git",
+            REPO_DIR,
+        ],
         env=env,
     )
     check_call.assert_any_call(args=["git", "checkout", PRIVATE_BRANCH], cwd=REPO_DIR)
@@ -251,7 +295,12 @@ def test_git_clone_repo_with_token_2fa(isfile, mkdtemp, check_call):
     env["GIT_TERMINAL_PROMPT"] = "0"
     ret = git_utils.git_clone_repo(git_config=git_config, entry_point=entry_point)
     check_call.assert_any_call(
-        ["git", "clone", "https://my-token@github.com/testAccount/private-repo.git", REPO_DIR],
+        [
+            "git",
+            "clone",
+            "https://my-token@github.com/testAccount/private-repo.git",
+            REPO_DIR,
+        ],
         env=env,
     )
     check_call.assert_any_call(args=["git", "checkout", PRIVATE_BRANCH], cwd=REPO_DIR)
@@ -265,7 +314,11 @@ def test_git_clone_repo_with_token_2fa(isfile, mkdtemp, check_call):
 @patch("tempfile.mkdtemp", return_value=REPO_DIR)
 @patch("os.path.isfile", return_value=True)
 def test_git_clone_repo_ssh(isfile, mkdtemp, check_call):
-    git_config = {"repo": PRIVATE_GIT_REPO_SSH, "branch": PRIVATE_BRANCH, "commit": PRIVATE_COMMIT}
+    git_config = {
+        "repo": PRIVATE_GIT_REPO_SSH,
+        "branch": PRIVATE_BRANCH,
+        "commit": PRIVATE_COMMIT,
+    }
     entry_point = "entry_point"
     ret = git_utils.git_clone_repo(git_config, entry_point)
     assert ret["entry_point"] == "/tmp/repo_dir/entry_point"
@@ -276,7 +329,9 @@ def test_git_clone_repo_ssh(isfile, mkdtemp, check_call):
 @patch("subprocess.check_call")
 @patch("tempfile.mkdtemp", return_value=REPO_DIR)
 @patch("os.path.isfile", return_value=True)
-def test_git_clone_repo_with_token_no_2fa_unnecessary_creds_provided(isfile, mkdtemp, check_call):
+def test_git_clone_repo_with_token_no_2fa_unnecessary_creds_provided(
+    isfile, mkdtemp, check_call
+):
     git_config = {
         "repo": PRIVATE_GIT_REPO,
         "branch": PRIVATE_BRANCH,
@@ -295,7 +350,12 @@ def test_git_clone_repo_with_token_no_2fa_unnecessary_creds_provided(isfile, mkd
         in warn[0].message.args[0]
     )
     check_call.assert_any_call(
-        ["git", "clone", "https://my-token@github.com/testAccount/private-repo.git", REPO_DIR],
+        [
+            "git",
+            "clone",
+            "https://my-token@github.com/testAccount/private-repo.git",
+            REPO_DIR,
+        ],
         env=env,
     )
     check_call.assert_any_call(args=["git", "checkout", PRIVATE_BRANCH], cwd=REPO_DIR)
@@ -308,7 +368,9 @@ def test_git_clone_repo_with_token_no_2fa_unnecessary_creds_provided(isfile, mkd
 @patch("subprocess.check_call")
 @patch("tempfile.mkdtemp", return_value=REPO_DIR)
 @patch("os.path.isfile", return_value=True)
-def test_git_clone_repo_with_token_2fa_unnecessary_creds_provided(isfile, mkdtemp, check_call):
+def test_git_clone_repo_with_token_2fa_unnecessary_creds_provided(
+    isfile, mkdtemp, check_call
+):
     git_config = {
         "repo": PRIVATE_GIT_REPO,
         "branch": PRIVATE_BRANCH,
@@ -327,7 +389,12 @@ def test_git_clone_repo_with_token_2fa_unnecessary_creds_provided(isfile, mkdtem
         in warn[0].message.args[0]
     )
     check_call.assert_any_call(
-        ["git", "clone", "https://my-token@github.com/testAccount/private-repo.git", REPO_DIR],
+        [
+            "git",
+            "clone",
+            "https://my-token@github.com/testAccount/private-repo.git",
+            REPO_DIR,
+        ],
         env=env,
     )
     check_call.assert_any_call(args=["git", "checkout", PRIVATE_BRANCH], cwd=REPO_DIR)
@@ -410,7 +477,9 @@ def test_git_clone_repo_with_and_token_2fa_wrong_creds(mkdtemp, check_call):
 @patch("subprocess.check_call")
 @patch("tempfile.mkdtemp", return_value=REPO_DIR)
 @patch("os.path.isfile", return_value=True)
-def test_git_clone_repo_codecommit_https_with_username_and_password(isfile, mkdtemp, check_call):
+def test_git_clone_repo_codecommit_https_with_username_and_password(
+    isfile, mkdtemp, check_call
+):
     git_config = {
         "repo": CODECOMMIT_REPO,
         "branch": CODECOMMIT_BRANCH,
@@ -430,7 +499,9 @@ def test_git_clone_repo_codecommit_https_with_username_and_password(isfile, mkdt
         ],
         env=env,
     )
-    check_call.assert_any_call(args=["git", "checkout", CODECOMMIT_BRANCH], cwd=REPO_DIR)
+    check_call.assert_any_call(
+        args=["git", "checkout", CODECOMMIT_BRANCH], cwd=REPO_DIR
+    )
     assert ret["entry_point"] == "/tmp/repo_dir/entry_point"
     assert ret["source_dir"] is None
     assert ret["dependencies"] is None

--- a/tests/unit/test_hyperparameter.py
+++ b/tests/unit/test_hyperparameter.py
@@ -20,7 +20,9 @@ class Test(object):
 
     blank = Hyperparameter(name="some-name", data_type=int)
     elizabeth = Hyperparameter(name="elizabeth")
-    validated = Hyperparameter(name="validated", validate=lambda value: value > 55, data_type=int)
+    validated = Hyperparameter(
+        name="validated", validate=lambda value: value > 55, data_type=int
+    )
 
 
 def test_blank_access():

--- a/tests/unit/test_image.py
+++ b/tests/unit/test_image.py
@@ -95,13 +95,19 @@ def test_sagemaker_container_hosts_should_have_lowercase_names():
         for host in hosts:
             assert host.lower() == host
 
-    sagemaker_container = _SageMakerContainer("local", 2, "my-image", sagemaker_session=Mock())
+    sagemaker_container = _SageMakerContainer(
+        "local", 2, "my-image", sagemaker_session=Mock()
+    )
     assert_all_lowercase(sagemaker_container.hosts)
 
-    sagemaker_container = _SageMakerContainer("local", 10, "my-image", sagemaker_session=Mock())
+    sagemaker_container = _SageMakerContainer(
+        "local", 10, "my-image", sagemaker_session=Mock()
+    )
     assert_all_lowercase(sagemaker_container.hosts)
 
-    sagemaker_container = _SageMakerContainer("local", 1, "my-image", sagemaker_session=Mock())
+    sagemaker_container = _SageMakerContainer(
+        "local", 1, "my-image", sagemaker_session=Mock()
+    )
     assert_all_lowercase(sagemaker_container.hosts)
 
 
@@ -111,7 +117,9 @@ def test_write_config_file(LocalSession, tmpdir):
     sagemaker_container.container_root = str(tmpdir.mkdir("container-root"))
     host = "algo-1"
 
-    sagemaker.local.image._create_config_file_directories(sagemaker_container.container_root, host)
+    sagemaker.local.image._create_config_file_directories(
+        sagemaker_container.container_root, host
+    )
 
     container_root = sagemaker_container.container_root
     config_file_root = os.path.join(container_root, host, "input", "config")
@@ -151,7 +159,9 @@ def test_write_config_files_input_content_type(LocalSession, tmpdir):
     sagemaker_container.container_root = str(tmpdir.mkdir("container-root"))
     host = "algo-1"
 
-    sagemaker.local.image._create_config_file_directories(sagemaker_container.container_root, host)
+    sagemaker.local.image._create_config_file_directories(
+        sagemaker_container.container_root, host
+    )
 
     container_root = sagemaker_container.container_root
     config_file_root = os.path.join(container_root, host, "input", "config")
@@ -307,7 +317,9 @@ def test_stream_output():
         )
         sagemaker.local.image._stream_output(p)
 
-    p = subprocess.Popen(["echo", "hello"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    p = subprocess.Popen(
+        ["echo", "hello"], stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    )
     exit_code = sagemaker.local.image._stream_output(p)
     assert exit_code == 0
 
@@ -332,7 +344,12 @@ def test_check_output():
 @patch("sagemaker.local.data.get_data_source_instance")
 @patch("subprocess.Popen")
 def test_train(
-    popen, get_data_source_instance, retrieve_artifacts, cleanup, tmpdir, sagemaker_session
+    popen,
+    get_data_source_instance,
+    retrieve_artifacts,
+    cleanup,
+    tmpdir,
+    sagemaker_session,
 ):
     data_source = Mock()
     data_source.get_root_dir.return_value = "foo"
@@ -340,7 +357,8 @@ def test_train(
 
     directories = [str(tmpdir.mkdir("container-root")), str(tmpdir.mkdir("data"))]
     with patch(
-        "sagemaker.local.image._SageMakerContainer._create_tmp_folder", side_effect=directories
+        "sagemaker.local.image._SageMakerContainer._create_tmp_folder",
+        side_effect=directories,
     ):
 
         instance_count = 2
@@ -383,8 +401,12 @@ def test_train(
                 )
 
         # assert that expected by sagemaker container output directories exist
-        assert os.path.exists(os.path.join(sagemaker_container.container_root, "output"))
-        assert os.path.exists(os.path.join(sagemaker_container.container_root, "output/data"))
+        assert os.path.exists(
+            os.path.join(sagemaker_container.container_root, "output")
+        )
+        assert os.path.exists(
+            os.path.join(sagemaker_container.container_root, "output/data")
+        )
 
     retrieve_artifacts.assert_called_once()
     cleanup.assert_called_once()
@@ -403,7 +425,8 @@ def test_train_with_hyperparameters_without_job_name(
 
     directories = [str(tmpdir.mkdir("container-root")), str(tmpdir.mkdir("data"))]
     with patch(
-        "sagemaker.local.image._SageMakerContainer._create_tmp_folder", side_effect=directories
+        "sagemaker.local.image._SageMakerContainer._create_tmp_folder",
+        side_effect=directories,
     ):
         instance_count = 2
         image = "my-image"
@@ -428,13 +451,20 @@ def test_train_with_hyperparameters_without_job_name(
 
 
 @patch("sagemaker.local.local_session.LocalSession", Mock())
-@patch("sagemaker.local.image._stream_output", side_effect=RuntimeError("this is expected"))
+@patch(
+    "sagemaker.local.image._stream_output", side_effect=RuntimeError("this is expected")
+)
 @patch("sagemaker.local.image._SageMakerContainer._cleanup")
 @patch("sagemaker.local.image._SageMakerContainer.retrieve_artifacts")
 @patch("sagemaker.local.data.get_data_source_instance")
 @patch("subprocess.Popen", Mock())
 def test_train_error(
-    get_data_source_instance, retrieve_artifacts, cleanup, _stream_output, tmpdir, sagemaker_session
+    get_data_source_instance,
+    retrieve_artifacts,
+    cleanup,
+    _stream_output,
+    tmpdir,
+    sagemaker_session,
 ):
     data_source = Mock()
     data_source.get_root_dir.return_value = "foo"
@@ -442,7 +472,8 @@ def test_train_error(
 
     directories = [str(tmpdir.mkdir("container-root")), str(tmpdir.mkdir("data"))]
     with patch(
-        "sagemaker.local.image._SageMakerContainer._create_tmp_folder", side_effect=directories
+        "sagemaker.local.image._SageMakerContainer._create_tmp_folder",
+        side_effect=directories,
     ):
         instance_count = 2
         image = "my-image"
@@ -452,7 +483,10 @@ def test_train_error(
 
         with pytest.raises(RuntimeError) as e:
             sagemaker_container.train(
-                INPUT_DATA_CONFIG, OUTPUT_DATA_CONFIG, HYPERPARAMETERS, TRAINING_JOB_NAME
+                INPUT_DATA_CONFIG,
+                OUTPUT_DATA_CONFIG,
+                HYPERPARAMETERS,
+                TRAINING_JOB_NAME,
             )
 
         assert "this is expected" in str(e)
@@ -473,7 +507,8 @@ def test_train_local_code(get_data_source_instance, tmpdir, sagemaker_session):
 
     directories = [str(tmpdir.mkdir("container-root")), str(tmpdir.mkdir("data"))]
     with patch(
-        "sagemaker.local.image._SageMakerContainer._create_tmp_folder", side_effect=directories
+        "sagemaker.local.image._SageMakerContainer._create_tmp_folder",
+        side_effect=directories,
     ):
         instance_count = 2
         image = "my-image"
@@ -482,7 +517,10 @@ def test_train_local_code(get_data_source_instance, tmpdir, sagemaker_session):
         )
 
         sagemaker_container.train(
-            INPUT_DATA_CONFIG, OUTPUT_DATA_CONFIG, LOCAL_CODE_HYPERPARAMETERS, TRAINING_JOB_NAME
+            INPUT_DATA_CONFIG,
+            OUTPUT_DATA_CONFIG,
+            LOCAL_CODE_HYPERPARAMETERS,
+            TRAINING_JOB_NAME,
         )
 
         docker_compose_file = os.path.join(
@@ -504,9 +542,13 @@ def test_train_local_code(get_data_source_instance, tmpdir, sagemaker_session):
             config_file_root = os.path.join(
                 sagemaker_container.container_root, h, "input", "config"
             )
-            hyperparameters_file = os.path.join(config_file_root, "hyperparameters.json")
+            hyperparameters_file = os.path.join(
+                config_file_root, "hyperparameters.json"
+            )
             hyperparameters_data = json.load(open(hyperparameters_file))
-            assert hyperparameters_data["sagemaker_submit_directory"] == json.dumps("/opt/ml/code")
+            assert hyperparameters_data["sagemaker_submit_directory"] == json.dumps(
+                "/opt/ml/code"
+            )
 
 
 @patch("sagemaker.local.local_session.LocalSession", Mock())
@@ -514,14 +556,17 @@ def test_train_local_code(get_data_source_instance, tmpdir, sagemaker_session):
 @patch("sagemaker.local.image._SageMakerContainer._cleanup", Mock())
 @patch("sagemaker.local.data.get_data_source_instance")
 @patch("subprocess.Popen", Mock())
-def test_train_local_intermediate_output(get_data_source_instance, tmpdir, sagemaker_session):
+def test_train_local_intermediate_output(
+    get_data_source_instance, tmpdir, sagemaker_session
+):
     data_source = Mock()
     data_source.get_root_dir.return_value = "foo"
     get_data_source_instance.return_value = data_source
 
     directories = [str(tmpdir.mkdir("container-root")), str(tmpdir.mkdir("data"))]
     with patch(
-        "sagemaker.local.image._SageMakerContainer._create_tmp_folder", side_effect=directories
+        "sagemaker.local.image._SageMakerContainer._create_tmp_folder",
+        side_effect=directories,
     ):
         instance_count = 2
         image = "my-image"
@@ -549,7 +594,10 @@ def test_train_local_intermediate_output(get_data_source_instance, tmpdir, sagem
                 assert config["services"][h]["image"] == image
                 assert config["services"][h]["command"] == "train"
                 volumes = config["services"][h]["volumes"]
-                assert "%s:/opt/ml/output/intermediate" % intermediate_folder_path in volumes
+                assert (
+                    "%s:/opt/ml/output/intermediate" % intermediate_folder_path
+                    in volumes
+                )
 
 
 def test_container_has_gpu_support(tmpdir, sagemaker_session):
@@ -559,7 +607,9 @@ def test_container_has_gpu_support(tmpdir, sagemaker_session):
         "local_gpu", instance_count, image, sagemaker_session=sagemaker_session
     )
 
-    docker_host = sagemaker_container._create_docker_host("host-1", {}, set(), "train", [])
+    docker_host = sagemaker_container._create_docker_host(
+        "host-1", {}, set(), "train", []
+    )
     assert "runtime" in docker_host
     assert docker_host["runtime"] == "nvidia"
 
@@ -571,12 +621,17 @@ def test_container_does_not_enable_nvidia_docker_for_cpu_containers(sagemaker_se
         "local", instance_count, image, sagemaker_session=sagemaker_session
     )
 
-    docker_host = sagemaker_container._create_docker_host("host-1", {}, set(), "train", [])
+    docker_host = sagemaker_container._create_docker_host(
+        "host-1", {}, set(), "train", []
+    )
     assert "runtime" not in docker_host
 
 
 @patch("sagemaker.local.image._HostingContainer.run", Mock())
-@patch("sagemaker.local.image._SageMakerContainer._prepare_serving_volumes", Mock(return_value=[]))
+@patch(
+    "sagemaker.local.image._SageMakerContainer._prepare_serving_volumes",
+    Mock(return_value=[]),
+)
 @patch("shutil.copy", Mock())
 @patch("shutil.copytree", Mock())
 def test_serve(tmpdir, sagemaker_session):
@@ -588,7 +643,11 @@ def test_serve(tmpdir, sagemaker_session):
         sagemaker_container = _SageMakerContainer(
             "local", 1, image, sagemaker_session=sagemaker_session
         )
-        environment = {"env1": 1, "env2": "b", "SAGEMAKER_SUBMIT_DIRECTORY": "s3://some/path"}
+        environment = {
+            "env1": 1,
+            "env2": "b",
+            "SAGEMAKER_SUBMIT_DIRECTORY": "s3://some/path",
+        }
 
         sagemaker_container.serve("/some/model/path", environment)
         docker_compose_file = os.path.join(
@@ -604,7 +663,10 @@ def test_serve(tmpdir, sagemaker_session):
 
 
 @patch("sagemaker.local.image._HostingContainer.run", Mock())
-@patch("sagemaker.local.image._SageMakerContainer._prepare_serving_volumes", Mock(return_value=[]))
+@patch(
+    "sagemaker.local.image._SageMakerContainer._prepare_serving_volumes",
+    Mock(return_value=[]),
+)
 @patch("shutil.copy", Mock())
 @patch("shutil.copytree", Mock())
 def test_serve_local_code(tmpdir, sagemaker_session):
@@ -616,7 +678,11 @@ def test_serve_local_code(tmpdir, sagemaker_session):
         sagemaker_container = _SageMakerContainer(
             "local", 1, image, sagemaker_session=sagemaker_session
         )
-        environment = {"env1": 1, "env2": "b", "SAGEMAKER_SUBMIT_DIRECTORY": "file:///tmp/code"}
+        environment = {
+            "env1": 1,
+            "env2": "b",
+            "SAGEMAKER_SUBMIT_DIRECTORY": "file:///tmp/code",
+        }
 
         sagemaker_container.serve("/some/model/path", environment)
         docker_compose_file = os.path.join(
@@ -639,7 +705,10 @@ def test_serve_local_code(tmpdir, sagemaker_session):
 
 
 @patch("sagemaker.local.image._HostingContainer.run", Mock())
-@patch("sagemaker.local.image._SageMakerContainer._prepare_serving_volumes", Mock(return_value=[]))
+@patch(
+    "sagemaker.local.image._SageMakerContainer._prepare_serving_volumes",
+    Mock(return_value=[]),
+)
 @patch("shutil.copy", Mock())
 @patch("shutil.copytree", Mock())
 def test_serve_local_code_no_env(tmpdir, sagemaker_session):
@@ -682,7 +751,9 @@ def test_prepare_serving_volumes_with_s3_model(
     get_data_source_instance.return_value = s3_data_source
     is_tarfile.return_value = True
 
-    volumes = sagemaker_container._prepare_serving_volumes("s3://bucket/my_model.tar.gz")
+    volumes = sagemaker_container._prepare_serving_volumes(
+        "s3://bucket/my_model.tar.gz"
+    )
     is_tarfile.assert_called_with("/tmp/downloaded/data/my_model.tar.gz")
 
     assert len(volumes) == 1
@@ -693,7 +764,9 @@ def test_prepare_serving_volumes_with_s3_model(
 @patch("sagemaker.local.data.get_data_source_instance")
 @patch("tarfile.is_tarfile", Mock(return_value=False))
 @patch("os.makedirs", Mock())
-def test_prepare_serving_volumes_with_local_model(get_data_source_instance, sagemaker_session):
+def test_prepare_serving_volumes_with_local_model(
+    get_data_source_instance, sagemaker_session
+):
     sagemaker_container = _SageMakerContainer(
         "local", 1, "some-image", sagemaker_session=sagemaker_session
     )
@@ -762,7 +835,8 @@ def test_ecr_login_needed(check_output):
     result = sagemaker.local.image._ecr_login_if_needed(session_mock, image)
 
     expected_command = (
-        "docker login -u AWS -p %s https://520713654638.dkr.ecr.us-east-1.amazonaws.com" % token
+        "docker login -u AWS -p %s https://520713654638.dkr.ecr.us-east-1.amazonaws.com"
+        % token
     )
 
     check_output.assert_called_with(expected_command, shell=True)
@@ -785,7 +859,9 @@ def test_pull_image(check_output):
 
 
 def test__aws_credentials_with_long_lived_credentials():
-    credentials = Credentials(access_key=_random_string(), secret_key=_random_string(), token=None)
+    credentials = Credentials(
+        access_key=_random_string(), secret_key=_random_string(), token=None
+    )
     session = Mock()
     session.get_credentials.return_value = credentials
 

--- a/tests/unit/test_inputs.py
+++ b/tests/unit/test_inputs.py
@@ -32,9 +32,7 @@ def test_s3_input_all_defaults(caplog):
     }
     assert actual.config == expected
 
-    warning_message = (
-        "'s3_input' class will be renamed to 'TrainingInput' in SageMaker Python SDK v2."
-    )
+    warning_message = "'s3_input' class will be renamed to 'TrainingInput' in SageMaker Python SDK v2."
     assert warning_message in caplog.text
 
 
@@ -155,7 +153,10 @@ def test_file_system_input_type_invalid():
             file_system_type=file_system_type,
             directory_path=directory_path,
         )
-    assert str(excinfo.value) == "Unrecognized file system type: ABC. Valid values: FSxLustre, EFS."
+    assert (
+        str(excinfo.value)
+        == "Unrecognized file system type: ABC. Valid values: FSxLustre, EFS."
+    )
 
 
 def test_file_system_input_mode_invalid():
@@ -170,4 +171,7 @@ def test_file_system_input_mode_invalid():
             directory_path=directory_path,
             file_system_access_mode=file_system_access_mode,
         )
-    assert str(excinfo.value) == "Unrecognized file system access mode: p. Valid values: ro, rw."
+    assert (
+        str(excinfo.value)
+        == "Unrecognized file system access mode: p. Valid values: ro, rw."
+    )

--- a/tests/unit/test_ipinsights.py
+++ b/tests/unit/test_ipinsights.py
@@ -33,16 +33,21 @@ COMMON_TRAIN_ARGS = {
     "train_instance_type": TRAIN_INSTANCE_TYPE,
 }
 ALL_REQ_ARGS = dict(
-    {"num_entity_vectors": NUM_ENTITY_VECTORS, "vector_dim": VECTOR_DIM}, **COMMON_TRAIN_ARGS
+    {"num_entity_vectors": NUM_ENTITY_VECTORS, "vector_dim": VECTOR_DIM},
+    **COMMON_TRAIN_ARGS
 )
 REGION = "us-west-2"
 BUCKET_NAME = "Some-Bucket"
 
-DESCRIBE_TRAINING_JOB_RESULT = {"ModelArtifacts": {"S3ModelArtifacts": "s3://bucket/model.tar.gz"}}
+DESCRIBE_TRAINING_JOB_RESULT = {
+    "ModelArtifacts": {"S3ModelArtifacts": "s3://bucket/model.tar.gz"}
+}
 
 ENDPOINT_DESC = {"EndpointConfigName": "test-endpoint"}
 
-ENDPOINT_CONFIG_DESC = {"ProductionVariants": [{"ModelName": "model-1"}, {"ModelName": "model-2"}]}
+ENDPOINT_CONFIG_DESC = {
+    "ProductionVariants": [{"ModelName": "model-1"}, {"ModelName": "model-2"}]
+}
 
 
 @pytest.fixture()
@@ -61,7 +66,9 @@ def sagemaker_session():
         name="describe_training_job", return_value=DESCRIBE_TRAINING_JOB_RESULT
     )
     sms.sagemaker_client.describe_endpoint = Mock(return_value=ENDPOINT_DESC)
-    sms.sagemaker_client.describe_endpoint_config = Mock(return_value=ENDPOINT_CONFIG_DESC)
+    sms.sagemaker_client.describe_endpoint_config = Mock(
+        return_value=ENDPOINT_CONFIG_DESC
+    )
 
     return sms
 
@@ -123,9 +130,12 @@ def test_image(sagemaker_session):
 
 
 @pytest.mark.parametrize(
-    "required_hyper_parameters, value", [("num_entity_vectors", "string"), ("vector_dim", "string")]
+    "required_hyper_parameters, value",
+    [("num_entity_vectors", "string"), ("vector_dim", "string")],
 )
-def test_required_hyper_parameters_type(sagemaker_session, required_hyper_parameters, value):
+def test_required_hyper_parameters_type(
+    sagemaker_session, required_hyper_parameters, value
+):
     with pytest.raises(ValueError):
         test_params = ALL_REQ_ARGS.copy()
         test_params[required_hyper_parameters] = value
@@ -141,7 +151,9 @@ def test_required_hyper_parameters_type(sagemaker_session, required_hyper_parame
         ("vector_dim", 4097),
     ],
 )
-def test_required_hyper_parameters_value(sagemaker_session, required_hyper_parameters, value):
+def test_required_hyper_parameters_value(
+    sagemaker_session, required_hyper_parameters, value
+):
     with pytest.raises(ValueError):
         test_params = ALL_REQ_ARGS.copy()
         test_params[required_hyper_parameters] = value
@@ -160,7 +172,9 @@ def test_required_hyper_parameters_value(sagemaker_session, required_hyper_param
         ("weight_decay", "string"),
     ],
 )
-def test_optional_hyper_parameters_type(sagemaker_session, optional_hyper_parameters, value):
+def test_optional_hyper_parameters_type(
+    sagemaker_session, optional_hyper_parameters, value
+):
     with pytest.raises(ValueError):
         test_params = ALL_REQ_ARGS.copy()
         test_params.update({optional_hyper_parameters: value})
@@ -184,7 +198,9 @@ def test_optional_hyper_parameters_type(sagemaker_session, optional_hyper_parame
         ("weight_decay", 11),
     ],
 )
-def test_optional_hyper_parameters_value(sagemaker_session, optional_hyper_parameters, value):
+def test_optional_hyper_parameters_value(
+    sagemaker_session, optional_hyper_parameters, value
+):
     with pytest.raises(ValueError):
         test_params = ALL_REQ_ARGS.copy()
         test_params.update({optional_hyper_parameters: value})

--- a/tests/unit/test_job.py
+++ b/tests/unit/test_job.py
@@ -74,7 +74,10 @@ def estimator(sagemaker_session):
 def sagemaker_session():
     boto_mock = Mock(name="boto_session")
     mock_session = Mock(
-        name="sagemaker_session", boto_session=boto_mock, s3_client=None, s3_resource=None
+        name="sagemaker_session",
+        boto_session=boto_mock,
+        s3_client=None,
+        s3_resource=None,
     )
     mock_session.expand_role = Mock(name="expand_role", return_value=ROLE)
 
@@ -88,13 +91,17 @@ class DummyFramework(Framework):
         return IMAGE_NAME
 
     def create_model(self, role=None, model_server_workers=None):
-        return DummyFrameworkModel(self.sagemaker_session, vpc_config=self.get_vpc_config())
+        return DummyFrameworkModel(
+            self.sagemaker_session, vpc_config=self.get_vpc_config()
+        )
 
     @classmethod
-    def _prepare_init_params_from_job_description(cls, job_details, model_channel_name=None):
-        init_params = super(DummyFramework, cls)._prepare_init_params_from_job_description(
-            job_details, model_channel_name
-        )
+    def _prepare_init_params_from_job_description(
+        cls, job_details, model_channel_name=None
+    ):
+        init_params = super(
+            DummyFramework, cls
+        )._prepare_init_params_from_job_description(job_details, model_channel_name)
         init_params.pop("image", None)
         return init_params
 
@@ -132,7 +139,9 @@ def test_load_config(estimator):
 
     config = _Job._load_config(inputs, estimator)
 
-    assert config["input_config"][0]["DataSource"]["S3DataSource"]["S3Uri"] == BUCKET_NAME
+    assert (
+        config["input_config"][0]["DataSource"]["S3DataSource"]["S3Uri"] == BUCKET_NAME
+    )
     assert config["role"] == ROLE
     assert config["output_config"]["S3OutputPath"] == S3_OUTPUT_PATH
     assert "KmsKeyId" not in config["output_config"]
@@ -150,7 +159,9 @@ def test_load_config_with_model_channel(estimator):
 
     config = _Job._load_config(inputs, estimator)
 
-    assert config["input_config"][0]["DataSource"]["S3DataSource"]["S3Uri"] == BUCKET_NAME
+    assert (
+        config["input_config"][0]["DataSource"]["S3DataSource"]["S3Uri"] == BUCKET_NAME
+    )
     assert config["input_config"][1]["DataSource"]["S3DataSource"]["S3Uri"] == MODEL_URI
     assert config["input_config"][1]["ChannelName"] == MODEL_CHANNEL_NAME
     assert config["role"] == ROLE
@@ -189,7 +200,9 @@ def test_load_config_with_code_channel(framework):
     config = _Job._load_config(inputs, framework)
 
     assert len(config["input_config"]) == 3
-    assert config["input_config"][0]["DataSource"]["S3DataSource"]["S3Uri"] == BUCKET_NAME
+    assert (
+        config["input_config"][0]["DataSource"]["S3DataSource"]["S3Uri"] == BUCKET_NAME
+    )
     assert config["input_config"][2]["DataSource"]["S3DataSource"]["S3Uri"] == CODE_URI
     assert config["input_config"][2]["ChannelName"] == framework.code_channel_name
     assert config["role"] == ROLE
@@ -208,7 +221,9 @@ def test_load_config_with_code_channel_no_code_uri(framework):
     config = _Job._load_config(inputs, framework)
 
     assert len(config["input_config"]) == 2
-    assert config["input_config"][0]["DataSource"]["S3DataSource"]["S3Uri"] == BUCKET_NAME
+    assert (
+        config["input_config"][0]["DataSource"]["S3DataSource"]["S3Uri"] == BUCKET_NAME
+    )
     assert config["role"] == ROLE
     assert config["output_config"]["S3OutputPath"] == S3_OUTPUT_PATH
     assert "KmsKeyId" not in config["output_config"]
@@ -255,7 +270,9 @@ def test_format_inputs_to_input_config_record_set():
     channels = _Job._format_inputs_to_input_config(inputs)
 
     assert channels[0]["DataSource"]["S3DataSource"]["S3Uri"] == inputs.s3_data
-    assert channels[0]["DataSource"]["S3DataSource"]["S3DataType"] == inputs.s3_data_type
+    assert (
+        channels[0]["DataSource"]["S3DataSource"]["S3DataType"] == inputs.s3_data_type
+    )
 
 
 def test_format_inputs_to_input_config_file_system_record_set():
@@ -272,10 +289,22 @@ def test_format_inputs_to_input_config_file_system_record_set():
         feature_dim=feature_dim,
     )
     channels = _Job._format_inputs_to_input_config(records)
-    assert channels[0]["DataSource"]["FileSystemDataSource"]["DirectoryPath"] == directory_path
-    assert channels[0]["DataSource"]["FileSystemDataSource"]["FileSystemId"] == file_system_id
-    assert channels[0]["DataSource"]["FileSystemDataSource"]["FileSystemType"] == file_system_type
-    assert channels[0]["DataSource"]["FileSystemDataSource"]["FileSystemAccessMode"] == "ro"
+    assert (
+        channels[0]["DataSource"]["FileSystemDataSource"]["DirectoryPath"]
+        == directory_path
+    )
+    assert (
+        channels[0]["DataSource"]["FileSystemDataSource"]["FileSystemId"]
+        == file_system_id
+    )
+    assert (
+        channels[0]["DataSource"]["FileSystemDataSource"]["FileSystemType"]
+        == file_system_type
+    )
+    assert (
+        channels[0]["DataSource"]["FileSystemDataSource"]["FileSystemAccessMode"]
+        == "ro"
+    )
 
 
 def test_format_inputs_to_input_config_list():
@@ -285,7 +314,9 @@ def test_format_inputs_to_input_config_list():
     channels = _Job._format_inputs_to_input_config(inputs)
 
     assert channels[0]["DataSource"]["S3DataSource"]["S3Uri"] == records.s3_data
-    assert channels[0]["DataSource"]["S3DataSource"]["S3DataType"] == records.s3_data_type
+    assert (
+        channels[0]["DataSource"]["S3DataSource"]["S3DataType"] == records.s3_data_type
+    )
 
 
 def test_format_record_set_list_input():
@@ -323,7 +354,10 @@ def test_prepare_channel(channel_uri, channel_name, content_type, input_mode):
     )
 
     assert channel["DataSource"]["S3DataSource"]["S3Uri"] == channel_uri
-    assert channel["DataSource"]["S3DataSource"]["S3DataDistributionType"] == "FullyReplicated"
+    assert (
+        channel["DataSource"]["S3DataSource"]["S3DataDistributionType"]
+        == "FullyReplicated"
+    )
     assert channel["DataSource"]["S3DataSource"]["S3DataType"] == "S3Prefix"
     assert channel["ChannelName"] == channel_name
     assert "CompressionType" not in channel
@@ -359,7 +393,9 @@ def test_prepare_channel_with_missing_name():
     with pytest.raises(ValueError) as ex:
         _Job._prepare_channel([], channel_uri=MODEL_URI, channel_name=None)
 
-    assert "Expected a channel name if a channel URI {} is specified".format(MODEL_URI) in str(ex)
+    assert "Expected a channel name if a channel URI {} is specified".format(
+        MODEL_URI
+    ) in str(ex)
 
 
 def test_prepare_channel_with_missing_uri():
@@ -403,7 +439,9 @@ def test_format_input_single_unamed_channel():
 
 
 def test_format_input_multiple_channels():
-    input_list = _Job._format_inputs_to_input_config({"a": "s3://blah/blah", "b": "s3://foo/bar"})
+    input_list = _Job._format_inputs_to_input_config(
+        {"a": "s3://blah/blah", "b": "s3://foo/bar"}
+    )
     expected = [
         {
             "ChannelName": "a",
@@ -428,7 +466,9 @@ def test_format_input_multiple_channels():
     ]
 
     # convert back into map for comparison so list order (which is arbitrary) is ignored
-    assert {c["ChannelName"]: c for c in input_list} == {c["ChannelName"]: c for c in expected}
+    assert {c["ChannelName"]: c for c in input_list} == {
+        c["ChannelName"]: c for c in expected
+    }
 
 
 def test_format_input_s3_input():
@@ -487,7 +527,9 @@ def test_dict_of_mixed_input_types():
     ]
 
     # convert back into map for comparison so list order (which is arbitrary) is ignored
-    assert {c["ChannelName"]: c for c in input_list} == {c["ChannelName"]: c for c in expected}
+    assert {c["ChannelName"]: c for c in input_list} == {
+        c["ChannelName"]: c for c in expected
+    }
 
 
 def test_format_inputs_to_input_config_exception():
@@ -535,7 +577,10 @@ def test_format_string_uri_input_string_exception():
 def test_format_string_uri_input_local_file():
     file_uri_input = _Job._format_string_uri_input(LOCAL_FILE_NAME)
 
-    assert file_uri_input.config["DataSource"]["FileDataSource"]["FileUri"] == LOCAL_FILE_NAME
+    assert (
+        file_uri_input.config["DataSource"]["FileDataSource"]["FileUri"]
+        == LOCAL_FILE_NAME
+    )
 
 
 def test_format_string_uri_input():
@@ -567,7 +612,10 @@ def test_format_model_uri_input_string():
 def test_format_model_uri_input_local_file():
     model_uri_input = _Job._format_model_uri_input(LOCAL_MODEL_NAME)
 
-    assert model_uri_input.config["DataSource"]["FileDataSource"]["FileUri"] == LOCAL_MODEL_NAME
+    assert (
+        model_uri_input.config["DataSource"]["FileDataSource"]["FileUri"]
+        == LOCAL_MODEL_NAME
+    )
 
 
 def test_format_model_uri_input_exception():

--- a/tests/unit/test_kmeans.py
+++ b/tests/unit/test_kmeans.py
@@ -33,11 +33,15 @@ ALL_REQ_ARGS = dict({"k": K}, **COMMON_TRAIN_ARGS)
 REGION = "us-west-2"
 BUCKET_NAME = "Some-Bucket"
 
-DESCRIBE_TRAINING_JOB_RESULT = {"ModelArtifacts": {"S3ModelArtifacts": "s3://bucket/model.tar.gz"}}
+DESCRIBE_TRAINING_JOB_RESULT = {
+    "ModelArtifacts": {"S3ModelArtifacts": "s3://bucket/model.tar.gz"}
+}
 
 ENDPOINT_DESC = {"EndpointConfigName": "test-endpoint"}
 
-ENDPOINT_CONFIG_DESC = {"ProductionVariants": [{"ModelName": "model-1"}, {"ModelName": "model-2"}]}
+ENDPOINT_CONFIG_DESC = {
+    "ProductionVariants": [{"ModelName": "model-1"}, {"ModelName": "model-2"}]
+}
 
 
 @pytest.fixture()
@@ -58,14 +62,20 @@ def sagemaker_session():
         name="describe_training_job", return_value=DESCRIBE_TRAINING_JOB_RESULT
     )
     sms.sagemaker_client.describe_endpoint = Mock(return_value=ENDPOINT_DESC)
-    sms.sagemaker_client.describe_endpoint_config = Mock(return_value=ENDPOINT_CONFIG_DESC)
+    sms.sagemaker_client.describe_endpoint_config = Mock(
+        return_value=ENDPOINT_CONFIG_DESC
+    )
 
     return sms
 
 
 def test_init_required_positional(sagemaker_session):
     kmeans = KMeans(
-        ROLE, TRAIN_INSTANCE_COUNT, TRAIN_INSTANCE_TYPE, K, sagemaker_session=sagemaker_session
+        ROLE,
+        TRAIN_INSTANCE_COUNT,
+        TRAIN_INSTANCE_TYPE,
+        K,
+        sagemaker_session=sagemaker_session,
     )
     assert kmeans.role == ROLE
     assert kmeans.train_instance_count == TRAIN_INSTANCE_COUNT
@@ -117,7 +127,9 @@ def test_image(sagemaker_session):
 
 
 @pytest.mark.parametrize("required_hyper_parameters, value", [("k", "string")])
-def test_required_hyper_parameters_type(sagemaker_session, required_hyper_parameters, value):
+def test_required_hyper_parameters_type(
+    sagemaker_session, required_hyper_parameters, value
+):
     with pytest.raises(ValueError):
         test_params = ALL_REQ_ARGS.copy()
         test_params[required_hyper_parameters] = value
@@ -125,7 +137,9 @@ def test_required_hyper_parameters_type(sagemaker_session, required_hyper_parame
 
 
 @pytest.mark.parametrize("required_hyper_parameters, value", [("k", 0)])
-def test_required_hyper_parameters_value(sagemaker_session, required_hyper_parameters, value):
+def test_required_hyper_parameters_value(
+    sagemaker_session, required_hyper_parameters, value
+):
     with pytest.raises(ValueError):
         test_params = ALL_REQ_ARGS.copy()
         test_params[required_hyper_parameters] = value
@@ -133,7 +147,9 @@ def test_required_hyper_parameters_value(sagemaker_session, required_hyper_param
 
 
 @pytest.mark.parametrize("iterable_hyper_parameters, value", [("eval_metrics", 0)])
-def test_iterable_hyper_parameters_type(sagemaker_session, iterable_hyper_parameters, value):
+def test_iterable_hyper_parameters_type(
+    sagemaker_session, iterable_hyper_parameters, value
+):
     with pytest.raises(TypeError):
         test_params = ALL_REQ_ARGS.copy()
         test_params.update({iterable_hyper_parameters: value})
@@ -153,7 +169,9 @@ def test_iterable_hyper_parameters_type(sagemaker_session, iterable_hyper_parame
         ("center_factor", "string"),
     ],
 )
-def test_optional_hyper_parameters_type(sagemaker_session, optional_hyper_parameters, value):
+def test_optional_hyper_parameters_type(
+    sagemaker_session, optional_hyper_parameters, value
+):
     with pytest.raises(ValueError):
         test_params = ALL_REQ_ARGS.copy()
         test_params.update({optional_hyper_parameters: value})
@@ -174,7 +192,9 @@ def test_optional_hyper_parameters_type(sagemaker_session, optional_hyper_parame
         ("center_factor", 0),
     ],
 )
-def test_optional_hyper_parameters_value(sagemaker_session, optional_hyper_parameters, value):
+def test_optional_hyper_parameters_value(
+    sagemaker_session, optional_hyper_parameters, value
+):
     with pytest.raises(ValueError):
         test_params = ALL_REQ_ARGS.copy()
         test_params.update({optional_hyper_parameters: value})
@@ -188,7 +208,9 @@ MINI_BATCH_SIZE = 200
 
 @patch("sagemaker.amazon.amazon_estimator.AmazonAlgorithmEstimatorBase.fit")
 def test_call_fit(base_fit, sagemaker_session):
-    kmeans = KMeans(base_job_name="kmeans", sagemaker_session=sagemaker_session, **ALL_REQ_ARGS)
+    kmeans = KMeans(
+        base_job_name="kmeans", sagemaker_session=sagemaker_session, **ALL_REQ_ARGS
+    )
 
     data = RecordSet(
         "s3://{}/{}".format(BUCKET_NAME, PREFIX),
@@ -206,7 +228,9 @@ def test_call_fit(base_fit, sagemaker_session):
 
 
 def test_prepare_for_training_no_mini_batch_size(sagemaker_session):
-    kmeans = KMeans(base_job_name="kmeans", sagemaker_session=sagemaker_session, **ALL_REQ_ARGS)
+    kmeans = KMeans(
+        base_job_name="kmeans", sagemaker_session=sagemaker_session, **ALL_REQ_ARGS
+    )
 
     data = RecordSet(
         "s3://{}/{}".format(BUCKET_NAME, PREFIX),
@@ -220,7 +244,9 @@ def test_prepare_for_training_no_mini_batch_size(sagemaker_session):
 
 
 def test_prepare_for_training_wrong_type_mini_batch_size(sagemaker_session):
-    kmeans = KMeans(base_job_name="kmeans", sagemaker_session=sagemaker_session, **ALL_REQ_ARGS)
+    kmeans = KMeans(
+        base_job_name="kmeans", sagemaker_session=sagemaker_session, **ALL_REQ_ARGS
+    )
 
     data = RecordSet(
         "s3://{}/{}".format(BUCKET_NAME, PREFIX),
@@ -234,7 +260,9 @@ def test_prepare_for_training_wrong_type_mini_batch_size(sagemaker_session):
 
 
 def test_prepare_for_training_wrong_value_mini_batch_size(sagemaker_session):
-    kmeans = KMeans(base_job_name="kmeans", sagemaker_session=sagemaker_session, **ALL_REQ_ARGS)
+    kmeans = KMeans(
+        base_job_name="kmeans", sagemaker_session=sagemaker_session, **ALL_REQ_ARGS
+    )
 
     data = RecordSet(
         "s3://{}/{}".format(BUCKET_NAME, PREFIX),

--- a/tests/unit/test_knn.py
+++ b/tests/unit/test_knn.py
@@ -39,11 +39,15 @@ ALL_REQ_ARGS = dict(
 REGION = "us-west-2"
 BUCKET_NAME = "Some-Bucket"
 
-DESCRIBE_TRAINING_JOB_RESULT = {"ModelArtifacts": {"S3ModelArtifacts": "s3://bucket/model.tar.gz"}}
+DESCRIBE_TRAINING_JOB_RESULT = {
+    "ModelArtifacts": {"S3ModelArtifacts": "s3://bucket/model.tar.gz"}
+}
 
 ENDPOINT_DESC = {"EndpointConfigName": "test-endpoint"}
 
-ENDPOINT_CONFIG_DESC = {"ProductionVariants": [{"ModelName": "model-1"}, {"ModelName": "model-2"}]}
+ENDPOINT_CONFIG_DESC = {
+    "ProductionVariants": [{"ModelName": "model-1"}, {"ModelName": "model-2"}]
+}
 
 
 @pytest.fixture()
@@ -64,7 +68,9 @@ def sagemaker_session():
         name="describe_training_job", return_value=DESCRIBE_TRAINING_JOB_RESULT
     )
     sms.sagemaker_client.describe_endpoint = Mock(return_value=ENDPOINT_DESC)
-    sms.sagemaker_client.describe_endpoint_config = Mock(return_value=ENDPOINT_CONFIG_DESC)
+    sms.sagemaker_client.describe_endpoint_config = Mock(
+        return_value=ENDPOINT_CONFIG_DESC
+    )
 
     return sms
 
@@ -152,15 +158,21 @@ def test_image(sagemaker_session):
     "required_hyper_parameters, value",
     [("k", "string"), ("sample_size", "string"), ("predictor_type", 1)],
 )
-def test_required_hyper_parameters_type(sagemaker_session, required_hyper_parameters, value):
+def test_required_hyper_parameters_type(
+    sagemaker_session, required_hyper_parameters, value
+):
     with pytest.raises(ValueError):
         test_params = ALL_REQ_ARGS.copy()
         test_params[required_hyper_parameters] = value
         KNN(sagemaker_session=sagemaker_session, **test_params)
 
 
-@pytest.mark.parametrize("required_hyper_parameters, value", [("predictor_type", "random_string")])
-def test_required_hyper_parameters_value(sagemaker_session, required_hyper_parameters, value):
+@pytest.mark.parametrize(
+    "required_hyper_parameters, value", [("predictor_type", "random_string")]
+)
+def test_required_hyper_parameters_value(
+    sagemaker_session, required_hyper_parameters, value
+):
     with pytest.raises(ValueError):
         test_params = ALL_REQ_ARGS.copy()
         test_params[required_hyper_parameters] = value
@@ -170,7 +182,9 @@ def test_required_hyper_parameters_value(sagemaker_session, required_hyper_param
 @pytest.mark.parametrize(
     "iterable_hyper_parameters, value", [("index_type", 1), ("index_metric", "string")]
 )
-def test_error_optional_hyper_parameters_type(sagemaker_session, iterable_hyper_parameters, value):
+def test_error_optional_hyper_parameters_type(
+    sagemaker_session, iterable_hyper_parameters, value
+):
     with pytest.raises(ValueError):
         test_params = ALL_REQ_ARGS.copy()
         test_params.update({iterable_hyper_parameters: value})
@@ -179,9 +193,15 @@ def test_error_optional_hyper_parameters_type(sagemaker_session, iterable_hyper_
 
 @pytest.mark.parametrize(
     "optional_hyper_parameters, value",
-    [("index_type", "faiss.random"), ("index_metric", "randomstring"), ("faiss_index_pq_m", -1)],
+    [
+        ("index_type", "faiss.random"),
+        ("index_metric", "randomstring"),
+        ("faiss_index_pq_m", -1),
+    ],
 )
-def test_error_optional_hyper_parameters_value(sagemaker_session, optional_hyper_parameters, value):
+def test_error_optional_hyper_parameters_value(
+    sagemaker_session, optional_hyper_parameters, value
+):
     with pytest.raises(ValueError):
         test_params = ALL_REQ_ARGS.copy()
         test_params.update({optional_hyper_parameters: value})
@@ -191,14 +211,18 @@ def test_error_optional_hyper_parameters_value(sagemaker_session, optional_hyper
 @pytest.mark.parametrize(
     "conditional_hyper_parameters",
     [
-        {"dimension_reduction_type": "sign"},  # errors due to missing dimension_reduction_target
+        {
+            "dimension_reduction_type": "sign"
+        },  # errors due to missing dimension_reduction_target
         {"dimension_reduction_type": "sign", "dimension_reduction_target": -2},
         {"dimension_reduction_type": "sign", "dimension_reduction_target": "string"},
         {"dimension_reduction_type": 2, "dimension_reduction_target": 20},
         {"dimension_reduction_type": "randomstring", "dimension_reduction_target": 20},
     ],
 )
-def test_error_conditional_hyper_parameters_value(sagemaker_session, conditional_hyper_parameters):
+def test_error_conditional_hyper_parameters_value(
+    sagemaker_session, conditional_hyper_parameters
+):
     with pytest.raises(ValueError):
         test_params = ALL_REQ_ARGS.copy()
         test_params.update(conditional_hyper_parameters)

--- a/tests/unit/test_lda.py
+++ b/tests/unit/test_lda.py
@@ -29,11 +29,15 @@ ALL_REQ_ARGS = dict({"num_topics": NUM_TOPICS}, **COMMON_TRAIN_ARGS)
 REGION = "us-west-2"
 BUCKET_NAME = "Some-Bucket"
 
-DESCRIBE_TRAINING_JOB_RESULT = {"ModelArtifacts": {"S3ModelArtifacts": "s3://bucket/model.tar.gz"}}
+DESCRIBE_TRAINING_JOB_RESULT = {
+    "ModelArtifacts": {"S3ModelArtifacts": "s3://bucket/model.tar.gz"}
+}
 
 ENDPOINT_DESC = {"EndpointConfigName": "test-endpoint"}
 
-ENDPOINT_CONFIG_DESC = {"ProductionVariants": [{"ModelName": "model-1"}, {"ModelName": "model-2"}]}
+ENDPOINT_CONFIG_DESC = {
+    "ProductionVariants": [{"ModelName": "model-1"}, {"ModelName": "model-2"}]
+}
 
 
 @pytest.fixture()
@@ -53,13 +57,17 @@ def sagemaker_session():
         name="describe_training_job", return_value=DESCRIBE_TRAINING_JOB_RESULT
     )
     sms.sagemaker_client.describe_endpoint = Mock(return_value=ENDPOINT_DESC)
-    sms.sagemaker_client.describe_endpoint_config = Mock(return_value=ENDPOINT_CONFIG_DESC)
+    sms.sagemaker_client.describe_endpoint_config = Mock(
+        return_value=ENDPOINT_CONFIG_DESC
+    )
 
     return sms
 
 
 def test_init_required_positional(sagemaker_session):
-    lda = LDA(ROLE, TRAIN_INSTANCE_TYPE, NUM_TOPICS, sagemaker_session=sagemaker_session)
+    lda = LDA(
+        ROLE, TRAIN_INSTANCE_TYPE, NUM_TOPICS, sagemaker_session=sagemaker_session
+    )
     assert lda.role == ROLE
     assert lda.train_instance_count == TRAIN_INSTANCE_COUNT
     assert lda.train_instance_type == TRAIN_INSTANCE_TYPE
@@ -99,7 +107,9 @@ def test_image(sagemaker_session):
 
 
 @pytest.mark.parametrize("required_hyper_parameters, value", [("num_topics", "string")])
-def test_required_hyper_parameters_type(sagemaker_session, required_hyper_parameters, value):
+def test_required_hyper_parameters_type(
+    sagemaker_session, required_hyper_parameters, value
+):
     with pytest.raises(ValueError):
         test_params = ALL_REQ_ARGS.copy()
         test_params[required_hyper_parameters] = value
@@ -107,7 +117,9 @@ def test_required_hyper_parameters_type(sagemaker_session, required_hyper_parame
 
 
 @pytest.mark.parametrize("required_hyper_parameters, value", [("num_topics", 0)])
-def test_required_hyper_parameters_value(sagemaker_session, required_hyper_parameters, value):
+def test_required_hyper_parameters_value(
+    sagemaker_session, required_hyper_parameters, value
+):
     with pytest.raises(ValueError):
         test_params = ALL_REQ_ARGS.copy()
         test_params[required_hyper_parameters] = value
@@ -123,7 +135,9 @@ def test_required_hyper_parameters_value(sagemaker_session, required_hyper_param
         ("tol", "string"),
     ],
 )
-def test_optional_hyper_parameters_type(sagemaker_session, optional_hyper_parameters, value):
+def test_optional_hyper_parameters_type(
+    sagemaker_session, optional_hyper_parameters, value
+):
     with pytest.raises(ValueError):
         test_params = ALL_REQ_ARGS.copy()
         test_params.update({optional_hyper_parameters: value})
@@ -131,9 +145,12 @@ def test_optional_hyper_parameters_type(sagemaker_session, optional_hyper_parame
 
 
 @pytest.mark.parametrize(
-    "optional_hyper_parameters, value", [("max_restarts", 0), ("max_iterations", 0), ("tol", 0)]
+    "optional_hyper_parameters, value",
+    [("max_restarts", 0), ("max_iterations", 0), ("tol", 0)],
 )
-def test_optional_hyper_parameters_value(sagemaker_session, optional_hyper_parameters, value):
+def test_optional_hyper_parameters_value(
+    sagemaker_session, optional_hyper_parameters, value
+):
     with pytest.raises(ValueError):
         test_params = ALL_REQ_ARGS.copy()
         test_params.update({optional_hyper_parameters: value})

--- a/tests/unit/test_linear_learner.py
+++ b/tests/unit/test_linear_learner.py
@@ -34,11 +34,15 @@ ALL_REQ_ARGS = dict({"predictor_type": PREDICTOR_TYPE}, **COMMON_TRAIN_ARGS)
 REGION = "us-west-2"
 BUCKET_NAME = "Some-Bucket"
 
-DESCRIBE_TRAINING_JOB_RESULT = {"ModelArtifacts": {"S3ModelArtifacts": "s3://bucket/model.tar.gz"}}
+DESCRIBE_TRAINING_JOB_RESULT = {
+    "ModelArtifacts": {"S3ModelArtifacts": "s3://bucket/model.tar.gz"}
+}
 
 ENDPOINT_DESC = {"EndpointConfigName": "test-endpoint"}
 
-ENDPOINT_CONFIG_DESC = {"ProductionVariants": [{"ModelName": "model-1"}, {"ModelName": "model-2"}]}
+ENDPOINT_CONFIG_DESC = {
+    "ProductionVariants": [{"ModelName": "model-1"}, {"ModelName": "model-2"}]
+}
 
 
 @pytest.fixture()
@@ -59,7 +63,9 @@ def sagemaker_session():
         name="describe_training_job", return_value=DESCRIBE_TRAINING_JOB_RESULT
     )
     sms.sagemaker_client.describe_endpoint = Mock(return_value=ENDPOINT_DESC)
-    sms.sagemaker_client.describe_endpoint_config = Mock(return_value=ENDPOINT_CONFIG_DESC)
+    sms.sagemaker_client.describe_endpoint_config = Mock(
+        return_value=ENDPOINT_CONFIG_DESC
+    )
 
     return sms
 
@@ -186,15 +192,21 @@ def test_image(sagemaker_session):
 
 
 @pytest.mark.parametrize("required_hyper_parameters, value", [("predictor_type", 0)])
-def test_required_hyper_parameters_type(sagemaker_session, required_hyper_parameters, value):
+def test_required_hyper_parameters_type(
+    sagemaker_session, required_hyper_parameters, value
+):
     with pytest.raises(ValueError):
         test_params = ALL_REQ_ARGS.copy()
         test_params[required_hyper_parameters] = value
         LinearLearner(sagemaker_session=sagemaker_session, **test_params)
 
 
-@pytest.mark.parametrize("required_hyper_parameters, value", [("predictor_type", "string")])
-def test_required_hyper_parameters_value(sagemaker_session, required_hyper_parameters, value):
+@pytest.mark.parametrize(
+    "required_hyper_parameters, value", [("predictor_type", "string")]
+)
+def test_required_hyper_parameters_value(
+    sagemaker_session, required_hyper_parameters, value
+):
     with pytest.raises(ValueError):
         test_params = ALL_REQ_ARGS.copy()
         test_params[required_hyper_parameters] = value
@@ -220,7 +232,9 @@ def test_num_classes_can_be_string_for_multiclass_classifier(sagemaker_session):
 
 
 @pytest.mark.parametrize("iterable_hyper_parameters, value", [("eval_metrics", 0)])
-def test_iterable_hyper_parameters_type(sagemaker_session, iterable_hyper_parameters, value):
+def test_iterable_hyper_parameters_type(
+    sagemaker_session, iterable_hyper_parameters, value
+):
     with pytest.raises(TypeError):
         test_params = ALL_REQ_ARGS.copy()
         test_params.update({iterable_hyper_parameters: value})
@@ -265,7 +279,9 @@ def test_iterable_hyper_parameters_type(sagemaker_session, iterable_hyper_parame
         ("f_beta", "string"),
     ],
 )
-def test_optional_hyper_parameters_type(sagemaker_session, optional_hyper_parameters, value):
+def test_optional_hyper_parameters_type(
+    sagemaker_session, optional_hyper_parameters, value
+):
     with pytest.raises(ValueError):
         test_params = ALL_REQ_ARGS.copy()
         test_params.update({optional_hyper_parameters: value})
@@ -313,7 +329,9 @@ def test_optional_hyper_parameters_type(sagemaker_session, optional_hyper_parame
         ("f_beta", -1.0),
     ],
 )
-def test_optional_hyper_parameters_value(sagemaker_session, optional_hyper_parameters, value):
+def test_optional_hyper_parameters_value(
+    sagemaker_session, optional_hyper_parameters, value
+):
     with pytest.raises(ValueError):
         test_params = ALL_REQ_ARGS.copy()
         test_params.update({optional_hyper_parameters: value})
@@ -326,7 +344,9 @@ DEFAULT_MINI_BATCH_SIZE = 1000
 
 
 def test_prepare_for_training_calculate_batch_size_1(sagemaker_session):
-    lr = LinearLearner(base_job_name="lr", sagemaker_session=sagemaker_session, **ALL_REQ_ARGS)
+    lr = LinearLearner(
+        base_job_name="lr", sagemaker_session=sagemaker_session, **ALL_REQ_ARGS
+    )
 
     data = RecordSet(
         "s3://{}/{}".format(BUCKET_NAME, PREFIX),
@@ -341,7 +361,9 @@ def test_prepare_for_training_calculate_batch_size_1(sagemaker_session):
 
 
 def test_prepare_for_training_calculate_batch_size_2(sagemaker_session):
-    lr = LinearLearner(base_job_name="lr", sagemaker_session=sagemaker_session, **ALL_REQ_ARGS)
+    lr = LinearLearner(
+        base_job_name="lr", sagemaker_session=sagemaker_session, **ALL_REQ_ARGS
+    )
 
     data = RecordSet(
         "s3://{}/{}".format(BUCKET_NAME, PREFIX),
@@ -356,7 +378,9 @@ def test_prepare_for_training_calculate_batch_size_2(sagemaker_session):
 
 
 def test_prepare_for_training_multiple_channel(sagemaker_session):
-    lr = LinearLearner(base_job_name="lr", sagemaker_session=sagemaker_session, **ALL_REQ_ARGS)
+    lr = LinearLearner(
+        base_job_name="lr", sagemaker_session=sagemaker_session, **ALL_REQ_ARGS
+    )
 
     data = RecordSet(
         "s3://{}/{}".format(BUCKET_NAME, PREFIX),
@@ -371,7 +395,9 @@ def test_prepare_for_training_multiple_channel(sagemaker_session):
 
 
 def test_prepare_for_training_multiple_channel_no_train(sagemaker_session):
-    lr = LinearLearner(base_job_name="lr", sagemaker_session=sagemaker_session, **ALL_REQ_ARGS)
+    lr = LinearLearner(
+        base_job_name="lr", sagemaker_session=sagemaker_session, **ALL_REQ_ARGS
+    )
 
     data = RecordSet(
         "s3://{}/{}".format(BUCKET_NAME, PREFIX),
@@ -388,7 +414,9 @@ def test_prepare_for_training_multiple_channel_no_train(sagemaker_session):
 
 @patch("sagemaker.amazon.amazon_estimator.AmazonAlgorithmEstimatorBase.fit")
 def test_call_fit_pass_batch_size(base_fit, sagemaker_session):
-    lr = LinearLearner(base_job_name="lr", sagemaker_session=sagemaker_session, **ALL_REQ_ARGS)
+    lr = LinearLearner(
+        base_job_name="lr", sagemaker_session=sagemaker_session, **ALL_REQ_ARGS
+    )
 
     data = RecordSet(
         "s3://{}/{}".format(BUCKET_NAME, PREFIX),

--- a/tests/unit/test_local_data.py
+++ b/tests/unit/test_local_data.py
@@ -22,7 +22,9 @@ import sagemaker.local.data
 
 
 @patch("sagemaker.local.data.LocalFileDataSource")
-def test_get_data_source_instance_with_file(LocalFileDataSource, sagemaker_local_session):
+def test_get_data_source_instance_with_file(
+    LocalFileDataSource, sagemaker_local_session
+):
     # file
     data_source = sagemaker.local.data.get_data_source_instance(
         "file:///my/file", sagemaker_local_session
@@ -53,7 +55,12 @@ def test_get_data_source_instance_with_s3(S3DataSource, sagemaker_local_session)
 @patch("os.listdir")
 def test_file_data_source_get_file_list_with_folder(listdir):
     data_source = sagemaker.local.data.LocalFileDataSource("/some/path/")
-    listdir.return_value = ["/some/path/a", "/some/path/b", "/some/path/c/", "/some/path/c/a"]
+    listdir.return_value = [
+        "/some/path/a",
+        "/some/path/b",
+        "/some/path/c/",
+        "/some/path/c/a",
+    ]
     expected = ["/some/path/a", "/some/path/b", "/some/path/c/a"]
     result = data_source.get_file_list()
     assert result == expected
@@ -123,10 +130,14 @@ def test_none_splitter(tmpdir):
     test_bin_file_path = tmpdir.join("none_test.bin")
 
     with test_bin_file_path.open("wb") as f:
-        f.write(b"\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00C")
+        f.write(
+            b"\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00C"
+        )
 
     data = [x for x in splitter.split(str(test_bin_file_path))]
-    assert data == [b"\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00C"]
+    assert data == [
+        b"\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00C"
+    ]
 
 
 def test_line_splitter(tmpdir):

--- a/tests/unit/test_local_entities.py
+++ b/tests/unit/test_local_entities.py
@@ -99,7 +99,9 @@ def test_local_transform_job_defaults_with_max_payload(local_transform_job):
 @patch("sagemaker.local.entities._wait_for_serving_container", Mock())
 @patch("sagemaker.local.entities._perform_request")
 @patch("sagemaker.local.entities._LocalTransformJob._perform_batch_inference")
-def test_start_local_transform_job(_perform_batch_inference, _perform_request, local_transform_job):
+def test_start_local_transform_job(
+    _perform_batch_inference, _perform_request, local_transform_job
+):
     input_data = {}
     output_data = {}
     transform_resources = {"InstanceType": "local"}
@@ -108,7 +110,9 @@ def test_start_local_transform_job(_perform_batch_inference, _perform_request, l
     _perform_request.return_value = (response, 200)
     response.read.return_value = '{"BatchStrategy": "SingleRecord"}'
     local_transform_job.primary_container["ModelDataUrl"] = "file:///some/model"
-    local_transform_job.start(input_data, output_data, transform_resources, Environment={})
+    local_transform_job.start(
+        input_data, output_data, transform_resources, Environment={}
+    )
 
     _perform_batch_inference.assert_called()
     response = local_transform_job.describe()
@@ -155,7 +159,9 @@ def test_local_transform_job_perform_batch_inference(
 
     local_transform_job.container = Mock()
 
-    local_transform_job._perform_batch_inference(input_data, output_data, **transform_kwargs)
+    local_transform_job._perform_batch_inference(
+        input_data, output_data, **transform_kwargs
+    )
 
     dir, output, job_name, session = move_to_destination.call_args[0]
     assert output == "s3://bucket/output"

--- a/tests/unit/test_local_session.py
+++ b/tests/unit/test_local_session.py
@@ -32,14 +32,20 @@ ENDPOINT_CONFIG_NAME = "test-endpoint-config"
 PRODUCTION_VARIANTS = [{"InstanceType": "ml.c4.99xlarge", "InitialInstanceCount": 10}]
 
 MODEL_NAME = "test-model"
-PRIMARY_CONTAINER = {"ModelDataUrl": "/some/model/path", "Environment": {"env1": 1, "env2": "b"}}
+PRIMARY_CONTAINER = {
+    "ModelDataUrl": "/some/model/path",
+    "Environment": {"env1": 1, "env2": "b"},
+}
 
 ENDPOINT_URL = "http://127.0.0.1:9000"
 BUCKET_NAME = "mybucket"
 LS_FILES = {"Contents": [{"Key": "/data/test.csv"}]}
 
 
-@patch("sagemaker.local.image._SageMakerContainer.train", return_value="/some/path/to/model")
+@patch(
+    "sagemaker.local.image._SageMakerContainer.train",
+    return_value="/some/path/to/model",
+)
 @patch("sagemaker.local.local_session.LocalSession")
 def test_create_training_job(train, LocalSession):
     local_sagemaker_client = sagemaker.local.local_session.LocalSagemakerClient()
@@ -91,7 +97,8 @@ def test_create_training_job(train, LocalSession):
 
     assert response["TrainingJobStatus"] == expected["TrainingJobStatus"]
     assert (
-        response["ResourceConfig"]["InstanceCount"] == expected["ResourceConfig"]["InstanceCount"]
+        response["ResourceConfig"]["InstanceCount"]
+        == expected["ResourceConfig"]["InstanceCount"]
     )
     assert (
         response["ModelArtifacts"]["S3ModelArtifacts"]
@@ -106,7 +113,10 @@ def test_describe_invalid_training_job(*args):
         local_sagemaker_client.describe_training_job("i-havent-created-this-job")
 
 
-@patch("sagemaker.local.image._SageMakerContainer.train", return_value="/some/path/to/model")
+@patch(
+    "sagemaker.local.image._SageMakerContainer.train",
+    return_value="/some/path/to/model",
+)
 @patch("sagemaker.local.local_session.LocalSession")
 def test_create_training_job_invalid_data_source(train, LocalSession):
     local_sagemaker_client = sagemaker.local.local_session.LocalSagemakerClient()
@@ -145,7 +155,10 @@ def test_create_training_job_invalid_data_source(train, LocalSession):
         )
 
 
-@patch("sagemaker.local.image._SageMakerContainer.train", return_value="/some/path/to/model")
+@patch(
+    "sagemaker.local.image._SageMakerContainer.train",
+    return_value="/some/path/to/model",
+)
 @patch("sagemaker.local.local_session.LocalSession")
 def test_create_training_job_not_fully_replicated(train, LocalSession):
     local_sagemaker_client = sagemaker.local.local_session.LocalSagemakerClient()
@@ -222,7 +235,9 @@ def test_describe_model(LocalSession):
 def test_create_transform_job(LocalSession, _LocalTransformJob):
     local_sagemaker_client = sagemaker.local.local_session.LocalSagemakerClient()
 
-    local_sagemaker_client.create_transform_job("transform-job", "some-model", None, None, None)
+    local_sagemaker_client.create_transform_job(
+        "transform-job", "some-model", None, None, None
+    )
     _LocalTransformJob().start.assert_called_with(None, None, None)
 
     local_sagemaker_client.describe_transform_job("transform-job")
@@ -246,8 +261,12 @@ def test_describe_endpoint_config(LocalSession):
     with pytest.raises(ClientError):
         local_sagemaker_client.describe_endpoint_config("some-endpoint-config")
 
-    production_variants = [{"InstanceType": "ml.c4.99xlarge", "InitialInstanceCount": 10}]
-    local_sagemaker_client.create_endpoint_config("test-endpoint-config", production_variants)
+    production_variants = [
+        {"InstanceType": "ml.c4.99xlarge", "InitialInstanceCount": 10}
+    ]
+    local_sagemaker_client.create_endpoint_config(
+        "test-endpoint-config", production_variants
+    )
 
     response = local_sagemaker_client.describe_endpoint_config("test-endpoint-config")
     assert response["EndpointConfigName"] == "test-endpoint-config"
@@ -257,10 +276,13 @@ def test_describe_endpoint_config(LocalSession):
 @patch("sagemaker.local.local_session.LocalSession")
 def test_create_endpoint_config(LocalSession):
     local_sagemaker_client = sagemaker.local.local_session.LocalSagemakerClient()
-    local_sagemaker_client.create_endpoint_config(ENDPOINT_CONFIG_NAME, PRODUCTION_VARIANTS)
+    local_sagemaker_client.create_endpoint_config(
+        ENDPOINT_CONFIG_NAME, PRODUCTION_VARIANTS
+    )
 
     assert (
-        ENDPOINT_CONFIG_NAME in sagemaker.local.local_session.LocalSagemakerClient._endpoint_configs
+        ENDPOINT_CONFIG_NAME
+        in sagemaker.local.local_session.LocalSagemakerClient._endpoint_configs
     )
 
 
@@ -268,9 +290,12 @@ def test_create_endpoint_config(LocalSession):
 def test_delete_endpoint_config(LocalSession):
     local_sagemaker_client = sagemaker.local.local_session.LocalSagemakerClient()
 
-    local_sagemaker_client.create_endpoint_config(ENDPOINT_CONFIG_NAME, PRODUCTION_VARIANTS)
+    local_sagemaker_client.create_endpoint_config(
+        ENDPOINT_CONFIG_NAME, PRODUCTION_VARIANTS
+    )
     assert (
-        ENDPOINT_CONFIG_NAME in sagemaker.local.local_session.LocalSagemakerClient._endpoint_configs
+        ENDPOINT_CONFIG_NAME
+        in sagemaker.local.local_session.LocalSagemakerClient._endpoint_configs
     )
 
     local_sagemaker_client.delete_endpoint_config(ENDPOINT_CONFIG_NAME)
@@ -363,7 +388,9 @@ def test_create_endpoint(describe_model, describe_endpoint_config, request, *arg
 
     local_sagemaker_client.create_endpoint("my-endpoint", "some-endpoint-config")
 
-    assert "my-endpoint" in sagemaker.local.local_session.LocalSagemakerClient._endpoints
+    assert (
+        "my-endpoint" in sagemaker.local.local_session.LocalSagemakerClient._endpoints
+    )
 
 
 @patch("sagemaker.local.local_session.LocalSession")
@@ -409,7 +436,9 @@ def test_serve_endpoint_with_correct_accelerator(request, *args):
     endpoint.serve()
 
     assert (
-        endpoint.primary_container["Environment"]["SAGEMAKER_INFERENCE_ACCELERATOR_PRESENT"]
+        endpoint.primary_container["Environment"][
+            "SAGEMAKER_INFERENCE_ACCELERATOR_PRESENT"
+        ]
         == "true"
     )
 
@@ -448,7 +477,9 @@ def test_serve_endpoint_with_incorrect_accelerator(request, *args):
 
     with pytest.raises(KeyError):
         assert (
-            endpoint.primary_container["Environment"]["SAGEMAKER_INFERENCE_ACCELERATOR_PRESENT"]
+            endpoint.primary_container["Environment"][
+                "SAGEMAKER_INFERENCE_ACCELERATOR_PRESENT"
+            ]
             == "true"
         )
 
@@ -458,7 +489,10 @@ def test_file_input_all_defaults():
     actual = sagemaker.local.local_session.file_input(fileUri=prefix)
     expected = {
         "DataSource": {
-            "FileDataSource": {"FileDataDistributionType": "FullyReplicated", "FileUri": prefix}
+            "FileDataSource": {
+                "FileDataDistributionType": "FullyReplicated",
+                "FileUri": prefix,
+            }
         }
     }
     assert actual.config == expected
@@ -466,10 +500,15 @@ def test_file_input_all_defaults():
 
 def test_file_input_content_type():
     prefix = "pre"
-    actual = sagemaker.local.local_session.file_input(fileUri=prefix, content_type="text/csv")
+    actual = sagemaker.local.local_session.file_input(
+        fileUri=prefix, content_type="text/csv"
+    )
     expected = {
         "DataSource": {
-            "FileDataSource": {"FileDataDistributionType": "FullyReplicated", "FileUri": prefix}
+            "FileDataSource": {
+                "FileDataDistributionType": "FullyReplicated",
+                "FileUri": prefix,
+            }
         },
         "ContentType": "text/csv",
     }
@@ -478,7 +517,9 @@ def test_file_input_content_type():
 
 def test_local_session_is_set_to_local_mode():
     boto_session = Mock(region_name="us-west-2")
-    local_session = sagemaker.local.local_session.LocalSession(boto_session=boto_session)
+    local_session = sagemaker.local.local_session.LocalSession(
+        boto_session=boto_session
+    )
     assert local_session.local_mode
 
 
@@ -512,13 +553,17 @@ def test_local_session_with_custom_s3_endpoint_url(sagemaker_session_custom_endp
     assert sagemaker_session_custom_endpoint.s3_resource is not None
 
 
-def test_local_session_download_with_custom_s3_endpoint_url(sagemaker_session_custom_endpoint):
+def test_local_session_download_with_custom_s3_endpoint_url(
+    sagemaker_session_custom_endpoint,
+):
 
     DOWNLOAD_DATA_TESTS_FILES_DIR = os.path.join(DATA_DIR, "download_data_tests")
     sagemaker_session_custom_endpoint.s3_client.list_objects_v2 = Mock(
         name="list_objects_v2", return_value=LS_FILES
     )
-    sagemaker_session_custom_endpoint.s3_client.download_file = Mock(name="download_file")
+    sagemaker_session_custom_endpoint.s3_client.download_file = Mock(
+        name="download_file"
+    )
 
     sagemaker_session_custom_endpoint.download_data(
         DOWNLOAD_DATA_TESTS_FILES_DIR, BUCKET_NAME, key_prefix="/data/test.csv"

--- a/tests/unit/test_local_utils.py
+++ b/tests/unit/test_local_utils.py
@@ -22,7 +22,9 @@ import sagemaker.local.utils
 @patch("sagemaker.local.utils.recursive_copy")
 def test_move_to_destination_local(recursive_copy):
     # local files will just be recursively copied
-    sagemaker.local.utils.move_to_destination("/tmp/data", "file:///target/dir/", "job", None)
+    sagemaker.local.utils.move_to_destination(
+        "/tmp/data", "file:///target/dir/", "job", None
+    )
     recursive_copy.assert_called_with("/tmp/data", "/target/dir/")
 
 
@@ -32,12 +34,16 @@ def test_move_to_destination_s3(recursive_copy):
     sms = Mock()
 
     # without trailing slash in prefix
-    sagemaker.local.utils.move_to_destination("/tmp/data", "s3://bucket/path", "job", sms)
+    sagemaker.local.utils.move_to_destination(
+        "/tmp/data", "s3://bucket/path", "job", sms
+    )
     sms.upload_data.assert_called_with("/tmp/data", "bucket", "path/job")
     recursive_copy.assert_not_called()
 
     # with trailing slash in prefix
-    sagemaker.local.utils.move_to_destination("/tmp/data", "s3://bucket/path/", "job", sms)
+    sagemaker.local.utils.move_to_destination(
+        "/tmp/data", "s3://bucket/path/", "job", sms
+    )
     sms.upload_data.assert_called_with("/tmp/data", "bucket", "path/job")
 
     # without path, with trailing slash
@@ -51,4 +57,6 @@ def test_move_to_destination_s3(recursive_copy):
 
 def test_move_to_destination_illegal_destination():
     with pytest.raises(ValueError):
-        sagemaker.local.utils.move_to_destination("/tmp/data", "ftp://ftp/in/2018", "job", None)
+        sagemaker.local.utils.move_to_destination(
+            "/tmp/data", "ftp://ftp/in/2018", "job", None
+        )

--- a/tests/unit/test_multidatamodel.py
+++ b/tests/unit/test_multidatamodel.py
@@ -35,7 +35,9 @@ REGION = "us-west-2"
 ROLE = "DummyRole"
 MODEL_NAME = "dummy-model"
 VALID_MULTI_MODEL_DATA_PREFIX = "s3://mybucket/path/"
-INVALID_S3_URL = "https://my-training-bucket.s3.myregion.amazonaws.com/output/model.tar.gz"
+INVALID_S3_URL = (
+    "https://my-training-bucket.s3.myregion.amazonaws.com/output/model.tar.gz"
+)
 VALID_S3_URL = "s3://my-training-bucket/output/model.tar.gz"
 S3_URL_SOURCE_BUCKET = "my-training-bucket"
 S3_URL_SOURCE_PREFIX = "output/model.tar.gz"
@@ -68,7 +70,9 @@ def sagemaker_session():
         s3_client=None,
     )
     session.sagemaker_client.describe_endpoint = Mock(return_value=ENDPOINT_DESC)
-    session.sagemaker_client.describe_endpoint_config = Mock(return_value=ENDPOINT_CONFIG_DESC)
+    session.sagemaker_client.describe_endpoint_config = Mock(
+        return_value=ENDPOINT_CONFIG_DESC
+    )
     session.list_s3_files(
         bucket=S3_URL_SOURCE_BUCKET, key_prefix=S3_URL_SOURCE_PREFIX
     ).return_value = Mock()
@@ -79,7 +83,9 @@ def sagemaker_session():
 
     s3_mock = Mock()
     boto_mock.client("s3").return_value = s3_mock
-    boto_mock.client("s3").get_paginator("list_objects_v2").paginate.return_value = Mock()
+    boto_mock.client("s3").get_paginator(
+        "list_objects_v2"
+    ).paginate.return_value = Mock()
     s3_mock.reset_mock()
 
     return session
@@ -112,7 +118,10 @@ def test_multi_data_model_create_with_invalid_model_data_prefix():
     invalid_model_data_prefix = "https://mybucket/path/"
     with pytest.raises(ValueError) as ex:
         MultiDataModel(
-            name=MODEL_NAME, model_data_prefix=invalid_model_data_prefix, image=IMAGE, role=ROLE
+            name=MODEL_NAME,
+            model_data_prefix=invalid_model_data_prefix,
+            image=IMAGE,
+            role=ROLE,
         )
     err_msg = 'ValueError: Expecting S3 model prefix beginning with "s3://". Received: "{}"'.format(
         invalid_model_data_prefix
@@ -156,7 +165,9 @@ def test_multi_data_model_create(sagemaker_session):
 @patch("sagemaker.multidatamodel.Session", MagicMock())
 def test_multi_data_model_create_with_model_arg_only(mxnet_model):
     model = MultiDataModel(
-        name=MODEL_NAME, model_data_prefix=VALID_MULTI_MODEL_DATA_PREFIX, model=mxnet_model
+        name=MODEL_NAME,
+        model_data_prefix=VALID_MULTI_MODEL_DATA_PREFIX,
+        model=mxnet_model,
     )
 
     assert model.model_data_prefix == VALID_MULTI_MODEL_DATA_PREFIX
@@ -304,16 +315,22 @@ def test_deploy_model_update(sagemaker_session):
 
 
 def test_add_model_local_file_path(multi_data_model):
-    valid_local_model_artifact_path = os.path.join(DATA_DIR, "sparkml_model", "mleap_model.tar.gz")
+    valid_local_model_artifact_path = os.path.join(
+        DATA_DIR, "sparkml_model", "mleap_model.tar.gz"
+    )
     uploaded_s3_path = multi_data_model.add_model(valid_local_model_artifact_path)
 
-    assert uploaded_s3_path == os.path.join(VALID_MULTI_MODEL_DATA_PREFIX, "mleap_model.tar.gz")
+    assert uploaded_s3_path == os.path.join(
+        VALID_MULTI_MODEL_DATA_PREFIX, "mleap_model.tar.gz"
+    )
 
 
 def test_add_model_s3_path(multi_data_model):
     uploaded_s3_path = multi_data_model.add_model(VALID_S3_URL)
 
-    assert uploaded_s3_path == os.path.join(VALID_MULTI_MODEL_DATA_PREFIX, "output/model.tar.gz")
+    assert uploaded_s3_path == os.path.join(
+        VALID_MULTI_MODEL_DATA_PREFIX, "output/model.tar.gz"
+    )
     multi_data_model.s3_client.copy.assert_called()
     calls = [
         call(
@@ -326,7 +343,9 @@ def test_add_model_s3_path(multi_data_model):
 
 
 def test_add_model_with_dst_path(multi_data_model):
-    uploaded_s3_path = multi_data_model.add_model(VALID_S3_URL, "customer-a/model.tar.gz")
+    uploaded_s3_path = multi_data_model.add_model(
+        VALID_S3_URL, "customer-a/model.tar.gz"
+    )
 
     assert uploaded_s3_path == os.path.join(
         VALID_MULTI_MODEL_DATA_PREFIX, "customer-a/model.tar.gz"

--- a/tests/unit/test_mxnet.py
+++ b/tests/unit/test_mxnet.py
@@ -52,7 +52,9 @@ LAUNCH_PS_DISTRIBUTIONS_DICT = {"parameter_server": {"enabled": True}}
 
 ENDPOINT_DESC = {"EndpointConfigName": "test-endpoint"}
 
-ENDPOINT_CONFIG_DESC = {"ProductionVariants": [{"ModelName": "model-1"}, {"ModelName": "model-2"}]}
+ENDPOINT_CONFIG_DESC = {
+    "ProductionVariants": [{"ModelName": "model-1"}, {"ModelName": "model-2"}]
+}
 
 LIST_TAGS_RESULT = {"Tags": [{"Key": "TagtestKey", "Value": "TagtestValue"}]}
 
@@ -77,10 +79,14 @@ def sagemaker_session():
     )
 
     describe = {"ModelArtifacts": {"S3ModelArtifacts": "s3://m/m.tar.gz"}}
-    describe_compilation = {"ModelArtifacts": {"S3ModelArtifacts": "s3://m/model_c5.tar.gz"}}
+    describe_compilation = {
+        "ModelArtifacts": {"S3ModelArtifacts": "s3://m/model_c5.tar.gz"}
+    }
     session.sagemaker_client.describe_training_job = Mock(return_value=describe)
     session.sagemaker_client.describe_endpoint = Mock(return_value=ENDPOINT_DESC)
-    session.sagemaker_client.describe_endpoint_config = Mock(return_value=ENDPOINT_CONFIG_DESC)
+    session.sagemaker_client.describe_endpoint_config = Mock(
+        return_value=ENDPOINT_CONFIG_DESC
+    )
     session.sagemaker_client.list_tags = Mock(return_value=LIST_TAGS_RESULT)
     session.wait_for_compilation_job = Mock(return_value=describe_compilation)
     session.default_bucket = Mock(name="default_bucket", return_value=BUCKET_NAME)
@@ -100,11 +106,15 @@ def skip_if_not_mms_version(mxnet_version):
         pytest.skip("Skipping because this version does not use MMS")
 
 
-def _get_full_image_uri(version, repo=IMAGE_REPO_NAME, processor="cpu", py_version="py2"):
+def _get_full_image_uri(
+    version, repo=IMAGE_REPO_NAME, processor="cpu", py_version="py2"
+):
     return FULL_IMAGE_URI.format(repo, version, processor, py_version)
 
 
-def _get_full_image_uri_with_ei(version, repo=IMAGE_REPO_NAME, processor="cpu", py_version="py2"):
+def _get_full_image_uri_with_ei(
+    version, repo=IMAGE_REPO_NAME, processor="cpu", py_version="py2"
+):
     return FULL_IMAGE_URI.format("{}-eia".format(repo), version, processor, py_version)
 
 
@@ -161,7 +171,10 @@ def _create_compilation_job(input_shape, output_location):
             "S3Uri": "s3://m/m.tar.gz",
         },
         "job_name": COMPILATION_JOB_NAME,
-        "output_model_config": {"S3OutputLocation": output_location, "TargetDevice": "ml_c4"},
+        "output_model_config": {
+            "S3OutputLocation": output_location,
+            "TargetDevice": "ml_c4",
+        },
         "role": ROLE,
         "stop_condition": {"MaxRuntimeInSeconds": 900},
         "tags": None,
@@ -296,7 +309,9 @@ def test_mxnet(strftime, sagemaker_session, mxnet_version, skip_if_mms_version):
     assert boto_call_names == ["resource"]
 
     expected_train_args = _create_train_job(mxnet_version)
-    expected_train_args["input_config"][0]["DataSource"]["S3DataSource"]["S3Uri"] = inputs
+    expected_train_args["input_config"][0]["DataSource"]["S3DataSource"][
+        "S3Uri"
+    ] = inputs
     expected_train_args["experiment_config"] = EXPERIMENT_CONFIG
 
     actual_train_args = sagemaker_session.method_calls[0][2]
@@ -304,7 +319,9 @@ def test_mxnet(strftime, sagemaker_session, mxnet_version, skip_if_mms_version):
 
     model = mx.create_model()
 
-    expected_image_base = "520713654638.dkr.ecr.us-west-2.amazonaws.com/sagemaker-mxnet:{}-gpu-py2"
+    expected_image_base = (
+        "520713654638.dkr.ecr.us-west-2.amazonaws.com/sagemaker-mxnet:{}-gpu-py2"
+    )
     environment = {
         "Environment": {
             "SAGEMAKER_SUBMIT_DIRECTORY": "s3://mybucket/sagemaker-mxnet-{}/source/sourcedir.tar.gz".format(
@@ -349,14 +366,18 @@ def test_mxnet_mms_version(
     assert boto_call_names == ["resource"]
 
     expected_train_args = _create_train_job(mxnet_version)
-    expected_train_args["input_config"][0]["DataSource"]["S3DataSource"]["S3Uri"] = inputs
+    expected_train_args["input_config"][0]["DataSource"]["S3DataSource"][
+        "S3Uri"
+    ] = inputs
 
     actual_train_args = sagemaker_session.method_calls[0][2]
     assert actual_train_args == expected_train_args
 
     model = mx.create_model()
 
-    expected_image_base = _get_full_image_uri(mxnet_version, IMAGE_REPO_SERVING_NAME, "gpu")
+    expected_image_base = _get_full_image_uri(
+        mxnet_version, IMAGE_REPO_SERVING_NAME, "gpu"
+    )
 
     environment = {
         "Environment": {
@@ -396,7 +417,9 @@ def test_mxnet_neo(strftime, sagemaker_session, mxnet_version, skip_if_mms_versi
     output_location = "s3://neo-sdk-test"
 
     compiled_model = mx.compile_model(
-        target_instance_family="ml_c4", input_shape=input_shape, output_path=output_location
+        target_instance_family="ml_c4",
+        input_shape=input_shape,
+        output_path=output_location,
     )
 
     sagemaker_call_names = [c[0] for c in sagemaker_session.method_calls]
@@ -408,7 +431,9 @@ def test_mxnet_neo(strftime, sagemaker_session, mxnet_version, skip_if_mms_versi
         "wait_for_compilation_job",
     ]
 
-    expected_compile_model_args = _create_compilation_job(json.dumps(input_shape), output_location)
+    expected_compile_model_args = _create_compilation_job(
+        json.dumps(input_shape), output_location
+    )
     actual_compile_model_args = sagemaker_session.method_calls[3][2]
     assert expected_compile_model_args == actual_compile_model_args
 
@@ -428,7 +453,10 @@ def test_mxnet_neo(strftime, sagemaker_session, mxnet_version, skip_if_mms_versi
 @patch("sagemaker.utils.create_tar_file", MagicMock())
 def test_model(sagemaker_session):
     model = MXNetModel(
-        MODEL_DATA, role=ROLE, entry_point=SCRIPT_PATH, sagemaker_session=sagemaker_session
+        MODEL_DATA,
+        role=ROLE,
+        entry_point=SCRIPT_PATH,
+        sagemaker_session=sagemaker_session,
     )
     predictor = model.deploy(1, GPU)
     assert isinstance(predictor, MXNetPredictor)
@@ -470,9 +498,14 @@ def test_model_mms_version(repack_model, sagemaker_session):
 @patch("sagemaker.fw_utils.tar_and_upload_dir", MagicMock())
 def test_model_image_accelerator(sagemaker_session):
     model = MXNetModel(
-        MODEL_DATA, role=ROLE, entry_point=SCRIPT_PATH, sagemaker_session=sagemaker_session
+        MODEL_DATA,
+        role=ROLE,
+        entry_point=SCRIPT_PATH,
+        sagemaker_session=sagemaker_session,
     )
-    container_def = model.prepare_container_def(INSTANCE_TYPE, accelerator_type=ACCELERATOR_TYPE)
+    container_def = model.prepare_container_def(
+        INSTANCE_TYPE, accelerator_type=ACCELERATOR_TYPE
+    )
     assert container_def["Image"] == _get_full_image_uri_with_ei(defaults.MXNET_VERSION)
 
 
@@ -485,7 +518,9 @@ def test_model_image_accelerator_mms_version(sagemaker_session):
         framework_version=MXNetModel._LOWEST_MMS_VERSION,
         sagemaker_session=sagemaker_session,
     )
-    container_def = model.prepare_container_def(INSTANCE_TYPE, accelerator_type=ACCELERATOR_TYPE)
+    container_def = model.prepare_container_def(
+        INSTANCE_TYPE, accelerator_type=ACCELERATOR_TYPE
+    )
     assert container_def["Image"] == _get_full_image_uri_with_ei(
         MXNetModel._LOWEST_MMS_VERSION, IMAGE_REPO_SERVING_NAME
     )
@@ -497,7 +532,9 @@ def test_model_prepare_container_def_no_instance_type_or_image():
     with pytest.raises(ValueError) as e:
         model.prepare_container_def()
 
-    expected_msg = "Must supply either an instance type (for choosing CPU vs GPU) or an image URI."
+    expected_msg = (
+        "Must supply either an instance type (for choosing CPU vs GPU) or an image URI."
+    )
     assert expected_msg in str(e)
 
 
@@ -518,7 +555,10 @@ def test_attach(sagemaker_session, mxnet_version):
         mxnet_version
     )
     returned_job_description = {
-        "AlgorithmSpecification": {"TrainingInputMode": "File", "TrainingImage": training_image},
+        "AlgorithmSpecification": {
+            "TrainingInputMode": "File",
+            "TrainingImage": training_image,
+        },
         "HyperParameters": {
             "sagemaker_submit_directory": '"s3://some/sourcedir.tar.gz"',
             "sagemaker_program": '"iris-dnn-classifier.py"',
@@ -546,7 +586,9 @@ def test_attach(sagemaker_session, mxnet_version):
         name="describe_training_job", return_value=returned_job_description
     )
 
-    estimator = MXNet.attach(training_job_name="neo", sagemaker_session=sagemaker_session)
+    estimator = MXNet.attach(
+        training_job_name="neo", sagemaker_session=sagemaker_session
+    )
     assert estimator.latest_training_job.job_name == "neo"
     assert estimator.py_version == "py2"
     assert estimator.framework_version == mxnet_version
@@ -596,7 +638,9 @@ def test_attach_old_container(sagemaker_session):
         name="describe_training_job", return_value=returned_job_description
     )
 
-    estimator = MXNet.attach(training_job_name="neo", sagemaker_session=sagemaker_session)
+    estimator = MXNet.attach(
+        training_job_name="neo", sagemaker_session=sagemaker_session
+    )
     assert estimator.latest_training_job.job_name == "neo"
     assert estimator.py_version == "py2"
     assert estimator.framework_version == "0.12"
@@ -652,7 +696,10 @@ def test_attach_wrong_framework(sagemaker_session):
 def test_attach_custom_image(sagemaker_session):
     training_image = "ubuntu:latest"
     returned_job_description = {
-        "AlgorithmSpecification": {"TrainingInputMode": "File", "TrainingImage": training_image},
+        "AlgorithmSpecification": {
+            "TrainingInputMode": "File",
+            "TrainingImage": training_image,
+        },
         "HyperParameters": {
             "sagemaker_submit_directory": '"s3://some/sourcedir.tar.gz"',
             "sagemaker_program": '"iris-dnn-classifier.py"',
@@ -680,7 +727,9 @@ def test_attach_custom_image(sagemaker_session):
         name="describe_training_job", return_value=returned_job_description
     )
 
-    estimator = MXNet.attach(training_job_name="neo", sagemaker_session=sagemaker_session)
+    estimator = MXNet.attach(
+        training_job_name="neo", sagemaker_session=sagemaker_session
+    )
     assert estimator.image_name == training_image
     assert estimator.train_image() == training_image
 
@@ -724,7 +773,9 @@ def test_estimator_wrong_version_launch_parameter_server(sagemaker_session):
             distributions=LAUNCH_PS_DISTRIBUTIONS_DICT,
             framework_version="1.2.1",
         )
-    assert "The distributions option is valid for only versions 1.3 and higher" in str(e)
+    assert "The distributions option is valid for only versions 1.3 and higher" in str(
+        e
+    )
 
 
 @patch("sagemaker.mxnet.estimator.python_deprecation_warning")
@@ -739,7 +790,9 @@ def test_estimator_py2_warning(warning, sagemaker_session):
     )
 
     assert estimator.py_version == "py2"
-    warning.assert_called_with(estimator.__framework_name__, defaults.LATEST_PY2_VERSION)
+    warning.assert_called_with(
+        estimator.__framework_name__, defaults.LATEST_PY2_VERSION
+    )
 
 
 @patch("sagemaker.mxnet.model.python_deprecation_warning")

--- a/tests/unit/test_ntm.py
+++ b/tests/unit/test_ntm.py
@@ -33,11 +33,15 @@ ALL_REQ_ARGS = dict({"num_topics": NUM_TOPICS}, **COMMON_TRAIN_ARGS)
 REGION = "us-west-2"
 BUCKET_NAME = "Some-Bucket"
 
-DESCRIBE_TRAINING_JOB_RESULT = {"ModelArtifacts": {"S3ModelArtifacts": "s3://bucket/model.tar.gz"}}
+DESCRIBE_TRAINING_JOB_RESULT = {
+    "ModelArtifacts": {"S3ModelArtifacts": "s3://bucket/model.tar.gz"}
+}
 
 ENDPOINT_DESC = {"EndpointConfigName": "test-endpoint"}
 
-ENDPOINT_CONFIG_DESC = {"ProductionVariants": [{"ModelName": "model-1"}, {"ModelName": "model-2"}]}
+ENDPOINT_CONFIG_DESC = {
+    "ProductionVariants": [{"ModelName": "model-1"}, {"ModelName": "model-2"}]
+}
 
 
 @pytest.fixture()
@@ -58,7 +62,9 @@ def sagemaker_session():
         name="describe_training_job", return_value=DESCRIBE_TRAINING_JOB_RESULT
     )
     sms.sagemaker_client.describe_endpoint = Mock(return_value=ENDPOINT_DESC)
-    sms.sagemaker_client.describe_endpoint_config = Mock(return_value=ENDPOINT_CONFIG_DESC)
+    sms.sagemaker_client.describe_endpoint_config = Mock(
+        return_value=ENDPOINT_CONFIG_DESC
+    )
 
     return sms
 
@@ -124,7 +130,9 @@ def test_image(sagemaker_session):
 
 
 @pytest.mark.parametrize("required_hyper_parameters, value", [("num_topics", "string")])
-def test_required_hyper_parameters_type(sagemaker_session, required_hyper_parameters, value):
+def test_required_hyper_parameters_type(
+    sagemaker_session, required_hyper_parameters, value
+):
     with pytest.raises(ValueError):
         test_params = ALL_REQ_ARGS.copy()
         test_params[required_hyper_parameters] = value
@@ -134,7 +142,9 @@ def test_required_hyper_parameters_type(sagemaker_session, required_hyper_parame
 @pytest.mark.parametrize(
     "required_hyper_parameters, value", [("num_topics", 0), ("num_topics", 10000)]
 )
-def test_required_hyper_parameters_value(sagemaker_session, required_hyper_parameters, value):
+def test_required_hyper_parameters_value(
+    sagemaker_session, required_hyper_parameters, value
+):
     with pytest.raises(ValueError):
         test_params = ALL_REQ_ARGS.copy()
         test_params[required_hyper_parameters] = value
@@ -142,7 +152,9 @@ def test_required_hyper_parameters_value(sagemaker_session, required_hyper_param
 
 
 @pytest.mark.parametrize("iterable_hyper_parameters, value", [("encoder_layers", 0)])
-def test_iterable_hyper_parameters_type(sagemaker_session, iterable_hyper_parameters, value):
+def test_iterable_hyper_parameters_type(
+    sagemaker_session, iterable_hyper_parameters, value
+):
     with pytest.raises(TypeError):
         test_params = ALL_REQ_ARGS.copy()
         test_params.update({iterable_hyper_parameters: value})
@@ -163,7 +175,9 @@ def test_iterable_hyper_parameters_type(sagemaker_session, iterable_hyper_parame
         ("learning_rate", "string"),
     ],
 )
-def test_optional_hyper_parameters_type(sagemaker_session, optional_hyper_parameters, value):
+def test_optional_hyper_parameters_type(
+    sagemaker_session, optional_hyper_parameters, value
+):
     with pytest.raises(ValueError):
         test_params = ALL_REQ_ARGS.copy()
         test_params.update({optional_hyper_parameters: value})
@@ -190,7 +204,9 @@ def test_optional_hyper_parameters_type(sagemaker_session, optional_hyper_parame
         ("learning_rate", 2),
     ],
 )
-def test_optional_hyper_parameters_value(sagemaker_session, optional_hyper_parameters, value):
+def test_optional_hyper_parameters_value(
+    sagemaker_session, optional_hyper_parameters, value
+):
     with pytest.raises(ValueError):
         test_params = ALL_REQ_ARGS.copy()
         test_params.update({optional_hyper_parameters: value})

--- a/tests/unit/test_object2vec.py
+++ b/tests/unit/test_object2vec.py
@@ -34,18 +34,26 @@ COMMON_TRAIN_ARGS = {
     "train_instance_type": TRAIN_INSTANCE_TYPE,
 }
 ALL_REQ_ARGS = dict(
-    {"epochs": EPOCHS, "enc0_max_seq_len": ENC0_MAX_SEQ_LEN, "enc0_vocab_size": ENC0_VOCAB_SIZE},
+    {
+        "epochs": EPOCHS,
+        "enc0_max_seq_len": ENC0_MAX_SEQ_LEN,
+        "enc0_vocab_size": ENC0_VOCAB_SIZE,
+    },
     **COMMON_TRAIN_ARGS
 )
 
 REGION = "us-west-2"
 BUCKET_NAME = "Some-Bucket"
 
-DESCRIBE_TRAINING_JOB_RESULT = {"ModelArtifacts": {"S3ModelArtifacts": "s3://bucket/model.tar.gz"}}
+DESCRIBE_TRAINING_JOB_RESULT = {
+    "ModelArtifacts": {"S3ModelArtifacts": "s3://bucket/model.tar.gz"}
+}
 
 ENDPOINT_DESC = {"EndpointConfigName": "test-endpoint"}
 
-ENDPOINT_CONFIG_DESC = {"ProductionVariants": [{"ModelName": "model-1"}, {"ModelName": "model-2"}]}
+ENDPOINT_CONFIG_DESC = {
+    "ProductionVariants": [{"ModelName": "model-1"}, {"ModelName": "model-2"}]
+}
 
 
 @pytest.fixture()
@@ -66,7 +74,9 @@ def sagemaker_session():
         name="describe_training_job", return_value=DESCRIBE_TRAINING_JOB_RESULT
     )
     sms.sagemaker_client.describe_endpoint = Mock(return_value=ENDPOINT_DESC)
-    sms.sagemaker_client.describe_endpoint_config = Mock(return_value=ENDPOINT_CONFIG_DESC)
+    sms.sagemaker_client.describe_endpoint_config = Mock(
+        return_value=ENDPOINT_CONFIG_DESC
+    )
 
     return sms
 
@@ -147,7 +157,9 @@ def test_image(sagemaker_session):
 
 
 @pytest.mark.parametrize("required_hyper_parameters, value", [("epochs", "string")])
-def test_required_hyper_parameters_type(sagemaker_session, required_hyper_parameters, value):
+def test_required_hyper_parameters_type(
+    sagemaker_session, required_hyper_parameters, value
+):
     with pytest.raises(ValueError):
         test_params = ALL_REQ_ARGS.copy()
         test_params[required_hyper_parameters] = value
@@ -155,9 +167,12 @@ def test_required_hyper_parameters_type(sagemaker_session, required_hyper_parame
 
 
 @pytest.mark.parametrize(
-    "required_hyper_parameters, value", [("enc0_vocab_size", 0), ("enc0_vocab_size", 1000000000)]
+    "required_hyper_parameters, value",
+    [("enc0_vocab_size", 0), ("enc0_vocab_size", 1000000000)],
 )
-def test_required_hyper_parameters_value(sagemaker_session, required_hyper_parameters, value):
+def test_required_hyper_parameters_value(
+    sagemaker_session, required_hyper_parameters, value
+):
     with pytest.raises(ValueError):
         test_params = ALL_REQ_ARGS.copy()
         test_params[required_hyper_parameters] = value
@@ -178,7 +193,9 @@ def test_required_hyper_parameters_value(sagemaker_session, required_hyper_param
         ("token_embedding_storage_type", 123),
     ],
 )
-def test_optional_hyper_parameters_type(sagemaker_session, optional_hyper_parameters, value):
+def test_optional_hyper_parameters_type(
+    sagemaker_session, optional_hyper_parameters, value
+):
     with pytest.raises(ValueError):
         test_params = ALL_REQ_ARGS.copy()
         test_params.update({optional_hyper_parameters: value})
@@ -205,7 +222,9 @@ def test_optional_hyper_parameters_type(sagemaker_session, optional_hyper_parame
         ("token_embedding_storage_type", "foobar"),
     ],
 )
-def test_optional_hyper_parameters_value(sagemaker_session, optional_hyper_parameters, value):
+def test_optional_hyper_parameters_value(
+    sagemaker_session, optional_hyper_parameters, value
+):
     with pytest.raises(ValueError):
         test_params = ALL_REQ_ARGS.copy()
         test_params.update({optional_hyper_parameters: value})

--- a/tests/unit/test_pca.py
+++ b/tests/unit/test_pca.py
@@ -33,11 +33,15 @@ ALL_REQ_ARGS = dict({"num_components": NUM_COMPONENTS}, **COMMON_TRAIN_ARGS)
 REGION = "us-west-2"
 BUCKET_NAME = "Some-Bucket"
 
-DESCRIBE_TRAINING_JOB_RESULT = {"ModelArtifacts": {"S3ModelArtifacts": "s3://bucket/model.tar.gz"}}
+DESCRIBE_TRAINING_JOB_RESULT = {
+    "ModelArtifacts": {"S3ModelArtifacts": "s3://bucket/model.tar.gz"}
+}
 
 ENDPOINT_DESC = {"EndpointConfigName": "test-endpoint"}
 
-ENDPOINT_CONFIG_DESC = {"ProductionVariants": [{"ModelName": "model-1"}, {"ModelName": "model-2"}]}
+ENDPOINT_CONFIG_DESC = {
+    "ProductionVariants": [{"ModelName": "model-1"}, {"ModelName": "model-2"}]
+}
 
 
 @pytest.fixture()
@@ -58,7 +62,9 @@ def sagemaker_session():
         name="describe_training_job", return_value=DESCRIBE_TRAINING_JOB_RESULT
     )
     sms.sagemaker_client.describe_endpoint = Mock(return_value=ENDPOINT_DESC)
-    sms.sagemaker_client.describe_endpoint_config = Mock(return_value=ENDPOINT_CONFIG_DESC)
+    sms.sagemaker_client.describe_endpoint_config = Mock(
+        return_value=ENDPOINT_CONFIG_DESC
+    )
 
     return sms
 
@@ -107,8 +113,12 @@ def test_image(sagemaker_session):
     assert pca.train_image() == registry(REGION, "pca") + "/pca:1"
 
 
-@pytest.mark.parametrize("required_hyper_parameters, value", [("num_components", "string")])
-def test_required_hyper_parameters_type(sagemaker_session, required_hyper_parameters, value):
+@pytest.mark.parametrize(
+    "required_hyper_parameters, value", [("num_components", "string")]
+)
+def test_required_hyper_parameters_type(
+    sagemaker_session, required_hyper_parameters, value
+):
     with pytest.raises(ValueError):
         test_params = ALL_REQ_ARGS.copy()
         test_params[required_hyper_parameters] = value
@@ -116,7 +126,9 @@ def test_required_hyper_parameters_type(sagemaker_session, required_hyper_parame
 
 
 @pytest.mark.parametrize("required_hyper_parameters, value", [("num_components", 0)])
-def test_required_hyper_parameters_value(sagemaker_session, required_hyper_parameters, value):
+def test_required_hyper_parameters_value(
+    sagemaker_session, required_hyper_parameters, value
+):
     with pytest.raises(ValueError):
         test_params = ALL_REQ_ARGS.copy()
         test_params[required_hyper_parameters] = value
@@ -124,17 +136,24 @@ def test_required_hyper_parameters_value(sagemaker_session, required_hyper_param
 
 
 @pytest.mark.parametrize(
-    "optional_hyper_parameters, value", [("algorithm_mode", 0), ("extra_components", "string")]
+    "optional_hyper_parameters, value",
+    [("algorithm_mode", 0), ("extra_components", "string")],
 )
-def test_optional_hyper_parameters_type(sagemaker_session, optional_hyper_parameters, value):
+def test_optional_hyper_parameters_type(
+    sagemaker_session, optional_hyper_parameters, value
+):
     with pytest.raises(ValueError):
         test_params = ALL_REQ_ARGS.copy()
         test_params.update({optional_hyper_parameters: value})
         PCA(sagemaker_session=sagemaker_session, **test_params)
 
 
-@pytest.mark.parametrize("optional_hyper_parameters, value", [("algorithm_mode", "string")])
-def test_optional_hyper_parameters_value(sagemaker_session, optional_hyper_parameters, value):
+@pytest.mark.parametrize(
+    "optional_hyper_parameters, value", [("algorithm_mode", "string")]
+)
+def test_optional_hyper_parameters_value(
+    sagemaker_session, optional_hyper_parameters, value
+):
     with pytest.raises(ValueError):
         test_params = ALL_REQ_ARGS.copy()
         test_params.update({optional_hyper_parameters: value})

--- a/tests/unit/test_pipeline_model.py
+++ b/tests/unit/test_pipeline_model.py
@@ -30,8 +30,12 @@ INSTANCE_TYPE = "ml.m4.xlarge"
 ROLE = "some-role"
 ENV_1 = {"SAGEMAKER_DEFAULT_INVOCATIONS_ACCEPT": "application/json"}
 ENV_2 = {"SAGEMAKER_DEFAULT_INVOCATIONS_ACCEPT": "text/csv"}
-MODEL_CONTAINER_1 = ModelContainer(image=MODEL_IMAGE_1, model_data=MODEL_DATA_1, env=ENV_1)
-MODEL_CONTAINER_2 = ModelContainer(image=MODEL_IMAGE_2, model_data=MODEL_DATA_2, env=ENV_2)
+MODEL_CONTAINER_1 = ModelContainer(
+    image=MODEL_IMAGE_1, model_data=MODEL_DATA_1, env=ENV_1
+)
+MODEL_CONTAINER_2 = ModelContainer(
+    image=MODEL_IMAGE_2, model_data=MODEL_DATA_2, env=ENV_2
+)
 ENDPOINT = "some-ep"
 
 
@@ -84,7 +88,9 @@ def test_prepare_container_def(tfo, time, sagemaker_session):
         env={"SAGEMAKER_DEFAULT_INVOCATIONS_ACCEPT": "text/csv"},
     )
     model = PipelineModel(
-        models=[framework_model, sparkml_model], role=ROLE, sagemaker_session=sagemaker_session
+        models=[framework_model, sparkml_model],
+        role=ROLE,
+        sagemaker_session=sagemaker_session,
     )
     assert model.pipeline_container_def(INSTANCE_TYPE) == [
         {
@@ -115,7 +121,9 @@ def test_deploy(tfo, time, sagemaker_session):
         model_data=MODEL_DATA_2, role=ROLE, sagemaker_session=sagemaker_session
     )
     model = PipelineModel(
-        models=[framework_model, sparkml_model], role=ROLE, sagemaker_session=sagemaker_session
+        models=[framework_model, sparkml_model],
+        role=ROLE,
+        sagemaker_session=sagemaker_session,
     )
     model.deploy(instance_type=INSTANCE_TYPE, initial_instance_count=1)
     sagemaker_session.endpoint_from_production_variants.assert_called_with(
@@ -143,7 +151,9 @@ def test_deploy_endpoint_name(tfo, time, sagemaker_session):
         model_data=MODEL_DATA_2, role=ROLE, sagemaker_session=sagemaker_session
     )
     model = PipelineModel(
-        models=[framework_model, sparkml_model], role=ROLE, sagemaker_session=sagemaker_session
+        models=[framework_model, sparkml_model],
+        role=ROLE,
+        sagemaker_session=sagemaker_session,
     )
     model.deploy(instance_type=INSTANCE_TYPE, initial_instance_count=1)
     sagemaker_session.endpoint_from_production_variants.assert_called_with(
@@ -172,7 +182,9 @@ def test_deploy_update_endpoint(tfo, time, sagemaker_session):
         model_data=MODEL_DATA_2, role=ROLE, sagemaker_session=sagemaker_session
     )
     model = PipelineModel(
-        models=[framework_model, sparkml_model], role=ROLE, sagemaker_session=sagemaker_session
+        models=[framework_model, sparkml_model],
+        role=ROLE,
+        sagemaker_session=sagemaker_session,
     )
     model.deploy(
         instance_type=INSTANCE_TYPE,
@@ -195,7 +207,9 @@ def test_deploy_update_endpoint(tfo, time, sagemaker_session):
         initial_instance_count=INSTANCE_COUNT,
         instance_type=INSTANCE_TYPE,
     )
-    sagemaker_session.update_endpoint.assert_called_with(endpoint_name, config_name, wait=True)
+    sagemaker_session.update_endpoint.assert_called_with(
+        endpoint_name, config_name, wait=True
+    )
     sagemaker_session.create_endpoint.assert_not_called()
 
 
@@ -262,7 +276,9 @@ def test_deploy_tags(tfo, time, sagemaker_session):
         model_data=MODEL_DATA_2, role=ROLE, sagemaker_session=sagemaker_session
     )
     model = PipelineModel(
-        models=[framework_model, sparkml_model], role=ROLE, sagemaker_session=sagemaker_session
+        models=[framework_model, sparkml_model],
+        role=ROLE,
+        sagemaker_session=sagemaker_session,
     )
     tags = [{"ModelName": "TestModel"}]
     model.deploy(instance_type=INSTANCE_TYPE, initial_instance_count=1, tags=tags)
@@ -286,7 +302,9 @@ def test_deploy_tags(tfo, time, sagemaker_session):
 def test_delete_model_without_deploy(sagemaker_session):
     pipeline_model = PipelineModel([], role=ROLE, sagemaker_session=sagemaker_session)
 
-    expected_error_message = "The SageMaker model must be created before attempting to delete."
+    expected_error_message = (
+        "The SageMaker model must be created before attempting to delete."
+    )
     with pytest.raises(ValueError, match=expected_error_message):
         pipeline_model.delete_model()
 

--- a/tests/unit/test_predictor.py
+++ b/tests/unit/test_predictor.py
@@ -173,7 +173,9 @@ def test_json_deserializer_array():
 
 
 def test_json_deserializer_2dimensional():
-    result = json_deserializer(io.BytesIO(b"[[1, 2, 3], [3, 4, 5]]"), "application/json")
+    result = json_deserializer(
+        io.BytesIO(b"[[1, 2, 3], [3, 4, 5]]"), "application/json"
+    )
 
     assert result == [[1, 2, 3], [3, 4, 5]]
 
@@ -197,7 +199,9 @@ def test_string_deserializer():
 
 
 def test_stream_deserializer():
-    stream, content_type = StreamDeserializer()(io.BytesIO(b"[1, 2, 3]"), "application/json")
+    stream, content_type = StreamDeserializer()(
+        io.BytesIO(b"[1, 2, 3]"), "application/json"
+    )
     result = stream.read()
     assert result == b"[1, 2, 3]"
     assert content_type == "application/json"
@@ -258,7 +262,9 @@ def test_npy_serializer_object():
 
     result = npy_serializer(object)
 
-    assert np.array_equal(np.array(object), np.load(io.BytesIO(result), allow_pickle=True))
+    assert np.array_equal(
+        np.array(object), np.load(io.BytesIO(result), allow_pickle=True)
+    )
 
 
 def test_npy_serializer_list_of_empty():
@@ -350,7 +356,9 @@ PRODUCTION_VARIANT_1 = "PRODUCTION_VARIANT_1"
 
 ENDPOINT_DESC = {"EndpointConfigName": ENDPOINT}
 
-ENDPOINT_CONFIG_DESC = {"ProductionVariants": [{"ModelName": "model-1"}, {"ModelName": "model-2"}]}
+ENDPOINT_CONFIG_DESC = {
+    "ProductionVariants": [{"ModelName": "model-1"}, {"ModelName": "model-2"}]
+}
 
 
 def empty_sagemaker_session():
@@ -358,7 +366,9 @@ def empty_sagemaker_session():
     ims.default_bucket = Mock(name="default_bucket", return_value=BUCKET_NAME)
     ims.sagemaker_runtime_client = Mock(name="sagemaker_runtime")
     ims.sagemaker_client.describe_endpoint = Mock(return_value=ENDPOINT_DESC)
-    ims.sagemaker_client.describe_endpoint_config = Mock(return_value=ENDPOINT_CONFIG_DESC)
+    ims.sagemaker_client.describe_endpoint_config = Mock(
+        return_value=ENDPOINT_CONFIG_DESC
+    )
 
     response_body = Mock("body")
     response_body.read = Mock("read", return_value=RETURN_VALUE)
@@ -379,7 +389,10 @@ def test_predict_call_pass_through():
     assert sagemaker_session.sagemaker_runtime_client.invoke_endpoint.called
 
     expected_request_args = {"Body": data, "EndpointName": ENDPOINT}
-    call_args, kwargs = sagemaker_session.sagemaker_runtime_client.invoke_endpoint.call_args
+    (
+        call_args,
+        kwargs,
+    ) = sagemaker_session.sagemaker_runtime_client.invoke_endpoint.call_args
     assert kwargs == expected_request_args
 
     assert result == RETURN_VALUE
@@ -388,7 +401,10 @@ def test_predict_call_pass_through():
 def test_predict_call_with_headers():
     sagemaker_session = empty_sagemaker_session()
     predictor = RealTimePredictor(
-        ENDPOINT, sagemaker_session, content_type=DEFAULT_CONTENT_TYPE, accept=DEFAULT_CONTENT_TYPE
+        ENDPOINT,
+        sagemaker_session,
+        content_type=DEFAULT_CONTENT_TYPE,
+        accept=DEFAULT_CONTENT_TYPE,
     )
 
     data = "untouched"
@@ -402,7 +418,10 @@ def test_predict_call_with_headers():
         "ContentType": DEFAULT_CONTENT_TYPE,
         "EndpointName": ENDPOINT,
     }
-    call_args, kwargs = sagemaker_session.sagemaker_runtime_client.invoke_endpoint.call_args
+    (
+        call_args,
+        kwargs,
+    ) = sagemaker_session.sagemaker_runtime_client.invoke_endpoint.call_args
     assert kwargs == expected_request_args
 
     assert result == RETURN_VALUE
@@ -411,7 +430,10 @@ def test_predict_call_with_headers():
 def test_predict_call_with_target_variant():
     sagemaker_session = empty_sagemaker_session()
     predictor = RealTimePredictor(
-        ENDPOINT, sagemaker_session, content_type=DEFAULT_CONTENT_TYPE, accept=DEFAULT_CONTENT_TYPE
+        ENDPOINT,
+        sagemaker_session,
+        content_type=DEFAULT_CONTENT_TYPE,
+        accept=DEFAULT_CONTENT_TYPE,
     )
 
     data = "untouched"
@@ -427,7 +449,10 @@ def test_predict_call_with_target_variant():
         "TargetVariant": PRODUCTION_VARIANT_1,
     }
 
-    call_args, kwargs = sagemaker_session.sagemaker_runtime_client.invoke_endpoint.call_args
+    (
+        call_args,
+        kwargs,
+    ) = sagemaker_session.sagemaker_runtime_client.invoke_endpoint.call_args
     assert kwargs == expected_request_args
 
     assert result == RETURN_VALUE
@@ -436,7 +461,10 @@ def test_predict_call_with_target_variant():
 def test_multi_model_predict_call_with_headers():
     sagemaker_session = empty_sagemaker_session()
     predictor = RealTimePredictor(
-        ENDPOINT, sagemaker_session, content_type=DEFAULT_CONTENT_TYPE, accept=DEFAULT_CONTENT_TYPE
+        ENDPOINT,
+        sagemaker_session,
+        content_type=DEFAULT_CONTENT_TYPE,
+        accept=DEFAULT_CONTENT_TYPE,
     )
 
     data = "untouched"
@@ -451,7 +479,10 @@ def test_multi_model_predict_call_with_headers():
         "EndpointName": ENDPOINT,
         "TargetModel": "model.tar.gz",
     }
-    call_args, kwargs = sagemaker_session.sagemaker_runtime_client.invoke_endpoint.call_args
+    (
+        call_args,
+        kwargs,
+    ) = sagemaker_session.sagemaker_runtime_client.invoke_endpoint.call_args
     assert kwargs == expected_request_args
 
     assert result == RETURN_VALUE
@@ -462,10 +493,14 @@ def json_sagemaker_session():
     ims.default_bucket = Mock(name="default_bucket", return_value=BUCKET_NAME)
     ims.sagemaker_runtime_client = Mock(name="sagemaker_runtime")
     ims.sagemaker_client.describe_endpoint = Mock(return_value=ENDPOINT_DESC)
-    ims.sagemaker_client.describe_endpoint_config = Mock(return_value=ENDPOINT_CONFIG_DESC)
+    ims.sagemaker_client.describe_endpoint_config = Mock(
+        return_value=ENDPOINT_CONFIG_DESC
+    )
 
     ims.sagemaker_client.describe_endpoint = Mock(return_value=ENDPOINT_DESC)
-    ims.sagemaker_client.describe_endpoint_config = Mock(return_value=ENDPOINT_CONFIG_DESC)
+    ims.sagemaker_client.describe_endpoint_config = Mock(
+        return_value=ENDPOINT_CONFIG_DESC
+    )
 
     response_body = Mock("body")
     response_body.read = Mock("read", return_value=json.dumps([RETURN_VALUE]))
@@ -498,7 +533,10 @@ def test_predict_call_with_headers_and_json():
         "ContentType": "not/json",
         "EndpointName": ENDPOINT,
     }
-    call_args, kwargs = sagemaker_session.sagemaker_runtime_client.invoke_endpoint.call_args
+    (
+        call_args,
+        kwargs,
+    ) = sagemaker_session.sagemaker_runtime_client.invoke_endpoint.call_args
     assert kwargs == expected_request_args
 
     assert result == json.dumps([RETURN_VALUE])
@@ -509,10 +547,14 @@ def ret_csv_sagemaker_session():
     ims.default_bucket = Mock(name="default_bucket", return_value=BUCKET_NAME)
     ims.sagemaker_runtime_client = Mock(name="sagemaker_runtime")
     ims.sagemaker_client.describe_endpoint = Mock(return_value=ENDPOINT_DESC)
-    ims.sagemaker_client.describe_endpoint_config = Mock(return_value=ENDPOINT_CONFIG_DESC)
+    ims.sagemaker_client.describe_endpoint_config = Mock(
+        return_value=ENDPOINT_CONFIG_DESC
+    )
 
     ims.sagemaker_client.describe_endpoint = Mock(return_value=ENDPOINT_DESC)
-    ims.sagemaker_client.describe_endpoint_config = Mock(return_value=ENDPOINT_CONFIG_DESC)
+    ims.sagemaker_client.describe_endpoint_config = Mock(
+        return_value=ENDPOINT_CONFIG_DESC
+    )
 
     response_body = Mock("body")
     response_body.read = Mock("read", return_value=CSV_RETURN_VALUE)
@@ -541,7 +583,10 @@ def test_predict_call_with_headers_and_csv():
         "ContentType": CSV_CONTENT_TYPE,
         "EndpointName": ENDPOINT,
     }
-    call_args, kwargs = sagemaker_session.sagemaker_runtime_client.invoke_endpoint.call_args
+    (
+        call_args,
+        kwargs,
+    ) = sagemaker_session.sagemaker_runtime_client.invoke_endpoint.call_args
     assert kwargs == expected_request_args
 
     assert result == CSV_RETURN_VALUE

--- a/tests/unit/test_processing.py
+++ b/tests/unit/test_processing.py
@@ -113,9 +113,7 @@ def test_sklearn_processor_with_required_parameters(
 
     expected_args = _get_expected_args(processor._current_job_name)
 
-    sklearn_image_uri = (
-        "246618743249.dkr.ecr.us-west-2.amazonaws.com/sagemaker-scikit-learn:0.20.0-cpu-py3"
-    )
+    sklearn_image_uri = "246618743249.dkr.ecr.us-west-2.amazonaws.com/sagemaker-scikit-learn:0.20.0-cpu-py3"
     expected_args["app_specification"]["ImageUri"] = sklearn_image_uri
 
     sagemaker_session.process.assert_called_with(**expected_args)
@@ -124,7 +122,9 @@ def test_sklearn_processor_with_required_parameters(
 @patch("sagemaker.fw_registry.get_ecr_image_uri_prefix", return_value=ECR_PREFIX)
 @patch("os.path.exists", return_value=True)
 @patch("os.path.isfile", return_value=True)
-def test_sklearn_with_all_parameters(exists_mock, isfile_mock, ecr_prefix, sagemaker_session):
+def test_sklearn_with_all_parameters(
+    exists_mock, isfile_mock, ecr_prefix, sagemaker_session
+):
     processor = SKLearnProcessor(
         role=ROLE,
         framework_version="0.20.0",
@@ -175,9 +175,7 @@ def test_sklearn_with_all_parameters(exists_mock, isfile_mock, ecr_prefix, sagem
     )
 
     expected_args = _get_expected_args_all_parameters(processor._current_job_name)
-    sklearn_image_uri = (
-        "246618743249.dkr.ecr.us-west-2.amazonaws.com/sagemaker-scikit-learn:0.20.0-cpu-py3"
-    )
+    sklearn_image_uri = "246618743249.dkr.ecr.us-west-2.amazonaws.com/sagemaker-scikit-learn:0.20.0-cpu-py3"
     expected_args["app_specification"]["ImageUri"] = sklearn_image_uri
 
     sagemaker_session.process.assert_called_with(**expected_args)
@@ -199,7 +197,9 @@ def test_sklearn_processor_errors_with_invalid_framework_version(
 
 
 @patch("os.path.exists", return_value=False)
-def test_script_processor_errors_with_nonexistent_local_code(exists_mock, sagemaker_session):
+def test_script_processor_errors_with_nonexistent_local_code(
+    exists_mock, sagemaker_session
+):
     processor = _get_script_processor(sagemaker_session)
     with pytest.raises(ValueError):
         processor.run(code="/local/path/to/processing_code.py")
@@ -207,7 +207,9 @@ def test_script_processor_errors_with_nonexistent_local_code(exists_mock, sagema
 
 @patch("os.path.exists", return_value=True)
 @patch("os.path.isfile", return_value=False)
-def test_script_processor_errors_with_code_directory(exists_mock, isfile_mock, sagemaker_session):
+def test_script_processor_errors_with_code_directory(
+    exists_mock, isfile_mock, sagemaker_session
+):
     processor = _get_script_processor(sagemaker_session)
     with pytest.raises(ValueError):
         processor.run(code="/local/path/to/code")
@@ -273,7 +275,9 @@ def test_script_processor_works_with_file_code_url_scheme(
 
 @patch("os.path.exists", return_value=True)
 @patch("os.path.isfile", return_value=True)
-def test_script_processor_works_with_s3_code_url(exists_mock, isfile_mock, sagemaker_session):
+def test_script_processor_works_with_s3_code_url(
+    exists_mock, isfile_mock, sagemaker_session
+):
     processor = _get_script_processor(sagemaker_session)
     processor.run(code="s3://bucket/path/to/processing_code.py")
 
@@ -290,7 +294,9 @@ def test_script_processor_with_one_input(exists_mock, isfile_mock, sagemaker_ses
     processor.run(
         code="/local/path/to/processing_code.py",
         inputs=[
-            ProcessingInput(source="/local/path/to/my/dataset/census.csv", destination="/data/")
+            ProcessingInput(
+                source="/local/path/to/my/dataset/census.csv", destination="/data/"
+            )
         ],
     )
 
@@ -302,7 +308,9 @@ def test_script_processor_with_one_input(exists_mock, isfile_mock, sagemaker_ses
 
 @patch("os.path.exists", return_value=True)
 @patch("os.path.isfile", return_value=True)
-def test_script_processor_with_required_parameters(exists_mock, isfile_mock, sagemaker_session):
+def test_script_processor_with_required_parameters(
+    exists_mock, isfile_mock, sagemaker_session
+):
     processor = _get_script_processor(sagemaker_session)
 
     processor.run(code="/local/path/to/processing_code.py")
@@ -313,7 +321,9 @@ def test_script_processor_with_required_parameters(exists_mock, isfile_mock, sag
 
 @patch("os.path.exists", return_value=True)
 @patch("os.path.isfile", return_value=True)
-def test_script_processor_with_all_parameters(exists_mock, isfile_mock, sagemaker_session):
+def test_script_processor_with_all_parameters(
+    exists_mock, isfile_mock, sagemaker_session
+):
     processor = ScriptProcessor(
         role=ROLE,
         image_uri=CUSTOM_IMAGE_URI,
@@ -495,10 +505,12 @@ def test_processing_job_from_processing_arn(sagemaker_session):
     )
     assert isinstance(processing_job, ProcessingJob)
     assert [
-        processing_input._to_request_dict() for processing_input in processing_job.inputs
+        processing_input._to_request_dict()
+        for processing_input in processing_job.inputs
     ] == PROCESSING_JOB_DESCRIPTION["ProcessingInputs"]
     assert [
-        processing_output._to_request_dict() for processing_output in processing_job.outputs
+        processing_output._to_request_dict()
+        for processing_output in processing_job.outputs
     ] == PROCESSING_JOB_DESCRIPTION["ProcessingOutputConfig"]["Outputs"]
     assert (
         processing_job.output_kms_key
@@ -544,7 +556,10 @@ def _get_expected_args(job_name, code_s3_uri="mocked_s3_uri_from_upload_data"):
         "stopping_condition": None,
         "app_specification": {
             "ImageUri": CUSTOM_IMAGE_URI,
-            "ContainerEntrypoint": ["python3", "/opt/ml/processing/input/code/processing_code.py"],
+            "ContainerEntrypoint": [
+                "python3",
+                "/opt/ml/processing/input/code/processing_code.py",
+            ],
         },
         "environment": None,
         "network_config": None,
@@ -621,7 +636,10 @@ def _get_expected_args_all_parameters(job_name):
         "app_specification": {
             "ImageUri": "012345678901.dkr.ecr.us-west-2.amazonaws.com/my-custom-image-uri",
             "ContainerArguments": ["--drop-columns", "'SelfEmployed'"],
-            "ContainerEntrypoint": ["python3", "/opt/ml/processing/input/code/processing_code.py"],
+            "ContainerEntrypoint": [
+                "python3",
+                "/opt/ml/processing/input/code/processing_code.py",
+            ],
         },
         "environment": {"my_env_variable": "my_env_variable_value"},
         "network_config": {

--- a/tests/unit/test_pytorch.py
+++ b/tests/unit/test_pytorch.py
@@ -46,7 +46,9 @@ CPU = "ml.c4.xlarge"
 
 ENDPOINT_DESC = {"EndpointConfigName": "test-endpoint"}
 
-ENDPOINT_CONFIG_DESC = {"ProductionVariants": [{"ModelName": "model-1"}, {"ModelName": "model-2"}]}
+ENDPOINT_CONFIG_DESC = {
+    "ProductionVariants": [{"ModelName": "model-1"}, {"ModelName": "model-2"}]
+}
 
 LIST_TAGS_RESULT = {"Tags": [{"Key": "TagtestKey", "Value": "TagtestValue"}]}
 
@@ -73,7 +75,9 @@ def fixture_sagemaker_session():
     describe = {"ModelArtifacts": {"S3ModelArtifacts": "s3://m/m.tar.gz"}}
     session.sagemaker_client.describe_training_job = Mock(return_value=describe)
     session.sagemaker_client.describe_endpoint = Mock(return_value=ENDPOINT_DESC)
-    session.sagemaker_client.describe_endpoint_config = Mock(return_value=ENDPOINT_CONFIG_DESC)
+    session.sagemaker_client.describe_endpoint_config = Mock(
+        return_value=ENDPOINT_CONFIG_DESC
+    )
     session.sagemaker_client.list_tags = Mock(return_value=LIST_TAGS_RESULT)
     session.default_bucket = Mock(name="default_bucket", return_value=BUCKET_NAME)
     session.expand_role = Mock(name="expand_role", return_value=ROLE)
@@ -81,11 +85,15 @@ def fixture_sagemaker_session():
 
 
 def _get_full_cpu_image_uri(version, py_version=PYTHON_VERSION):
-    return IMAGE_URI_FORMAT_STRING.format(REGION, IMAGE_NAME, version, "cpu", py_version)
+    return IMAGE_URI_FORMAT_STRING.format(
+        REGION, IMAGE_NAME, version, "cpu", py_version
+    )
 
 
 def _get_full_gpu_image_uri(version, py_version=PYTHON_VERSION):
-    return IMAGE_URI_FORMAT_STRING.format(REGION, IMAGE_NAME, version, "gpu", py_version)
+    return IMAGE_URI_FORMAT_STRING.format(
+        REGION, IMAGE_NAME, version, "gpu", py_version
+    )
 
 
 def _get_full_cpu_image_uri_with_ei(version, py_version=PYTHON_VERSION):
@@ -106,7 +114,9 @@ def _pytorch_estimator(
         role=ROLE,
         sagemaker_session=sagemaker_session,
         train_instance_count=INSTANCE_COUNT,
-        train_instance_type=train_instance_type if train_instance_type else INSTANCE_TYPE,
+        train_instance_type=train_instance_type
+        if train_instance_type
+        else INSTANCE_TYPE,
         base_job_name=base_job_name,
         **kwargs
     )
@@ -278,7 +288,9 @@ def test_pytorch(strftime, sagemaker_session, pytorch_version):
     assert boto_call_names == ["resource"]
 
     expected_train_args = _create_train_job(pytorch_version)
-    expected_train_args["input_config"][0]["DataSource"]["S3DataSource"]["S3Uri"] = inputs
+    expected_train_args["input_config"][0]["DataSource"]["S3DataSource"][
+        "S3Uri"
+    ] = inputs
     expected_train_args["experiment_config"] = EXPERIMENT_CONFIG
 
     actual_train_args = sagemaker_session.method_calls[0][2]
@@ -286,7 +298,9 @@ def test_pytorch(strftime, sagemaker_session, pytorch_version):
 
     model = pytorch.create_model()
 
-    expected_image_base = "520713654638.dkr.ecr.us-west-2.amazonaws.com/sagemaker-pytorch:{}-gpu-{}"
+    expected_image_base = (
+        "520713654638.dkr.ecr.us-west-2.amazonaws.com/sagemaker-pytorch:{}-gpu-{}"
+    )
     assert {
         "Environment": {
             "SAGEMAKER_SUBMIT_DIRECTORY": "s3://mybucket/sagemaker-pytorch-{}/source/sourcedir.tar.gz".format(
@@ -309,7 +323,10 @@ def test_pytorch(strftime, sagemaker_session, pytorch_version):
 @patch("sagemaker.utils.create_tar_file", MagicMock())
 def test_model(sagemaker_session):
     model = PyTorchModel(
-        MODEL_DATA, role=ROLE, entry_point=SCRIPT_PATH, sagemaker_session=sagemaker_session
+        MODEL_DATA,
+        role=ROLE,
+        entry_point=SCRIPT_PATH,
+        sagemaker_session=sagemaker_session,
     )
     predictor = model.deploy(1, GPU)
     assert isinstance(predictor, PyTorchPredictor)
@@ -363,8 +380,9 @@ def test_model_image_accelerator(sagemaker_session):
             py_version="py2",
         )
         model.deploy(1, CPU, accelerator_type=ACCELERATOR_TYPE)
-    assert "pytorch-serving is not supported with Amazon Elastic Inference in Python 2." in str(
-        error
+    assert (
+        "pytorch-serving is not supported with Amazon Elastic Inference in Python 2."
+        in str(error)
     )
 
 
@@ -374,7 +392,9 @@ def test_model_prepare_container_def_no_instance_type_or_image():
     with pytest.raises(ValueError) as e:
         model.prepare_container_def()
 
-    expected_msg = "Must supply either an instance type (for choosing CPU vs GPU) or an image URI."
+    expected_msg = (
+        "Must supply either an instance type (for choosing CPU vs GPU) or an image URI."
+    )
     assert expected_msg in str(e)
 
 
@@ -404,7 +424,9 @@ def test_train_image_cpu_instances(sagemaker_session, pytorch_version):
     )
     assert pytorch.train_image() == _get_full_cpu_image_uri(pytorch_version)
 
-    pytorch = _pytorch_estimator(sagemaker_session, pytorch_version, train_instance_type="ml.m16")
+    pytorch = _pytorch_estimator(
+        sagemaker_session, pytorch_version, train_instance_type="ml.m16"
+    )
     assert pytorch.train_image() == _get_full_cpu_image_uri(pytorch_version)
 
 
@@ -425,7 +447,10 @@ def test_attach(sagemaker_session, pytorch_version):
         pytorch_version, PYTHON_VERSION
     )
     returned_job_description = {
-        "AlgorithmSpecification": {"TrainingInputMode": "File", "TrainingImage": training_image},
+        "AlgorithmSpecification": {
+            "TrainingInputMode": "File",
+            "TrainingImage": training_image,
+        },
         "HyperParameters": {
             "sagemaker_submit_directory": '"s3://some/sourcedir.tar.gz"',
             "sagemaker_program": '"iris-dnn-classifier.py"',
@@ -453,7 +478,9 @@ def test_attach(sagemaker_session, pytorch_version):
         name="describe_training_job", return_value=returned_job_description
     )
 
-    estimator = PyTorch.attach(training_job_name="neo", sagemaker_session=sagemaker_session)
+    estimator = PyTorch.attach(
+        training_job_name="neo", sagemaker_session=sagemaker_session
+    )
     assert estimator.latest_training_job.job_name == "neo"
     assert estimator.py_version == PYTHON_VERSION
     assert estimator.framework_version == pytorch_version
@@ -509,7 +536,10 @@ def test_attach_wrong_framework(sagemaker_session):
 def test_attach_custom_image(sagemaker_session):
     training_image = "pytorch:latest"
     returned_job_description = {
-        "AlgorithmSpecification": {"TrainingInputMode": "File", "TrainingImage": training_image},
+        "AlgorithmSpecification": {
+            "TrainingInputMode": "File",
+            "TrainingImage": training_image,
+        },
         "HyperParameters": {
             "sagemaker_submit_directory": '"s3://some/sourcedir.tar.gz"',
             "sagemaker_program": '"iris-dnn-classifier.py"',
@@ -537,7 +567,9 @@ def test_attach_custom_image(sagemaker_session):
         name="describe_training_job", return_value=returned_job_description
     )
 
-    estimator = PyTorch.attach(training_job_name="neo", sagemaker_session=sagemaker_session)
+    estimator = PyTorch.attach(
+        training_job_name="neo", sagemaker_session=sagemaker_session
+    )
     assert estimator.latest_training_job.job_name == "neo"
     assert estimator.image_name == training_image
     assert estimator.train_image() == training_image
@@ -555,7 +587,9 @@ def test_estimator_py2_warning(warning, sagemaker_session):
     )
 
     assert estimator.py_version == "py2"
-    warning.assert_called_with(estimator.__framework_name__, defaults.LATEST_PY2_VERSION)
+    warning.assert_called_with(
+        estimator.__framework_name__, defaults.LATEST_PY2_VERSION
+    )
 
 
 @patch("sagemaker.pytorch.model.python_deprecation_warning")

--- a/tests/unit/test_randomcutforest.py
+++ b/tests/unit/test_randomcutforest.py
@@ -35,11 +35,15 @@ ALL_REQ_ARGS = dict(**COMMON_TRAIN_ARGS)
 REGION = "us-west-2"
 BUCKET_NAME = "Some-Bucket"
 
-DESCRIBE_TRAINING_JOB_RESULT = {"ModelArtifacts": {"S3ModelArtifacts": "s3://bucket/model.tar.gz"}}
+DESCRIBE_TRAINING_JOB_RESULT = {
+    "ModelArtifacts": {"S3ModelArtifacts": "s3://bucket/model.tar.gz"}
+}
 
 ENDPOINT_DESC = {"EndpointConfigName": "test-endpoint"}
 
-ENDPOINT_CONFIG_DESC = {"ProductionVariants": [{"ModelName": "model-1"}, {"ModelName": "model-2"}]}
+ENDPOINT_CONFIG_DESC = {
+    "ProductionVariants": [{"ModelName": "model-1"}, {"ModelName": "model-2"}]
+}
 
 
 @pytest.fixture()
@@ -58,7 +62,9 @@ def sagemaker_session():
         name="describe_training_job", return_value=DESCRIBE_TRAINING_JOB_RESULT
     )
     sms.sagemaker_client.describe_endpoint = Mock(return_value=ENDPOINT_DESC)
-    sms.sagemaker_client.describe_endpoint_config = Mock(return_value=ENDPOINT_CONFIG_DESC)
+    sms.sagemaker_client.describe_endpoint_config = Mock(
+        return_value=ENDPOINT_CONFIG_DESC
+    )
 
     return sms
 
@@ -82,11 +88,15 @@ def test_init_required_positional(sagemaker_session):
 
 
 def test_init_required_named(sagemaker_session):
-    randomcutforest = RandomCutForest(sagemaker_session=sagemaker_session, **ALL_REQ_ARGS)
+    randomcutforest = RandomCutForest(
+        sagemaker_session=sagemaker_session, **ALL_REQ_ARGS
+    )
 
     assert randomcutforest.role == COMMON_TRAIN_ARGS["role"]
     assert randomcutforest.train_instance_count == TRAIN_INSTANCE_COUNT
-    assert randomcutforest.train_instance_type == COMMON_TRAIN_ARGS["train_instance_type"]
+    assert (
+        randomcutforest.train_instance_type == COMMON_TRAIN_ARGS["train_instance_type"]
+    )
 
 
 def test_all_hyperparameters(sagemaker_session):
@@ -105,14 +115,19 @@ def test_all_hyperparameters(sagemaker_session):
 
 
 def test_image(sagemaker_session):
-    randomcutforest = RandomCutForest(sagemaker_session=sagemaker_session, **ALL_REQ_ARGS)
+    randomcutforest = RandomCutForest(
+        sagemaker_session=sagemaker_session, **ALL_REQ_ARGS
+    )
     assert (
-        randomcutforest.train_image() == registry(REGION, "randomcutforest") + "/randomcutforest:1"
+        randomcutforest.train_image()
+        == registry(REGION, "randomcutforest") + "/randomcutforest:1"
     )
 
 
 @pytest.mark.parametrize("iterable_hyper_parameters, value", [("eval_metrics", 0)])
-def test_iterable_hyper_parameters_type(sagemaker_session, iterable_hyper_parameters, value):
+def test_iterable_hyper_parameters_type(
+    sagemaker_session, iterable_hyper_parameters, value
+):
     with pytest.raises(TypeError):
         test_params = ALL_REQ_ARGS.copy()
         test_params.update({iterable_hyper_parameters: value})
@@ -123,7 +138,9 @@ def test_iterable_hyper_parameters_type(sagemaker_session, iterable_hyper_parame
     "optional_hyper_parameters, value",
     [("num_trees", "string"), ("num_samples_per_tree", "string")],
 )
-def test_optional_hyper_parameters_type(sagemaker_session, optional_hyper_parameters, value):
+def test_optional_hyper_parameters_type(
+    sagemaker_session, optional_hyper_parameters, value
+):
     with pytest.raises(ValueError):
         test_params = ALL_REQ_ARGS.copy()
         test_params.update({optional_hyper_parameters: value})
@@ -139,7 +156,9 @@ def test_optional_hyper_parameters_type(sagemaker_session, optional_hyper_parame
         ("num_samples_per_tree", 2049),
     ],
 )
-def test_optional_hyper_parameters_value(sagemaker_session, optional_hyper_parameters, value):
+def test_optional_hyper_parameters_value(
+    sagemaker_session, optional_hyper_parameters, value
+):
     with pytest.raises(ValueError):
         test_params = ALL_REQ_ARGS.copy()
         test_params.update({optional_hyper_parameters: value})
@@ -155,7 +174,9 @@ MINI_BATCH_SIZE = 1000
 @patch("sagemaker.amazon.amazon_estimator.AmazonAlgorithmEstimatorBase.fit")
 def test_call_fit(base_fit, sagemaker_session):
     randomcutforest = RandomCutForest(
-        base_job_name="randomcutforest", sagemaker_session=sagemaker_session, **ALL_REQ_ARGS
+        base_job_name="randomcutforest",
+        sagemaker_session=sagemaker_session,
+        **ALL_REQ_ARGS
     )
 
     data = RecordSet(
@@ -175,7 +196,9 @@ def test_call_fit(base_fit, sagemaker_session):
 
 def test_prepare_for_training_no_mini_batch_size(sagemaker_session):
     randomcutforest = RandomCutForest(
-        base_job_name="randomcutforest", sagemaker_session=sagemaker_session, **ALL_REQ_ARGS
+        base_job_name="randomcutforest",
+        sagemaker_session=sagemaker_session,
+        **ALL_REQ_ARGS
     )
 
     data = RecordSet(
@@ -191,7 +214,9 @@ def test_prepare_for_training_no_mini_batch_size(sagemaker_session):
 
 def test_prepare_for_training_wrong_type_mini_batch_size(sagemaker_session):
     randomcutforest = RandomCutForest(
-        base_job_name="randomcutforest", sagemaker_session=sagemaker_session, **ALL_REQ_ARGS
+        base_job_name="randomcutforest",
+        sagemaker_session=sagemaker_session,
+        **ALL_REQ_ARGS
     )
 
     data = RecordSet(
@@ -207,7 +232,9 @@ def test_prepare_for_training_wrong_type_mini_batch_size(sagemaker_session):
 
 def test_prepare_for_training_feature_dim_greater_than_max_allowed(sagemaker_session):
     randomcutforest = RandomCutForest(
-        base_job_name="randomcutforest", sagemaker_session=sagemaker_session, **ALL_REQ_ARGS
+        base_job_name="randomcutforest",
+        sagemaker_session=sagemaker_session,
+        **ALL_REQ_ARGS
     )
 
     data = RecordSet(
@@ -222,7 +249,9 @@ def test_prepare_for_training_feature_dim_greater_than_max_allowed(sagemaker_ses
 
 
 def test_model_image(sagemaker_session):
-    randomcutforest = RandomCutForest(sagemaker_session=sagemaker_session, **ALL_REQ_ARGS)
+    randomcutforest = RandomCutForest(
+        sagemaker_session=sagemaker_session, **ALL_REQ_ARGS
+    )
     data = RecordSet(
         "s3://{}/{}".format(BUCKET_NAME, PREFIX),
         num_records=1,
@@ -236,7 +265,9 @@ def test_model_image(sagemaker_session):
 
 
 def test_predictor_type(sagemaker_session):
-    randomcutforest = RandomCutForest(sagemaker_session=sagemaker_session, **ALL_REQ_ARGS)
+    randomcutforest = RandomCutForest(
+        sagemaker_session=sagemaker_session, **ALL_REQ_ARGS
+    )
     data = RecordSet(
         "s3://{}/{}".format(BUCKET_NAME, PREFIX),
         num_records=1,

--- a/tests/unit/test_rl.py
+++ b/tests/unit/test_rl.py
@@ -21,7 +21,12 @@ from mock import MagicMock, Mock
 from mock import patch
 
 from sagemaker.mxnet import MXNetModel, MXNetPredictor
-from sagemaker.rl import RLEstimator, RLFramework, RLToolkit, TOOLKIT_FRAMEWORK_VERSION_MAP
+from sagemaker.rl import (
+    RLEstimator,
+    RLFramework,
+    RLToolkit,
+    TOOLKIT_FRAMEWORK_VERSION_MAP,
+)
 import sagemaker.tensorflow.serving as tfs
 
 
@@ -42,7 +47,9 @@ CPU = "ml.c4.xlarge"
 
 ENDPOINT_DESC = {"EndpointConfigName": "test-endpoint"}
 
-ENDPOINT_CONFIG_DESC = {"ProductionVariants": [{"ModelName": "model-1"}, {"ModelName": "model-2"}]}
+ENDPOINT_CONFIG_DESC = {
+    "ProductionVariants": [{"ModelName": "model-1"}, {"ModelName": "model-2"}]
+}
 
 LIST_TAGS_RESULT = {"Tags": [{"Key": "TagtestKey", "Value": "TagtestValue"}]}
 
@@ -69,7 +76,9 @@ def fixture_sagemaker_session():
     describe = {"ModelArtifacts": {"S3ModelArtifacts": "s3://m/m.tar.gz"}}
     session.sagemaker_client.describe_training_job = Mock(return_value=describe)
     session.sagemaker_client.describe_endpoint = Mock(return_value=ENDPOINT_DESC)
-    session.sagemaker_client.describe_endpoint_config = Mock(return_value=ENDPOINT_CONFIG_DESC)
+    session.sagemaker_client.describe_endpoint_config = Mock(
+        return_value=ENDPOINT_CONFIG_DESC
+    )
     session.sagemaker_client.list_tags = Mock(return_value=LIST_TAGS_RESULT)
     session.default_bucket = Mock(name="default_bucket", return_value=BUCKET_NAME)
     session.expand_role = Mock(name="expand_role", return_value=ROLE)
@@ -182,7 +191,9 @@ def test_create_tf_model(sagemaker_session, rl_coach_tf_version):
     rl.fit(inputs="s3://mybucket/train", job_name="new_name")
     model = rl.create_model()
     supported_versions = TOOLKIT_FRAMEWORK_VERSION_MAP[RLToolkit.COACH.value]
-    framework_version = supported_versions[rl_coach_tf_version][RLFramework.TENSORFLOW.value]
+    framework_version = supported_versions[rl_coach_tf_version][
+        RLFramework.TENSORFLOW.value
+    ]
 
     assert isinstance(model, tfs.Model)
     assert model.sagemaker_session == sagemaker_session
@@ -213,7 +224,9 @@ def test_create_mxnet_model(sagemaker_session, rl_coach_mxnet_version):
     rl.fit(inputs="s3://mybucket/train", job_name="new_name")
     model = rl.create_model()
     supported_versions = TOOLKIT_FRAMEWORK_VERSION_MAP[RLToolkit.COACH.value]
-    framework_version = supported_versions[rl_coach_mxnet_version][RLFramework.MXNET.value]
+    framework_version = supported_versions[rl_coach_mxnet_version][
+        RLFramework.MXNET.value
+    ]
 
     assert isinstance(model, MXNetModel)
     assert model.sagemaker_session == sagemaker_session
@@ -250,7 +263,10 @@ def test_create_model_with_optional_params(sagemaker_session, rl_coach_mxnet_ver
     vpc_config = {"Subnets": ["foo"], "SecurityGroupIds": ["bar"]}
     model_name = "model-name"
     model = rl.create_model(
-        role=new_role, entry_point=new_entry_point, vpc_config_override=vpc_config, name=model_name
+        role=new_role,
+        entry_point=new_entry_point,
+        vpc_config_override=vpc_config,
+        name=model_name,
     )
 
     assert model.role == new_role
@@ -314,7 +330,9 @@ def test_rl(strftime, sagemaker_session, rl_coach_mxnet_version):
     expected_train_args = _create_train_job(
         RLToolkit.COACH.value, rl_coach_mxnet_version, RLFramework.MXNET.value
     )
-    expected_train_args["input_config"][0]["DataSource"]["S3DataSource"]["S3Uri"] = inputs
+    expected_train_args["input_config"][0]["DataSource"]["S3DataSource"][
+        "S3Uri"
+    ] = inputs
     expected_train_args["experiment_config"] = EXPERIMENT_CONFIG
 
     actual_train_args = sagemaker_session.method_calls[0][2]
@@ -322,10 +340,16 @@ def test_rl(strftime, sagemaker_session, rl_coach_mxnet_version):
 
     model = rl.create_model()
     supported_versions = TOOLKIT_FRAMEWORK_VERSION_MAP[RLToolkit.COACH.value]
-    framework_version = supported_versions[rl_coach_mxnet_version][RLFramework.MXNET.value]
+    framework_version = supported_versions[rl_coach_mxnet_version][
+        RLFramework.MXNET.value
+    ]
 
-    expected_image_base = "520713654638.dkr.ecr.us-west-2.amazonaws.com/sagemaker-mxnet:{}-gpu-py3"
-    submit_dir = "s3://notmybucket/sagemaker-rl-mxnet-{}/source/sourcedir.tar.gz".format(TIMESTAMP)
+    expected_image_base = (
+        "520713654638.dkr.ecr.us-west-2.amazonaws.com/sagemaker-mxnet:{}-gpu-py3"
+    )
+    submit_dir = "s3://notmybucket/sagemaker-rl-mxnet-{}/source/sourcedir.tar.gz".format(
+        TIMESTAMP
+    )
     assert {
         "Environment": {
             "SAGEMAKER_SUBMIT_DIRECTORY": submit_dir,
@@ -388,21 +412,33 @@ def test_train_image_cpu_instances(sagemaker_session, rl_ray_version):
     toolkit = RLToolkit.RAY
     framework = RLFramework.TENSORFLOW
     rl = _rl_estimator(
-        sagemaker_session, toolkit, rl_ray_version, framework, train_instance_type="ml.c2.2xlarge"
+        sagemaker_session,
+        toolkit,
+        rl_ray_version,
+        framework,
+        train_instance_type="ml.c2.2xlarge",
     )
     assert rl.train_image() == _get_full_cpu_image_uri(
         toolkit.value, rl_ray_version, framework.value
     )
 
     rl = _rl_estimator(
-        sagemaker_session, toolkit, rl_ray_version, framework, train_instance_type="ml.c4.2xlarge"
+        sagemaker_session,
+        toolkit,
+        rl_ray_version,
+        framework,
+        train_instance_type="ml.c4.2xlarge",
     )
     assert rl.train_image() == _get_full_cpu_image_uri(
         toolkit.value, rl_ray_version, framework.value
     )
 
     rl = _rl_estimator(
-        sagemaker_session, toolkit, rl_ray_version, framework, train_instance_type="ml.m16"
+        sagemaker_session,
+        toolkit,
+        rl_ray_version,
+        framework,
+        train_instance_type="ml.m16",
     )
     assert rl.train_image() == _get_full_cpu_image_uri(
         toolkit.value, rl_ray_version, framework.value
@@ -440,9 +476,14 @@ def test_attach(sagemaker_session, rl_coach_mxnet_version):
         RLFramework.MXNET.value, RLToolkit.COACH.value, rl_coach_mxnet_version
     )
     supported_versions = TOOLKIT_FRAMEWORK_VERSION_MAP[RLToolkit.COACH.value]
-    framework_version = supported_versions[rl_coach_mxnet_version][RLFramework.MXNET.value]
+    framework_version = supported_versions[rl_coach_mxnet_version][
+        RLFramework.MXNET.value
+    ]
     returned_job_description = {
-        "AlgorithmSpecification": {"TrainingInputMode": "File", "TrainingImage": training_image},
+        "AlgorithmSpecification": {
+            "TrainingInputMode": "File",
+            "TrainingImage": training_image,
+        },
         "HyperParameters": {
             "sagemaker_submit_directory": '"s3://some/sourcedir.tar.gz"',
             "sagemaker_program": '"train_coach.py"',
@@ -469,7 +510,9 @@ def test_attach(sagemaker_session, rl_coach_mxnet_version):
         name="describe_training_job", return_value=returned_job_description
     )
 
-    estimator = RLEstimator.attach(training_job_name="neo", sagemaker_session=sagemaker_session)
+    estimator = RLEstimator.attach(
+        training_job_name="neo", sagemaker_session=sagemaker_session
+    )
     assert estimator.latest_training_job.job_name == "neo"
     assert estimator.framework == RLFramework.MXNET.value
     assert estimator.toolkit == RLToolkit.COACH.value
@@ -485,13 +528,18 @@ def test_attach(sagemaker_session, rl_coach_mxnet_version):
     assert estimator.hyperparameters()["training_steps"] == "100"
     assert estimator.source_dir == "s3://some/sourcedir.tar.gz"
     assert estimator.entry_point == "train_coach.py"
-    assert estimator.metric_definitions == RLEstimator.default_metric_definitions(RLToolkit.COACH)
+    assert estimator.metric_definitions == RLEstimator.default_metric_definitions(
+        RLToolkit.COACH
+    )
 
 
 def test_attach_wrong_framework(sagemaker_session):
     training_image = "1.dkr.ecr.us-west-2.amazonaws.com/sagemaker-mxnet-py2-cpu:1.0.4"
     rjd = {
-        "AlgorithmSpecification": {"TrainingInputMode": "File", "TrainingImage": training_image},
+        "AlgorithmSpecification": {
+            "TrainingInputMode": "File",
+            "TrainingImage": training_image,
+        },
         "HyperParameters": {
             "sagemaker_submit_directory": '"s3://some/sourcedir.tar.gz"',
             "checkpoint_path": '"s3://other/1508872349"',
@@ -526,7 +574,10 @@ def test_attach_wrong_framework(sagemaker_session):
 def test_attach_custom_image(sagemaker_session):
     training_image = "rl:latest"
     returned_job_description = {
-        "AlgorithmSpecification": {"TrainingInputMode": "File", "TrainingImage": training_image},
+        "AlgorithmSpecification": {
+            "TrainingInputMode": "File",
+            "TrainingImage": training_image,
+        },
         "HyperParameters": {
             "sagemaker_submit_directory": '"s3://some/sourcedir.tar.gz"',
             "sagemaker_program": '"iris-dnn-classifier.py"',
@@ -554,7 +605,9 @@ def test_attach_custom_image(sagemaker_session):
         name="describe_training_job", return_value=returned_job_description
     )
 
-    estimator = RLEstimator.attach(training_job_name="neo", sagemaker_session=sagemaker_session)
+    estimator = RLEstimator.attach(
+        training_job_name="neo", sagemaker_session=sagemaker_session
+    )
     assert estimator.latest_training_job.job_name == "neo"
     assert estimator.image_name == training_image
     assert estimator.train_image() == training_image
@@ -604,7 +657,8 @@ def test_missing_required_parameters(sagemaker_session):
             train_instance_type=INSTANCE_TYPE,
         )
     assert (
-        "Please provide `toolkit`, `toolkit_version`, `framework`" + " or `image_name` parameter."
+        "Please provide `toolkit`, `toolkit_version`, `framework`"
+        + " or `image_name` parameter."
         in str(e.value)
     )
 

--- a/tests/unit/test_s3.py
+++ b/tests/unit/test_s3.py
@@ -35,7 +35,9 @@ def sagemaker_session():
         config=None,
         local_mode=False,
     )
-    session_mock.upload_data = Mock(name="upload_data", return_value="s3_uri_to_uploaded_data")
+    session_mock.upload_data = Mock(
+        name="upload_data", return_value="s3_uri_to_uploaded_data"
+    )
     session_mock.download_data = Mock(name="download_data")
     return session_mock
 
@@ -43,7 +45,9 @@ def sagemaker_session():
 def test_upload(sagemaker_session, caplog):
     desired_s3_uri = os.path.join("s3://", BUCKET_NAME, CURRENT_JOB_NAME, SOURCE_NAME)
     S3Uploader.upload(
-        local_path="/path/to/app.jar", desired_s3_uri=desired_s3_uri, session=sagemaker_session
+        local_path="/path/to/app.jar",
+        desired_s3_uri=desired_s3_uri,
+        session=sagemaker_session,
     )
     sagemaker_session.upload_data.assert_called_with(
         path="/path/to/app.jar",
@@ -52,7 +56,8 @@ def test_upload(sagemaker_session, caplog):
         extra_args=None,
     )
     warning_message = (
-        "Parameter 'session' will be renamed to 'sagemaker_session' " "in SageMaker Python SDK v2."
+        "Parameter 'session' will be renamed to 'sagemaker_session' "
+        "in SageMaker Python SDK v2."
     )
     assert warning_message in caplog.text
 
@@ -89,7 +94,10 @@ def test_download(sagemaker_session):
 def test_download_with_kms_key(sagemaker_session):
     s3_uri = os.path.join("s3://", BUCKET_NAME, CURRENT_JOB_NAME, SOURCE_NAME)
     S3Downloader.download(
-        s3_uri=s3_uri, local_path="/path/for/download/", kms_key=KMS_KEY, session=sagemaker_session
+        s3_uri=s3_uri,
+        local_path="/path/for/download/",
+        kms_key=KMS_KEY,
+        session=sagemaker_session,
     )
     sagemaker_session.download_data.assert_called_with(
         path="/path/for/download/",

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -45,9 +45,7 @@ def boto_session():
     boto_mock = Mock(name="boto_session", region_name=REGION)
 
     client_mock = Mock()
-    client_mock._client_config.user_agent = (
-        "Boto3/1.9.69 Python/3.6.5 Linux/4.14.77-70.82.amzn1.x86_64 Botocore/1.12.69 Resource"
-    )
+    client_mock._client_config.user_agent = "Boto3/1.9.69 Python/3.6.5 Linux/4.14.77-70.82.amzn1.x86_64 Botocore/1.12.69 Resource"
     boto_mock.client.return_value = client_mock
     return boto_mock
 
@@ -244,7 +242,9 @@ def test_process(boto_session):
         "ExperimentConfig": {"ExperimentName": "AnExperiment"},
     }
 
-    session.sagemaker_client.create_processing_job.assert_called_with(**expected_request)
+    session.sagemaker_client.create_processing_job.assert_called_with(
+        **expected_request
+    )
 
 
 def mock_exists(filepath_to_mock, exists_result):
@@ -261,7 +261,9 @@ def mock_exists(filepath_to_mock, exists_result):
 
 def test_get_execution_role():
     session = Mock()
-    session.get_caller_identity_arn.return_value = "arn:aws:iam::369233609183:role/SageMakerRole"
+    session.get_caller_identity_arn.return_value = (
+        "arn:aws:iam::369233609183:role/SageMakerRole"
+    )
 
     actual = get_execution_role(session)
     assert actual == "arn:aws:iam::369233609183:role/SageMakerRole"
@@ -269,9 +271,7 @@ def test_get_execution_role():
 
 def test_get_execution_role_works_with_service_role():
     session = Mock()
-    session.get_caller_identity_arn.return_value = (
-        "arn:aws:iam::369233609183:role/service-role/AmazonSageMaker-ExecutionRole-20171129T072388"
-    )
+    session.get_caller_identity_arn.return_value = "arn:aws:iam::369233609183:role/service-role/AmazonSageMaker-ExecutionRole-20171129T072388"
 
     actual = get_execution_role(session)
     assert (
@@ -282,7 +282,9 @@ def test_get_execution_role_works_with_service_role():
 
 def test_get_execution_role_throws_exception_if_arn_is_not_role():
     session = Mock()
-    session.get_caller_identity_arn.return_value = "arn:aws:iam::369233609183:user/marcos"
+    session.get_caller_identity_arn.return_value = (
+        "arn:aws:iam::369233609183:user/marcos"
+    )
 
     with pytest.raises(ValueError) as error:
         get_execution_role(session)
@@ -291,19 +293,28 @@ def test_get_execution_role_throws_exception_if_arn_is_not_role():
 
 def test_get_execution_role_throws_exception_if_arn_is_not_role_with_role_in_name():
     session = Mock()
-    session.get_caller_identity_arn.return_value = "arn:aws:iam::369233609183:user/marcos-role"
+    session.get_caller_identity_arn.return_value = (
+        "arn:aws:iam::369233609183:user/marcos-role"
+    )
 
     with pytest.raises(ValueError) as error:
         get_execution_role(session)
     assert "ValueError: The current AWS identity is not a role" in str(error)
 
 
-@patch("six.moves.builtins.open", mock_open(read_data='{"ResourceName": "SageMakerInstance"}'))
+@patch(
+    "six.moves.builtins.open",
+    mock_open(read_data='{"ResourceName": "SageMakerInstance"}'),
+)
 @patch("os.path.exists", side_effect=mock_exists(NOTEBOOK_METADATA_FILE, True))
 def test_get_caller_identity_arn_from_describe_notebook_instance(boto_session):
     sess = Session(boto_session)
-    expected_role = "arn:aws:iam::369233609183:role/service-role/SageMakerRole-20171129T072388"
-    sess.sagemaker_client.describe_notebook_instance.return_value = {"RoleArn": expected_role}
+    expected_role = (
+        "arn:aws:iam::369233609183:role/service-role/SageMakerRole-20171129T072388"
+    )
+    sess.sagemaker_client.describe_notebook_instance.return_value = {
+        "RoleArn": expected_role
+    }
 
     actual = sess.get_caller_identity_arn()
 
@@ -313,7 +324,10 @@ def test_get_caller_identity_arn_from_describe_notebook_instance(boto_session):
     )
 
 
-@patch("six.moves.builtins.open", mock_open(read_data='{"ResourceName": "SageMakerInstance"}'))
+@patch(
+    "six.moves.builtins.open",
+    mock_open(read_data='{"ResourceName": "SageMakerInstance"}'),
+)
 @patch("os.path.exists", side_effect=mock_exists(NOTEBOOK_METADATA_FILE, True))
 @patch("sagemaker.session.sts_regional_endpoint", return_value=STS_ENDPOINT)
 def test_get_caller_identity_arn_from_a_role_after_describe_notebook_exception(
@@ -321,19 +335,20 @@ def test_get_caller_identity_arn_from_a_role_after_describe_notebook_exception(
 ):
     sess = Session(boto_session)
     exception = ClientError(
-        {"Error": {"Code": "ValidationException", "Message": "RecordNotFound"}}, "Operation"
+        {"Error": {"Code": "ValidationException", "Message": "RecordNotFound"}},
+        "Operation",
     )
     sess.sagemaker_client.describe_notebook_instance.side_effect = exception
 
-    arn = (
-        "arn:aws:sts::369233609183:assumed-role/SageMakerRole/6d009ef3-5306-49d5-8efc-78db644d8122"
-    )
-    sess.boto_session.client("sts", endpoint_url=STS_ENDPOINT).get_caller_identity.return_value = {
-        "Arn": arn
-    }
+    arn = "arn:aws:sts::369233609183:assumed-role/SageMakerRole/6d009ef3-5306-49d5-8efc-78db644d8122"
+    sess.boto_session.client(
+        "sts", endpoint_url=STS_ENDPOINT
+    ).get_caller_identity.return_value = {"Arn": arn}
 
     expected_role = "arn:aws:iam::369233609183:role/SageMakerRole"
-    sess.boto_session.client("iam").get_role.return_value = {"Role": {"Arn": expected_role}}
+    sess.boto_session.client("iam").get_role.return_value = {
+        "Role": {"Arn": expected_role}
+    }
 
     with patch("logging.Logger.debug") as mock_logger:
         actual = sess.get_caller_identity_arn()
@@ -350,9 +365,9 @@ def test_get_caller_identity_arn_from_a_role_after_describe_notebook_exception(
 def test_get_caller_identity_arn_from_a_user(sts_regional_endpoint, boto_session):
     sess = Session(boto_session)
     arn = "arn:aws:iam::369233609183:user/mia"
-    sess.boto_session.client("sts", endpoint_url=STS_ENDPOINT).get_caller_identity.return_value = {
-        "Arn": arn
-    }
+    sess.boto_session.client(
+        "sts", endpoint_url=STS_ENDPOINT
+    ).get_caller_identity.return_value = {"Arn": arn}
     sess.boto_session.client("iam").get_role.return_value = {"Role": {"Arn": arn}}
 
     actual = sess.get_caller_identity_arn()
@@ -366,9 +381,9 @@ def test_get_caller_identity_arn_from_an_user_without_permissions(
 ):
     sess = Session(boto_session)
     arn = "arn:aws:iam::369233609183:user/mia"
-    sess.boto_session.client("sts", endpoint_url=STS_ENDPOINT).get_caller_identity.return_value = {
-        "Arn": arn
-    }
+    sess.boto_session.client(
+        "sts", endpoint_url=STS_ENDPOINT
+    ).get_caller_identity.return_value = {"Arn": arn}
     sess.boto_session.client("iam").get_role.side_effect = ClientError({}, {})
 
     with patch("logging.Logger.warning") as mock_logger:
@@ -381,15 +396,15 @@ def test_get_caller_identity_arn_from_an_user_without_permissions(
 @patch("sagemaker.session.sts_regional_endpoint", return_value=STS_ENDPOINT)
 def test_get_caller_identity_arn_from_a_role(sts_regional_endpoint, boto_session):
     sess = Session(boto_session)
-    arn = (
-        "arn:aws:sts::369233609183:assumed-role/SageMakerRole/6d009ef3-5306-49d5-8efc-78db644d8122"
-    )
-    sess.boto_session.client("sts", endpoint_url=STS_ENDPOINT).get_caller_identity.return_value = {
-        "Arn": arn
-    }
+    arn = "arn:aws:sts::369233609183:assumed-role/SageMakerRole/6d009ef3-5306-49d5-8efc-78db644d8122"
+    sess.boto_session.client(
+        "sts", endpoint_url=STS_ENDPOINT
+    ).get_caller_identity.return_value = {"Arn": arn}
 
     expected_role = "arn:aws:iam::369233609183:role/SageMakerRole"
-    sess.boto_session.client("iam").get_role.return_value = {"Role": {"Arn": expected_role}}
+    sess.boto_session.client("iam").get_role.return_value = {
+        "Role": {"Arn": expected_role}
+    }
 
     actual = sess.get_caller_identity_arn()
     assert actual == expected_role
@@ -397,12 +412,14 @@ def test_get_caller_identity_arn_from_a_role(sts_regional_endpoint, boto_session
 
 @patch("os.path.exists", side_effect=mock_exists(NOTEBOOK_METADATA_FILE, False))
 @patch("sagemaker.session.sts_regional_endpoint", return_value=STS_ENDPOINT)
-def test_get_caller_identity_arn_from_an_execution_role(sts_regional_endpoint, boto_session):
+def test_get_caller_identity_arn_from_an_execution_role(
+    sts_regional_endpoint, boto_session
+):
     sess = Session(boto_session)
     arn = "arn:aws:sts::369233609183:assumed-role/AmazonSageMaker-ExecutionRole-20171129T072388/SageMaker"
-    sess.boto_session.client("sts", endpoint_url=STS_ENDPOINT).get_caller_identity.return_value = {
-        "Arn": arn
-    }
+    sess.boto_session.client(
+        "sts", endpoint_url=STS_ENDPOINT
+    ).get_caller_identity.return_value = {"Arn": arn}
     sess.boto_session.client("iam").get_role.return_value = {"Role": {"Arn": arn}}
 
     actual = sess.get_caller_identity_arn()
@@ -414,17 +431,21 @@ def test_get_caller_identity_arn_from_an_execution_role(sts_regional_endpoint, b
 
 @patch("os.path.exists", side_effect=mock_exists(NOTEBOOK_METADATA_FILE, False))
 @patch("sagemaker.session.sts_regional_endpoint", return_value=STS_ENDPOINT)
-def test_get_caller_identity_arn_from_role_with_path(sts_regional_endpoint, boto_session):
+def test_get_caller_identity_arn_from_role_with_path(
+    sts_regional_endpoint, boto_session
+):
     sess = Session(boto_session)
     arn_prefix = "arn:aws:iam::369233609183:role"
     role_name = "name"
-    sess.boto_session.client("sts", endpoint_url=STS_ENDPOINT).get_caller_identity.return_value = {
-        "Arn": "/".join([arn_prefix, role_name])
-    }
+    sess.boto_session.client(
+        "sts", endpoint_url=STS_ENDPOINT
+    ).get_caller_identity.return_value = {"Arn": "/".join([arn_prefix, role_name])}
 
     role_path = "path"
     role_with_path = "/".join([arn_prefix, role_path, role_name])
-    sess.boto_session.client("iam").get_role.return_value = {"Role": {"Arn": role_with_path}}
+    sess.boto_session.client("iam").get_role.return_value = {
+        "Role": {"Arn": role_with_path}
+    }
 
     actual = sess.get_caller_identity_arn()
     assert actual == role_with_path
@@ -457,14 +478,21 @@ def test_delete_model(boto_session):
 
 def test_user_agent_injected(boto_session):
     assert (
-        "AWS-SageMaker-Python-SDK" not in boto_session.client("sagemaker")._client_config.user_agent
+        "AWS-SageMaker-Python-SDK"
+        not in boto_session.client("sagemaker")._client_config.user_agent
     )
 
     sess = Session(boto_session)
 
     assert "AWS-SageMaker-Python-SDK" in sess.sagemaker_client._client_config.user_agent
-    assert "AWS-SageMaker-Python-SDK" in sess.sagemaker_runtime_client._client_config.user_agent
-    assert "AWS-SageMaker-Notebook-Instance" not in sess.sagemaker_client._client_config.user_agent
+    assert (
+        "AWS-SageMaker-Python-SDK"
+        in sess.sagemaker_runtime_client._client_config.user_agent
+    )
+    assert (
+        "AWS-SageMaker-Notebook-Instance"
+        not in sess.sagemaker_client._client_config.user_agent
+    )
     assert (
         "AWS-SageMaker-Notebook-Instance"
         not in sess.sagemaker_runtime_client._client_config.user_agent
@@ -473,7 +501,8 @@ def test_user_agent_injected(boto_session):
 
 def test_user_agent_injected_with_nbi(boto_session):
     assert (
-        "AWS-SageMaker-Python-SDK" not in boto_session.client("sagemaker")._client_config.user_agent
+        "AWS-SageMaker-Python-SDK"
+        not in boto_session.client("sagemaker")._client_config.user_agent
     )
 
     with patch("six.moves.builtins.open", mock_open(read_data="120.0-0")) as mo:
@@ -482,26 +511,42 @@ def test_user_agent_injected_with_nbi(boto_session):
         mo.assert_called_with("/etc/opt/ml/sagemaker-notebook-instance-version.txt")
 
     assert "AWS-SageMaker-Python-SDK" in sess.sagemaker_client._client_config.user_agent
-    assert "AWS-SageMaker-Python-SDK" in sess.sagemaker_runtime_client._client_config.user_agent
-    assert "AWS-SageMaker-Notebook-Instance" in sess.sagemaker_client._client_config.user_agent
     assert (
-        "AWS-SageMaker-Notebook-Instance" in sess.sagemaker_runtime_client._client_config.user_agent
+        "AWS-SageMaker-Python-SDK"
+        in sess.sagemaker_runtime_client._client_config.user_agent
+    )
+    assert (
+        "AWS-SageMaker-Notebook-Instance"
+        in sess.sagemaker_client._client_config.user_agent
+    )
+    assert (
+        "AWS-SageMaker-Notebook-Instance"
+        in sess.sagemaker_runtime_client._client_config.user_agent
     )
 
 
 def test_user_agent_injected_with_nbi_ioerror(boto_session):
     assert (
-        "AWS-SageMaker-Python-SDK" not in boto_session.client("sagemaker")._client_config.user_agent
+        "AWS-SageMaker-Python-SDK"
+        not in boto_session.client("sagemaker")._client_config.user_agent
     )
 
-    with patch("six.moves.builtins.open", MagicMock(side_effect=IOError("File not found"))) as mo:
+    with patch(
+        "six.moves.builtins.open", MagicMock(side_effect=IOError("File not found"))
+    ) as mo:
         sess = Session(boto_session)
 
         mo.assert_called_with("/etc/opt/ml/sagemaker-notebook-instance-version.txt")
 
     assert "AWS-SageMaker-Python-SDK" in sess.sagemaker_client._client_config.user_agent
-    assert "AWS-SageMaker-Python-SDK" in sess.sagemaker_runtime_client._client_config.user_agent
-    assert "AWS-SageMaker-Notebook-Instance" not in sess.sagemaker_client._client_config.user_agent
+    assert (
+        "AWS-SageMaker-Python-SDK"
+        in sess.sagemaker_runtime_client._client_config.user_agent
+    )
+    assert (
+        "AWS-SageMaker-Notebook-Instance"
+        not in sess.sagemaker_client._client_config.user_agent
+    )
     assert (
         "AWS-SageMaker-Notebook-Instance"
         not in sess.sagemaker_runtime_client._client_config.user_agent
@@ -631,10 +676,17 @@ COMPLETED_DESCRIBE_TRANSFORM_JOB_RESULT = {
     "TransformJobStatus": "Completed",
     "ModelName": "some-model",
     "TransformJobName": JOB_NAME,
-    "TransformResources": {"InstanceCount": INSTANCE_COUNT, "InstanceType": INSTANCE_TYPE},
+    "TransformResources": {
+        "InstanceCount": INSTANCE_COUNT,
+        "InstanceType": INSTANCE_TYPE,
+    },
     "TransformEndTime": datetime.datetime(2018, 2, 17, 7, 19, 34, 953000),
     "TransformStartTime": datetime.datetime(2018, 2, 17, 7, 15, 0, 103000),
-    "TransformOutput": {"AssembleWith": "None", "KmsKeyId": "", "S3OutputPath": S3_OUTPUT},
+    "TransformOutput": {
+        "AssembleWith": "None",
+        "KmsKeyId": "",
+        "S3OutputPath": S3_OUTPUT,
+    },
     "TransformInput": {
         "CompressionType": "None",
         "ContentType": "text/csv",
@@ -646,16 +698,18 @@ COMPLETED_DESCRIBE_TRANSFORM_JOB_RESULT = {
 STOPPED_DESCRIBE_TRANSFORM_JOB_RESULT = dict(COMPLETED_DESCRIBE_TRANSFORM_JOB_RESULT)
 STOPPED_DESCRIBE_TRANSFORM_JOB_RESULT.update({"TransformJobStatus": "Stopped"})
 
-IN_PROGRESS_DESCRIBE_TRANSFORM_JOB_RESULT = dict(COMPLETED_DESCRIBE_TRANSFORM_JOB_RESULT)
+IN_PROGRESS_DESCRIBE_TRANSFORM_JOB_RESULT = dict(
+    COMPLETED_DESCRIBE_TRANSFORM_JOB_RESULT
+)
 IN_PROGRESS_DESCRIBE_TRANSFORM_JOB_RESULT.update({"TransformJobStatus": "InProgress"})
 
 
 @pytest.fixture()
 def sagemaker_session():
     boto_mock = Mock(name="boto_session")
-    boto_mock.client("sts", endpoint_url=STS_ENDPOINT).get_caller_identity.return_value = {
-        "Account": "123"
-    }
+    boto_mock.client(
+        "sts", endpoint_url=STS_ENDPOINT
+    ).get_caller_identity.return_value = {"Account": "123"}
     ims = sagemaker.Session(boto_session=boto_mock, sagemaker_client=Mock())
     ims.expand_role = Mock(return_value=EXPANDED_ROLE)
     return ims
@@ -749,7 +803,10 @@ SAMPLE_TUNING_JOB_REQUEST = {
     "HyperParameterTuningJobConfig": {
         "Strategy": "Bayesian",
         "HyperParameterTuningJobObjective": SAMPLE_OBJECTIVE,
-        "ResourceLimits": {"MaxNumberOfTrainingJobs": 100, "MaxParallelTrainingJobs": 5},
+        "ResourceLimits": {
+            "MaxNumberOfTrainingJobs": 100,
+            "MaxParallelTrainingJobs": 5,
+        },
         "ParameterRanges": SAMPLE_PARAM_RANGES,
         "TrainingJobEarlyStoppingType": "Off",
     },
@@ -772,7 +829,10 @@ SAMPLE_MULTI_ALGO_TUNING_JOB_REQUEST = {
     "HyperParameterTuningJobName": "dummy-tuning-1",
     "HyperParameterTuningJobConfig": {
         "Strategy": "Bayesian",
-        "ResourceLimits": {"MaxNumberOfTrainingJobs": 100, "MaxParallelTrainingJobs": 5},
+        "ResourceLimits": {
+            "MaxNumberOfTrainingJobs": 100,
+            "MaxParallelTrainingJobs": 5,
+        },
         "TrainingJobEarlyStoppingType": "Off",
     },
     "TrainingJobDefinitions": [
@@ -814,7 +874,10 @@ SAMPLE_MULTI_ALGO_TUNING_JOB_REQUEST = {
 
 @pytest.mark.parametrize(
     "warm_start_type, parents",
-    [("IdenticalDataAndAlgorithm", {"p1", "p2", "p3"}), ("TransferLearning", {"p1", "p2", "p3"})],
+    [
+        ("IdenticalDataAndAlgorithm", {"p1", "p2", "p3"}),
+        ("TransferLearning", {"p1", "p2", "p3"}),
+    ],
 )
 def test_tune_warm_start(sagemaker_session, warm_start_type, parents):
     def assert_create_tuning_job_request(**kwrags):
@@ -823,7 +886,10 @@ def test_tune_warm_start(sagemaker_session, warm_start_type, parents):
             == SAMPLE_TUNING_JOB_REQUEST["HyperParameterTuningJobConfig"]
         )
         assert kwrags["HyperParameterTuningJobName"] == "dummy-tuning-1"
-        assert kwrags["TrainingJobDefinition"] == SAMPLE_TUNING_JOB_REQUEST["TrainingJobDefinition"]
+        assert (
+            kwrags["TrainingJobDefinition"]
+            == SAMPLE_TUNING_JOB_REQUEST["TrainingJobDefinition"]
+        )
         assert kwrags["WarmStartConfig"] == {
             "WarmStartType": warm_start_type,
             "ParentHyperParameterTuningJobs": [
@@ -860,7 +926,8 @@ def test_tune_warm_start(sagemaker_session, warm_start_type, parents):
 
 def test_create_tuning_job_without_training_config_or_list(sagemaker_session):
     with pytest.raises(
-        ValueError, match="Either training_config or training_config_list should be provided."
+        ValueError,
+        match="Either training_config or training_config_list should be provided.",
     ):
         sagemaker_session.create_tuning_job(
             job_name="dummy-tuning-1",
@@ -877,7 +944,8 @@ def test_create_tuning_job_without_training_config_or_list(sagemaker_session):
 
 def test_create_tuning_job_with_both_training_config_and_list(sagemaker_session):
     with pytest.raises(
-        ValueError, match="Only one of training_config and training_config_list should be provided."
+        ValueError,
+        match="Only one of training_config and training_config_list should be provided.",
     ):
         sagemaker_session.create_tuning_job(
             job_name="dummy-tuning-1",
@@ -889,7 +957,10 @@ def test_create_tuning_job_with_both_training_config_and_list(sagemaker_session)
                 "max_parallel_jobs": 5,
                 "parameter_ranges": SAMPLE_PARAM_RANGES,
             },
-            training_config={"static_hyperparameters": STATIC_HPs, "image": "dummy-image-1"},
+            training_config={
+                "static_hyperparameters": STATIC_HPs,
+                "image": "dummy-image-1",
+            },
             training_config_list=[
                 {
                     "static_hyperparameters": STATIC_HPs,
@@ -912,7 +983,10 @@ def test_create_tuning_job(sagemaker_session):
             == SAMPLE_TUNING_JOB_REQUEST["HyperParameterTuningJobConfig"]
         )
         assert kwrags["HyperParameterTuningJobName"] == "dummy-tuning-1"
-        assert kwrags["TrainingJobDefinition"] == SAMPLE_TUNING_JOB_REQUEST["TrainingJobDefinition"]
+        assert (
+            kwrags["TrainingJobDefinition"]
+            == SAMPLE_TUNING_JOB_REQUEST["TrainingJobDefinition"]
+        )
         assert "TrainingJobDefinitions" not in kwrags
         assert kwrags.get("WarmStartConfig", None) is None
 
@@ -1009,7 +1083,10 @@ def test_tune(sagemaker_session):
             == SAMPLE_TUNING_JOB_REQUEST["HyperParameterTuningJobConfig"]
         )
         assert kwrags["HyperParameterTuningJobName"] == "dummy-tuning-1"
-        assert kwrags["TrainingJobDefinition"] == SAMPLE_TUNING_JOB_REQUEST["TrainingJobDefinition"]
+        assert (
+            kwrags["TrainingJobDefinition"]
+            == SAMPLE_TUNING_JOB_REQUEST["TrainingJobDefinition"]
+        )
         assert kwrags.get("WarmStartConfig", None) is None
 
     sagemaker_session.sagemaker_client.create_hyper_parameter_tuning_job.side_effect = (
@@ -1044,7 +1121,10 @@ def test_tune_with_encryption_flag(sagemaker_session):
             == SAMPLE_TUNING_JOB_REQUEST["HyperParameterTuningJobConfig"]
         )
         assert kwrags["HyperParameterTuningJobName"] == "dummy-tuning-1"
-        assert kwrags["TrainingJobDefinition"]["EnableInterContainerTrafficEncryption"] is True
+        assert (
+            kwrags["TrainingJobDefinition"]["EnableInterContainerTrafficEncryption"]
+            is True
+        )
         assert kwrags.get("WarmStartConfig", None) is None
 
     sagemaker_session.sagemaker_client.create_hyper_parameter_tuning_job.side_effect = (
@@ -1086,7 +1166,8 @@ def test_tune_with_spot_and_checkpoints(sagemaker_session):
             == "s3://mybucket/checkpoints/"
         )
         assert (
-            kwargs["TrainingJobDefinition"]["CheckpointConfig"]["LocalPath"] == "/tmp/checkpoints"
+            kwargs["TrainingJobDefinition"]["CheckpointConfig"]["LocalPath"]
+            == "/tmp/checkpoints"
         )
         assert kwargs.get("WarmStartConfig", None) is None
 
@@ -1215,11 +1296,19 @@ def test_train_pack_to_request_with_optional_params(sagemaker_session):
     assert actual_train_args["VpcConfig"] == VPC_CONFIG
     assert actual_train_args["HyperParameters"] == hyperparameters
     assert actual_train_args["Tags"] == TAGS
-    assert actual_train_args["AlgorithmSpecification"]["MetricDefinitions"] == METRIC_DEFINITONS
-    assert actual_train_args["AlgorithmSpecification"]["EnableSageMakerMetricsTimeSeries"] is True
+    assert (
+        actual_train_args["AlgorithmSpecification"]["MetricDefinitions"]
+        == METRIC_DEFINITONS
+    )
+    assert (
+        actual_train_args["AlgorithmSpecification"]["EnableSageMakerMetricsTimeSeries"]
+        is True
+    )
     assert actual_train_args["EnableInterContainerTrafficEncryption"] is True
     assert actual_train_args["EnableManagedSpotTraining"] is True
-    assert actual_train_args["CheckpointConfig"]["S3Uri"] == "s3://mybucket/checkpoints/"
+    assert (
+        actual_train_args["CheckpointConfig"]["S3Uri"] == "s3://mybucket/checkpoints/"
+    )
     assert actual_train_args["CheckpointConfig"]["LocalPath"] == "/tmp/checkpoints"
 
 
@@ -1230,7 +1319,9 @@ def test_transform_pack_to_request(sagemaker_session):
         "CompressionType": "None",
         "ContentType": "text/csv",
         "SplitType": "None",
-        "DataSource": {"S3DataSource": {"S3DataType": "S3Prefix", "S3Uri": S3_INPUT_URI}},
+        "DataSource": {
+            "S3DataSource": {"S3DataType": "S3Prefix", "S3Uri": S3_INPUT_URI}
+        },
     }
 
     out_config = {"S3OutputPath": S3_OUTPUT}
@@ -1356,7 +1447,9 @@ def sagemaker_session_complete():
     boto_mock.client("logs").describe_log_streams.return_value = DEFAULT_LOG_STREAMS
     boto_mock.client("logs").get_log_events.side_effect = DEFAULT_LOG_EVENTS
     ims = sagemaker.Session(boto_session=boto_mock, sagemaker_client=Mock())
-    ims.sagemaker_client.describe_training_job.return_value = COMPLETED_DESCRIBE_JOB_RESULT
+    ims.sagemaker_client.describe_training_job.return_value = (
+        COMPLETED_DESCRIBE_JOB_RESULT
+    )
     ims.sagemaker_client.describe_transform_job.return_value = (
         COMPLETED_DESCRIBE_TRANSFORM_JOB_RESULT
     )
@@ -1369,8 +1462,12 @@ def sagemaker_session_stopped():
     boto_mock.client("logs").describe_log_streams.return_value = DEFAULT_LOG_STREAMS
     boto_mock.client("logs").get_log_events.side_effect = DEFAULT_LOG_EVENTS
     ims = sagemaker.Session(boto_session=boto_mock, sagemaker_client=Mock())
-    ims.sagemaker_client.describe_training_job.return_value = STOPPED_DESCRIBE_JOB_RESULT
-    ims.sagemaker_client.describe_transform_job.return_value = STOPPED_DESCRIBE_TRANSFORM_JOB_RESULT
+    ims.sagemaker_client.describe_training_job.return_value = (
+        STOPPED_DESCRIBE_JOB_RESULT
+    )
+    ims.sagemaker_client.describe_transform_job.return_value = (
+        STOPPED_DESCRIBE_TRANSFORM_JOB_RESULT
+    )
     return ims
 
 
@@ -1416,7 +1513,9 @@ def sagemaker_session_full_lifecycle():
 def test_logs_for_job_no_wait(cw, sagemaker_session_complete):
     ims = sagemaker_session_complete
     ims.logs_for_job(JOB_NAME)
-    ims.sagemaker_client.describe_training_job.assert_called_once_with(TrainingJobName=JOB_NAME)
+    ims.sagemaker_client.describe_training_job.assert_called_once_with(
+        TrainingJobName=JOB_NAME
+    )
     cw().assert_called_with(0, "hi there #1")
 
 
@@ -1424,7 +1523,9 @@ def test_logs_for_job_no_wait(cw, sagemaker_session_complete):
 def test_logs_for_job_no_wait_stopped_job(cw, sagemaker_session_stopped):
     ims = sagemaker_session_stopped
     ims.logs_for_job(JOB_NAME)
-    ims.sagemaker_client.describe_training_job.assert_called_once_with(TrainingJobName=JOB_NAME)
+    ims.sagemaker_client.describe_training_job.assert_called_once_with(
+        TrainingJobName=JOB_NAME
+    )
     cw().assert_called_with(0, "hi there #1")
 
 
@@ -1479,7 +1580,9 @@ def test_logs_for_job_full_lifecycle(time, cw, sagemaker_session_full_lifecycle)
 def test_logs_for_transform_job_no_wait(cw, sagemaker_session_complete):
     ims = sagemaker_session_complete
     ims.logs_for_transform_job(JOB_NAME)
-    ims.sagemaker_client.describe_transform_job.assert_called_once_with(TransformJobName=JOB_NAME)
+    ims.sagemaker_client.describe_transform_job.assert_called_once_with(
+        TransformJobName=JOB_NAME
+    )
     cw().assert_called_with(0, "hi there #1")
 
 
@@ -1487,7 +1590,9 @@ def test_logs_for_transform_job_no_wait(cw, sagemaker_session_complete):
 def test_logs_for_transform_job_no_wait_stopped_job(cw, sagemaker_session_stopped):
     ims = sagemaker_session_stopped
     ims.logs_for_transform_job(JOB_NAME)
-    ims.sagemaker_client.describe_transform_job.assert_called_once_with(TransformJobName=JOB_NAME)
+    ims.sagemaker_client.describe_transform_job.assert_called_once_with(
+        TransformJobName=JOB_NAME
+    )
     cw().assert_called_with(0, "hi there #1")
 
 
@@ -1512,7 +1617,9 @@ def test_logs_for_transform_job_wait_on_stopped(cw, sagemaker_session_stopped):
 
 
 @patch("sagemaker.logs.ColorWrap")
-def test_logs_for_transform_job_no_wait_on_running(cw, sagemaker_session_ready_lifecycle):
+def test_logs_for_transform_job_no_wait_on_running(
+    cw, sagemaker_session_ready_lifecycle
+):
     ims = sagemaker_session_ready_lifecycle
     ims.logs_for_transform_job(JOB_NAME)
     assert ims.sagemaker_client.describe_transform_job.call_args_list == [
@@ -1523,7 +1630,9 @@ def test_logs_for_transform_job_no_wait_on_running(cw, sagemaker_session_ready_l
 
 @patch("sagemaker.logs.ColorWrap")
 @patch("time.time", side_effect=[0, 30, 60, 90, 120, 150, 180])
-def test_logs_for_transform_job_full_lifecycle(time, cw, sagemaker_session_full_lifecycle):
+def test_logs_for_transform_job_full_lifecycle(
+    time, cw, sagemaker_session_full_lifecycle
+):
     ims = sagemaker_session_full_lifecycle
     ims.logs_for_transform_job(JOB_NAME, wait=True, poll=0)
     assert (
@@ -1552,14 +1661,18 @@ def test_create_model(expand_container_def, sagemaker_session):
 
     assert model == MODEL_NAME
     sagemaker_session.sagemaker_client.create_model.assert_called_with(
-        ExecutionRoleArn=EXPANDED_ROLE, ModelName=MODEL_NAME, PrimaryContainer=PRIMARY_CONTAINER
+        ExecutionRoleArn=EXPANDED_ROLE,
+        ModelName=MODEL_NAME,
+        PrimaryContainer=PRIMARY_CONTAINER,
     )
 
 
 @patch("sagemaker.session._expand_container_def", return_value=PRIMARY_CONTAINER)
 def test_create_model_with_tags(expand_container_def, sagemaker_session):
     tags = [{"Key": "TagtestKey", "Value": "TagtestValue"}]
-    model = sagemaker_session.create_model(MODEL_NAME, ROLE, PRIMARY_CONTAINER, tags=tags)
+    model = sagemaker_session.create_model(
+        MODEL_NAME, ROLE, PRIMARY_CONTAINER, tags=tags
+    )
 
     assert model == MODEL_NAME
     tags = [{"Value": "TagtestValue", "Key": "TagtestKey"}]
@@ -1573,11 +1686,15 @@ def test_create_model_with_tags(expand_container_def, sagemaker_session):
 
 @patch("sagemaker.session._expand_container_def", return_value=PRIMARY_CONTAINER)
 def test_create_model_with_primary_container(expand_container_def, sagemaker_session):
-    model = sagemaker_session.create_model(MODEL_NAME, ROLE, container_defs=PRIMARY_CONTAINER)
+    model = sagemaker_session.create_model(
+        MODEL_NAME, ROLE, container_defs=PRIMARY_CONTAINER
+    )
 
     assert model == MODEL_NAME
     sagemaker_session.sagemaker_client.create_model.assert_called_with(
-        ExecutionRoleArn=EXPANDED_ROLE, ModelName=MODEL_NAME, PrimaryContainer=PRIMARY_CONTAINER
+        ExecutionRoleArn=EXPANDED_ROLE,
+        ModelName=MODEL_NAME,
+        PrimaryContainer=PRIMARY_CONTAINER,
     )
 
 
@@ -1585,7 +1702,10 @@ def test_create_model_with_primary_container(expand_container_def, sagemaker_ses
 def test_create_model_with_both(expand_container_def, sagemaker_session):
     with pytest.raises(ValueError):
         sagemaker_session.create_model(
-            MODEL_NAME, ROLE, container_defs=PRIMARY_CONTAINER, primary_container=PRIMARY_CONTAINER
+            MODEL_NAME,
+            ROLE,
+            container_defs=PRIMARY_CONTAINER,
+            primary_container=PRIMARY_CONTAINER,
         )
 
 
@@ -1611,7 +1731,9 @@ def test_create_pipeline_model(expand_container_def, sagemaker_session):
 
 @patch("sagemaker.session._expand_container_def", return_value=PRIMARY_CONTAINER)
 def test_create_model_vpc_config(expand_container_def, sagemaker_session):
-    model = sagemaker_session.create_model(MODEL_NAME, ROLE, PRIMARY_CONTAINER, VPC_CONFIG)
+    model = sagemaker_session.create_model(
+        MODEL_NAME, ROLE, PRIMARY_CONTAINER, VPC_CONFIG
+    )
 
     assert model == MODEL_NAME
     sagemaker_session.sagemaker_client.create_model.assert_called_with(
@@ -1638,7 +1760,10 @@ def test_create_pipeline_model_vpc_config(expand_container_def, sagemaker_sessio
 @patch("sagemaker.session._expand_container_def", return_value=PRIMARY_CONTAINER)
 def test_create_model_already_exists(expand_container_def, sagemaker_session, caplog):
     error_response = {
-        "Error": {"Code": "ValidationException", "Message": "Cannot create already existing model"}
+        "Error": {
+            "Code": "ValidationException",
+            "Message": "Cannot create already existing model",
+        }
     }
     exception = ClientError(error_response, "Operation")
     sagemaker_session.sagemaker_client.create_model.side_effect = exception
@@ -1657,7 +1782,9 @@ def test_create_model_already_exists(expand_container_def, sagemaker_session, ca
 @patch("sagemaker.session._expand_container_def", return_value=PRIMARY_CONTAINER)
 def test_create_model_failure(expand_container_def, sagemaker_session):
     error_message = "this is expected"
-    sagemaker_session.sagemaker_client.create_model.side_effect = RuntimeError(error_message)
+    sagemaker_session.sagemaker_client.create_model.side_effect = RuntimeError(
+        error_message
+    )
 
     with pytest.raises(RuntimeError) as e:
         sagemaker_session.create_model(MODEL_NAME, ROLE, PRIMARY_CONTAINER)
@@ -1667,11 +1794,14 @@ def test_create_model_failure(expand_container_def, sagemaker_session):
 
 def test_create_model_from_job(sagemaker_session):
     ims = sagemaker_session
-    ims.sagemaker_client.describe_training_job.return_value = COMPLETED_DESCRIBE_JOB_RESULT
+    ims.sagemaker_client.describe_training_job.return_value = (
+        COMPLETED_DESCRIBE_JOB_RESULT
+    )
     ims.create_model_from_job(JOB_NAME)
 
     assert (
-        call(TrainingJobName=JOB_NAME) in ims.sagemaker_client.describe_training_job.call_args_list
+        call(TrainingJobName=JOB_NAME)
+        in ims.sagemaker_client.describe_training_job.call_args_list
     )
     ims.sagemaker_client.create_model.assert_called_with(
         ExecutionRoleArn=EXPANDED_ROLE,
@@ -1683,11 +1813,14 @@ def test_create_model_from_job(sagemaker_session):
 
 def test_create_model_from_job_with_tags(sagemaker_session):
     ims = sagemaker_session
-    ims.sagemaker_client.describe_training_job.return_value = COMPLETED_DESCRIBE_JOB_RESULT
+    ims.sagemaker_client.describe_training_job.return_value = (
+        COMPLETED_DESCRIBE_JOB_RESULT
+    )
     ims.create_model_from_job(JOB_NAME, tags=TAGS)
 
     assert (
-        call(TrainingJobName=JOB_NAME) in ims.sagemaker_client.describe_training_job.call_args_list
+        call(TrainingJobName=JOB_NAME)
+        in ims.sagemaker_client.describe_training_job.call_args_list
     )
     ims.sagemaker_client.create_model.assert_called_with(
         ExecutionRoleArn=EXPANDED_ROLE,
@@ -1700,7 +1833,9 @@ def test_create_model_from_job_with_tags(sagemaker_session):
 
 def test_create_model_from_job_with_image(sagemaker_session):
     ims = sagemaker_session
-    ims.sagemaker_client.describe_training_job.return_value = COMPLETED_DESCRIBE_JOB_RESULT
+    ims.sagemaker_client.describe_training_job.return_value = (
+        COMPLETED_DESCRIBE_JOB_RESULT
+    )
     ims.create_model_from_job(JOB_NAME, primary_container_image="some-image")
     [create_model_call] = ims.sagemaker_client.create_model.call_args_list
     assert dict(create_model_call[1]["PrimaryContainer"])["Image"] == "some-image"
@@ -1708,9 +1843,14 @@ def test_create_model_from_job_with_image(sagemaker_session):
 
 def test_create_model_from_job_with_container_def(sagemaker_session):
     ims = sagemaker_session
-    ims.sagemaker_client.describe_training_job.return_value = COMPLETED_DESCRIBE_JOB_RESULT
+    ims.sagemaker_client.describe_training_job.return_value = (
+        COMPLETED_DESCRIBE_JOB_RESULT
+    )
     ims.create_model_from_job(
-        JOB_NAME, primary_container_image="some-image", model_data_url="some-data", env={"a": "b"}
+        JOB_NAME,
+        primary_container_image="some-image",
+        model_data_url="some-data",
+        env={"a": "b"},
     )
     [create_model_call] = ims.sagemaker_client.create_model.call_args_list
     c_def = create_model_call[1]["PrimaryContainer"]
@@ -1723,9 +1863,14 @@ def test_create_model_from_job_with_vpc_config_override(sagemaker_session):
     vpc_config_override = {"Subnets": ["foo", "bar"], "SecurityGroupIds": ["baz"]}
 
     ims = sagemaker_session
-    ims.sagemaker_client.describe_training_job.return_value = COMPLETED_DESCRIBE_JOB_RESULT
+    ims.sagemaker_client.describe_training_job.return_value = (
+        COMPLETED_DESCRIBE_JOB_RESULT
+    )
     ims.create_model_from_job(JOB_NAME, vpc_config_override=vpc_config_override)
-    assert ims.sagemaker_client.create_model.call_args[1]["VpcConfig"] == vpc_config_override
+    assert (
+        ims.sagemaker_client.create_model.call_args[1]["VpcConfig"]
+        == vpc_config_override
+    )
 
     ims.create_model_from_job(JOB_NAME, vpc_config_override=None)
     assert "VpcConfig" not in ims.sagemaker_client.create_model.call_args[1]
@@ -1733,13 +1878,21 @@ def test_create_model_from_job_with_vpc_config_override(sagemaker_session):
 
 def test_endpoint_from_production_variants(sagemaker_session):
     ims = sagemaker_session
-    ims.sagemaker_client.describe_endpoint = Mock(return_value={"EndpointStatus": "InService"})
+    ims.sagemaker_client.describe_endpoint = Mock(
+        return_value={"EndpointStatus": "InService"}
+    )
     pvs = [
         sagemaker.production_variant("A", "ml.p2.xlarge"),
         sagemaker.production_variant("B", "p299.4096xlarge"),
     ]
     ex = ClientError(
-        {"Error": {"Code": "ValidationException", "Message": "Could not find your thing"}}, "b"
+        {
+            "Error": {
+                "Code": "ValidationException",
+                "Message": "Could not find your thing",
+            }
+        },
+        "b",
     )
     ims.sagemaker_client.describe_endpoint_config = Mock(side_effect=ex)
     sagemaker_session.endpoint_from_production_variants("some-endpoint", pvs)
@@ -1754,7 +1907,9 @@ def test_endpoint_from_production_variants(sagemaker_session):
 def test_create_endpoint_config_with_tags(sagemaker_session):
     tags = [{"Key": "TagtestKey", "Value": "TagtestValue"}]
 
-    sagemaker_session.create_endpoint_config("endpoint-test", "simple-model", 1, "local", tags=tags)
+    sagemaker_session.create_endpoint_config(
+        "endpoint-test", "simple-model", 1, "local", tags=tags
+    )
 
     sagemaker_session.sagemaker_client.create_endpoint_config.assert_called_with(
         EndpointConfigName="endpoint-test", ProductionVariants=ANY, Tags=tags
@@ -1763,13 +1918,21 @@ def test_create_endpoint_config_with_tags(sagemaker_session):
 
 def test_endpoint_from_production_variants_with_tags(sagemaker_session):
     ims = sagemaker_session
-    ims.sagemaker_client.describe_endpoint = Mock(return_value={"EndpointStatus": "InService"})
+    ims.sagemaker_client.describe_endpoint = Mock(
+        return_value={"EndpointStatus": "InService"}
+    )
     pvs = [
         sagemaker.production_variant("A", "ml.p2.xlarge"),
         sagemaker.production_variant("B", "p299.4096xlarge"),
     ]
     ex = ClientError(
-        {"Error": {"Code": "ValidationException", "Message": "Could not find your thing"}}, "b"
+        {
+            "Error": {
+                "Code": "ValidationException",
+                "Message": "Could not find your thing",
+            }
+        },
+        "b",
     )
     ims.sagemaker_client.describe_endpoint_config = Mock(side_effect=ex)
     tags = [{"ModelName": "TestModel"}]
@@ -1784,13 +1947,25 @@ def test_endpoint_from_production_variants_with_tags(sagemaker_session):
 
 def test_endpoint_from_production_variants_with_accelerator_type(sagemaker_session):
     ims = sagemaker_session
-    ims.sagemaker_client.describe_endpoint = Mock(return_value={"EndpointStatus": "InService"})
+    ims.sagemaker_client.describe_endpoint = Mock(
+        return_value={"EndpointStatus": "InService"}
+    )
     pvs = [
-        sagemaker.production_variant("A", "ml.p2.xlarge", accelerator_type=ACCELERATOR_TYPE),
-        sagemaker.production_variant("B", "p299.4096xlarge", accelerator_type=ACCELERATOR_TYPE),
+        sagemaker.production_variant(
+            "A", "ml.p2.xlarge", accelerator_type=ACCELERATOR_TYPE
+        ),
+        sagemaker.production_variant(
+            "B", "p299.4096xlarge", accelerator_type=ACCELERATOR_TYPE
+        ),
     ]
     ex = ClientError(
-        {"Error": {"Code": "ValidationException", "Message": "Could not find your thing"}}, "b"
+        {
+            "Error": {
+                "Code": "ValidationException",
+                "Message": "Could not find your thing",
+            }
+        },
+        "b",
     )
     ims.sagemaker_client.describe_endpoint_config = Mock(side_effect=ex)
     tags = [{"ModelName": "TestModel"}]
@@ -1809,7 +1984,9 @@ def test_update_endpoint_succeed(sagemaker_session):
     )
     endpoint_name = "some-endpoint"
     endpoint_config = "some-endpoint-config"
-    returned_endpoint_name = sagemaker_session.update_endpoint(endpoint_name, endpoint_config)
+    returned_endpoint_name = sagemaker_session.update_endpoint(
+        endpoint_name, endpoint_config
+    )
     assert returned_endpoint_name == endpoint_name
 
 
@@ -1827,7 +2004,8 @@ def test_update_endpoint_no_wait(sagemaker_session):
 
 def test_update_endpoint_non_existing_endpoint(sagemaker_session):
     error = ClientError(
-        {"Error": {"Code": "ValidationException", "Message": "Could not find entity"}}, "foo"
+        {"Error": {"Code": "ValidationException", "Message": "Could not find entity"}},
+        "foo",
     )
     expected_error_message = (
         "Endpoint with name 'non-existing-endpoint' does not exist; "
@@ -1835,13 +2013,19 @@ def test_update_endpoint_non_existing_endpoint(sagemaker_session):
     )
     sagemaker_session.sagemaker_client.describe_endpoint = Mock(side_effect=error)
     with pytest.raises(ValueError, match=expected_error_message):
-        sagemaker_session.update_endpoint("non-existing-endpoint", "non-existing-config")
+        sagemaker_session.update_endpoint(
+            "non-existing-endpoint", "non-existing-config"
+        )
 
 
 def test_create_endpoint_config_from_existing(sagemaker_session):
     pvs = [sagemaker.production_variant("A", "ml.m4.xlarge")]
-    tags = [{"Key": "aws:cloudformation:stackname", "Value": "this-tag-should-be-ignored"}]
-    existing_endpoint_arn = "arn:aws:sagemaker:us-west-2:123412341234:endpoint-config/foo"
+    tags = [
+        {"Key": "aws:cloudformation:stackname", "Value": "this-tag-should-be-ignored"}
+    ]
+    existing_endpoint_arn = (
+        "arn:aws:sagemaker:us-west-2:123412341234:endpoint-config/foo"
+    )
     kms_key = "kms"
     sagemaker_session.sagemaker_client.describe_endpoint_config.return_value = {
         "Tags": tags,
@@ -1872,7 +2056,8 @@ def test_create_endpoint_config_from_existing(sagemaker_session):
 def test_wait_for_tuning_job(sleep, sagemaker_session):
     hyperparameter_tuning_job_desc = {"HyperParameterTuningJobStatus": "Completed"}
     sagemaker_session.sagemaker_client.describe_hyper_parameter_tuning_job = Mock(
-        name="describe_hyper_parameter_tuning_job", return_value=hyperparameter_tuning_job_desc
+        name="describe_hyper_parameter_tuning_job",
+        return_value=hyperparameter_tuning_job_desc,
     )
 
     result = sagemaker_session.wait_for_tuning_job(JOB_NAME)
@@ -1882,7 +2067,8 @@ def test_wait_for_tuning_job(sleep, sagemaker_session):
 def test_tune_job_status(sagemaker_session):
     hyperparameter_tuning_job_desc = {"HyperParameterTuningJobStatus": "Completed"}
     sagemaker_session.sagemaker_client.describe_hyper_parameter_tuning_job = Mock(
-        name="describe_hyper_parameter_tuning_job", return_value=hyperparameter_tuning_job_desc
+        name="describe_hyper_parameter_tuning_job",
+        return_value=hyperparameter_tuning_job_desc,
     )
 
     result = _tuning_job_status(sagemaker_session.sagemaker_client, JOB_NAME)
@@ -1893,7 +2079,8 @@ def test_tune_job_status(sagemaker_session):
 def test_tune_job_status_none(sagemaker_session):
     hyperparameter_tuning_job_desc = {"HyperParameterTuningJobStatus": "InProgress"}
     sagemaker_session.sagemaker_client.describe_hyper_parameter_tuning_job = Mock(
-        name="describe_hyper_parameter_tuning_job", return_value=hyperparameter_tuning_job_desc
+        name="describe_hyper_parameter_tuning_job",
+        return_value=hyperparameter_tuning_job_desc,
     )
 
     result = _tuning_job_status(sagemaker_session.sagemaker_client, JOB_NAME)
@@ -1908,7 +2095,10 @@ def test_wait_for_transform_job_completed(sleep, sagemaker_session):
         name="describe_transform_job", return_value=transform_job_desc
     )
 
-    assert sagemaker_session.wait_for_transform_job(JOB_NAME)["TransformJobStatus"] == "Completed"
+    assert (
+        sagemaker_session.wait_for_transform_job(JOB_NAME)["TransformJobStatus"]
+        == "Completed"
+    )
 
 
 @patch("time.sleep")
@@ -1921,7 +2111,8 @@ def test_wait_for_transform_job_in_progress(sleep, sagemaker_session):
     )
 
     assert (
-        sagemaker_session.wait_for_transform_job(JOB_NAME, 1)["TransformJobStatus"] == "Completed"
+        sagemaker_session.wait_for_transform_job(JOB_NAME, 1)["TransformJobStatus"]
+        == "Completed"
     )
     assert 2 == sagemaker_session.sagemaker_client.describe_transform_job.call_count
 
@@ -1978,7 +2169,9 @@ DEFAULT_EXPECTED_AUTO_ML_JOB_ARGS = {
     "AutoMLJobName": JOB_NAME,
     "InputDataConfig": [
         {
-            "DataSource": {"S3DataSource": {"S3DataType": "S3Prefix", "S3Uri": S3_INPUT_URI}},
+            "DataSource": {
+                "S3DataSource": {"S3DataType": "S3Prefix", "S3Uri": S3_INPUT_URI}
+            },
             "TargetAttributeName": "y",
         }
     ],
@@ -1999,7 +2192,9 @@ COMPLETE_EXPECTED_AUTO_ML_JOB_ARGS = {
     "AutoMLJobName": JOB_NAME,
     "InputDataConfig": [
         {
-            "DataSource": {"S3DataSource": {"S3DataType": "S3Prefix", "S3Uri": S3_INPUT_URI}},
+            "DataSource": {
+                "S3DataSource": {"S3DataType": "S3Prefix", "S3Uri": S3_INPUT_URI}
+            },
             "CompressionType": "Gzip",
             "TargetAttributeName": "y",
         }
@@ -2016,7 +2211,10 @@ COMPLETE_EXPECTED_AUTO_ML_JOB_ARGS = {
         "SecurityConfig": {
             "VolumeKmsKeyId": "volume-kms-key-id-string",
             "EnableInterContainerTrafficEncryption": False,
-            "VpcConfig": {"SecurityGroupIds": ["security-group-id"], "Subnets": ["subnet"]},
+            "VpcConfig": {
+                "SecurityGroupIds": ["security-group-id"],
+                "Subnets": ["subnet"],
+            },
         },
     },
     "RoleArn": EXPANDED_ROLE,
@@ -2036,7 +2234,9 @@ COMPLETE_EXPECTED_LIST_CANDIDATES_ARGS = {
 def test_auto_ml_pack_to_request(sagemaker_session):
     input_config = [
         {
-            "DataSource": {"S3DataSource": {"S3DataType": "S3Prefix", "S3Uri": S3_INPUT_URI}},
+            "DataSource": {
+                "S3DataSource": {"S3DataType": "S3Prefix", "S3Uri": S3_INPUT_URI}
+            },
             "TargetAttributeName": "y",
         }
     ]
@@ -2054,7 +2254,9 @@ def test_auto_ml_pack_to_request(sagemaker_session):
     job_name = JOB_NAME
     role = EXPANDED_ROLE
 
-    sagemaker_session.auto_ml(input_config, output_config, auto_ml_job_config, role, job_name)
+    sagemaker_session.auto_ml(
+        input_config, output_config, auto_ml_job_config, role, job_name
+    )
 
     assert sagemaker_session.sagemaker_client.method_calls[0] == (
         "create_auto_ml_job",
@@ -2066,7 +2268,9 @@ def test_auto_ml_pack_to_request(sagemaker_session):
 def test_auto_ml_pack_to_request_with_optional_args(sagemaker_session):
     input_config = [
         {
-            "DataSource": {"S3DataSource": {"S3DataType": "S3Prefix", "S3Uri": S3_INPUT_URI}},
+            "DataSource": {
+                "S3DataSource": {"S3DataType": "S3Prefix", "S3Uri": S3_INPUT_URI}
+            },
             "CompressionType": "Gzip",
             "TargetAttributeName": "y",
         }
@@ -2083,7 +2287,10 @@ def test_auto_ml_pack_to_request_with_optional_args(sagemaker_session):
         "SecurityConfig": {
             "VolumeKmsKeyId": "volume-kms-key-id-string",
             "EnableInterContainerTrafficEncryption": False,
-            "VpcConfig": {"SecurityGroupIds": ["security-group-id"], "Subnets": ["subnet"]},
+            "VpcConfig": {
+                "SecurityGroupIds": ["security-group-id"],
+                "Subnets": ["subnet"],
+            },
         },
     }
 

--- a/tests/unit/test_sklearn.py
+++ b/tests/unit/test_sklearn.py
@@ -43,7 +43,9 @@ CPU = "ml.c4.xlarge"
 
 ENDPOINT_DESC = {"EndpointConfigName": "test-endpoint"}
 
-ENDPOINT_CONFIG_DESC = {"ProductionVariants": [{"ModelName": "model-1"}, {"ModelName": "model-2"}]}
+ENDPOINT_CONFIG_DESC = {
+    "ProductionVariants": [{"ModelName": "model-1"}, {"ModelName": "model-2"}]
+}
 
 LIST_TAGS_RESULT = {"Tags": [{"Key": "TagtestKey", "Value": "TagtestValue"}]}
 
@@ -70,7 +72,9 @@ def sagemaker_session():
     describe = {"ModelArtifacts": {"S3ModelArtifacts": "s3://m/m.tar.gz"}}
     session.sagemaker_client.describe_training_job = Mock(return_value=describe)
     session.sagemaker_client.describe_endpoint = Mock(return_value=ENDPOINT_DESC)
-    session.sagemaker_client.describe_endpoint_config = Mock(return_value=ENDPOINT_CONFIG_DESC)
+    session.sagemaker_client.describe_endpoint_config = Mock(
+        return_value=ENDPOINT_CONFIG_DESC
+    )
     session.sagemaker_client.list_tags = Mock(return_value=LIST_TAGS_RESULT)
     session.default_bucket = Mock(name="default_bucket", return_value=BUCKET_NAME)
     session.expand_role = Mock(name="expand_role", return_value=ROLE)
@@ -78,7 +82,9 @@ def sagemaker_session():
 
 
 def _get_full_cpu_image_uri(version):
-    return IMAGE_URI_FORMAT_STRING.format(REGION, IMAGE_NAME, version, "cpu", PYTHON_VERSION)
+    return IMAGE_URI_FORMAT_STRING.format(
+        REGION, IMAGE_NAME, version, "cpu", PYTHON_VERSION
+    )
 
 
 def _sklearn_estimator(
@@ -93,7 +99,9 @@ def _sklearn_estimator(
         framework_version=framework_version,
         role=ROLE,
         sagemaker_session=sagemaker_session,
-        train_instance_type=train_instance_type if train_instance_type else INSTANCE_TYPE,
+        train_instance_type=train_instance_type
+        if train_instance_type
+        else INSTANCE_TYPE,
         base_job_name=base_job_name,
         py_version=PYTHON_VERSION,
         **kwargs
@@ -193,10 +201,15 @@ def test_create_model_with_network_isolation(upload, sagemaker_session):
         entry_point=SCRIPT_PATH,
         enable_network_isolation=True,
     )
-    sklearn_model.uploaded_code = UploadedCode(s3_prefix=repacked_model_data, script_name="script")
+    sklearn_model.uploaded_code = UploadedCode(
+        s3_prefix=repacked_model_data, script_name="script"
+    )
     sklearn_model.repacked_model_data = repacked_model_data
     model_values = sklearn_model.prepare_container_def(CPU)
-    assert model_values["Environment"]["SAGEMAKER_SUBMIT_DIRECTORY"] == "/opt/ml/model/code"
+    assert (
+        model_values["Environment"]["SAGEMAKER_SUBMIT_DIRECTORY"]
+        == "/opt/ml/model/code"
+    )
     assert model_values["ModelDataUrl"] == repacked_model_data
 
 
@@ -321,7 +334,9 @@ def test_sklearn(strftime, sagemaker_session, sklearn_version):
     assert boto_call_names == ["resource"]
 
     expected_train_args = _create_train_job(sklearn_version)
-    expected_train_args["input_config"][0]["DataSource"]["S3DataSource"]["S3Uri"] = inputs
+    expected_train_args["input_config"][0]["DataSource"]["S3DataSource"][
+        "S3Uri"
+    ] = inputs
     expected_train_args["experiment_config"] = EXPERIMENT_CONFIG
 
     actual_train_args = sagemaker_session.method_calls[0][2]
@@ -351,7 +366,9 @@ def test_sklearn(strftime, sagemaker_session, sklearn_version):
     assert isinstance(predictor, SKLearnPredictor)
 
 
-def test_transform_multiple_values_for_entry_point_issue(sagemaker_session, sklearn_version):
+def test_transform_multiple_values_for_entry_point_issue(
+    sagemaker_session, sklearn_version
+):
     # https://github.com/aws/sagemaker-python-sdk/issues/974
     sklearn = SKLearn(
         entry_point=SCRIPT_PATH,
@@ -432,7 +449,9 @@ def test_train_image_cpu_instances(sagemaker_session, sklearn_version):
     )
     assert sklearn.train_image() == _get_full_cpu_image_uri(sklearn_version)
 
-    sklearn = _sklearn_estimator(sagemaker_session, sklearn_version, train_instance_type="ml.m16")
+    sklearn = _sklearn_estimator(
+        sagemaker_session, sklearn_version, train_instance_type="ml.m16"
+    )
     assert sklearn.train_image() == _get_full_cpu_image_uri(sklearn_version)
 
 
@@ -441,7 +460,10 @@ def test_attach(sagemaker_session, sklearn_version):
         sklearn_version, PYTHON_VERSION
     )
     returned_job_description = {
-        "AlgorithmSpecification": {"TrainingInputMode": "File", "TrainingImage": training_image},
+        "AlgorithmSpecification": {
+            "TrainingInputMode": "File",
+            "TrainingImage": training_image,
+        },
         "HyperParameters": {
             "sagemaker_submit_directory": '"s3://some/sourcedir.tar.gz"',
             "sagemaker_program": '"iris-dnn-classifier.py"',
@@ -469,7 +491,9 @@ def test_attach(sagemaker_session, sklearn_version):
         name="describe_training_job", return_value=returned_job_description
     )
 
-    estimator = SKLearn.attach(training_job_name="neo", sagemaker_session=sagemaker_session)
+    estimator = SKLearn.attach(
+        training_job_name="neo", sagemaker_session=sagemaker_session
+    )
     assert estimator._current_job_name == "neo"
     assert estimator.latest_training_job.job_name == "neo"
     assert estimator.py_version == PYTHON_VERSION
@@ -526,7 +550,10 @@ def test_attach_wrong_framework(sagemaker_session):
 def test_attach_custom_image(sagemaker_session):
     training_image = "1.dkr.ecr.us-west-2.amazonaws.com/my_custom_sklearn_image:latest"
     returned_job_description = {
-        "AlgorithmSpecification": {"TrainingInputMode": "File", "TrainingImage": training_image},
+        "AlgorithmSpecification": {
+            "TrainingInputMode": "File",
+            "TrainingImage": training_image,
+        },
         "HyperParameters": {
             "sagemaker_submit_directory": '"s3://some/sourcedir.tar.gz"',
             "sagemaker_program": '"iris-dnn-classifier.py"',
@@ -554,7 +581,9 @@ def test_attach_custom_image(sagemaker_session):
         name="describe_training_job", return_value=returned_job_description
     )
 
-    estimator = SKLearn.attach(training_job_name="neo", sagemaker_session=sagemaker_session)
+    estimator = SKLearn.attach(
+        training_job_name="neo", sagemaker_session=sagemaker_session
+    )
     assert estimator.image_name == training_image
     assert estimator.train_image() == training_image
 
@@ -571,7 +600,9 @@ def test_estimator_py2_warning(warning, sagemaker_session):
     )
 
     assert estimator.py_version == "py2"
-    warning.assert_called_with(estimator.__framework_name__, defaults.LATEST_PY2_VERSION)
+    warning.assert_called_with(
+        estimator.__framework_name__, defaults.LATEST_PY2_VERSION
+    )
 
 
 @patch("sagemaker.sklearn.estimator.later_framework_version_warning")
@@ -600,7 +631,9 @@ def test_estimator_throws_error_for_unsupported_version(error, sagemaker_session
             framework_version="foo",
         )
         assert estimator.framework_version not in defaults.SKLEARN_SUPPORTED_VERSIONS
-        error.assert_called_with(defaults.SKLEARN_NAME, "foo", defaults.SKLEARN_SUPPORT_VERSIONS)
+        error.assert_called_with(
+            defaults.SKLEARN_NAME, "foo", defaults.SKLEARN_SUPPORT_VERSIONS
+        )
 
 
 @patch("sagemaker.sklearn.model.python_deprecation_warning")

--- a/tests/unit/test_sparkml_serving.py
+++ b/tests/unit/test_sparkml_serving.py
@@ -28,7 +28,9 @@ ENDPOINT = "some-endpoint"
 
 ENDPOINT_DESC = {"EndpointConfigName": ENDPOINT}
 
-ENDPOINT_CONFIG_DESC = {"ProductionVariants": [{"ModelName": "model-1"}, {"ModelName": "model-2"}]}
+ENDPOINT_CONFIG_DESC = {
+    "ProductionVariants": [{"ModelName": "model-1"}, {"ModelName": "model-2"}]
+}
 
 
 @pytest.fixture()
@@ -43,17 +45,26 @@ def sagemaker_session():
     )
     sms.boto_region_name = REGION
     sms.sagemaker_client.describe_endpoint = Mock(return_value=ENDPOINT_DESC)
-    sms.sagemaker_client.describe_endpoint_config = Mock(return_value=ENDPOINT_CONFIG_DESC)
+    sms.sagemaker_client.describe_endpoint_config = Mock(
+        return_value=ENDPOINT_CONFIG_DESC
+    )
     return sms
 
 
 def test_sparkml_model(sagemaker_session):
-    sparkml = SparkMLModel(sagemaker_session=sagemaker_session, model_data=MODEL_DATA, role=ROLE)
-    assert sparkml.image == registry(REGION, "sparkml-serving") + "/sagemaker-sparkml-serving:2.2"
+    sparkml = SparkMLModel(
+        sagemaker_session=sagemaker_session, model_data=MODEL_DATA, role=ROLE
+    )
+    assert (
+        sparkml.image
+        == registry(REGION, "sparkml-serving") + "/sagemaker-sparkml-serving:2.2"
+    )
 
 
 def test_predictor_type(sagemaker_session):
-    sparkml = SparkMLModel(sagemaker_session=sagemaker_session, model_data=MODEL_DATA, role=ROLE)
+    sparkml = SparkMLModel(
+        sagemaker_session=sagemaker_session, model_data=MODEL_DATA, role=ROLE
+    )
     predictor = sparkml.deploy(1, TRAIN_INSTANCE_TYPE)
 
     assert isinstance(predictor, SparkMLPredictor)

--- a/tests/unit/test_tf_estimator.py
+++ b/tests/unit/test_tf_estimator.py
@@ -23,7 +23,13 @@ from sagemaker.fw_utils import create_image_uri
 from sagemaker.estimator import _TrainingJob
 from sagemaker.model import MODEL_SERVER_WORKERS_PARAM_NAME
 from sagemaker.session import s3_input
-from sagemaker.tensorflow import defaults, serving, TensorFlow, TensorFlowModel, TensorFlowPredictor
+from sagemaker.tensorflow import (
+    defaults,
+    serving,
+    TensorFlow,
+    TensorFlowModel,
+    TensorFlowPredictor,
+)
 import sagemaker.tensorflow.estimator as tfe
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), "..", "data")
@@ -54,7 +60,9 @@ DISTRIBUTION_MPI_ENABLED = {
 
 ENDPOINT_DESC = {"EndpointConfigName": "test-endpoint"}
 
-ENDPOINT_CONFIG_DESC = {"ProductionVariants": [{"ModelName": "model-1"}, {"ModelName": "model-2"}]}
+ENDPOINT_CONFIG_DESC = {
+    "ProductionVariants": [{"ModelName": "model-1"}, {"ModelName": "model-2"}]
+}
 
 LIST_TAGS_RESULT = {"Tags": [{"Key": "TagtestKey", "Value": "TagtestValue"}]}
 
@@ -82,7 +90,9 @@ def sagemaker_session():
     describe = {"ModelArtifacts": {"S3ModelArtifacts": "s3://m/m.tar.gz"}}
     session.sagemaker_client.describe_training_job = Mock(return_value=describe)
     session.sagemaker_client.describe_endpoint = Mock(return_value=ENDPOINT_DESC)
-    session.sagemaker_client.describe_endpoint_config = Mock(return_value=ENDPOINT_CONFIG_DESC)
+    session.sagemaker_client.describe_endpoint_config = Mock(
+        return_value=ENDPOINT_CONFIG_DESC
+    )
     session.sagemaker_client.list_tags = Mock(return_value=LIST_TAGS_RESULT)
     return session
 
@@ -115,9 +125,13 @@ def _hyperparameters(script_mode=False, horovod=False):
         if horovod:
             hps["model_dir"] = json.dumps("/opt/ml/model")
         else:
-            hps["model_dir"] = json.dumps("s3://{}/{}/model".format(BUCKET_NAME, job_name))
+            hps["model_dir"] = json.dumps(
+                "s3://{}/{}/model".format(BUCKET_NAME, job_name)
+            )
     else:
-        hps["checkpoint_path"] = json.dumps("s3://{}/{}/checkpoints".format(BUCKET_NAME, job_name))
+        hps["checkpoint_path"] = json.dumps(
+            "s3://{}/{}/checkpoints".format(BUCKET_NAME, job_name)
+        )
         hps["training_steps"] = "1000"
         hps["evaluation_steps"] = "10"
         hps["sagemaker_requirements"] = '"{}"'.format(REQUIREMENTS_FILE)
@@ -133,7 +147,9 @@ def _create_train_job(
     py_version="py2",
 ):
     conf = {
-        "image": _get_full_cpu_image_uri(tf_version, repo=repo_name, py_version=py_version),
+        "image": _get_full_cpu_image_uri(
+            tf_version, repo=repo_name, py_version=py_version
+        ),
         "input_mode": "File",
         "input_config": [
             {
@@ -189,7 +205,9 @@ def _build_tf(
         role=ROLE,
         sagemaker_session=sagemaker_session,
         train_instance_count=INSTANCE_COUNT,
-        train_instance_type=train_instance_type if train_instance_type else INSTANCE_TYPE,
+        train_instance_type=train_instance_type
+        if train_instance_type
+        else INSTANCE_TYPE,
         checkpoint_path=checkpoint_path,
         base_job_name=base_job_name,
         **kwargs
@@ -225,7 +243,9 @@ def test_tf_deploy_model_server_workers(sagemaker_session):
     tf = _build_tf(sagemaker_session)
     tf.fit(inputs=s3_input("s3://mybucket/train"))
 
-    tf.deploy(initial_instance_count=1, instance_type="ml.c2.2xlarge", model_server_workers=2)
+    tf.deploy(
+        initial_instance_count=1, instance_type="ml.c2.2xlarge", model_server_workers=2
+    )
 
     assert (
         "2"
@@ -251,7 +271,9 @@ def test_tf_deploy_model_server_workers_unset(sagemaker_session):
 def test_tf_invalid_requirements_path(sagemaker_session):
     requirements_file = "/foo/bar/requirements.txt"
     with pytest.raises(ValueError) as e:
-        _build_tf(sagemaker_session, requirements_file=requirements_file, source_dir=DATA_DIR)
+        _build_tf(
+            sagemaker_session, requirements_file=requirements_file, source_dir=DATA_DIR
+        )
     assert "Requirements file {} is not a path relative to source_dir.".format(
         requirements_file
     ) in str(e.value)
@@ -260,8 +282,12 @@ def test_tf_invalid_requirements_path(sagemaker_session):
 def test_tf_nonexistent_requirements_path(sagemaker_session):
     requirements_file = "nonexistent_requirements.txt"
     with pytest.raises(ValueError) as e:
-        _build_tf(sagemaker_session, requirements_file=requirements_file, source_dir=DATA_DIR)
-    assert "Requirements file {} does not exist.".format(requirements_file) in str(e.value)
+        _build_tf(
+            sagemaker_session, requirements_file=requirements_file, source_dir=DATA_DIR
+        )
+    assert "Requirements file {} does not exist.".format(requirements_file) in str(
+        e.value
+    )
 
 
 def test_create_model(sagemaker_session, tf_version):
@@ -505,7 +531,9 @@ def test_tf(sagemaker_session, tf_version):
     assert call_names == ["train", "logs_for_job"]
 
     expected_train_args = _create_train_job(tf_version)
-    expected_train_args["input_config"][0]["DataSource"]["S3DataSource"]["S3Uri"] = inputs
+    expected_train_args["input_config"][0]["DataSource"]["S3DataSource"][
+        "S3Uri"
+    ] = inputs
     expected_train_args["experiment_config"] = EXPERIMENT_CONFIG
 
     actual_train_args = sagemaker_session.method_calls[0][2]
@@ -522,7 +550,9 @@ def test_tf(sagemaker_session, tf_version):
             "SAGEMAKER_REGION": "us-west-2",
             "SAGEMAKER_CONTAINER_LOG_LEVEL": "20",
         },
-        "Image": create_image_uri("us-west-2", "tensorflow", INSTANCE_TYPE, tf_version, "py2"),
+        "Image": create_image_uri(
+            "us-west-2", "tensorflow", INSTANCE_TYPE, tf_version, "py2"
+        ),
         "ModelDataUrl": "s3://m/m.tar.gz",
     }
     assert environment == model.prepare_container_def(INSTANCE_TYPE)
@@ -560,7 +590,10 @@ def test_run_tensorboard_locally_without_tensorboard_binary(
 @patch("sagemaker.utils.create_tar_file", MagicMock())
 def test_model(sagemaker_session, tf_version):
     model = TensorFlowModel(
-        MODEL_DATA, role=ROLE, entry_point=SCRIPT_PATH, sagemaker_session=sagemaker_session
+        MODEL_DATA,
+        role=ROLE,
+        entry_point=SCRIPT_PATH,
+        sagemaker_session=sagemaker_session,
     )
     predictor = model.deploy(1, INSTANCE_TYPE)
     assert isinstance(predictor, TensorFlowPredictor)
@@ -569,10 +602,17 @@ def test_model(sagemaker_session, tf_version):
 @patch("sagemaker.fw_utils.tar_and_upload_dir", MagicMock())
 def test_model_image_accelerator(sagemaker_session):
     model = TensorFlowModel(
-        MODEL_DATA, role=ROLE, entry_point=SCRIPT_PATH, sagemaker_session=sagemaker_session
+        MODEL_DATA,
+        role=ROLE,
+        entry_point=SCRIPT_PATH,
+        sagemaker_session=sagemaker_session,
     )
-    container_def = model.prepare_container_def(INSTANCE_TYPE, accelerator_type=ACCELERATOR_TYPE)
-    assert container_def["Image"] == _get_full_cpu_image_uri_with_ei(defaults.TF_VERSION)
+    container_def = model.prepare_container_def(
+        INSTANCE_TYPE, accelerator_type=ACCELERATOR_TYPE
+    )
+    assert container_def["Image"] == _get_full_cpu_image_uri_with_ei(
+        defaults.TF_VERSION
+    )
 
 
 def test_model_prepare_container_def_no_instance_type_or_image():
@@ -581,7 +621,9 @@ def test_model_prepare_container_def_no_instance_type_or_image():
     with pytest.raises(ValueError) as e:
         model.prepare_container_def()
 
-    expected_msg = "Must supply either an instance type (for choosing CPU vs GPU) or an image URI."
+    expected_msg = (
+        "Must supply either an instance type (for choosing CPU vs GPU) or an image URI."
+    )
     assert expected_msg in str(e)
 
 
@@ -636,7 +678,15 @@ def test_run_tensorboard_locally(
     tf.fit(inputs="s3://mybucket/train", run_tensorboard_locally=True)
 
     popen.assert_called_with(
-        ["tensorboard", "--logdir", "/my/temp/folder", "--host", "localhost", "--port", "6006"],
+        [
+            "tensorboard",
+            "--logdir",
+            "/my/temp/folder",
+            "--host",
+            "localhost",
+            "--port",
+            "6006",
+        ],
         stderr=-1,
         stdout=-1,
     )
@@ -654,7 +704,17 @@ def test_run_tensorboard_locally(
 @patch("time.time", return_value=TIME)
 @patch("time.sleep")
 def test_run_tensorboard_locally_port_in_use(
-    sleep, time, strftime, popen, call, access, socket, rmtree, mkdtemp, sync, sagemaker_session
+    sleep,
+    time,
+    strftime,
+    popen,
+    call,
+    access,
+    socket,
+    rmtree,
+    mkdtemp,
+    sync,
+    sagemaker_session,
 ):
     tf = TensorFlow(
         entry_point=SCRIPT_PATH,
@@ -669,13 +729,29 @@ def test_run_tensorboard_locally_port_in_use(
     tf.fit(inputs="s3://mybucket/train", run_tensorboard_locally=True)
 
     popen.assert_any_call(
-        ["tensorboard", "--logdir", "/my/temp/folder", "--host", "localhost", "--port", "6006"],
+        [
+            "tensorboard",
+            "--logdir",
+            "/my/temp/folder",
+            "--host",
+            "localhost",
+            "--port",
+            "6006",
+        ],
         stderr=-1,
         stdout=-1,
     )
 
     popen.assert_any_call(
-        ["tensorboard", "--logdir", "/my/temp/folder", "--host", "localhost", "--port", "6007"],
+        [
+            "tensorboard",
+            "--logdir",
+            "/my/temp/folder",
+            "--host",
+            "localhost",
+            "--port",
+            "6007",
+        ],
         stderr=-1,
         stdout=-1,
     )
@@ -701,10 +777,15 @@ def test_tf_checkpoint_not_set(sagemaker_session):
 @patch("sagemaker.utils.create_tar_file", MagicMock())
 def test_tf_training_and_evaluation_steps_not_set(sagemaker_session):
     job_name = "sagemaker-tensorflow-py2-gpu-2017-10-24-14-12-09"
-    output_path = "s3://{}/output/{}/".format(sagemaker_session.default_bucket(), job_name)
+    output_path = "s3://{}/output/{}/".format(
+        sagemaker_session.default_bucket(), job_name
+    )
 
     tf = _build_tf(
-        sagemaker_session, training_steps=None, evaluation_steps=None, output_path=output_path
+        sagemaker_session,
+        training_steps=None,
+        evaluation_steps=None,
+        output_path=output_path,
     )
     tf.fit(inputs=s3_input("s3://mybucket/train"))
     assert tf.hyperparameters()["training_steps"] == "null"
@@ -714,10 +795,15 @@ def test_tf_training_and_evaluation_steps_not_set(sagemaker_session):
 @patch("sagemaker.utils.create_tar_file", MagicMock())
 def test_tf_training_and_evaluation_steps(sagemaker_session):
     job_name = "sagemaker-tensorflow-py2-gpu-2017-10-24-14-12-09"
-    output_path = "s3://{}/output/{}/".format(sagemaker_session.default_bucket(), job_name)
+    output_path = "s3://{}/output/{}/".format(
+        sagemaker_session.default_bucket(), job_name
+    )
 
     tf = _build_tf(
-        sagemaker_session, training_steps=123, evaluation_steps=456, output_path=output_path
+        sagemaker_session,
+        training_steps=123,
+        evaluation_steps=456,
+        output_path=output_path,
     )
     tf.fit(inputs=s3_input("s3://mybucket/train"))
     assert tf.hyperparameters()["training_steps"] == "123"
@@ -727,7 +813,9 @@ def test_tf_training_and_evaluation_steps(sagemaker_session):
 @patch("sagemaker.utils.create_tar_file", MagicMock())
 def test_tf_checkpoint_set(sagemaker_session):
     tf = _build_tf(sagemaker_session, checkpoint_path="s3://my_checkpoint_bucket")
-    assert tf.hyperparameters()["checkpoint_path"] == json.dumps("s3://my_checkpoint_bucket")
+    assert tf.hyperparameters()["checkpoint_path"] == json.dumps(
+        "s3://my_checkpoint_bucket"
+    )
 
 
 @patch("sagemaker.utils.create_tar_file", MagicMock())
@@ -749,7 +837,10 @@ def test_attach(sagemaker_session, tf_version):
         tf_version
     )
     rjd = {
-        "AlgorithmSpecification": {"TrainingInputMode": "File", "TrainingImage": training_image},
+        "AlgorithmSpecification": {
+            "TrainingInputMode": "File",
+            "TrainingImage": training_image,
+        },
         "HyperParameters": {
             "sagemaker_submit_directory": '"s3://some/sourcedir.tar.gz"',
             "checkpoint_path": '"s3://other/1508872349"',
@@ -777,7 +868,9 @@ def test_attach(sagemaker_session, tf_version):
         name="describe_training_job", return_value=rjd
     )
 
-    estimator = TensorFlow.attach(training_job_name="neo", sagemaker_session=sagemaker_session)
+    estimator = TensorFlow.attach(
+        training_job_name="neo", sagemaker_session=sagemaker_session
+    )
     assert estimator.latest_training_job.job_name == "neo"
     assert estimator.py_version == "py2"
     assert estimator.framework_version == tf_version
@@ -803,7 +896,10 @@ def test_attach_new_repo_name(sagemaker_session, tf_version):
         tf_version
     )
     rjd = {
-        "AlgorithmSpecification": {"TrainingInputMode": "File", "TrainingImage": training_image},
+        "AlgorithmSpecification": {
+            "TrainingInputMode": "File",
+            "TrainingImage": training_image,
+        },
         "HyperParameters": {
             "sagemaker_submit_directory": '"s3://some/sourcedir.tar.gz"',
             "checkpoint_path": '"s3://other/1508872349"',
@@ -831,7 +927,9 @@ def test_attach_new_repo_name(sagemaker_session, tf_version):
         name="describe_training_job", return_value=rjd
     )
 
-    estimator = TensorFlow.attach(training_job_name="neo", sagemaker_session=sagemaker_session)
+    estimator = TensorFlow.attach(
+        training_job_name="neo", sagemaker_session=sagemaker_session
+    )
     assert estimator.latest_training_job.job_name == "neo"
     assert estimator.py_version == "py2"
     assert estimator.framework_version == tf_version
@@ -854,9 +952,14 @@ def test_attach_new_repo_name(sagemaker_session, tf_version):
 
 @patch("sagemaker.utils.create_tar_file", MagicMock())
 def test_attach_old_container(sagemaker_session):
-    training_image = "1.dkr.ecr.us-west-2.amazonaws.com/sagemaker-tensorflow-py2-cpu:1.0"
+    training_image = (
+        "1.dkr.ecr.us-west-2.amazonaws.com/sagemaker-tensorflow-py2-cpu:1.0"
+    )
     rjd = {
-        "AlgorithmSpecification": {"TrainingInputMode": "File", "TrainingImage": training_image},
+        "AlgorithmSpecification": {
+            "TrainingInputMode": "File",
+            "TrainingImage": training_image,
+        },
         "HyperParameters": {
             "sagemaker_submit_directory": '"s3://some/sourcedir.tar.gz"',
             "checkpoint_path": '"s3://other/1508872349"',
@@ -884,7 +987,9 @@ def test_attach_old_container(sagemaker_session):
         name="describe_training_job", return_value=rjd
     )
 
-    estimator = TensorFlow.attach(training_job_name="neo", sagemaker_session=sagemaker_session)
+    estimator = TensorFlow.attach(
+        training_job_name="neo", sagemaker_session=sagemaker_session
+    )
     assert estimator.latest_training_job.job_name == "neo"
     assert estimator.py_version == "py2"
     assert estimator.framework_version == "1.4"
@@ -940,9 +1045,14 @@ def test_attach_wrong_framework(sagemaker_session):
 
 
 def test_attach_custom_image(sagemaker_session):
-    training_image = "1.dkr.ecr.us-west-2.amazonaws.com/tensorflow_with_custom_binary:1.0"
+    training_image = (
+        "1.dkr.ecr.us-west-2.amazonaws.com/tensorflow_with_custom_binary:1.0"
+    )
     rjd = {
-        "AlgorithmSpecification": {"TrainingInputMode": "File", "TrainingImage": training_image},
+        "AlgorithmSpecification": {
+            "TrainingInputMode": "File",
+            "TrainingImage": training_image,
+        },
         "HyperParameters": {
             "sagemaker_submit_directory": '"s3://some/sourcedir.tar.gz"',
             "checkpoint_path": '"s3://other/1508872349"',
@@ -970,7 +1080,9 @@ def test_attach_custom_image(sagemaker_session):
         name="describe_training_job", return_value=rjd
     )
 
-    estimator = TensorFlow.attach(training_job_name="neo", sagemaker_session=sagemaker_session)
+    estimator = TensorFlow.attach(
+        training_job_name="neo", sagemaker_session=sagemaker_session
+    )
     assert estimator.image_name == training_image
     assert estimator.train_image() == training_image
 
@@ -987,7 +1099,9 @@ def test_estimator_py2_deprecation_warning(warning, sagemaker_session):
     )
 
     assert estimator.py_version == "py2"
-    warning.assert_called_with(estimator.__framework_name__, defaults.LATEST_PY2_VERSION)
+    warning.assert_called_with(
+        estimator.__framework_name__, defaults.LATEST_PY2_VERSION
+    )
 
     model = TensorFlowModel(
         MODEL_DATA,
@@ -1035,21 +1149,29 @@ def _deprecated_args_msg(args):
 def test_script_mode_deprecated_args(sagemaker_session):
     with pytest.raises(AttributeError) as e:
         _build_tf(
-            sagemaker_session=sagemaker_session, py_version="py3", checkpoint_path="some_path"
+            sagemaker_session=sagemaker_session,
+            py_version="py3",
+            checkpoint_path="some_path",
         )
     assert _deprecated_args_msg("checkpoint_path") in str(e.value)
 
     with pytest.raises(AttributeError) as e:
-        _build_tf(sagemaker_session=sagemaker_session, py_version="py3", training_steps=1)
+        _build_tf(
+            sagemaker_session=sagemaker_session, py_version="py3", training_steps=1
+        )
     assert _deprecated_args_msg("training_steps") in str(e.value)
 
     with pytest.raises(AttributeError) as e:
-        _build_tf(sagemaker_session=sagemaker_session, script_mode=True, evaluation_steps=1)
+        _build_tf(
+            sagemaker_session=sagemaker_session, script_mode=True, evaluation_steps=1
+        )
     assert _deprecated_args_msg("evaluation_steps") in str(e.value)
 
     with pytest.raises(AttributeError) as e:
         _build_tf(
-            sagemaker_session=sagemaker_session, script_mode=True, requirements_file="some_file"
+            sagemaker_session=sagemaker_session,
+            script_mode=True,
+            requirements_file="some_file",
         )
     assert _deprecated_args_msg("requirements_file") in str(e.value)
 
@@ -1088,7 +1210,9 @@ def test_py2_version_deprecated(sagemaker_session):
 
 def test_py2_version_is_not_deprecated(sagemaker_session):
     estimator = _build_tf(
-        sagemaker_session=sagemaker_session, framework_version="1.15.0", py_version="py2"
+        sagemaker_session=sagemaker_session,
+        framework_version="1.15.0",
+        py_version="py2",
     )
     assert estimator.py_version == "py2"
     estimator = _build_tf(
@@ -1138,7 +1262,9 @@ def test_script_mode_enabled(sagemaker_session):
 
 def test_script_mode_create_model(sagemaker_session):
     tf = _build_tf(
-        sagemaker_session=sagemaker_session, py_version="py3", enable_network_isolation=True
+        sagemaker_session=sagemaker_session,
+        py_version="py3",
+        enable_network_isolation=True,
     )
     tf._prepare_for_training()  # set output_path and job name as if training happened
 
@@ -1205,7 +1331,9 @@ def test_tf_script_mode(time, strftime, sagemaker_session):
     expected_train_args = _create_train_job(
         "1.11", script_mode=True, repo_name=SM_IMAGE_REPO_NAME, py_version="py3"
     )
-    expected_train_args["input_config"][0]["DataSource"]["S3DataSource"]["S3Uri"] = inputs
+    expected_train_args["input_config"][0]["DataSource"]["S3DataSource"][
+        "S3Uri"
+    ] = inputs
 
     actual_train_args = sagemaker_session.method_calls[0][2]
     assert actual_train_args == expected_train_args
@@ -1234,10 +1362,18 @@ def test_tf_script_mode_ps(time, strftime, sagemaker_session):
     assert call_names == ["train", "logs_for_job"]
 
     expected_train_args = _create_train_job(
-        "1.11", script_mode=True, ps=True, repo_name=SM_IMAGE_REPO_NAME, py_version="py3"
+        "1.11",
+        script_mode=True,
+        ps=True,
+        repo_name=SM_IMAGE_REPO_NAME,
+        py_version="py3",
     )
-    expected_train_args["input_config"][0]["DataSource"]["S3DataSource"]["S3Uri"] = inputs
-    expected_train_args["hyperparameters"][TensorFlow.LAUNCH_PS_ENV_NAME] = json.dumps(True)
+    expected_train_args["input_config"][0]["DataSource"]["S3DataSource"][
+        "S3Uri"
+    ] = inputs
+    expected_train_args["hyperparameters"][TensorFlow.LAUNCH_PS_ENV_NAME] = json.dumps(
+        True
+    )
 
     actual_train_args = sagemaker_session.method_calls[0][2]
     assert actual_train_args == expected_train_args
@@ -1266,14 +1402,24 @@ def test_tf_script_mode_mpi(time, strftime, sagemaker_session):
     assert call_names == ["train", "logs_for_job"]
 
     expected_train_args = _create_train_job(
-        "1.11", script_mode=True, horovod=True, repo_name=SM_IMAGE_REPO_NAME, py_version="py3"
+        "1.11",
+        script_mode=True,
+        horovod=True,
+        repo_name=SM_IMAGE_REPO_NAME,
+        py_version="py3",
     )
-    expected_train_args["input_config"][0]["DataSource"]["S3DataSource"]["S3Uri"] = inputs
-    expected_train_args["hyperparameters"][TensorFlow.LAUNCH_MPI_ENV_NAME] = json.dumps(True)
-    expected_train_args["hyperparameters"][TensorFlow.MPI_NUM_PROCESSES_PER_HOST] = json.dumps(2)
-    expected_train_args["hyperparameters"][TensorFlow.MPI_CUSTOM_MPI_OPTIONS] = json.dumps(
-        "options"
+    expected_train_args["input_config"][0]["DataSource"]["S3DataSource"][
+        "S3Uri"
+    ] = inputs
+    expected_train_args["hyperparameters"][TensorFlow.LAUNCH_MPI_ENV_NAME] = json.dumps(
+        True
     )
+    expected_train_args["hyperparameters"][
+        TensorFlow.MPI_NUM_PROCESSES_PER_HOST
+    ] = json.dumps(2)
+    expected_train_args["hyperparameters"][
+        TensorFlow.MPI_CUSTOM_MPI_OPTIONS
+    ] = json.dumps("options")
 
     actual_train_args = sagemaker_session.method_calls[0][2]
     assert actual_train_args == expected_train_args
@@ -1285,7 +1431,10 @@ def test_tf_script_mode_attach(sagemaker_session, tf_version):
         tf_version
     )
     rjd = {
-        "AlgorithmSpecification": {"TrainingInputMode": "File", "TrainingImage": training_image},
+        "AlgorithmSpecification": {
+            "TrainingInputMode": "File",
+            "TrainingImage": training_image,
+        },
         "HyperParameters": {
             "sagemaker_submit_directory": '"s3://some/sourcedir.tar.gz"',
             "sagemaker_program": '"iris-dnn-classifier.py"',
@@ -1310,7 +1459,9 @@ def test_tf_script_mode_attach(sagemaker_session, tf_version):
         name="describe_training_job", return_value=rjd
     )
 
-    estimator = TensorFlow.attach(training_job_name="neo", sagemaker_session=sagemaker_session)
+    estimator = TensorFlow.attach(
+        training_job_name="neo", sagemaker_session=sagemaker_session
+    )
     assert estimator.latest_training_job.job_name == "neo"
     assert estimator.py_version == "py3"
     assert estimator.framework_version == tf_version

--- a/tests/unit/test_tf_predictor.py
+++ b/tests/unit/test_tf_predictor.py
@@ -62,7 +62,9 @@ PROTO_CONTENT_TYPE = "application/octet-stream"
 
 ENDPOINT_DESC = {"EndpointConfigName": ENDPOINT}
 
-ENDPOINT_CONFIG_DESC = {"ProductionVariants": [{"ModelName": "model-1"}, {"ModelName": "model-2"}]}
+ENDPOINT_CONFIG_DESC = {
+    "ProductionVariants": [{"ModelName": "model-1"}, {"ModelName": "model-2"}]
+}
 
 
 @pytest.fixture()
@@ -71,13 +73,17 @@ def sagemaker_session():
     ims = Mock(name="sagemaker_session", boto_session=boto_mock)
     ims.default_bucket = Mock(name="default_bucket", return_value=BUCKET_NAME)
     ims.sagemaker_client.describe_endpoint = Mock(return_value=ENDPOINT_DESC)
-    ims.sagemaker_client.describe_endpoint_config = Mock(return_value=ENDPOINT_CONFIG_DESC)
+    ims.sagemaker_client.describe_endpoint_config = Mock(
+        return_value=ENDPOINT_CONFIG_DESC
+    )
     return ims
 
 
 def test_endpoint_initialization(sagemaker_session):
     endpoint_name = "endpoint"
-    predictor = RealTimePredictor(endpoint=endpoint_name, sagemaker_session=sagemaker_session)
+    predictor = RealTimePredictor(
+        endpoint=endpoint_name, sagemaker_session=sagemaker_session
+    )
     assert predictor.endpoint == endpoint_name
 
 
@@ -91,7 +97,9 @@ def test_classification_request_json(sagemaker_session):
     )
 
     mock_response(
-        json.dumps(CLASSIFICATION_RESPONSE).encode("utf-8"), sagemaker_session, JSON_CONTENT_TYPE
+        json.dumps(CLASSIFICATION_RESPONSE).encode("utf-8"),
+        sagemaker_session,
+        JSON_CONTENT_TYPE,
     )
 
     result = predictor.predict(data)
@@ -250,7 +258,9 @@ def test_classification_request_pb(sagemaker_session):
     request.model_spec.name = "generic_model"
     request.model_spec.signature_name = DEFAULT_SERVING_SIGNATURE_DEF_KEY
     example = request.input.example_list.examples.add()
-    example.features.feature[PREDICT_INPUTS].float_list.value.extend([6.4, 3.2, 4.5, 1.5])
+    example.features.feature[PREDICT_INPUTS].float_list.value.extend(
+        [6.4, 3.2, 4.5, 1.5]
+    )
 
     predictor = RealTimePredictor(
         sagemaker_session=sagemaker_session,
@@ -274,7 +284,9 @@ def test_classification_request_pb(sagemaker_session):
     class_2.label = "2"
     class_2.score = 0.0172787327319
 
-    mock_response(expected_response.SerializeToString(), sagemaker_session, PROTO_CONTENT_TYPE)
+    mock_response(
+        expected_response.SerializeToString(), sagemaker_session, PROTO_CONTENT_TYPE
+    )
 
     result = predictor.predict(request)
 
@@ -344,7 +356,9 @@ def test_predict_request_json(sagemaker_session):
     )
 
     mock_response(
-        json.dumps(CLASSIFICATION_RESPONSE).encode("utf-8"), sagemaker_session, JSON_CONTENT_TYPE
+        json.dumps(CLASSIFICATION_RESPONSE).encode("utf-8"),
+        sagemaker_session,
+        JSON_CONTENT_TYPE,
     )
 
     result = predictor.predict(tensor_proto)
@@ -372,7 +386,9 @@ def test_predict_tensor_request_csv(sagemaker_session):
     )
 
     mock_response(
-        json.dumps(CLASSIFICATION_RESPONSE).encode("utf-8"), sagemaker_session, JSON_CONTENT_TYPE
+        json.dumps(CLASSIFICATION_RESPONSE).encode("utf-8"),
+        sagemaker_session,
+        JSON_CONTENT_TYPE,
     )
 
     result = predictor.predict(tensor_proto)

--- a/tests/unit/test_tfs.py
+++ b/tests/unit/test_tfs.py
@@ -45,7 +45,9 @@ REGRESS_RESPONSE = {"results": [3.5, 4.0]}
 
 ENDPOINT_DESC = {"EndpointConfigName": "test-endpoint"}
 
-ENDPOINT_CONFIG_DESC = {"ProductionVariants": [{"ModelName": "model-1"}, {"ModelName": "model-2"}]}
+ENDPOINT_CONFIG_DESC = {
+    "ProductionVariants": [{"ModelName": "model-1"}, {"ModelName": "model-2"}]
+}
 
 
 @pytest.fixture()
@@ -65,7 +67,9 @@ def sagemaker_session():
     describe = {"ModelArtifacts": {"S3ModelArtifacts": "s3://m/m.tar.gz"}}
     session.sagemaker_client.describe_training_job = Mock(return_value=describe)
     session.sagemaker_client.describe_endpoint = Mock(return_value=ENDPOINT_DESC)
-    session.sagemaker_client.describe_endpoint_config = Mock(return_value=ENDPOINT_CONFIG_DESC)
+    session.sagemaker_client.describe_endpoint_config = Mock(
+        return_value=ENDPOINT_CONFIG_DESC
+    )
     return session
 
 
@@ -77,7 +81,9 @@ def test_tfs_model(sagemaker_session, tf_version):
         sagemaker_session=sagemaker_session,
     )
     cdef = model.prepare_container_def(INSTANCE_TYPE)
-    assert cdef["Image"].endswith("sagemaker-tensorflow-serving:{}-cpu".format(tf_version))
+    assert cdef["Image"].endswith(
+        "sagemaker-tensorflow-serving:{}-cpu".format(tf_version)
+    )
     assert cdef["Environment"] == {}
 
     predictor = model.deploy(INSTANCE_COUNT, INSTANCE_TYPE)
@@ -92,7 +98,9 @@ def test_tfs_model_image_accelerator(sagemaker_session, tf_version):
         sagemaker_session=sagemaker_session,
     )
     cdef = model.prepare_container_def(INSTANCE_TYPE, accelerator_type=ACCELERATOR_TYPE)
-    assert cdef["Image"].endswith("sagemaker-tensorflow-serving-eia:{}-cpu".format(tf_version))
+    assert cdef["Image"].endswith(
+        "sagemaker-tensorflow-serving-eia:{}-cpu".format(tf_version)
+    )
 
     predictor = model.deploy(INSTANCE_COUNT, INSTANCE_TYPE)
     assert isinstance(predictor, Predictor)
@@ -109,7 +117,9 @@ def test_tfs_model_image_accelerator_not_supported(sagemaker_session):
     # assert error is not raised
 
     model.deploy(
-        instance_type="ml.c4.xlarge", initial_instance_count=1, accelerator_type="ml.eia1.medium"
+        instance_type="ml.c4.xlarge",
+        initial_instance_count=1,
+        accelerator_type="ml.eia1.medium",
     )
 
     model = Model(
@@ -189,7 +199,9 @@ def test_tfs_model_with_entry_point(
 
 @mock.patch("sagemaker.fw_utils.model_code_key_prefix", return_value="key-prefix")
 @mock.patch("sagemaker.utils.repack_model")
-def test_tfs_model_with_source(repack_model, model_code_key_prefix, sagemaker_session, tf_version):
+def test_tfs_model_with_source(
+    repack_model, model_code_key_prefix, sagemaker_session, tf_version
+):
     model = Model(
         "s3://some/data.tar.gz",
         entry_point="train.py",
@@ -251,7 +263,9 @@ def test_model_prepare_container_def_no_instance_type_or_image():
     with pytest.raises(ValueError) as e:
         model.prepare_container_def()
 
-    expected_msg = "Must supply either an instance type (for choosing CPU vs GPU) or an image URI."
+    expected_msg = (
+        "Must supply either an instance type (for choosing CPU vs GPU) or an image URI."
+    )
     assert expected_msg in str(e)
 
 
@@ -276,7 +290,10 @@ def test_estimator_deploy(sagemaker_session):
     job_name = "doing something"
     tf.fit(inputs="s3://mybucket/train", job_name=job_name)
     predictor = tf.deploy(
-        INSTANCE_COUNT, INSTANCE_TYPE, endpoint_name="endpoint", endpoint_type="tensorflow-serving"
+        INSTANCE_COUNT,
+        INSTANCE_TYPE,
+        endpoint_name="endpoint",
+        endpoint_type="tensorflow-serving",
     )
     assert isinstance(predictor, Predictor)
 
@@ -335,7 +352,9 @@ def test_predictor_csv(sagemaker_session):
 
 
 def test_predictor_model_attributes(sagemaker_session):
-    predictor = Predictor("endpoint", sagemaker_session, model_name="model", model_version="123")
+    predictor = Predictor(
+        "endpoint", sagemaker_session, model_name="model", model_version="123"
+    )
 
     mock_response(json.dumps(PREDICT_RESPONSE).encode("utf-8"), sagemaker_session)
     result = predictor.predict(PREDICT_INPUT)
@@ -371,7 +390,9 @@ def test_predictor_classify(sagemaker_session):
 
 
 def test_predictor_regress(sagemaker_session):
-    predictor = Predictor("endpoint", sagemaker_session, model_name="model", model_version="123")
+    predictor = Predictor(
+        "endpoint", sagemaker_session, model_name="model", model_version="123"
+    )
 
     mock_response(json.dumps(REGRESS_RESPONSE).encode("utf-8"), sagemaker_session)
     result = predictor.regress(REGRESS_INPUT)
@@ -403,7 +424,9 @@ def test_predictor_classify_bad_content_type(sagemaker_session):
 
 
 def assert_invoked(sagemaker_session, **kwargs):
-    sagemaker_session.sagemaker_runtime_client.invoke_endpoint.assert_called_once_with(**kwargs)
+    sagemaker_session.sagemaker_runtime_client.invoke_endpoint.assert_called_once_with(
+        **kwargs
+    )
 
 
 def assert_invoked_with_body_dict(sagemaker_session, **kwargs):

--- a/tests/unit/test_timeout.py
+++ b/tests/unit/test_timeout.py
@@ -39,7 +39,9 @@ REGION = "us-west-2"
 BUCKET_NAME = "bucket-name"
 ENDPOINT_NAME = "endpoint_name"
 
-EXCEPTION_MESSAGE = "This Exception is expected and should not be swallowed by the timeout."
+EXCEPTION_MESSAGE = (
+    "This Exception is expected and should not be swallowed by the timeout."
+)
 SHORT_TIMEOUT_TO_FORCE_TIMEOUT_TO_OCCUR = 0.001
 LONG_DURATION_TO_EXCEED_TIMEOUT = 0.002
 LONG_TIMEOUT_THAT_WILL_NEVER_BE_EXCEEDED = 10
@@ -67,7 +69,9 @@ def transformer():
 
 def test_timeout_fails_correctly_when_method_throws_exception():
     with pytest.raises(ValueError) as exception:
-        with timeout(hours=0, minutes=0, seconds=LONG_TIMEOUT_THAT_WILL_NEVER_BE_EXCEEDED):
+        with timeout(
+            hours=0, minutes=0, seconds=LONG_TIMEOUT_THAT_WILL_NEVER_BE_EXCEEDED
+        ):
             raise ValueError(EXCEPTION_MESSAGE)
         assert EXCEPTION_MESSAGE in str(exception.value)
 
@@ -182,7 +186,11 @@ def test_timeout_and_delete_endpoint_by_name_retries_resource_deletion_on_failur
     autospec=True,
 )
 def test_timeout_and_delete_model_with_transformer_fails_when_method_throws_exception(
-    _show_logs, _cleanup_logs, _delete_schedules_associated_with_endpoint, session, transformer
+    _show_logs,
+    _cleanup_logs,
+    _delete_schedules_associated_with_endpoint,
+    session,
+    transformer,
 ):
     with pytest.raises(ValueError) as exception:
         with timeout_and_delete_model_with_transformer(
@@ -205,7 +213,11 @@ def test_timeout_and_delete_model_with_transformer_fails_when_method_throws_exce
     autospec=True,
 )
 def test_timeout_and_delete_model_with_transformer_throws_timeout_exception_when_method_times_out(
-    _show_logs, _cleanup_logs, _delete_schedules_associated_with_endpoint, session, transformer
+    _show_logs,
+    _cleanup_logs,
+    _delete_schedules_associated_with_endpoint,
+    session,
+    transformer,
 ):
     with pytest.raises(stopit.utils.TimeoutException):
         with timeout_and_delete_model_with_transformer(
@@ -227,7 +239,11 @@ def test_timeout_and_delete_model_with_transformer_throws_timeout_exception_when
     autospec=True,
 )
 def test_timeout_and_delete_model_with_transformer_does_not_throw_when_method_ends_gracefully(
-    _show_logs, _cleanup_logs, _delete_schedules_associated_with_endpoint, session, transformer
+    _show_logs,
+    _cleanup_logs,
+    _delete_schedules_associated_with_endpoint,
+    session,
+    transformer,
 ):
     with timeout_and_delete_model_with_transformer(
         sagemaker_session=session,
@@ -249,7 +265,11 @@ def test_timeout_and_delete_model_with_transformer_does_not_throw_when_method_en
     autospec=True,
 )
 def test_timeout_and_delete_model_with_transformer_retries_resource_deletion_on_failure(
-    _show_logs, _cleanup_logs, _delete_schedules_associated_with_endpoint, session, transformer
+    _show_logs,
+    _cleanup_logs,
+    _delete_schedules_associated_with_endpoint,
+    session,
+    transformer,
 ):
     transformer.delete_model = Mock(
         side_effect=ClientError(

--- a/tests/unit/test_transformer.py
+++ b/tests/unit/test_transformer.py
@@ -167,7 +167,10 @@ def test_transform_with_all_params(start_new_job, transformer):
         "TrialName": "t",
         "TrialComponentDisplayName": "tc",
     }
-    model_client_config = {"InvocationsTimeoutInSeconds": 60, "InvocationsMaxRetries": 2}
+    model_client_config = {
+        "InvocationsTimeoutInSeconds": 60,
+        "InvocationsMaxRetries": 2,
+    }
 
     transformer.transform(
         DATA,
@@ -202,7 +205,9 @@ def test_transform_with_all_params(start_new_job, transformer):
 
 @patch("sagemaker.transformer.name_from_base")
 @patch("sagemaker.transformer._TransformJob.start_new")
-def test_transform_with_base_job_name_provided(start_new_job, name_from_base, transformer):
+def test_transform_with_base_job_name_provided(
+    start_new_job, name_from_base, transformer
+):
     base_name = "base-job-name"
     full_name = "{}-{}".format(base_name, TIMESTAMP)
 
@@ -218,7 +223,9 @@ def test_transform_with_base_job_name_provided(start_new_job, name_from_base, tr
 @patch("sagemaker.transformer.Transformer._retrieve_base_name", return_value=IMAGE_NAME)
 @patch("sagemaker.transformer.name_from_base")
 @patch("sagemaker.transformer._TransformJob.start_new")
-def test_transform_with_base_name(start_new_job, name_from_base, retrieve_base_name, transformer):
+def test_transform_with_base_name(
+    start_new_job, name_from_base, retrieve_base_name, transformer
+):
     full_name = "{}-{}".format(IMAGE_NAME, TIMESTAMP)
     name_from_base.return_value = full_name
 
@@ -229,7 +236,9 @@ def test_transform_with_base_name(start_new_job, name_from_base, retrieve_base_n
     assert transformer._current_job_name == full_name
 
 
-@patch("sagemaker.transformer.Transformer._retrieve_image_name", return_value=IMAGE_NAME)
+@patch(
+    "sagemaker.transformer.Transformer._retrieve_image_name", return_value=IMAGE_NAME
+)
 @patch("sagemaker.transformer.name_from_base")
 @patch("sagemaker.transformer._TransformJob.start_new")
 def test_transform_with_job_name_based_on_image(
@@ -245,13 +254,17 @@ def test_transform_with_job_name_based_on_image(
     assert transformer._current_job_name == full_name
 
 
-@pytest.mark.parametrize("model_desc", [MODEL_DESC_PRIMARY_CONTAINER, MODEL_DESC_CONTAINERS_ONLY])
+@pytest.mark.parametrize(
+    "model_desc", [MODEL_DESC_PRIMARY_CONTAINER, MODEL_DESC_CONTAINERS_ONLY]
+)
 @patch("sagemaker.transformer.name_from_base")
 @patch("sagemaker.transformer._TransformJob.start_new")
 def test_transform_with_job_name_based_on_containers(
     start_new_job, name_from_base, model_desc, transformer
 ):
-    transformer.sagemaker_session.sagemaker_client.describe_model.return_value = model_desc
+    transformer.sagemaker_session.sagemaker_client.describe_model.return_value = (
+        model_desc
+    )
 
     full_name = "{}-{}".format(IMAGE_NAME, TIMESTAMP)
     name_from_base.return_value = full_name
@@ -273,7 +286,9 @@ def test_transform_with_job_name_based_on_containers(
 def test_transform_with_job_name_based_on_model_name(
     start_new_job, name_from_base, model_desc, transformer
 ):
-    transformer.sagemaker_session.sagemaker_client.describe_model.return_value = model_desc
+    transformer.sagemaker_session.sagemaker_client.describe_model.return_value = (
+        model_desc
+    )
 
     full_name = "{}-{}".format(MODEL_NAME, TIMESTAMP)
     name_from_base.return_value = full_name
@@ -288,7 +303,9 @@ def test_transform_with_job_name_based_on_model_name(
 
 
 @patch("sagemaker.transformer._TransformJob.start_new")
-def test_transform_with_generated_output_path(start_new_job, transformer, sagemaker_session):
+def test_transform_with_generated_output_path(
+    start_new_job, transformer, sagemaker_session
+):
     transformer.output_path = None
     sagemaker_session.default_bucket.return_value = S3_BUCKET
 
@@ -323,7 +340,9 @@ def test_wait(ensure_last_transform_job, transformer):
 
 
 def test_ensure_last_transform_job_exists(transformer, sagemaker_session):
-    transformer.latest_transform_job = _TransformJob(sagemaker_session, "some-transform-job")
+    transformer.latest_transform_job = _TransformJob(
+        sagemaker_session, "some-transform-job"
+    )
     transformer._ensure_last_transform_job()
 
 
@@ -340,7 +359,9 @@ def test_ensure_last_transform_job_none(transformer):
     return_value=INIT_PARAMS,
 )
 def test_attach(prepare_init_params, transformer, sagemaker_session):
-    sagemaker_session.sagemaker_client.describe_transform_job = Mock(name="describe_transform_job")
+    sagemaker_session.sagemaker_client.describe_transform_job = Mock(
+        name="describe_transform_job"
+    )
     attached = Transformer.attach(JOB_NAME, sagemaker_session)
 
     assert prepare_init_params.called_once
@@ -353,7 +374,10 @@ def test_attach(prepare_init_params, transformer, sagemaker_session):
 def test_prepare_init_params_from_job_description_missing_keys(transformer):
     job_details = {
         "ModelName": MODEL_NAME,
-        "TransformResources": {"InstanceCount": INSTANCE_COUNT, "InstanceType": INSTANCE_TYPE},
+        "TransformResources": {
+            "InstanceCount": INSTANCE_COUNT,
+            "InstanceType": INSTANCE_TYPE,
+        },
         "TransformOutput": {"S3OutputPath": None},
         "TransformJobName": JOB_NAME,
     }
@@ -431,7 +455,10 @@ def test_start_new(prepare_data_processing, load_config, sagemaker_session):
     split_type = "Line"
     io_filter = "$"
     join_source = "Input"
-    model_client_config = {"InvocationsTimeoutInSeconds": 60, "InvocationsMaxRetries": 2}
+    model_client_config = {
+        "InvocationsTimeoutInSeconds": 60,
+        "InvocationsMaxRetries": 2,
+    }
 
     job = _TransformJob.start_new(
         transformer=transformer,
@@ -485,12 +512,16 @@ def test_load_config(transformer):
         },
     }
 
-    actual_config = _TransformJob._load_config(DATA, S3_DATA_TYPE, None, None, None, transformer)
+    actual_config = _TransformJob._load_config(
+        DATA, S3_DATA_TYPE, None, None, None, transformer
+    )
     assert actual_config == expected_config
 
 
 def test_format_inputs_to_input_config():
-    expected_config = {"DataSource": {"S3DataSource": {"S3DataType": S3_DATA_TYPE, "S3Uri": DATA}}}
+    expected_config = {
+        "DataSource": {"S3DataSource": {"S3DataType": S3_DATA_TYPE, "S3Uri": DATA}}
+    }
 
     actual_config = _TransformJob._format_inputs_to_input_config(
         DATA, S3_DATA_TYPE, None, None, None
@@ -541,7 +572,9 @@ def test_prepare_output_config_with_optional_params():
 
 
 def test_prepare_resource_config():
-    config = _TransformJob._prepare_resource_config(INSTANCE_COUNT, INSTANCE_TYPE, KMS_KEY_ID)
+    config = _TransformJob._prepare_resource_config(
+        INSTANCE_COUNT, INSTANCE_TYPE, KMS_KEY_ID
+    )
     assert config == {
         "InstanceCount": INSTANCE_COUNT,
         "InstanceType": INSTANCE_TYPE,
@@ -560,7 +593,11 @@ def test_data_processing_config():
     assert actual_config == {"JoinSource": "Input"}
 
     actual_config = _TransformJob._prepare_data_processing("$[0]", "$[1]", "Input")
-    assert actual_config == {"InputFilter": "$[0]", "OutputFilter": "$[1]", "JoinSource": "Input"}
+    assert actual_config == {
+        "InputFilter": "$[0]",
+        "OutputFilter": "$[1]",
+        "JoinSource": "Input",
+    }
 
     actual_config = _TransformJob._prepare_data_processing(None, None, None)
     assert actual_config is None

--- a/tests/unit/test_tuner.py
+++ b/tests/unit/test_tuner.py
@@ -40,13 +40,20 @@ from .tuner_test_utils import *  # noqa: F403
 @pytest.fixture()
 def sagemaker_session():
     boto_mock = Mock(name="boto_session", region_name=REGION)
-    sms = Mock(name="sagemaker_session", boto_session=boto_mock, s3_client=None, s3_resource=None)
+    sms = Mock(
+        name="sagemaker_session",
+        boto_session=boto_mock,
+        s3_client=None,
+        s3_resource=None,
+    )
     sms.boto_region_name = REGION
     sms.default_bucket = Mock(name="default_bucket", return_value=BUCKET_NAME)
     sms.config = None
 
     sms.sagemaker_client.describe_endpoint = Mock(return_value=ENDPOINT_DESC)
-    sms.sagemaker_client.describe_endpoint_config = Mock(return_value=ENDPOINT_CONFIG_DESC)
+    sms.sagemaker_client.describe_endpoint_config = Mock(
+        return_value=ENDPOINT_CONFIG_DESC
+    )
 
     return sms
 
@@ -186,7 +193,10 @@ def test_fit_pca(sagemaker_session, tuner):
     assert tune_kwargs["job_name"].startswith("pca")
     assert tune_kwargs["tags"] == tags
 
-    assert len(tune_kwargs["tuning_config"]["parameter_ranges"]["IntegerParameterRanges"]) == 1
+    assert (
+        len(tune_kwargs["tuning_config"]["parameter_ranges"]["IntegerParameterRanges"])
+        == 1
+    )
     assert tune_kwargs["tuning_config"]["early_stopping_type"] == "Off"
     assert tuner.estimator.mini_batch_size == 9999
 
@@ -194,7 +204,10 @@ def test_fit_pca(sagemaker_session, tuner):
     assert "training_config_list" not in tune_kwargs
 
     assert len(tune_kwargs["training_config"]["static_hyperparameters"]) == 4
-    assert tune_kwargs["training_config"]["static_hyperparameters"]["extra_components"] == "5"
+    assert (
+        tune_kwargs["training_config"]["static_hyperparameters"]["extra_components"]
+        == "5"
+    )
 
     assert "estimator_name" not in tune_kwargs["training_config"]
     assert "objective_type" not in tune_kwargs["training_config"]
@@ -274,9 +287,13 @@ def test_s3_input_mode(sagemaker_session, tuner):
     }
     tuner._hyperparameter_ranges = hyperparameter_ranges
 
-    tuner.fit(inputs=s3_input("s3://mybucket/train_manifest", input_mode=expected_input_mode))
+    tuner.fit(
+        inputs=s3_input("s3://mybucket/train_manifest", input_mode=expected_input_mode)
+    )
 
-    actual_input_mode = sagemaker_session.method_calls[1][2]["training_config"]["input_mode"]
+    actual_input_mode = sagemaker_session.method_calls[1][2]["training_config"][
+        "input_mode"
+    ]
     assert actual_input_mode == expected_input_mode
 
 
@@ -334,7 +351,9 @@ def test_fit_pca_with_inter_container_traffic_encryption_flag(sagemaker_session,
         (
             {
                 ESTIMATOR_NAME: RecordSet(s3_data=INPUTS, num_records=1, feature_dim=1),
-                "Invalid estimator": RecordSet(s3_data=INPUTS, num_records=10, feature_dim=5),
+                "Invalid estimator": RecordSet(
+                    s3_data=INPUTS, num_records=10, feature_dim=5
+                ),
             },
             {ESTIMATOR_NAME_TWO: True},
             None,
@@ -347,7 +366,9 @@ def test_fit_pca_with_inter_container_traffic_encryption_flag(sagemaker_session,
 def test_fit_multi_estimators_invalid_inputs(
     sagemaker_session, inputs, include_cls_metadata, estimator_kwargs, error_message
 ):
-    (tuner, estimator_one, estimator_two) = _create_multi_estimator_tuner(sagemaker_session)
+    (tuner, estimator_one, estimator_two) = _create_multi_estimator_tuner(
+        sagemaker_session
+    )
 
     with pytest.raises(ValueError, match=error_message):
         tuner.fit(
@@ -359,13 +380,19 @@ def test_fit_multi_estimators_invalid_inputs(
 
 def test_fit_multi_estimators(sagemaker_session):
 
-    (tuner, estimator_one, estimator_two) = _create_multi_estimator_tuner(sagemaker_session)
+    (tuner, estimator_one, estimator_two) = _create_multi_estimator_tuner(
+        sagemaker_session
+    )
 
-    records = {ESTIMATOR_NAME_TWO: RecordSet(s3_data=INPUTS, num_records=1, feature_dim=1)}
+    records = {
+        ESTIMATOR_NAME_TWO: RecordSet(s3_data=INPUTS, num_records=1, feature_dim=1)
+    }
 
     estimator_kwargs = {ESTIMATOR_NAME_TWO: {"mini_batch_size": 4000}}
 
-    tuner.fit(inputs=records, include_cls_metadata={}, estimator_kwargs=estimator_kwargs)
+    tuner.fit(
+        inputs=records, include_cls_metadata={}, estimator_kwargs=estimator_kwargs
+    )
 
     _, _, tune_kwargs = sagemaker_session.create_tuning_job.mock_calls[0]
 
@@ -408,7 +435,10 @@ def test_fit_multi_estimators(sagemaker_session):
     assert training_config_two["objective_type"] == "Minimize"
     assert training_config_two["objective_metric_name"] == OBJECTIVE_METRIC_NAME_TWO
     assert len(training_config_two["input_config"]) == 1
-    assert training_config_two["input_config"][0]["DataSource"]["S3DataSource"]["S3Uri"] == INPUTS
+    assert (
+        training_config_two["input_config"][0]["DataSource"]["S3DataSource"]["S3Uri"]
+        == INPUTS
+    )
     assert training_config_two["image"] == estimator_two.train_image()
     assert training_config_two["metric_definitions"] is None
     assert training_config_two["static_hyperparameters"]["mini_batch_size"] == "4000"
@@ -520,7 +550,9 @@ def test_attach_tuning_job_with_estimator_from_hyperparameters_with_early_stoppi
     sagemaker_session,
 ):
     job_details = copy.deepcopy(TUNING_JOB_DETAILS)
-    job_details["HyperParameterTuningJobConfig"]["TrainingJobEarlyStoppingType"] = "Auto"
+    job_details["HyperParameterTuningJobConfig"][
+        "TrainingJobEarlyStoppingType"
+    ] = "Auto"
     sagemaker_session.sagemaker_client.describe_hyper_parameter_tuning_job = Mock(
         name="describe_tuning_job", return_value=job_details
     )
@@ -559,14 +591,18 @@ def test_attach_tuning_job_with_estimator_from_kwarg(sagemaker_session):
         name="describe_tuning_job", return_value=job_details
     )
     tuner = HyperparameterTuner.attach(
-        JOB_NAME, sagemaker_session=sagemaker_session, estimator_cls="sagemaker.estimator.Estimator"
+        JOB_NAME,
+        sagemaker_session=sagemaker_session,
+        estimator_cls="sagemaker.estimator.Estimator",
     )
     assert isinstance(tuner.estimator, Estimator)
 
 
 def test_attach_with_no_specified_estimator(sagemaker_session):
     job_details = copy.deepcopy(TUNING_JOB_DETAILS)
-    del job_details["TrainingJobDefinition"]["StaticHyperParameters"]["sagemaker_estimator_module"]
+    del job_details["TrainingJobDefinition"]["StaticHyperParameters"][
+        "sagemaker_estimator_module"
+    ]
     del job_details["TrainingJobDefinition"]["StaticHyperParameters"][
         "sagemaker_estimator_class_name"
     ]
@@ -632,11 +668,16 @@ def test_attach_tuning_job_with_multi_estimators(sagemaker_session):
     assert isinstance(tuner.estimator_dict[ESTIMATOR_NAME_TWO], Estimator)
 
     assert tuner.objective_metric_name_dict[ESTIMATOR_NAME] == OBJECTIVE_METRIC_NAME
-    assert tuner.objective_metric_name_dict[ESTIMATOR_NAME_TWO] == OBJECTIVE_METRIC_NAME_TWO
+    assert (
+        tuner.objective_metric_name_dict[ESTIMATOR_NAME_TWO]
+        == OBJECTIVE_METRIC_NAME_TWO
+    )
 
     parameter_ranges_one = tuner._hyperparameter_ranges_dict[ESTIMATOR_NAME]
     assert len(parameter_ranges_one) == 1
-    assert isinstance(parameter_ranges_one.get("mini_batch_size", None), IntegerParameter)
+    assert isinstance(
+        parameter_ranges_one.get("mini_batch_size", None), IntegerParameter
+    )
 
     parameter_ranges_two = tuner._hyperparameter_ranges_dict[ESTIMATOR_NAME_TWO]
     assert len(parameter_ranges_two) == 2
@@ -651,7 +692,9 @@ def test_serialize_parameter_ranges(tuner):
     hyperparameter_ranges = tuner.hyperparameter_ranges()
 
     for key, value in HYPERPARAMETER_RANGES.items():
-        assert hyperparameter_ranges[value.__name__ + "ParameterRanges"][0]["Name"] == key
+        assert (
+            hyperparameter_ranges[value.__name__ + "ParameterRanges"][0]["Name"] == key
+        )
 
 
 def test_analytics(tuner):
@@ -674,7 +717,10 @@ def test_serialize_categorical_ranges_for_frameworks(sagemaker_session, tuner):
     hyperparameter_ranges = tuner.hyperparameter_ranges()
 
     assert hyperparameter_ranges["CategoricalParameterRanges"][0]["Name"] == "blank"
-    assert hyperparameter_ranges["CategoricalParameterRanges"][0]["Values"] == ['"0"', '"5"']
+    assert hyperparameter_ranges["CategoricalParameterRanges"][0]["Values"] == [
+        '"0"',
+        '"5"',
+    ]
 
 
 def test_serialize_nonexistent_parameter_ranges(tuner):
@@ -892,11 +938,15 @@ def test_deploy_optional_params(_get_best_training_job, best_estimator, tuner):
 
 def test_wait(tuner):
     tuner.latest_tuning_job = _TuningJob(tuner.estimator.sagemaker_session, JOB_NAME)
-    tuner.estimator.sagemaker_session.wait_for_tuning_job = Mock(name="wait_for_tuning_job")
+    tuner.estimator.sagemaker_session.wait_for_tuning_job = Mock(
+        name="wait_for_tuning_job"
+    )
 
     tuner.wait()
 
-    tuner.estimator.sagemaker_session.wait_for_tuning_job.assert_called_once_with(JOB_NAME)
+    tuner.estimator.sagemaker_session.wait_for_tuning_job.assert_called_once_with(
+        JOB_NAME
+    )
 
 
 def test_delete_endpoint(tuner):
@@ -947,9 +997,18 @@ def test_identical_dataset_and_algorithm_tuner(sagemaker_session):
     )
 
     tuner = HyperparameterTuner.attach(JOB_NAME, sagemaker_session=sagemaker_session)
-    parent_tuner = tuner.identical_dataset_and_algorithm_tuner(additional_parents={"p1", "p2"})
-    assert parent_tuner.warm_start_config.type == WarmStartTypes.IDENTICAL_DATA_AND_ALGORITHM
-    assert parent_tuner.warm_start_config.parents == {tuner.latest_tuning_job.name, "p1", "p2"}
+    parent_tuner = tuner.identical_dataset_and_algorithm_tuner(
+        additional_parents={"p1", "p2"}
+    )
+    assert (
+        parent_tuner.warm_start_config.type
+        == WarmStartTypes.IDENTICAL_DATA_AND_ALGORITHM
+    )
+    assert parent_tuner.warm_start_config.parents == {
+        tuner.latest_tuning_job.name,
+        "p1",
+        "p2",
+    }
 
 
 def test_transfer_learning_tuner_with_estimator(sagemaker_session, estimator):
@@ -964,8 +1023,15 @@ def test_transfer_learning_tuner_with_estimator(sagemaker_session, estimator):
     )
 
     assert parent_tuner.warm_start_config.type == WarmStartTypes.TRANSFER_LEARNING
-    assert parent_tuner.warm_start_config.parents == {tuner.latest_tuning_job.name, "p1", "p2"}
-    assert parent_tuner.estimator == estimator and parent_tuner.estimator != tuner.estimator
+    assert parent_tuner.warm_start_config.parents == {
+        tuner.latest_tuning_job.name,
+        "p1",
+        "p2",
+    }
+    assert (
+        parent_tuner.estimator == estimator
+        and parent_tuner.estimator != tuner.estimator
+    )
 
 
 def test_transfer_learning_tuner(sagemaker_session):
@@ -978,7 +1044,11 @@ def test_transfer_learning_tuner(sagemaker_session):
     parent_tuner = tuner.transfer_learning_tuner(additional_parents={"p1", "p2"})
 
     assert parent_tuner.warm_start_config.type == WarmStartTypes.TRANSFER_LEARNING
-    assert parent_tuner.warm_start_config.parents == {tuner.latest_tuning_job.name, "p1", "p2"}
+    assert parent_tuner.warm_start_config.parents == {
+        tuner.latest_tuning_job.name,
+        "p1",
+        "p2",
+    }
     assert parent_tuner.estimator == tuner.estimator
 
 
@@ -993,7 +1063,10 @@ def test_transfer_learning_tuner(sagemaker_session):
         ),
         (
             {ESTIMATOR_NAME: ESTIMATOR, ESTIMATOR_NAME_TWO: ESTIMATOR_TWO},
-            {ESTIMATOR_NAME: OBJECTIVE_METRIC_NAME, ESTIMATOR_NAME_TWO: OBJECTIVE_METRIC_NAME_TWO},
+            {
+                ESTIMATOR_NAME: OBJECTIVE_METRIC_NAME,
+                ESTIMATOR_NAME_TWO: OBJECTIVE_METRIC_NAME_TWO,
+            },
             {
                 ESTIMATOR_NAME: HYPERPARAMETER_RANGES,
                 ESTIMATOR_NAME_TWO: {"gamma": ContinuousParameter(0, 1.5)},
@@ -1002,7 +1075,9 @@ def test_transfer_learning_tuner(sagemaker_session):
         ),
     ],
 )
-def test_create_tuner(estimator_dict, obj_metric_name_dict, param_ranges_dict, metric_def_dict):
+def test_create_tuner(
+    estimator_dict, obj_metric_name_dict, param_ranges_dict, metric_def_dict
+):
     tuner = HyperparameterTuner.create(
         base_tuning_job_name=BASE_JOB_NAME,
         estimator_dict=estimator_dict,
@@ -1100,7 +1175,11 @@ def test_create_tuner(estimator_dict, obj_metric_name_dict, param_ranges_dict, m
     ],
 )
 def test_create_tuner_negative(
-    estimator_dict, obj_metric_name_dict, param_ranges_dict, metric_def_dict, error_message
+    estimator_dict,
+    obj_metric_name_dict,
+    param_ranges_dict,
+    metric_def_dict,
+    error_message,
 ):
     with pytest.raises(ValueError, match=error_message):
         HyperparameterTuner.create(
@@ -1243,7 +1322,9 @@ def test_warm_start_config_init(type, parents):
     ), "Warm start parents config initialization failed."
 
     warm_start_config_req = warm_start_config.to_input_req()
-    assert warm_start_config.type == WarmStartTypes(warm_start_config_req["WarmStartType"])
+    assert warm_start_config.type == WarmStartTypes(
+        warm_start_config_req["WarmStartType"]
+    )
     for parent in warm_start_config_req["ParentHyperParameterTuningJobs"]:
         assert parent["HyperParameterTuningJobName"] in parents
 
@@ -1274,7 +1355,9 @@ def test_warm_start_config_init_negative(type, parents):
 )
 def test_prepare_warm_start_config_cls_negative(warm_start_config_req):
     warm_start_config = WarmStartConfig.from_job_desc(warm_start_config_req)
-    assert warm_start_config is None, "Warm start config should be None for invalid type/parents"
+    assert (
+        warm_start_config is None
+    ), "Warm start config should be None for invalid type/parents"
 
 
 @pytest.mark.parametrize(
@@ -1314,14 +1397,18 @@ def test_prepare_warm_start_config_cls(warm_start_config_req):
 
 
 @pytest.mark.parametrize("additional_parents", [{"p1", "p2"}, {}, None])
-def test_create_identical_dataset_and_algorithm_tuner(sagemaker_session, additional_parents):
+def test_create_identical_dataset_and_algorithm_tuner(
+    sagemaker_session, additional_parents
+):
     job_details = copy.deepcopy(TUNING_JOB_DETAILS)
     sagemaker_session.sagemaker_client.describe_hyper_parameter_tuning_job = Mock(
         name="describe_tuning_job", return_value=job_details
     )
 
     tuner = create_identical_dataset_and_algorithm_tuner(
-        parent=JOB_NAME, additional_parents=additional_parents, sagemaker_session=sagemaker_session
+        parent=JOB_NAME,
+        additional_parents=additional_parents,
+        sagemaker_session=sagemaker_session,
     )
 
     assert tuner.warm_start_config.type == WarmStartTypes.IDENTICAL_DATA_AND_ALGORITHM
@@ -1333,7 +1420,9 @@ def test_create_identical_dataset_and_algorithm_tuner(sagemaker_session, additio
 
 
 @pytest.mark.parametrize("additional_parents", [{"p1", "p2"}, {}, None])
-def test_create_transfer_learning_tuner(sagemaker_session, estimator, additional_parents):
+def test_create_transfer_learning_tuner(
+    sagemaker_session, estimator, additional_parents
+):
     job_details = copy.deepcopy(TUNING_JOB_DETAILS)
     sagemaker_session.sagemaker_client.describe_hyper_parameter_tuning_job = Mock(
         name="describe_tuning_job", return_value=job_details
@@ -1454,9 +1543,9 @@ def _convert_tuning_job_details(job_details, estimator_name):
 
     # When the 'TrainingJobDefinitions' field is used, tuning objective and parameter ranges must be set in each item
     # in it instead of the tuning job config.
-    training_details["TuningObjective"] = job_details_copy["HyperParameterTuningJobConfig"].pop(
-        "HyperParameterTuningJobObjective"
-    )
+    training_details["TuningObjective"] = job_details_copy[
+        "HyperParameterTuningJobConfig"
+    ].pop("HyperParameterTuningJobObjective")
     training_details["HyperParameterRanges"] = job_details_copy[
         "HyperParameterTuningJobConfig"
     ].pop("ParameterRanges")

--- a/tests/unit/test_upload_data.py
+++ b/tests/unit/test_upload_data.py
@@ -22,7 +22,9 @@ from tests.unit import DATA_DIR
 
 UPLOAD_DATA_TESTS_FILES_DIR = os.path.join(DATA_DIR, "upload_data_tests")
 SINGLE_FILE_NAME = "file1.py"
-UPLOAD_DATA_TESTS_SINGLE_FILE = os.path.join(UPLOAD_DATA_TESTS_FILES_DIR, SINGLE_FILE_NAME)
+UPLOAD_DATA_TESTS_SINGLE_FILE = os.path.join(
+    UPLOAD_DATA_TESTS_FILES_DIR, SINGLE_FILE_NAME
+)
 BUCKET_NAME = "mybucket"
 AES_ENCRYPTION_ENABLED = {"ServerSideEncryption": "AES256"}
 ENDPOINT_URL = "http://127.0.0.1:9000"
@@ -74,7 +76,9 @@ def test_upload_data_absolute_dir_custom_endpoint(sagemaker_session_custom_endpo
 
     sagemaker_session_custom_endpoint.s3_resource.Object = Mock()
 
-    result_s3_uri = sagemaker_session_custom_endpoint.upload_data(UPLOAD_DATA_TESTS_FILES_DIR)
+    result_s3_uri = sagemaker_session_custom_endpoint.upload_data(
+        UPLOAD_DATA_TESTS_FILES_DIR
+    )
 
     uploaded_files_with_args = [
         (args[0], kwargs)

--- a/tests/unit/test_upload_string_as_file_body.py
+++ b/tests/unit/test_upload_string_as_file_body.py
@@ -53,7 +53,9 @@ def test_upload_string_file(sagemaker_session):
         if name == "resource().Object().put"
     ]
 
-    assert result_s3_uri == "s3://{}/{}".format(BUCKET_NAME, DESTINATION_DATA_TESTS_FILE)
+    assert result_s3_uri == "s3://{}/{}".format(
+        BUCKET_NAME, DESTINATION_DATA_TESTS_FILE
+    )
     assert len(uploaded_files_with_args) == 1
     kwargs = uploaded_files_with_args[0]
     assert kwargs["Body"] == BODY
@@ -73,7 +75,9 @@ def test_upload_aes_encrypted_string_file(sagemaker_session):
         if name == "resource().Object().put"
     ]
 
-    assert result_s3_uri == "s3://{}/{}".format(BUCKET_NAME, DESTINATION_DATA_TESTS_FILE)
+    assert result_s3_uri == "s3://{}/{}".format(
+        BUCKET_NAME, DESTINATION_DATA_TESTS_FILE
+    )
     assert len(uploaded_files_with_args) == 1
     kwargs = uploaded_files_with_args[0]
     assert kwargs["Body"] == BODY

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -82,7 +82,9 @@ def test_name_from_base_short(sagemaker_short_timestamp):
 
 
 def test_unique_name_from_base():
-    assert re.match(r"base-\d{10}-[a-f0-9]{4}", sagemaker.utils.unique_name_from_base("base"))
+    assert re.match(
+        r"base-\d{10}-[a-f0-9]{4}", sagemaker.utils.unique_name_from_base("base")
+    )
 
 
 def test_unique_name_from_base_truncated():
@@ -120,7 +122,9 @@ TRAINING_JOB_DESCRIPTION_1 = {
     "SecondaryStatusTransitions": [{"StatusMessage": MESSAGE, "Status": STATUS}]
 }
 TRAINING_JOB_DESCRIPTION_2 = {
-    "SecondaryStatusTransitions": [{"StatusMessage": "different message", "Status": STATUS}]
+    "SecondaryStatusTransitions": [
+        {"StatusMessage": "different message", "Status": STATUS}
+    ]
 }
 
 TRAINING_JOB_DESCRIPTION_EMPTY = {"SecondaryStatusTransitions": []}
@@ -141,17 +145,23 @@ def test_secondary_training_status_changed_false():
 
 
 def test_secondary_training_status_changed_prev_missing():
-    changed = sagemaker.utils.secondary_training_status_changed(TRAINING_JOB_DESCRIPTION_1, {})
+    changed = sagemaker.utils.secondary_training_status_changed(
+        TRAINING_JOB_DESCRIPTION_1, {}
+    )
     assert changed is True
 
 
 def test_secondary_training_status_changed_prev_none():
-    changed = sagemaker.utils.secondary_training_status_changed(TRAINING_JOB_DESCRIPTION_1, None)
+    changed = sagemaker.utils.secondary_training_status_changed(
+        TRAINING_JOB_DESCRIPTION_1, None
+    )
     assert changed is True
 
 
 def test_secondary_training_status_changed_current_missing():
-    changed = sagemaker.utils.secondary_training_status_changed({}, TRAINING_JOB_DESCRIPTION_1)
+    changed = sagemaker.utils.secondary_training_status_changed(
+        {}, TRAINING_JOB_DESCRIPTION_1
+    )
     assert changed is False
 
 
@@ -166,7 +176,9 @@ def test_secondary_training_status_message_status_changed():
     now = datetime.now()
     TRAINING_JOB_DESCRIPTION_1["LastModifiedTime"] = now
     expected = "{} {} - {}".format(
-        datetime.utcfromtimestamp(time.mktime(now.timetuple())).strftime("%Y-%m-%d %H:%M:%S"),
+        datetime.utcfromtimestamp(time.mktime(now.timetuple())).strftime(
+            "%Y-%m-%d %H:%M:%S"
+        ),
         STATUS,
         MESSAGE,
     )
@@ -182,7 +194,9 @@ def test_secondary_training_status_message_status_not_changed():
     now = datetime.now()
     TRAINING_JOB_DESCRIPTION_1["LastModifiedTime"] = now
     expected = "{} {} - {}".format(
-        datetime.utcfromtimestamp(time.mktime(now.timetuple())).strftime("%Y-%m-%d %H:%M:%S"),
+        datetime.utcfromtimestamp(time.mktime(now.timetuple())).strftime(
+            "%Y-%m-%d %H:%M:%S"
+        ),
         STATUS,
         MESSAGE,
     )
@@ -198,12 +212,16 @@ def test_secondary_training_status_message_prev_missing():
     now = datetime.now()
     TRAINING_JOB_DESCRIPTION_1["LastModifiedTime"] = now
     expected = "{} {} - {}".format(
-        datetime.utcfromtimestamp(time.mktime(now.timetuple())).strftime("%Y-%m-%d %H:%M:%S"),
+        datetime.utcfromtimestamp(time.mktime(now.timetuple())).strftime(
+            "%Y-%m-%d %H:%M:%S"
+        ),
         STATUS,
         MESSAGE,
     )
     assert (
-        sagemaker.utils.secondary_training_status_message(TRAINING_JOB_DESCRIPTION_1, {})
+        sagemaker.utils.secondary_training_status_message(
+            TRAINING_JOB_DESCRIPTION_1, {}
+        )
         == expected
     )
 
@@ -380,7 +398,9 @@ def test_download_folder_points_to_single_file(makedirs):
     boto_mock.resource("s3").Object.return_value = obj_mock
 
     # all the S3 mocks are set, the test itself begins now.
-    sagemaker.utils.download_folder(BUCKET_NAME, "/prefix/train/train_data.csv", "/tmp", session)
+    sagemaker.utils.download_folder(
+        BUCKET_NAME, "/prefix/train/train_data.csv", "/tmp", session
+    )
 
     obj_mock.download_file.assert_called()
     calls = [call(os.path.join("/tmp", "train_data.csv"))]
@@ -400,7 +420,9 @@ def test_download_file():
         BUCKET_NAME, "/prefix/path/file.tar.gz", "/tmp/file.tar.gz", session
     )
 
-    bucket_mock.download_file.assert_called_with("prefix/path/file.tar.gz", "/tmp/file.tar.gz")
+    bucket_mock.download_file.assert_called_with(
+        "prefix/path/file.tar.gz", "/tmp/file.tar.gz"
+    )
 
 
 @patch("tarfile.open")
@@ -521,7 +543,10 @@ def test_repack_model_with_entry_point_without_path_without_source_dir(tmp, fake
     finally:
         os.chdir(cwd)
 
-    assert list_tar_files(fake_s3.fake_upload_path, tmp) == {"/code/inference.py", "/model"}
+    assert list_tar_files(fake_s3.fake_upload_path, tmp) == {
+        "/code/inference.py",
+        "/model",
+    }
 
 
 def test_repack_model_from_s3_to_s3(tmp, fake_s3):
@@ -573,12 +598,21 @@ def test_repack_model_from_file_to_file(tmp):
         sagemaker_session,
     )
 
-    assert list_tar_files(destination_path, tmp) == {"/code/lib/a", "/code/inference.py", "/model"}
+    assert list_tar_files(destination_path, tmp) == {
+        "/code/lib/a",
+        "/code/inference.py",
+        "/model",
+    }
 
 
 def test_repack_model_with_inference_code_should_replace_the_code(tmp, fake_s3):
     create_file_tree(
-        tmp, ["model-dir/model", "source-dir/new-inference.py", "model-dir/code/old-inference.py"]
+        tmp,
+        [
+            "model-dir/model",
+            "source-dir/new-inference.py",
+            "model-dir/code/old-inference.py",
+        ],
     )
 
     fake_s3.tar_and_upload("model-dir", "s3://fake/location")
@@ -592,7 +626,10 @@ def test_repack_model_with_inference_code_should_replace_the_code(tmp, fake_s3):
         fake_s3.sagemaker_session,
     )
 
-    assert list_tar_files(fake_s3.fake_upload_path, tmp) == {"/code/new-inference.py", "/model"}
+    assert list_tar_files(fake_s3.fake_upload_path, tmp) == {
+        "/code/new-inference.py",
+        "/model",
+    }
 
 
 def test_repack_model_from_file_to_folder(tmp):
@@ -750,7 +787,9 @@ def test_get_ecr_image_uri_prefix():
     ecr_prefix = sagemaker.utils.get_ecr_image_uri_prefix("123456789012", "us-west-2")
     assert ecr_prefix == "123456789012.dkr.ecr.us-west-2.amazonaws.com"
 
-    ecr_prefix = sagemaker.utils.get_ecr_image_uri_prefix("123456789012", "us-iso-east-1")
+    ecr_prefix = sagemaker.utils.get_ecr_image_uri_prefix(
+        "123456789012", "us-iso-east-1"
+    )
     assert ecr_prefix == "123456789012.dkr.ecr.us-iso-east-1.c2s.ic.gov"
 
 

--- a/tests/unit/test_vpc_utils.py
+++ b/tests/unit/test_vpc_utils.py
@@ -16,12 +16,22 @@ from __future__ import absolute_import
 
 import pytest
 
-from sagemaker.vpc_utils import SUBNETS_KEY, SECURITY_GROUP_IDS_KEY, to_dict, from_dict, sanitize
+from sagemaker.vpc_utils import (
+    SUBNETS_KEY,
+    SECURITY_GROUP_IDS_KEY,
+    to_dict,
+    from_dict,
+    sanitize,
+)
 
 subnets = ["subnet"]
 security_groups = ["sg"]
 good_vpc_config = {SUBNETS_KEY: subnets, SECURITY_GROUP_IDS_KEY: security_groups}
-foo_vpc_config = {SUBNETS_KEY: subnets, SECURITY_GROUP_IDS_KEY: security_groups, "foo": 1}
+foo_vpc_config = {
+    SUBNETS_KEY: subnets,
+    SECURITY_GROUP_IDS_KEY: security_groups,
+    "foo": 1,
+}
 
 
 def test_to_dict():

--- a/tests/unit/test_xgboost.py
+++ b/tests/unit/test_xgboost.py
@@ -45,7 +45,9 @@ CPU = "ml.c4.xlarge"
 
 ENDPOINT_DESC = {"EndpointConfigName": "test-endpoint"}
 
-ENDPOINT_CONFIG_DESC = {"ProductionVariants": [{"ModelName": "model-1"}, {"ModelName": "model-2"}]}
+ENDPOINT_CONFIG_DESC = {
+    "ProductionVariants": [{"ModelName": "model-1"}, {"ModelName": "model-2"}]
+}
 
 LIST_TAGS_RESULT = {"Tags": [{"Key": "TagtestKey", "Value": "TagtestValue"}]}
 
@@ -72,7 +74,9 @@ def sagemaker_session():
     describe = {"ModelArtifacts": {"S3ModelArtifacts": "s3://m/m.tar.gz"}}
     session.sagemaker_client.describe_training_job = Mock(return_value=describe)
     session.sagemaker_client.describe_endpoint = Mock(return_value=ENDPOINT_DESC)
-    session.sagemaker_client.describe_endpoint_config = Mock(return_value=ENDPOINT_CONFIG_DESC)
+    session.sagemaker_client.describe_endpoint_config = Mock(
+        return_value=ENDPOINT_CONFIG_DESC
+    )
     session.sagemaker_client.list_tags = Mock(return_value=LIST_TAGS_RESULT)
     session.default_bucket = Mock(name="default_bucket", return_value=BUCKET_NAME)
     session.expand_role = Mock(name="expand_role", return_value=ROLE)
@@ -80,7 +84,9 @@ def sagemaker_session():
 
 
 def _get_full_cpu_image_uri(version):
-    return IMAGE_URI_FORMAT_STRING.format(REGION, IMAGE_NAME, version, "cpu", PYTHON_VERSION)
+    return IMAGE_URI_FORMAT_STRING.format(
+        REGION, IMAGE_NAME, version, "cpu", PYTHON_VERSION
+    )
 
 
 def _xgboost_estimator(
@@ -97,7 +103,9 @@ def _xgboost_estimator(
         framework_version=framework_version,
         role=ROLE,
         sagemaker_session=sagemaker_session,
-        train_instance_type=train_instance_type if train_instance_type else INSTANCE_TYPE,
+        train_instance_type=train_instance_type
+        if train_instance_type
+        else INSTANCE_TYPE,
         train_instance_count=train_instance_count,
         base_job_name=base_job_name,
         py_version=PYTHON_VERSION,
@@ -313,7 +321,9 @@ def test_xgboost(strftime, sagemaker_session, xgboost_version):
     assert boto_call_names == ["resource"]
 
     expected_train_args = _create_train_job(xgboost_version)
-    expected_train_args["input_config"][0]["DataSource"]["S3DataSource"]["S3Uri"] = inputs
+    expected_train_args["input_config"][0]["DataSource"]["S3DataSource"][
+        "S3Uri"
+    ] = inputs
     expected_train_args["experiment_config"] = EXPERIMENT_CONFIG
 
     actual_train_args = sagemaker_session.method_calls[0][2]
@@ -321,7 +331,9 @@ def test_xgboost(strftime, sagemaker_session, xgboost_version):
 
     model = xgboost.create_model()
 
-    expected_image_base = "246618743249.dkr.ecr.us-west-2.amazonaws.com/sagemaker-xgboost:{}-cpu-{}"
+    expected_image_base = (
+        "246618743249.dkr.ecr.us-west-2.amazonaws.com/sagemaker-xgboost:{}-cpu-{}"
+    )
     assert {
         "Environment": {
             "SAGEMAKER_SUBMIT_DIRECTORY": "s3://mybucket/sagemaker-xgboost-{}/source/sourcedir.tar.gz".format(
@@ -363,14 +375,18 @@ def test_distributed_training(strftime, sagemaker_session, xgboost_version):
     assert boto_call_names == ["resource"]
 
     expected_train_args = _create_train_job(xgboost_version, DIST_INSTANCE_COUNT)
-    expected_train_args["input_config"][0]["DataSource"]["S3DataSource"]["S3Uri"] = inputs
+    expected_train_args["input_config"][0]["DataSource"]["S3DataSource"][
+        "S3Uri"
+    ] = inputs
 
     actual_train_args = sagemaker_session.method_calls[0][2]
     assert actual_train_args == expected_train_args
 
     model = xgboost.create_model()
 
-    expected_image_base = "246618743249.dkr.ecr.us-west-2.amazonaws.com/sagemaker-xgboost:{}-cpu-{}"
+    expected_image_base = (
+        "246618743249.dkr.ecr.us-west-2.amazonaws.com/sagemaker-xgboost:{}-cpu-{}"
+    )
     assert {
         "Environment": {
             "SAGEMAKER_SUBMIT_DIRECTORY": "s3://mybucket/sagemaker-xgboost-{}/source/sourcedir.tar.gz".format(
@@ -427,7 +443,9 @@ def test_train_image_cpu_instances(sagemaker_session, xgboost_version):
     )
     assert xgboost.train_image() == _get_full_cpu_image_uri(xgboost_version)
 
-    xgboost = _xgboost_estimator(sagemaker_session, xgboost_version, train_instance_type="ml.m16")
+    xgboost = _xgboost_estimator(
+        sagemaker_session, xgboost_version, train_instance_type="ml.m16"
+    )
     assert xgboost.train_image() == _get_full_cpu_image_uri(xgboost_version)
 
 
@@ -436,7 +454,10 @@ def test_attach(sagemaker_session, xgboost_version):
         xgboost_version, PYTHON_VERSION
     )
     returned_job_description = {
-        "AlgorithmSpecification": {"TrainingInputMode": "File", "TrainingImage": training_image},
+        "AlgorithmSpecification": {
+            "TrainingInputMode": "File",
+            "TrainingImage": training_image,
+        },
         "HyperParameters": {
             "sagemaker_submit_directory": '"s3://some/sourcedir.tar.gz"',
             "sagemaker_program": '"iris-dnn-classifier.py"',
@@ -464,7 +485,9 @@ def test_attach(sagemaker_session, xgboost_version):
         name="describe_training_job", return_value=returned_job_description
     )
 
-    estimator = XGBoost.attach(training_job_name="neo", sagemaker_session=sagemaker_session)
+    estimator = XGBoost.attach(
+        training_job_name="neo", sagemaker_session=sagemaker_session
+    )
     assert estimator._current_job_name == "neo"
     assert estimator.latest_training_job.job_name == "neo"
     assert estimator.py_version == PYTHON_VERSION
@@ -521,7 +544,10 @@ def test_attach_wrong_framework(sagemaker_session):
 def test_attach_custom_image(sagemaker_session):
     training_image = "1.dkr.ecr.us-west-2.amazonaws.com/my_custom_xgboost_image:latest"
     returned_job_description = {
-        "AlgorithmSpecification": {"TrainingInputMode": "File", "TrainingImage": training_image},
+        "AlgorithmSpecification": {
+            "TrainingInputMode": "File",
+            "TrainingImage": training_image,
+        },
         "HyperParameters": {
             "sagemaker_submit_directory": '"s3://some/sourcedir.tar.gz"',
             "sagemaker_program": '"iris-dnn-classifier.py"',

--- a/tests/unit/tuner_test_utils.py
+++ b/tests/unit/tuner_test_utils.py
@@ -17,7 +17,11 @@ import os
 from mock import Mock
 from sagemaker.amazon.pca import PCA
 from sagemaker.estimator import Estimator
-from sagemaker.parameter import CategoricalParameter, ContinuousParameter, IntegerParameter
+from sagemaker.parameter import (
+    CategoricalParameter,
+    ContinuousParameter,
+    IntegerParameter,
+)
 from sagemaker.tuner import WarmStartConfig, WarmStartTypes
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), "..", "data")
@@ -87,7 +91,8 @@ ESTIMATOR_TWO = PCA(
 )
 
 WARM_START_CONFIG = WarmStartConfig(
-    warm_start_type=WarmStartTypes.IDENTICAL_DATA_AND_ALGORITHM, parents={"p1", "p2", "p3"}
+    warm_start_type=WarmStartTypes.IDENTICAL_DATA_AND_ALGORITHM,
+    parents={"p1", "p2", "p3"},
 )
 
 TUNING_JOB_DETAILS = {
@@ -169,7 +174,10 @@ MULTI_ALGO_TUNING_JOB_DETAILS = {
     "TrainingJobDefinitions": [
         {
             "DefinitionName": ESTIMATOR_NAME,
-            "TuningObjective": {"MetricName": OBJECTIVE_METRIC_NAME, "Type": "Minimize"},
+            "TuningObjective": {
+                "MetricName": OBJECTIVE_METRIC_NAME,
+                "Type": "Minimize",
+            },
             "HyperParameterRanges": {
                 "CategoricalParameterRanges": [],
                 "ContinuousParameterRanges": [],
@@ -195,7 +203,10 @@ MULTI_ALGO_TUNING_JOB_DETAILS = {
                 "InstanceType": "ml.c4.xlarge",
                 "InstanceCount": 1,
             },
-            "AlgorithmSpecification": {"TrainingImage": IMAGE_NAME, "TrainingInputMode": "File"},
+            "AlgorithmSpecification": {
+                "TrainingImage": IMAGE_NAME,
+                "TrainingInputMode": "File",
+            },
             "InputDataConfig": [
                 {
                     "ChannelName": "train",
@@ -213,12 +224,22 @@ MULTI_ALGO_TUNING_JOB_DETAILS = {
         },
         {
             "DefinitionName": ESTIMATOR_NAME_TWO,
-            "TuningObjective": {"MetricName": OBJECTIVE_METRIC_NAME_TWO, "Type": "Minimize"},
+            "TuningObjective": {
+                "MetricName": OBJECTIVE_METRIC_NAME_TWO,
+                "Type": "Minimize",
+            },
             "HyperParameterRanges": {
-                "CategoricalParameterRanges": [{"Name": "kernel", "Values": ["rbf", "sigmoid"]}],
+                "CategoricalParameterRanges": [
+                    {"Name": "kernel", "Values": ["rbf", "sigmoid"]}
+                ],
                 "ContinuousParameterRanges": [],
                 "IntegerParameterRanges": [
-                    {"MaxValue": "10", "Name": "tree_count", "MinValue": "1", "ScalingType": "Auto"}
+                    {
+                        "MaxValue": "10",
+                        "Name": "tree_count",
+                        "MinValue": "1",
+                        "ScalingType": "Auto",
+                    }
                 ],
             },
             "RoleArn": ROLE,
@@ -281,7 +302,11 @@ TRAINING_JOB_DESCRIPTION = {
         "_tuning_objective_metric": "Validation-accuracy",
     },
     "RoleArn": ROLE,
-    "ResourceConfig": {"VolumeSizeInGB": 30, "InstanceCount": 1, "InstanceType": "ml.c4.xlarge"},
+    "ResourceConfig": {
+        "VolumeSizeInGB": 30,
+        "InstanceCount": 1,
+        "InstanceType": "ml.c4.xlarge",
+    },
     "StoppingCondition": {"MaxRuntimeInSeconds": 24 * 60 * 60},
     "TrainingJobName": TRAINING_JOB_NAME,
     "TrainingJobStatus": "Completed",
@@ -293,4 +318,6 @@ TRAINING_JOB_DESCRIPTION = {
 
 ENDPOINT_DESC = {"EndpointConfigName": "test-endpoint"}
 
-ENDPOINT_CONFIG_DESC = {"ProductionVariants": [{"ModelName": "model-1"}, {"ModelName": "model-2"}]}
+ENDPOINT_CONFIG_DESC = {
+    "ProductionVariants": [{"ModelName": "model-1"}, {"ModelName": "model-2"}]
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
While running black check for https://github.com/aws/sagemaker-python-sdk/pull/1581
I locally ran
```
black .
```
To find so many files not compliant. Not sure why the black-check only caught the 2 files that PR changed but not the issue with 200+ files

*Testing done:*
Locally tested

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
