### PR TITLE
fix: remove redundant information from the user_agent string.

### DIFF
--- a/src/sagemaker/user_agent.py
+++ b/src/sagemaker/user_agent.py
@@ -29,7 +29,7 @@ PYTHON_VERSION = "Python/{}.{}.{}".format(
 )
 
 
-def determine_prefix(user_agent):
+def determine_prefix(user_agent=""):
     """Placeholder docstring"""
     prefix = "AWS-SageMaker-Python-SDK/{}".format(SDK_VERSION)
 
@@ -56,7 +56,7 @@ def prepend_user_agent(client):
     Args:
         client:
     """
-    prefix = determine_prefix(client._client_config.user_agent or "")
+    prefix = determine_prefix(client._client_config.user_agent)
 
     if client._client_config.user_agent is None:
         client._client_config.user_agent = prefix

--- a/src/sagemaker/user_agent.py
+++ b/src/sagemaker/user_agent.py
@@ -16,8 +16,6 @@ from __future__ import absolute_import
 import platform
 import sys
 
-import boto3
-import botocore
 import importlib_metadata
 
 SDK_VERSION = importlib_metadata.version("sagemaker")

--- a/tests/unit/test_create_deploy_entities.py
+++ b/tests/unit/test_create_deploy_entities.py
@@ -13,7 +13,7 @@
 from __future__ import absolute_import
 
 import pytest
-from mock import Mock
+from mock import MagicMock, Mock
 
 import sagemaker
 
@@ -33,7 +33,7 @@ REGION = "us-west-2"
 
 @pytest.fixture()
 def sagemaker_session():
-    boto_mock = Mock(name="boto_session", region_name=REGION)
+    boto_mock = MagicMock(name="boto_session", region_name=REGION)
     ims = sagemaker.Session(boto_session=boto_mock)
     ims.expand_role = Mock(return_value=EXPANDED_ROLE)
     return ims

--- a/tests/unit/test_default_bucket.py
+++ b/tests/unit/test_default_bucket.py
@@ -14,7 +14,7 @@ from __future__ import absolute_import
 
 import pytest
 from botocore.exceptions import ClientError
-from mock import Mock
+from mock import MagicMock
 import sagemaker
 
 ACCOUNT_ID = "123"
@@ -24,7 +24,7 @@ DEFAULT_BUCKET_NAME = "sagemaker-{}-{}".format(REGION, ACCOUNT_ID)
 
 @pytest.fixture()
 def sagemaker_session():
-    boto_mock = Mock(name="boto_session", region_name=REGION)
+    boto_mock = MagicMock(name="boto_session", region_name=REGION)
     boto_mock.client("sts").get_caller_identity.return_value = {"Account": ACCOUNT_ID}
     sagemaker_session = sagemaker.Session(boto_session=boto_mock)
     sagemaker_session.boto_session.resource("s3").Bucket().creation_date = None

--- a/tests/unit/test_endpoint_from_job.py
+++ b/tests/unit/test_endpoint_from_job.py
@@ -13,7 +13,7 @@
 from __future__ import absolute_import
 
 import pytest
-from mock import Mock
+from mock import MagicMock, Mock
 
 import sagemaker
 
@@ -42,8 +42,8 @@ REGION = "us-west-2"
 
 @pytest.fixture()
 def sagemaker_session():
-    boto_mock = Mock(name="boto_session", region_name=REGION)
-    ims = sagemaker.Session(sagemaker_client=Mock(name="sagemaker_client"), boto_session=boto_mock)
+    boto_mock = MagicMock(name="boto_session", region_name=REGION)
+    ims = sagemaker.Session(sagemaker_client=MagicMock(name="sagemaker_client"), boto_session=boto_mock)
     ims.sagemaker_client.describe_training_job = Mock(
         name="describe_training_job", return_value=TRAINING_JOB_RESPONSE
     )

--- a/tests/unit/test_endpoint_from_job.py
+++ b/tests/unit/test_endpoint_from_job.py
@@ -43,7 +43,9 @@ REGION = "us-west-2"
 @pytest.fixture()
 def sagemaker_session():
     boto_mock = MagicMock(name="boto_session", region_name=REGION)
-    ims = sagemaker.Session(sagemaker_client=MagicMock(name="sagemaker_client"), boto_session=boto_mock)
+    ims = sagemaker.Session(
+        sagemaker_client=MagicMock(name="sagemaker_client"), boto_session=boto_mock
+    )
     ims.sagemaker_client.describe_training_job = Mock(
         name="describe_training_job", return_value=TRAINING_JOB_RESPONSE
     )

--- a/tests/unit/test_endpoint_from_model_data.py
+++ b/tests/unit/test_endpoint_from_model_data.py
@@ -14,7 +14,7 @@ from __future__ import absolute_import
 
 import pytest
 from botocore.exceptions import ClientError
-from mock import Mock
+from mock import MagicMock, Mock
 from mock import patch
 
 import sagemaker
@@ -35,8 +35,8 @@ REGION = "us-west-2"
 
 @pytest.fixture()
 def sagemaker_session():
-    boto_mock = Mock(name="boto_session", region_name=REGION)
-    ims = sagemaker.Session(sagemaker_client=Mock(name="sagemaker_client"), boto_session=boto_mock)
+    boto_mock = MagicMock(name="boto_session", region_name=REGION)
+    ims = sagemaker.Session(sagemaker_client=MagicMock(name="sagemaker_client"), boto_session=boto_mock)
     ims.sagemaker_client.describe_model = Mock(
         name="describe_model", side_effect=_raise_does_not_exist_client_error
     )

--- a/tests/unit/test_endpoint_from_model_data.py
+++ b/tests/unit/test_endpoint_from_model_data.py
@@ -36,7 +36,9 @@ REGION = "us-west-2"
 @pytest.fixture()
 def sagemaker_session():
     boto_mock = MagicMock(name="boto_session", region_name=REGION)
-    ims = sagemaker.Session(sagemaker_client=MagicMock(name="sagemaker_client"), boto_session=boto_mock)
+    ims = sagemaker.Session(
+        sagemaker_client=MagicMock(name="sagemaker_client"), boto_session=boto_mock
+    )
     ims.sagemaker_client.describe_model = Mock(
         name="describe_model", side_effect=_raise_does_not_exist_client_error
     )

--- a/tests/unit/test_exception_on_bad_status.py
+++ b/tests/unit/test_exception_on_bad_status.py
@@ -24,8 +24,8 @@ ENDPOINT_NAME = "the_point_of_end"
 
 
 def get_sagemaker_session(returns_status):
-    boto_mock = Mock(name="boto_session", region_name=REGION)
-    client_mock = Mock()
+    boto_mock = MagicMock(name="boto_session", region_name=REGION)
+    client_mock = MagicMock()
     client_mock.describe_model_package = MagicMock(
         return_value={"ModelPackageStatus": returns_status}
     )

--- a/tests/unit/test_image.py
+++ b/tests/unit/test_image.py
@@ -76,11 +76,11 @@ LOCAL_CODE_HYPERPARAMETERS = {
 
 @pytest.fixture()
 def sagemaker_session():
-    boto_mock = Mock(name="boto_session", region_name=REGION)
+    boto_mock = MagicMock(name="boto_session", region_name=REGION)
     boto_mock.client("sts").get_caller_identity.return_value = {"Account": "123"}
     boto_mock.resource("s3").Bucket(BUCKET_NAME).objects.filter.return_value = []
 
-    sms = sagemaker.Session(boto_session=boto_mock, sagemaker_client=Mock())
+    sms = sagemaker.Session(boto_session=boto_mock, sagemaker_client=MagicMock())
 
     sms.default_bucket = Mock(name="default_bucket", return_value=BUCKET_NAME)
     sms.expand_role = Mock(return_value=EXPANDED_ROLE)

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -652,11 +652,11 @@ IN_PROGRESS_DESCRIBE_TRANSFORM_JOB_RESULT.update({"TransformJobStatus": "InProgr
 
 @pytest.fixture()
 def sagemaker_session():
-    boto_mock = Mock(name="boto_session")
+    boto_mock = MagicMock(name="boto_session")
     boto_mock.client("sts", endpoint_url=STS_ENDPOINT).get_caller_identity.return_value = {
         "Account": "123"
     }
-    ims = sagemaker.Session(boto_session=boto_mock, sagemaker_client=Mock())
+    ims = sagemaker.Session(boto_session=boto_mock, sagemaker_client=MagicMock())
     ims.expand_role = Mock(return_value=EXPANDED_ROLE)
     return ims
 
@@ -1352,10 +1352,10 @@ STREAM_LOG_EVENTS = [
 
 @pytest.fixture()
 def sagemaker_session_complete():
-    boto_mock = Mock(name="boto_session")
+    boto_mock = MagicMock(name="boto_session")
     boto_mock.client("logs").describe_log_streams.return_value = DEFAULT_LOG_STREAMS
     boto_mock.client("logs").get_log_events.side_effect = DEFAULT_LOG_EVENTS
-    ims = sagemaker.Session(boto_session=boto_mock, sagemaker_client=Mock())
+    ims = sagemaker.Session(boto_session=boto_mock, sagemaker_client=MagicMock())
     ims.sagemaker_client.describe_training_job.return_value = COMPLETED_DESCRIBE_JOB_RESULT
     ims.sagemaker_client.describe_transform_job.return_value = (
         COMPLETED_DESCRIBE_TRANSFORM_JOB_RESULT
@@ -1365,10 +1365,10 @@ def sagemaker_session_complete():
 
 @pytest.fixture()
 def sagemaker_session_stopped():
-    boto_mock = Mock(name="boto_session")
+    boto_mock = MagicMock(name="boto_session")
     boto_mock.client("logs").describe_log_streams.return_value = DEFAULT_LOG_STREAMS
     boto_mock.client("logs").get_log_events.side_effect = DEFAULT_LOG_EVENTS
-    ims = sagemaker.Session(boto_session=boto_mock, sagemaker_client=Mock())
+    ims = sagemaker.Session(boto_session=boto_mock, sagemaker_client=MagicMock())
     ims.sagemaker_client.describe_training_job.return_value = STOPPED_DESCRIBE_JOB_RESULT
     ims.sagemaker_client.describe_transform_job.return_value = STOPPED_DESCRIBE_TRANSFORM_JOB_RESULT
     return ims
@@ -1376,10 +1376,10 @@ def sagemaker_session_stopped():
 
 @pytest.fixture()
 def sagemaker_session_ready_lifecycle():
-    boto_mock = Mock(name="boto_session")
+    boto_mock = MagicMock(name="boto_session")
     boto_mock.client("logs").describe_log_streams.return_value = DEFAULT_LOG_STREAMS
     boto_mock.client("logs").get_log_events.side_effect = STREAM_LOG_EVENTS
-    ims = sagemaker.Session(boto_session=boto_mock, sagemaker_client=Mock())
+    ims = sagemaker.Session(boto_session=boto_mock, sagemaker_client=MagicMock())
     ims.sagemaker_client.describe_training_job.side_effect = [
         IN_PROGRESS_DESCRIBE_JOB_RESULT,
         IN_PROGRESS_DESCRIBE_JOB_RESULT,
@@ -1395,10 +1395,10 @@ def sagemaker_session_ready_lifecycle():
 
 @pytest.fixture()
 def sagemaker_session_full_lifecycle():
-    boto_mock = Mock(name="boto_session")
+    boto_mock = MagicMock(name="boto_session")
     boto_mock.client("logs").describe_log_streams.side_effect = LIFECYCLE_LOG_STREAMS
     boto_mock.client("logs").get_log_events.side_effect = STREAM_LOG_EVENTS
-    ims = sagemaker.Session(boto_session=boto_mock, sagemaker_client=Mock())
+    ims = sagemaker.Session(boto_session=boto_mock, sagemaker_client=MagicMock())
     ims.sagemaker_client.describe_training_job.side_effect = [
         IN_PROGRESS_DESCRIBE_JOB_RESULT,
         IN_PROGRESS_DESCRIBE_JOB_RESULT,

--- a/tests/unit/test_upload_data.py
+++ b/tests/unit/test_upload_data.py
@@ -14,7 +14,7 @@ from __future__ import absolute_import
 
 import os
 
-from mock import Mock
+from mock import MagicMock, Mock
 import pytest
 
 import sagemaker
@@ -30,7 +30,7 @@ ENDPOINT_URL = "http://127.0.0.1:9000"
 
 @pytest.fixture()
 def sagemaker_session():
-    boto_mock = Mock(name="boto_session")
+    boto_mock = MagicMock(name="boto_session")
     ims = sagemaker.Session(boto_session=boto_mock)
     ims.default_bucket = Mock(name="default_bucket", return_value=BUCKET_NAME)
     return ims
@@ -39,9 +39,9 @@ def sagemaker_session():
 @pytest.fixture()
 def sagemaker_session_custom_endpoint():
 
-    boto_session = Mock("boto_session")
+    boto_session = MagicMock("boto_session")
     resource_mock = Mock("resource")
-    client_mock = Mock("client")
+    client_mock = MagicMock("client")
     boto_attrs = {"region_name": "us-east-1"}
     boto_session.configure_mock(**boto_attrs)
     boto_session.resource = Mock(name="resource", return_value=resource_mock)

--- a/tests/unit/test_upload_string_as_file_body.py
+++ b/tests/unit/test_upload_string_as_file_body.py
@@ -14,7 +14,7 @@ from __future__ import absolute_import
 
 import os
 
-from mock import Mock
+from mock import MagicMock, Mock
 import pytest
 
 import sagemaker
@@ -29,8 +29,8 @@ AES_ENCRYPTION_ENABLED = {"ServerSideEncryption": "AES256"}
 
 @pytest.fixture()
 def sagemaker_session():
-    boto_mock = Mock(name="boto_session")
-    client_mock = Mock()
+    boto_mock = MagicMock(name="boto_session")
+    client_mock = MagicMock()
     client_mock.get_caller_identity.return_value = {
         "UserId": "mock_user_id",
         "Account": "012345678910",

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -309,8 +309,8 @@ def test_generate_tensorboard_url_domain_non_string():
 
 @patch("os.makedirs")
 def test_download_folder(makedirs):
-    boto_mock = Mock(name="boto_session")
-    session = sagemaker.Session(boto_session=boto_mock, sagemaker_client=Mock())
+    boto_mock = MagicMock(name="boto_session")
+    session = sagemaker.Session(boto_session=boto_mock, sagemaker_client=MagicMock())
     s3_mock = boto_mock.resource("s3")
 
     obj_mock = Mock()
@@ -363,10 +363,10 @@ def test_download_folder(makedirs):
 
 @patch("os.makedirs")
 def test_download_folder_points_to_single_file(makedirs):
-    boto_mock = Mock(name="boto_session")
+    boto_mock = MagicMock(name="boto_session")
     boto_mock.client("sts").get_caller_identity.return_value = {"Account": "123"}
 
-    session = sagemaker.Session(boto_session=boto_mock, sagemaker_client=Mock())
+    session = sagemaker.Session(boto_session=boto_mock, sagemaker_client=MagicMock())
 
     train_data = Mock()
 
@@ -390,11 +390,11 @@ def test_download_folder_points_to_single_file(makedirs):
 
 
 def test_download_file():
-    boto_mock = Mock(name="boto_session")
+    boto_mock = MagicMock(name="boto_session")
     boto_mock.client("sts").get_caller_identity.return_value = {"Account": "123"}
     bucket_mock = Mock()
     boto_mock.resource("s3").Bucket.return_value = bucket_mock
-    session = sagemaker.Session(boto_session=boto_mock, sagemaker_client=Mock())
+    session = sagemaker.Session(boto_session=boto_mock, sagemaker_client=MagicMock())
 
     sagemaker.utils.download_file(
         BUCKET_NAME, "/prefix/path/file.tar.gz", "/tmp/file.tar.gz", session


### PR DESCRIPTION
Remove redundant information from the user_agent string.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
