### PR TITLE
infra: use unique model name in TFS integ tests

### DIFF
--- a/tests/integ/test_tfs.py
+++ b/tests/integ/test_tfs.py
@@ -39,6 +39,7 @@ def tfs_predictor(sagemaker_session, tf_full_version):
             role="SageMakerRole",
             framework_version=tf_full_version,
             sagemaker_session=sagemaker_session,
+            name=endpoint_name,
         )
         predictor = model.deploy(1, "ml.c5.xlarge", endpoint_name=endpoint_name)
         yield predictor
@@ -67,6 +68,7 @@ def tfs_predictor_with_model_and_entry_point_same_tar(
         role="SageMakerRole",
         framework_version=tf_full_version,
         sagemaker_session=sagemaker_local_session,
+        name=endpoint_name,
     )
     predictor = model.deploy(1, "local", endpoint_name=endpoint_name)
 
@@ -100,6 +102,7 @@ def tfs_predictor_with_model_and_entry_point_and_dependencies(
         dependencies=dependencies,
         framework_version=tf_full_version,
         sagemaker_session=sagemaker_local_session,
+        name=endpoint_name,
     )
 
     predictor = model.deploy(1, "local", endpoint_name=endpoint_name)
@@ -123,6 +126,7 @@ def tfs_predictor_with_accelerator(sagemaker_session, ei_tf_full_version, cpu_in
             role="SageMakerRole",
             framework_version=ei_tf_full_version,
             sagemaker_session=sagemaker_session,
+            name=endpoint_name,
         )
         predictor = model.deploy(
             1, cpu_instance_type, endpoint_name=endpoint_name, accelerator_type="ml.eia1.medium"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We're getting some collisions with our continuous testing when log groups are cleaned up

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
