### PR TITLE
change: Add allow_pickle parameter to NumpyDeserializer

### DIFF
--- a/src/sagemaker/deserializers.py
+++ b/src/sagemaker/deserializers.py
@@ -163,13 +163,15 @@ class NumpyDeserializer(BaseDeserializer):
 
     ACCEPT = "application/x-npy"
 
-    def __init__(self, dtype=None):
-        """Initialize the dtype.
+    def __init__(self, dtype=None, allow_pickle=True):
+        """Initialize the dtype and allow_pickle arguments.
 
         Args:
-            dtype (str): The dtype of the data.
+            dtype (str): The dtype of the data (default: None).
+            allow_pickle (bool): Allow loading pickled object arrays (default: True).
         """
         self.dtype = dtype
+        self.allow_pickle = allow_pickle
 
     def deserialize(self, stream, content_type):
         """Deserialize data from an inference endpoint into a NumPy array.
@@ -189,7 +191,7 @@ class NumpyDeserializer(BaseDeserializer):
             if content_type == "application/json":
                 return np.array(json.load(codecs.getreader("utf-8")(stream)), dtype=self.dtype)
             if content_type == "application/x-npy":
-                return np.load(io.BytesIO(stream.read()))
+                return np.load(io.BytesIO(stream.read()), allow_pickle=self.allow_pickle)
         finally:
             stream.close()
 

--- a/tests/unit/sagemaker/test_deserializers.py
+++ b/tests/unit/sagemaker/test_deserializers.py
@@ -141,7 +141,7 @@ def test_numpy_deserializer_from_npy(numpy_deserializer):
 
 
 def test_numpy_deserializer_from_npy_object_array(numpy_deserializer):
-    array = np.array(["one", "two"])
+    array = np.array([{"a": "", "b": ""}, {"c": "", "d": ""}])
     stream = io.BytesIO()
     np.save(stream, array)
     stream.seek(0)

--- a/tests/unit/sagemaker/test_deserializers.py
+++ b/tests/unit/sagemaker/test_deserializers.py
@@ -151,6 +151,18 @@ def test_numpy_deserializer_from_npy_object_array(numpy_deserializer):
     assert np.array_equal(array, result)
 
 
+def test_numpy_deserializer_from_npy_object_array_with_allow_pickle_false():
+    numpy_deserializer = NumpyDeserializer(allow_pickle=False)
+
+    array = np.array([{"a": "", "b": ""}, {"c": "", "d": ""}])
+    stream = io.BytesIO()
+    np.save(stream, array)
+    stream.seek(0)
+
+    with pytest.raises(ValueError):
+        numpy_deserializer.deserialize(stream, "application/x-npy")
+
+
 @pytest.fixture
 def json_deserializer():
     return JSONDeserializer()


### PR DESCRIPTION
*Issue #, if available:* #1753 

*Description of changes:*
* Added `allow_pickle` parameter to `NumpyDeserializer` with default argument `True`

*Testing done:*
* Updated one test to more accurately test deserializer picked objects
* Adding a new test.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
