### PR TITLE
doc: document name changes for TFS classes

### DIFF
--- a/doc/v2.rst
+++ b/doc/v2.rst
@@ -187,14 +187,33 @@ Specify Custom Serving Image
 
 The ``image`` parameter has been renamed to ``image_uri`` for specifying a custom Docker image URI to use with inference.
 
+TensorFlow Serving Model
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+``sagemaker.tensorflow.serving.Model`` has been renamed to :class:`sagemaker.tensorflow.model.TensorFlowModel`.
+(For the previous implementation of that class, see `Deprecate Legacy TensorFlow <#deprecate-legacy-tensorflow>`_).
+
 Predictors
 ----------
 
+Generic Predictor Class Name
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 ``sagemaker.predictor.RealTimePredictor`` has been renamed to :class:`sagemaker.predictor.Predictor`.
 
-In addition, for :class:`sagemaker.predictor.Predictor`, :class:`sagemaker.sparkml.model.SparkMLPredictor`,
+Endpoint Argument Name
+~~~~~~~~~~~~~~~~~~~~~~
+
+For :class:`sagemaker.predictor.Predictor`, :class:`sagemaker.sparkml.model.SparkMLPredictor`,
 and predictors for Amazon algorithm (e.g. Factorization Machines, Linear Learner, etc.),
 the ``endpoint`` attribute has been renamed to ``endpoint_name``.
+
+TensorFlow Serving Predictor
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``sagemaker.tensorflow.serving.Predictor`` has been renamed to :class:`sagemaker.tensorflow.model.TensorFlowPredictor`.
+(For the previous implementation of that class, see `Deprecate Legacy TensorFlow <#deprecate-legacy-tensorflow>`_).
+
 
 Airflow
 -------


### PR DESCRIPTION
*Issue #, if available:*
#1749, #1462 

*Description of changes:*
I forgot to document the TFS changes in #1462. 

*Testing done:*
* `tox -e sphinx,doc8 --parallel all`
* built the docs locally to check formatting and links

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
