### PR TITLE
fix: Fix scipy.sparse imports

### DIFF
--- a/src/sagemaker/serializers.py
+++ b/src/sagemaker/serializers.py
@@ -23,9 +23,9 @@ import numpy as np
 from sagemaker.utils import DeferredError
 
 try:
-    import scipy
+    import scipy.sparse
 except ImportError as e:
-    scipy = DeferredError(e)
+    scipy.sparse = DeferredError(e)
 
 
 class BaseSerializer(abc.ABC):

--- a/src/sagemaker/serializers.py
+++ b/src/sagemaker/serializers.py
@@ -25,7 +25,7 @@ from sagemaker.utils import DeferredError
 try:
     import scipy.sparse
 except ImportError as e:
-    scipy.sparse = DeferredError(e)
+    scipy = DeferredError(e)
 
 
 class BaseSerializer(abc.ABC):

--- a/tests/unit/sagemaker/test_serializers.py
+++ b/tests/unit/sagemaker/test_serializers.py
@@ -18,7 +18,7 @@ import os
 
 import numpy as np
 import pytest
-import scipy
+import scipy.sparse
 
 from sagemaker.serializers import (
     CSVSerializer,


### PR DESCRIPTION
*Issue #, if available:*

Depending on the version of scipy installed, you might not be able to do `import scipy` and then access the attribute `scipy.sparse`. Instead, you should either do `from scipy import sparse` or directly `import scipy.sparse`.

*Description of changes:*
* Updated import statement in `serializers.py`

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
