### PR TITLE
change: Improve code style of SerDe compatibility

### DIFF
--- a/src/sagemaker/cli/compatibility/v2/modifiers/serde.py
+++ b/src/sagemaker/cli/compatibility/v2/modifiers/serde.py
@@ -274,7 +274,7 @@ class SerdeImportFromAmazonCommonRenamer(Modifier):
                 the ``sagemaker.amazon.common`` module.
         """
         return node.module == "sagemaker.amazon.common" and any(
-            [alias.name in OLD_AMAZON_CLASS_NAMES for alias in node.names]
+            alias.name in OLD_AMAZON_CLASS_NAMES for alias in node.names
         )
 
     def modify_node(self, node):
@@ -368,7 +368,11 @@ class SerializerImportInserter(_ImportInserter):
     """
 
     def __init__(self):
-        # Amazon SerDe are not defined in the sagemaker.serializers module.
+        """Initialize the ``class_names`` and ``import_node`` attributes.
+
+        Amazon-specific serializers are ignored because they are not defined in
+        the ``sagemaker.serializers`` module.
+        """
         class_names = {
             class_name
             for class_name in NEW_CLASS_NAMES - NEW_AMAZON_CLASS_NAMES
@@ -398,7 +402,11 @@ class DeserializerImportInserter(_ImportInserter):
     """
 
     def __init__(self):
-        # Amazon SerDe are not defined in the sagemaker.serializers module.
+        """Initialize the ``class_names`` and ``import_node`` attributes.
+
+        Amazon-specific deserializers are ignored because they are not defined
+        in the ``sagemaker.deserializers`` module.
+        """
         class_names = {
             class_name
             for class_name in NEW_CLASS_NAMES - NEW_AMAZON_CLASS_NAMES


### PR DESCRIPTION
*Issue #, if available:*

This is a follow-up to #1735.

*Description of changes:*
Fixed a couple docstrings and a generator expresion.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
