### PR TITLE
change: rename __framework_name__ as _framework_name

### DIFF
--- a/src/sagemaker/chainer/estimator.py
+++ b/src/sagemaker/chainer/estimator.py
@@ -32,7 +32,7 @@ logger = logging.getLogger("sagemaker")
 class Chainer(Framework):
     """Handle end-to-end training and deployment of custom Chainer code."""
 
-    __framework_name__ = "chainer"
+    _framework_name = "chainer"
 
     # Hyperparameters
     _use_mpi = "sagemaker_use_mpi"
@@ -131,7 +131,7 @@ class Chainer(Framework):
         validate_version_or_image_args(framework_version, py_version, image_uri)
         if py_version == "py2":
             logger.warning(
-                python_deprecation_warning(self.__framework_name__, defaults.LATEST_PY2_VERSION)
+                python_deprecation_warning(self._framework_name, defaults.LATEST_PY2_VERSION)
             )
         self.framework_version = framework_version
         self.py_version = py_version
@@ -272,7 +272,7 @@ class Chainer(Framework):
             init_params["image_uri"] = image_uri
             return init_params
 
-        if framework != cls.__framework_name__:
+        if framework != cls._framework_name:
             raise ValueError(
                 "Training job: {} didn't use image for requested framework".format(
                     job_details["TrainingJobName"]

--- a/src/sagemaker/chainer/model.py
+++ b/src/sagemaker/chainer/model.py
@@ -59,7 +59,7 @@ class ChainerModel(FrameworkModel):
     ``Endpoint``.
     """
 
-    __framework_name__ = "chainer"
+    _framework_name = "chainer"
 
     def __init__(
         self,
@@ -116,7 +116,7 @@ class ChainerModel(FrameworkModel):
         validate_version_or_image_args(framework_version, py_version, image_uri)
         if py_version == "py2":
             logger.warning(
-                python_deprecation_warning(self.__framework_name__, defaults.LATEST_PY2_VERSION)
+                python_deprecation_warning(self._framework_name, defaults.LATEST_PY2_VERSION)
             )
         self.framework_version = framework_version
         self.py_version = py_version
@@ -176,7 +176,7 @@ class ChainerModel(FrameworkModel):
 
         """
         return image_uris.retrieve(
-            self.__framework_name__,
+            self._framework_name,
             region_name,
             version=self.framework_version,
             py_version=self.py_version,

--- a/src/sagemaker/estimator.py
+++ b/src/sagemaker/estimator.py
@@ -1418,7 +1418,7 @@ class Framework(EstimatorBase):
     such as training/deployment images and predictor instances.
     """
 
-    __framework_name__ = None
+    _framework_name = None
 
     LAUNCH_PS_ENV_NAME = "sagemaker_parameter_server_enabled"
     LAUNCH_MPI_ENV_NAME = "sagemaker_mpi_enabled"
@@ -1816,7 +1816,7 @@ class Framework(EstimatorBase):
         if self.image_uri:
             return self.image_uri
         return image_uris.retrieve(
-            self.__framework_name__,
+            self._framework_name,
             self.sagemaker_session.boto_region_name,
             instance_type=self.instance_type,
             version=self.framework_version,  # pylint: disable=no-member

--- a/src/sagemaker/model.py
+++ b/src/sagemaker/model.py
@@ -184,7 +184,7 @@ class Model(object):
 
     def _framework(self):
         """Placeholder docstring"""
-        return getattr(self, "__framework_name__", None)
+        return getattr(self, "_framework_name", None)
 
     def _get_framework_version(self):
         """Placeholder docstring"""

--- a/src/sagemaker/mxnet/estimator.py
+++ b/src/sagemaker/mxnet/estimator.py
@@ -34,7 +34,7 @@ logger = logging.getLogger("sagemaker")
 class MXNet(Framework):
     """Handle end-to-end training and deployment of custom MXNet code."""
 
-    __framework_name__ = "mxnet"
+    _framework_name = "mxnet"
     _LOWEST_SCRIPT_MODE_VERSION = ["1", "3"]
 
     def __init__(
@@ -114,7 +114,7 @@ class MXNet(Framework):
         validate_version_or_image_args(framework_version, py_version, image_uri)
         if py_version == "py2":
             logger.warning(
-                python_deprecation_warning(self.__framework_name__, defaults.LATEST_PY2_VERSION)
+                python_deprecation_warning(self._framework_name, defaults.LATEST_PY2_VERSION)
             )
         self.framework_version = framework_version
         self.py_version = py_version
@@ -280,7 +280,7 @@ class MXNet(Framework):
             init_params["image_uri"] = image_uri
             return init_params
 
-        if framework != cls.__framework_name__:
+        if framework != cls._framework_name:
             raise ValueError(
                 "Training job: {} didn't use image for requested framework".format(
                     job_details["TrainingJobName"]

--- a/src/sagemaker/mxnet/model.py
+++ b/src/sagemaker/mxnet/model.py
@@ -59,7 +59,7 @@ class MXNetPredictor(Predictor):
 class MXNetModel(FrameworkModel):
     """An MXNet SageMaker ``Model`` that can be deployed to a SageMaker ``Endpoint``."""
 
-    __framework_name__ = "mxnet"
+    _framework_name = "mxnet"
     _LOWEST_MMS_VERSION = "1.4.0"
 
     def __init__(
@@ -119,7 +119,7 @@ class MXNetModel(FrameworkModel):
         validate_version_or_image_args(framework_version, py_version, image_uri)
         if py_version == "py2":
             logger.warning(
-                python_deprecation_warning(self.__framework_name__, defaults.LATEST_PY2_VERSION)
+                python_deprecation_warning(self._framework_name, defaults.LATEST_PY2_VERSION)
             )
         self.framework_version = framework_version
         self.py_version = py_version
@@ -184,7 +184,7 @@ class MXNetModel(FrameworkModel):
 
         """
         return image_uris.retrieve(
-            self.__framework_name__,
+            self._framework_name,
             region_name,
             version=self.framework_version,
             py_version=self.py_version,

--- a/src/sagemaker/pytorch/estimator.py
+++ b/src/sagemaker/pytorch/estimator.py
@@ -33,7 +33,7 @@ logger = logging.getLogger("sagemaker")
 class PyTorch(Framework):
     """Handle end-to-end training and deployment of custom PyTorch code."""
 
-    __framework_name__ = "pytorch"
+    _framework_name = "pytorch"
 
     def __init__(
         self,
@@ -109,7 +109,7 @@ class PyTorch(Framework):
         validate_version_or_image_args(framework_version, py_version, image_uri)
         if py_version == "py2":
             logger.warning(
-                python_deprecation_warning(self.__framework_name__, defaults.LATEST_PY2_VERSION)
+                python_deprecation_warning(self._framework_name, defaults.LATEST_PY2_VERSION)
             )
         self.framework_version = framework_version
         self.py_version = py_version
@@ -221,7 +221,7 @@ class PyTorch(Framework):
             init_params["image_uri"] = image_uri
             return init_params
 
-        if framework != cls.__framework_name__:
+        if framework != cls._framework_name:
             raise ValueError(
                 "Training job: {} didn't use image for requested framework".format(
                     job_details["TrainingJobName"]

--- a/src/sagemaker/pytorch/model.py
+++ b/src/sagemaker/pytorch/model.py
@@ -60,7 +60,7 @@ class PyTorchModel(FrameworkModel):
     ``Endpoint``.
     """
 
-    __framework_name__ = "pytorch"
+    _framework_name = "pytorch"
     _LOWEST_MMS_VERSION = "1.2"
 
     def __init__(
@@ -118,7 +118,7 @@ class PyTorchModel(FrameworkModel):
         validate_version_or_image_args(framework_version, py_version, image_uri)
         if py_version == "py2":
             logger.warning(
-                python_deprecation_warning(self.__framework_name__, defaults.LATEST_PY2_VERSION)
+                python_deprecation_warning(self._framework_name, defaults.LATEST_PY2_VERSION)
             )
         self.framework_version = framework_version
         self.py_version = py_version
@@ -183,7 +183,7 @@ class PyTorchModel(FrameworkModel):
 
         """
         return image_uris.retrieve(
-            self.__framework_name__,
+            self._framework_name,
             region_name,
             version=self.framework_version,
             py_version=self.py_version,

--- a/src/sagemaker/sklearn/estimator.py
+++ b/src/sagemaker/sklearn/estimator.py
@@ -32,7 +32,7 @@ logger = logging.getLogger("sagemaker")
 class SKLearn(Framework):
     """Handle end-to-end training and deployment of custom Scikit-learn code."""
 
-    __framework_name__ = defaults.SKLEARN_NAME
+    _framework_name = defaults.SKLEARN_NAME
 
     def __init__(
         self,
@@ -138,7 +138,7 @@ class SKLearn(Framework):
 
         if image_uri is None:
             self.image_uri = image_uris.retrieve(
-                SKLearn.__framework_name__,
+                SKLearn._framework_name,
                 self.sagemaker_session.boto_region_name,
                 version=self.framework_version,
                 py_version=self.py_version,

--- a/src/sagemaker/sklearn/model.py
+++ b/src/sagemaker/sklearn/model.py
@@ -55,7 +55,7 @@ class SKLearnModel(FrameworkModel):
     ``Endpoint``.
     """
 
-    __framework_name__ = defaults.SKLEARN_NAME
+    _framework_name = defaults.SKLEARN_NAME
 
     def __init__(
         self,
@@ -175,7 +175,7 @@ class SKLearnModel(FrameworkModel):
 
         """
         return image_uris.retrieve(
-            self.__framework_name__,
+            self._framework_name,
             region_name,
             version=self.framework_version,
             py_version=self.py_version,

--- a/src/sagemaker/tensorflow/estimator.py
+++ b/src/sagemaker/tensorflow/estimator.py
@@ -33,7 +33,7 @@ logger = logging.getLogger("sagemaker")
 class TensorFlow(Framework):
     """Handle end-to-end training and deployment of user-provided TensorFlow code."""
 
-    __framework_name__ = "tensorflow"
+    _framework_name = "tensorflow"
 
     _HIGHEST_LEGACY_MODE_ONLY_VERSION = version.Version("1.10.0")
     _HIGHEST_PYTHON_2_VERSION = version.Version("2.1.0")
@@ -116,7 +116,7 @@ class TensorFlow(Framework):
         fw.validate_version_or_image_args(framework_version, py_version, image_uri)
         if py_version == "py2":
             logger.warning(
-                fw.python_deprecation_warning(self.__framework_name__, defaults.LATEST_PY2_VERSION)
+                fw.python_deprecation_warning(self._framework_name, defaults.LATEST_PY2_VERSION)
             )
         self.framework_version = framework_version
         self.py_version = py_version
@@ -221,7 +221,7 @@ class TensorFlow(Framework):
         if not script_mode:
             init_params["image_uri"] = image_uri
 
-        if framework != cls.__framework_name__:
+        if framework != cls._framework_name:
             raise ValueError(
                 "Training job: {} didn't use image for requested framework".format(
                     job_details["TrainingJobName"]

--- a/src/sagemaker/tensorflow/model.py
+++ b/src/sagemaker/tensorflow/model.py
@@ -121,7 +121,7 @@ class TensorFlowPredictor(Predictor):
 class TensorFlowModel(sagemaker.model.FrameworkModel):
     """A ``FrameworkModel`` implementation for inference with TensorFlow Serving."""
 
-    __framework_name__ = "tensorflow"
+    _framework_name = "tensorflow"
     LOG_LEVEL_PARAM_NAME = "SAGEMAKER_TFS_NGINX_LOGLEVEL"
     LOG_LEVEL_MAP = {
         logging.DEBUG: "debug",
@@ -286,7 +286,7 @@ class TensorFlowModel(sagemaker.model.FrameworkModel):
             return self.image_uri
 
         return image_uris.retrieve(
-            self.__framework_name__,
+            self._framework_name,
             self.sagemaker_session.boto_region_name,
             version=self.framework_version,
             instance_type=instance_type,

--- a/src/sagemaker/xgboost/estimator.py
+++ b/src/sagemaker/xgboost/estimator.py
@@ -34,7 +34,7 @@ class XGBoost(Framework):
     """Handle end-to-end training and deployment of XGBoost booster training or training using
     customer provided XGBoost entry point script."""
 
-    __framework_name__ = defaults.XGBOOST_NAME
+    _framework_name = defaults.XGBOOST_NAME
 
     def __init__(
         self,
@@ -103,7 +103,7 @@ class XGBoost(Framework):
 
         if image_uri is None:
             self.image_uri = image_uris.retrieve(
-                self.__framework_name__,
+                self._framework_name,
                 self.sagemaker_session.boto_region_name,
                 version=framework_version,
                 py_version=self.py_version,
@@ -252,7 +252,7 @@ class XGBoost(Framework):
         framework, py_version, tag, _ = framework_name_from_image(image_uri)
         init_params["py_version"] = py_version
 
-        if framework and framework != cls.__framework_name__:
+        if framework and framework != cls._framework_name:
             raise ValueError(
                 "Training job: {} didn't use image for requested framework".format(
                     job_details["TrainingJobName"]

--- a/src/sagemaker/xgboost/model.py
+++ b/src/sagemaker/xgboost/model.py
@@ -51,7 +51,7 @@ class XGBoostPredictor(Predictor):
 class XGBoostModel(FrameworkModel):
     """An XGBoost SageMaker ``Model`` that can be deployed to a SageMaker ``Endpoint``."""
 
-    __framework_name__ = XGBOOST_NAME
+    _framework_name = XGBOOST_NAME
 
     def __init__(
         self,
@@ -144,7 +144,7 @@ class XGBoostModel(FrameworkModel):
             str: The appropriate image URI based on the given parameters.
         """
         return image_uris.retrieve(
-            self.__framework_name__,
+            self._framework_name,
             region_name,
             version=self.framework_version,
             py_version=self.py_version,

--- a/tests/unit/sagemaker/tensorflow/test_estimator_init.py
+++ b/tests/unit/sagemaker/tensorflow/test_estimator_init.py
@@ -65,7 +65,7 @@ def test_py2_version_is_not_deprecated(sagemaker_session):
 
 def test_framework_name(sagemaker_session):
     tf = _build_tf(sagemaker_session, framework_version="1.15.2", py_version="py3")
-    assert tf.__framework_name__ == "tensorflow"
+    assert tf._framework_name == "tensorflow"
 
 
 def test_enable_sm_metrics(sagemaker_session):

--- a/tests/unit/test_chainer.py
+++ b/tests/unit/test_chainer.py
@@ -561,7 +561,7 @@ def test_estimator_py2_warning(warning, sagemaker_session, chainer_version):
     )
 
     assert estimator.py_version == "py2"
-    warning.assert_called_with(estimator.__framework_name__, defaults.LATEST_PY2_VERSION)
+    warning.assert_called_with(estimator._framework_name, defaults.LATEST_PY2_VERSION)
 
 
 @patch("sagemaker.chainer.model.python_deprecation_warning")
@@ -575,4 +575,4 @@ def test_model_py2_warning(warning, sagemaker_session, chainer_version):
         py_version="py2",
     )
     assert model.py_version == "py2"
-    warning.assert_called_with(model.__framework_name__, defaults.LATEST_PY2_VERSION)
+    warning.assert_called_with(model._framework_name, defaults.LATEST_PY2_VERSION)

--- a/tests/unit/test_estimator.py
+++ b/tests/unit/test_estimator.py
@@ -107,7 +107,7 @@ LIST_TAGS_RESULT = {"Tags": [{"Key": "TagtestKey", "Value": "TagtestValue"}]}
 
 
 class DummyFramework(Framework):
-    __framework_name__ = "dummy"
+    _framework_name = "dummy"
 
     def train_image(self):
         return IMAGE_URI

--- a/tests/unit/test_job.py
+++ b/tests/unit/test_job.py
@@ -81,7 +81,7 @@ def sagemaker_session():
 
 
 class DummyFramework(Framework):
-    __framework_name__ = "dummy"
+    _framework_name = "dummy"
 
     def train_image(self):
         return IMAGE_NAME

--- a/tests/unit/test_mxnet.py
+++ b/tests/unit/test_mxnet.py
@@ -715,7 +715,7 @@ def test_estimator_py2_warning(warning, sagemaker_session):
     )
 
     assert estimator.py_version == "py2"
-    warning.assert_called_with(estimator.__framework_name__, defaults.LATEST_PY2_VERSION)
+    warning.assert_called_with(estimator._framework_name, defaults.LATEST_PY2_VERSION)
 
 
 @patch("sagemaker.mxnet.model.python_deprecation_warning")
@@ -729,7 +729,7 @@ def test_model_py2_warning(warning, sagemaker_session):
         sagemaker_session=sagemaker_session,
     )
     assert model.py_version == "py2"
-    warning.assert_called_with(model.__framework_name__, defaults.LATEST_PY2_VERSION)
+    warning.assert_called_with(model._framework_name, defaults.LATEST_PY2_VERSION)
 
 
 def test_create_model_with_custom_hosting_image(sagemaker_session):

--- a/tests/unit/test_pytorch.py
+++ b/tests/unit/test_pytorch.py
@@ -553,7 +553,7 @@ def test_estimator_py2_warning(warning, sagemaker_session, pytorch_training_vers
     )
 
     assert estimator.py_version == "py2"
-    warning.assert_called_with(estimator.__framework_name__, defaults.LATEST_PY2_VERSION)
+    warning.assert_called_with(estimator._framework_name, defaults.LATEST_PY2_VERSION)
 
 
 @patch("sagemaker.pytorch.model.python_deprecation_warning")
@@ -567,7 +567,7 @@ def test_model_py2_warning(warning, sagemaker_session, pytorch_inference_version
         py_version="py2",
     )
     assert model.py_version == "py2"
-    warning.assert_called_with(model.__framework_name__, defaults.LATEST_PY2_VERSION)
+    warning.assert_called_with(model._framework_name, defaults.LATEST_PY2_VERSION)
 
 
 def test_pt_enable_sm_metrics(


### PR DESCRIPTION
*Issue #, if available:* #1607 

*Description of changes:*

rename `__framework_name__` as `_framework_name`

*Testing done:*

unit:

```
❯ tox tests/unit
...
  black-format: commands succeeded
  flake8: commands succeeded
  pylint: commands succeeded
  twine: commands succeeded
  sphinx: commands succeeded
  doc8: commands succeeded
  py36: commands succeeded
  py37: commands succeeded
  py38: commands succeeded
  congratulations :)
```

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
