### PR TITLE
feature: Update migration tool to support breaking changes to create_model

### DIFF
--- a/src/sagemaker/cli/compatibility/v2/ast_transformer.py
+++ b/src/sagemaker/cli/compatibility/v2/ast_transformer.py
@@ -37,6 +37,7 @@ FUNCTION_CALL_MODIFIERS = [
     modifiers.training_input.TrainingInputConstructorRefactor(),
     modifiers.training_input.ShuffleConfigModuleRenamer(),
     modifiers.serde.SerdeConstructorRenamer(),
+    modifiers.serde.SerdeKeywordRemover(),
 ]
 
 IMPORT_MODIFIERS = [modifiers.tfs.TensorFlowServingImportRenamer()]

--- a/tests/unit/sagemaker/cli/compatibility/v2/modifiers/test_serde.py
+++ b/tests/unit/sagemaker/cli/compatibility/v2/modifiers/test_serde.py
@@ -346,3 +346,42 @@ def test_deserializer_module_modify_node(src, expected):
     node = pasta.parse(src)
     modified_node = modifier.modify_node(node)
     assert expected == pasta.dump(modified_node)
+
+
+@pytest.mark.parametrize(
+    "src, expected",
+    [
+        ('estimator.create_model(entry_point="inference.py")', False),
+        ("estimator.create_model(serializer=CSVSerializer())", True),
+        ("estimator.create_model(deserializer=CSVDeserializer())", True),
+        (
+            "estimator.create_model(serializer=CSVSerializer(), deserializer=CSVDeserializer())",
+            True,
+        ),
+        ("estimator.deploy(serializer=CSVSerializer())", False),
+    ],
+)
+def test_create_model_call_node_should_be_modified(src, expected):
+    modifier = serde.SerdeKeywordRemover()
+    node = ast_call(src)
+    assert modifier.node_should_be_modified(node) is expected
+
+
+@pytest.mark.parametrize(
+    "src, expected",
+    [
+        (
+            'estimator.create_model(entry_point="inference.py", serializer=CSVSerializer())',
+            'estimator.create_model(entry_point="inference.py")',
+        ),
+        (
+            'estimator.create_model(entry_point="inference.py", deserializer=CSVDeserializer())',
+            'estimator.create_model(entry_point="inference.py")',
+        ),
+    ],
+)
+def test_create_model_call_modify_node(src, expected):
+    modifier = serde.SerdeKeywordRemover()
+    node = ast_call(src)
+    modified_node = modifier.modify_node(node)
+    assert expected == pasta.dump(modified_node)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Update `sagemaker.cli.compatibility.v2.serde.py` 

*Testing done:*
* Added two parameterized tests to `test_serde.py`

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
