### PR TITLE
change: upgrade airflow to 1.10.11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ extras["test"] = (
         "awslogs",
         "black==19.10b0 ; python_version >= '3.6'",
         "stopit==1.1.2",
-        "apache-airflow==1.10.9",
+        "apache-airflow==1.10.11",
         "fabric>=2.0",
         "requests>=2.20.0, <3",
     ],


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

upgrade airflow to latest stable release from 1.10.9 to 1.10.11

*Testing done:*

```
❯ tox tests/unit
...
  black-format: commands succeeded
  flake8: commands succeeded
  pylint: commands succeeded
  twine: commands succeeded
  sphinx: commands succeeded
  doc8: commands succeeded
  py36: commands succeeded
  py37: commands succeeded
  py38: commands succeeded
  congratulations :)
```
## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
