### PR TITLE
change: update rulesconfig to 0.1.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ required_packages = [
     "numpy>=1.9.0",
     "protobuf>=3.1",
     "protobuf3-to-dict>=0.1.5",
-    "smdebug-rulesconfig==0.1.4",
+    "smdebug-rulesconfig==0.1.5",
     "importlib-metadata>=1.4.0",
     "packaging>=20.0",
 ]


### PR DESCRIPTION
*Issue #, if available:*
We have recently released smdebug_rulesconfig package 0.1.5
This change updates the dependecy of this package of rulesconfig from 0.1.4 to 0.1.5

Testing done:
Ran tox -e py37 tests/unit 
Ran export IGNORE_COVERAGE=- ; tox -e py37 -- -s -vv tests/integ

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
