### PR TITLE
fix: check ast node on later renamers for cli v2 updater

### DIFF
--- a/src/sagemaker/cli/compatibility/v2/modifiers/image_uris.py
+++ b/src/sagemaker/cli/compatibility/v2/modifiers/image_uris.py
@@ -112,8 +112,10 @@ class ImageURIRetrieveImportFromRenamer(Modifier):
         Returns:
             bool: If the import statement imports ``get_image_uri`` from the correct module.
         """
-        return node.module in GET_IMAGE_URI_NAMESPACES and any(
-            name.name == GET_IMAGE_URI_NAME for name in node.names
+        return (
+            node is not None
+            and node.module in GET_IMAGE_URI_NAMESPACES
+            and any(name.name == GET_IMAGE_URI_NAME for name in node.names)
         )
 
     def modify_node(self, node):

--- a/tests/unit/sagemaker/cli/compatibility/v2/test_ast_transformer.py
+++ b/tests/unit/sagemaker/cli/compatibility/v2/test_ast_transformer.py
@@ -1,0 +1,48 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from __future__ import absolute_import
+
+import textwrap
+
+import pasta
+import pytest
+
+from sagemaker.cli.compatibility.v2.ast_transformer import ASTTransformer
+
+
+@pytest.fixture
+def input_code():
+    return textwrap.dedent(
+        """
+        from sagemaker.predictor import csv_serializer
+
+        csv_serializer.__doc__
+        """
+    )
+
+
+@pytest.fixture
+def output_code():
+    return textwrap.dedent(
+        """
+        from sagemaker import serializers
+
+        serializers.CSVSerializer().__doc__
+        """
+    )
+
+
+def test_simple_script(input_code, output_code):
+    input_ast = pasta.parse(input_code)
+    output_ast = ASTTransformer().visit(input_ast)
+    assert pasta.dump(output_ast) == output_code


### PR DESCRIPTION
*Issue #, if available:*
Fixes #1847 

*Description of changes:*

check for `None` on node for renamers following the serde renamers for the cli v2 updater

*Testing done:*

new test included:

```
❯ tox --parallel 3 -- -rfE --disable-warnings tests/unit
✔ OK black-format in 7.632 seconds
✔ OK flake8 in 23.871 seconds
✔ OK twine in 17.505 seconds
✔ OK pylint in 32.506 seconds
✔ OK doc8 in 19.725 seconds
✔ OK sphinx in 32.056 seconds
✔ OK py37 in 4 minutes, 18.556 seconds
✔ OK py36 in 4 minutes, 39.279 seconds
✔ OK py38 in 4 minutes, 26.307 seconds
```

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
