### PR TITLE
change: Set TF 2.1.1 as highest py2 version for TF

### DIFF
--- a/src/sagemaker/tensorflow/defaults.py
+++ b/src/sagemaker/tensorflow/defaults.py
@@ -13,4 +13,4 @@
 """Placeholder docstring"""
 from __future__ import absolute_import
 
-LATEST_PY2_VERSION = "2.1.0"
+LATEST_PY2_VERSION = "2.1.1"

--- a/src/sagemaker/tensorflow/estimator.py
+++ b/src/sagemaker/tensorflow/estimator.py
@@ -35,7 +35,7 @@ class TensorFlow(Framework):
     _framework_name = "tensorflow"
 
     _HIGHEST_LEGACY_MODE_ONLY_VERSION = version.Version("1.10.0")
-    _HIGHEST_PYTHON_2_VERSION = version.Version("2.1.0")
+    _HIGHEST_PYTHON_2_VERSION = version.Version("2.1.1")
 
     def __init__(
         self,

--- a/tests/unit/sagemaker/tensorflow/test_estimator_init.py
+++ b/tests/unit/sagemaker/tensorflow/test_estimator_init.py
@@ -39,18 +39,18 @@ def _build_tf(sagemaker_session, **kwargs):
 
 @patch("sagemaker.fw_utils.python_deprecation_warning")
 def test_estimator_py2_deprecation_warning(warning, sagemaker_session):
-    estimator = _build_tf(sagemaker_session, framework_version="2.1.0", py_version="py2")
+    estimator = _build_tf(sagemaker_session, framework_version="2.1.1", py_version="py2")
 
     assert estimator.py_version == "py2"
-    warning.assert_called_with("tensorflow", "2.1.0")
+    warning.assert_called_with("tensorflow", "2.1.1")
 
 
 def test_py2_version_deprecated(sagemaker_session):
     with pytest.raises(AttributeError) as e:
-        _build_tf(sagemaker_session, framework_version="2.1.1", py_version="py2")
+        _build_tf(sagemaker_session, framework_version="2.1.2", py_version="py2")
 
     msg = (
-        "Python 2 containers are only available with 2.1.0 and lower versions. "
+        "Python 2 containers are only available with 2.1.1 and lower versions. "
         "Please use a Python 3 container."
     )
     assert msg in str(e.value)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Set TF 2.1.1 as the highest version of TensorFlow which can be used with Python 2

*Testing done:*
Tested by running unit tests locally.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
