### PR TITLE
infra: add regional account ids for af-south-1 and eu-south-1 to unit test

### DIFF
--- a/tests/unit/sagemaker/image_uris/test_debugger.py
+++ b/tests/unit/sagemaker/image_uris/test_debugger.py
@@ -16,6 +16,7 @@ from sagemaker import image_uris
 from tests.unit.sagemaker.image_uris import expected_uris, regions
 
 ACCOUNTS = {
+    "af-south-1": "314341159256",
     "ap-east-1": "199566480951",
     "ap-northeast-1": "430734990657",
     "ap-northeast-2": "578805364391",
@@ -27,6 +28,7 @@ ACCOUNTS = {
     "cn-northwest-1": "658757709296",
     "eu-central-1": "482524230118",
     "eu-north-1": "314864569078",
+    "eu-south-1": "563282790590",
     "eu-west-1": "929884845733",
     "eu-west-2": "250201462417",
     "eu-west-3": "447278800020",


### PR DESCRIPTION
*Description of changes:*
Adding Debugger Repo Account IDs for `af-south-1` (Cape Town) and `eu-south-1` (Milan)

*Testing done:*
None

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.