### PR TITLE
reshape Parents into experiment analytics dataframe

### DIFF
--- a/src/sagemaker/analytics.py
+++ b/src/sagemaker/analytics.py
@@ -547,6 +547,23 @@ class ExperimentAnalytics(AnalyticsMetricsBase):
             out["{} - {}".format(name, "Value")] = value.get("Value")
         return out
 
+    def _reshape_parents(self, parents):
+        """Reshape trial component parents to a pandas column
+        Args:
+            parents: trial component parents (trials and experiments)
+        Returns:
+            dict: Key: artifacts name, Value: artifacts value
+        """
+        out = OrderedDict()
+        trials = []
+        experiments = []
+        for parent in parents:
+            trials.append(parent["TrialName"])
+            experiments.append(parent["ExperimentName"])
+        out["Trials"] = trials
+        out["Experiments"] = experiments
+        return out
+
     def _reshape(self, trial_component):
         """Reshape trial component data to pandas columns
         Args:
@@ -574,6 +591,7 @@ class ExperimentAnalytics(AnalyticsMetricsBase):
                 trial_component.get("OutputArtifacts", []), self._output_artifact_names
             )
         )
+        out.update(self._reshape_parents(trial_component.get("Parents", [])))
         return out
 
     def _fetch_dataframe(self):

--- a/tests/integ/test_experiments_analytics.py
+++ b/tests/integ/test_experiments_analytics.py
@@ -99,6 +99,8 @@ def test_experiment_analytics_artifacts(sagemaker_session):
             "inputArtifacts1 - Value",
             "outputArtifacts1 - MediaType",
             "outputArtifacts1 - Value",
+            "Trials",
+            "Experiments",
         ]
 
 
@@ -109,7 +111,13 @@ def test_experiment_analytics(sagemaker_session):
             experiment_name=experiment_name, sagemaker_session=sagemaker_session
         )
 
-        assert list(analytics.dataframe().columns) == ["TrialComponentName", "DisplayName", "hp1"]
+        assert list(analytics.dataframe().columns) == [
+            "TrialComponentName",
+            "DisplayName",
+            "hp1",
+            "Trials",
+            "Experiments",
+        ]
 
 
 def test_experiment_analytics_pagination(sagemaker_session):
@@ -118,7 +126,13 @@ def test_experiment_analytics_pagination(sagemaker_session):
             experiment_name=experiment_name, sagemaker_session=sagemaker_session
         )
 
-        assert list(analytics.dataframe().columns) == ["TrialComponentName", "DisplayName", "hp1"]
+        assert list(analytics.dataframe().columns) == [
+            "TrialComponentName",
+            "DisplayName",
+            "hp1",
+            "Trials",
+            "Experiments",
+        ]
         assert (
             len(analytics.dataframe()) > 10
         )  # TODO [owen-t] Replace with == 20 and put test in retry block
@@ -137,7 +151,13 @@ def test_experiment_analytics_search_by_nested_filter(sagemaker_session):
             sagemaker_session=sagemaker_session, search_expression=search_exp
         )
 
-        assert list(analytics.dataframe().columns) == ["TrialComponentName", "DisplayName", "hp1"]
+        assert list(analytics.dataframe().columns) == [
+            "TrialComponentName",
+            "DisplayName",
+            "hp1",
+            "Trials",
+            "Experiments",
+        ]
         assert (
             len(analytics.dataframe()) > 5
         )  # TODO [owen-t] Replace with == 10 and put test in retry block
@@ -159,7 +179,13 @@ def test_experiment_analytics_search_by_nested_filter_sort_ascending(sagemaker_s
             sort_order="Ascending",
         )
 
-        assert list(analytics.dataframe().columns) == ["TrialComponentName", "DisplayName", "hp1"]
+        assert list(analytics.dataframe().columns) == [
+            "TrialComponentName",
+            "DisplayName",
+            "hp1",
+            "Trials",
+            "Experiments",
+        ]
         assert (
             len(analytics.dataframe()) > 5
         )  # TODO [owen-t] Replace with == 10 and put test in retry block
@@ -183,7 +209,13 @@ def test_experiment_analytics_search_by_nested_filter_sort_descending(sagemaker_
             sort_by="Parameters.hp1",
         )
 
-        assert list(analytics.dataframe().columns) == ["TrialComponentName", "DisplayName", "hp1"]
+        assert list(analytics.dataframe().columns) == [
+            "TrialComponentName",
+            "DisplayName",
+            "hp1",
+            "Trials",
+            "Experiments",
+        ]
         assert (
             len(analytics.dataframe()) > 5
         )  # TODO [owen-t] Replace with == 10 and put test in retry block

--- a/tests/unit/test_experiments_analytics.py
+++ b/tests/unit/test_experiments_analytics.py
@@ -48,10 +48,11 @@ def trial_component(trial_component_name):
             "outputArtifacts1": {"MediaType": "text/csv", "Value": "s3:/sky/far1"},
             "outputArtifacts2": {"MediaType": "text/csv", "Value": "s3:/sky/far2"},
         },
+        "Parents": [{"TrialName": "trial1", "ExperimentName": "experiment1"}],
     }
 
 
-def test_trial_analytics_dataframe_all_metrics_hyperparams(mock_session):
+def test_trial_analytics_dataframe_all(mock_session):
     mock_session.sagemaker_client.search.return_value = {
         "Results": [
             {"TrialComponent": trial_component("trial-1")},
@@ -88,6 +89,8 @@ def test_trial_analytics_dataframe_all_metrics_hyperparams(mock_session):
                 ("outputArtifacts1 - Value", ["s3:/sky/far1", "s3:/sky/far1"]),
                 ("outputArtifacts2 - MediaType", ["text/csv", "text/csv"]),
                 ("outputArtifacts2 - Value", ["s3:/sky/far2", "s3:/sky/far2"]),
+                ("Trials", [["trial1"], ["trial1"]]),
+                ("Experiments", [["experiment1"], ["experiment1"]]),
             ]
         )
     )
@@ -141,6 +144,8 @@ def test_trial_analytics_dataframe_selected_hyperparams(mock_session):
                 ("outputArtifacts1 - Value", ["s3:/sky/far1", "s3:/sky/far1"]),
                 ("outputArtifacts2 - MediaType", ["text/csv", "text/csv"]),
                 ("outputArtifacts2 - Value", ["s3:/sky/far2", "s3:/sky/far2"]),
+                ("Trials", [["trial1"], ["trial1"]]),
+                ("Experiments", [["experiment1"], ["experiment1"]]),
             ]
         )
     )
@@ -189,6 +194,8 @@ def test_trial_analytics_dataframe_selected_metrics(mock_session):
                 ("outputArtifacts1 - Value", ["s3:/sky/far1", "s3:/sky/far1"]),
                 ("outputArtifacts2 - MediaType", ["text/csv", "text/csv"]),
                 ("outputArtifacts2 - Value", ["s3:/sky/far2", "s3:/sky/far2"]),
+                ("Trials", [["trial1"], ["trial1"]]),
+                ("Experiments", [["experiment1"], ["experiment1"]]),
             ]
         )
     )
@@ -243,6 +250,8 @@ def test_trial_analytics_dataframe_search_pagination(mock_session):
                 ("outputArtifacts1 - Value", ["s3:/sky/far1", "s3:/sky/far1"]),
                 ("outputArtifacts2 - MediaType", ["text/csv", "text/csv"]),
                 ("outputArtifacts2 - Value", ["s3:/sky/far2", "s3:/sky/far2"]),
+                ("Trials", [["trial1"], ["trial1"]]),
+                ("Experiments", [["experiment1"], ["experiment1"]]),
             ]
         )
     )


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/sagemaker-experiments/issues/99

*Description of changes:* map "Parents" field in search response to experiments analytics dataframe

*Testing done:* run unit tests

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
