### PR TITLE
fix: blazingtext tag and upgrade sparkml version

### DIFF
--- a/src/sagemaker/image_uri_config/blazingtext.json
+++ b/src/sagemaker/image_uri_config/blazingtext.json
@@ -1,7 +1,7 @@
 {
     "scope": ["inference", "training"],
     "versions": {
-        "1": {
+        "latest": {
             "registries": {
                 "af-south-1": "455444449433",
                 "ap-east-1": "286214385809",

--- a/src/sagemaker/image_uri_config/sparkml-serving.json
+++ b/src/sagemaker/image_uri_config/sparkml-serving.json
@@ -29,6 +29,35 @@
                 "us-west-2": "246618743249"
             },
             "repository": "sagemaker-sparkml-serving"
+        },
+        "2.4": {
+            "registries": {
+                "af-south-1": "510948584623",
+                "ap-east-1": "651117190479",
+                "ap-northeast-1": "354813040037",
+                "ap-northeast-2": "366743142698",
+                "ap-south-1": "720646828776",
+                "ap-southeast-1": "121021644041",
+                "ap-southeast-2": "783357654285",
+                "ca-central-1": "341280168497",
+                "cn-north-1": "450853457545",
+                "cn-northwest-1": "451049120500",
+                "eu-central-1": "492215442770",
+                "eu-north-1": "662702820516",
+                "eu-west-1": "141502667606",
+                "eu-west-2": "764974769150",
+                "eu-west-3": "659782779980",
+                "eu-south-1": "978288397137",
+                "me-south-1": "801668240914",
+                "sa-east-1": "737474898029",
+                "us-east-1": "683313688378",
+                "us-east-2": "257758044811",
+                "us-gov-west-1": "414596584902",
+                "us-iso-east-1": "833128469047",
+                "us-west-1": "746614075791",
+                "us-west-2": "246618743249"
+            },
+            "repository": "sagemaker-sparkml-serving"
         }
     }
 }

--- a/src/sagemaker/sparkml/model.py
+++ b/src/sagemaker/sparkml/model.py
@@ -59,7 +59,7 @@ class SparkMLModel(Model):
     model .
     """
 
-    def __init__(self, model_data, role=None, spark_version=2.2, sagemaker_session=None, **kwargs):
+    def __init__(self, model_data, role=None, spark_version="2.4", sagemaker_session=None, **kwargs):
         """Initialize a SparkMLModel.
 
         Args:
@@ -73,7 +73,7 @@ class SparkMLModel(Model):
                 artifacts. After the endpoint is created, the inference code
                 might use the IAM role, if it needs to access an AWS resource.
             spark_version (str): Spark version you want to use for executing the
-                inference (default: '2.2').
+                inference (default: '2.4').
             sagemaker_session (sagemaker.session.Session): Session object which
                 manages interactions with Amazon SageMaker APIs and any other
                 AWS services needed. If not specified, the estimator creates one

--- a/src/sagemaker/sparkml/model.py
+++ b/src/sagemaker/sparkml/model.py
@@ -59,7 +59,9 @@ class SparkMLModel(Model):
     model .
     """
 
-    def __init__(self, model_data, role=None, spark_version="2.4", sagemaker_session=None, **kwargs):
+    def __init__(
+        self, model_data, role=None, spark_version="2.4", sagemaker_session=None, **kwargs
+    ):
         """Initialize a SparkMLModel.
 
         Args:

--- a/tests/unit/sagemaker/image_uris/test_algos.py
+++ b/tests/unit/sagemaker/image_uris/test_algos.py
@@ -177,7 +177,8 @@ def test_algo_uris(algo):
 
     for region in regions.regions():
         uri = image_uris.retrieve(algo, region)
-        assert expected_uris.algo_uri(algo, accounts[region], region) == uri
+        version = "latest" if algo == "blazingtext" else 1
+        assert expected_uris.algo_uri(algo, accounts[region], region, version) == uri
 
 
 def test_lda():

--- a/tests/unit/test_pipeline_model.py
+++ b/tests/unit/test_pipeline_model.py
@@ -97,7 +97,7 @@ def test_prepare_container_def(tfo, time, sagemaker_session):
         {
             "Environment": {"SAGEMAKER_DEFAULT_INVOCATIONS_ACCEPT": "text/csv"},
             "Image": "246618743249.dkr.ecr.us-west-2.amazonaws.com"
-            + "/sagemaker-sparkml-serving:2.2",
+            + "/sagemaker-sparkml-serving:2.4",
             "ModelDataUrl": "s3://bucket/model_2.tar.gz",
         },
     ]

--- a/tests/unit/test_sparkml_serving.py
+++ b/tests/unit/test_sparkml_serving.py
@@ -49,7 +49,7 @@ def sagemaker_session():
 
 def test_sparkml_model(sagemaker_session):
     sparkml = SparkMLModel(sagemaker_session=sagemaker_session, model_data=MODEL_DATA, role=ROLE)
-    assert sparkml.image_uri == image_uris.retrieve("sparkml-serving", REGION, version="2.2")
+    assert sparkml.image_uri == image_uris.retrieve("sparkml-serving", REGION, version="2.4")
 
 
 def test_predictor_type(sagemaker_session):


### PR DESCRIPTION
*Issue #, if available:*
`image_uris` should retrieve blazingtext:latest but instead blazingtext:1 is retrieved: https://github.com/awslabs/amazon-sagemaker-examples/issues/1392

Also spark-ml-serving is upgraded to 2.4

*Description of changes:*
- update blazingtext version from "1" to "latest"
- upgrade spark-ml-serving version to 2.4

*Testing done:*
`tox -e py38 -- tests/unit/sagemaker/image_uris`

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
