### PR TITLE
fix: temporarily skip the MxNet Neo test until we fix them

### DIFF
--- a/tests/integ/test_neo_mxnet.py
+++ b/tests/integ/test_neo_mxnet.py
@@ -58,6 +58,9 @@ def mxnet_training_job(
 
 
 @pytest.mark.canary_quick
+@pytest.mark.skip(
+    reason="This test is failing because the image uri and the training script format has changed."
+)
 def test_attach_deploy(
     mxnet_training_job, sagemaker_session, cpu_instance_type, cpu_instance_family
 ):
@@ -86,6 +89,9 @@ def test_attach_deploy(
         predictor.predict(data)
 
 
+@pytest.mark.skip(
+    reason="This test is failing because the image uri and the training script format has changed."
+)
 def test_deploy_model(
     mxnet_training_job,
     sagemaker_session,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We need to upgrade the Neo version, update the image uri and update the training script.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
