### PR TITLE
Add a condition to retrieve correct image URI for xgboost

### DIFF
--- a/src/sagemaker/model.py
+++ b/src/sagemaker/model.py
@@ -281,7 +281,7 @@ class Model(object):
             framework_suffix = "-neo"
         else:
             if target_instance_type.startswith("ml_inf"):
-                framework_prefix = "inferentia"
+                framework_prefix = "inferentia-"
             else:
                 framework_prefix = "neo-"
 

--- a/src/sagemaker/model.py
+++ b/src/sagemaker/model.py
@@ -284,7 +284,7 @@ class Model(object):
 
 
         return image_uris.retrieve(
-            "{}{}".format(framework_prefix, framework, framework_suffix),
+            "{}{}{}".format(framework_prefix, framework, framework_suffix),
             region,
             instance_type=target_instance_type,
             version=framework_version,

--- a/src/sagemaker/model.py
+++ b/src/sagemaker/model.py
@@ -280,9 +280,10 @@ class Model(object):
         if framework == "xgboost":
             framework_suffix = "-neo"
         else:
-            framework_prefix = "inferentia-" if \
-            target_instance_type.startswith("ml_inf") else "neo-"
-
+            if target_instance_type.startswith("ml_inf"):
+                framework_prefix = "inferentia"
+            else:
+                framework_prefix = "neo-"
 
         return image_uris.retrieve(
             "{}{}{}".format(framework_prefix, framework, framework_suffix),

--- a/src/sagemaker/model.py
+++ b/src/sagemaker/model.py
@@ -276,11 +276,12 @@ class Model(object):
         """
         framework_prefix = ""
         framework_suffix = ""
-        
+
         if framework == "xgboost":
             framework_suffix = "-neo"
         else:
-            framework_prefix = "inferentia-" if target_instance_type.startswith("ml_inf") else "neo-"
+            framework_prefix = "inferentia-" if \
+            target_instance_type.startswith("ml_inf") else "neo-"
 
 
         return image_uris.retrieve(

--- a/src/sagemaker/model.py
+++ b/src/sagemaker/model.py
@@ -279,11 +279,10 @@ class Model(object):
 
         if framework == "xgboost":
             framework_suffix = "-neo"
+        elif target_instance_type.startswith("ml_inf"):
+            framework_prefix = "inferentia-"
         else:
-            if target_instance_type.startswith("ml_inf"):
-                framework_prefix = "inferentia-"
-            else:
-                framework_prefix = "neo-"
+            framework_prefix = "neo-"
 
         return image_uris.retrieve(
             "{}{}{}".format(framework_prefix, framework, framework_suffix),

--- a/src/sagemaker/model.py
+++ b/src/sagemaker/model.py
@@ -274,9 +274,17 @@ class Model(object):
             framework (str): The framework name.
             framework_version (str): The framework version.
         """
-        framework_prefix = "inferentia-" if target_instance_type.startswith("ml_inf") else "neo-"
+        framework_prefix = ""
+        framework_suffix = ""
+        
+        if framework == "xgboost":
+            framework_suffix = "-neo"
+        else:
+            framework_prefix = "inferentia-" if target_instance_type.startswith("ml_inf") else "neo-"
+
+
         return image_uris.retrieve(
-            "{}{}".format(framework_prefix, framework),
+            "{}{}".format(framework_prefix, framework, framework_suffix),
             region,
             instance_type=target_instance_type,
             version=framework_version,


### PR DESCRIPTION
*Issue #, if available:*
#1932 

*Description of changes:*
Rename the .json that holds registry information for neo containers.

*Testing done:*
```
tox -e flake8,pylint,twine,black-check --parallel all
tox -e py38 tests/unit
```

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
