### PR TITLE
fix: update kwargs target attribute

### DIFF
--- a/src/sagemaker/deprecations.py
+++ b/src/sagemaker/deprecations.py
@@ -51,22 +51,24 @@ def renamed_warning(phrase):
     _warn(f"{phrase} has been renamed")
 
 
-def renamed_kwargs(name, default, kwargs):
+def renamed_kwargs(old_name, new_name, value, kwargs):
     """Checks if the deprecated argument is in kwargs
 
     Raises warning, if present.
 
     Args:
-        name: name of deprecated argument
-        default: default value to use, if not present
+        old_name: name of deprecated argument
+        new_name: name of the new argument
+        value: value associated with new name, if supplied
         kwargs: keyword arguments dict
 
     Returns:
         value of the keyword argument, if present
     """
-    value = kwargs.get(name, default)
-    if value != default:
-        renamed_warning(name)
+    if old_name in kwargs:
+        value = kwargs.get(old_name, value)
+        kwargs[new_name] = value
+        renamed_warning(old_name)
     return value
 
 

--- a/src/sagemaker/estimator.py
+++ b/src/sagemaker/estimator.py
@@ -207,7 +207,8 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):
                 :class:`~sagemaker.debugger.Rule` objects used to define
                 rules for continuous analysis with SageMaker Debugger
                 (default: ``None``). For more, see
-                https://sagemaker.readthedocs.io/en/stable/amazon_sagemaker_debugger.html#continuous-analyses-through-rules
+                https://sagemaker.readthedocs.io/en/stable/amazon_sagemaker_debugger.html#
+                continuous-analyses-through-rules
             debugger_hook_config (:class:`~sagemaker.debugger.DebuggerHookConfig` or bool):
                 Configuration for how debugging information is emitted with
                 SageMaker Debugger. If not specified, a default one is created using
@@ -218,10 +219,12 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):
             tensorboard_output_config (:class:`~sagemaker.debugger.TensorBoardOutputConfig`):
                 Configuration for customizing debugging visualization using TensorBoard
                 (default: ``None``). For more, see
-                https://sagemaker.readthedocs.io/en/stable/amazon_sagemaker_debugger.html#capture-real-time-tensorboard-data-from-the-debugging-hook
+                https://sagemaker.readthedocs.io/en/stable/amazon_sagemaker_debugger.html#
+                capture-real-time-tensorboard-data-from-the-debugging-hook
             enable_sagemaker_metrics (bool): Enables SageMaker Metrics Time
                 Series. For more information see:
-                https://docs.aws.amazon.com/sagemaker/latest/dg/API_AlgorithmSpecification.html#SageMaker-Type-AlgorithmSpecification-EnableSageMakerMetricsTimeSeries
+                https://docs.aws.amazon.com/sagemaker/latest/dg/API_AlgorithmSpecification.html#
+                SageMaker-Type-AlgorithmSpecification-EnableSageMakerMetricsTimeSeries
                 (default: ``None``).
             enable_network_isolation (bool): Specifies whether container will
                 run in network isolation mode (default: ``False``). Network
@@ -229,13 +232,21 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):
                 (such as the Internet). The container does not make any inbound or
                 outbound network calls. Also known as Internet-free mode.
         """
-        instance_count = renamed_kwargs("train_instance_count", instance_count, kwargs)
-        instance_type = renamed_kwargs("train_instance_type", instance_type, kwargs)
-        max_run = renamed_kwargs("train_max_run", max_run, kwargs)
-        use_spot_instances = renamed_kwargs("train_use_spot_instances", use_spot_instances, kwargs)
-        max_wait = renamed_kwargs("train_max_run_wait", max_wait, kwargs)
-        volume_size = renamed_kwargs("train_volume_size", volume_size, kwargs)
-        volume_kms_key = renamed_kwargs("train_volume_kms_key", volume_kms_key, kwargs)
+        instance_count = renamed_kwargs(
+            "train_instance_count", "instance_count", instance_count, kwargs
+        )
+        instance_type = renamed_kwargs(
+            "train_instance_type", "instance_type", instance_type, kwargs
+        )
+        max_run = renamed_kwargs("train_max_run", "max_run", max_run, kwargs)
+        use_spot_instances = renamed_kwargs(
+            "train_use_spot_instances", "use_spot_instances", use_spot_instances, kwargs
+        )
+        max_wait = renamed_kwargs("train_max_run_wait", "max_wait", max_wait, kwargs)
+        volume_size = renamed_kwargs("train_volume_size", "volume_size", volume_size, kwargs)
+        volume_kms_key = renamed_kwargs(
+            "train_volume_kms_key", "volume_kms_key", volume_kms_key, kwargs
+        )
 
         if instance_count is None or instance_type is None:
             raise ValueError("Both instance_count and instance_type are required.")

--- a/src/sagemaker/mxnet/estimator.py
+++ b/src/sagemaker/mxnet/estimator.py
@@ -149,7 +149,7 @@ class MXNet(Framework):
             :class:`~sagemaker.estimator.Framework` and
             :class:`~sagemaker.estimator.EstimatorBase`.
         """
-        distribution = renamed_kwargs("distributions", distribution, kwargs)
+        distribution = renamed_kwargs("distributions", "distribution", distribution, kwargs)
         validate_version_or_image_args(framework_version, py_version, image_uri)
         if py_version == "py2":
             logger.warning(

--- a/src/sagemaker/predictor.py
+++ b/src/sagemaker/predictor.py
@@ -80,7 +80,7 @@ class Predictor(object):
         """
         removed_kwargs("content_type", kwargs)
         removed_kwargs("accept", kwargs)
-        endpoint_name = renamed_kwargs("endpoint", endpoint_name, kwargs)
+        endpoint_name = renamed_kwargs("endpoint", "endpoint_name", endpoint_name, kwargs)
         self.endpoint_name = endpoint_name
         self.sagemaker_session = sagemaker_session or Session()
         self.serializer = serializer

--- a/tests/unit/test_deprecations.py
+++ b/tests/unit/test_deprecations.py
@@ -27,14 +27,19 @@ from sagemaker.deprecations import (
 
 
 def test_renamed_kwargs():
-    kwargs, b = {"a": 1}, 2
-    val = renamed_kwargs("b", default=b, kwargs=kwargs)
+    kwargs, c = {"a": 1}, 2
+    val = renamed_kwargs("b", new_name="c", value=c, kwargs=kwargs)
+    assert val == 2
+
+    kwargs, c = {"a": 1, "c": 2}, 2
+    val = renamed_kwargs("b", new_name="c", value=c, kwargs=kwargs)
     assert val == 2
 
     with pytest.warns(DeprecationWarning):
-        kwargs, b = {"a": 1, "b": 3}, 2
-        val = renamed_kwargs("b", default=b, kwargs=kwargs)
+        kwargs, c = {"a": 1, "b": 3}, 2
+        val = renamed_kwargs("b", new_name="c", value=c, kwargs=kwargs)
         assert val == 3
+        assert kwargs == {"a": 1, "b": 3, "c": 3}
 
 
 def test_removed_arg():


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

In forward-porting of attributes, also update `kwargs`, as the instance attribute itself may not be used in the constructor, even if initially set.

*Testing done:*

```
❯ tox --parallel 3 -- -rfE --disable-warnings tests/unit
✔ OK black-format in 13.06 seconds
✔ OK flake8 in 31.197 seconds
✔ OK docstyle in 31.286 seconds
✔ OK pylint in 44.389 seconds
✔ OK twine in 7.858 seconds
✔ OK doc8 in 14.121 seconds
✔ OK sphinx in 40.423 seconds
✔ OK py36 in 5 minutes, 51.503 seconds
✔ OK py37 in 6 minutes, 2.295 seconds
✔ OK py38 in 5 minutes, 52.853 seconds
```

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
