### PR TITLE
feat: add network isolation support for PipelineModel

### DIFF
--- a/src/sagemaker/pipeline.py
+++ b/src/sagemaker/pipeline.py
@@ -26,7 +26,14 @@ class PipelineModel(object):
     """
 
     def __init__(
-        self, models, role, predictor_cls=None, name=None, vpc_config=None, sagemaker_session=None
+        self,
+        models,
+        role,
+        predictor_cls=None,
+        name=None,
+        vpc_config=None,
+        sagemaker_session=None,
+        enable_network_isolation=False,
     ):
         """Initialize a SageMaker `Model` instance.
 
@@ -57,6 +64,10 @@ class PipelineModel(object):
                 object, used for SageMaker interactions (default: None). If not
                 specified, one is created using the default AWS configuration
                 chain.
+            enable_network_isolation (bool): Default False. if True, enables
+                network isolation in the endpoint, isolating the model
+                container. No inbound or outbound network calls can be made to
+                or from the model container.Boolean
         """
         self.models = models
         self.role = role
@@ -64,6 +75,7 @@ class PipelineModel(object):
         self.name = name
         self.vpc_config = vpc_config
         self.sagemaker_session = sagemaker_session
+        self.enable_network_isolation = enable_network_isolation
         self.endpoint_name = None
 
     def pipeline_container_def(self, instance_type):
@@ -157,7 +169,11 @@ class PipelineModel(object):
 
         self.name = self.name or name_from_image(containers[0]["Image"])
         self.sagemaker_session.create_model(
-            self.name, self.role, containers, vpc_config=self.vpc_config
+            self.name,
+            self.role,
+            containers,
+            vpc_config=self.vpc_config,
+            enable_network_isolation=self.enable_network_isolation,
         )
 
         production_variant = sagemaker.production_variant(
@@ -214,7 +230,11 @@ class PipelineModel(object):
 
         self.name = self.name or name_from_image(containers[0]["Image"])
         self.sagemaker_session.create_model(
-            self.name, self.role, containers, vpc_config=self.vpc_config
+            self.name,
+            self.role,
+            containers,
+            vpc_config=self.vpc_config,
+            enable_network_isolation=self.enable_network_isolation,
         )
 
     def transformer(


### PR DESCRIPTION
*Description of changes:*
Pass `enable_network_isolation` to `create_model` when instantiating a `PipelineModel`.

*Testing done:*
Ran unit tests locally.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
