### PR TITLE
fix: use local updated args; use train_max_wait

### DIFF
--- a/doc/v2.rst
+++ b/doc/v2.rst
@@ -231,7 +231,7 @@ The following estimator parameters have been renamed:
 +------------------------------+------------------------+
 | ``train_use_spot_instances`` | ``use_spot_instances`` |
 +------------------------------+------------------------+
-| ``train_max_run_wait``       | ``max_wait``           |
+| ``train_max_wait``           | ``max_wait``           |
 +------------------------------+------------------------+
 | ``train_volume_size``        | ``volume_size``        |
 +------------------------------+------------------------+

--- a/src/sagemaker/cli/compatibility/v2/modifiers/training_params.py
+++ b/src/sagemaker/cli/compatibility/v2/modifiers/training_params.py
@@ -45,7 +45,7 @@ PARAMS = (
     "train_instance_count",
     "train_instance_type",
     "train_max_run",
-    "train_max_run_wait",
+    "train_max_wait",
     "train_use_spot_instances",
     "train_volume_size",
     "train_volume_kms_key",
@@ -63,7 +63,7 @@ class TrainPrefixRemover(Modifier):
         - ``train_instance_count``
         - ``train_instance_type``
         - ``train_max_run``
-        - ``train_max_run_wait``
+        - ``train_max_wait``
         - ``train_use_spot_instances``
         - ``train_volume_kms_key``
         - ``train_volume_size``

--- a/src/sagemaker/estimator.py
+++ b/src/sagemaker/estimator.py
@@ -242,7 +242,7 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):
         use_spot_instances = renamed_kwargs(
             "train_use_spot_instances", "use_spot_instances", use_spot_instances, kwargs
         )
-        max_wait = renamed_kwargs("train_max_run_wait", "max_wait", max_wait, kwargs)
+        max_wait = renamed_kwargs("train_max_wait", "max_wait", max_wait, kwargs)
         volume_size = renamed_kwargs("train_volume_size", "volume_size", volume_size, kwargs)
         volume_kms_key = renamed_kwargs(
             "train_volume_kms_key", "volume_kms_key", volume_kms_key, kwargs

--- a/src/sagemaker/mxnet/estimator.py
+++ b/src/sagemaker/mxnet/estimator.py
@@ -150,6 +150,9 @@ class MXNet(Framework):
             :class:`~sagemaker.estimator.EstimatorBase`.
         """
         distribution = renamed_kwargs("distributions", "distribution", distribution, kwargs)
+        instance_type = renamed_kwargs(
+            "train_instance_type", "instance_type", kwargs.get("instance_type"), kwargs
+        )
         validate_version_or_image_args(framework_version, py_version, image_uri)
         if py_version == "py2":
             logger.warning(
@@ -168,7 +171,6 @@ class MXNet(Framework):
         )
 
         if distribution is not None:
-            instance_type = kwargs.get("instance_type")
             warn_if_parameter_server_with_multi_gpu(
                 training_instance_type=instance_type, distribution=distribution
             )

--- a/src/sagemaker/sklearn/estimator.py
+++ b/src/sagemaker/sklearn/estimator.py
@@ -16,6 +16,7 @@ from __future__ import absolute_import
 import logging
 
 from sagemaker import image_uris
+from sagemaker.deprecations import renamed_kwargs
 from sagemaker.estimator import Framework
 from sagemaker.fw_utils import (
     framework_name_from_image,
@@ -107,6 +108,12 @@ class SKLearn(Framework):
             :class:`~sagemaker.estimator.Framework` and
             :class:`~sagemaker.estimator.EstimatorBase`.
         """
+        instance_type = renamed_kwargs(
+            "train_instance_type", "instance_type", kwargs.get("instance_type"), kwargs
+        )
+        instance_count = renamed_kwargs(
+            "train_instance_count", "instance_count", kwargs.get("instance_count"), kwargs
+        )
         validate_version_or_image_args(framework_version, py_version, image_uri)
         if py_version and py_version != "py3":
             raise AttributeError(
@@ -117,10 +124,8 @@ class SKLearn(Framework):
 
         # SciKit-Learn does not support distributed training or training on GPU instance types.
         # Fail fast.
-        instance_type = kwargs.get("instance_type")
         _validate_not_gpu_instance_type(instance_type)
 
-        instance_count = kwargs.get("instance_count")
         if instance_count:
             if instance_count != 1:
                 raise AttributeError(

--- a/src/sagemaker/tensorflow/estimator.py
+++ b/src/sagemaker/tensorflow/estimator.py
@@ -19,6 +19,7 @@ from packaging import version
 
 from sagemaker import image_uris, s3, utils
 from sagemaker.debugger import DebuggerHookConfig
+from sagemaker.deprecations import renamed_kwargs
 from sagemaker.estimator import Framework
 import sagemaker.fw_utils as fw
 from sagemaker.tensorflow import defaults
@@ -112,6 +113,9 @@ class TensorFlow(Framework):
             :class:`~sagemaker.estimator.Framework` and
             :class:`~sagemaker.estimator.EstimatorBase`.
         """
+        instance_type = renamed_kwargs(
+            "train_instance_type", "instance_type", kwargs.get("instance_type"), kwargs
+        )
         fw.validate_version_or_image_args(framework_version, py_version, image_uri)
         if py_version == "py2":
             logger.warning(
@@ -121,7 +125,6 @@ class TensorFlow(Framework):
         self.py_version = py_version
 
         if distribution is not None:
-            instance_type = kwargs.get("instance_type")
             fw.warn_if_parameter_server_with_multi_gpu(
                 training_instance_type=instance_type, distribution=distribution
             )

--- a/src/sagemaker/xgboost/estimator.py
+++ b/src/sagemaker/xgboost/estimator.py
@@ -16,6 +16,7 @@ from __future__ import absolute_import
 import logging
 
 from sagemaker import image_uris
+from sagemaker.deprecations import renamed_kwargs
 from sagemaker.estimator import Framework, _TrainingJob
 from sagemaker.fw_utils import (
     framework_name_from_image,
@@ -95,6 +96,9 @@ class XGBoost(Framework):
             :class:`~sagemaker.estimator.Framework` and
             :class:`~sagemaker.estimator.EstimatorBase`.
         """
+        instance_type = renamed_kwargs(
+            "train_instance_type", "instance_type", kwargs.get("instance_type"), kwargs
+        )
         super(XGBoost, self).__init__(
             entry_point, source_dir, hyperparameters, image_uri=image_uri, **kwargs
         )
@@ -111,7 +115,7 @@ class XGBoost(Framework):
                 self.sagemaker_session.boto_region_name,
                 version=framework_version,
                 py_version=self.py_version,
-                instance_type=kwargs.get("instance_type"),
+                instance_type=instance_type,
                 image_scope="training",
             )
 

--- a/tests/scripts/run-notebook-test.sh
+++ b/tests/scripts/run-notebook-test.sh
@@ -22,6 +22,7 @@ echo "set SAGEMAKER_ROLE_ARN=$SAGEMAKER_ROLE_ARN"
 ./amazon-sagemaker-examples/advanced_functionality/kmeans_bring_your_own_model/kmeans_bring_your_own_model.ipynb \
 ./amazon-sagemaker-examples/advanced_functionality/tensorflow_iris_byom/tensorflow_BYOM_iris.ipynb \
 ./amazon-sagemaker-examples/sagemaker-python-sdk/1P_kmeans_highlevel/kmeans_mnist.ipynb \
+./amazon-sagemaker-examples/sagemaker-python-sdk/managed_spot_training_mxnet/managed_spot_training_mxnet.ipynb \
 ./amazon-sagemaker-examples/sagemaker-python-sdk/mxnet_onnx_eia/mxnet_onnx_eia.ipynb \
 ./amazon-sagemaker-examples/sagemaker-python-sdk/mxnet_onnx_export/mxnet_onnx_export.ipynb \
 ./amazon-sagemaker-examples/sagemaker-python-sdk/pytorch_cnn_cifar10/pytorch_local_mode_cifar10.ipynb \


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

changes include:

* use local values as appropriate
* fix bug in v1->v2 transmogrification of `train_max_wait`
* include notebook test that was initially removed because of incompatibility with v2 upgrade

*Testing done:*

unit:

```

```

notebook testing:

```
!pip install -U git+git://github.com/metrizable/sagemaker-python-sdk@use-local-values
...

mnist_estimator.fit({'train': train_data_location, 'test': test_data_location})
...
2020-10-07 07:01:18 Completed - Training job completed
Training seconds: 70
Billable seconds: 24
Managed Spot Training savings: 65.7%
```

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
