### PR TITLE
feat: add Debugger account id for us-gov-west-1

### DIFF
--- a/src/sagemaker/image_uri_config/debugger.json
+++ b/src/sagemaker/image_uri_config/debugger.json
@@ -24,7 +24,8 @@
                 "us-east-1": "503895931360",
                 "us-east-2": "915447279597",
                 "us-west-1": "685455198987",
-                "us-west-2": "895741380848"
+                "us-west-2": "895741380848",
+                "us-gov-west-1": "515509971035"
             },
             "repository": "sagemaker-debugger-rules"
         }


### PR DESCRIPTION
This adds new account id for Debugger Rules repository in AWS Regions us-gov-west-1.

*Issue #, if available:*

*Description of changes:*

*Testing done:*
*No testing required*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
