### PR TITLE
fix: create default bucket only if needed

### DIFF
--- a/src/sagemaker/workflow/airflow.py
+++ b/src/sagemaker/workflow/airflow.py
@@ -143,7 +143,6 @@ def training_base_config(estimator, inputs=None, job_name=None, mini_batch_size=
     else:
         estimator.prepare_workflow_for_training(job_name=job_name)
 
-    default_bucket = estimator.sagemaker_session.default_bucket()
     s3_operations = {}
 
     if job_name is not None:
@@ -155,6 +154,7 @@ def training_base_config(estimator, inputs=None, job_name=None, mini_batch_size=
         estimator._current_job_name = utils.name_from_base(base_name)
 
     if estimator.output_path is None:
+        default_bucket = estimator.sagemaker_session.default_bucket()
         estimator.output_path = "s3://{}/".format(default_bucket)
 
     if isinstance(estimator, sagemaker.estimator.Framework):


### PR DESCRIPTION
*Description of changes:*
Create the default bucket only if the `output_path` is `None`.

*Testing done:*
`tox -e black-format,py38 tests/unit/test_airflow.py`

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
