### PR TITLE
fix: v2 upgrade tool should ignore cell starts with '%'

### DIFF
--- a/src/sagemaker/feature_store/feature_group.py
+++ b/src/sagemaker/feature_store/feature_group.py
@@ -179,10 +179,10 @@ class IngestionManagerPandas:
             end_index (int): ending position to ingest in this batch.
         """
         logger.info("Started ingesting index %d to %d", start_index, end_index)
-        for row in data_frame[start_index:end_index].itertuples(index=False):
+        for _, row in data_frame[start_index:end_index].iterrows():
             record = [
                 FeatureValue(feature_name=name, value_as_string=str(value))
-                for name, value in row._asdict().items()
+                for name, value in row.items()
             ]
             sagemaker_session.put_record(
                 feature_group_name=feature_group_name, record=[value.to_dict() for value in record]

--- a/tests/unit/sagemaker/feature_store/test_feature_store.py
+++ b/tests/unit/sagemaker/feature_store/test_feature_store.py
@@ -146,7 +146,7 @@ def test_load_feature_definition_unsupported_types(sagemaker_session_mock):
 @patch("sagemaker.feature_store.feature_group.IngestionManagerPandas")
 def test_ingest(ingestion_manager_init, sagemaker_session_mock):
     feature_group = FeatureGroup(name="MyGroup", sagemaker_session=sagemaker_session_mock)
-    df = pd.DataFrame({"float": pd.Series([2.0], dtype="float64")})
+    df = pd.DataFrame(dict((f"float{i}", pd.Series([2.0], dtype="float64")) for i in range(300)))
 
     mock_ingestion_manager_instance = Mock()
     ingestion_manager_init.return_value = mock_ingestion_manager_instance


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
currently updater has problems parsing this notebook because of the "%cd"
https://github.com/aws/amazon-sagemaker-examples/blob/master/aws_sagemaker_studio/getting_started/xgboost_customer_churn_studio.ipynb

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
