### PR TITLE
fix: v2 upgrade tool should ignore cell starts with '%'

### DIFF
--- a/src/sagemaker/cli/compatibility/v2/files.py
+++ b/src/sagemaker/cli/compatibility/v2/files.py
@@ -140,7 +140,7 @@ class JupyterNotebookFileUpdater(FileUpdater):
         """
         source = cell["source"]
 
-        if source[0].startswith("%%"):
+        if source[0].startswith("%"):
             return True
 
         return any(line.startswith("!") for line in source)

--- a/tests/unit/sagemaker/cli/compatibility/v2/test_file_updaters.py
+++ b/tests/unit/sagemaker/cli/compatibility/v2/test_file_updaters.py
@@ -115,6 +115,16 @@ def test_update(ast_transformer, pasta_parse, pasta_dump, json_dump):
           "metadata": {},
           "outputs": [],
           "source": [
+           "%%cd\\n",
+           "echo ignore this too"
+          ]
+         },
+         {
+          "cell_type": "code",
+          "execution_count": 4,
+          "metadata": {},
+          "outputs": [],
+          "source": [
            "# code to be modified\\n",
            "%s"
           ]


### PR DESCRIPTION
*Issue #, if available:*

We have example notebooks with cells contains "%cd". Those notebooks are failing to convert currently.

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
