### PR TITLE
fix: only run DataParallel and EdgePackaging tests in supported regions

### DIFF
--- a/tests/integ/__init__.py
+++ b/tests/integ/__init__.py
@@ -118,6 +118,18 @@ NO_AUTO_ML_REGIONS = [
     "eu-south-1",
 ]
 NO_MODEL_MONITORING_REGIONS = ["me-south-1", "af-south-1", "eu-south-1"]
+EDGE_PACKAGING_SUPPORTED_REGIONS = [
+    "us-east-2",
+    "us-west-2",
+    "us-east-1",
+    "eu-west-1",
+    "ap-northeast-1",
+    "eu-central-1",
+]
+# Data parallelism need to be tested with p3.16xlarge.
+# The instance type is expensive and not supported in all the regions.
+# Limiting the test to run in IAD and CMH
+DATA_PARALLEL_TESTING_REGIONS = ["us-east-2", "us-east-1"]
 
 
 EFS_TEST_ENABLED_REGION = []

--- a/tests/integ/test_edge.py
+++ b/tests/integ/test_edge.py
@@ -17,7 +17,12 @@ import os
 import pytest
 
 from sagemaker.mxnet.estimator import MXNet
-from tests.integ import DATA_DIR, TRAINING_DEFAULT_TIMEOUT_MINUTES
+from tests.integ import (
+    DATA_DIR,
+    TRAINING_DEFAULT_TIMEOUT_MINUTES,
+    EDGE_PACKAGING_SUPPORTED_REGIONS,
+    test_region,
+)
 from tests.integ.timeout import timeout
 
 
@@ -53,6 +58,10 @@ def mxnet_training_job(
         return mx.latest_training_job.name
 
 
+@pytest.mark.skipif(
+    test_region() not in EDGE_PACKAGING_SUPPORTED_REGIONS,
+    reason="Edge packaging isn't supported in that specific region.",
+)
 def test_edge_packaging_job(mxnet_training_job, sagemaker_session):
     estimator = MXNet.attach(mxnet_training_job, sagemaker_session=sagemaker_session)
     model = estimator.compile_model(

--- a/tests/integ/test_smdataparallel_pt.py
+++ b/tests/integ/test_smdataparallel_pt.py
@@ -14,6 +14,8 @@ from __future__ import absolute_import
 
 import os
 
+import pytest
+
 import sagemaker.utils
 import tests.integ as integ
 
@@ -26,6 +28,10 @@ smdataparallel_dir = os.path.join(
 )
 
 
+@pytest.mark.skipif(
+    integ.test_region() not in integ.DATA_PARALLEL_TESTING_REGIONS,
+    reason="Only allow this test to run in IAD and CMH to limit usage of p3.16xlarge",
+)
 def test_smdataparallel_pt_mnist(
     sagemaker_session,
     pytorch_training_latest_version,

--- a/tests/integ/test_smdataparallel_tf.py
+++ b/tests/integ/test_smdataparallel_tf.py
@@ -14,6 +14,8 @@ from __future__ import absolute_import
 
 import os
 
+import pytest
+
 import sagemaker.utils
 import tests.integ as integ
 
@@ -25,6 +27,10 @@ smdataparallel_dir = os.path.join(
 )
 
 
+@pytest.mark.skipif(
+    integ.test_region() not in integ.DATA_PARALLEL_TESTING_REGIONS,
+    reason="Only allow this test to run in IAD and CMH to limit usage of p3.16xlarge",
+)
 def test_smdataparallel_tf_mnist(
     sagemaker_session,
     tensorflow_training_latest_version,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
