### PR TITLE
documentation: adding note about CUDA 11 to SMP

### DIFF
--- a/doc/api/training/smd_data_parallel.rst
+++ b/doc/api/training/smd_data_parallel.rst
@@ -20,7 +20,6 @@ with multiple GPUs. As the cluster size increases, so does the significant drop
 in performance. This drop in performance is primarily caused the communications
 overhead between nodes in a cluster.
 
-
 .. rubric:: Customize your training script
 
 To customize your own training script, you will need the following:

--- a/doc/api/training/smd_model_parallel.rst
+++ b/doc/api/training/smd_model_parallel.rst
@@ -11,6 +11,15 @@ across multiple GPUs with minimal code changes. The SMP API can be accessed thro
 
 Use the following sections to learn more about the model parallelism and the SMP library.
 
+.. important::
+   SMP only supports training jobs using CUDA 11. When you define a PyTorch or TensorFlow
+   ``Estimator`` with ``smdistributed`` ``enabled``,
+   it uses CUDA 11. When you extend or customize your own training image
+   you must use a CUDA 11 base image. See
+   `Extend or Adapt A Docker Container that Contains SMP
+   <https://integ-docs-aws.amazon.com/sagemaker/latest/dg/model-parallel-use-api.html#model-parallel-customize-container>`__
+   for more information.
+
 It is recommended to use this documentation alongside `SageMaker Distributed Model Parallel
 <http://docs.aws.amazon.com/sagemaker/latest/dg/model-parallel.html>`__ in the Amazon SageMaker
 developer guide. This developer guide documentation includes:

--- a/doc/frameworks/pytorch/using_pytorch.rst
+++ b/doc/frameworks/pytorch/using_pytorch.rst
@@ -1,6 +1,6 @@
-###########################################
-Using PyTorch with the SageMaker Python SDK
-###########################################
+#########################################
+Use PyTorch with the SageMaker Python SDK
+#########################################
 
 With PyTorch Estimators and Models, you can train and host PyTorch models on Amazon SageMaker.
 


### PR DESCRIPTION
*Description of changes:*
* Adding note to clarify SMP CUDA version support

*Testing done:*
* ```tox -e black-check,flake8,pylint,docstyle,sphinx,doc8 --parallel all```

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
