### PR TITLE
documentation: fix SMP code example, added note for CUDA 11 to SDP

### DIFF
--- a/doc/api/training/smd_data_parallel.rst
+++ b/doc/api/training/smd_data_parallel.rst
@@ -20,6 +20,15 @@ with multiple GPUs. As the cluster size increases, so does the significant drop
 in performance. This drop in performance is primarily caused the communications
 overhead between nodes in a cluster.
 
+.. important::
+   SDP only supports training jobs using CUDA 11. When you define a PyTorch or TensorFlow
+   ``Estimator`` with ``dataparallel`` parameter ``enabled`` set to ``True``,
+   it uses CUDA 11. When you extend or customize your own training image
+   you must use a CUDA 11 base image. See
+   `SageMaker Python SDK's SDP APIs
+   <https://docs.aws.amazon.com/sagemaker/latest/dg/data-parallel-use-api.html#data-parallel-use-python-skd-api>`__
+   for more information.
+
 .. rubric:: Customize your training script
 
 To customize your own training script, you will need the following:

--- a/doc/api/training/smd_model_parallel.rst
+++ b/doc/api/training/smd_model_parallel.rst
@@ -13,7 +13,7 @@ Use the following sections to learn more about the model parallelism and the SMP
 
 .. important::
    SMP only supports training jobs using CUDA 11. When you define a PyTorch or TensorFlow
-   ``Estimator`` with ``smdistributed`` ``enabled``,
+   ``Estimator`` with ``modelparallel`` parameter ``enabled`` set to ``True``,
    it uses CUDA 11. When you extend or customize your own training image
    you must use a CUDA 11 base image. See
    `Extend or Adapt A Docker Container that Contains SMP

--- a/doc/api/training/smd_model_parallel_general.rst
+++ b/doc/api/training/smd_model_parallel_general.rst
@@ -47,7 +47,7 @@ The following is an example of how you can launch a new PyTorch training job wit
             py_version='py3',
             instance_count=1,
             distribution={
-               "smdistributed": smp_options,
+               "smdistributed": {"modelparallel": smp_options},
                "mpi": mpi_options
             },
             base_job_name="SMD-MP-demo",


### PR DESCRIPTION
*Issue #, if available:*
* SMP code sample was incorrect - missing `modelparallel` parameter

*Description of changes:*
* Added `modelparallel` to estimator definition code example
* Added note about CUDA 11 in SDP documentation 

*Testing done:*
* ` tox -e black-check,flake8,pylint,docstyle,sphinx,doc8 --parallel all` 

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
