### PR TITLE
fix: lower value used in featurestore test

### DIFF
--- a/tests/integ/test_feature_store.py
+++ b/tests/integ/test_feature_store.py
@@ -110,7 +110,7 @@ def pandas_data_frame_without_string():
     df = pd.DataFrame(
         {
             "feature1": pd.Series(np.arange(10), dtype="int64"),
-            "feature2": pd.Series([time.time()] * 10, dtype="float64"),
+            "feature2": pd.Series([3141592.6535897] * 10, dtype="float64"),
         }
     )
     return df


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

changes include:
* lower value used and use deterministic value in featurestore integ test

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
