### PR TITLE
documentation: adjust naming convention; fix links

### DIFF
--- a/doc/api/training/smd_data_parallel.rst
+++ b/doc/api/training/smd_data_parallel.rst
@@ -2,12 +2,12 @@
 Distributed data parallel
 ###################################
 
-SageMaker distributed data parallel (SDP) extends SageMaker’s training
+SageMaker's distributed data parallel library extends SageMaker’s training
 capabilities on deep learning models with near-linear scaling efficiency,
 achieving fast time-to-train with minimal code changes.
 
-- SDP optimizes your training job for AWS network infrastructure and EC2 instance topology.
-- SDP takes advantage of gradient update to communicate between nodes with a custom AllReduce algorithm.
+- optimizes your training job for AWS network infrastructure and EC2 instance topology.
+- takes advantage of gradient update to communicate between nodes with a custom AllReduce algorithm.
 
 When training a model on a large amount of data, machine learning practitioners
 will often turn to distributed training to reduce the time to train.
@@ -21,11 +21,11 @@ in performance. This drop in performance is primarily caused the communications
 overhead between nodes in a cluster.
 
 .. important::
-   SDP only supports training jobs using CUDA 11. When you define a PyTorch or TensorFlow
+   The distributed data parallel library only supports training jobs using CUDA 11. When you define a PyTorch or TensorFlow
    ``Estimator`` with ``dataparallel`` parameter ``enabled`` set to ``True``,
    it uses CUDA 11. When you extend or customize your own training image
    you must use a CUDA 11 base image. See
-   `SageMaker Python SDK's SDP APIs
+   `SageMaker Python SDK's distributed data parallel library APIs
    <https://docs.aws.amazon.com/sagemaker/latest/dg/data-parallel-use-api.html#data-parallel-use-python-skd-api>`__
    for more information.
 
@@ -38,7 +38,7 @@ To customize your own training script, you will need the following:
    <div data-section-style="5" style="">
 
 -  You must provide TensorFlow / PyTorch training scripts that are
-   adapted to use SDP.
+   adapted to use the distributed data parallel library.
 -  Your input data must be in an S3 bucket or in FSx in the AWS region
    that you will use to launch your training job. If you use the Jupyter
    notebooks provided, create a SageMaker notebook instance in the same
@@ -53,7 +53,7 @@ To customize your own training script, you will need the following:
 
 Use the API guides for each framework to see
 examples of training scripts that can be used to convert your training scripts.
-Then, use one of the example notebooks as your template to launch a training job.
+Then use one of the example notebooks as your template to launch a training job.
 You’ll need to swap your training script with the one that came with the
 notebook and modify any input functions as necessary.
 Once you have launched a training job, you can monitor it using CloudWatch.

--- a/doc/api/training/smd_data_parallel_pytorch.rst
+++ b/doc/api/training/smd_data_parallel_pytorch.rst
@@ -1,6 +1,6 @@
-####################
-PyTorch Guide to SDP
-####################
+##############################################################
+PyTorch Guide to SageMaker's distributed data parallel library
+##############################################################
 
 .. admonition:: Contents
 
@@ -13,16 +13,16 @@ Modify a PyTorch training script to use SageMaker data parallel
 ======================================================================
 
 The following steps show you how to convert a PyTorch training script to
-utilize SageMaker Distributed Data Parallel (SDP).
+utilize SageMaker's distributed data parallel library.
 
-The SDP APIs are designed to be close to PyTorch Distributed Data
-Parallel (DDP) APIs. Please see `SageMaker Distributed Data Parallel
-PyTorch API documentation <http://#>`__ for additional details on each
-API SDP offers for PyTorch.
+The distributed data parallel library APIs are designed to be close to PyTorch Distributed Data
+Parallel (DDP) APIs.
+See `SageMaker distributed data parallel PyTorch examples <https://sagemaker-examples.readthedocs.io/en/latest/training/distributed_training/index.html#pytorch-distributed>`__ for additional details on how to implement the data parallel library
+API offered for PyTorch.
 
 
--  First import SDP’s PyTorch client and initialize it. You also import
-   the SDP module for distributed training.
+-  First import the distributed data parallel library’s PyTorch client and initialize it. You also import
+   the distributed data parallel library module for distributed training.
 
    .. code:: python
 
@@ -33,7 +33,7 @@ API SDP offers for PyTorch.
       dist.init_process_group()
 
 
--  Pin each GPU to a single SDP process with ``local_rank`` - this
+-  Pin each GPU to a single distributed data parallel library process with ``local_rank`` - this
    refers to the relative rank of the process within a given node.
    ``smdistributed.dataparallel.torch.get_local_rank()`` API provides
    you the local rank of the device. The leader node will be rank 0, and
@@ -45,12 +45,12 @@ API SDP offers for PyTorch.
       torch.cuda.set_device(dist.get_local_rank())
 
 
--  Then wrap the PyTorch model with SDP’s DDP.
+-  Then wrap the PyTorch model with the distributed data parallel library’s DDP.
 
    .. code:: python
 
       model = ...
-      # Wrap model with SDP DistributedDataParallel
+      # Wrap model with SageMaker's DistributedDataParallel
       model = DDP(model)
 
 
@@ -82,17 +82,17 @@ API SDP offers for PyTorch.
 
 
 All put together, the following is an example PyTorch training script
-you will have for distributed training with SDP:
+you will have for distributed training with the distributed data parallel library:
 
 .. code:: python
 
-   # SDP: Import SDP PyTorch API
+   # Import distributed data parallel library PyTorch API
    import smdistributed.dataparallel.torch.distributed as dist
 
-   # SDP: Import SDP PyTorch DDP
+   # Import distributed data parallel library PyTorch DDP
    from smdistributed.dataparallel.torch.parallel.distributed import DistributedDataParallel as DDP
 
-   # SDP: Initialize SDP
+   # Initialize distributed data parallel library
    dist.init_process_group()
 
    class Net(nn.Module):
@@ -109,14 +109,14 @@ you will have for distributed training with SDP:
 
    def main():
 
-       # SDP: Scale batch size by world size
+       # Scale batch size by world size
        batch_size //= dist.get_world_size() // 8
        batch_size = max(batch_size, 1)
 
        # Prepare dataset
        train_dataset = torchvision.datasets.MNIST(...)
 
-       # SDP: Set num_replicas and rank in DistributedSampler
+       # Set num_replicas and rank in DistributedSampler
        train_sampler = torch.utils.data.distributed.DistributedSampler(
                train_dataset,
                num_replicas=dist.get_world_size(),
@@ -124,10 +124,10 @@ you will have for distributed training with SDP:
 
        train_loader = torch.utils.data.DataLoader(..)
 
-       # SDP: Wrap the PyTorch model with SDP’s DDP
+       # Wrap the PyTorch model with distributed data parallel library’s DDP
        model = DDP(Net().to(device))
 
-       # SDP: Pin each GPU to a single SDP process.
+       # Pin each GPU to a single distributed data parallel library process.
        torch.cuda.set_device(local_rank)
        model.cuda(local_rank)
 
@@ -140,7 +140,7 @@ you will have for distributed training with SDP:
                test(...)
            scheduler.step()
 
-       # SDP: Save model on master node.
+       # Save model on master node.
        if dist.get_rank() == 0:
            torch.save(...)
 

--- a/doc/api/training/smd_model_parallel.rst
+++ b/doc/api/training/smd_model_parallel.rst
@@ -1,22 +1,22 @@
 Distributed model parallel
 --------------------------
 
-Amazon SageMaker Distributed Model Parallel (SMP) is a model parallelism library for training
+The Amazon SageMaker distributed model parallel library is a model parallelism library for training
 large deep learning models that were previously difficult to train due to GPU memory limitations.
-SMP automatically and efficiently splits a model across multiple GPUs and instances and coordinates model training,
+The library automatically and efficiently splits a model across multiple GPUs and instances and coordinates model training,
 allowing you to increase prediction accuracy by creating larger models with more parameters.
 
-You can use SMP to automatically partition your existing TensorFlow and PyTorch workloads
-across multiple GPUs with minimal code changes. The SMP API can be accessed through the Amazon SageMaker SDK.
+You can use the library to automatically partition your existing TensorFlow and PyTorch workloads
+across multiple GPUs with minimal code changes. The library's API can be accessed through the Amazon SageMaker SDK.
 
-Use the following sections to learn more about the model parallelism and the SMP library.
+Use the following sections to learn more about the model parallelism and the library.
 
 .. important::
-   SMP only supports training jobs using CUDA 11. When you define a PyTorch or TensorFlow
+   The model parallel library only supports training jobs using CUDA 11. When you define a PyTorch or TensorFlow
    ``Estimator`` with ``modelparallel`` parameter ``enabled`` set to ``True``,
    it uses CUDA 11. When you extend or customize your own training image
    you must use a CUDA 11 base image. See
-   `Extend or Adapt A Docker Container that Contains SMP
+   `Extend or Adapt A Docker Container that Contains the Model Parallel Library
    <https://integ-docs-aws.amazon.com/sagemaker/latest/dg/model-parallel-use-api.html#model-parallel-customize-container>`__
    for more information.
 
@@ -24,7 +24,7 @@ It is recommended to use this documentation alongside `SageMaker Distributed Mod
 <http://docs.aws.amazon.com/sagemaker/latest/dg/model-parallel.html>`__ in the Amazon SageMaker
 developer guide. This developer guide documentation includes:
 
-   -  An overview of model parallelism and the SMP library
+   -  An overview of model parallelism and the library
       `core features <https://docs.aws.amazon.com/sagemaker/latest/dg/model-parallel-core-features.html>`__
    -  Instructions on how to modify `TensorFlow
       <https://docs.aws.amazon.com/sagemaker/latest/dg/model-parallel-customize-training-script.html#model-parallel-customize-training-script-tf>`__
@@ -36,8 +36,8 @@ developer guide. This developer guide documentation includes:
 
 **How to Use this Guide**
 
-The SMP library contains a Common API that is shared across frameworks, as well as APIs
-that are specific to supported frameworks, TensorFlow and PyTroch. To use SMP, reference the
+The library contains a Common API that is shared across frameworks, as well as APIs
+that are specific to supported frameworks, TensorFlow and PyTroch. To use the library, reference the
 **Common API** documentation alongside framework specific API documentation.
 
 

--- a/doc/api/training/smd_model_parallel_common_api.rst
+++ b/doc/api/training/smd_model_parallel_common_api.rst
@@ -1,7 +1,7 @@
-Common SMP API
---------------
+Common SageMaker distributed model parallel library APIs
+--------------------------------------------------------
 
-The following API is common across all frameworks.
+The following APIs are common across all frameworks.
 
 **Important**: This API document assumes you use the following import statement in your training scripts.
 
@@ -20,7 +20,7 @@ The following API is common across all frameworks.
 
 .. function:: smp.init( )
 
-   Initialize SMP. Must be called at the beginning of training script.
+   Initialize the library. Must be called at the beginning of training script.
 
 .. function:: @smp.step(non_split_inputs, input_split_axes, [*args, **kwargs])
 
@@ -32,7 +32,7 @@ The following API is common across all frameworks.
    By default, every tensor input to the function is split across its batch
    dimension into a number of microbatches specified while launching the
    training job. This behavior can be customized through the arguments to
-   ``smp.step``, described below. SMP then orchestrates the execution of
+   ``smp.step``, described below. The library then orchestrates the execution of
    each microbatch across all partitions, based on the chosen pipeline
    type.
 
@@ -101,7 +101,7 @@ The following API is common across all frameworks.
    -  All arguments of ``tf.function``. Note:
       The \ ``experimental_compile`` argument of ``tf.function`` may not
       work as expected with ``smp.step``, since it interferes with
-      pipelining and model partitioning. To enable XLA with SMP, you can
+      pipelining and model partitioning. To enable XLA with the library, you can
       instead use \ ``tf.config.optimizer.set_jit(True)``.
 
    **PyTorch-only parameters**
@@ -200,15 +200,15 @@ The following API is common across all frameworks.
       **Parameters**
 
       -  ``method`` (``"add_n"`` or ``"accumulate_n"`` or ``"variable"``):
-         If ``"add_n"`` or ``"accumulate_n"``, SMP uses
+         If ``"add_n"`` or ``"accumulate_n"``, the library uses
          ``tf.add_n`` and ``tf.accumulate_n``, respectively, to implement
-         accumulation. If ``"variable"``, SMP uses an internal ``tf.Variable``
+         accumulation. If ``"variable"``, the library uses an internal ``tf.Variable``
          into which to accumulate the tensors. Default is \ ``"variable"``.
          Note: Memory usage behavior of these choices can depend on the model
          and implementation.
 
-      -  ``var``: A ``tf.Variable`` into which, if provided, SMP uses to
-         accumulate the tensors. If \ ``None``, SMP internally creates a
+      -  ``var``: A ``tf.Variable`` into which, if provided, the library uses to
+         accumulate the tensors. If \ ``None``, the library internally creates a
          variable. If ``method`` is not ``"variable"``, this argument is
          ignored.
 
@@ -216,7 +216,7 @@ The following API is common across all frameworks.
 MPI Basics
 ^^^^^^^^^^
 
-SMP exposes the following basic MPI primitives to its Python API:
+The library exposes the following basic MPI primitives to its Python API:
 
 -  ``smp.rank()``: The rank of the current process.
 -  ``smp.size()``: The total number of processes.
@@ -237,7 +237,7 @@ SMP exposes the following basic MPI primitives to its Python API:
 Communication API
 =================
 
-SMP provides a few communication primitives which can be helpful while
+The library provides a few communication primitives which can be helpful while
 developing the training script. These primitives use the following
 ``enum`` s as arguments to specify which processes the communication
 should involve.

--- a/doc/api/training/smd_model_parallel_general.rst
+++ b/doc/api/training/smd_model_parallel_general.rst
@@ -10,10 +10,10 @@ SageMaker Python SDK ``modelparallel`` parameters
 
 The TensorFlow and PyTorch ``Estimator`` objects contains a ``distribution`` parameter,
 which is used to enable and specify parameters for the
-initialization of the SMP library. SMP internally uses MPI,
+initialization of the SageMaker distributed model parallel library. The library internally uses MPI,
 so in order to use model parallelism, MPI must be enabled using the ``distribution`` parameter.
 
-The following is an example of how you can launch a new PyTorch training job with SMP.
+The following is an example of how you can launch a new PyTorch training job with the library.
 
 .. code-block:: python3
 
@@ -55,7 +55,7 @@ The following is an example of how you can launch a new PyTorch training job wit
 
    smd_mp_estimator.fit('s3://my_bucket/my_training_data/')
 
-You can use the following parameters to initialize SMP using the ``parameters``
+You can use the following parameters to initialize the library using the ``parameters``
 in the ``smdistributed`` of ``distribution``.
 
 Note: ``partitions`` is required in ``parameters`` of ``smp_options``. All other parameters in the following
@@ -88,7 +88,7 @@ table are optional.
    |                           | or ``"simple"``         |                   | schedule.             |
    |                           |                         |                   |                       |
    +---------------------------+-------------------------+-------------------+-----------------------+
-   | ``optimize``              | ``"memory"`` or         | ``"memory"``      | Whether SMP           |
+   | ``optimize``              | ``"memory"`` or         | ``"memory"``      | Whether the library   |
    |                           | ``"speed"``             |                   | should optimize       |
    |                           |                         |                   | for speed or          |
    |                           |                         |                   | memory during         |
@@ -99,7 +99,7 @@ table are optional.
    |                           |                         |                   |                       |
    |                           |                         |                   |                       |
    |                           |                         |                   | **speed**             |
-   |                           |                         |                   | When SMP is           |
+   |                           |                         |                   | When the library is   |
    |                           |                         |                   | configured to         |
    |                           |                         |                   | optimize speed,       |
    |                           |                         |                   | it attempts to        |
@@ -124,7 +124,7 @@ table are optional.
    |                           |                         |                   |                       |
    |                           |                         |                   |                       |
    |                           |                         |                   | **memory**            |
-   |                           |                         |                   | When SMP              |
+   |                           |                         |                   | When the library      |
    |                           |                         |                   | optimizes             |
    |                           |                         |                   | memory, it            |
    |                           |                         |                   | attempts to           |
@@ -273,10 +273,10 @@ table are optional.
    |                   |                         |                 | balancing                         |
    |                   |                         |                 | computational                     |
    |                   |                         |                 | load. If 0.0,                     |
-   |                   |                         |                 | SMP only tries                    |
+   |                   |                         |                 | the library only tries            |
    |                   |                         |                 | to balance                        |
    |                   |                         |                 | computation; if                   |
-   |                   |                         |                 | 1.0 SMP only                      |
+   |                   |                         |                 | 1.0 the library only              |
    |                   |                         |                 | tries to                          |
    |                   |                         |                 | balance the                       |
    |                   |                         |                 | memory use. Any                   |
@@ -308,23 +308,23 @@ table are optional.
 Ranking Basics
 --------------
 
-SMP maintains a one-to-one mapping between processes and available GPUs:
+The library maintains a one-to-one mapping between processes and available GPUs:
 for each GPU, there is a corresponding CPU process. Each CPU process
 maintains a “rank” assigned by MPI, which is a 0-based unique index for
 the process. For instance, if a training job is launched with 4
-P3dn.24xlarge instances using all its GPUs, there are 32 processes
+``p3dn.24xlarge`` instances using all its GPUs, there are 32 processes
 across all instances, and the ranks of these processes range from 0 to
 31.
 
 The ``local_rank`` of a process is the rank of the process among the
 processes in the same instance. This can range from 0 up to the number
-of GPUs in the instance, but can be lower if fewer processes are
-launched than GPUs in the instance. For instance, in the preceding
+of GPUs in the instance, but can be lower if fewer processes than GPUs are
+launched in the instance. For instance, in the preceding
 example, ``local_rank``\ s of the processes will range from 0 to 7,
-since there are 8 GPUs in a P3dn.24xlarge instance.
+since there are 8 GPUs in a ``p3dn.24xlarge`` instance.
 
-When SMP is used together with data parallelism (Horovod for TensorFlow
-and DDP for PyTorch), SMP partitions the set of processes into
+When the library is used together with data parallelism (Horovod for TensorFlow
+and DDP for PyTorch), the library partitions the set of processes into
 disjoint \ ``mp_group``\ s. An ``mp_group`` is a subset of all processes
 that together hold a single, partitioned model replica. For instance, if
 a single node job is launched with 8 local processes, and
@@ -337,7 +337,7 @@ this example, if ``placement_strategy`` is ``spread``, then the four
 previous example, the ``mp_rank`` of process 1 is 0, and ``mp_rank`` of
 process 6 is 1.
 
-Analogously, SMP defines ``dp_group``\ s as the sets of processes that
+Analogously, the library defines ``dp_group``\ s as the sets of processes that
 all hold the same model partition, and perform data parallelism among
 each other. In the example above, there are two ``dp_group``\ s,
 ``[0, 1, 2, 3]`` and ``[4, 5, 6, 7]``,

--- a/doc/api/training/smd_model_parallel_pytorch.rst
+++ b/doc/api/training/smd_model_parallel_pytorch.rst
@@ -91,7 +91,7 @@ This API document assumes you use the following import statements in your traini
       fit in a single GPU, then ``trace_device`` should be set to CPU.
 
    -  ``trace_execution_times`` (``bool``) (default: ``False``): If ``True``,
-      SMP profiles the execution time of each module during tracing, and uses
+      the library profiles the execution time of each module during tracing, and uses
       it in the partitioning decision. This improves the partitioning
       decision, but it might make the tracing slower. It may also introduce
       some degree of non-determinism in partitioning results, because of the
@@ -100,7 +100,7 @@ This API document assumes you use the following import statements in your traini
 
    -  ``overlapping_allreduce`` (``bool``) (default: ``True``): This is only
       applicable for hybrid data parallelism/model parallelism use cases (when
-      ``ddp`` is set to ``True`` while launching training). SMP uses this flag
+      ``ddp`` is set to ``True`` while launching training). The library uses this flag
       to decide whether to do overlapping allreduce whenever a parameter
       gradients are ready. This leads to overlapping of communication and
       computation and can improve performance. If this is set to ``False`` ,
@@ -318,7 +318,7 @@ This API document assumes you use the following import statements in your traini
 .. data:: smp.nn.FusedLayerNorm
 
    `Apex Fused Layer Norm <https://nvidia.github.io/apex/layernorm.html>`__ is currently not
-   supported by SMP. ``smp.nn.FusedLayerNorm`` replaces ``apex``
+   supported by the library. ``smp.nn.FusedLayerNorm`` replaces ``apex``
    ``FusedLayerNorm`` and provides the same functionality. This requires
    ``apex`` to be installed on the system.
 
@@ -326,7 +326,7 @@ This API document assumes you use the following import statements in your traini
 
 
    `Fused Novo Grad optimizer <https://nvidia.github.io/apex/optimizers.html#apex.optimizers.FusedNovoGrad>`__ is
-   currently not supported by SMP. ``smp.optimizers.FusedNovoGrad`` replaces ``apex`` ``FusedNovoGrad``
+   currently not supported by the library. ``smp.optimizers.FusedNovoGrad`` replaces ``apex`` ``FusedNovoGrad``
    optimizer and provides the same functionality. This requires ``apex`` to
    be installed on the system.
 
@@ -334,14 +334,14 @@ This API document assumes you use the following import statements in your traini
 
 
    `FusedLamb optimizer <https://nvidia.github.io/apex/optimizers.html#apex.optimizers.FusedLAMB>`__
-   currently doesn’t work with SMP. ``smp.optimizers.FusedLamb`` replaces
+   currently doesn’t work with the library. ``smp.optimizers.FusedLamb`` replaces
    ``apex`` ``FusedLamb`` optimizer and provides the same functionality.
    This requires ``apex`` to be installed on the system.
 
 .. data:: smp.amp.GradScaler
 
    `Torch AMP Gradscaler <https://pytorch.org/docs/stable/amp.html#torch.cuda.amp.GradScaler>`__
-   currently doesn’t work with SMP. ``smp.amp.GradScaler`` replaces
+   currently doesn’t work with the library. ``smp.amp.GradScaler`` replaces
    ``torch.amp.GradScaler`` and provides the same functionality.
 
 
@@ -353,7 +353,7 @@ APIs for Saving and Loading
    Saves an object. This operation is similar to ``torch.save()``, except
    it has an additional keyword argument, ``partial``, and accepts only
    string type for the argument ``f`` (file). If ``partial=True``, each
-   ``mp_rank`` saves a separate checkpoint file and SMP adds an ``mp_rank``
+   ``mp_rank`` saves a separate checkpoint file and the library adds an ``mp_rank``
    index to your saved file.
 
    **Parameters**
@@ -361,7 +361,7 @@ APIs for Saving and Loading
    -  ``obj`` (dict): A saved object.
    -  ``f`` (str): A string containing a file name.
    -  ``partial`` (bool, default= ``True``):  When set to ``True``, each
-      ``mp_rank`` saves a separate checkpoint file and SMP adds an
+      ``mp_rank`` saves a separate checkpoint file and the library adds an
       ``mp_rank`` index to the saved file. If you want to be able to load
       and further train a model that you save with ``smp.save()``, you must
       set ``partial=True``.
@@ -392,16 +392,16 @@ APIs for Saving and Loading
       passed to ``pickle_module.load()`` and ``pickle_module.Unpickler()``.
    -  ``partial`` (bool, default= ``True``): When set to ``True``, each
       ``mp_rank`` loads the checkpoint corresponding to the ``mp_rank``.
-      Should be used when loading a model trained with SMP.
+      Should be used when loading a model trained with the library.
 
 General Instruction For Saving and Loading
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-SMP can save partial or full checkpoints.
+The library can save partial or full checkpoints.
 
 -  For partial checkpoints, each ``mp_rank`` saves its own checkpoint
    file with only the parameters that belong to that rank.
--  For full checkpoints, SMP saves a single checkpoint that contains
+-  For full checkpoints, the library saves a single checkpoint that contains
    entire model parameters.
 
 When **saving** using ``smp.save()``, each rank only holds its own
@@ -410,9 +410,9 @@ communication between the ranks to create the full model. If you save
 checkpoints often, you should save partial checkpoints for best
 performance.
 
-When **loading** using ``smp.load()``, SMP can load either partial or |
-full checkpoints or full checkpoints saved by a non-SMP model. If you
-want to resume training with a non-SMP model or do inference, you need
+When **loading** using ``smp.load()``, the library can load either partial or |
+full checkpoints or full checkpoints saved by a non-model-parallel model. If you
+want to resume training with a non-model-parallel model or do inference, you need
 a full checkpoint.
 
 The following is an example of how you can save and load a checkpoint:
@@ -423,14 +423,14 @@ The following is an example of how you can save and load a checkpoint:
    model = MyModel(...)
    optimizer = MyOpt(...)
 
-   # SMP wrapper
+   # model parallel wrapper
    model = smp.DistributedModel(model)
    optimizer = smp.DistributedOptimizer(optimizer)
 
    # To save, always save on dp_rank 0 to avoid data racing
    if partial:
        # To save the partial model on each mp rank
-       # SMP will create `checkpoint.pt_{mprank}` for each mp rank
+       # the library will create `checkpoint.pt_{mprank}` for each mp rank
        if save_partial_model:
            if smp.dp_rank() == 0:
                model_dict = model.local_state_dict() # save the partial model


### PR DESCRIPTION
*Description of changes:*

* Fix a couple of missing links
* Refactor distributed training libraries' naming convention.

**Please push a new version, so that the RTD website gets these updates ASAP.**

*Testing done:*

`tox -e black-check,flake8,pylint,docstyle,sphinx,doc8 --parallel all`

```
  black-check: commands succeeded
  flake8: commands succeeded
  pylint: commands succeeded
  docstyle: commands succeeded
  sphinx: commands succeeded
  doc8: commands succeeded
  congratulations :)
```
## Merge Checklist

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
