### PR TITLE
fix: Check if metadata dir exists locally before mounting

### DIFF
--- a/src/sagemaker/local/image.py
+++ b/src/sagemaker/local/image.py
@@ -469,9 +469,12 @@ class _SageMakerContainer(object):
 
         volumes.append(_Volume(model_dir, "/opt/ml/model"))
 
-        # Mount the metadata directory on the notebook instance,
-        # this is used by some DeepEngine libraries
-        volumes.append(_Volume("/opt/ml/metadata", "/opt/ml/metadata"))
+        # Mount the metadata directory if present.
+        # Only expected to be present on SM notebook instances.
+        # This is used by some DeepEngine libraries
+        metadata_dir = "/opt/ml/metadata"
+        if os.path.isdir(metadata_dir):
+            volumes.append(_Volume(metadata_dir, metadata_dir))
 
         # Set up the channels for the containers. For local data we will
         # mount the local directory to the container. For S3 Data we will download the S3 data


### PR DESCRIPTION
*Issue #, if available:*
Fixes https://github.com/aws/sagemaker-python-sdk/issues/2043  
Fixes https://github.com/aws/sagemaker-python-sdk/issues/2022
*Description of changes:*
Check if metadata dir exists locally before mounting
*Testing done:*
Tested on Mac locally, a scenario which threw the error reported earlier, and now works fine. 
## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
