### PR TITLE
fix: include sparkml 2.4 in image uri config properly

### DIFF
--- a/src/sagemaker/image_uri_config/sparkml-serving.json
+++ b/src/sagemaker/image_uri_config/sparkml-serving.json
@@ -29,8 +29,7 @@
                 "us-west-2": "246618743249"
             },
             "repository": "sagemaker-sparkml-serving"
-        }
-    },
+        },
         "2.4": {
             "registries": {
                 "af-south-1": "510948584623",
@@ -60,4 +59,5 @@
             },
             "repository": "sagemaker-sparkml-serving"
         }
+    }
 }

--- a/src/sagemaker/sparkml/model.py
+++ b/src/sagemaker/sparkml/model.py
@@ -70,7 +70,9 @@ class SparkMLModel(Model):
     model .
     """
 
-    def __init__(self, model_data, role=None, spark_version=2.4, sagemaker_session=None, **kwargs):
+    def __init__(
+        self, model_data, role=None, spark_version="2.4", sagemaker_session=None, **kwargs
+    ):
         """Initialize a SparkMLModel.
 
         Args:

--- a/tests/unit/sagemaker/image_uris/test_sparkml.py
+++ b/tests/unit/sagemaker/image_uris/test_sparkml.py
@@ -12,6 +12,8 @@
 # language governing permissions and limitations under the License.
 from __future__ import absolute_import
 
+import pytest
+
 from sagemaker import image_uris
 from tests.unit.sagemaker.image_uris import expected_uris, regions
 
@@ -41,14 +43,15 @@ ACCOUNTS = {
     "us-west-1": "746614075791",
     "us-west-2": "246618743249",
 }
-VERSION = "2.2"
+VERSIONS = ["2.2", "2.4"]
 
 
-def test_sparkml():
+@pytest.mark.parametrize("version", VERSIONS)
+def test_sparkml(version):
     for region in regions.regions():
-        uri = image_uris.retrieve("sparkml-serving", region=region, version=VERSION)
+        uri = image_uris.retrieve("sparkml-serving", region=region, version=version)
 
         expected = expected_uris.algo_uri(
-            "sagemaker-sparkml-serving", ACCOUNTS[region], region, version=VERSION
+            "sagemaker-sparkml-serving", ACCOUNTS[region], region, version=version
         )
         assert expected == uri

--- a/tests/unit/test_pipeline_model.py
+++ b/tests/unit/test_pipeline_model.py
@@ -97,7 +97,7 @@ def test_prepare_container_def(tfo, time, sagemaker_session):
         {
             "Environment": {"SAGEMAKER_DEFAULT_INVOCATIONS_ACCEPT": "text/csv"},
             "Image": "246618743249.dkr.ecr.us-west-2.amazonaws.com"
-            + "/sagemaker-sparkml-serving:2.2",
+            + "/sagemaker-sparkml-serving:2.4",
             "ModelDataUrl": "s3://bucket/model_2.tar.gz",
         },
     ]
@@ -335,7 +335,7 @@ def test_network_isolation(tfo, time, sagemaker_session):
                 "ModelDataUrl": "s3://bucket/model_1.tar.gz",
             },
             {
-                "Image": "246618743249.dkr.ecr.us-west-2.amazonaws.com/sagemaker-sparkml-serving:2.2",
+                "Image": "246618743249.dkr.ecr.us-west-2.amazonaws.com/sagemaker-sparkml-serving:2.4",
                 "Environment": {},
                 "ModelDataUrl": "s3://bucket/model_2.tar.gz",
             },


### PR DESCRIPTION
*Issue #, if available:*

fixes: #2021 

*Description of changes:*

changes include:
* properly include version 2.4 in image uri config
* updated default value to properly use `"2.4"` as string
* added unit test, updated tests

*Testing done:*

unit:

```
❯ tox --parallel 3 -- -rfE --disable-warnings tests/unit
✔ OK black-format in 11.873 seconds
✔ OK flake8 in 42.442 seconds
✔ OK docstyle in 46.608 seconds
✔ OK pylint in 59.418 seconds
✔ OK twine in 12.52 seconds
✔ OK doc8 in 16.759 seconds
✔ OK sphinx in 54.736 seconds
✔ OK py36 in 7 minutes, 37.158 seconds
✔ OK py37 in 7 minutes, 50.654 seconds
✔ OK py38 in 7 minutes, 32.257 seconds
```

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
