### PR TITLE
fix: update git utils temp file

### DIFF
--- a/src/sagemaker/git_utils.py
+++ b/src/sagemaker/git_utils.py
@@ -282,8 +282,7 @@ def _run_clone_command(repo_url, dest_dir):
             write_pipe = open(sshnoprompt.name, "w")
             write_pipe.write("ssh -oBatchMode=yes $@")
             write_pipe.close()
-            # 511 in decimal is same as 777 in octal
-            os.chmod(sshnoprompt.name, 511)
+            os.chmod(sshnoprompt.name, 0o511)
             my_env["GIT_SSH"] = sshnoprompt.name
             subprocess.check_call(["git", "clone", repo_url, dest_dir], env=my_env)
 

--- a/tests/unit/test_git_utils.py
+++ b/tests/unit/test_git_utils.py
@@ -15,7 +15,7 @@ from __future__ import absolute_import
 import pytest
 import os
 import subprocess
-from mock import patch
+from mock import patch, ANY
 
 from sagemaker import git_utils
 
@@ -180,7 +180,7 @@ def test_git_clone_repo_dependencies_not_exist(exists, isdir, isfile, mkdtemp, c
 @patch("subprocess.check_call")
 @patch("tempfile.mkdtemp", return_value=REPO_DIR)
 @patch("os.path.isfile", return_value=True)
-def test_git_clone_repo_with_username_password_no_2fa(sfile, mkdtemp, check_call):
+def test_git_clone_repo_with_username_password_no_2fa(isfile, mkdtemp, check_call):
     git_config = {
         "repo": PRIVATE_GIT_REPO,
         "branch": PRIVATE_BRANCH,
@@ -262,12 +262,14 @@ def test_git_clone_repo_with_token_2fa(isfile, mkdtemp, check_call):
 
 
 @patch("subprocess.check_call")
+@patch("os.chmod")
 @patch("tempfile.mkdtemp", return_value=REPO_DIR)
 @patch("os.path.isfile", return_value=True)
-def test_git_clone_repo_ssh(isfile, mkdtemp, check_call):
+def test_git_clone_repo_ssh(isfile, mkdtemp, chmod, check_call):
     git_config = {"repo": PRIVATE_GIT_REPO_SSH, "branch": PRIVATE_BRANCH, "commit": PRIVATE_COMMIT}
     entry_point = "entry_point"
     ret = git_utils.git_clone_repo(git_config, entry_point)
+    chmod.assert_any_call(ANY, 0o511)
     assert ret["entry_point"] == "/tmp/repo_dir/entry_point"
     assert ret["source_dir"] is None
     assert ret["dependencies"] is None


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

changes include:
* set permissions correctly using octal 0o511
* add assertions in unit tests

*Testing done:*

unit testing:
```
❯ tox --parallel 3 -- -rfE --disable-warnings tests/unit
✔ OK black-format in 12.333 seconds
✔ OK flake8 in 36.332 seconds
✔ OK docstyle in 39.275 seconds
✔ OK pylint in 53.395 seconds
✔ OK twine in 11.169 seconds
✔ OK doc8 in 16.069 seconds
✔ OK sphinx in 48.019 seconds
✔ OK py36 in 7 minutes, 5.922 seconds
✔ OK py37 in 7 minutes, 17.774 seconds
✔ OK py38 in 7 minutes, 7.518 seconds
```

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
