### PR TITLE
fix: remove shell=True in subprocess.check_output

### DIFF
--- a/src/sagemaker/local/image.py
+++ b/src/sagemaker/local/image.py
@@ -1067,7 +1067,7 @@ def _ecr_login_if_needed(boto_session, image):
     ecr_url = auth["authorizationData"][0]["proxyEndpoint"]
 
     cmd = "docker login -u AWS -p %s %s" % (token, ecr_url)
-    subprocess.check_output(cmd, shell=True)
+    subprocess.check_output(cmd.split())
 
     return True
 
@@ -1081,5 +1081,5 @@ def _pull_image(image):
     pull_image_command = ("docker pull %s" % image).strip()
     logger.info("docker command: %s", pull_image_command)
 
-    subprocess.check_output(pull_image_command, shell=True)
+    subprocess.check_output(pull_image_command.split())
     logger.info("image pulled: %s", image)

--- a/tests/unit/test_image.py
+++ b/tests/unit/test_image.py
@@ -765,7 +765,7 @@ def test_ecr_login_needed(check_output):
         "docker login -u AWS -p %s https://520713654638.dkr.ecr.us-east-1.amazonaws.com" % token
     )
 
-    check_output.assert_called_with(expected_command, shell=True)
+    check_output.assert_called_with(expected_command.split())
     session_mock.client("ecr").get_authorization_token.assert_called_with(
         registryIds=["520713654638"]
     )
@@ -781,7 +781,7 @@ def test_pull_image(check_output):
 
     expected_command = "docker pull %s" % image
 
-    check_output.assert_called_once_with(expected_command, shell=True)
+    check_output.assert_called_once_with(expected_command.split())
 
 
 def test__aws_credentials_with_long_lived_credentials():


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Using `shell=True` is a security risk - https://docs.python.org/2/library/subprocess.html#subprocess.check_output

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
