### PR TITLE
fix: assert step execution first in pipeline test

### DIFF
--- a/tests/integ/test_workflow.py
+++ b/tests/integ/test_workflow.py
@@ -508,7 +508,7 @@ def test_training_job_with_debugger(
         execution_steps = execution.list_steps()
 
         assert len(execution_steps) == 1
-        assert execution_steps[0]["FailureReason"] == ""
+        assert execution_steps[0].get("FailureReason", "") == ""
         assert execution_steps[0]["StepName"] == "pytorch-train"
         assert execution_steps[0]["StepStatus"] == "Succeeded"
 

--- a/tests/integ/test_workflow.py
+++ b/tests/integ/test_workflow.py
@@ -506,14 +506,16 @@ def test_training_job_with_debugger(
         except WaiterError:
             pass
         execution_steps = execution.list_steps()
+
+        assert len(execution_steps) == 1
+        assert execution_steps[0]["FailureReason"] == ""
+        assert execution_steps[0]["StepName"] == "pytorch-train"
+        assert execution_steps[0]["StepStatus"] == "Succeeded"
+
         training_job_arn = execution_steps[0]["Metadata"]["TrainingJob"]["Arn"]
         job_description = sagemaker_session.sagemaker_client.describe_training_job(
             TrainingJobName=training_job_arn.split("/")[1]
         )
-
-        assert len(execution_steps) == 1
-        assert execution_steps[0]["StepName"] == "pytorch-train"
-        assert execution_steps[0]["StepStatus"] == "Succeeded"
 
         for index, rule in enumerate(rules):
             config = job_description["DebugRuleConfigurations"][index]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This test is failing in ARN. Right now we are only seeing keyerror. this should output the failure reason in the log.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
