### PR TITLE
fix: increase time allowed for trial components to index

### DIFF
--- a/tests/integ/sagemaker/lineage/test_artifact.py
+++ b/tests/integ/sagemaker/lineage/test_artifact.py
@@ -78,10 +78,12 @@ def test_list(artifact_objs, sagemaker_session):
 
 
 def test_downstream_trials(trial_associated_artifact, trial_obj, sagemaker_session):
-    # wait for TC to index
-    time.sleep(3)
-
-    trials = trial_associated_artifact.downstream_trials(sagemaker_session=sagemaker_session)
+    # allow trial components to index, 30 seconds max
+    for i in range(3):
+        time.sleep(10)
+        trials = trial_associated_artifact.downstream_trials(sagemaker_session=sagemaker_session)
+        if len(trials) > 0:
+            break
 
     assert len(trials) == 1
     assert trial_obj.trial_name in trials


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

changes include:
* increase time allowed for trial components to index in integration testing

*Testing done:*



## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
