### PR TITLE
Add sleep time of 1s in lineage tests

### DIFF
--- a/tests/integ/sagemaker/lineage/test_action.py
+++ b/tests/integ/sagemaker/lineage/test_action.py
@@ -15,6 +15,7 @@ from __future__ import absolute_import
 
 import datetime
 import logging
+import time
 
 from sagemaker.lineage import action
 
@@ -90,6 +91,7 @@ def test_tag(action_obj, sagemaker_session):
         )["Tags"]
         if actual_tags:
             break
+        time.sleep(1)
     # When sagemaker-client-config endpoint-url is passed as argument to hit some endpoints,
     # length of actual tags will be greater than 1
     assert len(actual_tags) > 0
@@ -106,6 +108,7 @@ def test_tags(action_obj, sagemaker_session):
         )["Tags"]
         if actual_tags:
             break
+        time.sleep(1)
     # When sagemaker-client-config endpoint-url is passed as argument to hit some endpoints,
     # length of actual tags will be greater than 1
     assert len(actual_tags) > 0

--- a/tests/integ/sagemaker/lineage/test_artifact.py
+++ b/tests/integ/sagemaker/lineage/test_artifact.py
@@ -121,6 +121,7 @@ def test_tag(artifact_obj, sagemaker_session):
         )["Tags"]
         if actual_tags:
             break
+        time.sleep(1)
     # When sagemaker-client-config endpoint-url is passed as argument to hit some endpoints,
     # length of actual tags will be greater than 1
     assert len(actual_tags) > 0
@@ -137,6 +138,7 @@ def test_tags(artifact_obj, sagemaker_session):
         )["Tags"]
         if actual_tags:
             break
+        time.sleep(1)
     # When sagemaker-client-config endpoint-url is passed as argument to hit some endpoints,
     # length of actual tags will be greater than 1
     assert len(actual_tags) > 0

--- a/tests/integ/sagemaker/lineage/test_context.py
+++ b/tests/integ/sagemaker/lineage/test_context.py
@@ -15,6 +15,7 @@ from __future__ import absolute_import
 
 import datetime
 import logging
+import time
 
 from sagemaker.lineage import context
 
@@ -88,6 +89,7 @@ def test_tag(context_obj, sagemaker_session):
         )["Tags"]
         if actual_tags:
             break
+        time.sleep(1)
     # When sagemaker-client-config endpoint-url is passed as argument to hit some endpoints,
     # length of actual tags will be greater than 1
     assert len(actual_tags) > 0
@@ -104,6 +106,7 @@ def test_tags(context_obj, sagemaker_session):
         )["Tags"]
         if actual_tags:
             break
+        time.sleep(1)
     # When sagemaker-client-config endpoint-url is passed as argument to hit some endpoints,
     # length of actual tags will be greater than 1
     assert len(actual_tags) > 0


### PR DESCRIPTION
*Issue #, if available:* https://sim.amazon.com/issues/AML-97027

*Description of changes:* Remove  pytest test skips in association integration tests

*Testing done:* 

tox -e py39 -- tests/unit/sagemaker/lineage

collected 45 items

tests/unit/sagemaker/lineage/test_action.py ........... [ 24%]
tests/unit/sagemaker/lineage/test_artifact.py ............ [ 51%]
tests/unit/sagemaker/lineage/test_association.py ....... [ 66%]
tests/unit/sagemaker/lineage/test_context.py ........... [ 91%]
tests/unit/sagemaker/lineage/test_dataset_artifact.py . [ 93%]
tests/unit/sagemaker/lineage/test_endpoint_context.py . [ 95%]
tests/unit/sagemaker/lineage/test_model_artifact.py . [ 97%]
tests/unit/sagemaker/lineage/test_visualizer.py . [100%]

-> tox -e py39 -- tests/integ/sagemaker/lineage

collected 28 items

tests/integ/sagemaker/lineage/test_action.py ....... [ 25%]
tests/integ/sagemaker/lineage/test_artifact.py ........ [ 53%]
tests/integ/sagemaker/lineage/test_association.py sss [ 64%]
tests/integ/sagemaker/lineage/test_context.py ....... [ 89%]
tests/integ/sagemaker/lineage/test_dataset_artifact.py . [ 92%]
tests/integ/sagemaker/lineage/test_endpoint_context.py . [ 96%]
tests/integ/sagemaker/lineage/test_model_artifact.py . [100%]


