### PR TITLE
test_tag/test_tags method assert fix in association tests

### DIFF
--- a/tests/integ/sagemaker/lineage/test_action.py
+++ b/tests/integ/sagemaker/lineage/test_action.py
@@ -90,8 +90,8 @@ def test_tag(action_obj, sagemaker_session):
         )["Tags"]
         if actual_tags:
             break
-    # When sagemaker-client-config endpoint-url is passed as argument to hit beta,
-    # length of actual tags will be 2
+    # When sagemaker-client-config endpoint-url is passed as argument to hit some endpoints,
+    # length of actual tags will be greater than 1
     assert len(actual_tags) > 0
     assert actual_tags[0] == tag
 
@@ -106,7 +106,7 @@ def test_tags(action_obj, sagemaker_session):
         )["Tags"]
         if actual_tags:
             break
-    # When sagemaker-client-config endpoint-url is passed as argument to hit beta,
-    # length of actual tags will be 2
+    # When sagemaker-client-config endpoint-url is passed as argument to hit some endpoints,
+    # length of actual tags will be greater than 1
     assert len(actual_tags) > 0
     assert [actual_tags[-1]] == tags

--- a/tests/integ/sagemaker/lineage/test_artifact.py
+++ b/tests/integ/sagemaker/lineage/test_artifact.py
@@ -121,8 +121,8 @@ def test_tag(artifact_obj, sagemaker_session):
         )["Tags"]
         if actual_tags:
             break
-    # When sagemaker-client-config endpoint-url is passed as argument to hit beta,
-    # length of actual tags will be 2
+    # When sagemaker-client-config endpoint-url is passed as argument to hit some endpoints,
+    # length of actual tags will be greater than 1
     assert len(actual_tags) > 0
     assert actual_tags[0] == tag
 
@@ -137,7 +137,7 @@ def test_tags(artifact_obj, sagemaker_session):
         )["Tags"]
         if actual_tags:
             break
-    # When sagemaker-client-config endpoint-url is passed as argument to hit beta,
-    # length of actual tags will be 2
+    # When sagemaker-client-config endpoint-url is passed as argument to hit some endpoints,
+    # length of actual tags will be greater than 1
     assert len(actual_tags) > 0
     assert [actual_tags[-1]] == tags

--- a/tests/integ/sagemaker/lineage/test_association.py
+++ b/tests/integ/sagemaker/lineage/test_association.py
@@ -66,7 +66,9 @@ def test_set_tag(association_obj, sagemaker_session):
         if actual_tags:
             break
         time.sleep(1)
-    assert len(actual_tags) == 1
+    # When sagemaker-client-config endpoint-url is passed as argument to hit some endpoints,
+    # length of actual tags will be greater than 1
+    assert len(actual_tags) > 0
     assert actual_tags[0] == tag
 
 
@@ -81,5 +83,7 @@ def test_tags(association_obj, sagemaker_session):
         if actual_tags:
             break
         time.sleep(1)
-    assert len(actual_tags) == 1
-    assert actual_tags == tags
+    # When sagemaker-client-config endpoint-url is passed as argument to hit some endpoints,
+    # length of actual tags will be greater than 1
+    assert len(actual_tags) > 0
+    assert [actual_tags[-1]] == tags

--- a/tests/integ/sagemaker/lineage/test_context.py
+++ b/tests/integ/sagemaker/lineage/test_context.py
@@ -88,8 +88,8 @@ def test_tag(context_obj, sagemaker_session):
         )["Tags"]
         if actual_tags:
             break
-    # When sagemaker-client-config endpoint-url is passed as argument to hit beta,
-    # length of actual tags will be 2
+    # When sagemaker-client-config endpoint-url is passed as argument to hit some endpoints,
+    # length of actual tags will be greater than 1
     assert len(actual_tags) > 0
     assert actual_tags[0] == tag
 
@@ -104,7 +104,7 @@ def test_tags(context_obj, sagemaker_session):
         )["Tags"]
         if actual_tags:
             break
-    # When sagemaker-client-config endpoint-url is passed as argument to hit beta,
-    # length of actual tags will be 2
+    # When sagemaker-client-config endpoint-url is passed as argument to hit some endpoints,
+    # length of actual tags will be greater than 1
     assert len(actual_tags) > 0
     assert [actual_tags[-1]] == tags


### PR DESCRIPTION
*Issue #, if available:* https://sim.amazon.com/issues/AML-109079

*Description of changes:* Fix assert statements in test_tag/test_tags method in association tests

*Testing done:*  tox -e py39 -- tests/integ/sagemaker/lineage --sagemaker-client-config {\"endpoint_url\":\"https://api.sagemaker.beta.us-west-2.ml-platform.aws.a2z.com\"}

collected 30 items                                                                                                                                                                                                                        

tests/integ/sagemaker/lineage/test_action.py .......                                                                                                                                                                                [ 23%]
tests/integ/sagemaker/lineage/test_artifact.py .........                                                                                                                                                                            [ 53%]
tests/integ/sagemaker/lineage/test_association.py ....                                                                                                                                                                              [ 66%]
tests/integ/sagemaker/lineage/test_context.py .......                                                                                                                                                                               [ 90%]
tests/integ/sagemaker/lineage/test_dataset_artifact.py .                                                                                                                                                                            [ 93%]
tests/integ/sagemaker/lineage/test_endpoint_context.py .                                                                                                                                                                            [ 96%]
tests/integ/sagemaker/lineage/test_model_artifact.py .                                                                                                                                                                              [100%]


