### PR TITLE
documentation: removing mention of TF 2.4 from SM mp docs

### DIFF
--- a/doc/api/training/smd_model_parallel_release_notes/smd_model_parallel_change_log.md
+++ b/doc/api/training/smd_model_parallel_release_notes/smd_model_parallel_change_log.md
@@ -17,10 +17,6 @@
 
 - Adds support for `_register_comm_hook` (PyTorch 1.7 only) which will register the callable as a communication hook for DDP. NOTE: Like in DDP, this is an experimental API and subject to change.
 
-### Tensorflow
-
-- Adds support for Tensorflow 2.4
-
 ## Bug Fixes
 
 ### PyTorch

--- a/doc/api/training/smp_versions/v1.2.0/smd_model_parallel_tensorflow.rst
+++ b/doc/api/training/smp_versions/v1.2.0/smd_model_parallel_tensorflow.rst
@@ -1,7 +1,7 @@
 TensorFlow API
 ==============
 
-**Supported version: 2.4, 2.3**
+**Supported version: 2.3**
 
 **Important**: This API document assumes you use the following import statement in your training scripts.
 


### PR DESCRIPTION
*Description of changes:*
* removing mention of TF 2.4 from SM distributed model parallel docs

*Testing done:*
`tox -e black-check,flake8,pylint,docstyle,sphinx,doc8 --parallel all`

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
