### PR TITLE
fix: pin astroid to 2.4.2

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -85,6 +85,7 @@ skipdist = true
 skip_install = true
 deps =
     pylint
+    astroid==2.4.2
 commands =
     python -m pylint --rcfile=.pylintrc -j 0 src/sagemaker
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

a recent update to a transitive dep rolled in that caused breakages: https://pypi.org/project/astroid/#history

changes include:
* pin astroid to 2.4.2 for the time being

*Testing done:*

```
❯ tox -e pylint
...
pylint installdeps: pylint, astroid==2.4.2
pylint installed: astroid==2.4.2,isort==5.7.0,lazy-object-proxy==1.4.3,mccabe==0.6.1,pylint==2.6.0,six==1.15.0,toml==0.10.2,wrapt==1.12.1
pylint run-test-pre: PYTHONHASHSEED='231695462'
pylint run-test: commands[0] | python -m pylint --rcfile=.pylintrc -j 0 src/sagemaker

--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

______________________________________________ summary ______________________________________________
  pylint: commands succeeded
  congratulations :)
tox -e pylint  84.45s user 1.92s system 309% cpu 27.884 total
```

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
