### PR TITLE
change: use sagemaker_session in workflow tests

### DIFF
--- a/tests/integ/test_workflow.py
+++ b/tests/integ/test_workflow.py
@@ -18,10 +18,8 @@ import re
 import time
 import uuid
 
-import boto3
 import pytest
 
-from botocore.config import Config
 from botocore.exceptions import WaiterError
 from sagemaker.debugger import (
     DebuggerHookConfig,
@@ -32,7 +30,7 @@ from sagemaker.inputs import CreateModelInput, TrainingInput
 from sagemaker.model import Model
 from sagemaker.processing import ProcessingInput, ProcessingOutput
 from sagemaker.pytorch.estimator import PyTorch
-from sagemaker.session import get_execution_role, Session
+from sagemaker.session import get_execution_role
 from sagemaker.sklearn.estimator import SKLearn
 from sagemaker.sklearn.processing import SKLearnProcessor
 from sagemaker.workflow.conditions import ConditionGreaterThanOrEqualTo

--- a/tests/integ/test_workflow.py
+++ b/tests/integ/test_workflow.py
@@ -75,21 +75,6 @@ def role(sagemaker_session):
 
 
 @pytest.fixture(scope="module")
-def workflow_session(region_name):
-    boto_session = boto3.Session(region_name=region_name)
-
-    sagemaker_client_config = dict()
-    sagemaker_client_config.setdefault("config", Config(retries=dict(max_attempts=2)))
-    sagemaker_client = boto_session.client("sagemaker", **sagemaker_client_config)
-
-    return Session(
-        boto_session=boto_session,
-        sagemaker_client=sagemaker_client,
-        sagemaker_runtime_client=None,
-    )
-
-
-@pytest.fixture(scope="module")
 def script_dir():
     return os.path.join(DATA_DIR, "sklearn_processing")
 
@@ -119,7 +104,6 @@ def athena_dataset_definition(sagemaker_session):
 
 def test_three_step_definition(
     sagemaker_session,
-    workflow_session,
     region_name,
     role,
     script_dir,
@@ -205,7 +189,7 @@ def test_three_step_definition(
         name=pipeline_name,
         parameters=[instance_type, instance_count, output_prefix],
         steps=[step_process, step_train, step_model],
-        sagemaker_session=workflow_session,
+        sagemaker_session=sagemaker_session,
     )
 
     definition = json.loads(pipeline.definition())
@@ -277,7 +261,6 @@ def test_three_step_definition(
 
 def test_one_step_sklearn_processing_pipeline(
     sagemaker_session,
-    workflow_session,
     role,
     sklearn_latest_version,
     cpu_instance_type,
@@ -313,7 +296,7 @@ def test_one_step_sklearn_processing_pipeline(
         name=pipeline_name,
         parameters=[instance_count],
         steps=[step_sklearn],
-        sagemaker_session=workflow_session,
+        sagemaker_session=sagemaker_session,
     )
 
     try:
@@ -363,7 +346,6 @@ def test_one_step_sklearn_processing_pipeline(
 
 def test_conditional_pytorch_training_model_registration(
     sagemaker_session,
-    workflow_session,
     role,
     cpu_instance_type,
     pipeline_name,
@@ -433,7 +415,7 @@ def test_conditional_pytorch_training_model_registration(
         name=pipeline_name,
         parameters=[good_enough_input, instance_count, instance_type],
         steps=[step_cond],
-        sagemaker_session=workflow_session,
+        sagemaker_session=sagemaker_session,
     )
 
     try:


### PR DESCRIPTION
*Issue #, if available:*
We are using a separate workflow_session in some of the workflow tests which is not required. We can simply use sagemaker_session.

*Description of changes:*
updated test_workflow.py to use sagemaker_session in all the tests

*Testing done:*
Ran integ tests locally

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
