### PR TITLE
fix: use ECR public for multidatamodel tests

### DIFF
--- a/buildspec-slowtests.yml
+++ b/buildspec-slowtests.yml
@@ -1,6 +1,10 @@
 version: 0.2
 
 phases:
+  pre_build:
+    commands:
+      - start-dockerd
+
   build:
     commands:
       - IGNORE_COVERAGE=-

--- a/buildspec-slowtests.yml
+++ b/buildspec-slowtests.yml
@@ -11,5 +11,5 @@ phases:
 
       # slow tests
       - start_time=`date +%s`
-      - execute-command-if-has-matching-changes "tox -e py38 -- tests/integ -m slow_test -n 10 --durations 0" "tests/integ" "tests/data" "tests/conftest.py" "tests/__init__.py" "src/*.py" "setup.py" "setup.cfg" "buildspec-slowtests.yml"
+      - execute-command-if-has-matching-changes "tox -e py38 -- tests/integ -m slow_test -n 16 --durations 0" "tests/integ" "tests/data" "tests/conftest.py" "tests/__init__.py" "src/*.py" "setup.py" "setup.cfg" "buildspec-slowtests.yml"
       - ./ci-scripts/displaytime.sh 'py38 slow tests' $start_time

--- a/tests/data/multimodel/container/Dockerfile
+++ b/tests/data/multimodel/container/Dockerfile
@@ -1,4 +1,4 @@
-FROM 142577830533.dkr.ecr.us-east-2.amazonaws.com/ubuntu:16.04
+FROM public.ecr.aws/ubuntu/ubuntu:18.04
 
 # Set a docker label to advertise multi-model support on the container
 LABEL com.amazonaws.sagemaker.capabilities.multi-models=true
@@ -15,7 +15,7 @@ RUN apt-get update && \
     curl \
     vim \
     && rm -rf /var/lib/apt/lists/* \
-    && curl -O https://bootstrap.pypa.io/3.5/get-pip.py \
+    && curl -O https://bootstrap.pypa.io/get-pip.py \
     && python3 get-pip.py
 
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1

--- a/tests/integ/test_lda.py
+++ b/tests/integ/test_lda.py
@@ -26,6 +26,7 @@ from tests.integ.timeout import timeout, timeout_and_delete_endpoint_by_name
 from tests.integ.record_set import prepare_record_set_from_local_files
 
 
+@pytest.mark.slow_test
 @pytest.mark.skipif(
     tests.integ.test_region() in tests.integ.NO_LDA_REGIONS,
     reason="LDA image is not supported in certain regions",

--- a/tests/integ/test_model_quality_monitor.py
+++ b/tests/integ/test_model_quality_monitor.py
@@ -230,6 +230,7 @@ def test_model_quality_monitor(
     monitor.delete_monitoring_schedule()
 
 
+@pytest.mark.slow_test
 @pytest.mark.skipif(
     tests.integ.test_region() in tests.integ.NO_MODEL_MONITORING_REGIONS,
     reason="ModelMonitoring is not yet supported in this region.",

--- a/tests/integ/test_multidatamodel.py
+++ b/tests/integ/test_multidatamodel.py
@@ -22,8 +22,6 @@ import numpy
 import pytest
 from botocore.exceptions import ClientError
 
-import tests
-
 from sagemaker import utils
 from sagemaker.amazon.randomcutforest import RandomCutForest
 from sagemaker.deserializers import StringDeserializer
@@ -52,10 +50,6 @@ def container_image(sagemaker_session):
     username, password = _ecr_login(ecr_client)
 
     docker_client = docker.from_env()
-
-    # Base image pull
-    base_image = "142577830533.dkr.ecr.us-east-2.amazonaws.com/ubuntu:16.04"
-    docker_client.images.pull(base_image, auth_config={"username": username, "password": password})
 
     # Build and tag docker image locally
     image, build_log = docker_client.images.build(
@@ -134,10 +128,6 @@ def _ecr_login(ecr_client):
     return username, password
 
 
-@pytest.mark.skipif(
-    tests.integ.test_region() != "us-east-2",
-    reason="Pulling the base image is currently limited to us-east-2.",
-)
 def test_multi_data_model_deploy_pretrained_models(
     container_image, sagemaker_session, cpu_instance_type
 ):
@@ -198,10 +188,6 @@ def test_multi_data_model_deploy_pretrained_models(
 
 
 @pytest.mark.local_mode
-@pytest.mark.skipif(
-    tests.integ.test_region() != "us-east-2",
-    reason="Pulling the base image is currently limited to us-east-2.",
-)
 def test_multi_data_model_deploy_pretrained_models_local_mode(container_image, sagemaker_session):
     timestamp = sagemaker_timestamp()
     endpoint_name = "test-multimodel-endpoint-{}".format(timestamp)
@@ -262,11 +248,6 @@ def test_multi_data_model_deploy_pretrained_models_local_mode(container_image, s
         assert "Could not find endpoint" in str(exception.value)
 
 
-@pytest.mark.slow_test
-@pytest.mark.skipif(
-    tests.integ.test_region() != "us-east-2",
-    reason="Pulling the base image is currently limited to us-east-2.",
-)
 def test_multi_data_model_deploy_trained_model_from_framework_estimator(
     container_image,
     sagemaker_session,
@@ -381,10 +362,7 @@ def _mxnet_training_job(
         return mx.create_model(image_uri=container_image)
 
 
-@pytest.mark.skipif(
-    tests.integ.test_region() != "us-east-2",
-    reason="Pulling the base image is currently limited to us-east-2.",
-)
+@pytest.mark.slow_test
 def test_multi_data_model_deploy_train_model_from_amazon_first_party_estimator(
     container_image, sagemaker_session, cpu_instance_type
 ):
@@ -482,11 +460,6 @@ def __rcf_training_job(
         return rcf_model
 
 
-@pytest.mark.slow_test
-@pytest.mark.skipif(
-    tests.integ.test_region() != "us-east-2",
-    reason="Pulling the base image is currently limited to us-east-2.",
-)
 def test_multi_data_model_deploy_pretrained_models_update_endpoint(
     container_image, sagemaker_session, cpu_instance_type, alternative_cpu_instance_type
 ):

--- a/tests/integ/test_tf.py
+++ b/tests/integ/test_tf.py
@@ -155,6 +155,7 @@ def test_mnist_distributed(
     )
 
 
+@pytest.mark.slow_test
 def test_mnist_async(sagemaker_session, cpu_instance_type, tf_full_version, tf_full_py_version):
     estimator = TensorFlow(
         entry_point=SCRIPT,

--- a/tests/integ/test_tuner.py
+++ b/tests/integ/test_tuner.py
@@ -402,6 +402,7 @@ def test_tuning_kmeans_identical_dataset_algorithm_tuner_from_non_terminal_paren
         )
 
 
+@pytest.mark.slow_test
 @pytest.mark.skipif(
     tests.integ.test_region() in tests.integ.NO_LDA_REGIONS,
     reason="LDA image is not supported in certain regions",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Couple of the slow tests were not running because the slow tests run in us-west-2 and the multimodel tests only runs in us-east-2. They only run in us-east-2 because the base ubuntu16 image was only pushed to us-east-2 in the dev account. Switching to ECR public and upgrade to ubuntu18 so we can run the tests in all regions. 

This change also mark a few more tests as slow_test.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
