### PR TITLE
fix: remove FailStep from pipelines

### DIFF
--- a/doc/workflows/pipelines/sagemaker.workflow.pipelines.rst
+++ b/doc/workflows/pipelines/sagemaker.workflow.pipelines.rst
@@ -110,8 +110,6 @@ Steps
 
 .. autoclass:: sagemaker.workflow.steps.ProcessingStep
 
-.. autoclass:: sagemaker.workflow.steps.FailStep
-
 Utilities
 ---------
 

--- a/src/sagemaker/workflow/steps.py
+++ b/src/sagemaker/workflow/steps.py
@@ -50,7 +50,6 @@ class StepTypeEnum(Enum, metaclass=DefaultEnumMeta):
 
     CONDITION = "Condition"
     CREATE_MODEL = "Model"
-    FAIL = "Fail"
     PROCESSING = "Processing"
     REGISTER_MODEL = "RegisterModel"
     TRAINING = "Training"
@@ -341,44 +340,3 @@ class ProcessingStep(Step):
                 property_file.expr for property_file in self.property_files
             ]
         return request_dict
-
-
-class FailStep(Step):
-    """Pipeline step to indicate failure."""
-
-    def __init__(self, name: str = "Fail"):
-        """Construct a FailStep.
-
-        Causes the pipeline execution to terminate in a failed state.
-
-        Args:
-            name (str): The name of the step.
-        """
-        super(FailStep, self).__init__(name, StepTypeEnum.FAIL)
-        root_path = f"Steps.{name}"
-        root_prop = Properties(path=root_path)
-        root_prop.__dict__["Fail"] = Properties(f"{root_path}.Fail")
-        self._properties = root_prop
-
-    @property
-    def arguments(self) -> RequestType:
-        """The arguments to the particular step service call."""
-        return {}
-
-    @property
-    def properties(self):
-        """The properties of the particular step."""
-        return self._properties
-
-    def to_request(self) -> RequestType:
-        """Get the request structure for workflow service calls."""
-        return {
-            "Name": self.name,
-            "Type": self.step_type.value,
-            "Arguments": self.arguments,
-        }
-
-    @property
-    def ref(self) -> Dict[str, str]:
-        """Get a reference dict for steps"""
-        return {"Name": self.name}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

remove unsupported `FailStep`

*Testing done:*

```
❯ tox --parallel 3 -- -rfE --disable-warnings tests/unit
✔ OK flake8 in 35.836 seconds
✔ OK black-format in 46.193 seconds
✔ OK pylint in 53.496 seconds
✔ OK docstyle in 36.988 seconds
✔ OK doc8 in 34.241 seconds
✔ OK twine in 42.776 seconds
✔ OK sphinx in 3 minutes, 31.701 seconds
✔ OK py36 in 9 minutes, 32.944 seconds
✔ OK py37 in 9 minutes, 32.309 seconds
✔ OK py38 in 7 minutes, 54.123 seconds
```

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
