### PR TITLE
infra: unblock regional release builds

### DIFF
--- a/buildspec-release.yml
+++ b/buildspec-release.yml
@@ -18,4 +18,4 @@ phases:
         tox -e py36,py37,py38 -- tests/unit
 
       # run a subset of the integration tests
-      - IGNORE_COVERAGE=- tox -e py36 -- tests/integ -m canary_quick -n 32 --boxed --reruns 2
+      - IGNORE_COVERAGE=- tox -e py36 -- tests/integ -m not (local_mode or slow_test) -n 32 --boxed --reruns 2

--- a/buildspec-release.yml
+++ b/buildspec-release.yml
@@ -18,4 +18,4 @@ phases:
         tox -e py36,py37,py38 -- tests/unit
 
       # run a subset of the integration tests
-      - IGNORE_COVERAGE=- tox -e py36 -- tests/integ -m canary_quick -n 64 --boxed --reruns 2
+      - IGNORE_COVERAGE=- tox -e py36 -- tests/integ -m canary_quick -n 32 --boxed --reruns 2

--- a/tests/integ/test_experiments_analytics.py
+++ b/tests/integ/test_experiments_analytics.py
@@ -128,22 +128,6 @@ def test_experiment_analytics_artifacts(sagemaker_session):
         ]
 
 
-@pytest.mark.canary_quick
-def test_experiment_analytics(sagemaker_session):
-    with experiment(sagemaker_session) as experiment_name:
-        analytics = ExperimentAnalytics(
-            experiment_name=experiment_name, sagemaker_session=sagemaker_session
-        )
-
-        assert list(analytics.dataframe().columns) == [
-            "TrialComponentName",
-            "DisplayName",
-            "hp1",
-            "Trials",
-            "Experiments",
-        ]
-
-
 def test_experiment_analytics_pagination(sagemaker_session):
     with experiment(sagemaker_session) as experiment_name:
         analytics = ExperimentAnalytics(


### PR DESCRIPTION
*Description of changes:*
- reduce concurrency of release builds to reduce likelihood of throttling
- increase test set to `not (local_mode or slow_test)`
- eliminate redundant `experiment_analytics` test

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
