### PR TITLE
infra: remove canary_quick pytest mark from flaky/unnecessary tests

### DIFF
--- a/tests/integ/test_airflow_config.py
+++ b/tests/integ/test_airflow_config.py
@@ -475,7 +475,6 @@ def test_mxnet_airflow_config_uploads_data_source_to_s3(
         )
 
 
-@pytest.mark.canary_quick
 def test_sklearn_airflow_config_uploads_data_source_to_s3(
     sagemaker_session,
     cpu_instance_type,

--- a/tests/integ/test_airflow_config.py
+++ b/tests/integ/test_airflow_config.py
@@ -402,7 +402,6 @@ def test_rcf_airflow_config_uploads_data_source_to_s3(sagemaker_session, cpu_ins
         )
 
 
-@pytest.mark.canary_quick
 def test_chainer_airflow_config_uploads_data_source_to_s3(
     sagemaker_local_session, cpu_instance_type, chainer_latest_version, chainer_latest_py_version
 ):

--- a/tests/integ/test_chainer.py
+++ b/tests/integ/test_chainer.py
@@ -70,7 +70,6 @@ def test_training_with_additional_hyperparameters(
     chainer.fit({"train": train_input, "test": test_input})
 
 
-@pytest.mark.canary_quick
 def test_attach_deploy(
     sagemaker_session, chainer_latest_version, chainer_latest_py_version, cpu_instance_type
 ):

--- a/tests/integ/test_debugger.py
+++ b/tests/integ/test_debugger.py
@@ -528,7 +528,6 @@ def test_mxnet_with_tensorboard_output_config(
         _wait_and_assert_that_no_rule_jobs_errored(training_job=mx.latest_training_job)
 
 
-@pytest.mark.canary_quick
 def test_mxnet_with_all_rules_and_configs(
     sagemaker_session,
     mxnet_training_latest_version,

--- a/tests/integ/test_mxnet.py
+++ b/tests/integ/test_mxnet.py
@@ -305,7 +305,6 @@ def test_deploy_model_and_update_endpoint(
         assert new_config["ProductionVariants"][0]["InitialInstanceCount"] == 1
 
 
-@pytest.mark.canary_quick
 @pytest.mark.skipif(
     tests.integ.test_region() not in tests.integ.EI_SUPPORTED_REGIONS,
     reason="EI isn't supported in that specific region.",


### PR DESCRIPTION
*Description of changes:*
Remove the `canary_quick` pytest mark from some tests that are flaky, redundant, or otherwise not needed.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
