### PR TITLE
infra: rename canary_quick pytest mark to release

### DIFF
--- a/tests/integ/test_artifact_analytics.py
+++ b/tests/integ/test_artifact_analytics.py
@@ -44,7 +44,7 @@ def generate_artifacts(sagemaker_session):
         _delete_resources(artifacts)
 
 
-@pytest.mark.canary_quick
+@pytest.mark.release
 @pytest.mark.skip("Failing as restricted to the SageMaker/Pipeline runtimes")
 def test_artifact_analytics(sagemaker_session):
     with generate_artifacts(sagemaker_session):

--- a/tests/integ/test_auto_ml.py
+++ b/tests/integ/test_auto_ml.py
@@ -52,7 +52,7 @@ EXPECTED_DEFAULT_JOB_CONFIG = {
     tests.integ.test_region() in tests.integ.NO_AUTO_ML_REGIONS,
     reason="AutoML is not supported in the region yet.",
 )
-@pytest.mark.canary_quick
+@pytest.mark.release
 def test_auto_ml_fit(sagemaker_session):
     auto_ml = AutoML(
         role=ROLE,
@@ -260,7 +260,7 @@ def test_best_candidate(sagemaker_session):
     tests.integ.test_region() in tests.integ.NO_AUTO_ML_REGIONS,
     reason="AutoML is not supported in the region yet.",
 )
-@pytest.mark.canary_quick
+@pytest.mark.release
 def test_deploy_best_candidate(sagemaker_session, cpu_instance_type):
     auto_ml_utils.create_auto_ml_job_if_not_exist(sagemaker_session)
 

--- a/tests/integ/test_byo_estimator.py
+++ b/tests/integ/test_byo_estimator.py
@@ -46,7 +46,7 @@ class _FactorizationMachineSerializer(SimpleBaseSerializer):
         return json.dumps(js)
 
 
-@pytest.mark.canary_quick
+@pytest.mark.release
 def test_byo_estimator(sagemaker_session, region, cpu_instance_type, training_set):
     """Use Factorization Machines algorithm as an example here.
 

--- a/tests/integ/test_experiments_analytics.py
+++ b/tests/integ/test_experiments_analytics.py
@@ -108,7 +108,7 @@ def experiment_with_artifacts(sagemaker_session):
         _delete_resources(sm, experiment_name, trials)
 
 
-@pytest.mark.canary_quick
+@pytest.mark.release
 def test_experiment_analytics_artifacts(sagemaker_session):
     with experiment_with_artifacts(sagemaker_session) as experiment_name:
         analytics = ExperimentAnalytics(

--- a/tests/integ/test_horovod.py
+++ b/tests/integ/test_horovod.py
@@ -28,7 +28,7 @@ from tests.integ import timeout
 horovod_dir = os.path.join(os.path.dirname(__file__), "..", "data", "horovod")
 
 
-@pytest.mark.canary_quick
+@pytest.mark.release
 def test_hvd_cpu(
     sagemaker_session,
     tensorflow_training_latest_version,
@@ -45,7 +45,7 @@ def test_hvd_cpu(
     )
 
 
-@pytest.mark.canary_quick
+@pytest.mark.release
 @pytest.mark.skipif(
     integ.test_region() in integ.TRAINING_NO_P2_REGIONS, reason="no ml.p2 instances in this region"
 )

--- a/tests/integ/test_horovod_mx.py
+++ b/tests/integ/test_horovod_mx.py
@@ -28,7 +28,7 @@ from tests.integ import timeout
 horovod_dir = os.path.join(os.path.dirname(__file__), "..", "data", "horovod")
 
 
-@pytest.mark.canary_quick
+@pytest.mark.release
 def test_hvd_cpu(
     mxnet_training_latest_version,
     mxnet_training_latest_py_version,
@@ -45,7 +45,7 @@ def test_hvd_cpu(
     )
 
 
-@pytest.mark.canary_quick
+@pytest.mark.release
 @pytest.mark.skipif(
     integ.test_region() in integ.TRAINING_NO_P2_REGIONS, reason="no ml.p2 instances in this region"
 )

--- a/tests/integ/test_inference_pipeline.py
+++ b/tests/integ/test_inference_pipeline.py
@@ -90,7 +90,7 @@ def test_inference_pipeline_batch_transform(sagemaker_session, cpu_instance_type
         transformer.wait()
 
 
-@pytest.mark.canary_quick
+@pytest.mark.release
 @pytest.mark.skip(
     reason="This test has always failed, but the failure was masked by a bug. "
     "This test should be fixed. Details in https://github.com/aws/sagemaker-python-sdk/pull/968"

--- a/tests/integ/test_linear_learner.py
+++ b/tests/integ/test_linear_learner.py
@@ -28,7 +28,7 @@ def training_set():
     return datasets.one_p_mnist()
 
 
-@pytest.mark.canary_quick
+@pytest.mark.release
 def test_linear_learner(sagemaker_session, cpu_instance_type, training_set):
     job_name = unique_name_from_base("linear-learner")
 

--- a/tests/integ/test_marketplace.py
+++ b/tests/integ/test_marketplace.py
@@ -51,7 +51,7 @@ MODEL_PACKAGE_ARN = (
 )
 
 
-@pytest.mark.canary_quick
+@pytest.mark.release
 @pytest.mark.skipif(
     tests.integ.test_region() in tests.integ.NO_MARKET_PLACE_REGIONS,
     reason="Marketplace is not available in {}".format(tests.integ.test_region()),
@@ -150,7 +150,7 @@ def test_marketplace_attach(sagemaker_session, cpu_instance_type):
         print(predictor.predict(test_x.values).decode("utf-8"))
 
 
-@pytest.mark.canary_quick
+@pytest.mark.release
 @pytest.mark.skipif(
     tests.integ.test_region() in tests.integ.NO_MARKET_PLACE_REGIONS,
     reason="Marketplace is not available in {}".format(tests.integ.test_region()),

--- a/tests/integ/test_model_monitor.py
+++ b/tests/integ/test_model_monitor.py
@@ -271,7 +271,7 @@ def updated_output_kms_key(sagemaker_session):
     tests.integ.test_region() in tests.integ.NO_MODEL_MONITORING_REGIONS,
     reason="ModelMonitoring is not yet supported in this region.",
 )
-@pytest.mark.canary_quick
+@pytest.mark.release
 def test_default_monitor_suggest_baseline_and_create_monitoring_schedule_with_customizations(
     sagemaker_session, output_kms_key, volume_kms_key, predictor
 ):

--- a/tests/integ/test_mxnet.py
+++ b/tests/integ/test_mxnet.py
@@ -65,7 +65,7 @@ def mxnet_training_job(
         return mx.latest_training_job.name
 
 
-@pytest.mark.canary_quick
+@pytest.mark.release
 def test_attach_deploy(mxnet_training_job, sagemaker_session, cpu_instance_type):
     endpoint_name = "test-mxnet-attach-deploy-{}".format(sagemaker_timestamp())
 

--- a/tests/integ/test_neo_mxnet.py
+++ b/tests/integ/test_neo_mxnet.py
@@ -57,7 +57,7 @@ def mxnet_training_job(
         return mx.latest_training_job.name
 
 
-@pytest.mark.canary_quick
+@pytest.mark.release
 @pytest.mark.skip(
     reason="This test is failing because the image uri and the training script format has changed."
 )

--- a/tests/integ/test_ntm.py
+++ b/tests/integ/test_ntm.py
@@ -25,7 +25,7 @@ from tests.integ.timeout import timeout, timeout_and_delete_endpoint_by_name
 from tests.integ.record_set import prepare_record_set_from_local_files
 
 
-@pytest.mark.canary_quick
+@pytest.mark.release
 @pytest.mark.skip(
     reason="This test has always failed, but the failure was masked by a bug. "
     "This test should be fixed. Details in https://github.com/aws/sagemaker-python-sdk/pull/968"

--- a/tests/integ/test_processing.py
+++ b/tests/integ/test_processing.py
@@ -153,7 +153,7 @@ def test_sklearn(sagemaker_session, sklearn_latest_version, cpu_instance_type):
     assert ROLE in job_description["RoleArn"]
 
 
-@pytest.mark.canary_quick
+@pytest.mark.release
 def test_sklearn_with_customizations(
     sagemaker_session, image_uri, sklearn_latest_version, cpu_instance_type, output_kms_key
 ):
@@ -369,7 +369,7 @@ def test_sklearn_with_no_inputs_or_outputs(
     assert job_description["StoppingCondition"] == {"MaxRuntimeInSeconds": 3600}
 
 
-@pytest.mark.canary_quick
+@pytest.mark.release
 def test_script_processor(sagemaker_session, image_uri, cpu_instance_type, output_kms_key):
     input_file_path = os.path.join(DATA_DIR, "dummy_input.txt")
 
@@ -528,7 +528,7 @@ def test_script_processor_with_no_inputs_or_outputs(
     assert job_description["StoppingCondition"] == {"MaxRuntimeInSeconds": 3600}
 
 
-@pytest.mark.canary_quick
+@pytest.mark.release
 def test_processor(sagemaker_session, image_uri, cpu_instance_type, output_kms_key):
     script_path = os.path.join(DATA_DIR, "dummy_script.py")
 

--- a/tests/integ/test_pytorch.py
+++ b/tests/integ/test_pytorch.py
@@ -95,7 +95,7 @@ def fixture_training_job_with_latest_inference_version(
         return pytorch.latest_training_job.name
 
 
-@pytest.mark.canary_quick
+@pytest.mark.release
 def test_fit_deploy(
     pytorch_training_job_with_latest_infernce_version, sagemaker_session, cpu_instance_type
 ):

--- a/tests/integ/test_rl.py
+++ b/tests/integ/test_rl.py
@@ -23,7 +23,7 @@ from tests.integ import DATA_DIR, RL_SUPPORTED_REGIONS, test_region
 from tests.integ.timeout import timeout, timeout_and_delete_endpoint_by_name
 
 
-@pytest.mark.canary_quick
+@pytest.mark.release
 def test_coach_mxnet(sagemaker_session, coach_mxnet_latest_version, cpu_instance_type):
     estimator = _test_coach(
         sagemaker_session, RLFramework.MXNET, coach_mxnet_latest_version, cpu_instance_type
@@ -106,7 +106,7 @@ def _test_coach(sagemaker_session, rl_framework, rl_coach_version, cpu_instance_
     test_region() not in RL_SUPPORTED_REGIONS,
     reason="Updated RL images aren't in {}".format(test_region()),
 )
-@pytest.mark.canary_quick
+@pytest.mark.release
 def test_ray_tf(sagemaker_session, ray_tensorflow_latest_version, cpu_instance_type):
     source_dir = os.path.join(DATA_DIR, "ray_cartpole")
     cartpole = "train_ray.py"

--- a/tests/integ/test_sklearn.py
+++ b/tests/integ/test_sklearn.py
@@ -111,7 +111,7 @@ def test_training_with_network_isolation(
         ]
 
 
-@pytest.mark.canary_quick
+@pytest.mark.release
 @pytest.mark.skip(
     reason="This test has always failed, but the failure was masked by a bug. "
     "This test should be fixed. Details in https://github.com/aws/sagemaker-python-sdk/pull/968"

--- a/tests/integ/test_sparkml_serving.py
+++ b/tests/integ/test_sparkml_serving.py
@@ -25,7 +25,7 @@ from tests.integ import DATA_DIR
 from tests.integ.timeout import timeout_and_delete_endpoint_by_name
 
 
-@pytest.mark.canary_quick
+@pytest.mark.release
 def test_sparkml_model_deploy(sagemaker_session, cpu_instance_type):
     # Uploads an MLeap serialized MLeap model to S3 and use that to deploy
     # a SparkML model to perform inference

--- a/tests/integ/test_tf.py
+++ b/tests/integ/test_tf.py
@@ -125,7 +125,7 @@ def test_server_side_encryption(sagemaker_session, tf_full_version, tf_full_py_v
             )
 
 
-@pytest.mark.canary_quick
+@pytest.mark.release
 def test_mnist_distributed(
     sagemaker_session,
     instance_type,

--- a/tests/integ/test_tfs.py
+++ b/tests/integ/test_tfs.py
@@ -138,7 +138,7 @@ def tfs_predictor_with_accelerator(
         yield predictor
 
 
-@pytest.mark.canary_quick
+@pytest.mark.release
 def test_predict(tfs_predictor):
     input_data = {"instances": [1.0, 2.0, 5.0]}
     expected_result = {"predictions": [3.5, 4.0, 5.5]}
@@ -151,7 +151,7 @@ def test_predict(tfs_predictor):
     tests.integ.test_region() not in tests.integ.EI_SUPPORTED_REGIONS,
     reason="EI is not supported in region {}".format(tests.integ.test_region()),
 )
-@pytest.mark.canary_quick
+@pytest.mark.release
 def test_predict_with_accelerator(tfs_predictor_with_accelerator):
     input_data = {"instances": [1.0, 2.0, 5.0]}
     expected_result = {"predictions": [3.5, 4.0, 5.5]}

--- a/tests/integ/test_transformer.py
+++ b/tests/integ/test_transformer.py
@@ -78,7 +78,7 @@ def mxnet_transform_input(sagemaker_session):
     )
 
 
-@pytest.mark.canary_quick
+@pytest.mark.release
 def test_transform_mxnet(
     mxnet_estimator, mxnet_transform_input, sagemaker_session, cpu_instance_type
 ):
@@ -108,7 +108,7 @@ def test_transform_mxnet(
     assert input_filter == job_desc["DataProcessing"]["InputFilter"]
 
 
-@pytest.mark.canary_quick
+@pytest.mark.release
 def test_attach_transform_kmeans(sagemaker_session, cpu_instance_type):
     kmeans = KMeans(
         role="SageMakerRole",

--- a/tests/integ/test_tuner.py
+++ b/tests/integ/test_tuner.py
@@ -158,7 +158,7 @@ def _tune(
     return tuner
 
 
-@pytest.mark.canary_quick
+@pytest.mark.release
 def test_tuning_kmeans(
     sagemaker_session, kmeans_train_set, kmeans_estimator, hyperparameter_ranges, cpu_instance_type
 ):
@@ -525,7 +525,7 @@ def test_stop_tuning_job(sagemaker_session, cpu_instance_type):
 
 
 @pytest.mark.slow_test
-@pytest.mark.canary_quick
+@pytest.mark.release
 def test_tuning_mxnet(
     sagemaker_session,
     mxnet_training_latest_version,
@@ -578,7 +578,7 @@ def test_tuning_mxnet(
         predictor.predict(data)
 
 
-@pytest.mark.canary_quick
+@pytest.mark.release
 def test_tuning_tf(
     sagemaker_session,
     cpu_instance_type,
@@ -675,7 +675,7 @@ def test_tuning_tf_vpc_multi(
         tuner.fit(inputs, job_name=tuning_job_name)
 
 
-@pytest.mark.canary_quick
+@pytest.mark.release
 def test_tuning_chainer(
     sagemaker_session, chainer_latest_version, chainer_latest_py_version, cpu_instance_type
 ):
@@ -742,7 +742,7 @@ def test_tuning_chainer(
         assert len(output) == batch_size
 
 
-@pytest.mark.canary_quick
+@pytest.mark.release
 @pytest.mark.skip(
     reason="This test has always failed, but the failure was masked by a bug. "
     "This test should be fixed. Details in https://github.com/aws/sagemaker-python-sdk/pull/968"
@@ -817,7 +817,7 @@ def test_attach_tuning_pytorch(
         _assert_model_name_match(sagemaker_session.sagemaker_client, endpoint_name, model_name)
 
 
-@pytest.mark.canary_quick
+@pytest.mark.release
 def test_tuning_byo_estimator(sagemaker_session, cpu_instance_type):
     """Use Factorization Machines algorithm as an example here.
 


### PR DESCRIPTION
*Description of changes:*
Rename the `canary_quick` pytest mark to `release` for the regional release builds.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
