### PR TITLE
fix: add description parameter for RegisterModelStep

### DIFF
--- a/src/sagemaker/workflow/_utils.py
+++ b/src/sagemaker/workflow/_utils.py
@@ -220,6 +220,7 @@ class _RegisterModelStep(Step):
         approval_status="PendingManualApproval",
         image_uri=None,
         compile_model_family=None,
+        description=None,
         **kwargs,
     ):
         """Constructor of a register model step.
@@ -246,6 +247,7 @@ class _RegisterModelStep(Step):
                 Estimator's training container image will be used (default: None).
             compile_model_family (str): Instance family for compiled model, if specified, a compiled
                 model will be used (default: None).
+            description (str): Model Package description (default: None).
             **kwargs: additional arguments to `create_model`.
         """
         super(_RegisterModelStep, self).__init__(name, StepTypeEnum.REGISTER_MODEL)
@@ -261,6 +263,7 @@ class _RegisterModelStep(Step):
         self.approval_status = approval_status
         self.image_uri = image_uri
         self.compile_model_family = compile_model_family
+        self.description = description
         self.kwargs = kwargs
 
         self._properties = Properties(
@@ -314,6 +317,7 @@ class _RegisterModelStep(Step):
             model_metrics=self.model_metrics,
             metadata_properties=self.metadata_properties,
             approval_status=self.approval_status,
+            description=self.description,
         )
         request_dict = model.sagemaker_session._get_create_model_package_request(
             **model_package_args

--- a/src/sagemaker/workflow/step_collections.py
+++ b/src/sagemaker/workflow/step_collections.py
@@ -65,6 +65,7 @@ class RegisterModel(StepCollection):
         approval_status=None,
         image_uri=None,
         compile_model_family=None,
+        description=None,
         **kwargs,
     ):
         """Construct steps `_RepackModelStep` and `_RegisterModelStep` based on the estimator.
@@ -89,6 +90,7 @@ class RegisterModel(StepCollection):
                 Estimator's training container image is used (default: None).
             compile_model_family (str): The instance family for the compiled model. If
                 specified, a compiled model is used (default: None).
+            description (str): Model Package description (default: None).
             **kwargs: additional arguments to `create_model`.
         """
         steps: List[Step] = []
@@ -120,6 +122,7 @@ class RegisterModel(StepCollection):
             approval_status=approval_status,
             image_uri=image_uri,
             compile_model_family=compile_model_family,
+            description=description,
             **kwargs,
         )
         steps.append(register_model_step)

--- a/tests/integ/test_workflow.py
+++ b/tests/integ/test_workflow.py
@@ -393,6 +393,7 @@ def test_conditional_pytorch_training_model_registration(
         response_types=["*"],
         inference_instances=["*"],
         transform_instances=["*"],
+        description="test-description",
     )
 
     model = Model(

--- a/tests/unit/sagemaker/workflow/test_step_collections.py
+++ b/tests/unit/sagemaker/workflow/test_step_collections.py
@@ -143,6 +143,7 @@ def test_register_model(estimator, model_metrics):
         model_package_group_name="mpg",
         model_metrics=model_metrics,
         approval_status="Approved",
+        description="description",
     )
     assert ordered(register_model.request_dicts()) == ordered(
         [
@@ -168,6 +169,7 @@ def test_register_model(estimator, model_metrics):
                             },
                         },
                     },
+                    "ModelPackageDescription": "description",
                     "ModelPackageGroupName": "mpg",
                 },
             },


### PR DESCRIPTION
*Issue #, if available:*
Addresses: https://github.com/aws/sagemaker-python-sdk/issues/2104

*Description of changes:*
Add description parameter for RegisterModelStep.

This allows setting the ModelPackageDescription, as per: https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_CreateModelPackage.html#sagemaker-CreateModelPackage-request-ModelPackageDescription

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
