### PR TITLE
change: move service-role path parsing for AmazonSageMaker-ExecutionRole for get_execution_role() into except block of IAM get_role() call and add warning message

### DIFF
--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -3514,12 +3514,14 @@ class Session(object):  # pylint: disable=too-many-public-methods
             # Guessing this conditional's purpose was to handle lack of IAM permissions
             # https://github.com/aws/sagemaker-python-sdk/issues/2089#issuecomment-791802713
             if "AmazonSageMaker-ExecutionRole" in assumed_role:
-                LOGGER.warning('Assuming role was created in SageMaker AWS console, '
-                               'as the name contains `AmazonSageMaker-ExecutionRole`. '
-                               'Defaulting to Role ARN with service-role in path. '
-                               'If this Role ARN is incorrect, please add '
-                               'IAM read permissions to your role or supply the '
-                               'Role Arn directly.')
+                LOGGER.warning(
+                    "Assuming role was created in SageMaker AWS console, "
+                    "as the name contains `AmazonSageMaker-ExecutionRole`. "
+                    "Defaulting to Role ARN with service-role in path. "
+                    "If this Role ARN is incorrect, please add "
+                    "IAM read permissions to your role or supply the "
+                    "Role Arn directly."
+                )
                 role = re.sub(
                     r"^(.+)sts::(\d+):assumed-role/(.+?)/.*$",
                     r"\1iam::\2:role/service-role/\3",

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -408,6 +408,24 @@ def test_get_caller_identity_arn_from_an_execution_role(sts_regional_endpoint, b
     actual = sess.get_caller_identity_arn()
     assert (
         actual
+        == "arn:aws:iam::369233609183:role/AmazonSageMaker-ExecutionRole-20171129T072388"
+    )
+
+
+@patch("os.path.exists", side_effect=mock_exists(NOTEBOOK_METADATA_FILE, False))
+@patch("sagemaker.session.sts_regional_endpoint", return_value=STS_ENDPOINT)
+def test_get_caller_identity_arn_from_a_sagemaker_execution_role_with_iam_client_error(sts_regional_endpoint, boto_session):
+    sess = Session(boto_session)
+    arn = "arn:aws:sts::369233609183:assumed-role/AmazonSageMaker-ExecutionRole-20171129T072388/SageMaker"
+    sess.boto_session.client("sts", endpoint_url=STS_ENDPOINT).get_caller_identity.return_value = {
+        "Arn": arn
+    }
+
+    sess.boto_session.client("iam").get_role.side_effect = ClientError({}, {})
+
+    actual = sess.get_caller_identity_arn()
+    assert (
+        actual
         == "arn:aws:iam::369233609183:role/service-role/AmazonSageMaker-ExecutionRole-20171129T072388"
     )
 

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -406,15 +406,14 @@ def test_get_caller_identity_arn_from_an_execution_role(sts_regional_endpoint, b
     sess.boto_session.client("iam").get_role.return_value = {"Role": {"Arn": arn}}
 
     actual = sess.get_caller_identity_arn()
-    assert (
-        actual
-        == "arn:aws:iam::369233609183:role/AmazonSageMaker-ExecutionRole-20171129T072388"
-    )
+    assert actual == "arn:aws:iam::369233609183:role/AmazonSageMaker-ExecutionRole-20171129T072388"
 
 
 @patch("os.path.exists", side_effect=mock_exists(NOTEBOOK_METADATA_FILE, False))
 @patch("sagemaker.session.sts_regional_endpoint", return_value=STS_ENDPOINT)
-def test_get_caller_identity_arn_from_a_sagemaker_execution_role_with_iam_client_error(sts_regional_endpoint, boto_session):
+def test_get_caller_identity_arn_from_a_sagemaker_execution_role_with_iam_client_error(
+    sts_regional_endpoint, boto_session
+):
     sess = Session(boto_session)
     arn = "arn:aws:sts::369233609183:assumed-role/AmazonSageMaker-ExecutionRole-20171129T072388/SageMaker"
     sess.boto_session.client("sts", endpoint_url=STS_ENDPOINT).get_caller_identity.return_value = {

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -399,14 +399,15 @@ def test_get_caller_identity_arn_from_a_role(sts_regional_endpoint, boto_session
 @patch("sagemaker.session.sts_regional_endpoint", return_value=STS_ENDPOINT)
 def test_get_caller_identity_arn_from_an_execution_role(sts_regional_endpoint, boto_session):
     sess = Session(boto_session)
-    arn = "arn:aws:sts::369233609183:assumed-role/AmazonSageMaker-ExecutionRole-20171129T072388/SageMaker"
+    sts_arn = "arn:aws:sts::369233609183:assumed-role/AmazonSageMaker-ExecutionRole-20171129T072388/SageMaker"
     sess.boto_session.client("sts", endpoint_url=STS_ENDPOINT).get_caller_identity.return_value = {
-        "Arn": arn
+        "Arn": sts_arn
     }
-    sess.boto_session.client("iam").get_role.return_value = {"Role": {"Arn": arn}}
+    iam_arn = "arn:aws:iam::369233609183:role/AmazonSageMaker-ExecutionRole-20171129T072388"
+    sess.boto_session.client("iam").get_role.return_value = {"Role": {"Arn": iam_arn}}
 
     actual = sess.get_caller_identity_arn()
-    assert actual == "arn:aws:iam::369233609183:role/AmazonSageMaker-ExecutionRole-20171129T072388"
+    assert actual == iam_arn
 
 
 @patch("os.path.exists", side_effect=mock_exists(NOTEBOOK_METADATA_FILE, False))


### PR DESCRIPTION
…ole for get_execution_role() into except block of IAM get_role() call and add warning message

*Issue #, if available:*
https://github.com/aws/sagemaker-python-sdk/issues/2089

*Description of changes:*
Moved the conditional for parsing a Role Arn if the role name contains `AmazonSageMaker-ExecutionRole` into the except block of the try/except clause for calling IAM `get_role()`.

This change should work for users who are still depending on this logic for getting a proper role ARN without IAM read permissions, while also allowing those with IAM read permissions to get the correct path in their role.

Also added a warning message.

*Testing done:*
I tested my change by creating separate UserProfiles with the corresponding roles defined below.

If my assumed role contained `AmazonSageMaker-ExecutionRole` and didn't have IAM permissions, it default to the role with the path service-role. It doesn't seem possible to get the role path through STS in the perspective of the Python SDK.

I installed my Python SDK dist file in each notebook:

1. Role with service-role path and name contains `AmazonSageMaker-ExecutionRole`
---

> UserProfile role: arn:aws:iam::AWS_ACCOUNT:role/service-role/AmazonSageMaker-ExecutionRole-20210110T050484

import sagemaker
sagemaker.get_execution_role()

arn:aws:iam::AWS_ACCOUNT:role/service-role/AmazonSageMaker-ExecutionRole-20181116T200565

2. Role with no service-role path and contains `AmazonSageMaker-ExecutionRole`
---

> UserProfile role: arn:aws:iam::AWS_ACCOUNT:role/AmazonSageMaker-ExecutionRole-NO_PATH

import sagemaker
sagemaker.get_execution_role()

arn:aws:iam::AWS_ACCOUNT:role/AmazonSageMaker-ExecutionRole-NO_PATH

3. Role name does not contain `AmazonSageMaker-ExecutionRole`
---

> UserProfile role: arn:aws:iam::AWS_ACCOUNT:role/SageMakerRole

import sagemaker
sagemaker.get_execution_role()

arn:aws:iam::AWS_ACCOUNT:role/SageMakerRole


## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
