### PR TITLE
fix: return all failed row indices in feature_group.ingest

### DIFF
--- a/tests/integ/test_feature_store.py
+++ b/tests/integ/test_feature_store.py
@@ -196,7 +196,8 @@ def test_create_feature_store(
         ingestion_manager = feature_group.ingest(
             data_frame=pandas_data_frame, max_workers=3, wait=False
         )
-        ingestion_manager.wait()
+        failed = ingestion_manager.wait()
+        assert 0 == len(failed)
 
         # Query the integrated Glue table.
         athena_query = feature_group.athena_query()

--- a/tests/integ/test_feature_store.py
+++ b/tests/integ/test_feature_store.py
@@ -196,8 +196,8 @@ def test_create_feature_store(
         ingestion_manager = feature_group.ingest(
             data_frame=pandas_data_frame, max_workers=3, wait=False
         )
-        failed = ingestion_manager.wait()
-        assert 0 == len(failed)
+        ingestion_manager.wait()
+        assert 0 == len(ingestion_manager.failed_rows)
 
         # Query the integrated Glue table.
         athena_query = feature_group.athena_query()

--- a/tests/unit/sagemaker/feature_store/test_feature_store.py
+++ b/tests/unit/sagemaker/feature_store/test_feature_store.py
@@ -284,7 +284,10 @@ def test_ingestion_manager_run_failure():
         data_frame=df,
         max_workers=1,
     )
-    assert manager.run() == [1]
+    with pytest.raises(RuntimeError) as error:
+        manager.run()
+    assert "Failed to ingest some data into FeatureGroup MyGroup" in str(error)
+    assert manager.failed_rows == [1]
 
 
 @pytest.fixture

--- a/tests/unit/sagemaker/feature_store/test_feature_store.py
+++ b/tests/unit/sagemaker/feature_store/test_feature_store.py
@@ -274,7 +274,7 @@ def test_ingestion_manager_run_success():
 
 @patch(
     "sagemaker.feature_store.feature_group.IngestionManagerPandas._ingest_single_batch",
-    MagicMock(side_effect=Exception("Failed!")),
+    MagicMock(return_value=[1]),
 )
 def test_ingestion_manager_run_failure():
     df = pd.DataFrame({"float": pd.Series([2.0], dtype="float64")})
@@ -282,11 +282,9 @@ def test_ingestion_manager_run_failure():
         feature_group_name="MyGroup",
         sagemaker_session=sagemaker_session_mock,
         data_frame=df,
-        max_workers=10,
+        max_workers=1,
     )
-    with pytest.raises(RuntimeError) as error:
-        manager.run()
-    assert "Failed to ingest some data into FeatureGroup MyGroup" in str(error)
+    assert manager.run() == [1]
 
 
 @pytest.fixture


### PR DESCRIPTION
*Issue #, if available:*
Preparation for: https://github.com/aws/sagemaker-python-sdk/issues/2111

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
