### PR TITLE
change: Do lazy initialization in predictor

### DIFF
--- a/src/sagemaker/predictor.py
+++ b/src/sagemaker/predictor.py
@@ -86,9 +86,7 @@ class Predictor(object):
         """
         removed_kwargs("content_type", kwargs)
         removed_kwargs("accept", kwargs)
-        endpoint_name = renamed_kwargs(
-            "endpoint", "endpoint_name", endpoint_name, kwargs
-        )
+        endpoint_name = renamed_kwargs("endpoint", "endpoint_name", endpoint_name, kwargs)
         self.endpoint_name = endpoint_name
         self.sagemaker_session = sagemaker_session or Session()
         self.serializer = serializer
@@ -135,9 +133,7 @@ class Predictor(object):
         request_args = self._create_request_args(
             data, initial_args, target_model, target_variant, inference_id
         )
-        response = self.sagemaker_session.sagemaker_runtime_client.invoke_endpoint(
-            **request_args
-        )
+        response = self.sagemaker_session.sagemaker_runtime_client.invoke_endpoint(**request_args)
         return self._handle_response(response)
 
     def _handle_response(self, response):
@@ -397,11 +393,7 @@ class Predictor(object):
             endpoint_name=self.endpoint_name
         )
         if len(monitoring_schedules_dict["MonitoringScheduleSummaries"]) == 0:
-            print(
-                "No monitors found for endpoint. endpoint: {}".format(
-                    self.endpoint_name
-                )
-            )
+            print("No monitors found for endpoint. endpoint: {}".format(self.endpoint_name))
             return []
 
         monitors = []
@@ -443,9 +435,7 @@ class Predictor(object):
                 "MonitoringJobDefinition"
             )
             if embedded_job_definition is not None:  # legacy v1 schedule
-                image_uri = embedded_job_definition["MonitoringAppSpecification"][
-                    "ImageUri"
-                ]
+                image_uri = embedded_job_definition["MonitoringAppSpecification"]["ImageUri"]
                 if image_uri.endswith(DEFAULT_REPOSITORY_NAME):
                     clazz = DefaultModelMonitor
                 else:
@@ -483,9 +473,7 @@ class Predictor(object):
 
         # list context by source uri using arn
         contexts = list(
-            EndpointContext.list(
-                sagemaker_session=self.sagemaker_session, source_uri=endpoint_arn
-            )
+            EndpointContext.list(sagemaker_session=self.sagemaker_session, source_uri=endpoint_arn)
         )
 
         if len(contexts) != 0:
@@ -512,10 +500,8 @@ class Predictor(object):
         if self._model_names is not None:
             return self._model_names
         current_endpoint_config_name = self._get_endpoint_config_name()
-        endpoint_config = (
-            self.sagemaker_session.sagemaker_client.describe_endpoint_config(
-                EndpointConfigName=current_endpoint_config_name
-            )
+        endpoint_config = self.sagemaker_session.sagemaker_client.describe_endpoint_config(
+            EndpointConfigName=current_endpoint_config_name
         )
         production_variants = endpoint_config["ProductionVariants"]
         self._model_names = [d["ModelName"] for d in production_variants]

--- a/src/sagemaker/predictor.py
+++ b/src/sagemaker/predictor.py
@@ -86,7 +86,9 @@ class Predictor(object):
         """
         removed_kwargs("content_type", kwargs)
         removed_kwargs("accept", kwargs)
-        endpoint_name = renamed_kwargs("endpoint", "endpoint_name", endpoint_name, kwargs)
+        endpoint_name = renamed_kwargs(
+            "endpoint", "endpoint_name", endpoint_name, kwargs
+        )
         self.endpoint_name = endpoint_name
         self.sagemaker_session = sagemaker_session or Session()
         self.serializer = serializer
@@ -96,7 +98,12 @@ class Predictor(object):
         self._context = None
 
     def predict(
-        self, data, initial_args=None, target_model=None, target_variant=None, inference_id=None
+        self,
+        data,
+        initial_args=None,
+        target_model=None,
+        target_variant=None,
+        inference_id=None,
     ):
         """Return the inference from the specified endpoint.
 
@@ -128,7 +135,9 @@ class Predictor(object):
         request_args = self._create_request_args(
             data, initial_args, target_model, target_variant, inference_id
         )
-        response = self.sagemaker_session.sagemaker_runtime_client.invoke_endpoint(**request_args)
+        response = self.sagemaker_session.sagemaker_runtime_client.invoke_endpoint(
+            **request_args
+        )
         return self._handle_response(response)
 
     def _handle_response(self, response):
@@ -138,7 +147,12 @@ class Predictor(object):
         return self.deserializer.deserialize(response_body, content_type)
 
     def _create_request_args(
-        self, data, initial_args=None, target_model=None, target_variant=None, inference_id=None
+        self,
+        data,
+        initial_args=None,
+        target_model=None,
+        target_variant=None,
+        inference_id=None,
     ):
         """Placeholder docstring"""
         args = dict(initial_args) if initial_args else {}
@@ -231,7 +245,10 @@ class Predictor(object):
                     "Missing initial_instance_count and/or instance_type. Provided values: "
                     "initial_instance_count={}, instance_type={}, accelerator_type={}, "
                     "model_name={}.".format(
-                        initial_instance_count, instance_type, accelerator_type, model_name
+                        initial_instance_count,
+                        instance_type,
+                        accelerator_type,
+                        model_name,
                     )
                 )
 
@@ -239,7 +256,9 @@ class Predictor(object):
                 if len(current_model_names) > 1:
                     raise ValueError(
                         "Unable to choose a default model for a new EndpointConfig because "
-                        "the endpoint has multiple models: {}".format(", ".join(current_model_names))
+                        "the endpoint has multiple models: {}".format(
+                            ", ".join(current_model_names)
+                        )
                     )
                 model_name = current_model_names[0]
             else:
@@ -378,7 +397,11 @@ class Predictor(object):
             endpoint_name=self.endpoint_name
         )
         if len(monitoring_schedules_dict["MonitoringScheduleSummaries"]) == 0:
-            print("No monitors found for endpoint. endpoint: {}".format(self.endpoint_name))
+            print(
+                "No monitors found for endpoint. endpoint: {}".format(
+                    self.endpoint_name
+                )
+            )
             return []
 
         monitors = []
@@ -420,7 +443,9 @@ class Predictor(object):
                 "MonitoringJobDefinition"
             )
             if embedded_job_definition is not None:  # legacy v1 schedule
-                image_uri = embedded_job_definition["MonitoringAppSpecification"]["ImageUri"]
+                image_uri = embedded_job_definition["MonitoringAppSpecification"][
+                    "ImageUri"
+                ]
                 if image_uri.endswith(DEFAULT_REPOSITORY_NAME):
                     clazz = DefaultModelMonitor
                 else:
@@ -458,13 +483,16 @@ class Predictor(object):
 
         # list context by source uri using arn
         contexts = list(
-            EndpointContext.list(sagemaker_session=self.sagemaker_session, source_uri=endpoint_arn)
+            EndpointContext.list(
+                sagemaker_session=self.sagemaker_session, source_uri=endpoint_arn
+            )
         )
 
         if len(contexts) != 0:
             # create endpoint context object
             self._context = EndpointContext.load(
-                sagemaker_session=self.sagemaker_session, context_name=contexts[0].context_name
+                sagemaker_session=self.sagemaker_session,
+                context_name=contexts[0].context_name,
             )
 
         return self._context
@@ -484,8 +512,10 @@ class Predictor(object):
         if self._model_names is not None:
             return self._model_names
         current_endpoint_config_name = self._get_endpoint_config_name()
-        endpoint_config = self.sagemaker_session.sagemaker_client.describe_endpoint_config(
-            EndpointConfigName=current_endpoint_config_name
+        endpoint_config = (
+            self.sagemaker_session.sagemaker_client.describe_endpoint_config(
+                EndpointConfigName=current_endpoint_config_name
+            )
         )
         production_variants = endpoint_config["ProductionVariants"]
         self._model_names = [d["ModelName"] for d in production_variants]

--- a/tests/integ/test_mxnet.py
+++ b/tests/integ/test_mxnet.py
@@ -97,7 +97,7 @@ def test_deploy_estimator_with_different_instance_types(
             try:
                 predictor = estimator.deploy(1, instance_type)
 
-                model_name = predictor._model_names[0]
+                model_name = predictor._get_model_names()[0]
                 config_name = sagemaker_session.sagemaker_client.describe_endpoint(
                     EndpointName=predictor.endpoint_name
                 )["EndpointConfigName"]

--- a/tests/unit/test_predictor.py
+++ b/tests/unit/test_predictor.py
@@ -62,8 +62,8 @@ def test_predict_call_pass_through():
     result = predictor.predict(data)
 
     assert sagemaker_session.sagemaker_runtime_client.invoke_endpoint.called
-    sagemaker_session.describe_endpoint.assert_not_called()
-    sagemaker_session.describe_endpoint_config.assert_not_called()
+    assert sagemaker_session.sagemaker_client.describe_endpoint.not_called
+    assert sagemaker_session.sagemaker_client.describe_endpoint_config.not_called
 
     expected_request_args = {
         "Accept": DEFAULT_ACCEPT,

--- a/tests/unit/test_predictor.py
+++ b/tests/unit/test_predictor.py
@@ -62,6 +62,8 @@ def test_predict_call_pass_through():
     result = predictor.predict(data)
 
     assert sagemaker_session.sagemaker_runtime_client.invoke_endpoint.called
+    sagemaker_session.describe_endpoint.assert_not_called()
+    sagemaker_session.describe_endpoint_config.assert_not_called()
 
     expected_request_args = {
         "Accept": DEFAULT_ACCEPT,


### PR DESCRIPTION
Do lazy initialization of model names and endpoint configuration name in predictor

*Issue #, if available:*

*Description of changes:*
When a predictor object is created, the initialization issues DescribeEndpoint and DescribeEndpointConfiguration API calls to get the model names and endpoint configuration name. These fields are only necessary for updating the predictor. They are unnecessary if we only want to make predict calls on the predictor object. The changes move the initialization to the relevant update functions to call the describe APIs if the fields have not been populated yet. This helps make the predictor object become more scalable by reducing the required API calls when only making predict requests.

*Testing done:*
The changes are covered by existing unit tests in test_predictor.py. All unit tests and integration tests still pass with the changes.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [X] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [X] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [X] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [X] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [X] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [X] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [X] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
