### PR TITLE
change: use ResolvedOutputS3Uir for Hive DDL LOCATION

### DIFF
--- a/src/sagemaker/feature_store/feature_group.py
+++ b/src/sagemaker/feature_store/feature_group.py
@@ -511,8 +511,13 @@ class FeatureGroup:
         """
         if not table_name:
             table_name = self.name
-            
-        resolved_output_s3_uri = self.describe().get("OfflineStoreConfig").get("S3StorageConfig").get("ResolvedOutputS3Uri")
+
+        resolved_output_s3_uri = (
+            self.describe()
+            .get("OfflineStoreConfig")
+            .get("S3StorageConfig")
+            .get("ResolvedOutputS3Uri")
+        )
 
         ddl = f"CREATE EXTERNAL TABLE IF NOT EXISTS {database}.{table_name} (\n"
         for definition in self.feature_definitions:

--- a/src/sagemaker/feature_store/feature_group.py
+++ b/src/sagemaker/feature_store/feature_group.py
@@ -511,16 +511,8 @@ class FeatureGroup:
         """
         if not table_name:
             table_name = self.name
-
-        s3_uri = self.describe().get("OfflineStoreConfig").get("S3StorageConfig").get("S3Uri")
-        offline_store_s3_uri = os.path.join(
-            s3_uri,
-            self.sagemaker_session.account_id(),
-            "sagemaker",
-            self.sagemaker_session.boto_session.region_name,
-            "offline-store",
-            self.name,
-        )
+            
+        resolved_output_s3_uri = self.describe().get("OfflineStoreConfig").get("S3StorageConfig").get("ResolvedOutputS3Uri")
 
         ddl = f"CREATE EXTERNAL TABLE IF NOT EXISTS {database}.{table_name} (\n"
         for definition in self.feature_definitions:
@@ -537,6 +529,6 @@ class FeatureGroup:
             "  STORED AS\n"
             "  INPUTFORMAT 'parquet.hive.DeprecatedParquetInputFormat'\n"
             "  OUTPUTFORMAT 'parquet.hive.DeprecatedParquetOutputFormat'\n"
-            f"LOCATION '{offline_store_s3_uri}'"
+            f"LOCATION '{resolved_output_s3_uri}'"
         )
         return ddl

--- a/tests/integ/test_feature_store.py
+++ b/tests/integ/test_feature_store.py
@@ -179,8 +179,7 @@ def test_create_feature_store(
 ):
     feature_group = FeatureGroup(name=feature_group_name, sagemaker_session=feature_store_session)
     feature_group.load_feature_definitions(data_frame=pandas_data_frame)
-    resolved_output_s3_uri = feature_group.describe().get("OfflineStoreConfig").get("S3StorageConfig").get("ResolvedOutputS3Uri")
-    
+
     with cleanup_feature_group(feature_group):
         output = feature_group.create(
             s3_uri=offline_store_s3_uri,
@@ -191,6 +190,12 @@ def test_create_feature_store(
         )
         _wait_for_feature_group_create(feature_group)
 
+        resolved_output_s3_uri = (
+            feature_group.describe()
+            .get("OfflineStoreConfig")
+            .get("S3StorageConfig")
+            .get("ResolvedOutputS3Uri")
+        )
         # Ingest data
         feature_group.put_record(record=record)
         ingestion_manager = feature_group.ingest(
@@ -225,7 +230,7 @@ def test_create_feature_store(
                 feature_group_name=feature_group_name,
                 region=feature_store_session.boto_session.region_name,
                 account=feature_store_session.account_id(),
-                resolved_output_s3_uri=resolved_output_s3_uri
+                resolved_output_s3_uri=resolved_output_s3_uri,
             )
             == feature_group.as_hive_ddl()
         )

--- a/tests/integ/test_feature_store.py
+++ b/tests/integ/test_feature_store.py
@@ -142,8 +142,7 @@ def create_table_ddl():
         "  STORED AS\n"
         "  INPUTFORMAT 'parquet.hive.DeprecatedParquetInputFormat'\n"
         "  OUTPUTFORMAT 'parquet.hive.DeprecatedParquetOutputFormat'\n"
-        "LOCATION 's3://sagemaker-test-featurestore-{region}-{account}"
-        "/{account}/sagemaker/us-east-2/offline-store/{feature_group_name}'"
+        "LOCATION '{resolved_output_s3_uri}'"
     )
 
 
@@ -180,7 +179,8 @@ def test_create_feature_store(
 ):
     feature_group = FeatureGroup(name=feature_group_name, sagemaker_session=feature_store_session)
     feature_group.load_feature_definitions(data_frame=pandas_data_frame)
-
+    resolved_output_s3_uri = feature_group.describe().get("OfflineStoreConfig").get("S3StorageConfig").get("ResolvedOutputS3Uri")
+    
     with cleanup_feature_group(feature_group):
         output = feature_group.create(
             s3_uri=offline_store_s3_uri,
@@ -225,6 +225,7 @@ def test_create_feature_store(
                 feature_group_name=feature_group_name,
                 region=feature_store_session.boto_session.region_name,
                 account=feature_store_session.account_id(),
+                resolved_output_s3_uri=resolved_output_s3_uri
             )
             == feature_group.as_hive_ddl()
         )

--- a/tests/unit/sagemaker/feature_store/test_feature_store.py
+++ b/tests/unit/sagemaker/feature_store/test_feature_store.py
@@ -66,8 +66,7 @@ def create_table_ddl():
         "  STORED AS\n"
         "  INPUTFORMAT 'parquet.hive.DeprecatedParquetInputFormat'\n"
         "  OUTPUTFORMAT 'parquet.hive.DeprecatedParquetOutputFormat'\n"
-        "LOCATION 's3://some-bucket"
-        "/{account}/sagemaker/{region}/offline-store/{feature_group_name}'"
+        "LOCATION 's3://resolved_output_s3_uri'"
     )
 
 
@@ -217,7 +216,12 @@ def test_as_hive_ddl_with_default_values(
     create_table_ddl, feature_group_dummy_definitions, sagemaker_session_mock
 ):
     sagemaker_session_mock.describe_feature_group.return_value = {
-        "OfflineStoreConfig": {"S3StorageConfig": {"S3Uri": "s3://some-bucket"}}
+        "OfflineStoreConfig": {
+            "S3StorageConfig": {
+                "S3Uri": "s3://some-bucket",
+                "ResolvedOutputS3Uri": "s3://resolved_output_s3_uri",
+            }
+        }
     }
     sagemaker_session_mock.account_id.return_value = "1234"
     sagemaker_session_mock.boto_session.region_name = "us-west-2"
@@ -238,7 +242,12 @@ def test_as_hive_ddl_with_default_values(
 
 def test_as_hive_ddl(create_table_ddl, feature_group_dummy_definitions, sagemaker_session_mock):
     sagemaker_session_mock.describe_feature_group.return_value = {
-        "OfflineStoreConfig": {"S3StorageConfig": {"S3Uri": "s3://some-bucket"}}
+        "OfflineStoreConfig": {
+            "S3StorageConfig": {
+                "S3Uri": "s3://some-bucket",
+                "ResolvedOutputS3Uri": "s3://resolved_output_s3_uri",
+            }
+        }
     }
     sagemaker_session_mock.account_id.return_value = "1234"
     sagemaker_session_mock.boto_session.region_name = "us-west-2"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
