### PR TITLE
infra: disable_profiler on mx-horovod test

### DIFF
--- a/tests/integ/test_horovod_mx.py
+++ b/tests/integ/test_horovod_mx.py
@@ -92,6 +92,7 @@ def _create_and_fit_estimator(mxnet_version, py_version, sagemaker_session, inst
         py_version=py_version,
         framework_version=mxnet_version,
         distribution={"mpi": {"enabled": True}},
+        disable_profiler=True,
     )
 
     with timeout.timeout(minutes=integ.TRAINING_DEFAULT_TIMEOUT_MINUTES):


### PR DESCRIPTION
*Issue #, if available:*
Continuation of https://github.com/aws/sagemaker-python-sdk/pull/2261

*Description of changes:*
Disable profiler on a release test to avoid ISEs.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
