### PR TITLE
doc: add Documentation for how to use

### DIFF
--- a/doc/frameworks/huggingface/index.rst
+++ b/doc/frameworks/huggingface/index.rst
@@ -9,3 +9,4 @@ For general information about using the SageMaker Python SDK, see :ref:`overview
     :maxdepth: 2
 
     sagemaker.huggingface
+    Use Hugging Face with the SageMaker Python SDK <https://huggingface.co/transformers/sagemaker.html>


### PR DESCRIPTION
# This PR adds

A link/documentation on how to "Use Hugging Face with SageMaker Python SDK". We (@icywang86rui & I) decided not to create a separate documentation page in the SDK rather than referring to the documentation page in `transformers` at https://huggingface.co/transformers/sagemaker.html. This Documentation page will be always updated and maintained by the HF team. 

Screenshot of Sagemaker python SDK documentation page
![image](https://user-images.githubusercontent.com/32632186/114177193-67977a00-993c-11eb-9aae-0ff0aa2f9030.png)
