### PR TITLE
Revert "documentation: release notes for smdistributed.dataparallel v…

### DIFF
--- a/doc/api/training/sdp_versions/latest.rst
+++ b/doc/api/training/sdp_versions/latest.rst
@@ -1,5 +1,5 @@
 
-Version 1.1.1 (Latest)
+Version 1.1.0 (Latest)
 ======================
 
 .. toctree::

--- a/doc/api/training/smd_data_parallel_release_notes/smd_data_parallel_change_log.md
+++ b/doc/api/training/smd_data_parallel_release_notes/smd_data_parallel_change_log.md
@@ -1,21 +1,3 @@
-# Sagemaker Distributed Data Parallel 1.1.1 Release Notes
-
-* New Features
-* Bug Fixes
-* Known Issues
-
-*New Features:*
-
-* Adds support for PyTorch 1.8.1
-
-*Bug Fixes:*
-
-* Fixes a bug that was causing gradients from one of the worker nodes to be added twice resulting in incorrect `all_reduce` results under some conditions.
-
-*Known Issues:*
-
-* SageMaker distributed data parallel still is not efficient when run using a single node. For the best performance, use multi-node distributed training with `smdistributed.dataparallel`. Use a single node only for experimental runs while preparing your training pipeline.
-
 # Sagemaker Distributed Data Parallel 1.1.0 Release Notes
 
 * New Features
@@ -23,19 +5,19 @@
 * Improvements
 * Known Issues
 
-*New Features:*
+New Features:
 
 * Adds support for PyTorch 1.8.0 with CUDA 11.1 and CUDNN 8
 
-*Bug Fixes:*
+Bug Fixes:
 
 * Fixes crash issue when importing `smdataparallel` before PyTorch
 
-*Improvements:*
+Improvements:
 
 * Update `smdataparallel` name in python packages, descriptions, and log outputs
 
-*Known Issues:*
+Known Issues:
 
 * SageMaker DataParallel is not efficient when run using a single node. For the best performance, use multi-node distributed training with `smdataparallel`. Use a single node only for experimental runs while preparing your training pipeline.
 


### PR DESCRIPTION
…1.1.1 (#2280)"

This reverts commit 7fec6c191a07b1b15dc1fb5ac719355e56b8580f.

*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
