### PR TITLE
fix: Fix issue where Processing job in Local mode would call Describe…

### DIFF
--- a/src/sagemaker/local/local_session.py
+++ b/src/sagemaker/local/local_session.py
@@ -546,6 +546,21 @@ class LocalSession(Session):
         # on local mode.
         pass  # pylint: disable=unnecessary-pass
 
+    def logs_for_processing_job(self, job_name, wait=False, poll=10):
+        """A no-op method meant to override the sagemaker client.
+
+        Args:
+          job_name:
+          wait:  (Default value = False)
+          poll:  (Default value = 10)
+
+        Returns:
+
+        """
+        # override logs_for_job() as it doesn't need to perform any action
+        # on local mode.
+        pass  # pylint: disable=unnecessary-pass
+
 
 class file_input(object):
     """Amazon SageMaker channel configuration for FILE data sources, used in local mode."""

--- a/tests/unit/test_local_session.py
+++ b/tests/unit/test_local_session.py
@@ -551,6 +551,20 @@ def test_describe_transform_job_does_not_exist(LocalSession, _LocalTransformJob)
         local_sagemaker_client.describe_transform_job("transform-job-does-not-exist")
 
 
+@patch("sagemaker.local.image._SageMakerContainer.process")
+@patch("sagemaker.local.local_session.LocalSession")
+def test_logs_for_job(process, LocalSession):
+    local_job_logs = LocalSession.logs_for_job("my-processing-job")
+    assert local_job_logs is not None
+
+
+@patch("sagemaker.local.image._SageMakerContainer.process")
+@patch("sagemaker.local.local_session.LocalSession")
+def test_logs_for_processing_job(process, LocalSession):
+    local_processing_job_logs = LocalSession.logs_for_processing_job("my-processing-job")
+    assert local_processing_job_logs is not None
+
+
 @patch("sagemaker.local.local_session.LocalSession")
 def test_describe_endpoint_config(LocalSession):
     local_sagemaker_client = sagemaker.local.local_session.LocalSagemakerClient()


### PR DESCRIPTION
…LogStreams() against CloudWatch logs endpoint. Issue #2253

*Issue #, if available:* #2253

*Description of changes:*
This solution to this problem came from @giuseppeporcelli

For this change, provided a no-op method in local_session.py and two tests to verify that the correct methods are being called when using SageMaker Processing in local mode.

*Testing done:*
I tested by creating a Processing job. From the log output and the Cloudtrail history, I confirmed that DescribeLogStreams API is not being invoked against CloudWatch Logs endpoint
## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
