### PR TITLE
Add customized error message for retrieving debugger rule container

### DIFF
--- a/tests/unit/sagemaker/image_uris/test_debugger.py
+++ b/tests/unit/sagemaker/image_uris/test_debugger.py
@@ -12,6 +12,8 @@
 # language governing permissions and limitations under the License.
 from __future__ import absolute_import
 
+import pytest
+
 from sagemaker import image_uris
 from tests.unit.sagemaker.image_uris import expected_uris, regions
 
@@ -42,7 +44,7 @@ ACCOUNTS = {
 }
 
 
-def test_debugger():
+def test_retrieve_debugger_rule_container_in_supported_regions():
     for region in regions.regions():
         if region in ACCOUNTS.keys():
             uri = image_uris.retrieve("debugger", region=region)
@@ -51,3 +53,11 @@ def test_debugger():
                 "sagemaker-debugger-rules", ACCOUNTS[region], region, version="latest"
             )
             assert expected == uri
+
+
+def test_retrieve_debugger_rule_container_in_unsupported_regions():
+    for region in regions.regions():
+        if region not in ACCOUNTS.keys():
+            with pytest.raises(ValueError, match=".*for debugger rule container.*"):
+                image_uris.retrieve("debugger", region=region)
+            break


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When retrieving the debugger rule container in ECR registry in one region and if the container is not supported in that region,  the current error message is not so intuitive to customers. 

The current msg is like below, customers have no idea what is not supported in that region and may think sagemaker is not supported in that region. 
"Unsupported region: {region}. You may need to upgrade your SDK version (pip install -U sagemaker) for newer regions. Supported region(s): {list of regions}."

In this pr, I only change error message for debugger framework. 

*Testing done:*
Added unit test to test the new error message.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
