### PR TITLE
fix: use subprocess.run and f-strings in sagemaker.local.image

### DIFF
--- a/src/sagemaker/local/image.py
+++ b/src/sagemaker/local/image.py
@@ -905,13 +905,14 @@ def _check_output(cmd):
         cmd = shlex.split(cmd)
 
     success = True
+    output = None
+
     try:
-        output = subprocess.run(cmd, shell=True, check=True)
+        subprocess.run(cmd, shell=True, check=True)
     except subprocess.CalledProcessError as e:
         output = e.output
         success = False
 
-    output = output.decode("utf-8")
     if not success:
         logger.error("Command output: %s", output)
         raise Exception(f"Failed to run {','.join(cmd)}")

--- a/src/sagemaker/local/image.py
+++ b/src/sagemaker/local/image.py
@@ -151,7 +151,11 @@ class _SageMakerContainer(object):
             _pull_image(self.image)
 
         process = subprocess.run(
-            compose_command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True
+            compose_command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            shell=True,
+            check=True,
         )
 
         try:
@@ -231,7 +235,11 @@ class _SageMakerContainer(object):
             _pull_image(self.image)
 
         process = subprocess.run(
-            compose_command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True
+            compose_command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            shell=True,
+            check=True,
         )
 
         try:
@@ -300,7 +308,6 @@ class _SageMakerContainer(object):
         tasks.
         """
         if self.container:
-            self.container.down()
             self.container.join()
             self._cleanup()
         # for serving we can delete everything in the container root.
@@ -830,7 +837,7 @@ class _HostingContainer(Thread):
     def run(self):
         """Placeholder docstring"""
         self.process = subprocess.run(
-            self.command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True
+            self.command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True, check=True
         )
         try:
             _write_output(self.process)
@@ -839,10 +846,6 @@ class _HostingContainer(Thread):
             # which contains the exit code and append the command line to it.
             msg = f"Failed to run: {self.command}, {str(e)}"
             raise RuntimeError(msg)
-
-    def down(self):
-        """Placeholder docstring"""
-        self.process.terminate()
 
 
 class _Volume(object):

--- a/src/sagemaker/local/image.py
+++ b/src/sagemaker/local/image.py
@@ -1054,7 +1054,7 @@ def _ecr_login_if_needed(boto_session, image):
         return False
 
     # do we have the image?
-    if _check_output(f"docker images -q {image}").strip():
+    if _check_output(f"docker images -q {image}"):
         return False
 
     if not boto_session:

--- a/tests/unit/test_image.py
+++ b/tests/unit/test_image.py
@@ -306,28 +306,25 @@ def test_stream_output():
         p = subprocess.Popen(
             ["ls", "/some/unknown/path"], stdout=subprocess.PIPE, stderr=subprocess.PIPE
         )
-        sagemaker.local.image._stream_output(p)
+        sagemaker.local.image._write_output(p)
 
     p = subprocess.Popen(["echo", "hello"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    exit_code = sagemaker.local.image._stream_output(p)
+    exit_code = sagemaker.local.image._write_output(p)
     assert exit_code == 0
 
 
 def test_check_output():
     with pytest.raises(Exception):
-        sagemaker.local.image._check_output(["ls", "/some/unknown/path"])
+        sagemaker.local.image._check_output("ls /some/unknown/path")
 
     msg = "hello!"
 
-    output = sagemaker.local.image._check_output(["echo", msg]).strip()
-    assert output == msg
-
-    output = sagemaker.local.image._check_output("echo %s" % msg).strip()
+    output = sagemaker.local.image._check_output(f"echo {msg}").strip()
     assert output == msg
 
 
 @patch("sagemaker.local.local_session.LocalSession", Mock())
-@patch("sagemaker.local.image._stream_output", Mock())
+@patch("sagemaker.local.image._write_output", Mock())
 @patch("sagemaker.local.image._SageMakerContainer._cleanup")
 @patch("sagemaker.local.image._SageMakerContainer.retrieve_artifacts")
 @patch("sagemaker.local.data.get_data_source_instance")
@@ -395,7 +392,7 @@ def test_train(
 
 
 @patch("sagemaker.local.local_session.LocalSession", Mock())
-@patch("sagemaker.local.image._stream_output", Mock())
+@patch("sagemaker.local.image._write_output", Mock())
 @patch("sagemaker.local.image._SageMakerContainer._cleanup", Mock())
 @patch("sagemaker.local.data.get_data_source_instance")
 def test_train_with_hyperparameters_without_job_name(
@@ -432,7 +429,7 @@ def test_train_with_hyperparameters_without_job_name(
 
 
 @patch("sagemaker.local.local_session.LocalSession", Mock())
-@patch("sagemaker.local.image._stream_output", side_effect=RuntimeError("this is expected"))
+@patch("sagemaker.local.image._write_output", side_effect=RuntimeError("this is expected"))
 @patch("sagemaker.local.image._SageMakerContainer._cleanup")
 @patch("sagemaker.local.image._SageMakerContainer.retrieve_artifacts")
 @patch("sagemaker.local.data.get_data_source_instance")
@@ -466,7 +463,7 @@ def test_train_error(
 
 
 @patch("sagemaker.local.local_session.LocalSession", Mock())
-@patch("sagemaker.local.image._stream_output", Mock())
+@patch("sagemaker.local.image._write_output", Mock())
 @patch("sagemaker.local.image._SageMakerContainer._cleanup", Mock())
 @patch("sagemaker.local.data.get_data_source_instance")
 @patch("subprocess.Popen", Mock())
@@ -514,7 +511,7 @@ def test_train_local_code(get_data_source_instance, tmpdir, sagemaker_session):
 
 
 @patch("sagemaker.local.local_session.LocalSession", Mock())
-@patch("sagemaker.local.image._stream_output", Mock())
+@patch("sagemaker.local.image._write_output", Mock())
 @patch("sagemaker.local.image._SageMakerContainer._cleanup", Mock())
 @patch("sagemaker.local.data.get_data_source_instance")
 @patch("subprocess.Popen", Mock())


### PR DESCRIPTION
*Description of changes:*
This PR updates usage of `subprocess` to the recommended `run` function. It also updates strings to f-strings.

From the `subprocess` [documentation](https://docs.python.org/3/library/subprocess.html#using-the-subprocess-module):
> The recommended approach to invoking subprocesses is to use the run() function for all use cases it can handle.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
