### PR TITLE
Feature: prefix data loading

### DIFF
--- a/src/sagemaker/processing.py
+++ b/src/sagemaker/processing.py
@@ -135,7 +135,7 @@ class Processor(object):
         job_name=None,
         experiment_config=None,
         kms_key=None,
-        prefix=None
+        prefix=None,
     ):
         """Runs a processing job.
 
@@ -158,7 +158,7 @@ class Processor(object):
                 'ExperimentName', 'TrialName', and 'TrialComponentDisplayName'.
             kms_key (str): The ARN of the KMS key that is used to encrypt the
                 user code file (default: None).
-            prefix (str): Bucket prefix the processing job will upload the local app and 
+            prefix (str): Bucket prefix the processing job will upload the local app and
                 inputs to before downloading to container.
 
         Raises:
@@ -176,7 +176,7 @@ class Processor(object):
             inputs=inputs,
             kms_key=kms_key,
             outputs=outputs,
-            prefix=prefix
+            prefix=prefix,
         )
 
         self.latest_job = ProcessingJob.start_new(
@@ -201,7 +201,7 @@ class Processor(object):
         outputs=None,
         code=None,
         kms_key=None,
-        prefix=None
+        prefix=None,
     ):
         """Normalizes the arguments so that they can be passed to the job run
 
@@ -221,11 +221,11 @@ class Processor(object):
                 script to run (default: None). A no op in the base class.
             kms_key (str): The ARN of the KMS key that is used to encrypt the
                 user code file (default: None).
-            prefix (str): Bucket prefix the processing job will upload the local app and 
+            prefix (str): Bucket prefix the processing job will upload the local app and
                 inputs to before downloading to container.
         """
         self._current_job_name = self._generate_current_job_name(job_name=job_name)
-        self._prefix = self._current_job_name if self._prefix == None else prefix
+        self._prefix = self._current_job_name if self._prefix is None else prefix
 
         inputs_with_code = self._include_code_in_inputs(inputs, code, kms_key)
         normalized_inputs = self._normalize_inputs(inputs_with_code, kms_key)
@@ -494,6 +494,7 @@ class ScriptProcessor(Processor):
         job_name=None,
         experiment_config=None,
         kms_key=None,
+        prefix=None,
     ):
         """Runs a processing job.
 
@@ -518,6 +519,8 @@ class ScriptProcessor(Processor):
                 'ExperimentName', 'TrialName', and 'TrialComponentDisplayName'.
             kms_key (str): The ARN of the KMS key that is used to encrypt the
                 user code file (default: None).
+            prefix (str): Bucket prefix the processing job will upload the local app and
+                inputs to before downloading to container.
         """
         normalized_inputs, normalized_outputs = self._normalize_args(
             job_name=job_name,
@@ -526,6 +529,7 @@ class ScriptProcessor(Processor):
             outputs=outputs,
             code=code,
             kms_key=kms_key,
+            prefix=prefix,
         )
 
         self.latest_job = ProcessingJob.start_new(

--- a/src/sagemaker/processing.py
+++ b/src/sagemaker/processing.py
@@ -30,7 +30,6 @@ from sagemaker.job import _Job
 from sagemaker.local import LocalSession
 from sagemaker.utils import base_name_from_image, name_from_base
 from sagemaker.session import Session
-from sagemaker.network import NetworkConfig  # noqa: F401 # pylint: disable=unused-import
 from sagemaker.workflow.properties import Properties
 from sagemaker.workflow.parameters import Parameter
 from sagemaker.workflow.entities import Expression
@@ -219,14 +218,14 @@ class Processor(object):
         """
         self._current_job_name = self._generate_current_job_name(job_name=job_name)
 
-        inputs_with_code = self._include_code_in_inputs(inputs, code)
+        inputs_with_code = self._include_code_in_inputs(inputs, code, kms_key)
         normalized_inputs = self._normalize_inputs(inputs_with_code, kms_key)
         normalized_outputs = self._normalize_outputs(outputs)
         self.arguments = arguments
 
         return normalized_inputs, normalized_outputs
 
-    def _include_code_in_inputs(self, inputs, _code):
+    def _include_code_in_inputs(self, inputs, _code, _kms_key):
         """A no op in the base class to include code in the processing job inputs.
 
         Args:
@@ -235,6 +234,8 @@ class Processor(object):
                 :class:`~sagemaker.processing.ProcessingInput` objects.
             _code (str): This can be an S3 URI or a local path to a file with the framework
                 script to run (default: None). A no op in the base class.
+            kms_key (str): The ARN of the KMS key that is used to encrypt the
+                user code file (default: None).
 
         Returns:
             list[:class:`~sagemaker.processing.ProcessingInput`]: inputs
@@ -528,7 +529,7 @@ class ScriptProcessor(Processor):
         if wait:
             self.latest_job.wait(logs=logs)
 
-    def _include_code_in_inputs(self, inputs, code):
+    def _include_code_in_inputs(self, inputs, code, kms_key=None):
         """Converts code to appropriate input and includes in input list.
 
         Side effects include:
@@ -541,12 +542,14 @@ class ScriptProcessor(Processor):
                 :class:`~sagemaker.processing.ProcessingInput` objects.
             code (str): This can be an S3 URI or a local path to a file with the framework
                 script to run (default: None).
+            kms_key (str): The ARN of the KMS key that is used to encrypt the
+                user code file (default: None).
 
         Returns:
             list[:class:`~sagemaker.processing.ProcessingInput`]: inputs together with the
                 code as `ProcessingInput`.
         """
-        user_code_s3_uri = self._handle_user_code_url(code)
+        user_code_s3_uri = self._handle_user_code_url(code, kms_key)
         user_script_name = self._get_user_code_name(code)
 
         inputs_with_code = self._convert_code_and_add_to_inputs(inputs, user_code_s3_uri)
@@ -567,7 +570,7 @@ class ScriptProcessor(Processor):
         code_url = urlparse(code)
         return os.path.basename(code_url.path)
 
-    def _handle_user_code_url(self, code):
+    def _handle_user_code_url(self, code, kms_key=None):
         """Gets the S3 URL containing the user's code.
 
            Inspects the scheme the customer passed in ("s3://" for code in S3, "file://" or nothing
@@ -575,6 +578,8 @@ class ScriptProcessor(Processor):
 
         Args:
             code (str): A URL to the customer's code.
+            kms_key (str): The ARN of the KMS key that is used to encrypt the
+                user code file (default: None).
 
         Returns:
             str: The S3 URL to the customer's code.
@@ -603,7 +608,7 @@ class ScriptProcessor(Processor):
                         code
                     )
                 )
-            user_code_s3_uri = self._upload_code(code_path)
+            user_code_s3_uri = self._upload_code(code_path, kms_key)
         else:
             raise ValueError(
                 "code {} url scheme {} is not recognized. Please pass a file path or S3 url".format(
@@ -612,11 +617,13 @@ class ScriptProcessor(Processor):
             )
         return user_code_s3_uri
 
-    def _upload_code(self, code):
+    def _upload_code(self, code, kms_key=None):
         """Uploads a code file or directory specified as a string and returns the S3 URI.
 
         Args:
             code (str): A file or directory to be uploaded to S3.
+            kms_key (str): The ARN of the KMS key that is used to encrypt the
+                user code file (default: None).
 
         Returns:
             str: The S3 URI of the uploaded file or directory.
@@ -630,7 +637,10 @@ class ScriptProcessor(Processor):
             self._CODE_CONTAINER_INPUT_NAME,
         )
         return s3.S3Uploader.upload(
-            local_path=code, desired_s3_uri=desired_s3_uri, sagemaker_session=self.sagemaker_session
+            local_path=code,
+            desired_s3_uri=desired_s3_uri,
+            kms_key=kms_key,
+            sagemaker_session=self.sagemaker_session,
         )
 
     def _convert_code_and_add_to_inputs(self, inputs, s3_uri):
@@ -666,7 +676,9 @@ class ScriptProcessor(Processor):
         """
         user_script_location = str(
             pathlib.PurePosixPath(
-                self._CODE_CONTAINER_BASE_PATH, self._CODE_CONTAINER_INPUT_NAME, user_script_name
+                self._CODE_CONTAINER_BASE_PATH,
+                self._CODE_CONTAINER_INPUT_NAME,
+                user_script_name,
             )
         )
         self.entrypoint = command + [user_script_location]
@@ -1066,7 +1078,10 @@ class ProcessingInput(object):
         """Generates a request dictionary using the parameters provided to the class."""
 
         # Create the request dictionary.
-        s3_input_request = {"InputName": self.input_name, "AppManaged": self.app_managed}
+        s3_input_request = {
+            "InputName": self.input_name,
+            "AppManaged": self.app_managed,
+        }
 
         if self.s3_input:
             # Check the compression type, then add it to the dictionary.

--- a/src/sagemaker/spark/processing.py
+++ b/src/sagemaker/spark/processing.py
@@ -148,7 +148,12 @@ class _SparkProcessorBase(ScriptProcessor):
         region = session.boto_region_name
 
         self.image_uri = self._retrieve_image_uri(
-            image_uri, framework_version, py_version, container_version, region, instance_type
+            image_uri,
+            framework_version,
+            py_version,
+            container_version,
+            region,
+            instance_type,
         )
 
         env = env or {}
@@ -234,7 +239,7 @@ class _SparkProcessorBase(ScriptProcessor):
                 Only meaningful when wait is True (default: True).
             job_name (str): Processing job name. If not specified, the processor generates
                 a default job name, based on the base job name and current timestamp.
-            prefix (str): Bucket prefix the processing job will upload the local app and 
+            prefix (str): Bucket prefix the processing job will upload the local app and
                 inputs to before downloading to container.
             experiment_config (dict[str, str]): Experiment management configuration.
                 Dictionary contains three optional keys:
@@ -315,7 +320,13 @@ class _SparkProcessorBase(ScriptProcessor):
             self.history_server = None
 
     def _retrieve_image_uri(
-        self, image_uri, framework_version, py_version, container_version, region, instance_type
+        self,
+        image_uri,
+        framework_version,
+        py_version,
+        container_version,
+        region,
+        instance_type,
     ):
         """Builds an image URI."""
         if not image_uri:
@@ -448,7 +459,9 @@ class _SparkProcessorBase(ScriptProcessor):
                             f"{self._submit_deps_error_message}"
                         )
                     logger.info(
-                        "Copying dependency from local path %s to tmpdir %s", dep_path, tmpdir
+                        "Copying dependency from local path %s to tmpdir %s",
+                        dep_path,
+                        tmpdir,
                     )
                     shutil.copy(dep_path, tmpdir)
                 else:
@@ -460,7 +473,9 @@ class _SparkProcessorBase(ScriptProcessor):
             # If any local files were found and copied, upload the temp directory to S3
             if os.listdir(tmpdir):
                 logger.info(
-                    "Uploading dependencies from tmpdir %s to S3 %s", tmpdir, input_channel_s3_uri
+                    "Uploading dependencies from tmpdir %s to S3 %s",
+                    tmpdir,
+                    input_channel_s3_uri,
                 )
                 S3Uploader.upload(
                     local_path=tmpdir,
@@ -559,7 +574,8 @@ class _SparkProcessorBase(ScriptProcessor):
                     )
                 else:
                     logger.info(
-                        "History server is up on http://0.0.0.0%s", self._history_server_url_suffix
+                        "History server is up on http://0.0.0.0%s",
+                        self._history_server_url_suffix,
                     )
                 break
             if time.time() > timeout:
@@ -1158,7 +1174,9 @@ class _HistoryServer:
         self.down()
         logger.info("Starting history server...")
         subprocess.Popen(
-            self.run_history_server_command.split(), stdout=subprocess.PIPE, stderr=subprocess.PIPE
+            self.run_history_server_command.split(),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
         )
 
     def down(self):

--- a/src/sagemaker/spark/processing.py
+++ b/src/sagemaker/spark/processing.py
@@ -213,6 +213,7 @@ class _SparkProcessorBase(ScriptProcessor):
         wait=True,
         logs=True,
         job_name=None,
+        prefix=None,
         experiment_config=None,
         kms_key=None,
     ):
@@ -233,6 +234,8 @@ class _SparkProcessorBase(ScriptProcessor):
                 Only meaningful when wait is True (default: True).
             job_name (str): Processing job name. If not specified, the processor generates
                 a default job name, based on the base job name and current timestamp.
+            prefix (str): Bucket prefix the processing job will upload the local app and 
+                inputs to before downloading to container.
             experiment_config (dict[str, str]): Experiment management configuration.
                 Dictionary contains three optional keys:
                 'ExperimentName', 'TrialName', and 'TrialComponentDisplayName'.
@@ -249,6 +252,7 @@ class _SparkProcessorBase(ScriptProcessor):
             wait,
             logs,
             job_name,
+            prefix,
             experiment_config,
             kms_key,
         )

--- a/tests/unit/sagemaker/spark/test_processing.py
+++ b/tests/unit/sagemaker/spark/test_processing.py
@@ -200,7 +200,7 @@ def test_configuration_validation(config, expected, sagemaker_session) -> None:
 def test_spark_processor_base_run(mock_super_run, spark_processor_base):
     spark_processor_base.run(submit_app="app")
 
-    mock_super_run.assert_called_with("app", None, None, None, True, True, None, None, None)
+    mock_super_run.assert_called_with("app", None, None, None, True, True, None, None, None, None)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
Add prefix for local app code and input data to allow dynamic control of where the data is uploaded.
*Testing done:*
N/A
## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ `x`] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [`x` ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [`x` ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ `x`] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ `x`] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [`x` ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ `x`] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
