### PR TITLE
fix: default value removed if zero for integer param

### DIFF
--- a/src/sagemaker/workflow/parameters.py
+++ b/src/sagemaker/workflow/parameters.py
@@ -80,7 +80,7 @@ class Parameter(Entity):
             "Name": self.name,
             "Type": self.parameter_type.value,
         }
-        if self.default_value:
+        if self.default_value is not None:
             value["DefaultValue"] = self.default_value
         return value
 

--- a/tests/unit/sagemaker/workflow/test_parameters.py
+++ b/tests/unit/sagemaker/workflow/test_parameters.py
@@ -37,6 +37,10 @@ def test_parameter_with_default():
     assert param.to_request() == {"Name": "MyFloat", "Type": "Float", "DefaultValue": 1.2}
 
 
+def test_parameter_with_default_value_zero():
+    param = ParameterInteger(name="MyInteger", default_value=0)
+    assert param.to_request() == {"Name": "MyInteger", "Type": "Integer", "DefaultValue": 0}
+
 def test_parameter_string_with_enum_values():
     param = ParameterString("MyString", enum_values=["a", "b"])
     assert param.to_request() == {"Name": "MyString", "Type": "String", "EnumValues": ["a", "b"]}

--- a/tests/unit/sagemaker/workflow/test_parameters.py
+++ b/tests/unit/sagemaker/workflow/test_parameters.py
@@ -41,6 +41,7 @@ def test_parameter_with_default_value_zero():
     param = ParameterInteger(name="MyInteger", default_value=0)
     assert param.to_request() == {"Name": "MyInteger", "Type": "Integer", "DefaultValue": 0}
 
+
 def test_parameter_string_with_enum_values():
     param = ParameterString("MyString", enum_values=["a", "b"])
     assert param.to_request() == {"Name": "MyString", "Type": "String", "EnumValues": ["a", "b"]}


### PR DESCRIPTION
*Issue #, if available:* #2144

*Description of changes:*
Correctly Check if the pipeline parameter is null, the previous check ignored value for `ParameterInteger` if default value is 0

*Testing done:*
Added unit test for the parameter

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
