### PR TITLE
fix: stop repeating tags when deploying endpoint

### DIFF
--- a/src/sagemaker/_studio.py
+++ b/src/sagemaker/_studio.py
@@ -46,8 +46,11 @@ def _append_project_tags(tags=None, working_dir=None):
         return tags
 
     all_tags = tags or []
-    all_tags.extend(additional_tags)
-
+    # Don't add project tags multiple times.
+    all_tag_keys = set(map(lambda t: t["Key"], all_tags))
+    for tag in additional_tags:
+        if not tag["Key"] in all_tag_keys:
+            all_tags.append(tag)
     return all_tags
 
 

--- a/tests/unit/sagemaker/test_studio.py
+++ b/tests/unit/sagemaker/test_studio.py
@@ -94,3 +94,24 @@ def test_append_project_tags(tmpdir):
         {"Key": "sagemaker:project-id", "Value": "proj-1234"},
         {"Key": "sagemaker:project-name", "Value": "proj-name"},
     ]
+
+
+def test_append_project_tags_multiple_times(tmpdir):
+    # This test case ensures that project tags only get added once.
+    # Sagemaker API fails when the same tag is added multiple times in the tags array.
+    config = tmpdir.join(".sagemaker-code-config")
+    config.write('{"sagemakerProjectId": "proj-1234", "sagemakerProjectName": "proj-name"}')
+    working_dir = tmpdir.mkdir("sub")
+
+    tags = _append_project_tags([{"Key": "a", "Value": "b"}], working_dir)
+    assert tags == [
+        {"Key": "a", "Value": "b"},
+        {"Key": "sagemaker:project-id", "Value": "proj-1234"},
+        {"Key": "sagemaker:project-name", "Value": "proj-name"},
+    ]
+    tags = _append_project_tags(tags, working_dir)
+    assert tags == [
+        {"Key": "a", "Value": "b"},
+        {"Key": "sagemaker:project-id", "Value": "proj-1234"},
+        {"Key": "sagemaker:project-name", "Value": "proj-name"},
+    ]


### PR DESCRIPTION
This addresses https://github.com/aws/sagemaker-python-sdk/issues/2313

*Issue #, if available:*
#2313 

*Description of changes:*
Ensure that project tags are not appended to tag list already containing project tags.

*Testing done:*
Unit tests run and single test added to pass.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)
Not appropriate. Now functions the way it is supposed to function
#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate) - N/A
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate) - N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
