### PR TITLE
feat: support passing endpoint_name_prefix, seed and version for clarify

### DIFF
--- a/src/sagemaker/clarify.py
+++ b/src/sagemaker/clarify.py
@@ -126,7 +126,7 @@ class ModelConfig:
         accelerator_type=None,
         endpoint_name_prefix=None,
     ):
-        """Initializes a configuration of a model and the endpoint to be created for it.
+        r"""Initializes a configuration of a model and the endpoint to be created for it.
 
         Args:
             model_name (str): Model name (as created by 'CreateModel').
@@ -321,8 +321,9 @@ class SHAPConfig(ExplainabilityConfig):
             "agg_method": agg_method,
             "use_logit": use_logit,
             "save_local_shap_values": save_local_shap_values,
-            "seed": seed,
         }
+        if seed is not None:
+            self.shap_config["seed"] = seed
 
     def get_explainability_config(self):
         """Returns config."""

--- a/src/sagemaker/clarify.py
+++ b/src/sagemaker/clarify.py
@@ -157,7 +157,7 @@ class ModelConfig:
                 endpoint instance for making inferences to the model, see
                 https://docs.aws.amazon.com/sagemaker/latest/dg/ei.html.
             endpoint_name_prefix (str): The endpoint name prefix of a new endpoint. Must follow
-                pattern ^[a-zA-Z0-9](-*[a-zA-Z0-9].
+                pattern "^[a-zA-Z0-9](-\*[a-zA-Z0-9]".
         """
         self.predictor_config = {
             "model_name": model_name,
@@ -349,6 +349,7 @@ class SageMakerClarifyProcessor(Processor):
         env=None,
         tags=None,
         network_config=None,
+        version="1.0",
     ):
         """Initializes a ``Processor`` instance, computing bias metrics and model explanations.
 
@@ -382,8 +383,9 @@ class SageMakerClarifyProcessor(Processor):
                 A :class:`~sagemaker.network.NetworkConfig`
                 object that configures network isolation, encryption of
                 inter-container traffic, security group IDs, and subnets.
+            version (str): Clarify version want to be used (default: "1.0").
         """
-        container_uri = image_uris.retrieve("clarify", sagemaker_session.boto_region_name)
+        container_uri = image_uris.retrieve("clarify", sagemaker_session.boto_region_name, version)
         super(SageMakerClarifyProcessor, self).__init__(
             role,
             container_uri,

--- a/src/sagemaker/clarify.py
+++ b/src/sagemaker/clarify.py
@@ -19,7 +19,7 @@ from abc import ABC, abstractmethod
 import json
 import os
 import tempfile
-
+import re
 from sagemaker.processing import ProcessingInput, ProcessingOutput, Processor
 from sagemaker import image_uris, s3, utils
 
@@ -124,6 +124,7 @@ class ModelConfig:
         content_template=None,
         custom_attributes=None,
         accelerator_type=None,
+        endpoint_name_prefix=None,
     ):
         """Initializes a configuration of a model and the endpoint to be created for it.
 
@@ -155,12 +156,21 @@ class ModelConfig:
             accelerator_type (str): The Elastic Inference accelerator type to deploy to the model
                 endpoint instance for making inferences to the model, see
                 https://docs.aws.amazon.com/sagemaker/latest/dg/ei.html.
+            endpoint_name_prefix (str): The endpoint name prefix of a new endpoint. Must follow
+                pattern ^[a-zA-Z0-9](-*[a-zA-Z0-9].
         """
         self.predictor_config = {
             "model_name": model_name,
             "instance_type": instance_type,
             "initial_instance_count": instance_count,
         }
+        if endpoint_name_prefix is not None:
+            if re.search("^[a-zA-Z0-9](-*[a-zA-Z0-9])", endpoint_name_prefix) is None:
+                raise ValueError(
+                    "Invalid endpoint_name_prefix."
+                    " Please follow pattern ^[a-zA-Z0-9](-*[a-zA-Z0-9])."
+                )
+            self.predictor_config["endpoint_name_prefix"] = endpoint_name_prefix
         if accept_type is not None:
             if accept_type not in ["text/csv", "application/jsonlines"]:
                 raise ValueError(
@@ -277,6 +287,7 @@ class SHAPConfig(ExplainabilityConfig):
         agg_method,
         use_logit=False,
         save_local_shap_values=True,
+        seed=None,
     ):
         """Initializes config for SHAP.
 
@@ -297,6 +308,7 @@ class SHAPConfig(ExplainabilityConfig):
                 have log-odds units.
             save_local_shap_values (bool): Indicator of whether to save the local SHAP values
                 in the output location. Default is True.
+            seed (int): seed value to get deterministic SHAP values. Default is None.
         """
         if agg_method not in ["mean_abs", "median", "mean_sq"]:
             raise ValueError(
@@ -309,6 +321,7 @@ class SHAPConfig(ExplainabilityConfig):
             "agg_method": agg_method,
             "use_logit": use_logit,
             "save_local_shap_values": save_local_shap_values,
+            "seed": seed,
         }
 
     def get_explainability_config(self):

--- a/tests/unit/test_clarify.py
+++ b/tests/unit/test_clarify.py
@@ -128,6 +128,21 @@ def test_invalid_model_config():
     )
 
 
+def test_invalid_model_config_with_bad_endpoint_name_prefix():
+    with pytest.raises(ValueError) as error:
+        ModelConfig(
+            model_name="xgboost-model",
+            instance_type="ml.c5.xlarge",
+            instance_count=1,
+            accept_type="invalid_accept_type",
+            endpoint_name_prefix="~invalid_endpoint_prefix",
+        )
+    assert (
+        "Invalid endpoint_name_prefix. Please follow pattern ^[a-zA-Z0-9](-*[a-zA-Z0-9])."
+        in str(error.value)
+    )
+
+
 def test_model_predicted_label_config():
     label = "label"
     probability = "pr"
@@ -171,11 +186,13 @@ def test_shap_config():
     num_samples = 100
     agg_method = "mean_sq"
     use_logit = True
+    seed = 123
     shap_config = SHAPConfig(
         baseline=baseline,
         num_samples=num_samples,
         agg_method=agg_method,
         use_logit=use_logit,
+        seed=seed,
     )
     expected_config = {
         "shap": {
@@ -184,6 +201,7 @@ def test_shap_config():
             "agg_method": agg_method,
             "use_logit": use_logit,
             "save_local_shap_values": True,
+            "seed": seed,
         }
     }
     assert expected_config == shap_config.get_explainability_config()
@@ -394,6 +412,7 @@ def test_shap(clarify_processor, data_config, model_config, shap_config):
                     "agg_method": "mean_sq",
                     "use_logit": False,
                     "save_local_shap_values": True,
+                    "seed": None,
                 }
             },
             "predictor": {

--- a/tests/unit/test_clarify.py
+++ b/tests/unit/test_clarify.py
@@ -412,7 +412,6 @@ def test_shap(clarify_processor, data_config, model_config, shap_config):
                     "agg_method": "mean_sq",
                     "use_logit": False,
                     "save_local_shap_values": True,
-                    "seed": None,
                 }
             },
             "predictor": {


### PR DESCRIPTION
*Issue #, if available:*
1. Support endpoint_name_prefix
2. Support seed
3. Support version

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
