### PR TITLE
change: add default retries to feature group ingestion.

### DIFF
--- a/src/sagemaker/feature_store/feature_group.py
+++ b/src/sagemaker/feature_store/feature_group.py
@@ -21,6 +21,7 @@ list feature groups APIs can be used to manage feature groups.
 
 from __future__ import absolute_import
 
+import copy
 import logging
 import math
 import os
@@ -193,6 +194,10 @@ class IngestionManagerPandas:
         Returns:
             List of row indices that failed to be ingested.
         """
+        retry_config = client_config.retries
+        if "max_attempts" not in retry_config and "total_max_attempts" not in retry_config:
+            client_config = copy.deepcopy(client_config)
+            client_config.retries = {"max_attempts": 10, "mode": "standard"}
         sagemaker_featurestore_runtime_client = boto3.Session().client(
             service_name="sagemaker-featurestore-runtime", config=client_config
         )


### PR DESCRIPTION
*Issue #, if available:* 
N/A

*Description of changes:* 
Adding a default retry strategy configuration to the feature group ingestion's boto3 client.

*Testing done:*
Manual E2E testing:
- Verified that overrides are honored (max_attempts and total_max_attempts) when configured in the SageMaker Session.
- Verified that the new defaults take effect when there are no overrides to retry attempts. 
- Verified that other configurations (e.g. region_name) are not retained even after defaults are set.


## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
