### PR TITLE
Add PyTorch 1.8.1 to HF image config

### DIFF
--- a/src/sagemaker/image_uri_config/huggingface.json
+++ b/src/sagemaker/image_uri_config/huggingface.json
@@ -143,6 +143,7 @@
                 "version_aliases": {
                     "pytorch1.6": "pytorch1.6.0",
                     "pytorch1.7": "pytorch1.7.1",
+                    "pytorch1.8": "pytorch1.8.1",
                     "tensorflow2.4": "tensorflow2.4.1"
                 },
                 "pytorch1.6.0": {
@@ -176,6 +177,36 @@
                     "repository": "huggingface-pytorch-training"
                 },
                 "pytorch1.7.1": {
+                    "py_versions": ["py36"],
+                    "registries": {
+                        "af-south-1": "626614931356",
+                        "ap-east-1": "871362719292",
+                        "ap-northeast-1": "763104351884",
+                        "ap-northeast-2": "763104351884",
+                        "ap-south-1": "763104351884",
+                        "ap-southeast-1": "763104351884",
+                        "ap-southeast-2": "763104351884",
+                        "ca-central-1": "763104351884",
+                        "cn-north-1": "727897471807",
+                        "cn-northwest-1": "727897471807",
+                        "eu-central-1": "763104351884",
+                        "eu-north-1": "763104351884",
+                        "eu-west-1": "763104351884",
+                        "eu-west-2": "763104351884",
+                        "eu-west-3": "763104351884",
+                        "eu-south-1": "692866216735",
+                        "me-south-1": "217643126080",
+                        "sa-east-1": "763104351884",
+                        "us-east-1": "763104351884",
+                        "us-east-2": "763104351884",
+                        "us-gov-west-1": "442386744353",
+                        "us-iso-east-1": "886529160074",
+                        "us-west-1": "763104351884",
+                        "us-west-2": "763104351884"
+                    },
+                    "repository": "huggingface-pytorch-training"
+                },
+                "pytorch1.8.1": {
                     "py_versions": ["py36"],
                     "registries": {
                         "af-south-1": "626614931356",


### PR DESCRIPTION
# What does this PR do?

This PR adds the version aliases for PyTorch 1.8.1. Can be merged after https://github.com/aws/deep-learning-containers/pull/1156 is merged. 