### PR TITLE
change: Register model step tags

### DIFF
--- a/src/sagemaker/model.py
+++ b/src/sagemaker/model.py
@@ -195,6 +195,7 @@ class Model(object):
         marketplace_cert=False,
         approval_status=None,
         description=None,
+        tags=None,
     ):
         """Get arguments for session.create_model_package method.
 
@@ -250,6 +251,8 @@ class Model(object):
             model_package_args["approval_status"] = approval_status
         if description is not None:
             model_package_args["description"] = description
+        if tags is not None:
+            model_package_args["tags"] = tags
         return model_package_args
 
     def _init_sagemaker_session_if_does_not_exist(self, instance_type):

--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -2724,6 +2724,7 @@ class Session(object):  # pylint: disable=too-many-public-methods
         marketplace_cert=False,
         approval_status="PendingManualApproval",
         description=None,
+        tags=None,
     ):
         """Get request dictionary for CreateModelPackage API.
 
@@ -2761,6 +2762,8 @@ class Session(object):  # pylint: disable=too-many-public-methods
             request_dict["ModelPackageGroupName"] = model_package_group_name
         if description is not None:
             request_dict["ModelPackageDescription"] = description
+        if tags is not None:
+            request_dict["Tags"] = tags
         if model_metrics:
             request_dict["ModelMetrics"] = model_metrics
         if metadata_properties:

--- a/src/sagemaker/workflow/_utils.py
+++ b/src/sagemaker/workflow/_utils.py
@@ -225,6 +225,7 @@ class _RegisterModelStep(Step):
         compile_model_family=None,
         description=None,
         depends_on: List[str] = None,
+        tags=None,
         **kwargs,
     ):
         """Constructor of a register model step.
@@ -264,6 +265,7 @@ class _RegisterModelStep(Step):
         self.inference_instances = inference_instances
         self.transform_instances = transform_instances
         self.model_package_group_name = model_package_group_name
+        self.tags = tags
         self.model_metrics = model_metrics
         self.metadata_properties = metadata_properties
         self.approval_status = approval_status
@@ -324,10 +326,12 @@ class _RegisterModelStep(Step):
             metadata_properties=self.metadata_properties,
             approval_status=self.approval_status,
             description=self.description,
+            tags=self.tags,
         )
         request_dict = model.sagemaker_session._get_create_model_package_request(
             **model_package_args
         )
+
         # these are not available in the workflow service and will cause rejection
         if "CertifyForMarketplace" in request_dict:
             request_dict.pop("CertifyForMarketplace")

--- a/src/sagemaker/workflow/step_collections.py
+++ b/src/sagemaker/workflow/step_collections.py
@@ -96,8 +96,9 @@ class RegisterModel(StepCollection):
                 specified, a compiled model is used (default: None).
             description (str): Model Package description (default: None).
             tags (List[dict[str, str]]): The list of tags to attach to the model package group. Note
-                that tags will only be applied to newly created model package groups; if the 
-                name of an existing group is passed to "model_package_group_name", tags will not be applied.
+                that tags will only be applied to newly created model package groups; if the
+                name of an existing group is passed to "model_package_group_name",
+                tags will not be applied.
             **kwargs: additional arguments to `create_model`.
         """
         steps: List[Step] = []

--- a/src/sagemaker/workflow/step_collections.py
+++ b/src/sagemaker/workflow/step_collections.py
@@ -67,6 +67,7 @@ class RegisterModel(StepCollection):
         image_uri=None,
         compile_model_family=None,
         description=None,
+        tags=None,
         **kwargs,
     ):
         """Construct steps `_RepackModelStep` and `_RegisterModelStep` based on the estimator.
@@ -94,6 +95,9 @@ class RegisterModel(StepCollection):
             compile_model_family (str): The instance family for the compiled model. If
                 specified, a compiled model is used (default: None).
             description (str): Model Package description (default: None).
+            tags (List[dict[str, str]]): The list of tags to attach to the model package group. Note
+                that tags will only be applied to newly created model package groups; if the 
+                name of an existing group is passed to "model_package_group_name", tags will not be applied.
             **kwargs: additional arguments to `create_model`.
         """
         steps: List[Step] = []
@@ -134,6 +138,7 @@ class RegisterModel(StepCollection):
             image_uri=image_uri,
             compile_model_family=compile_model_family,
             description=description,
+            tags=tags,
             **kwargs,
         )
         if not repack_model:

--- a/tests/unit/sagemaker/workflow/test_step_collections.py
+++ b/tests/unit/sagemaker/workflow/test_step_collections.py
@@ -182,6 +182,7 @@ def test_register_model(estimator, model_metrics):
         approval_status="Approved",
         description="description",
         depends_on=["TestStep"],
+        tags=[{"Key": "myKey", "Value": "myValue"}]
     )
     assert ordered(register_model.request_dicts()) == ordered(
         [
@@ -210,6 +211,7 @@ def test_register_model(estimator, model_metrics):
                     },
                     "ModelPackageDescription": "description",
                     "ModelPackageGroupName": "mpg",
+                    "Tags": [{"Key": "myKey", "Value": "myValue"}]
                 },
             },
         ]

--- a/tests/unit/sagemaker/workflow/test_step_collections.py
+++ b/tests/unit/sagemaker/workflow/test_step_collections.py
@@ -182,7 +182,7 @@ def test_register_model(estimator, model_metrics):
         approval_status="Approved",
         description="description",
         depends_on=["TestStep"],
-        tags=[{"Key": "myKey", "Value": "myValue"}]
+        tags=[{"Key": "myKey", "Value": "myValue"}],
     )
     assert ordered(register_model.request_dicts()) == ordered(
         [
@@ -211,7 +211,7 @@ def test_register_model(estimator, model_metrics):
                     },
                     "ModelPackageDescription": "description",
                     "ModelPackageGroupName": "mpg",
-                    "Tags": [{"Key": "myKey", "Value": "myValue"}]
+                    "Tags": [{"Key": "myKey", "Value": "myValue"}],
                 },
             },
         ]


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Add tags argument to RegisterModel step to allow for tagging model package groups.

*Testing done:*
Manual, unit.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
