### PR TITLE
infra: enable py38 tox env

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = black-format,flake8,pylint,docstyle,sphinx,doc8,twine,py36,py37
+envlist = black-format,flake8,pylint,docstyle,sphinx,doc8,twine,py36,py37,py38
 
 skip_missing_interpreters = False
 
@@ -71,7 +71,7 @@ commands =
     {env:IGNORE_COVERAGE:} coverage report -i --fail-under=86
 deps = .[test]
 depends =
-    {py36,py37}: clean
+    {py36,py37,py38}: clean
 
 [testenv:flake8]
 skipdist = true


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Enable py38 for tests
*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
