### PR TITLE
feature: add LambdaStep support for SageMaker Pipelines

### DIFF
--- a/doc/api/utility/lambda_helper.rst
+++ b/doc/api/utility/lambda_helper.rst
@@ -1,0 +1,7 @@
+Lambda Utilities
+----------------
+
+.. automodule:: sagemaker.lambda_helper
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/api/utility/lambda_helper.rst
+++ b/doc/api/utility/lambda_helper.rst
@@ -5,4 +5,3 @@ Lambda Utilities
     :members:
     :undoc-members:
     :show-inheritance:
-    

--- a/doc/api/utility/lambda_helper.rst
+++ b/doc/api/utility/lambda_helper.rst
@@ -5,3 +5,4 @@ Lambda Utilities
     :members:
     :undoc-members:
     :show-inheritance:
+    

--- a/doc/workflows/pipelines/sagemaker.workflow.pipelines.rst
+++ b/doc/workflows/pipelines/sagemaker.workflow.pipelines.rst
@@ -127,8 +127,3 @@ Steps
 .. autoclass:: sagemaker.workflow.steps.CacheConfig
 
 .. autoclass:: sagemaker.workflow.lambda_step.LambdaStep
-
-Utilities
----------
-
-.. autofunction:: sagemaker.workflow.utilities.list_to_request

--- a/doc/workflows/pipelines/sagemaker.workflow.pipelines.rst
+++ b/doc/workflows/pipelines/sagemaker.workflow.pipelines.rst
@@ -125,3 +125,10 @@ Steps
 .. autoclass:: sagemaker.workflow.callback_step.CallbackStep
 
 .. autoclass:: sagemaker.workflow.steps.CacheConfig
+
+.. autoclass:: sagemaker.workflow.lambda_step.LambdaStep
+
+Utilities
+---------
+
+.. autofunction:: sagemaker.workflow.utilities.list_to_request

--- a/src/sagemaker/lambda_helper.py
+++ b/src/sagemaker/lambda_helper.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You
 # may not use this file except in compliance with the License. A copy of

--- a/src/sagemaker/lambda_helper.py
+++ b/src/sagemaker/lambda_helper.py
@@ -1,0 +1,253 @@
+# Copyright 2019-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+"""This module contains helper methods related to Lambda."""
+from __future__ import print_function, absolute_import
+
+from io import BytesIO
+import zipfile
+from botocore.exceptions import ClientError
+from sagemaker.session import Session
+
+
+class Lambda:
+    """Contains lambda boto3 wrappers to Create, Update, Delete and Invoke Lambda functions."""
+
+    def __init__(
+        self,
+        function_arn: str = None,
+        function_name: str = None,
+        execution_role_arn: str = None,
+        zipped_code_dir: str = None,
+        s3_bucket: str = None,
+        script: str = None,
+        handler: str = None,
+        session: Session = Session(),
+        timeout: int = 120,
+        memory_size: int = 128,
+        runtime: str = "python3.8",
+    ):
+        """Constructs a Lambda instance.
+
+        This instance represents a Lambda function and provides methods for updating,
+        deleting and invoking the function.
+
+        This class can be used either for creating a new Lambda function or using an existing one.
+        When using an existing Lambda function, only the function_arn argument is required.
+        When creating a new one the function_name, execution_role_arn and handler arguments
+        are required, as well as either script or zipped_code_dir.
+
+        Args:
+            function_arn (str): The arn of the Lambda function.
+            function_name (str): The name of the Lambda function.
+                Function name must be provided to create a Lambda function.
+            execution_role_arn (str): The role to be attached to Lambda function.
+            zipped_code_dir (str): The path of the zipped code package of the Lambda function.
+            s3_bucket (str): The bucket where zipped code is uploaded.
+                If not provided, default session bucket is used to upload zipped_code_dir.
+            script (str): The path of Lambda function script for direct zipped upload
+            handler (str): The Lambda handler. The format for handler should be
+                file_name.function_name. For ex: if the name of the Lambda script is
+                hello_world.py and Lambda function definition in that script is
+                lambda_handler(event, context), the handler should be hello_world.lambda_handler
+            session (sagemaker.session.Session): Session object which manages interactions
+                with Amazon SageMaker APIs and any other AWS services needed.
+                If not specified, new session is created.
+            timeout (int): Timeout of the Lambda function in seconds. Default is 120 seconds.
+            memory_size (int): Memory of the Lambda function in megabytes. Default is 128 MB.
+            runtime (str): Runtime of the Lambda function. Default is set to python3.8.
+        """
+        self.function_arn = function_arn
+        self.function_name = function_name
+        self.zipped_code_dir = zipped_code_dir
+        self.s3_bucket = s3_bucket
+        self.script = script
+        self.handler = handler
+        self.execution_role_arn = execution_role_arn
+        self.session = session
+        self.timeout = timeout
+        self.memory_size = memory_size
+        self.runtime = runtime
+
+        if function_arn is None and function_name is None:
+            raise ValueError("Either function_arn or function_name must be provided.")
+
+        if function_name is not None:
+            if execution_role_arn is None:
+                raise ValueError("execution_role_arn must be provided.")
+            if zipped_code_dir is None and script is None:
+                raise ValueError("Either zipped_code_dir or script must be provided.")
+            if zipped_code_dir and script:
+                raise ValueError("Provide either script or zipped_code_dir, not both.")
+            if handler is None:
+                raise ValueError("Lambda handler must be provided.")
+
+    def create(self):
+        """Method to create a lambda function.
+
+        Returns: boto3 response from Lambda's create_function method.
+        """
+        lambda_client = _get_lambda_client(self.session)
+
+        if self.function_name is None:
+            raise ValueError("FunctionName must be provided to create a Lambda function.")
+
+        if self.script is not None:
+            code = {"ZipFile": _zip_lambda_code(self.script)}
+        else:
+            bucket = self.s3_bucket or self.session.default_bucket()
+            key = _upload_to_s3(
+                s3_client=_get_s3_client(self.session),
+                function_name=self.function_name,
+                zipped_code_dir=self.zipped_code_dir,
+                s3_bucket=bucket,
+            )
+            code = {"S3Bucket": bucket, "S3Key": key}
+
+        try:
+            response = lambda_client.create_function(
+                FunctionName=self.function_name,
+                Runtime=self.runtime,
+                Handler=self.handler,
+                Role=self.execution_role_arn,
+                Code=code,
+                Timeout=self.timeout,
+                MemorySize=self.memory_size,
+            )
+            return response
+        except ClientError as e:
+            error = e.response["Error"]
+            raise ValueError(error)
+
+    def update(self):
+        """Method to update a lambda function.
+
+        Returns: boto3 response from Lambda's update_function method.
+        """
+        lambda_client = _get_lambda_client(self.session)
+
+        if self.script is not None:
+            try:
+                response = lambda_client.update_function_code(
+                    FunctionName=self.function_name, ZipFile=_zip_lambda_code(self.script)
+                )
+                return response
+            except ClientError as e:
+                error = e.response["Error"]
+                raise ValueError(error)
+        else:
+            try:
+                response = lambda_client.update_function_code(
+                    FunctionName=(self.function_name or self.function_arn),
+                    S3Bucket=self.s3_bucket,
+                    S3Key=_upload_to_s3(
+                        s3_client=_get_s3_client(self.session),
+                        function_name=self.function_name,
+                        zipped_code_dir=self.zipped_code_dir,
+                        s3_bucket=self.s3_bucket,
+                    ),
+                )
+                return response
+            except ClientError as e:
+                error = e.response["Error"]
+                raise ValueError(error)
+
+    def invoke(self):
+        """Method to invoke a lambda function.
+
+        Returns: boto3 response from Lambda's invoke method.
+        """
+        lambda_client = _get_lambda_client(self.session)
+        try:
+            response = lambda_client.invoke(
+                FunctionName=self.function_name or self.function_arn,
+                InvocationType="RequestResponse",
+            )
+            return response
+        except ClientError as e:
+            error = e.response["Error"]
+            raise ValueError(error)
+
+    def delete(self):
+        """Method to delete a lambda function.
+
+        Returns: boto3 response from Lambda's delete_function method.
+        """
+        lambda_client = _get_lambda_client(self.session)
+        try:
+            response = lambda_client.delete_function(
+                FunctionName=self.function_name or self.function_arn
+            )
+            return response
+        except ClientError as e:
+            error = e.response["Error"]
+            raise ValueError(error)
+
+
+def _get_s3_client(session):
+    """Method to get a boto3 s3 client.
+
+    Returns: a s3 client.
+    """
+    sagemaker_session = session or Session()
+    if sagemaker_session.s3_client is None:
+        s3_client = sagemaker_session.boto_session.client(
+            "s3", region_name=sagemaker_session.boto_region_name
+        )
+    else:
+        s3_client = sagemaker_session.s3_client
+    return s3_client
+
+
+def _get_lambda_client(session):
+    """Method to get a boto3 lambda client.
+
+    Returns: a lambda client.
+    """
+    sagemaker_session = session or Session()
+    if sagemaker_session.lambda_client is None:
+        lambda_client = sagemaker_session.boto_session.client(
+            "lambda", region_name=sagemaker_session.boto_region_name
+        )
+    else:
+        lambda_client = sagemaker_session.lambda_client
+    return lambda_client
+
+
+def _upload_to_s3(s3_client, function_name, zipped_code_dir, s3_bucket):
+    """Upload the zipped code to S3 bucket provided in the Lambda instance.
+
+    Lambda instance must have a path to the zipped code folder and a S3 bucket to upload
+    the code. The key will lambda/function_name/code and the S3 URI where the code is
+    uploaded is in this format: s3://bucket_name/lambda/function_name/code.
+
+    Returns: the S3 key where the code is uploaded.
+    """
+    key = "{}/{}/{}".format("lambda", function_name, "code")
+    s3_client.upload_file(zipped_code_dir, s3_bucket, key)
+    return key
+
+
+def _zip_lambda_code(script):
+    """This method zips the lambda function script.
+
+    Lambda function script is provided in the lambda instance and reads that zipped file.
+
+    Returns: A buffer of zipped lambda function script.
+    """
+    buffer = BytesIO()
+    code_dir = script.split("/")[-1]
+
+    with zipfile.ZipFile(buffer, "w") as z:
+        z.write(script, code_dir)
+    buffer.seek(0)
+    return buffer.read()

--- a/src/sagemaker/lambda_helper.py
+++ b/src/sagemaker/lambda_helper.py
@@ -31,7 +31,7 @@ class Lambda:
         s3_bucket: str = None,
         script: str = None,
         handler: str = None,
-        session: Session = Session(),
+        session: Session = None,
         timeout: int = 120,
         memory_size: int = 128,
         runtime: str = "python3.8",
@@ -73,7 +73,7 @@ class Lambda:
         self.script = script
         self.handler = handler
         self.execution_role_arn = execution_role_arn
-        self.session = session
+        self.session = session if session is not None else Session()
         self.timeout = timeout
         self.memory_size = memory_size
         self.runtime = runtime

--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -116,6 +116,7 @@ class Session(object):  # pylint: disable=too-many-public-methods
         self.s3_resource = None
         self.s3_client = None
         self.config = None
+        self.lambda_client = None
 
         self._initialize(
             boto_session=boto_session,

--- a/src/sagemaker/workflow/lambda_step.py
+++ b/src/sagemaker/workflow/lambda_step.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You
 # may not use this file except in compliance with the License. A copy of

--- a/src/sagemaker/workflow/lambda_step.py
+++ b/src/sagemaker/workflow/lambda_step.py
@@ -82,8 +82,8 @@ class LambdaStep(Step):
         self,
         name: str,
         lambda_func: Lambda,
-        inputs: dict = {},
-        outputs: List[LambdaOutput] = [],
+        inputs: dict = None,
+        outputs: List[LambdaOutput] = None,
         cache_config: CacheConfig = None,
         depends_on: List[str] = None,
     ):
@@ -103,15 +103,15 @@ class LambdaStep(Step):
         """
         super(LambdaStep, self).__init__(name, StepTypeEnum.LAMBDA, depends_on)
         self.lambda_func = lambda_func
-        self.outputs = outputs
+        self.outputs = outputs if outputs is not None else []
         self.cache_config = cache_config
-        self.inputs = inputs
+        self.inputs = inputs if inputs is not None else {}
 
         root_path = f"Steps.{name}"
         root_prop = Properties(path=root_path)
 
         property_dict = {}
-        for output in outputs:
+        for output in self.outputs:
             property_dict[output.output_name] = Properties(
                 f"{root_path}.OutputParameters['{output.output_name}']"
             )
@@ -150,7 +150,7 @@ class LambdaStep(Step):
         """
         account_id = self.lambda_func.session.account_id()
         region = self.lambda_func.session.boto_region_name
-        if "cn" in region.lower():
+        if region.lower() == "cn-north-1" or region.lower() == "cn-northwest-1":
             partition = "aws-cn"
         else:
             partition = "aws"

--- a/src/sagemaker/workflow/lambda_step.py
+++ b/src/sagemaker/workflow/lambda_step.py
@@ -1,0 +1,170 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+"""The step definitions for workflow."""
+from __future__ import absolute_import
+
+from typing import List, Dict
+from enum import Enum
+
+import attr
+
+from sagemaker.workflow.entities import (
+    RequestType,
+)
+from sagemaker.workflow.properties import (
+    Properties,
+)
+from sagemaker.workflow.entities import (
+    DefaultEnumMeta,
+)
+from sagemaker.workflow.steps import Step, StepTypeEnum, CacheConfig
+from sagemaker.lambda_helper import Lambda
+
+
+class LambdaOutputTypeEnum(Enum, metaclass=DefaultEnumMeta):
+    """LambdaOutput type enum."""
+
+    String = "String"
+    Integer = "Integer"
+    Boolean = "Boolean"
+    Float = "Float"
+
+
+@attr.s
+class LambdaOutput:
+    """Output for a lambdaback step.
+
+    Attributes:
+        output_name (str): The output name
+        output_type (LambdaOutputTypeEnum): The output type
+    """
+
+    output_name: str = attr.ib(default=None)
+    output_type: LambdaOutputTypeEnum = attr.ib(default=LambdaOutputTypeEnum.String)
+
+    def to_request(self) -> RequestType:
+        """Get the request structure for workflow service calls."""
+        return {
+            "OutputName": self.output_name,
+            "OutputType": self.output_type.value,
+        }
+
+    def expr(self, step_name) -> Dict[str, str]:
+        """The 'Get' expression dict for a `LambdaOutput`."""
+        return LambdaOutput._expr(self.output_name, step_name)
+
+    @classmethod
+    def _expr(cls, name, step_name):
+        """An internal classmethod for the 'Get' expression dict for a `LambdaOutput`.
+
+        Args:
+            name (str): The name of the lambda output.
+            step_name (str): The name of the step the lambda step associated
+                with this output belongs to.
+        """
+        return {"Get": f"Steps.{step_name}.OutputParameters['{name}']"}
+
+
+class LambdaStep(Step):
+    """Lambda step for workflow."""
+
+    def __init__(
+        self,
+        name: str,
+        lambda_func: Lambda,
+        inputs: dict = {},
+        outputs: List[LambdaOutput] = [],
+        cache_config: CacheConfig = None,
+        depends_on: List[str] = None,
+    ):
+        """Constructs a LambdaStep.
+
+        Args:
+            name (str): The name of the lambda step.
+            lambda_func (str): An instance of sagemaker.lambda_helper.Lambda.
+                If lambda arn is specified in the instance, LambdaStep just invokes the function,
+                else lambda function will be created while creating the pipeline.
+            inputs (dict): Input arguments that will be provided
+                to the lambda function.
+            outputs (List[LambdaOutput]): List of outputs from the lambda function.
+            cache_config (CacheConfig):  A `sagemaker.workflow.steps.CacheConfig` instance.
+            depends_on (List[str]): A list of step names this `sagemaker.workflow.steps.LambdaStep`
+                depends on
+        """
+        super(LambdaStep, self).__init__(name, StepTypeEnum.LAMBDA, depends_on)
+        self.lambda_func = lambda_func
+        self.outputs = outputs
+        self.cache_config = cache_config
+        self.inputs = inputs
+
+        root_path = f"Steps.{name}"
+        root_prop = Properties(path=root_path)
+
+        property_dict = {}
+        for output in outputs:
+            property_dict[output.output_name] = Properties(
+                f"{root_path}.OutputParameters['{output.output_name}']"
+            )
+
+        root_prop.__dict__["Outputs"] = property_dict
+        self._properties = root_prop
+
+    @property
+    def arguments(self) -> RequestType:
+        """The arguments dict that is used to define the lambda step."""
+        return self.inputs
+
+    @property
+    def properties(self):
+        """A Properties object representing the output parameters of the lambda step."""
+        return self._properties
+
+    def to_request(self) -> RequestType:
+        """Updates the dictionary with cache configuration."""
+        request_dict = super().to_request()
+        if self.cache_config:
+            request_dict.update(self.cache_config.config)
+
+        function_arn = self._get_function_arn()
+        request_dict["FunctionArn"] = function_arn
+
+        request_dict["OutputParameters"] = list(map(lambda op: op.to_request(), self.outputs))
+
+        return request_dict
+
+    def _get_function_arn(self):
+        """Returns the lamba function arn
+
+        Method creates a lambda function and returns it's arn.
+        If the lambda is already present, it will build it's arn and return that.
+        """
+        account_id = self.lambda_func.session.account_id()
+        region = self.lambda_func.session.boto_region_name
+        if "cn" in region.lower():
+            partition = "aws-cn"
+        else:
+            partition = "aws"
+
+        if self.lambda_func.function_arn is None:
+            try:
+                response = self.lambda_func.create()
+                return response["FunctionArn"]
+            except ValueError as error:
+                if "ResourceConflictException" not in str(error):
+                    raise
+                return (
+                    f"arn:{partition}:lambda:{region}:{account_id}:"
+                    f"function:{self.lambda_func.function_name}"
+                )
+        else:
+            return self.lambda_func.function_arn

--- a/src/sagemaker/workflow/steps.py
+++ b/src/sagemaker/workflow/steps.py
@@ -54,6 +54,7 @@ class StepTypeEnum(Enum, metaclass=DefaultEnumMeta):
     TRANSFORM = "Transform"
     CALLBACK = "Callback"
     TUNING = "Tuning"
+    LAMBDA = "Lambda"
 
 
 @attr.s

--- a/tests/integ/test_workflow.py
+++ b/tests/integ/test_workflow.py
@@ -845,7 +845,8 @@ def test_two_step_lambda_pipeline_with_output_reference(
     step_lambda2 = LambdaStep(
         name="lambda-step2",
         lambda_func=Lambda(
-            function_arn="arn:aws:lambda:us-west-2:123456789012:function:sagemaker_test_lambda"
+            function_arn="arn:aws:lambda:us-west-2:123456789012:function:sagemaker_test_lambda",
+            session=sagemaker_session
         ),
         inputs={"arg1": outputParam1},
         outputs=[],

--- a/tests/integ/test_workflow.py
+++ b/tests/integ/test_workflow.py
@@ -52,6 +52,7 @@ from sagemaker.spark.processing import PySparkProcessor, SparkJarProcessor
 from sagemaker.workflow.conditions import ConditionGreaterThanOrEqualTo, ConditionIn
 from sagemaker.workflow.condition_step import ConditionStep
 from sagemaker.workflow.callback_step import CallbackStep, CallbackOutput, CallbackOutputTypeEnum
+from sagemaker.workflow.lambda_step import LambdaStep, LambdaOutput, LambdaOutputTypeEnum
 from sagemaker.wrangler.processing import DataWranglerProcessor
 from sagemaker.dataset_definition.inputs import DatasetDefinition, AthenaDatasetDefinition
 from sagemaker.workflow.execution_variables import ExecutionVariables
@@ -70,6 +71,7 @@ from sagemaker.workflow.steps import (
 )
 from sagemaker.workflow.step_collections import RegisterModel
 from sagemaker.workflow.pipeline import Pipeline
+from sagemaker.lambda_helper import Lambda
 from sagemaker.feature_store.feature_group import FeatureGroup, FeatureDefinition, FeatureTypeEnum
 from tests.integ import DATA_DIR
 from tests.integ.kms_utils import get_or_create_kms_key
@@ -764,6 +766,93 @@ def test_two_step_callback_pipeline_with_output_reference(
         name=pipeline_name,
         parameters=[instance_count],
         steps=[step_callback1, step_callback2],
+        sagemaker_session=sagemaker_session,
+    )
+
+    try:
+        response = pipeline.create(role)
+        create_arn = response["PipelineArn"]
+        assert re.match(
+            fr"arn:aws:sagemaker:{region_name}:\d{{12}}:pipeline/{pipeline_name}",
+            create_arn,
+        )
+    finally:
+        try:
+            pipeline.delete()
+        except Exception:
+            pass
+
+
+def test_one_step_lambda_pipeline(sagemaker_session, role, pipeline_name, region_name):
+    instance_count = ParameterInteger(name="InstanceCount", default_value=2)
+
+    outputParam1 = LambdaOutput(output_name="output1", output_type=LambdaOutputTypeEnum.String)
+    step_lambda = LambdaStep(
+        name="lambda-step",
+        lambda_func=Lambda(
+            function_arn="arn:aws:lambda:us-west-2:123456789012:function:sagemaker_test_lambda"
+        ),
+        inputs={"arg1": "foo"},
+        outputs=[outputParam1],
+    )
+
+    pipeline = Pipeline(
+        name=pipeline_name,
+        parameters=[instance_count],
+        steps=[step_lambda],
+        sagemaker_session=sagemaker_session,
+    )
+
+    try:
+        response = pipeline.create(role)
+        create_arn = response["PipelineArn"]
+        assert re.match(
+            fr"arn:aws:sagemaker:{region_name}:\d{{12}}:pipeline/{pipeline_name}",
+            create_arn,
+        )
+
+        pipeline.parameters = [ParameterInteger(name="InstanceCount", default_value=1)]
+        response = pipeline.update(role)
+        update_arn = response["PipelineArn"]
+        assert re.match(
+            fr"arn:aws:sagemaker:{region_name}:\d{{12}}:pipeline/{pipeline_name}",
+            update_arn,
+        )
+    finally:
+        try:
+            pipeline.delete()
+        except Exception:
+            pass
+
+
+def test_two_step_lambda_pipeline_with_output_reference(
+    sagemaker_session, role, pipeline_name, region_name
+):
+    instance_count = ParameterInteger(name="InstanceCount", default_value=2)
+
+    outputParam1 = LambdaOutput(output_name="output1", output_type=LambdaOutputTypeEnum.String)
+    step_lambda1 = LambdaStep(
+        name="lambda-step1",
+        lambda_func=Lambda(
+            function_arn="arn:aws:lambda:us-west-2:123456789012:function:sagemaker_test_lambda"
+        ),
+        inputs={"arg1": "foo"},
+        outputs=[outputParam1],
+    )
+
+    step_lambda2 = LambdaStep(
+        name="lambda-step2",
+        lambda_func=Lambda(
+            function_arn="arn:aws:lambda:us-west-2:123456789012:function:sagemaker_test_lambda"
+        ),
+        inputs={"arg1": outputParam1},
+        outputs=[],
+    )
+
+    pipeline = Pipeline(
+        name=pipeline_name,
+        parameters=[instance_count],
+        steps=[step_lambda1, step_lambda2],
         sagemaker_session=sagemaker_session,
     )
 

--- a/tests/integ/test_workflow.py
+++ b/tests/integ/test_workflow.py
@@ -791,7 +791,7 @@ def test_one_step_lambda_pipeline(sagemaker_session, role, pipeline_name, region
         name="lambda-step",
         lambda_func=Lambda(
             function_arn="arn:aws:lambda:us-west-2:123456789012:function:sagemaker_test_lambda",
-            session=sagemaker_session
+            session=sagemaker_session,
         ),
         inputs={"arg1": "foo"},
         outputs=[outputParam1],
@@ -836,7 +836,7 @@ def test_two_step_lambda_pipeline_with_output_reference(
         name="lambda-step1",
         lambda_func=Lambda(
             function_arn="arn:aws:lambda:us-west-2:123456789012:function:sagemaker_test_lambda",
-            session=sagemaker_session
+            session=sagemaker_session,
         ),
         inputs={"arg1": "foo"},
         outputs=[outputParam1],
@@ -846,7 +846,7 @@ def test_two_step_lambda_pipeline_with_output_reference(
         name="lambda-step2",
         lambda_func=Lambda(
             function_arn="arn:aws:lambda:us-west-2:123456789012:function:sagemaker_test_lambda",
-            session=sagemaker_session
+            session=sagemaker_session,
         ),
         inputs={"arg1": outputParam1},
         outputs=[],

--- a/tests/integ/test_workflow.py
+++ b/tests/integ/test_workflow.py
@@ -790,7 +790,8 @@ def test_one_step_lambda_pipeline(sagemaker_session, role, pipeline_name, region
     step_lambda = LambdaStep(
         name="lambda-step",
         lambda_func=Lambda(
-            function_arn="arn:aws:lambda:us-west-2:123456789012:function:sagemaker_test_lambda"
+            function_arn="arn:aws:lambda:us-west-2:123456789012:function:sagemaker_test_lambda",
+            session=sagemaker_session
         ),
         inputs={"arg1": "foo"},
         outputs=[outputParam1],
@@ -834,7 +835,8 @@ def test_two_step_lambda_pipeline_with_output_reference(
     step_lambda1 = LambdaStep(
         name="lambda-step1",
         lambda_func=Lambda(
-            function_arn="arn:aws:lambda:us-west-2:123456789012:function:sagemaker_test_lambda"
+            function_arn="arn:aws:lambda:us-west-2:123456789012:function:sagemaker_test_lambda",
+            session=sagemaker_session
         ),
         inputs={"arg1": "foo"},
         outputs=[outputParam1],

--- a/tests/unit/sagemaker/workflow/test_lambda_step.py
+++ b/tests/unit/sagemaker/workflow/test_lambda_step.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You
 # may not use this file except in compliance with the License. A copy of

--- a/tests/unit/sagemaker/workflow/test_lambda_step.py
+++ b/tests/unit/sagemaker/workflow/test_lambda_step.py
@@ -1,0 +1,137 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from __future__ import absolute_import
+
+import json
+
+import pytest
+
+from mock import Mock
+
+from sagemaker.workflow.parameters import ParameterInteger, ParameterString
+from sagemaker.workflow.pipeline import Pipeline
+from sagemaker.workflow.lambda_step import LambdaStep, LambdaOutput, LambdaOutputTypeEnum
+from sagemaker.lambda_helper import Lambda
+
+
+@pytest.fixture
+def sagemaker_session_mock():
+    return Mock()
+
+
+def test_lambda_step():
+    param = ParameterInteger(name="MyInt")
+    outputParam1 = LambdaOutput(output_name="output1", output_type=LambdaOutputTypeEnum.String)
+    outputParam2 = LambdaOutput(output_name="output2", output_type=LambdaOutputTypeEnum.Boolean)
+    lambda_step = LambdaStep(
+        name="MyLambdaStep",
+        depends_on=["TestStep"],
+        lambda_func=Lambda(
+            function_arn="arn:aws:lambda:us-west-2:123456789012:function:sagemaker_test_lambda"
+        ),
+        inputs={"arg1": "foo", "arg2": 5, "arg3": param},
+        outputs=[outputParam1, outputParam2],
+    )
+    lambda_step.add_depends_on(["SecondTestStep"])
+    assert lambda_step.to_request() == {
+        "Name": "MyLambdaStep",
+        "Type": "Lambda",
+        "DependsOn": ["TestStep", "SecondTestStep"],
+        "FunctionArn": "arn:aws:lambda:us-west-2:123456789012:function:sagemaker_test_lambda",
+        "OutputParameters": [
+            {"OutputName": "output1", "OutputType": "String"},
+            {"OutputName": "output2", "OutputType": "Boolean"},
+        ],
+        "Arguments": {"arg1": "foo", "arg2": 5, "arg3": param},
+    }
+
+
+def test_lambda_step_output_expr():
+    param = ParameterInteger(name="MyInt")
+    outputParam1 = LambdaOutput(output_name="output1", output_type=LambdaOutputTypeEnum.String)
+    outputParam2 = LambdaOutput(output_name="output2", output_type=LambdaOutputTypeEnum.Boolean)
+    lambda_step = LambdaStep(
+        name="MyLambdaStep",
+        depends_on=["TestStep"],
+        lambda_func=Lambda(
+            function_arn="arn:aws:lambda:us-west-2:123456789012:function:sagemaker_test_lambda"
+        ),
+        inputs={"arg1": "foo", "arg2": 5, "arg3": param},
+        outputs=[outputParam1, outputParam2],
+    )
+
+    assert lambda_step.properties.Outputs["output1"].expr == {
+        "Get": "Steps.MyLambdaStep.OutputParameters['output1']"
+    }
+    assert lambda_step.properties.Outputs["output2"].expr == {
+        "Get": "Steps.MyLambdaStep.OutputParameters['output2']"
+    }
+
+
+def test_pipeline_interpolates_lambda_outputs():
+    parameter = ParameterString("MyStr")
+    outputParam1 = LambdaOutput(output_name="output1", output_type=LambdaOutputTypeEnum.String)
+    outputParam2 = LambdaOutput(output_name="output2", output_type=LambdaOutputTypeEnum.String)
+    lambda_step1 = LambdaStep(
+        name="MyLambdaStep1",
+        depends_on=["TestStep"],
+        lambda_func=Lambda(
+            function_arn="arn:aws:lambda:us-west-2:123456789012:function:sagemaker_test_lambda"
+        ),
+        inputs={"arg1": "foo"},
+        outputs=[outputParam1],
+    )
+    lambda_step2 = LambdaStep(
+        name="MyLambdaStep2",
+        depends_on=["TestStep"],
+        lambda_func=Lambda(
+            function_arn="arn:aws:lambda:us-west-2:123456789012:function:sagemaker_test_lambda"
+        ),
+        inputs={"arg1": outputParam1},
+        outputs=[outputParam2],
+    )
+
+    pipeline = Pipeline(
+        name="MyPipeline",
+        parameters=[parameter],
+        steps=[lambda_step1, lambda_step2],
+        sagemaker_session=sagemaker_session_mock,
+    )
+
+    assert json.loads(pipeline.definition()) == {
+        "Version": "2020-12-01",
+        "Metadata": {},
+        "Parameters": [{"Name": "MyStr", "Type": "String"}],
+        "PipelineExperimentConfig": {
+            "ExperimentName": {"Get": "Execution.PipelineName"},
+            "TrialName": {"Get": "Execution.PipelineExecutionId"},
+        },
+        "Steps": [
+            {
+                "Name": "MyLambdaStep1",
+                "Type": "Lambda",
+                "Arguments": {"arg1": "foo"},
+                "DependsOn": ["TestStep"],
+                "FunctionArn": "arn:aws:lambda:us-west-2:123456789012:function:sagemaker_test_lambda",
+                "OutputParameters": [{"OutputName": "output1", "OutputType": "String"}],
+            },
+            {
+                "Name": "MyLambdaStep2",
+                "Type": "Lambda",
+                "Arguments": {"arg1": {"Get": "Steps.MyLambdaStep1.OutputParameters['output1']"}},
+                "DependsOn": ["TestStep"],
+                "FunctionArn": "arn:aws:lambda:us-west-2:123456789012:function:sagemaker_test_lambda",
+                "OutputParameters": [{"OutputName": "output2", "OutputType": "String"}],
+            },
+        ],
+    }

--- a/tests/unit/sagemaker/workflow/test_lambda_step.py
+++ b/tests/unit/sagemaker/workflow/test_lambda_step.py
@@ -106,7 +106,8 @@ def test_pipeline_interpolates_lambda_outputs(sagemaker_session):
         name="MyLambdaStep2",
         depends_on=["TestStep"],
         lambda_func=Lambda(
-            function_arn="arn:aws:lambda:us-west-2:123456789012:function:sagemaker_test_lambda"
+            function_arn="arn:aws:lambda:us-west-2:123456789012:function:sagemaker_test_lambda",
+            session=sagemaker_session,
         ),
         inputs={"arg1": outputParam1},
         outputs=[outputParam2],

--- a/tests/unit/sagemaker/workflow/test_lambda_step.py
+++ b/tests/unit/sagemaker/workflow/test_lambda_step.py
@@ -135,3 +135,24 @@ def test_pipeline_interpolates_lambda_outputs():
             },
         ],
     }
+
+
+def test_lambda_step_no_inputs_outputs():
+    lambda_step = LambdaStep(
+        name="MyLambdaStep",
+        depends_on=["TestStep"],
+        lambda_func=Lambda(
+            function_arn="arn:aws:lambda:us-west-2:123456789012:function:sagemaker_test_lambda"
+        ),
+        inputs={},
+        outputs=[],
+    )
+    lambda_step.add_depends_on(["SecondTestStep"])
+    assert lambda_step.to_request() == {
+        "Name": "MyLambdaStep",
+        "Type": "Lambda",
+        "DependsOn": ["TestStep", "SecondTestStep"],
+        "FunctionArn": "arn:aws:lambda:us-west-2:123456789012:function:sagemaker_test_lambda",
+        "OutputParameters": [],
+        "Arguments": {},
+    }

--- a/tests/unit/sagemaker/workflow/test_lambda_step.py
+++ b/tests/unit/sagemaker/workflow/test_lambda_step.py
@@ -24,12 +24,20 @@ from sagemaker.workflow.lambda_step import LambdaStep, LambdaOutput, LambdaOutpu
 from sagemaker.lambda_helper import Lambda
 
 
-@pytest.fixture
-def sagemaker_session_mock():
-    return Mock()
+@pytest.fixture()
+def sagemaker_session():
+    boto_mock = Mock(name="boto_session", region_name="us-west-2")
+    session_mock = Mock(
+        name="sagemaker_session",
+        boto_session=boto_mock,
+        boto_region_name="us-west-2",
+        config=None,
+        local_mode=False,
+    )
+    return session_mock
 
 
-def test_lambda_step():
+def test_lambda_step(sagemaker_session):
     param = ParameterInteger(name="MyInt")
     outputParam1 = LambdaOutput(output_name="output1", output_type=LambdaOutputTypeEnum.String)
     outputParam2 = LambdaOutput(output_name="output2", output_type=LambdaOutputTypeEnum.Boolean)
@@ -37,7 +45,8 @@ def test_lambda_step():
         name="MyLambdaStep",
         depends_on=["TestStep"],
         lambda_func=Lambda(
-            function_arn="arn:aws:lambda:us-west-2:123456789012:function:sagemaker_test_lambda"
+            function_arn="arn:aws:lambda:us-west-2:123456789012:function:sagemaker_test_lambda",
+            session=sagemaker_session,
         ),
         inputs={"arg1": "foo", "arg2": 5, "arg3": param},
         outputs=[outputParam1, outputParam2],
@@ -56,7 +65,7 @@ def test_lambda_step():
     }
 
 
-def test_lambda_step_output_expr():
+def test_lambda_step_output_expr(sagemaker_session):
     param = ParameterInteger(name="MyInt")
     outputParam1 = LambdaOutput(output_name="output1", output_type=LambdaOutputTypeEnum.String)
     outputParam2 = LambdaOutput(output_name="output2", output_type=LambdaOutputTypeEnum.Boolean)
@@ -64,7 +73,8 @@ def test_lambda_step_output_expr():
         name="MyLambdaStep",
         depends_on=["TestStep"],
         lambda_func=Lambda(
-            function_arn="arn:aws:lambda:us-west-2:123456789012:function:sagemaker_test_lambda"
+            function_arn="arn:aws:lambda:us-west-2:123456789012:function:sagemaker_test_lambda",
+            session=sagemaker_session,
         ),
         inputs={"arg1": "foo", "arg2": 5, "arg3": param},
         outputs=[outputParam1, outputParam2],
@@ -78,7 +88,7 @@ def test_lambda_step_output_expr():
     }
 
 
-def test_pipeline_interpolates_lambda_outputs():
+def test_pipeline_interpolates_lambda_outputs(sagemaker_session):
     parameter = ParameterString("MyStr")
     outputParam1 = LambdaOutput(output_name="output1", output_type=LambdaOutputTypeEnum.String)
     outputParam2 = LambdaOutput(output_name="output2", output_type=LambdaOutputTypeEnum.String)
@@ -86,7 +96,8 @@ def test_pipeline_interpolates_lambda_outputs():
         name="MyLambdaStep1",
         depends_on=["TestStep"],
         lambda_func=Lambda(
-            function_arn="arn:aws:lambda:us-west-2:123456789012:function:sagemaker_test_lambda"
+            function_arn="arn:aws:lambda:us-west-2:123456789012:function:sagemaker_test_lambda",
+            session=sagemaker_session,
         ),
         inputs={"arg1": "foo"},
         outputs=[outputParam1],
@@ -105,7 +116,7 @@ def test_pipeline_interpolates_lambda_outputs():
         name="MyPipeline",
         parameters=[parameter],
         steps=[lambda_step1, lambda_step2],
-        sagemaker_session=sagemaker_session_mock,
+        sagemaker_session=sagemaker_session,
     )
 
     assert json.loads(pipeline.definition()) == {
@@ -137,12 +148,13 @@ def test_pipeline_interpolates_lambda_outputs():
     }
 
 
-def test_lambda_step_no_inputs_outputs():
+def test_lambda_step_no_inputs_outputs(sagemaker_session):
     lambda_step = LambdaStep(
         name="MyLambdaStep",
         depends_on=["TestStep"],
         lambda_func=Lambda(
-            function_arn="arn:aws:lambda:us-west-2:123456789012:function:sagemaker_test_lambda"
+            function_arn="arn:aws:lambda:us-west-2:123456789012:function:sagemaker_test_lambda",
+            session=sagemaker_session,
         ),
         inputs={},
         outputs=[],

--- a/tests/unit/test_lambda_helper.py
+++ b/tests/unit/test_lambda_helper.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You
 # may not use this file except in compliance with the License. A copy of

--- a/tests/unit/test_lambda_helper.py
+++ b/tests/unit/test_lambda_helper.py
@@ -53,7 +53,7 @@ def s3_client(sagemaker_session):
 
 
 def test_lambda_object_with_arn_happycase():
-    lambda_obj = lambda_helper.Lambda(function_arn=LAMBDA_ARN)
+    lambda_obj = lambda_helper.Lambda(function_arn=LAMBDA_ARN, session=sagemaker_session)
     assert lambda_obj.function_arn == LAMBDA_ARN
 
 

--- a/tests/unit/test_lambda_helper.py
+++ b/tests/unit/test_lambda_helper.py
@@ -1,0 +1,344 @@
+# Copyright 2019-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from __future__ import print_function, absolute_import
+import os
+
+import pytest
+from mock import Mock, patch
+from botocore.exceptions import ClientError
+from sagemaker import lambda_helper
+
+BUCKET_NAME = "mybucket"
+REGION = "us-west-2"
+LAMBDA_ARN = "arn:aws:lambda:us-west-2:123456789012:function:test_function"
+FUNCTION_NAME = "test_function"
+EXECUTION_ROLE = "arn:aws:iam::123456789012:role/execution_role"
+SCRIPT = "test_function.py"
+HANDLER = "test_function.lambda_handler"
+ZIPPED_CODE_DIR = "code.zip"
+S3_BUCKET = "sagemaker-us-west-2-123456789012"
+ZIPPED_CODE = "Zipped code"
+S3_KEY = "{}/{}/{}".format("lambda", FUNCTION_NAME, "code")
+DATA_DIR = os.path.join(os.path.dirname(__file__), "..", "data")
+
+
+@pytest.fixture()
+def sagemaker_session():
+    boto_mock = Mock(name="boto_session", region_name=REGION)
+    session_mock = Mock(
+        name="sagemaker_session",
+        boto_session=boto_mock,
+        boto_region_name=REGION,
+        config=None,
+        local_mode=False,
+    )
+    return session_mock
+
+
+@pytest.fixture()
+def s3_client(sagemaker_session):
+    return sagemaker_session.boto_session.client(
+        "s3", region_name=sagemaker_session.boto_region_name
+    )
+
+
+def test_lambda_object_with_arn_happycase():
+    lambda_obj = lambda_helper.Lambda(function_arn=LAMBDA_ARN)
+    assert lambda_obj.function_arn == LAMBDA_ARN
+
+
+def test_lambda_object_with_name_happycase1():
+    lambda_obj = lambda_helper.Lambda(
+        function_name=FUNCTION_NAME,
+        execution_role_arn=EXECUTION_ROLE,
+        script=SCRIPT,
+        handler=HANDLER,
+        session=sagemaker_session,
+    )
+
+    assert lambda_obj.function_name == FUNCTION_NAME
+    assert lambda_obj.execution_role_arn == EXECUTION_ROLE
+    assert lambda_obj.script == SCRIPT
+    assert lambda_obj.handler == HANDLER
+    assert lambda_obj.timeout == 120
+    assert lambda_obj.memory_size == 128
+    assert lambda_obj.runtime == "python3.8"
+
+
+def test_lambda_object_with_name_happycase2():
+    lambda_obj = lambda_helper.Lambda(
+        function_name=FUNCTION_NAME,
+        execution_role_arn=EXECUTION_ROLE,
+        zipped_code_dir=ZIPPED_CODE_DIR,
+        s3_bucket=S3_BUCKET,
+        handler=HANDLER,
+        session=sagemaker_session,
+    )
+
+    assert lambda_obj.function_name == FUNCTION_NAME
+    assert lambda_obj.execution_role_arn == EXECUTION_ROLE
+    assert lambda_obj.zipped_code_dir == ZIPPED_CODE_DIR
+    assert lambda_obj.s3_bucket == S3_BUCKET
+    assert lambda_obj.handler == HANDLER
+    assert lambda_obj.timeout == 120
+    assert lambda_obj.memory_size == 128
+    assert lambda_obj.runtime == "python3.8"
+
+
+def test_lambda_object_with_no_name_and_arn_error():
+    with pytest.raises(ValueError) as error:
+        lambda_helper.Lambda(
+            execution_role_arn=EXECUTION_ROLE,
+            script=SCRIPT,
+            handler=HANDLER,
+            session=sagemaker_session,
+        )
+    assert "Either function_arn or function_name must be provided" in str(error)
+
+
+def test_lambda_object_no_code_error():
+    with pytest.raises(ValueError) as error:
+        lambda_helper.Lambda(
+            function_name=FUNCTION_NAME,
+            execution_role_arn=EXECUTION_ROLE,
+            handler=HANDLER,
+            session=sagemaker_session,
+        )
+    assert "Either zipped_code_dir or script must be provided" in str(error)
+
+
+def test_lambda_object_both_script_and_code_dir_error():
+    with pytest.raises(ValueError) as error:
+        lambda_helper.Lambda(
+            function_name=FUNCTION_NAME,
+            execution_role_arn=EXECUTION_ROLE,
+            script=SCRIPT,
+            zipped_code_dir=ZIPPED_CODE_DIR,
+            handler=HANDLER,
+            session=sagemaker_session,
+        )
+    assert "Provide either script or zipped_code_dir, not both." in str(error)
+
+
+def test_lambda_object_no_handler_error():
+    with pytest.raises(ValueError) as error:
+        lambda_helper.Lambda(
+            function_name=FUNCTION_NAME,
+            execution_role_arn=EXECUTION_ROLE,
+            zipped_code_dir=ZIPPED_CODE_DIR,
+            s3_bucket=S3_BUCKET,
+            session=sagemaker_session,
+        )
+    assert "Lambda handler must be provided." in str(error)
+
+
+def test_lambda_object_no_execution_role_error():
+    with pytest.raises(ValueError) as error:
+        lambda_helper.Lambda(
+            function_name=FUNCTION_NAME,
+            zipped_code_dir=ZIPPED_CODE_DIR,
+            s3_bucket=S3_BUCKET,
+            handler=HANDLER,
+            session=sagemaker_session,
+        )
+    assert "execution_role_arn must be provided." in str(error)
+
+
+@patch("sagemaker.lambda_helper._zip_lambda_code", return_value=ZIPPED_CODE)
+def test_create_lambda_happycase1(sagemaker_session):
+    lambda_obj = lambda_helper.Lambda(
+        function_name=FUNCTION_NAME,
+        execution_role_arn=EXECUTION_ROLE,
+        script=SCRIPT,
+        handler=HANDLER,
+        session=sagemaker_session,
+    )
+
+    lambda_obj.create()
+    code = {"ZipFile": ZIPPED_CODE}
+
+    sagemaker_session.lambda_client.create_function.assert_called_with(
+        FunctionName=FUNCTION_NAME,
+        Runtime="python3.8",
+        Handler=HANDLER,
+        Role=EXECUTION_ROLE,
+        Code=code,
+        Timeout=120,
+        MemorySize=128,
+    )
+
+
+@patch("sagemaker.lambda_helper._upload_to_s3", return_value=S3_KEY)
+def test_create_lambda_happycase2(sagemaker_session):
+    lambda_obj = lambda_helper.Lambda(
+        function_name=FUNCTION_NAME,
+        execution_role_arn=EXECUTION_ROLE,
+        zipped_code_dir=ZIPPED_CODE_DIR,
+        s3_bucket=S3_BUCKET,
+        handler=HANDLER,
+        session=sagemaker_session,
+    )
+
+    lambda_obj.create()
+    code = {"S3Bucket": lambda_obj.s3_bucket, "S3Key": S3_KEY}
+
+    sagemaker_session.lambda_client.create_function.assert_called_with(
+        FunctionName=FUNCTION_NAME,
+        Runtime="python3.8",
+        Handler=HANDLER,
+        Role=EXECUTION_ROLE,
+        Code=code,
+        Timeout=120,
+        MemorySize=128,
+    )
+
+
+def test_create_lambda_no_function_name_error(sagemaker_session):
+    lambda_obj = lambda_helper.Lambda(
+        function_arn=LAMBDA_ARN,
+        execution_role_arn=EXECUTION_ROLE,
+        zipped_code_dir=ZIPPED_CODE_DIR,
+        s3_bucket=S3_BUCKET,
+        handler=HANDLER,
+        session=sagemaker_session,
+    )
+
+    with pytest.raises(ValueError) as error:
+        lambda_obj.create()
+    assert "FunctionName must be provided to create a Lambda function" in str(error)
+
+
+@patch("sagemaker.lambda_helper._upload_to_s3", return_value=S3_KEY)
+def test_create_lambda_client_error(sagemaker_session):
+    lambda_obj = lambda_helper.Lambda(
+        function_name=FUNCTION_NAME,
+        execution_role_arn=EXECUTION_ROLE,
+        zipped_code_dir=ZIPPED_CODE_DIR,
+        s3_bucket=S3_BUCKET,
+        handler=HANDLER,
+        session=sagemaker_session,
+    )
+    sagemaker_session.lambda_client.create_function.side_effect = ClientError(
+        {"Error": {"Code": "ResourceConflictException", "Message": "Function already exists"}},
+        "CreateFunction",
+    )
+
+    with pytest.raises(ValueError) as error:
+        lambda_obj.create()
+
+    assert "Function already exists" in str(error)
+
+
+@patch("sagemaker.lambda_helper._zip_lambda_code", return_value=ZIPPED_CODE)
+def test_update_lambda_happycase1(sagemaker_session):
+    lambda_obj = lambda_helper.Lambda(
+        function_name=FUNCTION_NAME,
+        execution_role_arn=EXECUTION_ROLE,
+        script=SCRIPT,
+        handler=HANDLER,
+        session=sagemaker_session,
+    )
+
+    lambda_obj.update()
+
+    sagemaker_session.lambda_client.update_function_code.assert_called_with(
+        FunctionName=FUNCTION_NAME, ZipFile=ZIPPED_CODE
+    )
+
+
+@patch("sagemaker.lambda_helper._upload_to_s3", return_value=S3_KEY)
+def test_update_lambda_happycase2(sagemaker_session):
+    lambda_obj = lambda_helper.Lambda(
+        function_arn=LAMBDA_ARN,
+        execution_role_arn=EXECUTION_ROLE,
+        zipped_code_dir=ZIPPED_CODE_DIR,
+        s3_bucket=S3_BUCKET,
+        handler=HANDLER,
+        session=sagemaker_session,
+    )
+
+    lambda_obj.update()
+
+    sagemaker_session.lambda_client.update_function_code.assert_called_with(
+        FunctionName=LAMBDA_ARN, S3Bucket=S3_BUCKET, S3Key=S3_KEY
+    )
+
+
+@patch("sagemaker.lambda_helper._zip_lambda_code", return_value=ZIPPED_CODE)
+def test_update_lambda_client_error(sagemaker_session):
+    lambda_obj = lambda_helper.Lambda(
+        function_name=FUNCTION_NAME,
+        execution_role_arn=EXECUTION_ROLE,
+        script=SCRIPT,
+        handler=HANDLER,
+        session=sagemaker_session,
+    )
+
+    sagemaker_session.lambda_client.update_function_code.side_effect = ClientError(
+        {"Error": {"Code": "InvalidCodeException", "Message": "Cannot update code"}},
+        "UpdateFunction",
+    )
+    with pytest.raises(ValueError) as error:
+        lambda_obj.update()
+
+    assert "Cannot update code" in str(error)
+
+
+def test_invoke_lambda_happycase(sagemaker_session):
+    lambda_obj = lambda_helper.Lambda(function_arn=LAMBDA_ARN, session=sagemaker_session)
+    lambda_obj.invoke()
+
+    sagemaker_session.lambda_client.invoke.assert_called_with(
+        FunctionName=LAMBDA_ARN, InvocationType="RequestResponse"
+    )
+
+
+def test_invoke_lambda_client_error(sagemaker_session):
+    lambda_obj = lambda_helper.Lambda(function_arn=LAMBDA_ARN, session=sagemaker_session)
+
+    sagemaker_session.lambda_client.invoke.side_effect = ClientError(
+        {"Error": {"Code": "InvalidCodeException", "Message": "invoke failed"}}, "Invoke"
+    )
+    with pytest.raises(ValueError) as error:
+        lambda_obj.invoke()
+
+    assert "invoke failed" in str(error)
+
+
+def test_delete_lambda_happycase(sagemaker_session):
+    lambda_obj = lambda_helper.Lambda(function_arn=LAMBDA_ARN, session=sagemaker_session)
+    lambda_obj.delete()
+    sagemaker_session.lambda_client.delete_function.assert_called_with(FunctionName=LAMBDA_ARN)
+
+
+def test_delete_lambda_client_error(sagemaker_session):
+    lambda_obj = lambda_helper.Lambda(function_arn=LAMBDA_ARN, session=sagemaker_session)
+
+    sagemaker_session.lambda_client.delete_function.side_effect = ClientError(
+        {"Error": {"Code": "Invalid", "Message": "Delete failed"}}, "Invoke"
+    )
+    with pytest.raises(ValueError) as error:
+        lambda_obj.delete()
+
+    assert "Delete failed" in str(error)
+
+
+def test_upload_to_s3(s3_client):
+    key = lambda_helper._upload_to_s3(s3_client, FUNCTION_NAME, ZIPPED_CODE_DIR, S3_BUCKET)
+    s3_client.upload_file.assert_called_with(ZIPPED_CODE_DIR, S3_BUCKET, key)
+    assert key == S3_KEY
+
+
+def test_zip_lambda_code():
+    code = lambda_helper._zip_lambda_code(os.path.join(DATA_DIR, "dummy_script.py"))
+    assert code is not None


### PR DESCRIPTION
*Issue #, if available:*
AML-116688

*Description of changes:*
Added a new Lambda_helper class and boto3 wrappers to create, update, delete and invoke lambdas.
Added support for LambdaStep
Added relevant unit tests and integ tests
*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.