### PR TITLE
documentation: add dataset_definition to processing page

### DIFF
--- a/doc/api/utility/inputs.rst
+++ b/doc/api/utility/inputs.rst
@@ -6,3 +6,8 @@ Inputs
     :undoc-members:
     :show-inheritance:
     :noindex:
+
+.. automodule:: sagemaker.dataset_definition.inputs
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/api/utility/inputs.rst
+++ b/doc/api/utility/inputs.rst
@@ -5,7 +5,6 @@ Inputs
     :members:
     :undoc-members:
     :show-inheritance:
-    :noindex:
 
 .. automodule:: sagemaker.dataset_definition.inputs
     :members:

--- a/src/sagemaker/dataset_definition/inputs.py
+++ b/src/sagemaker/dataset_definition/inputs.py
@@ -27,7 +27,7 @@ class RedshiftDatasetDefinition(ApiObject):
 
     With this input, SQL queries will be executed using Redshift to generate datasets to S3.
 
-    Attributes:
+    Parameters:
         cluster_id (str): The Redshift cluster Identifier.
         database (str): The name of the Redshift database used in Redshift query execution.
         db_user (str): The database user name used in Redshift query execution.
@@ -60,7 +60,7 @@ class AthenaDatasetDefinition(ApiObject):
 
     With this input, SQL queries will be executed using Athena to generate datasets to S3.
 
-    Attributes:
+    Parameters:
         catalog (str): The name of the data catalog used in Athena query execution.
         database (str): The name of the database used in the Athena query execution.
         query_string (str): The SQL query statements, to be executed.
@@ -87,7 +87,7 @@ class AthenaDatasetDefinition(ApiObject):
 class DatasetDefinition(ApiObject):
     """DatasetDefinition input.
 
-    Attributes:
+    Parameters:
         data_distribution_type (str): Whether the generated dataset is FullyReplicated or
             ShardedByS3Key (default).
         input_mode (str): Whether to use File or Pipe input mode. In File (default) mode, Amazon
@@ -98,9 +98,8 @@ class DatasetDefinition(ApiObject):
         local_path (str): The local path where you want Amazon SageMaker to download the Dataset
             Definition inputs to run a processing job. LocalPath is an absolute path to the input
             data. This is a required parameter when `AppManaged` is False (default).
-        redshift_dataset_definition
-            (:class:`~sagemaker.dataset_definition.inputs.RedshiftDatasetDefinition`): Redshift
-            dataset definition.
+        redshift_dataset_definition (:class:`~sagemaker.dataset_definition.inputs.RedshiftDatasetDefinition`):
+            Configuration for Redshift Dataset Definition input.
         athena_dataset_definition (:class:`~sagemaker.dataset_definition.inputs.AthenaDatasetDefinition`):
             Configuration for Athena Dataset Definition input.
     """
@@ -126,7 +125,7 @@ class S3Input(ApiObject):
     S3 list operations are not strongly consistent.
     Use ManifestFile if strong consistency is required.
 
-    Attributes:
+    Parameters:
         s3_uri (str): the path to a specific S3 object or a S3 prefix
         local_path (str): the path to a local directory. If not provided, skips data download
             by SageMaker platform.

--- a/src/sagemaker/inputs.py
+++ b/src/sagemaker/inputs.py
@@ -127,7 +127,7 @@ class ShuffleConfig(object):
 class CreateModelInput(object):
     """A class containing parameters which can be used to create a SageMaker Model
 
-    Attributes:
+    Parameters:
         instance_type (str): type or EC2 instance will be used for model deployment.
         accelerator_type (str): elastic inference accelerator type.
     """


### PR DESCRIPTION
*Issue #, if available:*
PR #2456 fixed `dataset_definition.inputs` path to corretly link the classes in the documentation:
- `sagemaker.dataset_definition.inputs.S3Input`
- `sagemaker.dataset_definition.inputs.DatasetDefinition`
- `sagemaker.dataset_definition.inputs.AthenaDatasetDefinition`
- `sagemaker.dataset_definition.inputs.RedshiftDatasetDefinition`

However, the aforementioned classes are still missing on the documentation.

*Description of changes:*
Added `sagemaker.dataset_definition.inputs` to sphinx's automodule.
I also took the opportunity to fix the link for `sagemaker.inputs` as well.

*Testing done:*

I built sphinx doc locally, using instructions from the [README](https://github.com/tuliocasagrande/sagemaker-python-sdk/tree/master#building-sphinx-docs), and verified that the links are working properly.

From https://sagemaker.readthedocs.io/en/stable/api/training/processing.html#sagemaker.processing.ProcessingInput:
<img width="456" alt="Screen Shot 2021-08-20 at 19 47 18" src="https://user-images.githubusercontent.com/1420513/130300509-de540138-d3bb-4bb6-936f-6f15eaaaf8e7.png">
From https://sagemaker.readthedocs.io/en/stable/api/training/estimators.html#sagemaker.estimator.EstimatorBase.fit:
<img width="528" alt="Screen Shot 2021-08-20 at 19 49 45" src="https://user-images.githubusercontent.com/1420513/130300514-ffe52b2a-5593-454f-a843-2e7587374c0e.png">

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [X] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [X] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [X] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
