### PR TITLE
Propagate tags and VPC configs to repack model steps

### DIFF
--- a/src/sagemaker/workflow/_utils.py
+++ b/src/sagemaker/workflow/_utils.py
@@ -42,13 +42,10 @@ REPACK_SCRIPT = "_repack_model.py"
 
 
 class _RepackModelStep(TrainingStep):
-    """Repacks model artifacts with inference entry point.
+    """Repacks model artifacts with custom inference entry points.
 
-    Attributes:
-        name (str): The name of the training step.
-        step_type (StepTypeEnum): The type of the step with value `StepTypeEnum.Training`.
-        estimator (EstimatorBase): A `sagemaker.estimator.EstimatorBase` instance.
-        inputs (TrainingInput): A `sagemaker.inputs.TrainingInput` instance. Defaults to `None`.
+    The SDK automatically adds this step to pipelines that have RegisterModelSteps with models
+    that have a custom entry point.
     """
 
     def __init__(
@@ -61,19 +58,77 @@ class _RepackModelStep(TrainingStep):
         source_dir: str = None,
         dependencies: List = None,
         depends_on: Union[List[str], List[Step]] = None,
+        subnets=None,
+        security_group_ids=None,
         **kwargs,
     ):
-        """Constructs a TrainingStep, given an `EstimatorBase` instance.
-
-        In addition to the estimator instance, the other arguments are those that are supplied to
-        the `fit` method of the `sagemaker.estimator.Estimator`.
+        """Base class initializer.
 
         Args:
             name (str): The name of the training step.
-            estimator (EstimatorBase): A `sagemaker.estimator.EstimatorBase` instance.
-            inputs (TrainingInput): A `sagemaker.inputs.TrainingInput` instance. Defaults to `None`.
+            sagemaker_session (sagemaker.session.Session): Session object which manages
+                    interactions with Amazon SageMaker APIs and any other AWS services needed. If
+                    not specified, the estimator creates one using the default
+                    AWS configuration chain.
+            role (str): An AWS IAM role (either name or full ARN). The Amazon
+                    SageMaker training jobs and APIs that create Amazon SageMaker
+                    endpoints use this role to access training data and model
+                    artifacts. After the endpoint is created, the inference code
+                    might use the IAM role, if it needs to access an AWS resource.
+            model_data (str): The S3 location of a SageMaker model data
+                    ``.tar.gz`` file (default: None).
+            entry_point (str): Path (absolute or relative) to the local Python
+                    source file which should be executed as the entry point to
+                    inference. If ``source_dir`` is specified, then ``entry_point``
+                    must point to a file located at the root of ``source_dir``.
+                    If 'git_config' is provided, 'entry_point' should be
+                    a relative location to the Python source file in the Git repo.
+
+                    Example:
+                        With the following GitHub repo directory structure:
+
+                        >>> |----- README.md
+                        >>> |----- src
+                        >>>         |----- train.py
+                        >>>         |----- test.py
+
+                        You can assign entry_point='src/train.py'.
+            source_dir (str): A relative location to a directory with other training
+                or model hosting source code dependencies aside from the entry point
+                file in the Git repo (default: None). Structure within this
+                directory are preserved when training on Amazon SageMaker.
+            dependencies (list[str]): A list of paths to directories (absolute
+                    or relative) with any additional libraries that will be exported
+                    to the container (default: []). The library folders will be
+                    copied to SageMaker in the same folder where the entrypoint is
+                    copied. If 'git_config' is provided, 'dependencies' should be a
+                    list of relative locations to directories with any additional
+                    libraries needed in the Git repo.
+
+                    .. admonition:: Example
+
+                        The following call
+
+                        >>> Estimator(entry_point='train.py',
+                        ...           dependencies=['my/libs/common', 'virtual-env'])
+
+                        results in the following inside the container:
+
+                        >>> $ ls
+
+                        >>> opt/ml/code
+                        >>>     |------ train.py
+                        >>>     |------ common
+                        >>>     |------ virtual-env
+
+                    This is not supported with "local code" in Local Mode.
+            depends_on (List[str] or List[Step]): A list of step names or instances
+                    this step depends on
+            subnets (list[str]): List of subnet ids. If not specified, the re-packing
+                    job will be created without VPC config.
+            security_group_ids (list[str]): List of security group ids. If not
+                specified, the re-packing job will be created without VPC config.
         """
-        # yeah, go ahead and save the originals for now
         self._model_data = model_data
         self.sagemaker_session = sagemaker_session
         self.role = role
@@ -101,6 +156,8 @@ class _RepackModelStep(TrainingStep):
                 "inference_script": self._entry_point_basename,
                 "model_archive": self._model_archive,
             },
+            subnets=subnets,
+            security_group_ids=security_group_ids,
             **kwargs,
         )
         repacker.disable_profiler = True

--- a/tests/unit/sagemaker/workflow/test_step_collections.py
+++ b/tests/unit/sagemaker/workflow/test_step_collections.py
@@ -29,7 +29,7 @@ from mock import (
 
 from sagemaker import PipelineModel
 from sagemaker.estimator import Estimator
-from sagemaker.model import Model
+from sagemaker.model import Model, FrameworkModel
 from sagemaker.tensorflow import TensorFlow
 from sagemaker.inputs import CreateModelInput, TransformInput
 from sagemaker.model_metrics import (
@@ -120,6 +120,31 @@ def estimator(sagemaker_session):
         instance_count=1,
         instance_type="ml.c4.4xlarge",
         sagemaker_session=sagemaker_session,
+        subnets=["abc", "def"],
+        security_group_ids=["123", "456"],
+    )
+
+
+@pytest.fixture
+def model(sagemaker_session):
+    return FrameworkModel(
+        image_uri=IMAGE_URI,
+        model_data=f"s3://{BUCKET}/model.tar.gz",
+        role=ROLE,
+        sagemaker_session=sagemaker_session,
+        entry_point=f"{DATA_DIR}/dummy_script.py",
+        name="modelName",
+        vpc_config={"Subnets": ["abc", "def"], "SecurityGroupIds": ["123", "456"]},
+    )
+
+
+@pytest.fixture
+def pipeline_model(sagemaker_session, model):
+    return PipelineModel(
+        models=[model],
+        role=ROLE,
+        sagemaker_session=sagemaker_session,
+        vpc_config={"Subnets": ["abc", "def"], "SecurityGroupIds": ["123", "456"]},
     )
 
 
@@ -334,7 +359,7 @@ def test_register_model_sip(estimator, model_metrics):
     )
 
 
-def test_register_model_with_model_repack(estimator, model_metrics):
+def test_register_model_with_model_repack_with_estimator(estimator, model_metrics):
     model_data = f"s3://{BUCKET}/model.tar.gz"
     register_model = RegisterModel(
         name="RegisterModelStep",
@@ -350,6 +375,7 @@ def test_register_model_with_model_repack(estimator, model_metrics):
         description="description",
         entry_point=f"{DATA_DIR}/dummy_script.py",
         depends_on=["TestStep"],
+        tags=[{"Key": "myKey", "Value": "myValue"}],
     )
 
     request_dicts = register_model.request_dicts()
@@ -403,6 +429,11 @@ def test_register_model_with_model_repack(estimator, model_metrics):
                     },
                     "RoleArn": ROLE,
                     "StoppingCondition": {"MaxRuntimeInSeconds": 86400},
+                    "Tags": [{"Key": "myKey", "Value": "myValue"}],
+                    "VpcConfig": [
+                        ("SecurityGroupIds", ["123", "456"]),
+                        ("Subnets", ["abc", "def"]),
+                    ],
                 }
             )
         elif request_dict["Type"] == "RegisterModel":
@@ -437,6 +468,234 @@ def test_register_model_with_model_repack(estimator, model_metrics):
                     },
                     "ModelPackageDescription": "description",
                     "ModelPackageGroupName": "mpg",
+                    "Tags": [{"Key": "myKey", "Value": "myValue"}],
+                }
+            )
+        else:
+            raise Exception("A step exists in the collection of an invalid type.")
+
+
+def test_register_model_with_model_repack_with_model(model, model_metrics):
+    model_data = f"s3://{BUCKET}/model.tar.gz"
+    register_model = RegisterModel(
+        name="RegisterModelStep",
+        model=model,
+        model_data=model_data,
+        content_types=["content_type"],
+        response_types=["response_type"],
+        inference_instances=["inference_instance"],
+        transform_instances=["transform_instance"],
+        model_package_group_name="mpg",
+        model_metrics=model_metrics,
+        approval_status="Approved",
+        description="description",
+        depends_on=["TestStep"],
+        tags=[{"Key": "myKey", "Value": "myValue"}],
+    )
+
+    request_dicts = register_model.request_dicts()
+    assert len(request_dicts) == 2
+
+    for request_dict in request_dicts:
+        if request_dict["Type"] == "Training":
+            assert request_dict["Name"] == "modelNameRepackModel"
+            assert len(request_dict["DependsOn"]) == 1
+            assert request_dict["DependsOn"][0] == "TestStep"
+            arguments = request_dict["Arguments"]
+            repacker_job_name = arguments["HyperParameters"]["sagemaker_job_name"]
+            assert ordered(arguments) == ordered(
+                {
+                    "AlgorithmSpecification": {
+                        "TrainingImage": MODEL_REPACKING_IMAGE_URI,
+                        "TrainingInputMode": "File",
+                    },
+                    "DebugHookConfig": {
+                        "CollectionConfigurations": [],
+                        "S3OutputPath": f"s3://{BUCKET}/",
+                    },
+                    "HyperParameters": {
+                        "inference_script": '"dummy_script.py"',
+                        "model_archive": '"model.tar.gz"',
+                        "sagemaker_submit_directory": '"s3://{}/{}/source/sourcedir.tar.gz"'.format(
+                            BUCKET, repacker_job_name.replace('"', "")
+                        ),
+                        "sagemaker_program": '"_repack_model.py"',
+                        "sagemaker_container_log_level": "20",
+                        "sagemaker_job_name": repacker_job_name,
+                        "sagemaker_region": f'"{REGION}"',
+                    },
+                    "InputDataConfig": [
+                        {
+                            "ChannelName": "training",
+                            "DataSource": {
+                                "S3DataSource": {
+                                    "S3DataDistributionType": "FullyReplicated",
+                                    "S3DataType": "S3Prefix",
+                                    "S3Uri": f"s3://{BUCKET}",
+                                }
+                            },
+                        }
+                    ],
+                    "OutputDataConfig": {"S3OutputPath": f"s3://{BUCKET}/"},
+                    "ResourceConfig": {
+                        "InstanceCount": 1,
+                        "InstanceType": "ml.m5.large",
+                        "VolumeSizeInGB": 30,
+                    },
+                    "RoleArn": ROLE,
+                    "StoppingCondition": {"MaxRuntimeInSeconds": 86400},
+                    "Tags": [{"Key": "myKey", "Value": "myValue"}],
+                    "VpcConfig": [
+                        ("SecurityGroupIds", ["123", "456"]),
+                        ("Subnets", ["abc", "def"]),
+                    ],
+                }
+            )
+        elif request_dict["Type"] == "RegisterModel":
+            assert request_dict["Name"] == "RegisterModelStep"
+            assert "DependsOn" not in request_dict
+            arguments = request_dict["Arguments"]
+            assert len(arguments["InferenceSpecification"]["Containers"]) == 1
+            assert arguments["InferenceSpecification"]["Containers"][0]["Image"] == model.image_uri
+            assert isinstance(
+                arguments["InferenceSpecification"]["Containers"][0]["ModelDataUrl"], Properties
+            )
+            del arguments["InferenceSpecification"]["Containers"]
+            assert ordered(arguments) == ordered(
+                {
+                    "InferenceSpecification": {
+                        "SupportedContentTypes": ["content_type"],
+                        "SupportedRealtimeInferenceInstanceTypes": ["inference_instance"],
+                        "SupportedResponseMIMETypes": ["response_type"],
+                        "SupportedTransformInstanceTypes": ["transform_instance"],
+                    },
+                    "ModelApprovalStatus": "Approved",
+                    "ModelMetrics": {
+                        "ModelQuality": {
+                            "Statistics": {
+                                "ContentType": "text/csv",
+                                "S3Uri": f"s3://{BUCKET}/metrics.csv",
+                            },
+                        },
+                    },
+                    "ModelPackageDescription": "description",
+                    "ModelPackageGroupName": "mpg",
+                    "Tags": [{"Key": "myKey", "Value": "myValue"}],
+                }
+            )
+        else:
+            raise Exception("A step exists in the collection of an invalid type.")
+
+
+def test_register_model_with_model_repack_with_pipeline_model(pipeline_model, model_metrics):
+    model_data = f"s3://{BUCKET}/model.tar.gz"
+    register_model = RegisterModel(
+        name="RegisterModelStep",
+        model=pipeline_model,
+        model_data=model_data,
+        content_types=["content_type"],
+        response_types=["response_type"],
+        inference_instances=["inference_instance"],
+        transform_instances=["transform_instance"],
+        model_package_group_name="mpg",
+        model_metrics=model_metrics,
+        approval_status="Approved",
+        description="description",
+        depends_on=["TestStep"],
+        tags=[{"Key": "myKey", "Value": "myValue"}],
+    )
+
+    request_dicts = register_model.request_dicts()
+    assert len(request_dicts) == 2
+
+    for request_dict in request_dicts:
+        if request_dict["Type"] == "Training":
+            assert request_dict["Name"] == "modelNameRepackModel"
+            assert len(request_dict["DependsOn"]) == 1
+            assert request_dict["DependsOn"][0] == "TestStep"
+            arguments = request_dict["Arguments"]
+            repacker_job_name = arguments["HyperParameters"]["sagemaker_job_name"]
+            assert ordered(arguments) == ordered(
+                {
+                    "AlgorithmSpecification": {
+                        "TrainingImage": MODEL_REPACKING_IMAGE_URI,
+                        "TrainingInputMode": "File",
+                    },
+                    "DebugHookConfig": {
+                        "CollectionConfigurations": [],
+                        "S3OutputPath": f"s3://{BUCKET}/",
+                    },
+                    "HyperParameters": {
+                        "inference_script": '"dummy_script.py"',
+                        "model_archive": '"model.tar.gz"',
+                        "sagemaker_submit_directory": '"s3://{}/{}/source/sourcedir.tar.gz"'.format(
+                            BUCKET, repacker_job_name.replace('"', "")
+                        ),
+                        "sagemaker_program": '"_repack_model.py"',
+                        "sagemaker_container_log_level": "20",
+                        "sagemaker_job_name": repacker_job_name,
+                        "sagemaker_region": f'"{REGION}"',
+                    },
+                    "InputDataConfig": [
+                        {
+                            "ChannelName": "training",
+                            "DataSource": {
+                                "S3DataSource": {
+                                    "S3DataDistributionType": "FullyReplicated",
+                                    "S3DataType": "S3Prefix",
+                                    "S3Uri": f"s3://{BUCKET}",
+                                }
+                            },
+                        }
+                    ],
+                    "OutputDataConfig": {"S3OutputPath": f"s3://{BUCKET}/"},
+                    "ResourceConfig": {
+                        "InstanceCount": 1,
+                        "InstanceType": "ml.m5.large",
+                        "VolumeSizeInGB": 30,
+                    },
+                    "RoleArn": ROLE,
+                    "StoppingCondition": {"MaxRuntimeInSeconds": 86400},
+                    "Tags": [{"Key": "myKey", "Value": "myValue"}],
+                    "VpcConfig": [
+                        ("SecurityGroupIds", ["123", "456"]),
+                        ("Subnets", ["abc", "def"]),
+                    ],
+                }
+            )
+        elif request_dict["Type"] == "RegisterModel":
+            assert request_dict["Name"] == "RegisterModelStep"
+            assert "DependsOn" not in request_dict
+            arguments = request_dict["Arguments"]
+            assert len(arguments["InferenceSpecification"]["Containers"]) == 1
+            assert (
+                arguments["InferenceSpecification"]["Containers"][0]["Image"]
+                == pipeline_model.models[0].image_uri
+            )
+            assert isinstance(
+                arguments["InferenceSpecification"]["Containers"][0]["ModelDataUrl"], Properties
+            )
+            del arguments["InferenceSpecification"]["Containers"]
+            assert ordered(arguments) == ordered(
+                {
+                    "InferenceSpecification": {
+                        "SupportedContentTypes": ["content_type"],
+                        "SupportedRealtimeInferenceInstanceTypes": ["inference_instance"],
+                        "SupportedResponseMIMETypes": ["response_type"],
+                        "SupportedTransformInstanceTypes": ["transform_instance"],
+                    },
+                    "ModelApprovalStatus": "Approved",
+                    "ModelMetrics": {
+                        "ModelQuality": {
+                            "Statistics": {
+                                "ContentType": "text/csv",
+                                "S3Uri": f"s3://{BUCKET}/metrics.csv",
+                            },
+                        },
+                    },
+                    "ModelPackageDescription": "description",
+                    "ModelPackageGroupName": "mpg",
+                    "Tags": [{"Key": "myKey", "Value": "myValue"}],
                 }
             )
         else:


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/sagemaker-python-sdk/issues/2302

*Description of changes:*
Adding a RegisterModel step to a pipeline causes a RepackModel step to be automatically added if the model has a custom entry point. Tags and VPC configs from the RegisterModel step are not being propagated to the RepackModel step, causing problems for network isolated users.

Propagate tags as well as VPC config to the Repack step. The VPC config will be pulled either from the estimator, model, or pipeline model passed to the RegisterModel step.

*Testing done:*
Manual, unit

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
