### PR TITLE
fix: propagate KMS key to model.deploy

### DIFF
--- a/src/sagemaker/automl/automl.py
+++ b/src/sagemaker/automl/automl.py
@@ -420,7 +420,7 @@ class AutoML(object):
             serializer=serializer,
             deserializer=deserializer,
             endpoint_name=endpoint_name,
-            model_kms_key=model_kms_key,
+            kms_key=model_kms_key,
             tags=tags,
             wait=wait,
         )

--- a/tests/unit/sagemaker/automl/test_auto_ml.py
+++ b/tests/unit/sagemaker/automl/test_auto_ml.py
@@ -595,7 +595,7 @@ def test_deploy_optional_args(candidate_estimator, sagemaker_session, candidate_
         serializer=None,
         deserializer=None,
         endpoint_name=JOB_NAME,
-        model_kms_key=OUTPUT_KMS_KEY,
+        kms_key=OUTPUT_KMS_KEY,
         tags=TAGS,
         wait=False,
     )


### PR DESCRIPTION
*Issue #, if available:*
https://tiny.amazon.com/1icjcjclz

*Description of changes:*

In AUTOML functionality, propagate KMS Key to the model's deploy step and fix units

*Testing done:* Ran all unit tests

------------------
TOTAL                                                                                                 14759   1618    89%

5001 passed, 447 skipped, 1 xfailed, 1 xpassed, 3046 warnings in 323.62s (0:05:23) 

Ran tox -e flake8,pylint,docstyle,black-check,twine --parallel successfully
✔ OK black-check in 12.013 seconds
✔ OK twine in 13.856 seconds
✔ OK pylint in 26.937 seconds
✔ OK docstyle in 28.902 seconds
✔ OK flake8 in 47.925 seconds

TOTAL                                                                                                 14759   1618    89%

==================== 5001 passed, 447 skipped, 1 xfailed, 1 xpassed, 3046 warnings in 323.62s (0:05:23) =====================


## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
