### PR TITLE
documentation: Info about offline s3 bucket key when creating feature group

### DIFF
--- a/src/sagemaker/feature_store/feature_group.py
+++ b/src/sagemaker/feature_store/feature_group.py
@@ -457,12 +457,13 @@ class FeatureGroup:
             online_store_kms_key_id (str): KMS key id for online store.
             enable_online_store (bool): whether to enable online store or not.
             offline_store_kms_key_id (str): KMS key id for offline store.
-                If KMS encryption key is not specified, by default we encrypt all data at
-                rest using AWS KMS key. By defining your bucket-level key for SSE, you can
-                reduce AWS KMS requests costs by up to 99 percent.
-                For more information, see the S3 documentation for
+                If a KMS encryption key is not specified, SageMaker encrypts all data at
+                rest using the default AWS KMS key. By defining your bucket-level key for
+                SSE, you can reduce the cost of AWS KMS requests.
+                For more information, see
                 `Bucket Key
-                <https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucket-key.html>`_.
+                <https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucket-key.html>`_
+                in the Amazon S3 User Guide.
             disable_glue_table_creation (bool): whether to turn off Glue table creation no not.
             data_catalog_config (DataCatalogConfig): configuration for Metadata store.
             description (str): description of the FeatureGroup.

--- a/src/sagemaker/feature_store/feature_group.py
+++ b/src/sagemaker/feature_store/feature_group.py
@@ -457,6 +457,12 @@ class FeatureGroup:
             online_store_kms_key_id (str): KMS key id for online store.
             enable_online_store (bool): whether to enable online store or not.
             offline_store_kms_key_id (str): KMS key id for offline store.
+                If KMS encryption key is not specified, by default we encrypt all data at 
+                rest using AWS KMS key. By defining your bucket-level key for SSE, you can 
+                reduce AWS KMS requests costs by up to 99 percent.
+                For more information, see the S3 documentation for
+                `Bucket Key
+                <https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucket-key.html>`_.
             disable_glue_table_creation (bool): whether to turn off Glue table creation no not.
             data_catalog_config (DataCatalogConfig): configuration for Metadata store.
             description (str): description of the FeatureGroup.

--- a/src/sagemaker/feature_store/feature_group.py
+++ b/src/sagemaker/feature_store/feature_group.py
@@ -457,8 +457,8 @@ class FeatureGroup:
             online_store_kms_key_id (str): KMS key id for online store.
             enable_online_store (bool): whether to enable online store or not.
             offline_store_kms_key_id (str): KMS key id for offline store.
-                If KMS encryption key is not specified, by default we encrypt all data at 
-                rest using AWS KMS key. By defining your bucket-level key for SSE, you can 
+                If KMS encryption key is not specified, by default we encrypt all data at
+                rest using AWS KMS key. By defining your bucket-level key for SSE, you can
                 reduce AWS KMS requests costs by up to 99 percent.
                 For more information, see the S3 documentation for
                 `Bucket Key


### PR DESCRIPTION
*Issue #, if available:*
Documentation offline_store_kms_key_id is not inclusive and lead charging customers more on encryption.

*Description of changes:*
Add more descriptive documentation message of offline_store_kms_key_id in create feature group to elaborate how to bring down the cost of using bucket key.

*Testing done:*
tox

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
