### PR TITLE
fix: add checks for ExecutionRole in UserSettings, adds more unit tests

### DIFF
--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -3554,7 +3554,10 @@ class Session(object):  # pylint: disable=too-many-public-methods
                 user_profile_desc = self.sagemaker_client.describe_user_profile(
                     DomainId=domain_id, UserProfileName=user_profile_name
                 )
-                if user_profile_desc.get("UserSettings") is not None:
+                if (
+                    user_profile_desc.get("UserSettings") is not None
+                    and "ExecutionRole" in user_profile_desc.get("UserSettings").keys()
+                ):
                     return user_profile_desc["UserSettings"]["ExecutionRole"]
 
                 domain_desc = self.sagemaker_client.describe_domain(DomainId=domain_id)

--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -3554,12 +3554,12 @@ class Session(object):  # pylint: disable=too-many-public-methods
                 user_profile_desc = self.sagemaker_client.describe_user_profile(
                     DomainId=domain_id, UserProfileName=user_profile_name
                 )
-                if (
-                    user_profile_desc.get("UserSettings") is not None
-                    and "ExecutionRole" in user_profile_desc.get("UserSettings").keys()
-                ):
+
+                # First, try to find role in userSettings
+                if user_profile_desc.get("UserSettings", {}).get("ExecutionRole", None):
                     return user_profile_desc["UserSettings"]["ExecutionRole"]
 
+                # If not found, fallback to the domain
                 domain_desc = self.sagemaker_client.describe_domain(DomainId=domain_id)
                 return domain_desc["DefaultUserSettings"]["ExecutionRole"]
             except ClientError:

--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -3556,7 +3556,7 @@ class Session(object):  # pylint: disable=too-many-public-methods
                 )
 
                 # First, try to find role in userSettings
-                if user_profile_desc.get("UserSettings", {}).get("ExecutionRole", None):
+                if user_profile_desc.get("UserSettings", {}).get("ExecutionRole"):
                     return user_profile_desc["UserSettings"]["ExecutionRole"]
 
                 # If not found, fallback to the domain

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -343,10 +343,44 @@ def test_get_caller_identity_arn_from_describe_user_profile(boto_session):
     ),
 )
 @patch("os.path.exists", side_effect=mock_exists(NOTEBOOK_METADATA_FILE, True))
-def test_get_caller_identity_arn_from_describe_domain(boto_session):
+def test_get_caller_identity_arn_from_describe_domain_if_no_user_settings(boto_session):
     sess = Session(boto_session)
     expected_role = "arn:aws:iam::369233609183:role/service-role/SageMakerRole-20171129T072388"
     sess.sagemaker_client.describe_user_profile.return_value = {}
+    sess.sagemaker_client.describe_domain.return_value = {
+        "DefaultUserSettings": {"ExecutionRole": expected_role}
+    }
+
+    actual = sess.get_caller_identity_arn()
+
+    assert actual == expected_role
+    sess.sagemaker_client.describe_user_profile.assert_called_once_with(
+        DomainId="d-kbnw5yk6tg8j",
+        UserProfileName="default-1617915559064",
+    )
+    sess.sagemaker_client.describe_domain.assert_called_once_with(DomainId="d-kbnw5yk6tg8j")
+
+
+@patch(
+    "six.moves.builtins.open",
+    mock_open(
+        read_data='{"ResourceName": "SageMakerInstance", '
+        '"DomainId": "d-kbnw5yk6tg8j", '
+        '"UserProfileName": "default-1617915559064"}'
+    ),
+)
+@patch("os.path.exists", side_effect=mock_exists(NOTEBOOK_METADATA_FILE, True))
+def test_fallback_to_domain_if_role_unavailable_in_user_settings(boto_session):
+    sess = Session(boto_session)
+    expected_role = "arn:aws:iam::369233609183:role/service-role/SageMakerRole-20171129T072388"
+    sess.sagemaker_client.describe_user_profile.return_value = {
+        "DomainId": "d-kbnw5yk6tg8j",
+        "UserSettings": {
+            "JupyterServerAppSettings": {},
+            "KernelGatewayAppSettings": {},
+        },
+    }
+
     sess.sagemaker_client.describe_domain.return_value = {
         "DefaultUserSettings": {"ExecutionRole": expected_role}
     }

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -372,7 +372,7 @@ def test_get_caller_identity_arn_from_describe_domain_if_no_user_settings(boto_s
 @patch("os.path.exists", side_effect=mock_exists(NOTEBOOK_METADATA_FILE, True))
 def test_fallback_to_domain_if_role_unavailable_in_user_settings(boto_session):
     sess = Session(boto_session)
-    expected_role = "arn:aws:iam::369233609183:role/service-role/SageMakerRole-20171129T072388"
+    expected_role = "expected_role"
     sess.sagemaker_client.describe_user_profile.return_value = {
         "DomainId": "d-kbnw5yk6tg8j",
         "UserSettings": {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add additional safety check for Execution Role when fetching from UserSettings since it is not a required parameter. Additionally, add more unit tests for all the scenarios.

*Testing done:*

Ran unit tests

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
