### PR TITLE
fix: fix feature store ingestion via data wrangler test

### DIFF
--- a/tests/integ/test_workflow.py
+++ b/tests/integ/test_workflow.py
@@ -2116,6 +2116,7 @@ def test_one_step_ingestion_pipeline(
     input_data_uri = os.path.join(
         "s3://", sagemaker_session.default_bucket(), "py-sdk-ingestion-test-input/features.csv"
     )
+
     with open(input_file_path, "r") as data:
         body = data.read()
         S3Uploader.upload_string_as_file_body(
@@ -2152,6 +2153,10 @@ def test_one_step_ingestion_pipeline(
         )
     ]
 
+    output_content_type = "CSV"
+    output_config = {output_name: {"content_type": output_content_type}}
+    job_argument = [f"--output-config '{json.dumps(output_config)}'"]
+
     temp_flow_path = "./ingestion.flow"
     with cleanup_feature_group(feature_group):
         json.dump(ingestion_only_flow, open(temp_flow_path, "w"))
@@ -2166,7 +2171,11 @@ def test_one_step_ingestion_pipeline(
         )
 
         data_wrangler_step = ProcessingStep(
-            name="ingestion-step", processor=data_wrangler_processor, inputs=inputs, outputs=outputs
+            name="ingestion-step",
+            processor=data_wrangler_processor,
+            inputs=inputs,
+            outputs=outputs,
+            job_arguments=job_argument,
         )
 
         pipeline = Pipeline(


### PR DESCRIPTION
*Issue #, if available:*
https://t.corp.amazon.com/P53429294

*Description of changes:*
Fix feature store ingestion using Data Wrangler in SageMaker pipeline by updating the input parameter. 

*Testing done:*
Yes

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
