### PR TITLE
change: expose num_clusters parameter for clarify shap in shapconfig

### DIFF
--- a/src/sagemaker/clarify.py
+++ b/src/sagemaker/clarify.py
@@ -303,6 +303,7 @@ class SHAPConfig(ExplainabilityConfig):
         baseline,
         num_samples,
         agg_method,
+        num_clusters=None,
         use_logit=False,
         save_local_shap_values=True,
         seed=None,
@@ -322,6 +323,9 @@ class SHAPConfig(ExplainabilityConfig):
                 "mean_abs" (mean of absolute SHAP values for all instances),
                 "median" (median of SHAP values for all instances) and
                 "mean_sq" (mean of squared SHAP values for all instances).
+            num_clusters (int): If a baseline is not provided, Clarify automatically computes a
+                baseline dataset using K-means clustering. num_clusters is a parameter for K-means.
+                Default is None.
             use_logit (bool): Indicator of whether the logit function is to be applied to the model
                 predictions. Default is False. If "use_logit" is true then the SHAP values will
                 have log-odds units.
@@ -333,7 +337,6 @@ class SHAPConfig(ExplainabilityConfig):
             raise ValueError(
                 f"Invalid agg_method {agg_method}." f" Please choose mean_abs, median, or mean_sq."
             )
-
         self.shap_config = {
             "baseline": baseline,
             "num_samples": num_samples,
@@ -341,6 +344,9 @@ class SHAPConfig(ExplainabilityConfig):
             "use_logit": use_logit,
             "save_local_shap_values": save_local_shap_values,
         }
+
+        if num_clusters is not None:
+            self.shap_config["num_clusters"] = num_clusters
         if seed is not None:
             self.shap_config["seed"] = seed
 

--- a/tests/unit/test_clarify.py
+++ b/tests/unit/test_clarify.py
@@ -252,6 +252,7 @@ def test_shap_config():
         baseline=baseline,
         num_samples=num_samples,
         agg_method=agg_method,
+        num_clusters=2,
         use_logit=use_logit,
         seed=seed,
     )
@@ -260,6 +261,7 @@ def test_shap_config():
             "baseline": baseline,
             "num_samples": num_samples,
             "agg_method": agg_method,
+            "num_clusters": 2,
             "use_logit": use_logit,
             "save_local_shap_values": True,
             "seed": seed,
@@ -370,6 +372,7 @@ def shap_config():
             ]
         ],
         num_samples=100,
+        num_clusters=2,
         agg_method="mean_sq",
     )
 
@@ -538,6 +541,7 @@ def _run_test_shap(
                         ]
                     ],
                     "num_samples": 100,
+                    "num_clusters": 2,
                     "agg_method": "mean_sq",
                     "use_logit": False,
                     "save_local_shap_values": True,


### PR DESCRIPTION
*Description of changes:*
Added an optional parameter 'num_clusters' to SHAPConfig class to allow users to specify the number of clusters used by K-Means clustering. This parameter is used when a baseline dataset is not provided for SHAP, so a dataset is generated using K-means clustering.

*Testing done:*
Added this parameter to unit test for SHAPConfig.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ x] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
