### PR TITLE
fix: local mode docker networks are unique per job

### DIFF
--- a/src/sagemaker/local/image.py
+++ b/src/sagemaker/local/image.py
@@ -659,7 +659,9 @@ class _SageMakerContainer(object):
             # Use version 2.3 as a minimum so that we can specify the runtime
             "version": "2.3",
             "services": services,
-            "networks": {"sagemaker-local": {"name": "sagemaker-local"}},
+            "networks": {
+                f"sagemaker-local-{self.hosts[0]}": {"name": f"sagemaker-local-{self.hosts[0]}"}
+            },
         }
 
         docker_compose_path = os.path.join(self.container_root, DOCKER_COMPOSE_FILENAME)
@@ -727,7 +729,7 @@ class _SageMakerContainer(object):
             "tty": True,
             "volumes": [v.map for v in optml_volumes],
             "environment": environment,
-            "networks": {"sagemaker-local": {"aliases": [host]}},
+            "networks": {f"sagemaker-local-{self.hosts[0]}": {"aliases": [host]}},
         }
 
         if command != "process":


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*
Encountered an issue when running multiple local mode jobs concurrently. The docker compose network was named the same between all jobs, so containers end up on the same network and some jobs will fail due to the network being deleted by another job. 

This pr adds a unique element to the network based on the first host's name, which is generated randomly.

Some use cases for running multiple local jobs are:
* Ci using parallel testing like xdist
* User developing multiple models locally at the same time
* In case a compose gets left up due to a failed job
* Multi-user environment where users share the same docker host

*Testing done:*
* Ran test suite
* pip installed the edited version and ran it against a couple projects that use sagemaker local for testing custom images
    - One using xdist to run multiple jobs at the same time
    - One that has multiple containers on the network

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.