### PR TITLE
fix: local mode - support relative file structure

### DIFF
--- a/src/sagemaker/local/image.py
+++ b/src/sagemaker/local/image.py
@@ -277,7 +277,8 @@ class _SageMakerContainer(object):
             script_dir = environment[sagemaker.estimator.DIR_PARAM_NAME.upper()]
             parsed_uri = urlparse(script_dir)
             if parsed_uri.scheme == "file":
-                volumes.append(_Volume(parsed_uri.path, "/opt/ml/code"))
+                host_dir = os.path.abspath(parsed_uri.netloc + parsed_uri.path)
+                volumes.append(_Volume(host_dir, "/opt/ml/code"))
                 # Update path to mount location
                 environment = environment.copy()
                 environment[sagemaker.estimator.DIR_PARAM_NAME.upper()] = "/opt/ml/code"
@@ -495,7 +496,8 @@ class _SageMakerContainer(object):
             training_dir = json.loads(hyperparameters[sagemaker.estimator.DIR_PARAM_NAME])
             parsed_uri = urlparse(training_dir)
             if parsed_uri.scheme == "file":
-                volumes.append(_Volume(parsed_uri.path, "/opt/ml/code"))
+                host_dir = os.path.abspath(parsed_uri.netloc + parsed_uri.path)
+                volumes.append(_Volume(host_dir, "/opt/ml/code"))
                 # Also mount a directory that all the containers can access.
                 volumes.append(_Volume(shared_dir, "/opt/ml/shared"))
 
@@ -504,7 +506,8 @@ class _SageMakerContainer(object):
             parsed_uri.scheme == "file"
             and sagemaker.model.SAGEMAKER_OUTPUT_LOCATION in hyperparameters
         ):
-            intermediate_dir = os.path.join(parsed_uri.path, "output", "intermediate")
+            dir_path = os.path.abspath(parsed_uri.netloc + parsed_uri.path)
+            intermediate_dir = os.path.join(dir_path, "output", "intermediate")
             if not os.path.exists(intermediate_dir):
                 os.makedirs(intermediate_dir)
             volumes.append(_Volume(intermediate_dir, "/opt/ml/output/intermediate"))

--- a/src/sagemaker/local/utils.py
+++ b/src/sagemaker/local/utils.py
@@ -64,7 +64,8 @@ def move_to_destination(source, destination, job_name, sagemaker_session):
     """
     parsed_uri = urlparse(destination)
     if parsed_uri.scheme == "file":
-        recursive_copy(source, parsed_uri.path)
+        dir_path = os.path.abspath(parsed_uri.netloc + parsed_uri.path)
+        recursive_copy(source, dir_path)
         final_uri = destination
     elif parsed_uri.scheme == "s3":
         bucket = parsed_uri.netloc
@@ -116,9 +117,8 @@ def get_child_process_ids(pid):
         (List[int]): Child process ids
     """
     cmd = f"pgrep -P {pid}".split()
-    output, err = subprocess.Popen(
-        cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE
-    ).communicate()
+    process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    output, err = process.communicate()
     if err:
         return []
     pids = [int(pid) for pid in output.decode("utf-8").split()]

--- a/tests/unit/test_local_utils.py
+++ b/tests/unit/test_local_utils.py
@@ -12,18 +12,31 @@
 # language governing permissions and limitations under the License.
 from __future__ import absolute_import
 
+import os
 import pytest
 from mock import patch, Mock
 
 import sagemaker.local.utils
 
 
+@patch("sagemaker.local.utils.os.path")
+@patch("sagemaker.local.utils.os")
+def test_copy_directory_structure(m_os, m_os_path):
+    m_os_path.exists.return_value = False
+    sagemaker.local.utils.copy_directory_structure("/tmp/", "code/")
+    m_os.makedirs.assert_called_with("/tmp/", "code/")
+
+
 @patch("shutil.rmtree", Mock())
 @patch("sagemaker.local.utils.recursive_copy")
 def test_move_to_destination_local(recursive_copy):
     # local files will just be recursively copied
-    sagemaker.local.utils.move_to_destination("/tmp/data", "file:///target/dir/", "job", None)
-    recursive_copy.assert_called_with("/tmp/data", "/target/dir/")
+    # given absolute path
+    sagemaker.local.utils.move_to_destination("/tmp/data", "file:///target/dir", "job", None)
+    recursive_copy.assert_called_with("/tmp/data", "/target/dir")
+    # given relative path
+    sagemaker.local.utils.move_to_destination("/tmp/data", "file://root/target/dir", "job", None)
+    recursive_copy.assert_called_with("/tmp/data", os.path.abspath("./root/target/dir"))
 
 
 @patch("shutil.rmtree", Mock())
@@ -52,3 +65,30 @@ def test_move_to_destination_s3(recursive_copy):
 def test_move_to_destination_illegal_destination():
     with pytest.raises(ValueError):
         sagemaker.local.utils.move_to_destination("/tmp/data", "ftp://ftp/in/2018", "job", None)
+
+
+@patch("sagemaker.local.utils.os.path")
+@patch("sagemaker.local.utils.copy_tree")
+def test_recursive_copy(copy_tree, m_os_path):
+    m_os_path.isdir.return_value = True
+    sagemaker.local.utils.recursive_copy("source", "destination")
+    copy_tree.assert_called_with("source", "destination")
+
+
+@patch("sagemaker.local.utils.os")
+@patch("sagemaker.local.utils.get_child_process_ids")
+def test_kill_child_processes(m_get_child_process_ids, m_os):
+    m_get_child_process_ids.return_value = ["child_pids"]
+    sagemaker.local.utils.kill_child_processes("pid")
+    m_os.kill.assert_called_with("child_pids", 15)
+
+
+@patch("sagemaker.local.utils.subprocess")
+def test_get_child_process_ids(m_subprocess):
+    cmd = "pgrep -P pid".split()
+    process_mock = Mock()
+    attrs = {"communicate.return_value": (b"\n", False), "returncode": 0}
+    process_mock.configure_mock(**attrs)
+    m_subprocess.Popen.return_value = process_mock
+    sagemaker.local.utils.get_child_process_ids("pid")
+    m_subprocess.Popen.assert_called_with(cmd, stdout=m_subprocess.PIPE, stderr=m_subprocess.PIPE)


### PR DESCRIPTION
*Issue #, if available:*
https://t.corp.amazon.com/P54529910

*Description of changes:*
Local mode: support relative file structure

Current support exists for absolute path Ex: file:///target/dir (host directory: /target/dir)
This change will add support for relative path for Ex: file://relative_dir/target/dir (host directory: ./relative_dir/target/dir)

*Testing done:*
Tested locally: https://paste.amazon.com/show/mufi/1637692063
Also added and tested unit tests.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
