### PR TITLE
fix: allow kms_key to be passed for processing step

### DIFF
--- a/src/sagemaker/workflow/steps.py
+++ b/src/sagemaker/workflow/steps.py
@@ -475,6 +475,7 @@ class ProcessingStep(ConfigurableRetryStep):
         cache_config: CacheConfig = None,
         depends_on: Union[List[str], List[Step]] = None,
         retry_policies: List[RetryPolicy] = None,
+        kms_key=None,
     ):
         """Construct a ProcessingStep, given a `Processor` instance.
 
@@ -500,6 +501,8 @@ class ProcessingStep(ConfigurableRetryStep):
             depends_on (List[str] or List[Step]): A list of step names or step instance
                 this `sagemaker.workflow.steps.ProcessingStep` depends on
             retry_policies (List[RetryPolicy]):  A list of retry policy
+            kms_key (str): The ARN of the KMS key that is used to encrypt the
+                user code file. Defaults to `None`.
         """
         super(ProcessingStep, self).__init__(
             name, StepTypeEnum.PROCESSING, display_name, description, depends_on, retry_policies
@@ -511,6 +514,7 @@ class ProcessingStep(ConfigurableRetryStep):
         self.code = code
         self.property_files = property_files
         self.job_name = None
+        self.kms_key = kms_key
 
         # Examine why run method in sagemaker.processing.Processor mutates the processor instance
         # by setting the instance's arguments attribute. Refactor Processor.run, if possible.
@@ -545,8 +549,8 @@ class ProcessingStep(ConfigurableRetryStep):
             inputs=self.inputs,
             outputs=self.outputs,
             code=self.code,
+            kms_key=self.kms_key,
         )
-
         process_args = ProcessingJob._get_process_args(
             self.processor, normalized_inputs, normalized_outputs, experiment_config=dict()
         )

--- a/tests/unit/sagemaker/workflow/test_steps.py
+++ b/tests/unit/sagemaker/workflow/test_steps.py
@@ -598,6 +598,7 @@ def test_processing_step_normalizes_args_with_local_code(mock_normalize_args, sc
         inputs=step.inputs,
         outputs=step.outputs,
         code=step.code,
+        kms_key=None,
     )
 
 
@@ -624,6 +625,7 @@ def test_processing_step_normalizes_args_with_s3_code(mock_normalize_args, scrip
         outputs=outputs,
         job_arguments=["arg1", "arg2"],
         cache_config=cache_config,
+        kms_key="arn:aws:kms:us-west-2:012345678901:key/s3-kms-key",
     )
     mock_normalize_args.return_value = [step.inputs, step.outputs]
     step.to_request()
@@ -633,6 +635,7 @@ def test_processing_step_normalizes_args_with_s3_code(mock_normalize_args, scrip
         inputs=step.inputs,
         outputs=step.outputs,
         code=step.code,
+        kms_key=step.kms_key,
     )
 
 
@@ -667,6 +670,7 @@ def test_processing_step_normalizes_args_with_no_code(mock_normalize_args, scrip
         inputs=step.inputs,
         outputs=step.outputs,
         code=None,
+        kms_key=None,
     )
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change will allow ARN of the KMS key to be passed as kms_key that is used to encrypt the user code file kms_key to be passed for processing step

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ x ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ x ] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ x ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ x ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ x ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ x ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ x ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ x ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ x ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
