### PR TITLE
fix: Recreate static lineage test data

### DIFF
--- a/tests/integ/sagemaker/lineage/conftest.py
+++ b/tests/integ/sagemaker/lineage/conftest.py
@@ -36,8 +36,8 @@ from botocore.exceptions import ClientError
 from tests.integ.sagemaker.lineage.helpers import name, names
 
 SLEEP_TIME_SECONDS = 1
-STATIC_PIPELINE_NAME = "SdkIntegTestStaticPipeline13"
-STATIC_ENDPOINT_NAME = "SdkIntegTestStaticEndpoint13"
+STATIC_PIPELINE_NAME = "SdkIntegTestStaticPipeline14"
+STATIC_ENDPOINT_NAME = "SdkIntegTestStaticEndpoint14"
 
 
 @pytest.fixture


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Lineage tests are failing here:

```
    def test_endpoint_contexts(
        static_model_artifact,
        sagemaker_session,
    ):
        contexts_from_query = static_model_artifact.endpoint_contexts()
    
        associations_from_api = traverse_graph_forward(
            static_model_artifact.artifact_arn, sagemaker_session=sagemaker_session
        )
    
>       assert len(contexts_from_query) > 0
E       assert 0 > 0
E        +  where 0 = len([])

tests/integ/sagemaker/lineage/test_model_artifact.py:43: AssertionError
```

Recreate the test data to see if this is transient.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
