### PR TITLE
change: Add action type to lineage object

### DIFF
--- a/src/sagemaker/lineage/query.py
+++ b/src/sagemaker/lineage/query.py
@@ -83,10 +83,11 @@ class Vertex:
         self._session = sagemaker_session
 
     def to_lineage_object(self):
-        """Convert the ``Vertex`` object to its corresponding ``Artifact`` or ``Context`` object."""
+        """Convert the ``Vertex`` object to its corresponding Artifact, Action, Context object."""
         from sagemaker.lineage.artifact import Artifact, ModelArtifact
         from sagemaker.lineage.context import Context, EndpointContext
         from sagemaker.lineage.artifact import DatasetArtifact
+        from sagemaker.lineage.action import Action
 
         if self.lineage_entity == LineageEntityEnum.CONTEXT.value:
             resource_name = get_resource_name_from_arn(self.arn)
@@ -102,6 +103,9 @@ class Vertex:
             if self.lineage_source == LineageSourceEnum.DATASET.value:
                 return DatasetArtifact.load(artifact_arn=self.arn, sagemaker_session=self._session)
             return Artifact.load(artifact_arn=self.arn, sagemaker_session=self._session)
+
+        if self.lineage_entity == LineageEntityEnum.ACTION.value:
+            return Action.load(action_name=self.arn.split("/")[1], sagemaker_session=self._session)
 
         raise ValueError("Vertex cannot be converted to a lineage object.")
 

--- a/tests/unit/sagemaker/lineage/test_query.py
+++ b/tests/unit/sagemaker/lineage/test_query.py
@@ -13,6 +13,7 @@
 from __future__ import absolute_import
 from sagemaker.lineage.artifact import DatasetArtifact, ModelArtifact, Artifact
 from sagemaker.lineage.context import EndpointContext, Context
+from sagemaker.lineage.action import Action
 from sagemaker.lineage.query import LineageEntityEnum, LineageSourceEnum, Vertex, LineageQuery
 import pytest
 
@@ -240,10 +241,38 @@ def test_vertex_to_object_artifact(sagemaker_session):
     assert isinstance(artifact, Artifact)
 
 
+def test_vertex_to_object_action(sagemaker_session):
+    vertex = Vertex(
+        arn="arn:aws:sagemaker:us-west-2:0123456789012:action/cp-m5-20210424t041405868z-1619237657-1-aws-endpoint",
+        lineage_entity=LineageEntityEnum.ACTION.value,
+        lineage_source="A",
+        sagemaker_session=sagemaker_session,
+    )
+
+    sagemaker_session.sagemaker_client.describe_action.return_value = {
+        "ActionName": "cp-m5-20210424t041405868z-1619237657-1-aws-endpoint",
+        "Source": {
+            "SourceUri": "246618743249.dkr.ecr.us-west-2.amazonaws.com/sagemaker-scikit-learn:0.23-1-cpu-py3",
+            "SourceTypes": [],
+        },
+        "ActionType": "A",
+        "Properties": {},
+        "CreationTime": 1608224704.149,
+        "CreatedBy": {},
+        "LastModifiedTime": 1608224704.149,
+        "LastModifiedBy": {},
+    }
+
+    action = vertex.to_lineage_object()
+
+    assert action.action_name == "cp-m5-20210424t041405868z-1619237657-1-aws-endpoint"
+    assert isinstance(action, Action)
+
+
 def test_vertex_to_object_unconvertable(sagemaker_session):
     vertex = Vertex(
         arn="arn:aws:sagemaker:us-west-2:0123456789012:artifact/e66eef7f19c05e75284089183491bd4f",
-        lineage_entity=LineageEntityEnum.ACTION.value,
+        lineage_entity=LineageEntityEnum.TRIAL_COMPONENT.value,
         lineage_source=LineageSourceEnum.TENSORBOARD.value,
         sagemaker_session=sagemaker_session,
     )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Support new type "Action" to lineage response object

*Testing done:*
unit test

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
