### PR TITLE
feature: Add models_v2 under lineage context

### DIFF
--- a/tests/integ/sagemaker/lineage/conftest.py
+++ b/tests/integ/sagemaker/lineage/conftest.py
@@ -36,6 +36,7 @@ from botocore.exceptions import ClientError
 from tests.integ.sagemaker.lineage.helpers import name, names
 
 SLEEP_TIME_SECONDS = 1
+SLEEP_TIME_TWO_SECONDS = 2
 STATIC_PIPELINE_NAME = "SdkIntegTestStaticPipeline17"
 STATIC_ENDPOINT_NAME = "SdkIntegTestStaticEndpoint17"
 
@@ -360,12 +361,10 @@ def endpoint_context_obj(sagemaker_session):
 
 @pytest.fixture
 def model_obj(sagemaker_session):
-    model = context.Context.create(
-        context_name=name(),
+    model = artifact.Artifact.create(
+        artifact_name=name(),
+        artifact_type="Model",
         source_uri="bar1",
-        source_type="test-source-type1",
-        context_type="Model",
-        description="test-description",
         properties={"k1": "v1"},
         sagemaker_session=sagemaker_session,
     )
@@ -417,11 +416,12 @@ def endpoint_context_associate_with_model(sagemaker_session, endpoint_action_obj
 
     association.Association.create(
         source_arn=endpoint_action_obj.action_arn,
-        destination_arn=model_obj.context_arn,
+        destination_arn=model_obj.artifact_arn,
         sagemaker_session=sagemaker_session,
     )
     yield obj
-    time.sleep(SLEEP_TIME_SECONDS)
+    # sleep 2 seconds since take longer for lineage injection
+    time.sleep(SLEEP_TIME_TWO_SECONDS)
     obj.delete(disassociate=True)
 
 

--- a/tests/integ/sagemaker/lineage/test_endpoint_context.py
+++ b/tests/integ/sagemaker/lineage/test_endpoint_context.py
@@ -12,15 +12,29 @@
 # language governing permissions and limitations under the License.
 """This module contains code to test SageMaker ``Contexts``"""
 from __future__ import absolute_import
+import time
+
+SLEEP_TIME_ONE_SECONDS = 1
 
 
 def test_model(endpoint_context_associate_with_model, model_obj, endpoint_action_obj):
     model_list = endpoint_context_associate_with_model.models()
     for model in model_list:
         assert model.source_arn == endpoint_action_obj.action_arn
-        assert model.destination_arn == model_obj.context_arn
+        assert model.destination_arn == model_obj.artifact_arn
         assert model.source_type == "ModelDeployment"
         assert model.destination_type == "Model"
+
+
+def test_model_v2(endpoint_context_associate_with_model, model_obj, sagemaker_session):
+    time.sleep(SLEEP_TIME_ONE_SECONDS)
+    model_list = endpoint_context_associate_with_model.models_v2()
+    assert len(model_list) == 1
+    for model in model_list:
+        assert model.artifact_arn == model_obj.artifact_arn
+        assert model.artifact_name == model_obj.artifact_name
+        assert model.artifact_type == "Model"
+        assert model.properties == model_obj.properties
 
 
 def test_dataset_artifacts(static_endpoint_context):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add models_v2 under lineage context. models_v2 return list of models by using lineage query

*Testing done:*
- unit test:
`tox -e py36 -- tests/unit/sagemaker/lineage/test_endpoint_context.py -vv`

tests/unit/sagemaker/lineage/test_endpoint_context.py::test_models PASSED                                                                                                                                                              [ 50%]
tests/unit/sagemaker/lineage/test_endpoint_context.py::test_models_v2 PASSED                                                                                                                                                           [100%]
==========================================================================================2 passed in 2.04s ========================================================================================

- integ test:
`tox -e py36 -- tests/integ/sagemaker/lineage/test_endpoint_context.py`

collected 5 items
tests/integ/sagemaker/lineage/test_endpoint_context.py::test_model PASSED                                                                                                                                                              [ 50%]
tests/integ/sagemaker/lineage/test_endpoint_context.py::test_model_v2 PASSED                                                                                                                                                           [100%]
.....
tests/integ/sagemaker/lineage/test_endpoint_context.py .....
========================================================================================= 5 passed in 14.45s =========================================================================================
## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

