### PR TITLE
doc: Document the available ExecutionVariables

### DIFF
--- a/src/sagemaker/workflow/execution_variables.py
+++ b/src/sagemaker/workflow/execution_variables.py
@@ -37,7 +37,15 @@ class ExecutionVariable(Expression):
 
 
 class ExecutionVariables:
-    """All available ExecutionVariable."""
+    """Provide access to all available execution variables:
+
+    - ExecutionVariables.START_DATETIME
+    - ExecutionVariables.CURRENT_DATETIME
+    - ExecutionVariables.PIPELINE_NAME
+    - ExecutionVariables.PIPELINE_ARN
+    - ExecutionVariables.PIPELINE_EXECUTION_ID
+    - ExecutionVariables.PIPELINE_EXECUTION_ARN
+    """
 
     START_DATETIME = ExecutionVariable("StartDateTime")
     CURRENT_DATETIME = ExecutionVariable("CurrentDateTime")


### PR DESCRIPTION
*Description of changes:*
The documentation for [`workflow.execution_variables.ExecutionVariables`](https://sagemaker.readthedocs.io/en/stable/workflows/pipelines/sagemaker.workflow.pipelines.html#sagemaker.workflow.execution_variables.ExecutionVariables) does not show the available variables:
![image](https://user-images.githubusercontent.com/1420513/146935605-6eae337a-b13b-41cc-bed9-f37f4a7886f2.png)

This PR adds the existing execution variables to the docstring, so they get rendered in the Sphinx documentation:
![image](https://user-images.githubusercontent.com/1420513/146935529-6a86f340-ffba-407d-a76f-0c3b569b086e.png)

*Testing done:*
Build Sphinx docs locally.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
