### PR TITLE
fix: remove unnecessary session call while generating pipeline definition for lambda step

### DIFF
--- a/src/sagemaker/workflow/lambda_step.py
+++ b/src/sagemaker/workflow/lambda_step.py
@@ -154,7 +154,6 @@ class LambdaStep(Step):
         Method creates a lambda function and returns it's arn.
         If the lambda is already present, it will build it's arn and return that.
         """
-        account_id = self.lambda_func.session.account_id()
         region = self.lambda_func.session.boto_region_name
         if region.lower() == "cn-north-1" or region.lower() == "cn-northwest-1":
             partition = "aws-cn"
@@ -163,6 +162,7 @@ class LambdaStep(Step):
 
         if self.lambda_func.function_arn is None:
             try:
+                account_id = self.lambda_func.session.account_id()
                 response = self.lambda_func.create()
                 return response["FunctionArn"]
             except ValueError as error:

--- a/tests/unit/sagemaker/workflow/test_lambda_step.py
+++ b/tests/unit/sagemaker/workflow/test_lambda_step.py
@@ -16,7 +16,7 @@ import json
 
 import pytest
 
-from mock import Mock
+from mock import Mock, MagicMock
 
 from sagemaker.workflow.parameters import ParameterInteger, ParameterString
 from sagemaker.workflow.pipeline import Pipeline
@@ -27,12 +27,13 @@ from sagemaker.lambda_helper import Lambda
 @pytest.fixture()
 def sagemaker_session():
     boto_mock = Mock(name="boto_session", region_name="us-west-2")
-    session_mock = Mock(
+    session_mock = MagicMock(
         name="sagemaker_session",
         boto_session=boto_mock,
         boto_region_name="us-west-2",
         config=None,
         local_mode=False,
+        account_id=Mock(),
     )
     return session_mock
 
@@ -173,3 +174,36 @@ def test_lambda_step_no_inputs_outputs(sagemaker_session):
         "OutputParameters": [],
         "Arguments": {},
     }
+
+
+def test_lambda_step_with_function_arn(sagemaker_session):
+    lambda_step = LambdaStep(
+        name="MyLambdaStep",
+        depends_on=["TestStep"],
+        lambda_func=Lambda(
+            function_arn="arn:aws:lambda:us-west-2:123456789012:function:sagemaker_test_lambda",
+            session=sagemaker_session,
+        ),
+        inputs={},
+        outputs=[],
+    )
+    lambda_step._get_function_arn()
+    sagemaker_session.account_id.assert_not_called()
+
+
+def test_lambda_step_without_function_arn(sagemaker_session):
+    lambda_step = LambdaStep(
+        name="MyLambdaStep",
+        depends_on=["TestStep"],
+        lambda_func=Lambda(
+            function_name="name",
+            execution_role_arn="arn:aws:lambda:us-west-2:123456789012:execution_role",
+            zipped_code_dir="",
+            handler="",
+            session=sagemaker_session,
+        ),
+        inputs={},
+        outputs=[],
+    )
+    lambda_step._get_function_arn()
+    sagemaker_session.account_id.assert_called_once()


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/sagemaker-python-sdk/issues/2676

*Description of changes:*
remove unnecessary session call while generating pipeline definition for lambda step

*Testing done:*
Unit test and integ test

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ x] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
