### PR TITLE
feature: Add support for SageMaker lineage queries context

### DIFF
--- a/src/sagemaker/lineage/context.py
+++ b/src/sagemaker/lineage/context.py
@@ -490,3 +490,15 @@ class EndpointContext(Context):
                     return tag["Value"]
 
         return None
+
+
+class ModelPackageGroup(Context):
+    """An Amazon SageMaker model package group context, which is part of a SageMaker lineage."""
+
+    def pipeline_execution_arn(self) -> str:
+        """Get the ARN for the pipeline execution associated with this model package group (if any).
+
+        Returns:
+            str: A pipeline execution ARN.
+        """
+        return self.properties.get("PipelineExecutionArn")

--- a/tests/integ/sagemaker/lineage/test_model_package_group_context.py
+++ b/tests/integ/sagemaker/lineage/test_model_package_group_context.py
@@ -1,0 +1,20 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+"""This module contains code to test SageMaker ``ModelPackageGroup``"""
+from __future__ import absolute_import
+
+
+def test_pipeline_execution_arn(static_model_package_group_context, static_pipeline_execution_arn):
+    pipeline_execution_arn = static_model_package_group_context.pipeline_execution_arn()
+
+    assert pipeline_execution_arn == static_pipeline_execution_arn

--- a/tests/unit/sagemaker/lineage/test_model_package_group_context.py
+++ b/tests/unit/sagemaker/lineage/test_model_package_group_context.py
@@ -1,0 +1,36 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+"""This module contains code to test SageMaker ``ModelPackageGroup``"""
+from __future__ import absolute_import
+
+import unittest.mock
+import pytest
+from sagemaker.lineage import context
+
+
+@pytest.fixture
+def sagemaker_session():
+    return unittest.mock.Mock()
+
+
+def test_pipeline_execution_arn(sagemaker_session):
+    obj = context.ModelPackageGroup(
+        sagemaker_session,
+        context_name="foo",
+        description="test-description",
+        properties={"PipelineExecutionArn": "abcd", "k2": "v2"},
+        properties_to_remove=["E"],
+    )
+    actual_result = obj.pipeline_execution_arn()
+    expected_result = "abcd"
+    assert expected_result == actual_result


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add support for SageMaker lineage queries context
- Return Pipeline Execution in ModelPackageGroup

*Testing done:*
Integration test
 tox -e py36 -- tests/integ/sagemaker/lineage/test_model_package_group_context.py -vv

`tests/integ/sagemaker/lineage/test_model_package_group_context.py::test_pipeline_execution_arn PASSED                                                                                                        [100%]`


 tox -e py36 -- tests/integ/sagemaker/lineage/test_endpoint_context.py -vv
`
collected 6 items
tests/integ/sagemaker/lineage/test_endpoint_context.py::test_pipeline_execution_arn PASSED                                                                                                                   [100%]
`

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
