### PR TITLE
feature: Support model pipelines in CreateModelStep

### DIFF
--- a/tests/unit/sagemaker/workflow/test_steps.py
+++ b/tests/unit/sagemaker/workflow/test_steps.py
@@ -62,6 +62,10 @@ from sagemaker.workflow.steps import (
     CreateModelStep,
     CacheConfig,
 )
+from sagemaker.pipeline import PipelineModel
+from sagemaker.sparkml import SparkMLModel
+from sagemaker.predictor import Predictor
+from sagemaker.model import FrameworkModel
 from tests.unit import DATA_DIR
 
 DUMMY_SCRIPT_PATH = os.path.join(DATA_DIR, "dummy_script.py")
@@ -87,6 +91,21 @@ class CustomStep(ConfigurableRetryStep):
     @property
     def properties(self):
         return self._properties
+
+
+class DummyFrameworkModel(FrameworkModel):
+    def __init__(self, sagemaker_session, **kwargs):
+        super(DummyFrameworkModel, self).__init__(
+            "s3://bucket/model_1.tar.gz",
+            "mi-1",
+            ROLE,
+            os.path.join(DATA_DIR, "dummy_script.py"),
+            sagemaker_session=sagemaker_session,
+            **kwargs,
+        )
+
+    def create_predictor(self, endpoint_name):
+        return Predictor(endpoint_name, self.sagemaker_session)
 
 
 @pytest.fixture
@@ -699,6 +718,63 @@ def test_create_model_step(sagemaker_session):
         "Arguments": {
             "ExecutionRoleArn": "DummyRole",
             "PrimaryContainer": {"Environment": {}, "Image": "fakeimage"},
+        },
+    }
+    assert step.properties.ModelName.expr == {"Get": "Steps.MyCreateModelStep.ModelName"}
+
+
+@patch("tarfile.open")
+@patch("time.strftime", return_value="2017-10-10-14-14-15")
+def test_create_model_step_with_model_pipeline(tfo, time, sagemaker_session):
+    framework_model = DummyFrameworkModel(sagemaker_session)
+    sparkml_model = SparkMLModel(
+        model_data="s3://bucket/model_2.tar.gz",
+        role=ROLE,
+        sagemaker_session=sagemaker_session,
+        env={"SAGEMAKER_DEFAULT_INVOCATIONS_ACCEPT": "text/csv"},
+    )
+    model = PipelineModel(
+        models=[framework_model, sparkml_model], role=ROLE, sagemaker_session=sagemaker_session
+    )
+    inputs = CreateModelInput(
+        instance_type="c4.4xlarge",
+        accelerator_type="ml.eia1.medium",
+    )
+    step = CreateModelStep(
+        name="MyCreateModelStep",
+        depends_on=["TestStep"],
+        display_name="MyCreateModelStep",
+        description="TestDescription",
+        model=model,
+        inputs=inputs,
+    )
+    step.add_depends_on(["SecondTestStep"])
+
+    assert step.to_request() == {
+        "Name": "MyCreateModelStep",
+        "Type": "Model",
+        "Description": "TestDescription",
+        "DisplayName": "MyCreateModelStep",
+        "DependsOn": ["TestStep", "SecondTestStep"],
+        "Arguments": {
+            "Containers": [
+                {
+                    "Environment": {
+                        "SAGEMAKER_PROGRAM": "dummy_script.py",
+                        "SAGEMAKER_SUBMIT_DIRECTORY": "s3://my-bucket/mi-1-2017-10-10-14-14-15/sourcedir.tar.gz",
+                        "SAGEMAKER_CONTAINER_LOG_LEVEL": "20",
+                        "SAGEMAKER_REGION": "us-west-2",
+                    },
+                    "Image": "mi-1",
+                    "ModelDataUrl": "s3://bucket/model_1.tar.gz",
+                },
+                {
+                    "Environment": {"SAGEMAKER_DEFAULT_INVOCATIONS_ACCEPT": "text/csv"},
+                    "Image": "246618743249.dkr.ecr.us-west-2.amazonaws.com/sagemaker-sparkml-serving:2.4",
+                    "ModelDataUrl": "s3://bucket/model_2.tar.gz",
+                },
+            ],
+            "ExecutionRoleArn": "DummyRole",
         },
     }
     assert step.properties.ModelName.expr == {"Get": "Steps.MyCreateModelStep.ModelName"}


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Add support for `PipelineModel` to the `CreateModelStep`

*Testing done:*
Unit, manual

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
