### PR TITLE
Add deprecation warning for s3_data_distribution_type in Clarify Data Config

### DIFF
--- a/src/sagemaker/clarify.py
+++ b/src/sagemaker/clarify.py
@@ -22,11 +22,17 @@ import re
 import tempfile
 from abc import ABC, abstractmethod
 from sagemaker import image_uris, s3, utils
+from sagemaker.deprecations import deprecation_warning
 from sagemaker.processing import ProcessingInput, ProcessingOutput, Processor
 
 logger = logging.getLogger(__name__)
 
 
+@deprecation_warning(
+    msg="s3_data_distribution_type parameter will no longer be supported. Everything else will"
+    " remain as is",
+    date="15 Mar 2022",
+)
 class DataConfig:
     """Config object related to configurations of the input and output dataset."""
 
@@ -58,8 +64,8 @@ class DataConfig:
                 dataset format is JSONLines.
             dataset_type (str): Format of the dataset. Valid values are "text/csv" for CSV,
                 "application/jsonlines" for JSONLines, and "application/x-parquet" for Parquet.
-            s3_data_distribution_type (str): Valid options are "FullyReplicated" or
-                "ShardedByS3Key".
+            s3_data_distribution_type (str): Deprecated. Only valid option is "FullyReplicated".
+                Any other value is ignored.
             s3_compression_type (str): Valid options are "None" or "Gzip".
             joinsource (str): The name or index of the column in the dataset that acts as an
                 identifier column (for instance, while performing a join). This column is only
@@ -80,7 +86,13 @@ class DataConfig:
         self.s3_data_input_path = s3_data_input_path
         self.s3_output_path = s3_output_path
         self.s3_analysis_config_output_path = s3_analysis_config_output_path
-        self.s3_data_distribution_type = s3_data_distribution_type
+        if s3_data_distribution_type != "FullyReplicated":
+            logger.warning(
+                "s3_data_distribution_type parameter, set to %s, is being ignored. Only"
+                " valid option is FullyReplicated",
+                s3_data_distribution_type,
+            )
+        self.s3_data_distribution_type = "FullyReplicated"
         self.s3_compression_type = s3_compression_type
         self.label = label
         self.headers = headers

--- a/tests/unit/test_clarify.py
+++ b/tests/unit/test_clarify.py
@@ -82,6 +82,19 @@ def test_invalid_data_config():
         )
 
 
+def test_s3_data_distribution_type_ignorance():
+    data_config = DataConfig(
+        s3_data_input_path="s3://input/train.csv",
+        s3_output_path="s3://output/analysis_test_result",
+        label="Label",
+        headers=["Label", "F1", "F2", "F3", "F4"],
+        dataset_type="text/csv",
+        joinsource="F4",
+        s3_data_distribution_type="ShardedByS3Key",
+    )
+    assert data_config.s3_data_distribution_type == "FullyReplicated"
+
+
 def test_bias_config():
     label_values = [1]
     facet_name = "F1"


### PR DESCRIPTION
*Description of changes:*
In Clarify DataConfig, there is a parameter called `s3_data_distribution_type` which can currently take two values: `FullyReplicated` or `ShardedByS3Key`. However, going forward, the only valid option for this variable will be `FullyReplicated`. This CR also adds a deprecation warning to the class `DataConfig` so that customers get time to make changes to their code, as we will eventually remove this parameter (which will be a backward incompatible change). 

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
