### PR TITLE
feature: support checkpoint to be passed from estimator

### DIFF
--- a/src/sagemaker/workflow/airflow.py
+++ b/src/sagemaker/workflow/airflow.py
@@ -195,6 +195,11 @@ def training_base_config(estimator, inputs=None, job_name=None, mini_batch_size=
     if s3_operations:
         train_config["S3Operations"] = s3_operations
 
+    if (estimator.checkpoint_local_path is not None) & (estimator.checkpoint_s3_uri is not None):
+        train_config["CheckpointConfig"] = {
+            "LocalPath": estimator.checkpoint_local_path,
+            "S3Uri": estimator.checkpoint_s3_uri,
+        }
     return train_config
 
 

--- a/tests/unit/test_airflow.py
+++ b/tests/unit/test_airflow.py
@@ -262,7 +262,7 @@ def test_framework_training_config_all_args(retrieve_image_uri, sagemaker_sessio
         py_version="py3",
         framework_version="1.15.2",
         role="{{ role }}",
-        instance_count="{{ instance_count }}",
+        instance_count=1,
         instance_type="ml.c4.2xlarge",
         volume_size="{{ volume_size }}",
         volume_kms_key="{{ volume_kms_key }}",
@@ -276,6 +276,8 @@ def test_framework_training_config_all_args(retrieve_image_uri, sagemaker_sessio
         security_group_ids=["{{ security_group_ids }}"],
         metric_definitions=[{"Name": "{{ name }}", "Regex": "{{ regex }}"}],
         sagemaker_session=sagemaker_session,
+        checkpoint_local_path="{{ checkpoint_local_path }}",
+        checkpoint_s3_uri="{{ checkpoint_s3_uri }}",
     )
 
     data = "{{ training_data }}"
@@ -294,7 +296,7 @@ def test_framework_training_config_all_args(retrieve_image_uri, sagemaker_sessio
         "TrainingJobName": "{{ base_job_name }}-%s" % TIME_STAMP,
         "StoppingCondition": {"MaxRuntimeInSeconds": "{{ max_run }}"},
         "ResourceConfig": {
-            "InstanceCount": "{{ instance_count }}",
+            "InstanceCount": 1,
             "InstanceType": "ml.c4.2xlarge",
             "VolumeSizeInGB": "{{ volume_size }}",
             "VolumeKmsKeyId": "{{ volume_kms_key }}",
@@ -337,6 +339,10 @@ def test_framework_training_config_all_args(retrieve_image_uri, sagemaker_sessio
                     "Tar": True,
                 }
             ]
+        },
+        "CheckpointConfig": {
+            "LocalPath": "{{ checkpoint_local_path }}",
+            "S3Uri": "{{ checkpoint_s3_uri }}",
         },
     }
     assert config == expected_config


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add Support for checkpoint to be passed from estimator.
Updated unit test to test change. 

*Testing done:*
python3 -m tox -e py38 test/unit/

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
