### PR TITLE
doc: Enhance smddp 1.2.2 doc

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line.
 SPHINXOPTS    = -W
-SPHINXBUILD   = python -msphinx 
+SPHINXBUILD   = python3 -msphinx
 SPHINXPROJ    = sagemaker
 SOURCEDIR     = .
 BUILDDIR      = _build

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line.
 SPHINXOPTS    = -W
-SPHINXBUILD   = python3 -msphinx
+SPHINXBUILD   = python -msphinx
 SPHINXPROJ    = sagemaker
 SOURCEDIR     = .
 BUILDDIR      = _build

--- a/doc/api/training/sdp_versions/latest/smd_data_parallel_pytorch.rst
+++ b/doc/api/training/sdp_versions/latest/smd_data_parallel_pytorch.rst
@@ -112,7 +112,7 @@ you will have for distributed training with the distributed data parallel librar
    def main():
 
        # Scale batch size by world size
-       batch_size //= dist.get_world_size() // 8
+       batch_size //= dist.get_world_size()
        batch_size = max(batch_size, 1)
 
        # Prepare dataset

--- a/doc/api/training/sdp_versions/latest/smd_data_parallel_tensorflow.rst
+++ b/doc/api/training/sdp_versions/latest/smd_data_parallel_tensorflow.rst
@@ -155,10 +155,6 @@ script you will have for distributed training with the library.
 TensorFlow API
 ==============
 
-.. rubric:: Supported versions
-
-**TensorFlow 2.3.1, 2.4.1, 2.5.0**
-
 .. function:: smdistributed.dataparallel.tensorflow.init()
 
    Initialize ``smdistributed.dataparallel``. Must be called at the

--- a/doc/api/training/smd_data_parallel_release_notes/smd_data_parallel_change_log.rst
+++ b/doc/api/training/smd_data_parallel_release_notes/smd_data_parallel_change_log.rst
@@ -1,5 +1,42 @@
-Sagemaker Distributed Data Parallel 1.2.1 Release Notes
+.. _sdp_1.2.2_release_note:
+
+Sagemaker Distributed Data Parallel 1.2.2 Release Notes
 =======================================================
+
+*Date: November. 24. 2021*
+
+**New Features**
+
+* Added support for PyTorch 1.10
+* PyTorch ``no_sync`` API support for DistributedDataParallel
+* Timeout when training stalls due to allreduce and broadcast collective calls
+
+**Bug Fixes**
+
+* Fixed a bug that would impact correctness in the mixed dtype case
+* Fixed a bug related to the timeline writer that would cause a crash when SageMaker Profiler is enabled for single node jobs.
+
+**Improvements**
+
+* Performance optimizations for small models on small clusters
+
+**Migration to AWS Deep Learning Containers**
+
+This version passed benchmark testing and is migrated to the following AWS Deep Learning Containers:
+
+- PyTorch 1.10 DLC release: `v1.0-pt-sagemaker-1.10.0-py38 <https://github.com/aws/deep-learning-containers/releases/tag/v1.0-pt-sagemaker-1.10.0-py38>`_
+
+  .. code::
+
+    763104351884.dkr.ecr.<region>.amazonaws.com/pytorch-training:1.10.0-gpu-py38-cu113-ubuntu20.04-sagemaker
+
+----
+
+Release History
+===============
+
+Sagemaker Distributed Data Parallel 1.2.1 Release Notes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 *Date: June. 29. 2021*
 
@@ -28,10 +65,6 @@ This version passed benchmark testing and is migrated to the following AWS Deep 
 
     763104351884.dkr.ecr.<region>.amazonaws.com/tensorflow-training:2.5.0-gpu-py37-cu112-ubuntu18.04-v1.0
 
-----
-
-Release History
-===============
 
 Sagemaker Distributed Data Parallel 1.2.0 Release Notes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/api/training/smd_data_parallel_release_notes/smd_data_parallel_change_log.rst
+++ b/doc/api/training/smd_data_parallel_release_notes/smd_data_parallel_change_log.rst
@@ -1,6 +1,6 @@
 .. _sdp_1.2.2_release_note:
 
-Sagemaker Distributed Data Parallel 1.2.2 Release Notes
+SageMaker Distributed Data Parallel 1.2.2 Release Notes
 =======================================================
 
 *Date: November. 24. 2021*
@@ -35,7 +35,7 @@ This version passed benchmark testing and is migrated to the following AWS Deep 
 Release History
 ===============
 
-Sagemaker Distributed Data Parallel 1.2.1 Release Notes
+SageMaker Distributed Data Parallel 1.2.1 Release Notes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 *Date: June. 29. 2021*
@@ -66,7 +66,7 @@ This version passed benchmark testing and is migrated to the following AWS Deep 
     763104351884.dkr.ecr.<region>.amazonaws.com/tensorflow-training:2.5.0-gpu-py37-cu112-ubuntu18.04-v1.0
 
 
-Sagemaker Distributed Data Parallel 1.2.0 Release Notes
+SageMaker Distributed Data Parallel 1.2.0 Release Notes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 -  New features
@@ -79,7 +79,7 @@ Sagemaker Distributed Data Parallel 1.2.0 Release Notes
    AllReduce. For best performance, it is recommended you use an
    instance type that supports Amazon Elastic Fabric Adapter
    (ml.p3dn.24xlarge and ml.p4d.24xlarge) when you train a model using
-   Sagemaker Distributed data parallel.
+   SageMaker Distributed data parallel.
 
 **Bug Fixes:**
 
@@ -87,7 +87,7 @@ Sagemaker Distributed Data Parallel 1.2.0 Release Notes
 
 ----
 
-Sagemaker Distributed Data Parallel 1.1.2 Release Notes
+SageMaker Distributed Data Parallel 1.1.2 Release Notes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 -  Bug Fixes
@@ -101,7 +101,7 @@ Sagemaker Distributed Data Parallel 1.1.2 Release Notes
 
 **Known Issues:**
 
--  Sagemaker Distributed data parallel has slower throughput than NCCL
+-  SageMaker Distributed data parallel has slower throughput than NCCL
    when run using a single node. For the best performance, use
    multi-node distributed training with smdistributed.dataparallel. Use
    a single node only for experimental runs while preparing your
@@ -109,7 +109,7 @@ Sagemaker Distributed Data Parallel 1.1.2 Release Notes
 
 ----
 
-Sagemaker Distributed Data Parallel 1.1.1 Release Notes
+SageMaker Distributed Data Parallel 1.1.1 Release Notes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 -  New Features
@@ -136,7 +136,7 @@ Sagemaker Distributed Data Parallel 1.1.1 Release Notes
 
 ----
 
-Sagemaker Distributed Data Parallel 1.1.0 Release Notes
+SageMaker Distributed Data Parallel 1.1.0 Release Notes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 -  New Features
@@ -172,7 +172,7 @@ SDK Guide
 
 ----
 
-Sagemaker Distributed Data Parallel 1.0.0 Release Notes
+SageMaker Distributed Data Parallel 1.0.0 Release Notes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 -  First Release


### PR DESCRIPTION
*Description of changes:*

- Add SageMaker distributed data parallal v1.2.2 release note.
- Add `no_sync()` to the `DistributedDataParallel` class.
- Minor typo and style fixes.

*Testing done:*

![Screenshot 2022-01-12 at 16-43-25 PyTorch Guide to SageMaker’s distributed data parallel library — sagemaker 2 71 1 dev0 do](https://user-images.githubusercontent.com/21208346/149245941-9f557e77-2569-422d-9f3b-0f68cffb79ea.png)

![Screenshot 2022-01-12 at 16-43-50 Sagemaker Distributed Data Parallel 1 2 2 Release Notes — sagemaker 2 71 1 dev0 documenta](https://user-images.githubusercontent.com/21208346/149245954-4dc0fec3-ecf6-43c0-a51a-2ab5e4e81756.png)


## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
