### PR TITLE
feature: Add support for SageMaker lineage queries in action

### DIFF
--- a/src/sagemaker/lineage/action.py
+++ b/src/sagemaker/lineage/action.py
@@ -13,13 +13,23 @@
 """This module contains code to create and manage SageMaker ``Actions``."""
 from __future__ import absolute_import
 
-from typing import Optional, Iterator
+from typing import Optional, Iterator, List
 from datetime import datetime
 
 from sagemaker import Session
 from sagemaker.apiutils import _base_types
 from sagemaker.lineage import _api_types, _utils
 from sagemaker.lineage._api_types import ActionSource, ActionSummary
+from sagemaker.lineage.artifact import Artifact
+from sagemaker.lineage.context import Context
+
+from sagemaker.lineage.query import (
+    LineageQuery,
+    LineageFilter,
+    LineageSourceEnum,
+    LineageEntityEnum,
+    LineageQueryDirectionEnum,
+)
 
 
 class Action(_base_types.Record):
@@ -250,3 +260,86 @@ class Action(_base_types.Record):
             max_results=max_results,
             next_token=next_token,
         )
+
+    def artifacts(
+        self, direction: LineageQueryDirectionEnum = LineageQueryDirectionEnum.BOTH
+    ) -> List[Artifact]:
+        """Use a lineage query to retrieve all artifacts that use this action.
+
+        Args:
+            direction (LineageQueryDirectionEnum, optional): The query direction.
+
+        Returns:
+            list of Artifacts: Artifacts.
+        """
+        query_filter = LineageFilter(entities=[LineageEntityEnum.ARTIFACT])
+        query_result = LineageQuery(self.sagemaker_session).query(
+            start_arns=[self.action_arn],
+            query_filter=query_filter,
+            direction=direction,
+            include_edges=False,
+        )
+        return [vertex.to_lineage_object() for vertex in query_result.vertices]
+
+
+class ModelPackageApprovalAction(Action):
+    """An Amazon SageMaker model package approval action, which is part of a SageMaker lineage."""
+
+    def datasets(
+        self, direction: LineageQueryDirectionEnum = LineageQueryDirectionEnum.ASCENDANTS
+    ) -> List[Artifact]:
+        """Use a lineage query to retrieve all upstream datasets that use this action.
+
+        Args:
+            direction (LineageQueryDirectionEnum, optional): The query direction.
+
+        Returns:
+            list of Artifacts: Artifacts representing a dataset.
+        """
+        query_filter = LineageFilter(
+            entities=[LineageEntityEnum.ARTIFACT], sources=[LineageSourceEnum.DATASET]
+        )
+        query_result = LineageQuery(self.sagemaker_session).query(
+            start_arns=[self.action_arn],
+            query_filter=query_filter,
+            direction=direction,
+            include_edges=False,
+        )
+        return [vertex.to_lineage_object() for vertex in query_result.vertices]
+
+    def model_package(self):
+        """Get model package from model package approval action.
+
+        Returns:
+            Model package.
+        """
+        source_uri = self.source.source_uri
+        if source_uri is None:
+            return None
+
+        model_package_name = source_uri.split("/")[1]
+        return self.sagemaker_session.sagemaker_client.describe_model_package(
+            ModelPackageName=model_package_name
+        )
+
+    def endpoints(
+        self, direction: LineageQueryDirectionEnum = LineageQueryDirectionEnum.DESCENDANTS
+    ) -> List[Context]:
+        """Use a lineage query to retrieve downstream endpoint contexts that use this action.
+
+        Args:
+            direction (LineageQueryDirectionEnum, optional): The query direction.
+
+        Returns:
+            list of Contexts: Contexts representing an endpoint.
+        """
+        query_filter = LineageFilter(
+            entities=[LineageEntityEnum.CONTEXT], sources=[LineageSourceEnum.ENDPOINT]
+        )
+        query_result = LineageQuery(self.sagemaker_session).query(
+            start_arns=[self.action_arn],
+            query_filter=query_filter,
+            direction=direction,
+            include_edges=False,
+        )
+        return [vertex.to_lineage_object() for vertex in query_result.vertices]

--- a/src/sagemaker/lineage/query.py
+++ b/src/sagemaker/lineage/query.py
@@ -43,6 +43,7 @@ class LineageSourceEnum(Enum):
     MODEL_REPLACE = "ModelReplaced"
     TENSORBOARD = "TensorBoard"
     TRAINING_JOB = "TrainingJob"
+    APPROVAL = "Approval"
 
 
 class LineageQueryDirectionEnum(Enum):
@@ -203,11 +204,11 @@ class LineageFilter(object):
     def _to_request_dict(self):
         """Convert the lineage filter to its API representation."""
         filter_request = {}
-        if self.entities:
+        if self.sources:
             filter_request["Types"] = list(
                 map(lambda x: x.value if isinstance(x, LineageSourceEnum) else x, self.sources)
             )
-        if self.sources:
+        if self.entities:
             filter_request["LineageTypes"] = list(
                 map(lambda x: x.value if isinstance(x, LineageEntityEnum) else x, self.entities)
             )

--- a/tests/integ/sagemaker/lineage/test_action.py
+++ b/tests/integ/sagemaker/lineage/test_action.py
@@ -20,6 +20,7 @@ import time
 import pytest
 
 from sagemaker.lineage import action
+from sagemaker.lineage.query import LineageQueryDirectionEnum
 
 
 def test_create_delete(action_obj):
@@ -117,3 +118,50 @@ def test_tags(action_obj, sagemaker_session):
     # length of actual tags will be greater than 1
     assert len(actual_tags) > 0
     assert [actual_tags[-1]] == tags
+
+
+def test_upstream_artifacts(static_model_deployment_action):
+    artifacts_from_query = static_model_deployment_action.artifacts(
+        direction=LineageQueryDirectionEnum.ASCENDANTS
+    )
+    assert len(artifacts_from_query) > 0
+    for artifact in artifacts_from_query:
+        assert "artifact" in artifact.artifact_arn
+
+
+def test_downstream_artifacts(static_approval_action):
+    artifacts_from_query = static_approval_action.artifacts(
+        direction=LineageQueryDirectionEnum.DESCENDANTS
+    )
+    assert len(artifacts_from_query) > 0
+    for artifact in artifacts_from_query:
+        assert "artifact" in artifact.artifact_arn
+
+
+def test_datasets(static_approval_action, static_dataset_artifact, sagemaker_session):
+
+    sagemaker_session.sagemaker_client.add_association(
+        SourceArn=static_dataset_artifact.artifact_arn,
+        DestinationArn=static_approval_action.action_arn,
+        AssociationType="ContributedTo",
+    )
+    time.sleep(3)
+    artifacts_from_query = static_approval_action.datasets()
+
+    assert len(artifacts_from_query) > 0
+    for artifact in artifacts_from_query:
+        assert "artifact" in artifact.artifact_arn
+        assert artifact.artifact_type == "DataSet"
+
+    sagemaker_session.sagemaker_client.delete_association(
+        SourceArn=static_dataset_artifact.artifact_arn,
+        DestinationArn=static_approval_action.action_arn,
+    )
+
+
+def test_endpoints(static_approval_action):
+    endpoint_contexts_from_query = static_approval_action.endpoints()
+    assert len(endpoint_contexts_from_query) > 0
+    for endpoint in endpoint_contexts_from_query:
+        assert endpoint.context_type == "Endpoint"
+        assert "endpoint" in endpoint.context_arn

--- a/tests/unit/sagemaker/lineage/test_action.py
+++ b/tests/unit/sagemaker/lineage/test_action.py
@@ -16,6 +16,7 @@ import datetime
 import unittest.mock
 
 from sagemaker.lineage import action, _api_types
+from sagemaker.lineage._api_types import ActionSource
 
 
 def test_create(sagemaker_session):
@@ -332,4 +333,24 @@ def test_create_delete_with_association(sagemaker_session):
     assert (
         delete_with_association_expected_calls
         == sagemaker_session.sagemaker_client.delete_association.mock_calls
+    )
+
+
+def test_model_package(sagemaker_session):
+    obj = action.ModelPackageApprovalAction(
+        sagemaker_session,
+        action_name="abcd-aws-model-package",
+        source=ActionSource(
+            source_uri="arn:aws:sagemaker:us-west-2:123456789012:model-package/pipeline88modelpackage/1",
+            source_type="ARN",
+        ),
+        status="updated-status",
+        properties={"k1": "v1"},
+        properties_to_remove=["k2"],
+    )
+    sagemaker_session.sagemaker_client.describe_model_package.return_value = {}
+    obj.model_package()
+
+    sagemaker_session.sagemaker_client.describe_model_package.assert_called_with(
+        ModelPackageName="pipeline88modelpackage",
     )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
feature: Add support for SageMaker lineage queries in action.
- Get downstream Artifacts in aciton
- Get upstream Artifacts in action
- Get dataset in ModelPackageApprovalAction
- Get ModelPackage in ModelPackageApprovalAction
- Get Endpoint in ModelPackageApprovalAction


*Testing done:*
- unit test
- integration test

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.