### PR TITLE
feature: jumpstart vulnerability and deprecated check

### DIFF
--- a/src/sagemaker/environment_variables.py
+++ b/src/sagemaker/environment_variables.py
@@ -46,8 +46,4 @@ def retrieve_default(
     if not jumpstart_utils.is_jumpstart_model_input(model_id, model_version):
         raise ValueError("Must specify `model_id` and `model_version` when retrieving script URIs.")
 
-    # mypy type checking require these assertions
-    assert model_id is not None
-    assert model_version is not None
-
     return artifacts._retrieve_default_environment_variables(model_id, model_version, region)

--- a/src/sagemaker/image_uris.py
+++ b/src/sagemaker/image_uris.py
@@ -45,6 +45,8 @@ def retrieve(
     training_compiler_config=None,
     model_id=None,
     model_version=None,
+    tolerate_vulnerable_model=None,
+    tolerate_deprecated_model=None,
 ) -> str:
     """Retrieves the ECR URI for the Docker image matching the given arguments.
 
@@ -79,6 +81,10 @@ def retrieve(
             (default: None).
         model_version (str): Version of the JumpStart model for which to retrieve the
             image URI (default: None).
+        tolerate_vulnerable_model (bool): True if vulnerable models should be tolerated (exception
+            not thrown). False if these models should throw an exception. (Default: None).
+        tolerate_deprecated_model (bool): True if deprecated models should be tolerated (exception
+            not thrown). False if these models should throw an exception. (Default: None).
 
     Returns:
         str: the ECR URI for the corresponding SageMaker Docker image.
@@ -106,6 +112,8 @@ def retrieve(
             distribution,
             base_framework_version,
             training_compiler_config,
+            tolerate_vulnerable_model,
+            tolerate_deprecated_model,
         )
 
     if training_compiler_config is None:

--- a/src/sagemaker/image_uris.py
+++ b/src/sagemaker/image_uris.py
@@ -93,7 +93,11 @@ def retrieve(
         str: the ECR URI for the corresponding SageMaker Docker image.
 
     Raises:
+        NotImplementedError: If the scope is not supported.
         ValueError: If the combination of arguments specified is not supported.
+        VulnerableJumpStartModelError: If any of the dependencies required by the script have
+            known security vulnerabilities.
+        DeprecatedJumpStartModelError: If the version of the model is deprecated.
     """
     if is_jumpstart_model_input(model_id, model_version):
 

--- a/src/sagemaker/image_uris.py
+++ b/src/sagemaker/image_uris.py
@@ -81,10 +81,13 @@ def retrieve(
             (default: None).
         model_version (str): Version of the JumpStart model for which to retrieve the
             image URI (default: None).
-        tolerate_vulnerable_model (bool): True if vulnerable models should be tolerated (exception
-            not raised). False if these models should raise an exception. (Default: None).
-        tolerate_deprecated_model (bool): True if deprecated models should be tolerated (exception
-            not raised). False if these models should raise an exception. (Default: None).
+        tolerate_vulnerable_model (bool): True if vulnerable versions of model specifications
+            should be tolerated (exception not raised). False or None, raises an exception if
+            the script used by this version of the model has dependencies with known security
+            vulnerabilities. (Default: None).
+        tolerate_deprecated_model (bool): True if deprecated versions of model specifications
+            should be tolerated (exception not raised). False or None, raises an exception
+            if the version of the model is deprecated. (Default: None).
 
     Returns:
         str: the ECR URI for the corresponding SageMaker Docker image.

--- a/src/sagemaker/image_uris.py
+++ b/src/sagemaker/image_uris.py
@@ -82,9 +82,9 @@ def retrieve(
         model_version (str): Version of the JumpStart model for which to retrieve the
             image URI (default: None).
         tolerate_vulnerable_model (bool): True if vulnerable models should be tolerated (exception
-            not thrown). False if these models should throw an exception. (Default: None).
+            not raised). False if these models should raise an exception. (Default: None).
         tolerate_deprecated_model (bool): True if deprecated models should be tolerated (exception
-            not thrown). False if these models should throw an exception. (Default: None).
+            not raised). False if these models should raise an exception. (Default: None).
 
     Returns:
         str: the ECR URI for the corresponding SageMaker Docker image.

--- a/src/sagemaker/image_uris.py
+++ b/src/sagemaker/image_uris.py
@@ -45,8 +45,8 @@ def retrieve(
     training_compiler_config=None,
     model_id=None,
     model_version=None,
-    tolerate_vulnerable_model=None,
-    tolerate_deprecated_model=None,
+    tolerate_vulnerable_model=False,
+    tolerate_deprecated_model=False,
 ) -> str:
     """Retrieves the ECR URI for the Docker image matching the given arguments.
 
@@ -82,12 +82,12 @@ def retrieve(
         model_version (str): Version of the JumpStart model for which to retrieve the
             image URI (default: None).
         tolerate_vulnerable_model (bool): True if vulnerable versions of model specifications
-            should be tolerated (exception not raised). False or None, raises an exception if
+            should be tolerated (exception not raised). If False, raises an exception if
             the script used by this version of the model has dependencies with known security
-            vulnerabilities. (Default: None).
+            vulnerabilities. (Default: False).
         tolerate_deprecated_model (bool): True if deprecated versions of model specifications
-            should be tolerated (exception not raised). False or None, raises an exception
-            if the version of the model is deprecated. (Default: None).
+            should be tolerated (exception not raised). If False, raises an exception
+            if the version of the model is deprecated. (Default: False).
 
     Returns:
         str: the ECR URI for the corresponding SageMaker Docker image.
@@ -100,10 +100,6 @@ def retrieve(
         DeprecatedJumpStartModelError: If the version of the model is deprecated.
     """
     if is_jumpstart_model_input(model_id, model_version):
-
-        # adding assert statements to satisfy mypy type checker
-        assert model_id is not None
-        assert model_version is not None
 
         return artifacts._retrieve_image_uri(
             model_id,

--- a/src/sagemaker/jumpstart/accessors.py
+++ b/src/sagemaker/jumpstart/accessors.py
@@ -56,7 +56,6 @@ class JumpStartModelsAccessor(object):
             region (str): The region to validate along with the kwargs.
         """
         cache_kwargs_dict = {} if cache_kwargs is None else cache_kwargs
-        assert isinstance(cache_kwargs_dict, dict)
         if region is not None and "region" in cache_kwargs_dict:
             if region != cache_kwargs_dict["region"]:
                 raise ValueError(
@@ -92,8 +91,7 @@ class JumpStartModelsAccessor(object):
             JumpStartModelsAccessor._cache_kwargs, region
         )
         JumpStartModelsAccessor._set_cache_and_region(region, cache_kwargs)
-        assert JumpStartModelsAccessor._cache is not None
-        return JumpStartModelsAccessor._cache.get_header(
+        return JumpStartModelsAccessor._cache.get_header(  # type: ignore
             model_id=model_id, semantic_version_str=version
         )
 
@@ -110,8 +108,7 @@ class JumpStartModelsAccessor(object):
             JumpStartModelsAccessor._cache_kwargs, region
         )
         JumpStartModelsAccessor._set_cache_and_region(region, cache_kwargs)
-        assert JumpStartModelsAccessor._cache is not None
-        return JumpStartModelsAccessor._cache.get_specs(
+        return JumpStartModelsAccessor._cache.get_specs(  # type: ignore
             model_id=model_id, semantic_version_str=version
         )
 

--- a/src/sagemaker/jumpstart/artifacts.py
+++ b/src/sagemaker/jumpstart/artifacts.py
@@ -41,8 +41,8 @@ def _retrieve_image_uri(
     distribution: Optional[str],
     base_framework_version: Optional[str],
     training_compiler_config: Optional[str],
-    tolerate_vulnerable_model: Optional[bool],
-    tolerate_deprecated_model: Optional[bool],
+    tolerate_vulnerable_model: bool,
+    tolerate_deprecated_model: bool,
 ):
     """Retrieves the container image URI for JumpStart models.
 
@@ -75,12 +75,12 @@ def _retrieve_image_uri(
         distribution (dict): A dictionary with information on how to run distributed training
         training_compiler_config (:class:`~sagemaker.training_compiler.TrainingCompilerConfig`):
             A configuration class for the SageMaker Training Compiler.
-        tolerate_vulnerable_model (Optional[bool]): True if vulnerable versions of model
-            specifications should be tolerated (exception not raised). False or None, raises an
+        tolerate_vulnerable_model (bool): True if vulnerable versions of model
+            specifications should be tolerated (exception not raised). If False, raises an
             exception if the script used by this version of the model has dependencies with known
             security vulnerabilities.
-        tolerate_deprecated_model (Optional[bool]): True if deprecated versions of model
-            specifications should be tolerated (exception not raised). False or None, raises
+        tolerate_deprecated_model (bool): True if deprecated versions of model
+            specifications should be tolerated (exception not raised). If False, raises
             an exception if the version of the model is deprecated.
 
     Returns:
@@ -95,8 +95,6 @@ def _retrieve_image_uri(
     if region is None:
         region = JUMPSTART_DEFAULT_REGION_NAME
 
-    assert region is not None
-
     model_specs = verify_model_region_and_return_specs(
         model_id=model_id,
         version=model_version,
@@ -109,7 +107,6 @@ def _retrieve_image_uri(
     if image_scope == JumpStartScriptScope.INFERENCE:
         ecr_specs = model_specs.hosting_ecr_specs
     elif image_scope == JumpStartScriptScope.TRAINING:
-        assert model_specs.training_ecr_specs is not None
         ecr_specs = model_specs.training_ecr_specs
 
     if framework is not None and framework != ecr_specs.framework:
@@ -172,8 +169,8 @@ def _retrieve_model_uri(
     model_version: str,
     model_scope: Optional[str],
     region: Optional[str],
-    tolerate_vulnerable_model: Optional[bool],
-    tolerate_deprecated_model: Optional[bool],
+    tolerate_vulnerable_model: bool,
+    tolerate_deprecated_model: bool,
 ):
     """Retrieves the model artifact S3 URI for the model matching the given arguments.
 
@@ -185,12 +182,12 @@ def _retrieve_model_uri(
         model_scope (str): The model type, i.e. what it is used for.
             Valid values: "training" and "inference".
         region (str): Region for which to retrieve model S3 URI.
-        tolerate_vulnerable_model (Optional[bool]): True if vulnerable versions of model
-            specifications should be tolerated (exception not raised). False or None, raises an
+        tolerate_vulnerable_model (bool): True if vulnerable versions of model
+            specifications should be tolerated (exception not raised). If False, raises an
             exception if the script used by this version of the model has dependencies with known
             security vulnerabilities.
-        tolerate_deprecated_model (Optional[bool]): True if deprecated versions of model
-            specifications should be tolerated (exception not raised). False or None, raises
+        tolerate_deprecated_model (bool): True if deprecated versions of model
+            specifications should be tolerated (exception not raised). If False, raises
             an exception if the version of the model is deprecated.
     Returns:
         str: the model artifact S3 URI for the corresponding model.
@@ -204,8 +201,6 @@ def _retrieve_model_uri(
     if region is None:
         region = JUMPSTART_DEFAULT_REGION_NAME
 
-    assert region is not None
-
     model_specs = verify_model_region_and_return_specs(
         model_id=model_id,
         version=model_version,
@@ -218,7 +213,6 @@ def _retrieve_model_uri(
     if model_scope == JumpStartScriptScope.INFERENCE:
         model_artifact_key = model_specs.hosting_artifact_key
     elif model_scope == JumpStartScriptScope.TRAINING:
-        assert model_specs.training_artifact_key is not None
         model_artifact_key = model_specs.training_artifact_key
 
     bucket = get_jumpstart_content_bucket(region)
@@ -233,8 +227,8 @@ def _retrieve_script_uri(
     model_version: str,
     script_scope: Optional[str],
     region: Optional[str],
-    tolerate_vulnerable_model: Optional[bool],
-    tolerate_deprecated_model: Optional[bool],
+    tolerate_vulnerable_model: bool,
+    tolerate_deprecated_model: bool,
 ):
     """Retrieves the script S3 URI associated with the model matching the given arguments.
 
@@ -246,12 +240,12 @@ def _retrieve_script_uri(
         script_scope (str): The script type, i.e. what it is used for.
             Valid values: "training" and "inference".
         region (str): Region for which to retrieve model script S3 URI.
-        tolerate_vulnerable_model (Optional[bool]): True if vulnerable versions of model
-            specifications should be tolerated (exception not raised). False or None, raises an
+        tolerate_vulnerable_model (bool): True if vulnerable versions of model
+            specifications should be tolerated (exception not raised). If False, raises an
             exception if the script used by this version of the model has dependencies with known
             security vulnerabilities.
-        tolerate_deprecated_model (Optional[bool]): True if deprecated versions of model
-            specifications should be tolerated (exception not raised). False or None, raises
+        tolerate_deprecated_model (bool): True if deprecated versions of model
+            specifications should be tolerated (exception not raised). If False, raises
             an exception if the version of the model is deprecated.
     Returns:
         str: the model script URI for the corresponding model.
@@ -265,8 +259,6 @@ def _retrieve_script_uri(
     if region is None:
         region = JUMPSTART_DEFAULT_REGION_NAME
 
-    assert region is not None
-
     model_specs = verify_model_region_and_return_specs(
         model_id=model_id,
         version=model_version,
@@ -279,7 +271,6 @@ def _retrieve_script_uri(
     if script_scope == JumpStartScriptScope.INFERENCE:
         model_script_key = model_specs.hosting_script_key
     elif script_scope == JumpStartScriptScope.TRAINING:
-        assert model_specs.training_script_key is not None
         model_script_key = model_specs.training_script_key
 
     bucket = get_jumpstart_content_bucket(region)
@@ -316,8 +307,6 @@ def _retrieve_default_hyperparameters(
 
     if region is None:
         region = JUMPSTART_DEFAULT_REGION_NAME
-
-    assert region is not None
 
     model_specs = jumpstart_accessors.JumpStartModelsAccessor.get_model_specs(
         region=region, model_id=model_id, version=model_version

--- a/src/sagemaker/jumpstart/artifacts.py
+++ b/src/sagemaker/jumpstart/artifacts.py
@@ -16,8 +16,7 @@ from typing import Dict, Optional
 from sagemaker import image_uris
 from sagemaker.jumpstart.constants import (
     JUMPSTART_DEFAULT_REGION_NAME,
-    INFERENCE,
-    TRAINING,
+    JumpStartScriptScope,
     ModelFramework,
     VariableScope,
 )
@@ -77,9 +76,9 @@ def _retrieve_image_uri(
         training_compiler_config (:class:`~sagemaker.training_compiler.TrainingCompilerConfig`):
             A configuration class for the SageMaker Training Compiler.
         tolerate_vulnerable_model (bool): True if vulnerable models should be tolerated (exception
-            not thrown). False if these models should throw an exception.
+            not raised). False if these models should raise an exception.
         tolerate_deprecated_model (bool): True if deprecated models should be tolerated (exception
-            not thrown). False if these models should throw an exception.
+            not raised). False if these models should raise an exception.
 
     Returns:
         str: the ECR URI for the corresponding SageMaker Docker image.
@@ -103,9 +102,9 @@ def _retrieve_image_uri(
         tolerate_deprecated_model=tolerate_deprecated_model,
     )
 
-    if image_scope == INFERENCE:
+    if image_scope == JumpStartScriptScope.INFERENCE.value:
         ecr_specs = model_specs.hosting_ecr_specs
-    elif image_scope == TRAINING:
+    elif image_scope == JumpStartScriptScope.TRAINING.value:
         assert model_specs.training_ecr_specs is not None
         ecr_specs = model_specs.training_ecr_specs
 
@@ -133,7 +132,7 @@ def _retrieve_image_uri(
         base_framework_version_override = ecr_specs.framework_version
         version_override = ecr_specs.huggingface_transformers_version
 
-    if image_scope == TRAINING:
+    if image_scope == JumpStartScriptScope.TRAINING.value:
         return image_uris.get_training_image_uri(
             region=region,
             framework=ecr_specs.framework,
@@ -183,9 +182,9 @@ def _retrieve_model_uri(
             Valid values: "training" and "inference".
         region (str): Region for which to retrieve model S3 URI.
         tolerate_vulnerable_model (bool): True if vulnerable models should be tolerated (exception
-            not thrown). False if these models should throw an exception.
+            not raised). False if these models should raise an exception.
         tolerate_deprecated_model (bool): True if deprecated models should be tolerated (exception
-            not thrown). False if these models should throw an exception.
+            not raised). False if these models should raise an exception.
     Returns:
         str: the model artifact S3 URI for the corresponding model.
 
@@ -208,9 +207,9 @@ def _retrieve_model_uri(
         tolerate_deprecated_model=tolerate_deprecated_model,
     )
 
-    if model_scope == INFERENCE:
+    if model_scope == JumpStartScriptScope.INFERENCE.value:
         model_artifact_key = model_specs.hosting_artifact_key
-    elif model_scope == TRAINING:
+    elif model_scope == JumpStartScriptScope.TRAINING.value:
         assert model_specs.training_artifact_key is not None
         model_artifact_key = model_specs.training_artifact_key
 
@@ -240,9 +239,9 @@ def _retrieve_script_uri(
             Valid values: "training" and "inference".
         region (str): Region for which to retrieve model script S3 URI.
         tolerate_vulnerable_model (bool): True if vulnerable models should be tolerated (exception
-            not thrown). False if these models should throw an exception.
+            not raised). False if these models should raise an exception.
         tolerate_deprecated_model (bool): True if deprecated models should be tolerated (exception
-            not thrown). False if these models should throw an exception.
+            not raised). False if these models should raise an exception.
     Returns:
         str: the model script URI for the corresponding model.
 
@@ -265,9 +264,9 @@ def _retrieve_script_uri(
         tolerate_deprecated_model=tolerate_deprecated_model,
     )
 
-    if script_scope == INFERENCE:
+    if script_scope == JumpStartScriptScope.INFERENCE.value:
         model_script_key = model_specs.hosting_script_key
-    elif script_scope == TRAINING:
+    elif script_scope == JumpStartScriptScope.TRAINING.value:
         assert model_specs.training_script_key is not None
         model_script_key = model_specs.training_script_key
 

--- a/src/sagemaker/jumpstart/artifacts.py
+++ b/src/sagemaker/jumpstart/artifacts.py
@@ -75,18 +75,22 @@ def _retrieve_image_uri(
         distribution (dict): A dictionary with information on how to run distributed training
         training_compiler_config (:class:`~sagemaker.training_compiler.TrainingCompilerConfig`):
             A configuration class for the SageMaker Training Compiler.
-        tolerate_vulnerable_model (bool): True if vulnerable models should be tolerated (exception
-            not raised). False if these models should raise an exception.
-        tolerate_deprecated_model (bool): True if deprecated models should be tolerated (exception
-            not raised). False if these models should raise an exception.
+        tolerate_vulnerable_model (Optional[bool]): True if vulnerable versions of model
+            specifications should be tolerated (exception not raised). False or None, raises an
+            exception if the script used by this version of the model has dependencies with known
+            security vulnerabilities.
+        tolerate_deprecated_model (Optional[bool]): True if deprecated versions of model
+            specifications should be tolerated (exception not raised). False or None, raises
+            an exception if the version of the model is deprecated.
 
     Returns:
         str: the ECR URI for the corresponding SageMaker Docker image.
 
     Raises:
         ValueError: If the combination of arguments specified is not supported.
-        VulnerableJumpStartModelError: If the model is vulnerable.
-        DeprecatedJumpStartModelError: If the model is deprecated.
+        VulnerableJumpStartModelError: If any of the dependencies required by the script have
+            known security vulnerabilities.
+        DeprecatedJumpStartModelError: If the version of the model is deprecated.
     """
     if region is None:
         region = JUMPSTART_DEFAULT_REGION_NAME
@@ -102,9 +106,9 @@ def _retrieve_image_uri(
         tolerate_deprecated_model=tolerate_deprecated_model,
     )
 
-    if image_scope == JumpStartScriptScope.INFERENCE.value:
+    if image_scope == JumpStartScriptScope.INFERENCE:
         ecr_specs = model_specs.hosting_ecr_specs
-    elif image_scope == JumpStartScriptScope.TRAINING.value:
+    elif image_scope == JumpStartScriptScope.TRAINING:
         assert model_specs.training_ecr_specs is not None
         ecr_specs = model_specs.training_ecr_specs
 
@@ -128,11 +132,11 @@ def _retrieve_image_uri(
 
     base_framework_version_override: Optional[str] = None
     version_override: Optional[str] = None
-    if ecr_specs.framework == ModelFramework.HUGGINGFACE.value:
+    if ecr_specs.framework == ModelFramework.HUGGINGFACE:
         base_framework_version_override = ecr_specs.framework_version
         version_override = ecr_specs.huggingface_transformers_version
 
-    if image_scope == JumpStartScriptScope.TRAINING.value:
+    if image_scope == JumpStartScriptScope.TRAINING:
         return image_uris.get_training_image_uri(
             region=region,
             framework=ecr_specs.framework,
@@ -181,17 +185,21 @@ def _retrieve_model_uri(
         model_scope (str): The model type, i.e. what it is used for.
             Valid values: "training" and "inference".
         region (str): Region for which to retrieve model S3 URI.
-        tolerate_vulnerable_model (bool): True if vulnerable models should be tolerated (exception
-            not raised). False if these models should raise an exception.
-        tolerate_deprecated_model (bool): True if deprecated models should be tolerated (exception
-            not raised). False if these models should raise an exception.
+        tolerate_vulnerable_model (Optional[bool]): True if vulnerable versions of model
+            specifications should be tolerated (exception not raised). False or None, raises an
+            exception if the script used by this version of the model has dependencies with known
+            security vulnerabilities.
+        tolerate_deprecated_model (Optional[bool]): True if deprecated versions of model
+            specifications should be tolerated (exception not raised). False or None, raises
+            an exception if the version of the model is deprecated.
     Returns:
         str: the model artifact S3 URI for the corresponding model.
 
     Raises:
         ValueError: If the combination of arguments specified is not supported.
-        VulnerableJumpStartModelError: If the model is vulnerable.
-        DeprecatedJumpStartModelError: If the model is deprecated.
+        VulnerableJumpStartModelError: If any of the dependencies required by the script have
+            known security vulnerabilities.
+        DeprecatedJumpStartModelError: If the version of the model is deprecated.
     """
     if region is None:
         region = JUMPSTART_DEFAULT_REGION_NAME
@@ -207,9 +215,9 @@ def _retrieve_model_uri(
         tolerate_deprecated_model=tolerate_deprecated_model,
     )
 
-    if model_scope == JumpStartScriptScope.INFERENCE.value:
+    if model_scope == JumpStartScriptScope.INFERENCE:
         model_artifact_key = model_specs.hosting_artifact_key
-    elif model_scope == JumpStartScriptScope.TRAINING.value:
+    elif model_scope == JumpStartScriptScope.TRAINING:
         assert model_specs.training_artifact_key is not None
         model_artifact_key = model_specs.training_artifact_key
 
@@ -238,17 +246,21 @@ def _retrieve_script_uri(
         script_scope (str): The script type, i.e. what it is used for.
             Valid values: "training" and "inference".
         region (str): Region for which to retrieve model script S3 URI.
-        tolerate_vulnerable_model (bool): True if vulnerable models should be tolerated (exception
-            not raised). False if these models should raise an exception.
-        tolerate_deprecated_model (bool): True if deprecated models should be tolerated (exception
-            not raised). False if these models should raise an exception.
+        tolerate_vulnerable_model (Optional[bool]): True if vulnerable versions of model
+            specifications should be tolerated (exception not raised). False or None, raises an
+            exception if the script used by this version of the model has dependencies with known
+            security vulnerabilities.
+        tolerate_deprecated_model (Optional[bool]): True if deprecated versions of model
+            specifications should be tolerated (exception not raised). False or None, raises
+            an exception if the version of the model is deprecated.
     Returns:
         str: the model script URI for the corresponding model.
 
     Raises:
         ValueError: If the combination of arguments specified is not supported.
-        VulnerableJumpStartModelError: If the model is vulnerable.
-        DeprecatedJumpStartModelError: If the model is deprecated.
+        VulnerableJumpStartModelError: If any of the dependencies required by the script have
+            known security vulnerabilities.
+        DeprecatedJumpStartModelError: If the version of the model is deprecated.
     """
     if region is None:
         region = JUMPSTART_DEFAULT_REGION_NAME
@@ -264,9 +276,9 @@ def _retrieve_script_uri(
         tolerate_deprecated_model=tolerate_deprecated_model,
     )
 
-    if script_scope == JumpStartScriptScope.INFERENCE.value:
+    if script_scope == JumpStartScriptScope.INFERENCE:
         model_script_key = model_specs.hosting_script_key
-    elif script_scope == JumpStartScriptScope.TRAINING.value:
+    elif script_scope == JumpStartScriptScope.TRAINING:
         assert model_specs.training_script_key is not None
         model_script_key = model_specs.training_script_key
 

--- a/src/sagemaker/jumpstart/cache.py
+++ b/src/sagemaker/jumpstart/cache.py
@@ -166,13 +166,12 @@ class JumpStartModelsCache:
         manifest = self._s3_cache.get(
             JumpStartCachedS3ContentKey(JumpStartS3FileType.MANIFEST, self._manifest_file_s3_key)
         ).formatted_content
-        assert isinstance(manifest, dict)
 
         sm_version = utils.get_sagemaker_version()
 
         versions_compatible_with_sagemaker = [
             Version(header.version)
-            for header in manifest.values()
+            for header in manifest.values()  # type: ignore
             if header.model_id == model_id and Version(header.min_version) <= Version(sm_version)
         ]
 
@@ -184,7 +183,8 @@ class JumpStartModelsCache:
             return JumpStartVersionedModelId(model_id, sm_compatible_model_version)
 
         versions_incompatible_with_sagemaker = [
-            Version(header.version) for header in manifest.values() if header.model_id == model_id
+            Version(header.version) for header in manifest.values()  # type: ignore
+            if header.model_id == model_id
         ]
         sm_incompatible_model_version = self._select_version(
             version, versions_incompatible_with_sagemaker
@@ -194,7 +194,7 @@ class JumpStartModelsCache:
             model_version_to_use_incompatible_with_sagemaker = sm_incompatible_model_version
             sm_version_to_use_list = [
                 header.min_version
-                for header in manifest.values()
+                for header in manifest.values()  # type: ignore
                 if header.model_id == model_id
                 and header.version == model_version_to_use_incompatible_with_sagemaker
             ]
@@ -262,8 +262,7 @@ class JumpStartModelsCache:
         manifest_dict = self._s3_cache.get(
             JumpStartCachedS3ContentKey(JumpStartS3FileType.MANIFEST, self._manifest_file_s3_key)
         ).formatted_content
-        assert isinstance(manifest_dict, dict)
-        manifest = list(manifest_dict.values())
+        manifest = list(manifest_dict.values())  # type: ignore
         return manifest
 
     def get_header(self, model_id: str, semantic_version_str: str) -> JumpStartModelHeader:
@@ -324,9 +323,7 @@ class JumpStartModelsCache:
             JumpStartCachedS3ContentKey(JumpStartS3FileType.MANIFEST, self._manifest_file_s3_key)
         ).formatted_content
         try:
-            assert isinstance(manifest, dict)
-            header = manifest[versioned_model_id]
-            assert isinstance(header, JumpStartModelHeader)
+            header = manifest[versioned_model_id]  # type: ignore
             return header
         except KeyError:
             if attempt > 0:
@@ -348,8 +345,7 @@ class JumpStartModelsCache:
         specs = self._s3_cache.get(
             JumpStartCachedS3ContentKey(JumpStartS3FileType.SPECS, spec_key)
         ).formatted_content
-        assert isinstance(specs, JumpStartModelSpecs)
-        return specs
+        return specs  # type: ignore
 
     def clear(self) -> None:
         """Clears the model id/version and s3 cache."""

--- a/src/sagemaker/jumpstart/constants.py
+++ b/src/sagemaker/jumpstart/constants.py
@@ -116,12 +116,19 @@ JUMPSTART_DEFAULT_REGION_NAME = boto3.session.Session().region_name or "us-west-
 
 JUMPSTART_DEFAULT_MANIFEST_FILE_S3_KEY = "models_manifest.json"
 
-INFERENCE = "inference"
-TRAINING = "training"
-SUPPORTED_JUMPSTART_SCOPES = set([INFERENCE, TRAINING])
 
 INFERENCE_ENTRYPOINT_SCRIPT_NAME = "inference.py"
 TRAINING_ENTRYPOINT_SCRIPT_NAME = "transfer_learning.py"
+
+
+class JumpStartScriptScope(str, Enum):
+    """Enum class for JumpStart script scopes."""
+
+    INFERENCE = "inference"
+    TRAINING = "training"
+
+
+SUPPORTED_JUMPSTART_SCOPES = set(scope.value for scope in JumpStartScriptScope)
 
 
 class ModelFramework(str, Enum):

--- a/src/sagemaker/jumpstart/exceptions.py
+++ b/src/sagemaker/jumpstart/exceptions.py
@@ -12,46 +12,79 @@
 # language governing permissions and limitations under the License.
 """This module stores exceptions related to SageMaker JumpStart."""
 
+from __future__ import absolute_import
 from typing import List, Optional
+
+from sagemaker.jumpstart.constants import JumpStartScriptScope
 
 
 class VulnerableJumpStartModelError(Exception):
-    """Exception raised for errors with vulnerable JumpStart models."""
+    """Exception raised when trying to access a JumpStart model specs flagged as vulnerable.
+
+    Raise this exception only if the scope of attributes accessed in the specifications have
+    vulnerabilities. For example, a model training script may have vulnerabilities, but not
+    the hosting scripts. In such a case, raise a ``VulnerableJumpStartModelError`` only when
+    accessing the training specifications.
+    """
 
     def __init__(
         self,
         model_id: Optional[str] = None,
         version: Optional[str] = None,
         vulnerabilities: Optional[List[str]] = None,
-        inference: Optional[bool] = None,
+        scope: Optional[JumpStartScriptScope] = None,
         message: Optional[str] = None,
     ):
+        """Instantiates VulnerableJumpStartModelError exception.
+
+        Args:
+            model_id (Optional[str]): model id of vulnerable JumpStart model.
+                (Default: None).
+            version (Optional[str]): version of vulnerable JumpStart model.
+                (Default: None).
+            vulnerabilities (Optional[List[str]]): vulnerabilities associated with
+                model. (Default: None).
+
+        """
         if message:
             self.message = message
         else:
-            if None in [model_id, version, vulnerabilities, inference]:
+            if None in [model_id, version, vulnerabilities, scope]:
                 raise ValueError(
-                    "Must specify `model_id`, `version`, `vulnerabilities`, "
-                    "and inference arguments."
+                    "Must specify `model_id`, `version`, `vulnerabilities`, " "and scope arguments."
                 )
-            if inference is True:
+            if scope == JumpStartScriptScope.INFERENCE:
                 self.message = (
-                    f"JumpStart model '{model_id}' and version '{version}' has at least 1 "
-                    "vulnerable dependency in the inference scripts. "
-                    f"List of vulnerabilities: {', '.join(vulnerabilities)}"
+                    f"Version '{version}' of JumpStart model '{model_id}' "  # type: ignore
+                    "has at least 1 vulnerable dependency in the inference script. "
+                    "Please try targetting a higher version of the model. "
+                    f"List of vulnerabilities: {', '.join(vulnerabilities)}"  # type: ignore
+                )
+            elif scope == JumpStartScriptScope.TRAINING:
+                self.message = (
+                    f"Version '{version}' of JumpStart model '{model_id}' "  # type: ignore
+                    "has at least 1 vulnerable dependency in the training script. "
+                    "Please try targetting a higher version of the model. "
+                    f"List of vulnerabilities: {', '.join(vulnerabilities)}"  # type: ignore
                 )
             else:
-                self.message = (
-                    f"JumpStart model '{model_id}' and version '{version}' has at least 1 "
-                    "vulnerable dependency in the training scripts. "
-                    f"List of vulnerabilities: {', '.join(vulnerabilities)}"
+                raise NotImplementedError(
+                    "Unsupported scope for VulnerableJumpStartModelError: "  # type: ignore
+                    f"'{scope.value}'"
                 )
 
         super().__init__(self.message)
 
 
 class DeprecatedJumpStartModelError(Exception):
-    """Exception raised for errors with deprecated JumpStart models."""
+    """Exception raised when trying to access a JumpStart model deprecated specifications.
+
+    A deprecated specification for a JumpStart model does not mean the whole model is
+    deprecated. There may be more recent specifications available for this model. For
+    example, all specification before version ``2.0.0`` may be deprecated, in such a
+    case, the SDK would raise this exception only when specifications ``1.*`` are
+    accessed.
+    """
 
     def __init__(
         self,
@@ -64,6 +97,9 @@ class DeprecatedJumpStartModelError(Exception):
         else:
             if None in [model_id, version]:
                 raise ValueError("Must specify `model_id` and `version` arguments.")
-            self.message = f"JumpStart model '{model_id}' and version '{version}' is deprecated."
+            self.message = (
+                f"Version '{version}' of JumpStart model '{model_id}' is deprecated. "
+                "Please try targetting a higher version of the model."
+            )
 
         super().__init__(self.message)

--- a/src/sagemaker/jumpstart/exceptions.py
+++ b/src/sagemaker/jumpstart/exceptions.py
@@ -1,0 +1,69 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+"""This module stores exceptions related to SageMaker JumpStart."""
+
+from typing import List, Optional
+
+
+class VulnerableJumpStartModelError(Exception):
+    """Exception raised for errors with vulnerable JumpStart models."""
+
+    def __init__(
+        self,
+        model_id: Optional[str] = None,
+        version: Optional[str] = None,
+        vulnerabilities: Optional[List[str]] = None,
+        inference: Optional[bool] = None,
+        message: Optional[str] = None,
+    ):
+        if message:
+            self.message = message
+        else:
+            if None in [model_id, version, vulnerabilities, inference]:
+                raise ValueError(
+                    "Must specify `model_id`, `version`, `vulnerabilities`, "
+                    "and inference arguments."
+                )
+            if inference is True:
+                self.message = (
+                    f"JumpStart model '{model_id}' and version '{version}' has at least 1 "
+                    "vulnerable dependency in the inference scripts. "
+                    f"List of vulnerabilities: {', '.join(vulnerabilities)}"
+                )
+            else:
+                self.message = (
+                    f"JumpStart model '{model_id}' and version '{version}' has at least 1 "
+                    "vulnerable dependency in the training scripts. "
+                    f"List of vulnerabilities: {', '.join(vulnerabilities)}"
+                )
+
+        super().__init__(self.message)
+
+
+class DeprecatedJumpStartModelError(Exception):
+    """Exception raised for errors with deprecated JumpStart models."""
+
+    def __init__(
+        self,
+        model_id: Optional[str] = None,
+        version: Optional[str] = None,
+        message: Optional[str] = None,
+    ):
+        if message:
+            self.message = message
+        else:
+            if None in [model_id, version]:
+                raise ValueError("Must specify `model_id` and `version` arguments.")
+            self.message = f"JumpStart model '{model_id}' and version '{version}' is deprecated."
+
+        super().__init__(self.message)

--- a/src/sagemaker/jumpstart/types.py
+++ b/src/sagemaker/jumpstart/types.py
@@ -274,6 +274,13 @@ class JumpStartModelSpecs(JumpStartDataHolderType):
         "training_script_key",
         "hyperparameters",
         "inference_environment_variables",
+        "inference_vulnerable",
+        "inference_dependencies",
+        "inference_vulnerabilities",
+        "training_vulnerable",
+        "training_dependencies",
+        "training_vulnerabilities",
+        "deprecated",
     ]
 
     def __init__(self, spec: Dict[str, Any]):
@@ -302,6 +309,14 @@ class JumpStartModelSpecs(JumpStartDataHolderType):
             JumpStartEnvironmentVariable(env_variable)
             for env_variable in json_obj["inference_environment_variables"]
         ]
+        self.inference_vulnerable: bool = bool(json_obj["inference_vulnerable"])
+        self.inference_dependencies: List[str] = json_obj["inference_dependencies"]
+        self.inference_vulnerabilities: List[str] = json_obj["inference_vulnerabilities"]
+        self.training_vulnerable: bool = bool(json_obj["training_vulnerable"])
+        self.training_dependencies: List[str] = json_obj["training_dependencies"]
+        self.training_vulnerabilities: List[str] = json_obj["training_vulnerabilities"]
+        self.deprecated: bool = bool(json_obj["deprecated"])
+
         if self.training_supported:
             self.training_ecr_specs: JumpStartECRSpecs = JumpStartECRSpecs(
                 json_obj["training_ecr_specs"]

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -164,19 +164,21 @@ def verify_model_region_and_return_specs(
         scope (Optional[str]): scope of the JumpStart model to verify.
         region (Optional[str]): region of the JumpStart model to verify and
             obtains specs.
-        tolerate_vulnerable_model (Optional[bool]): True if vulnerable models should be tolerated
-            (exception not raised). False if these models should raise an exception.
-            (Default: None).
+        tolerate_vulnerable_model (Optional[bool]): True if vulnerable versions of model
+            specifications should be tolerated (exception not raised). False or None, raises an
+            exception if the script used by this version of the model has dependencies with known
+            security vulnerabilities. (Default: None).
         tolerate_deprecated_model (Optional[bool]): True if deprecated models should be tolerated
             (exception not raised). False if these models should raise an exception.
             (Default: None).
 
 
     Raises:
-        ValueError: If the combination of arguments specified is not supported.
         NotImplementedError: If the scope is not supported.
-        VulnerableJumpStartModelError: If the model is vulnerable.
-        DeprecatedJumpStartModelError: If the model is deprecated.
+        ValueError: If the combination of arguments specified is not supported.
+        VulnerableJumpStartModelError: If any of the dependencies required by the script have
+            known security vulnerabilities.
+        DeprecatedJumpStartModelError: If the version of the model is deprecated.
     """
 
     if tolerate_vulnerable_model is None:

--- a/src/sagemaker/model_uris.py
+++ b/src/sagemaker/model_uris.py
@@ -28,6 +28,8 @@ def retrieve(
     model_id=None,
     model_version: Optional[str] = None,
     model_scope: Optional[str] = None,
+    tolerate_vulnerable_model: Optional[bool] = None,
+    tolerate_deprecated_model: Optional[bool] = None,
 ) -> str:
     """Retrieves the model artifact S3 URI for the model matching the given arguments.
 
@@ -39,6 +41,10 @@ def retrieve(
             the model artifact S3 URI.
         model_scope (str): The model type, i.e. what it is used for.
             Valid values: "training" and "inference".
+        tolerate_vulnerable_model (bool): True if vulnerable models should be tolerated (exception
+            not thrown). False if these models should throw an exception. (Default: None).
+        tolerate_deprecated_model (bool): True if deprecated models should be tolerated (exception
+            not thrown). False if these models should throw an exception. (Default: None).
     Returns:
         str: the model artifact S3 URI for the corresponding model.
 
@@ -52,4 +58,11 @@ def retrieve(
     assert model_id is not None
     assert model_version is not None
 
-    return artifacts._retrieve_model_uri(model_id, model_version, model_scope, region)
+    return artifacts._retrieve_model_uri(
+        model_id,
+        model_version,
+        model_scope,
+        region,
+        tolerate_vulnerable_model,
+        tolerate_deprecated_model,
+    )

--- a/src/sagemaker/model_uris.py
+++ b/src/sagemaker/model_uris.py
@@ -42,9 +42,9 @@ def retrieve(
         model_scope (str): The model type, i.e. what it is used for.
             Valid values: "training" and "inference".
         tolerate_vulnerable_model (bool): True if vulnerable models should be tolerated (exception
-            not thrown). False if these models should throw an exception. (Default: None).
+            not raised). False if these models should raise an exception. (Default: None).
         tolerate_deprecated_model (bool): True if deprecated models should be tolerated (exception
-            not thrown). False if these models should throw an exception. (Default: None).
+            not raised). False if these models should raise an exception. (Default: None).
     Returns:
         str: the model artifact S3 URI for the corresponding model.
 

--- a/src/sagemaker/model_uris.py
+++ b/src/sagemaker/model_uris.py
@@ -52,7 +52,11 @@ def retrieve(
         str: the model artifact S3 URI for the corresponding model.
 
     Raises:
+        NotImplementedError: If the scope is not supported.
         ValueError: If the combination of arguments specified is not supported.
+        VulnerableJumpStartModelError: If any of the dependencies required by the script have
+            known security vulnerabilities.
+        DeprecatedJumpStartModelError: If the version of the model is deprecated.
     """
     if not jumpstart_utils.is_jumpstart_model_input(model_id, model_version):
         raise ValueError("Must specify `model_id` and `model_version` when retrieving script URIs.")

--- a/src/sagemaker/model_uris.py
+++ b/src/sagemaker/model_uris.py
@@ -41,10 +41,13 @@ def retrieve(
             the model artifact S3 URI.
         model_scope (str): The model type, i.e. what it is used for.
             Valid values: "training" and "inference".
-        tolerate_vulnerable_model (bool): True if vulnerable models should be tolerated (exception
-            not raised). False if these models should raise an exception. (Default: None).
-        tolerate_deprecated_model (bool): True if deprecated models should be tolerated (exception
-            not raised). False if these models should raise an exception. (Default: None).
+        tolerate_vulnerable_model (Optional[bool]): True if vulnerable versions of model
+            specifications should be tolerated (exception not raised). False or None, raises an
+            exception if the script used by this version of the model has dependencies with known
+            security vulnerabilities. (Default: None).
+        tolerate_deprecated_model (Optional[bool]): True if deprecated versions of model
+            specifications should be tolerated (exception not raised). False or None, raises
+            an exception if the version of the model is deprecated. (Default: None).
     Returns:
         str: the model artifact S3 URI for the corresponding model.
 

--- a/src/sagemaker/model_uris.py
+++ b/src/sagemaker/model_uris.py
@@ -28,8 +28,8 @@ def retrieve(
     model_id=None,
     model_version: Optional[str] = None,
     model_scope: Optional[str] = None,
-    tolerate_vulnerable_model: Optional[bool] = None,
-    tolerate_deprecated_model: Optional[bool] = None,
+    tolerate_vulnerable_model: bool = False,
+    tolerate_deprecated_model: bool = False,
 ) -> str:
     """Retrieves the model artifact S3 URI for the model matching the given arguments.
 
@@ -41,13 +41,13 @@ def retrieve(
             the model artifact S3 URI.
         model_scope (str): The model type, i.e. what it is used for.
             Valid values: "training" and "inference".
-        tolerate_vulnerable_model (Optional[bool]): True if vulnerable versions of model
-            specifications should be tolerated (exception not raised). False or None, raises an
+        tolerate_vulnerable_model (bool): True if vulnerable versions of model
+            specifications should be tolerated (exception not raised). If False, raises an
             exception if the script used by this version of the model has dependencies with known
-            security vulnerabilities. (Default: None).
-        tolerate_deprecated_model (Optional[bool]): True if deprecated versions of model
-            specifications should be tolerated (exception not raised). False or None, raises
-            an exception if the version of the model is deprecated. (Default: None).
+            security vulnerabilities. (Default: False).
+        tolerate_deprecated_model (bool): True if deprecated versions of model
+            specifications should be tolerated (exception not raised). If False, raises
+            an exception if the version of the model is deprecated. (Default: False).
     Returns:
         str: the model artifact S3 URI for the corresponding model.
 
@@ -61,13 +61,9 @@ def retrieve(
     if not jumpstart_utils.is_jumpstart_model_input(model_id, model_version):
         raise ValueError("Must specify `model_id` and `model_version` when retrieving script URIs.")
 
-    # mypy type checking require these assertions
-    assert model_id is not None
-    assert model_version is not None
-
     return artifacts._retrieve_model_uri(
         model_id,
-        model_version,
+        model_version,  # type: ignore
         model_scope,
         region,
         tolerate_vulnerable_model,

--- a/src/sagemaker/script_uris.py
+++ b/src/sagemaker/script_uris.py
@@ -15,6 +15,7 @@
 from __future__ import absolute_import
 
 import logging
+from typing import Optional
 
 from sagemaker.jumpstart import utils as jumpstart_utils
 from sagemaker.jumpstart import artifacts
@@ -27,6 +28,8 @@ def retrieve(
     model_id=None,
     model_version=None,
     script_scope=None,
+    tolerate_vulnerable_model: Optional[bool] = None,
+    tolerate_deprecated_model: Optional[bool] = None,
 ) -> str:
     """Retrieves the script S3 URI associated with the model matching the given arguments.
 
@@ -38,6 +41,10 @@ def retrieve(
             model script S3 URI.
         script_scope (str): The script type, i.e. what it is used for.
             Valid values: "training" and "inference".
+        tolerate_vulnerable_model (bool): True if vulnerable models should be tolerated (exception
+            not thrown). False if these models should throw an exception. (Default: None).
+        tolerate_deprecated_model (bool): True if deprecated models should be tolerated (exception
+            not thrown). False if these models should throw an exception. (Default: None).
     Returns:
         str: the model script URI for the corresponding model.
 
@@ -51,4 +58,11 @@ def retrieve(
     assert model_id is not None
     assert model_version is not None
 
-    return artifacts._retrieve_script_uri(model_id, model_version, script_scope, region)
+    return artifacts._retrieve_script_uri(
+        model_id,
+        model_version,
+        script_scope,
+        region,
+        tolerate_vulnerable_model,
+        tolerate_deprecated_model,
+    )

--- a/src/sagemaker/script_uris.py
+++ b/src/sagemaker/script_uris.py
@@ -52,7 +52,11 @@ def retrieve(
         str: the model script URI for the corresponding model.
 
     Raises:
+        NotImplementedError: If the scope is not supported.
         ValueError: If the combination of arguments specified is not supported.
+        VulnerableJumpStartModelError: If any of the dependencies required by the script have
+            known security vulnerabilities.
+        DeprecatedJumpStartModelError: If the version of the model is deprecated.
     """
     if not jumpstart_utils.is_jumpstart_model_input(model_id, model_version):
         raise ValueError("Must specify `model_id` and `model_version` when retrieving script URIs.")

--- a/src/sagemaker/script_uris.py
+++ b/src/sagemaker/script_uris.py
@@ -42,9 +42,9 @@ def retrieve(
         script_scope (str): The script type, i.e. what it is used for.
             Valid values: "training" and "inference".
         tolerate_vulnerable_model (bool): True if vulnerable models should be tolerated (exception
-            not thrown). False if these models should throw an exception. (Default: None).
+            not raised). False if these models should raise an exception. (Default: None).
         tolerate_deprecated_model (bool): True if deprecated models should be tolerated (exception
-            not thrown). False if these models should throw an exception. (Default: None).
+            not raised). False if these models should raise an exception. (Default: None).
     Returns:
         str: the model script URI for the corresponding model.
 

--- a/src/sagemaker/script_uris.py
+++ b/src/sagemaker/script_uris.py
@@ -41,10 +41,13 @@ def retrieve(
             model script S3 URI.
         script_scope (str): The script type, i.e. what it is used for.
             Valid values: "training" and "inference".
-        tolerate_vulnerable_model (bool): True if vulnerable models should be tolerated (exception
-            not raised). False if these models should raise an exception. (Default: None).
-        tolerate_deprecated_model (bool): True if deprecated models should be tolerated (exception
-            not raised). False if these models should raise an exception. (Default: None).
+        tolerate_vulnerable_model (Optional[bool]): True if vulnerable versions of model
+            specifications should be tolerated (exception not raised). False or None, raises an
+            exception if the script used by this version of the model has dependencies with known
+            security vulnerabilities. (Default: None).
+        tolerate_deprecated_model (Optional[bool]): True if deprecated models should be tolerated
+            (exception not raised). False if these models should raise an exception.
+            (Default: None).
     Returns:
         str: the model script URI for the corresponding model.
 

--- a/src/sagemaker/script_uris.py
+++ b/src/sagemaker/script_uris.py
@@ -15,7 +15,6 @@
 from __future__ import absolute_import
 
 import logging
-from typing import Optional
 
 from sagemaker.jumpstart import utils as jumpstart_utils
 from sagemaker.jumpstart import artifacts
@@ -28,8 +27,8 @@ def retrieve(
     model_id=None,
     model_version=None,
     script_scope=None,
-    tolerate_vulnerable_model: Optional[bool] = None,
-    tolerate_deprecated_model: Optional[bool] = None,
+    tolerate_vulnerable_model: bool = False,
+    tolerate_deprecated_model: bool = False,
 ) -> str:
     """Retrieves the script S3 URI associated with the model matching the given arguments.
 
@@ -41,13 +40,13 @@ def retrieve(
             model script S3 URI.
         script_scope (str): The script type, i.e. what it is used for.
             Valid values: "training" and "inference".
-        tolerate_vulnerable_model (Optional[bool]): True if vulnerable versions of model
-            specifications should be tolerated (exception not raised). False or None, raises an
+        tolerate_vulnerable_model (bool): True if vulnerable versions of model
+            specifications should be tolerated (exception not raised). If False, raises an
             exception if the script used by this version of the model has dependencies with known
-            security vulnerabilities. (Default: None).
-        tolerate_deprecated_model (Optional[bool]): True if deprecated models should be tolerated
+            security vulnerabilities. (Default: False).
+        tolerate_deprecated_model (bool): True if deprecated models should be tolerated
             (exception not raised). False if these models should raise an exception.
-            (Default: None).
+            (Default: False).
     Returns:
         str: the model script URI for the corresponding model.
 
@@ -60,10 +59,6 @@ def retrieve(
     """
     if not jumpstart_utils.is_jumpstart_model_input(model_id, model_version):
         raise ValueError("Must specify `model_id` and `model_version` when retrieving script URIs.")
-
-    # mypy type checking require these assertions
-    assert model_id is not None
-    assert model_version is not None
 
     return artifacts._retrieve_script_uri(
         model_id,

--- a/tests/unit/sagemaker/image_uris/jumpstart/test_common.py
+++ b/tests/unit/sagemaker/image_uris/jumpstart/test_common.py
@@ -96,7 +96,7 @@ def test_jumpstart_common_image_uri(
     )
     patched_verify_model_region_and_return_specs.assert_called_once()
 
-    with pytest.raises(ValueError):
+    with pytest.raises(NotImplementedError):
         image_uris.retrieve(
             framework=None,
             region="us-west-2",

--- a/tests/unit/sagemaker/image_uris/jumpstart/test_common.py
+++ b/tests/unit/sagemaker/image_uris/jumpstart/test_common.py
@@ -16,13 +16,19 @@ from mock.mock import patch
 import pytest
 
 from sagemaker import image_uris
+from sagemaker.jumpstart.utils import verify_model_region_and_return_specs
 
 from tests.unit.sagemaker.jumpstart.utils import get_spec_from_base_spec
 from sagemaker.jumpstart import constants as sagemaker_constants
 
 
+@patch("sagemaker.jumpstart.artifacts.verify_model_region_and_return_specs")
 @patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
-def test_jumpstart_common_image_uri(patched_get_model_specs):
+def test_jumpstart_common_image_uri(
+    patched_get_model_specs, patched_verify_model_region_and_return_specs
+):
+
+    patched_verify_model_region_and_return_specs.side_effect = verify_model_region_and_return_specs
     patched_get_model_specs.side_effect = get_spec_from_base_spec
 
     image_uris.retrieve(
@@ -36,8 +42,10 @@ def test_jumpstart_common_image_uri(patched_get_model_specs):
     patched_get_model_specs.assert_called_once_with(
         region="us-west-2", model_id="pytorch-ic-mobilenet-v2", version="*"
     )
+    patched_verify_model_region_and_return_specs.assert_called_once()
 
     patched_get_model_specs.reset_mock()
+    patched_verify_model_region_and_return_specs.reset_mock()
 
     image_uris.retrieve(
         framework=None,
@@ -50,8 +58,10 @@ def test_jumpstart_common_image_uri(patched_get_model_specs):
     patched_get_model_specs.assert_called_once_with(
         region="us-west-2", model_id="pytorch-ic-mobilenet-v2", version="1.*"
     )
+    patched_verify_model_region_and_return_specs.assert_called_once()
 
     patched_get_model_specs.reset_mock()
+    patched_verify_model_region_and_return_specs.reset_mock()
 
     image_uris.retrieve(
         framework=None,
@@ -66,8 +76,10 @@ def test_jumpstart_common_image_uri(patched_get_model_specs):
         model_id="pytorch-ic-mobilenet-v2",
         version="*",
     )
+    patched_verify_model_region_and_return_specs.assert_called_once()
 
     patched_get_model_specs.reset_mock()
+    patched_verify_model_region_and_return_specs.reset_mock()
 
     image_uris.retrieve(
         framework=None,
@@ -82,6 +94,7 @@ def test_jumpstart_common_image_uri(patched_get_model_specs):
         model_id="pytorch-ic-mobilenet-v2",
         version="1.*",
     )
+    patched_verify_model_region_and_return_specs.assert_called_once()
 
     with pytest.raises(ValueError):
         image_uris.retrieve(

--- a/tests/unit/sagemaker/jumpstart/constants.py
+++ b/tests/unit/sagemaker/jumpstart/constants.py
@@ -1167,6 +1167,13 @@ BASE_SPEC = {
             "scope": "container",
         },
     ],
+    "inference_vulnerable": False,
+    "inference_dependencies": [],
+    "inference_vulnerabilities": [],
+    "training_vulnerable": False,
+    "training_dependencies": [],
+    "training_vulnerabilities": [],
+    "deprecated": False,
 }
 
 BASE_HEADER = {

--- a/tests/unit/sagemaker/jumpstart/test_utils.py
+++ b/tests/unit/sagemaker/jumpstart/test_utils.py
@@ -14,7 +14,7 @@ from __future__ import absolute_import
 from mock.mock import Mock, patch
 import pytest
 from sagemaker.jumpstart import utils
-from sagemaker.jumpstart.constants import INFERENCE, JUMPSTART_REGION_NAME_SET, TRAINING
+from sagemaker.jumpstart.constants import JUMPSTART_REGION_NAME_SET, JumpStartScriptScope
 from sagemaker.jumpstart.exceptions import (
     DeprecatedJumpStartModelError,
     VulnerableJumpStartModelError,
@@ -131,19 +131,23 @@ def test_jumpstart_vulnerable_model(patched_get_model_specs):
 
     with pytest.raises(VulnerableJumpStartModelError) as e:
         utils.verify_model_region_and_return_specs(
-            model_id="pytorch-eqa-bert-base-cased", version="*", scope=INFERENCE, region="us-west-2"
+            model_id="pytorch-eqa-bert-base-cased",
+            version="*",
+            scope=JumpStartScriptScope.INFERENCE.value,
+            region="us-west-2",
         )
     assert (
-        "JumpStart model 'pytorch-eqa-bert-base-cased' and version '*' has "
-        "at least 1 vulnerable dependency in the inference scripts. List of vulnerabilities: "
-        "some, vulnerability" == str(e.value.message)
-    )
+        "Version '*' of JumpStart model 'pytorch-eqa-bert-base-cased' has at least 1 "
+        "vulnerable dependency in the inference script. "
+        "Please try targetting a higher version of the model. "
+        "List of vulnerabilities: some, vulnerability"
+    ) == str(e.value.message)
 
     assert (
         utils.verify_model_region_and_return_specs(
             model_id="pytorch-eqa-bert-base-cased",
             version="*",
-            scope=INFERENCE,
+            scope=JumpStartScriptScope.INFERENCE.value,
             region="us-west-2",
             tolerate_vulnerable_model=True,
         )
@@ -160,19 +164,23 @@ def test_jumpstart_vulnerable_model(patched_get_model_specs):
 
     with pytest.raises(VulnerableJumpStartModelError) as e:
         utils.verify_model_region_and_return_specs(
-            model_id="pytorch-eqa-bert-base-cased", version="*", scope=TRAINING, region="us-west-2"
+            model_id="pytorch-eqa-bert-base-cased",
+            version="*",
+            scope=JumpStartScriptScope.TRAINING.value,
+            region="us-west-2",
         )
     assert (
-        "JumpStart model 'pytorch-eqa-bert-base-cased' and version '*' has "
-        "at least 1 vulnerable dependency in the training scripts. List of vulnerabilities: "
-        "some, vulnerability" == str(e.value.message)
-    )
+        "Version '*' of JumpStart model 'pytorch-eqa-bert-base-cased' has at least 1 "
+        "vulnerable dependency in the training script. "
+        "Please try targetting a higher version of the model. "
+        "List of vulnerabilities: some, vulnerability"
+    ) == str(e.value.message)
 
     assert (
         utils.verify_model_region_and_return_specs(
             model_id="pytorch-eqa-bert-base-cased",
             version="*",
-            scope=TRAINING,
+            scope=JumpStartScriptScope.TRAINING.value,
             region="us-west-2",
             tolerate_vulnerable_model=True,
         )
@@ -191,17 +199,19 @@ def test_jumpstart_deprecated_model(patched_get_model_specs):
 
     with pytest.raises(DeprecatedJumpStartModelError) as e:
         utils.verify_model_region_and_return_specs(
-            model_id="pytorch-eqa-bert-base-cased", version="*", scope=INFERENCE, region="us-west-2"
+            model_id="pytorch-eqa-bert-base-cased",
+            version="*",
+            scope=JumpStartScriptScope.INFERENCE.value,
+            region="us-west-2",
         )
-    assert "JumpStart model 'pytorch-eqa-bert-base-cased' and version '*' is deprecated." == str(
-        e.value.message
-    )
+    assert "Version '*' of JumpStart model 'pytorch-eqa-bert-base-cased' is deprecated. "
+    "Please try targetting a higher version of the model." == str(e.value.message)
 
     assert (
         utils.verify_model_region_and_return_specs(
             model_id="pytorch-eqa-bert-base-cased",
             version="*",
-            scope=INFERENCE,
+            scope=JumpStartScriptScope.INFERENCE.value,
             region="us-west-2",
             tolerate_deprecated_model=True,
         )

--- a/tests/unit/sagemaker/jumpstart/test_utils.py
+++ b/tests/unit/sagemaker/jumpstart/test_utils.py
@@ -143,16 +143,22 @@ def test_jumpstart_vulnerable_model(patched_get_model_specs):
         "List of vulnerabilities: some, vulnerability"
     ) == str(e.value.message)
 
-    assert (
-        utils.verify_model_region_and_return_specs(
-            model_id="pytorch-eqa-bert-base-cased",
-            version="*",
-            scope=JumpStartScriptScope.INFERENCE.value,
-            region="us-west-2",
-            tolerate_vulnerable_model=True,
+    with patch("logging.Logger.warning") as mocked_warning_log:
+        assert (
+            utils.verify_model_region_and_return_specs(
+                model_id="pytorch-eqa-bert-base-cased",
+                version="*",
+                scope=JumpStartScriptScope.INFERENCE.value,
+                region="us-west-2",
+                tolerate_vulnerable_model=True,
+            )
+            is not None
         )
-        is not None
-    )
+        mocked_warning_log.assert_called_once_with(
+            "Using vulnerable JumpStart model '%s' and version '%s' (inference).",
+            "pytorch-eqa-bert-base-cased",
+            "*",
+        )
 
     def make_vulnerable_training_spec(*largs, **kwargs):
         spec = get_spec_from_base_spec(*largs, **kwargs)
@@ -176,16 +182,22 @@ def test_jumpstart_vulnerable_model(patched_get_model_specs):
         "List of vulnerabilities: some, vulnerability"
     ) == str(e.value.message)
 
-    assert (
-        utils.verify_model_region_and_return_specs(
-            model_id="pytorch-eqa-bert-base-cased",
-            version="*",
-            scope=JumpStartScriptScope.TRAINING.value,
-            region="us-west-2",
-            tolerate_vulnerable_model=True,
+    with patch("logging.Logger.warning") as mocked_warning_log:
+        assert (
+            utils.verify_model_region_and_return_specs(
+                model_id="pytorch-eqa-bert-base-cased",
+                version="*",
+                scope=JumpStartScriptScope.TRAINING.value,
+                region="us-west-2",
+                tolerate_vulnerable_model=True,
+            )
+            is not None
         )
-        is not None
-    )
+        mocked_warning_log.assert_called_once_with(
+            "Using vulnerable JumpStart model '%s' and version '%s' (training).",
+            "pytorch-eqa-bert-base-cased",
+            "*",
+        )
 
 
 @patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
@@ -207,13 +219,19 @@ def test_jumpstart_deprecated_model(patched_get_model_specs):
     assert "Version '*' of JumpStart model 'pytorch-eqa-bert-base-cased' is deprecated. "
     "Please try targetting a higher version of the model." == str(e.value.message)
 
-    assert (
-        utils.verify_model_region_and_return_specs(
-            model_id="pytorch-eqa-bert-base-cased",
-            version="*",
-            scope=JumpStartScriptScope.INFERENCE.value,
-            region="us-west-2",
-            tolerate_deprecated_model=True,
+    with patch("logging.Logger.warning") as mocked_warning_log:
+        assert (
+            utils.verify_model_region_and_return_specs(
+                model_id="pytorch-eqa-bert-base-cased",
+                version="*",
+                scope=JumpStartScriptScope.INFERENCE.value,
+                region="us-west-2",
+                tolerate_deprecated_model=True,
+            )
+            is not None
         )
-        is not None
-    )
+        mocked_warning_log.assert_called_once_with(
+            "Using deprecated JumpStart model '%s' and version '%s'.",
+            "pytorch-eqa-bert-base-cased",
+            "*",
+        )

--- a/tests/unit/sagemaker/model_uris/jumpstart/test_common.py
+++ b/tests/unit/sagemaker/model_uris/jumpstart/test_common.py
@@ -16,14 +16,19 @@ from mock.mock import patch
 import pytest
 
 from sagemaker import model_uris
+from sagemaker.jumpstart.utils import verify_model_region_and_return_specs
 
 from tests.unit.sagemaker.jumpstart.utils import get_spec_from_base_spec
 from sagemaker.jumpstart import constants as sagemaker_constants
 
 
+@patch("sagemaker.jumpstart.artifacts.verify_model_region_and_return_specs")
 @patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
-def test_jumpstart_common_model_uri(patched_get_model_specs):
+def test_jumpstart_common_model_uri(
+    patched_get_model_specs, patched_verify_model_region_and_return_specs
+):
 
+    patched_verify_model_region_and_return_specs.side_effect = verify_model_region_and_return_specs
     patched_get_model_specs.side_effect = get_spec_from_base_spec
 
     model_uris.retrieve(
@@ -36,8 +41,10 @@ def test_jumpstart_common_model_uri(patched_get_model_specs):
         model_id="pytorch-ic-mobilenet-v2",
         version="*",
     )
+    patched_verify_model_region_and_return_specs.assert_called_once()
 
     patched_get_model_specs.reset_mock()
+    patched_verify_model_region_and_return_specs.reset_mock()
 
     model_uris.retrieve(
         model_scope="inference",
@@ -49,8 +56,10 @@ def test_jumpstart_common_model_uri(patched_get_model_specs):
         model_id="pytorch-ic-mobilenet-v2",
         version="1.*",
     )
+    patched_verify_model_region_and_return_specs.assert_called_once()
 
     patched_get_model_specs.reset_mock()
+    patched_verify_model_region_and_return_specs.reset_mock()
 
     model_uris.retrieve(
         region="us-west-2",
@@ -61,8 +70,10 @@ def test_jumpstart_common_model_uri(patched_get_model_specs):
     patched_get_model_specs.assert_called_once_with(
         region="us-west-2", model_id="pytorch-ic-mobilenet-v2", version="*"
     )
+    patched_verify_model_region_and_return_specs.assert_called_once()
 
     patched_get_model_specs.reset_mock()
+    patched_verify_model_region_and_return_specs.reset_mock()
 
     model_uris.retrieve(
         region="us-west-2",
@@ -73,6 +84,7 @@ def test_jumpstart_common_model_uri(patched_get_model_specs):
     patched_get_model_specs.assert_called_once_with(
         region="us-west-2", model_id="pytorch-ic-mobilenet-v2", version="1.*"
     )
+    patched_verify_model_region_and_return_specs.assert_called_once()
 
     with pytest.raises(ValueError):
         model_uris.retrieve(

--- a/tests/unit/sagemaker/model_uris/jumpstart/test_common.py
+++ b/tests/unit/sagemaker/model_uris/jumpstart/test_common.py
@@ -86,7 +86,7 @@ def test_jumpstart_common_model_uri(
     )
     patched_verify_model_region_and_return_specs.assert_called_once()
 
-    with pytest.raises(ValueError):
+    with pytest.raises(NotImplementedError):
         model_uris.retrieve(
             region="us-west-2",
             model_scope="BAD_SCOPE",

--- a/tests/unit/sagemaker/script_uris/jumpstart/test_common.py
+++ b/tests/unit/sagemaker/script_uris/jumpstart/test_common.py
@@ -86,7 +86,7 @@ def test_jumpstart_common_script_uri(
     )
     patched_verify_model_region_and_return_specs.assert_called_once()
 
-    with pytest.raises(ValueError):
+    with pytest.raises(NotImplementedError):
         script_uris.retrieve(
             region="us-west-2",
             script_scope="BAD_SCOPE",

--- a/tests/unit/sagemaker/script_uris/jumpstart/test_common.py
+++ b/tests/unit/sagemaker/script_uris/jumpstart/test_common.py
@@ -16,14 +16,19 @@ import pytest
 from mock.mock import patch
 
 from sagemaker import script_uris
+from sagemaker.jumpstart.utils import verify_model_region_and_return_specs
 
 from tests.unit.sagemaker.jumpstart.utils import get_spec_from_base_spec
 from sagemaker.jumpstart import constants as sagemaker_constants
 
 
+@patch("sagemaker.jumpstart.artifacts.verify_model_region_and_return_specs")
 @patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
-def test_jumpstart_common_script_uri(patched_get_model_specs):
+def test_jumpstart_common_script_uri(
+    patched_get_model_specs, patched_verify_model_region_and_return_specs
+):
 
+    patched_verify_model_region_and_return_specs.side_effect = verify_model_region_and_return_specs
     patched_get_model_specs.side_effect = get_spec_from_base_spec
 
     script_uris.retrieve(
@@ -36,8 +41,10 @@ def test_jumpstart_common_script_uri(patched_get_model_specs):
         model_id="pytorch-ic-mobilenet-v2",
         version="*",
     )
+    patched_verify_model_region_and_return_specs.assert_called_once()
 
     patched_get_model_specs.reset_mock()
+    patched_verify_model_region_and_return_specs.reset_mock()
 
     script_uris.retrieve(
         script_scope="inference",
@@ -49,8 +56,10 @@ def test_jumpstart_common_script_uri(patched_get_model_specs):
         model_id="pytorch-ic-mobilenet-v2",
         version="1.*",
     )
+    patched_verify_model_region_and_return_specs.assert_called_once()
 
     patched_get_model_specs.reset_mock()
+    patched_verify_model_region_and_return_specs.reset_mock()
 
     script_uris.retrieve(
         region="us-west-2",
@@ -61,8 +70,10 @@ def test_jumpstart_common_script_uri(patched_get_model_specs):
     patched_get_model_specs.assert_called_once_with(
         region="us-west-2", model_id="pytorch-ic-mobilenet-v2", version="*"
     )
+    patched_verify_model_region_and_return_specs.assert_called_once()
 
     patched_get_model_specs.reset_mock()
+    patched_verify_model_region_and_return_specs.reset_mock()
 
     script_uris.retrieve(
         region="us-west-2",
@@ -73,6 +84,7 @@ def test_jumpstart_common_script_uri(patched_get_model_specs):
     patched_get_model_specs.assert_called_once_with(
         region="us-west-2", model_id="pytorch-ic-mobilenet-v2", version="1.*"
     )
+    patched_verify_model_region_and_return_specs.assert_called_once()
 
     with pytest.raises(ValueError):
         script_uris.retrieve(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR adds adds support for the deprecated and vulnerability fields of the JumpStart model specs. If specs for a vulnerable or deprecated model are requested, a new exception type will be surfaced. There is a user option to override these safety checks, so they may use a vulnerable/deprecated model if they wish.  

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
