### PR TITLE
feature: Add FailStep Support for Sagemaker Pipeline

### DIFF
--- a/doc/workflows/pipelines/sagemaker.workflow.pipelines.rst
+++ b/doc/workflows/pipelines/sagemaker.workflow.pipelines.rst
@@ -147,3 +147,5 @@ Steps
 .. autoclass:: sagemaker.workflow.clarify_check_step.ClarifyCheckConfig
 
 .. autoclass:: sagemaker.workflow.clarify_check_step.ClarifyCheckStep
+
+.. autoclass:: sagemaker.workflow.fail_step.FailStep

--- a/src/sagemaker/workflow/fail_step.py
+++ b/src/sagemaker/workflow/fail_step.py
@@ -36,13 +36,17 @@ class FailStep(Step):
         """Constructs a `FailStep`.
 
         Args:
-            name (str): The name of the `FailStep`. A name is required and must be unique within a pipeline.
-            error_message (str or PipelineNonPrimitiveInputTypes): An error message defined by the user.
+            name (str): The name of the `FailStep`. A name is required and must be
+                unique within a pipeline.
+            error_message (str or PipelineNonPrimitiveInputTypes):
+                An error message defined by the user.
                 Once the `FailStep` is reached, the execution fails and the
                 error message is set as the failure reason (default: None).
-            display_name (str): The display name of the `FailStep`. The display name provides better UI readability. (default: None).
+            display_name (str): The display name of the `FailStep`.
+                The display name provides better UI readability. (default: None).
             description (str): The description of the `FailStep` (default: None).
-            depends_on (List[str] or List[Step]): A list of `Step` names or `Step` instances that this `FailStep` depends on. 
+            depends_on (List[str] or List[Step]): A list of `Step` names or `Step` instances
+                that this `FailStep` depends on.
                 If a listed `Step` name does not exist, an error is returned (default: None).
         """
         super(FailStep, self).__init__(
@@ -57,9 +61,11 @@ class FailStep(Step):
 
     @property
     def properties(self):
-        """A `Properties` object is not available for the `FailStep`. Executing a `FailStep` will terminate the pipeline. 
-            `FailStep` properties should not be referenced and no other `Step` should depend on the `FailStep`."""
+        """A `Properties` object is not available for the `FailStep`.
+
+        Executing a `FailStep` will terminate the pipeline.
+        `FailStep` properties should not be referenced.
+        """
         raise RuntimeError(
-            "The Properties object is not available for the FailStep "
-            + "as it cannot be referenced by other steps."
+            "FailStep is a terminal step and the Properties object is not available for it."
         )

--- a/src/sagemaker/workflow/fail_step.py
+++ b/src/sagemaker/workflow/fail_step.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-"""The step definitions for workflow."""
+"""The `Step` definitions for SageMaker Pipelines Workflows."""
 from __future__ import absolute_import
 
 from typing import List, Union
@@ -23,7 +23,7 @@ from sagemaker.workflow.steps import Step, StepTypeEnum
 
 
 class FailStep(Step):
-    """Fail step for workflow."""
+    """`FailStep` for SageMaker Pipelines Workflows."""
 
     def __init__(
         self,
@@ -33,17 +33,17 @@ class FailStep(Step):
         description: str = None,
         depends_on: Union[List[str], List[Step]] = None,
     ):
-        """Constructs a FailStep.
+        """Constructs a `FailStep`.
 
         Args:
-            name (str): The name of the Fail step.
-            error_message (str or PipelineNonPrimitiveInputTypes): Error message defined by user.
-                Once the Fail step is reached the execution will fail and the
-                error message will be set as the failure reason (default: None).
-            display_name (str): The display name of the Fail step (default: None).
-            description (str): The description of the Fail step (default: None).
-            depends_on (List[str] or List[Step]): A list of step names or step instances
-                this `sagemaker.workflow.steps.FailStep` depends on (default: None).
+            name (str): The name of the `FailStep`. A name is required and must be unique within a pipeline.
+            error_message (str or PipelineNonPrimitiveInputTypes): An error message defined by the user.
+                Once the `FailStep` is reached, the execution fails and the
+                error message is set as the failure reason (default: None).
+            display_name (str): The display name of the `FailStep`. The display name provides better UI readability. (default: None).
+            description (str): The description of the `FailStep` (default: None).
+            depends_on (List[str] or List[Step]): A list of `Step` names or `Step` instances that this `FailStep` depends on. 
+                If a listed `Step` name does not exist, an error is returned (default: None).
         """
         super(FailStep, self).__init__(
             name, display_name, description, StepTypeEnum.FAIL, depends_on
@@ -52,13 +52,14 @@ class FailStep(Step):
 
     @property
     def arguments(self) -> RequestType:
-        """The arguments dict that is used to define the Fail step."""
+        """The arguments dictionary that is used to define the `FailStep`."""
         return dict(ErrorMessage=self.error_message)
 
     @property
     def properties(self):
-        """A Properties object is not available for the Fail step"""
+        """A `Properties` object is not available for the `FailStep`. Executing a `FailStep` will terminate the pipeline. 
+            `FailStep` properties should not be referenced and no other `Step` should depend on the `FailStep`."""
         raise RuntimeError(
-            "The Properties object is not available for the Fail step "
+            "The Properties object is not available for the FailStep "
             + "as it cannot be referenced by other steps."
         )

--- a/src/sagemaker/workflow/fail_step.py
+++ b/src/sagemaker/workflow/fail_step.py
@@ -1,0 +1,64 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+"""The step definitions for workflow."""
+from __future__ import absolute_import
+
+from typing import List, Union
+
+from sagemaker.workflow import PipelineNonPrimitiveInputTypes
+from sagemaker.workflow.entities import (
+    RequestType,
+)
+from sagemaker.workflow.steps import Step, StepTypeEnum
+
+
+class FailStep(Step):
+    """Fail step for workflow."""
+
+    def __init__(
+        self,
+        name: str,
+        error_message: Union[str, PipelineNonPrimitiveInputTypes] = None,
+        display_name: str = None,
+        description: str = None,
+        depends_on: Union[List[str], List[Step]] = None,
+    ):
+        """Constructs a FailStep.
+
+        Args:
+            name (str): The name of the Fail step.
+            error_message (str or PipelineNonPrimitiveInputTypes): Error message defined by user.
+                Once the Fail step is reached the execution will fail and the
+                error message will be set as the failure reason (default: None).
+            display_name (str): The display name of the Fail step (default: None).
+            description (str): The description of the Fail step (default: None).
+            depends_on (List[str] or List[Step]): A list of step names or step instances
+                this `sagemaker.workflow.steps.FailStep` depends on (default: None).
+        """
+        super(FailStep, self).__init__(
+            name, display_name, description, StepTypeEnum.FAIL, depends_on
+        )
+        self.error_message = error_message if error_message is not None else ""
+
+    @property
+    def arguments(self) -> RequestType:
+        """The arguments dict that is used to define the Fail step."""
+        return dict(ErrorMessage=self.error_message)
+
+    @property
+    def properties(self):
+        """A Properties object is not available for the Fail step"""
+        raise RuntimeError(
+            "The Properties object is not available for the Fail step "
+            + "as it cannot be referenced by other steps."
+        )

--- a/src/sagemaker/workflow/steps.py
+++ b/src/sagemaker/workflow/steps.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-"""The step definitions for workflow."""
+"""The `Step` definitions for SageMaker Pipelines Workflows."""
 from __future__ import absolute_import
 
 import abc
@@ -48,7 +48,7 @@ from sagemaker.workflow.retry import RetryPolicy
 
 
 class StepTypeEnum(Enum, metaclass=DefaultEnumMeta):
-    """Enum of step types."""
+    """Enum of `Step` types."""
 
     CONDITION = "Condition"
     CREATE_MODEL = "Model"
@@ -67,16 +67,16 @@ class StepTypeEnum(Enum, metaclass=DefaultEnumMeta):
 
 @attr.s
 class Step(Entity):
-    """Pipeline step for workflow.
+    """Pipeline `Step` for SageMaker Pipelines Workflows.
 
     Attributes:
-        name (str): The name of the step.
-        display_name (str): The display name of the step.
-        description (str): The description of the step.
-        step_type (StepTypeEnum): The type of the step.
-        depends_on (List[str] or List[Step]): The list of step names or step
-            instances the current step depends on
-        retry_policies (List[RetryPolicy]): The custom retry policy configuration
+        name (str): The name of the `Step`.
+        display_name (str): The display name of the `Step`.
+        description (str): The description of the `Step`.
+        step_type (StepTypeEnum): The type of the `Step`.
+        depends_on (List[str] or List[Step]): The list of `Step` names or `Step`
+            instances that the current `Step` depends on.
+        retry_policies (List[RetryPolicy]): The custom retry policy configuration.
     """
 
     name: str = attr.ib(factory=str)
@@ -88,12 +88,12 @@ class Step(Entity):
     @property
     @abc.abstractmethod
     def arguments(self) -> RequestType:
-        """The arguments to the particular step service call."""
+        """The arguments to the particular `Step` service call."""
 
     @property
     @abc.abstractmethod
     def properties(self):
-        """The properties of the particular step."""
+        """The properties of the particular `Step`."""
 
     def to_request(self) -> RequestType:
         """Gets the request structure for workflow service calls."""
@@ -112,7 +112,7 @@ class Step(Entity):
         return request_dict
 
     def add_depends_on(self, step_names: Union[List[str], List["Step"]]):
-        """Add step names or step instances to the current step depends on list"""
+        """Add `Step` names or `Step` instances to the current `Step` depends on list."""
 
         if not step_names:
             return
@@ -123,12 +123,12 @@ class Step(Entity):
 
     @property
     def ref(self) -> Dict[str, str]:
-        """Gets a reference dict for steps"""
+        """Gets a reference dictionary for `Step` instances."""
         return {"Name": self.name}
 
     @staticmethod
     def _resolve_depends_on(depends_on_list: Union[List[str], List["Step"]]) -> List[str]:
-        """Resolve the step depends on list"""
+        """Resolve the `Step` depends on list."""
         depends_on = []
         for step in depends_on_list:
             if isinstance(step, Step):
@@ -142,18 +142,18 @@ class Step(Entity):
 
 @attr.s
 class CacheConfig:
-    """Configuration class to enable caching in pipeline workflow.
+    """Configuration class to enable caching in SageMaker Pipelines Workflows.
 
-    If caching is enabled, the pipeline attempts to find a previous execution of a step
-    that was called with the same arguments. Step caching only considers successful execution.
+    If caching is enabled, the pipeline attempts to find a previous execution of a `Step`
+    that was called with the same arguments. `Step` caching only considers successful execution.
     If a successful previous execution is found, the pipeline propagates the values
-    from previous execution rather than recomputing the step. When multiple successful executions
+    from the previous execution rather than recomputing the `Step`. When multiple successful executions
     exist within the timeout period, it uses the result for the most recent successful execution.
 
 
     Attributes:
-        enable_caching (bool): To enable step caching. Defaults to `False`.
-        expire_after (str): If step caching is enabled, a timeout also needs to defined.
+        enable_caching (bool): To enable `Step` caching. Defaults to `False`.
+        expire_after (str): If `Step` caching is enabled, a timeout also needs to defined.
             It defines how old a previous execution can be to be considered for reuse.
             Value should be an ISO 8601 duration string. Defaults to `None`.
 
@@ -171,7 +171,7 @@ class CacheConfig:
 
     @property
     def config(self):
-        """Configures caching in pipeline steps."""
+        """Configures `Step` caching for SageMaker Pipelines Workflows."""
         config = {"Enabled": self.enable_caching}
         if self.expire_after is not None:
             config["ExpireAfter"] = self.expire_after
@@ -179,7 +179,7 @@ class CacheConfig:
 
 
 class ConfigurableRetryStep(Step):
-    """ConfigurableRetryStep step for workflow."""
+    """`ConfigurableRetryStep` for SageMaker Pipelines Workflows."""
 
     def __init__(
         self,
@@ -200,7 +200,7 @@ class ConfigurableRetryStep(Step):
         self.retry_policies = [] if not retry_policies else retry_policies
 
     def add_retry_policy(self, retry_policy: RetryPolicy):
-        """Add a retry policy to the current step retry policies list."""
+        """Add a policy to the current `ConfigurableRetryStep` retry policies list."""
         if not retry_policy:
             return
 
@@ -209,7 +209,7 @@ class ConfigurableRetryStep(Step):
         self.retry_policies.append(retry_policy)
 
     def to_request(self) -> RequestType:
-        """Gets the request structure for ConfigurableRetryStep"""
+        """Gets the request structure for `ConfigurableRetryStep`."""
         step_dict = super().to_request()
         if self.retry_policies:
             step_dict["RetryPolicies"] = self._resolve_retry_policy(self.retry_policies)
@@ -217,12 +217,12 @@ class ConfigurableRetryStep(Step):
 
     @staticmethod
     def _resolve_retry_policy(retry_policy_list: List[RetryPolicy]) -> List[RequestType]:
-        """Resolve the step retry policy list"""
+        """Resolve the `ConfigurableRetryStep` retry policy list."""
         return [retry_policy.to_request() for retry_policy in retry_policy_list]
 
 
 class TrainingStep(ConfigurableRetryStep):
-    """Training step for workflow."""
+    """`TrainingStep` for SageMaker Pipelines Workflows."""
 
     def __init__(
         self,
@@ -235,23 +235,23 @@ class TrainingStep(ConfigurableRetryStep):
         depends_on: Union[List[str], List[Step]] = None,
         retry_policies: List[RetryPolicy] = None,
     ):
-        """Construct a TrainingStep, given an `EstimatorBase` instance.
+        """Construct a `TrainingStep`, given an `EstimatorBase` instance.
 
-        In addition to the estimator instance, the other arguments are those that are supplied to
+        In addition to the `EstimatorBase` instance, the other arguments are those that are supplied to
         the `fit` method of the `sagemaker.estimator.Estimator`.
 
         Args:
-            name (str): The name of the training step.
+            name (str): The name of the `TrainingStep`.
             estimator (EstimatorBase): A `sagemaker.estimator.EstimatorBase` instance.
-            display_name (str): The display name of the training step.
-            description (str): The description of the training step.
+            display_name (str): The display name of the `TrainingStep`.
+            description (str): The description of the `TrainingStep`.
             inputs (Union[str, dict, TrainingInput, FileSystemInput]): Information
                 about the training data. This can be one of three types:
 
                 * (str) the S3 location where training data is saved, or a file:// path in
                   local mode.
                 * (dict[str, str] or dict[str, sagemaker.inputs.TrainingInput]) If using multiple
-                  channels for training data, you can specify a dict mapping channel names to
+                  channels for training data, you can specify a dictionary mapping channel names to
                   strings or :func:`~sagemaker.inputs.TrainingInput` objects.
                 * (sagemaker.inputs.TrainingInput) - channel configuration for S3 data sources
                   that can provide additional information as well as the path to the training
@@ -262,9 +262,9 @@ class TrainingStep(ConfigurableRetryStep):
                   the path to the training dataset.
 
             cache_config (CacheConfig):  A `sagemaker.workflow.steps.CacheConfig` instance.
-            depends_on (List[str] or List[Step]): A list of step names or step instances
-                this `sagemaker.workflow.steps.TrainingStep` depends on
-            retry_policies (List[RetryPolicy]):  A list of retry policy
+            depends_on (List[str] or List[Step]): A list of `Step` names or `Step` instances
+                this `sagemaker.workflow.steps.TrainingStep` depends on.
+            retry_policies (List[RetryPolicy]):  A list of retry policies.
         """
         super(TrainingStep, self).__init__(
             name, StepTypeEnum.TRAINING, display_name, description, depends_on, retry_policies
@@ -288,10 +288,10 @@ class TrainingStep(ConfigurableRetryStep):
 
     @property
     def arguments(self) -> RequestType:
-        """The arguments dict that is used to call `create_training_job`.
+        """The arguments dictionary that is used to call `create_training_job`.
 
-        NOTE: The CreateTrainingJob request is not quite the args list that workflow needs.
-        The TrainingJobName and ExperimentConfig attributes cannot be included.
+        NOTE: The `CreateTrainingJob` request is not quite the args list that workflow needs.
+        The `TrainingJobName` and `ExperimentConfig` attributes cannot be included.
         """
 
         self.estimator._prepare_for_training()
@@ -305,11 +305,11 @@ class TrainingStep(ConfigurableRetryStep):
 
     @property
     def properties(self):
-        """A Properties object representing the DescribeTrainingJobResponse data model."""
+        """A `Properties` object representing the `DescribeTrainingJobResponse` data model."""
         return self._properties
 
     def to_request(self) -> RequestType:
-        """Updates the dictionary with cache configuration."""
+        """Updates the request dictionary with cache configuration."""
         request_dict = super().to_request()
         if self.cache_config:
             request_dict.update(self.cache_config.config)
@@ -318,7 +318,7 @@ class TrainingStep(ConfigurableRetryStep):
 
 
 class CreateModelStep(ConfigurableRetryStep):
-    """CreateModel step for workflow."""
+    """`CreateModelStep` for SageMaker Pipelines Workflows."""
 
     def __init__(
         self,
@@ -330,22 +330,22 @@ class CreateModelStep(ConfigurableRetryStep):
         display_name: str = None,
         description: str = None,
     ):
-        """Construct a CreateModelStep, given an `sagemaker.model.Model` instance.
+        """Construct a `CreateModelStep`, given an `sagemaker.model.Model` instance.
 
-        In addition to the Model instance, the other arguments are those that are supplied to
+        In addition to the `Model` instance, the other arguments are those that are supplied to
         the `_create_sagemaker_model` method of the `sagemaker.model.Model._create_sagemaker_model`.
 
         Args:
-            name (str): The name of the CreateModel step.
+            name (str): The name of the `CreateModelStep`.
             model (Model or PipelineModel): A `sagemaker.model.Model`
                 or `sagemaker.pipeline.PipelineModel` instance.
             inputs (CreateModelInput): A `sagemaker.inputs.CreateModelInput` instance.
                 Defaults to `None`.
-            depends_on (List[str] or List[Step]): A list of step names or step instances
-                this `sagemaker.workflow.steps.CreateModelStep` depends on
-            retry_policies (List[RetryPolicy]):  A list of retry policy
-            display_name (str): The display name of the CreateModel step.
-            description (str): The description of the CreateModel step.
+            depends_on (List[str] or List[Step]): A list of `Step` names or `Step` instances
+                this `sagemaker.workflow.steps.CreateModelStep` depends on.
+            retry_policies (List[RetryPolicy]):  A list of retry policies.
+            display_name (str): The display name of the `CreateModelStep`.
+            description (str): The description of the `CreateModelStep`.
         """
         super(CreateModelStep, self).__init__(
             name, StepTypeEnum.CREATE_MODEL, display_name, description, depends_on, retry_policies
@@ -357,10 +357,10 @@ class CreateModelStep(ConfigurableRetryStep):
 
     @property
     def arguments(self) -> RequestType:
-        """The arguments dict that is used to call `create_model`.
+        """The arguments dictionary that is used to call `create_model`.
 
-        NOTE: The CreateModelRequest is not quite the args list that workflow needs.
-        ModelName cannot be included in the arguments.
+        NOTE: The `CreateModelRequest` is not quite the args list that workflow needs.
+        `ModelName` cannot be included in the arguments.
         """
 
         if isinstance(self.model, PipelineModel):
@@ -388,12 +388,12 @@ class CreateModelStep(ConfigurableRetryStep):
 
     @property
     def properties(self):
-        """A Properties object representing the DescribeModelResponse data model."""
+        """A `Properties` object representing the `DescribeModelResponse` data model."""
         return self._properties
 
 
 class TransformStep(ConfigurableRetryStep):
-    """Transform step for workflow."""
+    """`TransformStep` for SageMaker Pipelines Workflows."""
 
     def __init__(
         self,
@@ -406,21 +406,21 @@ class TransformStep(ConfigurableRetryStep):
         depends_on: Union[List[str], List[Step]] = None,
         retry_policies: List[RetryPolicy] = None,
     ):
-        """Constructs a TransformStep, given an `Transformer` instance.
+        """Constructs a `TransformStep`, given a `Transformer` instance.
 
-        In addition to the transformer instance, the other arguments are those that are supplied to
+        In addition to the `Transformer` instance, the other arguments are those that are supplied to
         the `transform` method of the `sagemaker.transformer.Transformer`.
 
         Args:
-            name (str): The name of the transform step.
+            name (str): The name of the `TransformStep`.
             transformer (Transformer): A `sagemaker.transformer.Transformer` instance.
             inputs (TransformInput): A `sagemaker.inputs.TransformInput` instance.
-            cache_config (CacheConfig):  A `sagemaker.workflow.steps.CacheConfig` instance.
-            display_name (str): The display name of the transform step.
-            description (str): The description of the transform step.
-            depends_on (List[str]): A list of step names this `sagemaker.workflow.steps.TransformStep`
-                depends on
-            retry_policies (List[RetryPolicy]):  A list of retry policy
+            cache_config (CacheConfig): A `sagemaker.workflow.steps.CacheConfig` instance.
+            display_name (str): The display name of the `TransformStep`.
+            description (str): The description of the `TransformStep`.
+            depends_on (List[str]): A list of `Step` names that this `sagemaker.workflow.steps.TransformStep`
+                depends on.
+            retry_policies (List[RetryPolicy]): A list of retry policies.
         """
         super(TransformStep, self).__init__(
             name, StepTypeEnum.TRANSFORM, display_name, description, depends_on, retry_policies
@@ -434,10 +434,10 @@ class TransformStep(ConfigurableRetryStep):
 
     @property
     def arguments(self) -> RequestType:
-        """The arguments dict that is used to call `create_transform_job`.
+        """The arguments dictionary that is used to call `create_transform_job`.
 
-        NOTE: The CreateTransformJob request is not quite the args list that workflow needs.
-        TransformJobName and ExperimentConfig cannot be included in the arguments.
+        NOTE: The `CreateTransformJob` request is not quite the args list that workflow needs.
+        `TransformJobName` and `ExperimentConfig` cannot be included in the arguments.
         """
         transform_args = _TransformJob._get_transform_args(
             transformer=self.transformer,
@@ -460,7 +460,7 @@ class TransformStep(ConfigurableRetryStep):
 
     @property
     def properties(self):
-        """A Properties object representing the DescribeTransformJobResponse data model."""
+        """A `Properties` object representing the `DescribeTransformJobResponse` data model."""
         return self._properties
 
     def to_request(self) -> RequestType:
@@ -473,7 +473,7 @@ class TransformStep(ConfigurableRetryStep):
 
 
 class ProcessingStep(ConfigurableRetryStep):
-    """Processing step for workflow."""
+    """`ProcessingStep` for SageMaker Pipelines Workflows."""
 
     def __init__(
         self,
@@ -491,16 +491,16 @@ class ProcessingStep(ConfigurableRetryStep):
         retry_policies: List[RetryPolicy] = None,
         kms_key=None,
     ):
-        """Construct a ProcessingStep, given a `Processor` instance.
+        """Construct a `ProcessingStep`, given a `Processor` instance.
 
-        In addition to the processor instance, the other arguments are those that are supplied to
+        In addition to the `Processor` instance, the other arguments are those that are supplied to
         the `process` method of the `sagemaker.processing.Processor`.
 
         Args:
-            name (str): The name of the processing step.
+            name (str): The name of the `ProcessingStep`.
             processor (Processor): A `sagemaker.processing.Processor` instance.
-            display_name (str): The display name of the processing step.
-            description (str): The description of the processing step.
+            display_name (str): The display name of the `ProcessingStep`.
+            description (str): The description of the `ProcessingStep`
             inputs (List[ProcessingInput]): A list of `sagemaker.processing.ProcessorInput`
                 instances. Defaults to `None`.
             outputs (List[ProcessingOutput]): A list of `sagemaker.processing.ProcessorOutput`
@@ -512,9 +512,9 @@ class ProcessingStep(ConfigurableRetryStep):
             property_files (List[PropertyFile]): A list of property files that workflow looks
                 for and resolves from the configured processing output list.
             cache_config (CacheConfig):  A `sagemaker.workflow.steps.CacheConfig` instance.
-            depends_on (List[str] or List[Step]): A list of step names or step instance
-                this `sagemaker.workflow.steps.ProcessingStep` depends on
-            retry_policies (List[RetryPolicy]):  A list of retry policy
+            depends_on (List[str] or List[Step]): A list of `Step` names or `Step` instances that
+                this `sagemaker.workflow.steps.ProcessingStep` depends on.
+            retry_policies (List[RetryPolicy]):  A list of retry policies.
             kms_key (str): The ARN of the KMS key that is used to encrypt the
                 user code file. Defaults to `None`.
         """
@@ -530,8 +530,8 @@ class ProcessingStep(ConfigurableRetryStep):
         self.job_name = None
         self.kms_key = kms_key
 
-        # Examine why run method in sagemaker.processing.Processor mutates the processor instance
-        # by setting the instance's arguments attribute. Refactor Processor.run, if possible.
+        # Examine why run method in `sagemaker.processing.Processor` mutates the processor instance
+        # by setting the instance's arguments attribute. Refactor `Processor.run`, if possible.
         self.processor.arguments = job_arguments
 
         self._properties = Properties(
@@ -542,20 +542,20 @@ class ProcessingStep(ConfigurableRetryStep):
         if code:
             code_url = urlparse(code)
             if code_url.scheme == "" or code_url.scheme == "file":
-                # By default, Processor will upload the local code to an S3 path
+                # By default, `Processor` will upload the local code to an S3 path
                 # containing a timestamp. This causes cache misses whenever a
                 # pipeline is updated, even if the underlying script hasn't changed.
                 # To avoid this, hash the contents of the script and include it
-                # in the job_name passed to the Processor, which will be used
+                # in the `job_name` passed to the `Processor`, which will be used
                 # instead of the timestamped path.
                 self.job_name = self._generate_code_upload_path()
 
     @property
     def arguments(self) -> RequestType:
-        """The arguments dict that is used to call `create_processing_job`.
+        """The arguments dictionary that is used to call `create_processing_job`.
 
-        NOTE: The CreateProcessingJob request is not quite the args list that workflow needs.
-        ProcessingJobName and ExperimentConfig cannot be included in the arguments.
+        NOTE: The `CreateProcessingJob` request is not quite the args list that workflow needs.
+        `ProcessingJobName` and `ExperimentConfig` cannot be included in the arguments.
         """
         normalized_inputs, normalized_outputs = self.processor._normalize_args(
             job_name=self.job_name,
@@ -575,7 +575,7 @@ class ProcessingStep(ConfigurableRetryStep):
 
     @property
     def properties(self):
-        """A Properties object representing the DescribeProcessingJobResponse data model."""
+        """A `Properties` object representing the `DescribeProcessingJobResponse` data model."""
         return self._properties
 
     def to_request(self) -> RequestType:
@@ -590,7 +590,7 @@ class ProcessingStep(ConfigurableRetryStep):
         return request_dict
 
     def _generate_code_upload_path(self) -> str:
-        """Generate an upload path for local processing scripts based on its contents"""
+        """Generate an upload path for local processing scripts based on its contents."""
         from sagemaker.workflow.utilities import hash_file
 
         code_hash = hash_file(self.code)
@@ -598,7 +598,7 @@ class ProcessingStep(ConfigurableRetryStep):
 
 
 class TuningStep(ConfigurableRetryStep):
-    """Tuning step for workflow."""
+    """`TuningStep` for SageMaker Pipelines Workflows."""
 
     def __init__(
         self,
@@ -612,24 +612,24 @@ class TuningStep(ConfigurableRetryStep):
         depends_on: Union[List[str], List[Step]] = None,
         retry_policies: List[RetryPolicy] = None,
     ):
-        """Construct a TuningStep, given a `HyperparameterTuner` instance.
+        """Construct a `TuningStep`, given a `HyperparameterTuner` instance.
 
-        In addition to the tuner instance, the other arguments are those that are supplied to
+        In addition to the `HyperparameterTuner` instance, the other arguments are those that are supplied to
         the `fit` method of the `sagemaker.tuner.HyperparameterTuner`.
 
         Args:
-            name (str): The name of the tuning step.
+            name (str): The name of the `TuningStep`.
             tuner (HyperparameterTuner): A `sagemaker.tuner.HyperparameterTuner` instance.
-            display_name (str): The display name of the tuning step.
-            description (str): The description of the tuning step.
+            display_name (str): The display name of the `TuningStep`.
+            description (str): The description of the `TuningStep`.
             inputs: Information about the training data. Please refer to the
-                ``fit()`` method of the associated estimator, as this can take
+                `fit()` method of the associated estimator, as this can take
                 any of the following forms:
 
                 * (str) - The S3 location where training data is saved.
                 * (dict[str, str] or dict[str, sagemaker.inputs.TrainingInput]) -
                     If using multiple channels for training data, you can specify
-                    a dict mapping channel names to strings or
+                    a dictionary mapping channel names to strings or
                     :func:`~sagemaker.inputs.TrainingInput` objects.
                 * (sagemaker.inputs.TrainingInput) - Channel configuration for S3 data sources
                     that can provide additional information about the training dataset.
@@ -652,9 +652,9 @@ class TuningStep(ConfigurableRetryStep):
             job_arguments (List[str]): A list of strings to be passed into the processing job.
                 Defaults to `None`.
             cache_config (CacheConfig):  A `sagemaker.workflow.steps.CacheConfig` instance.
-            depends_on (List[str] or List[Step]): A list of step names or step instance
-                this `sagemaker.workflow.steps.ProcessingStep` depends on
-            retry_policies (List[RetryPolicy]):  A list of retry policy
+            depends_on (List[str] or List[Step]): A list of `Step` names or `Step` instances that 
+                this `sagemaker.workflow.steps.ProcessingStep` depends on.
+            retry_policies (List[RetryPolicy]):  A list of retry policies.
         """
         super(TuningStep, self).__init__(
             name, StepTypeEnum.TUNING, display_name, description, depends_on, retry_policies
@@ -673,11 +673,11 @@ class TuningStep(ConfigurableRetryStep):
 
     @property
     def arguments(self) -> RequestType:
-        """The arguments dict that is used to call `create_hyper_parameter_tuning_job`.
+        """The arguments dictionary that is used to call `create_hyper_parameter_tuning_job`.
 
-        NOTE: The CreateHyperParameterTuningJob request is not quite the
+        NOTE: The `CreateHyperParameterTuningJob` request is not quite the
             args list that workflow needs.
-        The HyperParameterTuningJobName attribute cannot be included.
+        The `HyperParameterTuningJobName` attribute cannot be included.
         """
         if self.tuner.estimator is not None:
             self.tuner.estimator._prepare_for_training()
@@ -694,8 +694,7 @@ class TuningStep(ConfigurableRetryStep):
 
     @property
     def properties(self):
-        """A Properties object representing
-
+        """A `Properties` object representing
         `DescribeHyperParameterTuningJobResponse` and
         `ListTrainingJobsForHyperParameterTuningJobResponse` data model.
         """
@@ -710,15 +709,15 @@ class TuningStep(ConfigurableRetryStep):
         return request_dict
 
     def get_top_model_s3_uri(self, top_k: int, s3_bucket: str, prefix: str = "") -> Join:
-        """Get the model artifact s3 uri from the top performing training jobs.
+        """Get the model artifact S3 URI from the top performing training jobs.
 
         Args:
-            top_k (int): the index of the top performing training job
-                tuning step stores up to 50 top performing training jobs, hence
-                a valid top_k value is from 0 to 49. The best training job
-                model is at index 0
-            s3_bucket (str): the s3 bucket to store the training job output artifact
-            prefix (str): the s3 key prefix to store the training job output artifact
+            top_k (int): The index of the top performing training job
+                tuning step stores up to 50 top performing training jobs. 
+                A valid top_k value is from 0 to 49. The best training job
+                model is at index 0.
+            s3_bucket (str): The S3 bucket to store the training job output artifact.
+            prefix (str): The S3 key prefix to store the training job output artifact.
         """
         values = ["s3:/", s3_bucket]
         if prefix != "" and prefix is not None:

--- a/src/sagemaker/workflow/steps.py
+++ b/src/sagemaker/workflow/steps.py
@@ -147,8 +147,9 @@ class CacheConfig:
     If caching is enabled, the pipeline attempts to find a previous execution of a `Step`
     that was called with the same arguments. `Step` caching only considers successful execution.
     If a successful previous execution is found, the pipeline propagates the values
-    from the previous execution rather than recomputing the `Step`. When multiple successful executions
-    exist within the timeout period, it uses the result for the most recent successful execution.
+    from the previous execution rather than recomputing the `Step`.
+    When multiple successful executions exist within the timeout period,
+    it uses the result for the most recent successful execution.
 
 
     Attributes:
@@ -237,8 +238,8 @@ class TrainingStep(ConfigurableRetryStep):
     ):
         """Construct a `TrainingStep`, given an `EstimatorBase` instance.
 
-        In addition to the `EstimatorBase` instance, the other arguments are those that are supplied to
-        the `fit` method of the `sagemaker.estimator.Estimator`.
+        In addition to the `EstimatorBase` instance, the other arguments are those
+        that are supplied to the `fit` method of the `sagemaker.estimator.Estimator`.
 
         Args:
             name (str): The name of the `TrainingStep`.
@@ -408,8 +409,8 @@ class TransformStep(ConfigurableRetryStep):
     ):
         """Constructs a `TransformStep`, given a `Transformer` instance.
 
-        In addition to the `Transformer` instance, the other arguments are those that are supplied to
-        the `transform` method of the `sagemaker.transformer.Transformer`.
+        In addition to the `Transformer` instance, the other arguments are those
+        that are supplied to the `transform` method of the `sagemaker.transformer.Transformer`.
 
         Args:
             name (str): The name of the `TransformStep`.
@@ -614,8 +615,8 @@ class TuningStep(ConfigurableRetryStep):
     ):
         """Construct a `TuningStep`, given a `HyperparameterTuner` instance.
 
-        In addition to the `HyperparameterTuner` instance, the other arguments are those that are supplied to
-        the `fit` method of the `sagemaker.tuner.HyperparameterTuner`.
+        In addition to the `HyperparameterTuner` instance, the other arguments are those
+        that are supplied to the `fit` method of the `sagemaker.tuner.HyperparameterTuner`.
 
         Args:
             name (str): The name of the `TuningStep`.
@@ -652,7 +653,7 @@ class TuningStep(ConfigurableRetryStep):
             job_arguments (List[str]): A list of strings to be passed into the processing job.
                 Defaults to `None`.
             cache_config (CacheConfig):  A `sagemaker.workflow.steps.CacheConfig` instance.
-            depends_on (List[str] or List[Step]): A list of `Step` names or `Step` instances that 
+            depends_on (List[str] or List[Step]): A list of `Step` names or `Step` instances that
                 this `sagemaker.workflow.steps.ProcessingStep` depends on.
             retry_policies (List[RetryPolicy]):  A list of retry policies.
         """
@@ -694,8 +695,9 @@ class TuningStep(ConfigurableRetryStep):
 
     @property
     def properties(self):
-        """A `Properties` object representing
-        `DescribeHyperParameterTuningJobResponse` and
+        """A `Properties` object
+
+        A `Properties` object representing `DescribeHyperParameterTuningJobResponse` and
         `ListTrainingJobsForHyperParameterTuningJobResponse` data model.
         """
         return self._properties
@@ -713,7 +715,7 @@ class TuningStep(ConfigurableRetryStep):
 
         Args:
             top_k (int): The index of the top performing training job
-                tuning step stores up to 50 top performing training jobs. 
+                tuning step stores up to 50 top performing training jobs.
                 A valid top_k value is from 0 to 49. The best training job
                 model is at index 0.
             s3_bucket (str): The S3 bucket to store the training job output artifact.

--- a/src/sagemaker/workflow/steps.py
+++ b/src/sagemaker/workflow/steps.py
@@ -62,6 +62,7 @@ class StepTypeEnum(Enum, metaclass=DefaultEnumMeta):
     QUALITY_CHECK = "QualityCheck"
     CLARIFY_CHECK = "ClarifyCheck"
     EMR = "EMR"
+    FAIL = "Fail"
 
 
 @attr.s

--- a/tests/integ/test_workflow_with_fail_steps.py
+++ b/tests/integ/test_workflow_with_fail_steps.py
@@ -1,0 +1,325 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from __future__ import absolute_import
+
+import pytest
+from botocore.exceptions import WaiterError
+
+from sagemaker import get_execution_role, utils
+from sagemaker.workflow.condition_step import ConditionStep
+from sagemaker.workflow.conditions import ConditionEquals
+from sagemaker.workflow.fail_step import FailStep
+
+from sagemaker.workflow.functions import Join
+from sagemaker.workflow.parameters import ParameterInteger, ParameterString
+from sagemaker.workflow.pipeline import Pipeline
+
+
+@pytest.fixture
+def role(sagemaker_session):
+    return get_execution_role(sagemaker_session)
+
+
+@pytest.fixture
+def pipeline_name():
+    return utils.unique_name_from_base("my-pipeline-fail-step")
+
+
+def test_two_step_fail_pipeline_with_str_err_msg(sagemaker_session, role, pipeline_name):
+    param = ParameterInteger(name="MyInt", default_value=2)
+    cond = ConditionEquals(left=param, right=1)
+    step_fail = FailStep(
+        name="FailStep",
+        error_message="Failed due to hitting in else branch",
+    )
+    step_cond = ConditionStep(
+        name="CondStep",
+        conditions=[cond],
+        if_steps=[],
+        else_steps=[step_fail],
+    )
+    pipeline = Pipeline(
+        name=pipeline_name,
+        steps=[step_cond],
+        sagemaker_session=sagemaker_session,
+        parameters=[param],
+    )
+
+    try:
+        response = pipeline.create(role)
+        pipeline_arn = response["PipelineArn"]
+        execution = pipeline.start(parameters={})
+        response = execution.describe()
+        assert response["PipelineArn"] == pipeline_arn
+
+        try:
+            execution.wait(delay=30, max_attempts=60)
+        except WaiterError:
+            pass
+        execution_steps = execution.list_steps()
+
+        assert len(execution_steps) == 2
+        for execution_step in execution_steps:
+            if execution_step["StepName"] == "CondStep":
+                assert execution_step["StepStatus"] == "Succeeded"
+                continue
+            assert execution_step["StepName"] == "FailStep"
+            assert execution_step["StepStatus"] == "Failed"
+            assert execution_step["FailureReason"] == "Failed due to hitting in else branch"
+            metadata = execution_steps[0]["Metadata"]["Fail"]
+            assert metadata["ErrorMessage"] == "Failed due to hitting in else branch"
+
+        # Check FailureReason field in ListPipelineExecutions
+        executions = sagemaker_session.sagemaker_client.list_pipeline_executions(
+            PipelineName=pipeline.name
+        )["PipelineExecutionSummaries"]
+
+        assert len(executions) == 1
+        assert executions[0]["PipelineExecutionStatus"] == "Failed"
+        assert (
+            "Step failure: One or multiple steps failed"
+            in executions[0]["PipelineExecutionFailureReason"]
+        )
+    finally:
+        try:
+            pipeline.delete()
+        except Exception:
+            pass
+
+
+def test_two_step_fail_pipeline_with_parameter_err_msg(sagemaker_session, role, pipeline_name):
+    cond_param = ParameterInteger(name="MyInt")
+    cond = ConditionEquals(left=cond_param, right=1)
+    err_msg_param = ParameterString(name="MyString")
+    step_fail = FailStep(
+        name="FailStep",
+        error_message=err_msg_param,
+    )
+    step_cond = ConditionStep(
+        name="CondStep",
+        conditions=[cond],
+        if_steps=[],
+        else_steps=[step_fail],
+    )
+    pipeline = Pipeline(
+        name=pipeline_name,
+        steps=[step_cond],
+        sagemaker_session=sagemaker_session,
+        parameters=[cond_param, err_msg_param],
+    )
+
+    try:
+        response = pipeline.create(role)
+        pipeline_arn = response["PipelineArn"]
+        execution = pipeline.start(
+            parameters={
+                "MyInt": 3,
+                "MyString": "Failed due to hitting in else branch",
+            }
+        )
+        response = execution.describe()
+        assert response["PipelineArn"] == pipeline_arn
+
+        try:
+            execution.wait(delay=30, max_attempts=60)
+        except WaiterError:
+            pass
+        execution_steps = execution.list_steps()
+
+        assert len(execution_steps) == 2
+        for execution_step in execution_steps:
+            if execution_step["StepName"] == "CondStep":
+                assert execution_step["StepStatus"] == "Succeeded"
+                continue
+            assert execution_step["StepName"] == "FailStep"
+            assert execution_step["StepStatus"] == "Failed"
+            assert execution_step["FailureReason"] == "Failed due to hitting in else branch"
+            metadata = execution_steps[0]["Metadata"]["Fail"]
+            assert metadata["ErrorMessage"] == "Failed due to hitting in else branch"
+
+        # Check FailureReason field in ListPipelineExecutions
+        executions = sagemaker_session.sagemaker_client.list_pipeline_executions(
+            PipelineName=pipeline.name
+        )["PipelineExecutionSummaries"]
+
+        assert len(executions) == 1
+        assert executions[0]["PipelineExecutionStatus"] == "Failed"
+        assert (
+            "Step failure: One or multiple steps failed"
+            in executions[0]["PipelineExecutionFailureReason"]
+        )
+    finally:
+        try:
+            pipeline.delete()
+        except Exception:
+            pass
+
+
+def test_two_step_fail_pipeline_with_join_fn(sagemaker_session, role, pipeline_name):
+    param = ParameterInteger(name="MyInt", default_value=2)
+    cond = ConditionEquals(left=param, right=1)
+    step_cond = ConditionStep(
+        name="CondStep",
+        conditions=[cond],
+        if_steps=[],
+        else_steps=[],
+    )
+    step_fail = FailStep(
+        name="FailStep",
+        error_message=Join(
+            on=": ", values=["Failed due to xxx == yyy returns", step_cond.properties.Outcome]
+        ),
+    )
+    pipeline = Pipeline(
+        name=pipeline_name,
+        steps=[step_cond, step_fail],
+        sagemaker_session=sagemaker_session,
+        parameters=[param],
+    )
+
+    try:
+        response = pipeline.create(role)
+        pipeline_arn = response["PipelineArn"]
+        execution = pipeline.start(
+            parameters={"MyInt": 3},
+        )
+        response = execution.describe()
+        assert response["PipelineArn"] == pipeline_arn
+
+        try:
+            execution.wait(delay=30, max_attempts=60)
+        except WaiterError:
+            pass
+        execution_steps = execution.list_steps()
+
+        assert len(execution_steps) == 2
+        for execution_step in execution_steps:
+            if execution_step["StepName"] == "CondStep":
+                assert execution_step["StepStatus"] == "Succeeded"
+                continue
+            assert execution_step["StepName"] == "FailStep"
+            assert execution_step["StepStatus"] == "Failed"
+            assert execution_step["FailureReason"] == "Failed due to xxx == yyy returns: false"
+            metadata = execution_steps[0]["Metadata"]["Fail"]
+            assert metadata["ErrorMessage"] == "Failed due to xxx == yyy returns: false"
+
+        # Check FailureReason field in ListPipelineExecutions
+        executions = sagemaker_session.sagemaker_client.list_pipeline_executions(
+            PipelineName=pipeline.name
+        )["PipelineExecutionSummaries"]
+
+        assert len(executions) == 1
+        assert executions[0]["PipelineExecutionStatus"] == "Failed"
+        assert (
+            "Step failure: One or multiple steps failed"
+            in executions[0]["PipelineExecutionFailureReason"]
+        )
+    finally:
+        try:
+            pipeline.delete()
+        except Exception:
+            pass
+
+
+def test_two_step_fail_pipeline_with_no_err_msg(sagemaker_session, role, pipeline_name):
+    param = ParameterInteger(name="MyInt", default_value=2)
+    cond = ConditionEquals(left=param, right=1)
+    step_fail = FailStep(
+        name="FailStep",
+    )
+    step_cond = ConditionStep(
+        name="CondStep",
+        conditions=[cond],
+        if_steps=[],
+        else_steps=[step_fail],
+    )
+    pipeline = Pipeline(
+        name=pipeline_name,
+        steps=[step_cond],
+        sagemaker_session=sagemaker_session,
+        parameters=[param],
+    )
+
+    try:
+        response = pipeline.create(role)
+        pipeline_arn = response["PipelineArn"]
+        execution = pipeline.start(parameters={})
+        response = execution.describe()
+        assert response["PipelineArn"] == pipeline_arn
+
+        try:
+            execution.wait(delay=30, max_attempts=60)
+        except WaiterError:
+            pass
+        execution_steps = execution.list_steps()
+
+        assert len(execution_steps) == 2
+        for execution_step in execution_steps:
+            if execution_step["StepName"] == "CondStep":
+                assert execution_step["StepStatus"] == "Succeeded"
+                continue
+            assert execution_step["StepName"] == "FailStep"
+            assert execution_step["StepStatus"] == "Failed"
+            assert execution_step.get("FailureReason", None) is None
+            metadata = execution_steps[0]["Metadata"]["Fail"]
+            assert metadata["ErrorMessage"] == ""
+
+        # Check FailureReason field in ListPipelineExecutions
+        executions = sagemaker_session.sagemaker_client.list_pipeline_executions(
+            PipelineName=pipeline.name
+        )["PipelineExecutionSummaries"]
+
+        assert len(executions) == 1
+        assert executions[0]["PipelineExecutionStatus"] == "Failed"
+        assert (
+            "Step failure: One or multiple steps failed"
+            in executions[0]["PipelineExecutionFailureReason"]
+        )
+    finally:
+        try:
+            pipeline.delete()
+        except Exception:
+            pass
+
+
+def test_invalid_pipeline_depended_on_fail_step(sagemaker_session, role, pipeline_name):
+    param = ParameterInteger(name="MyInt", default_value=2)
+    cond = ConditionEquals(left=param, right=1)
+    step_fail = FailStep(
+        name="FailStep",
+        error_message="Failed pipeline execution",
+    )
+    step_cond = ConditionStep(
+        name="CondStep",
+        conditions=[cond],
+        if_steps=[],
+        else_steps=[],
+        depends_on=["FailStep"],
+    )
+    pipeline = Pipeline(
+        name=pipeline_name,
+        steps=[step_cond, step_fail],
+        sagemaker_session=sagemaker_session,
+        parameters=[param],
+    )
+
+    try:
+        with pytest.raises(Exception) as error:
+            pipeline.create(role)
+
+        assert "CondStep can not depends on FailStep" in str(error.value)
+    finally:
+        try:
+            pipeline.delete()
+        except Exception:
+            pass

--- a/tests/unit/sagemaker/workflow/test_fail_step.py
+++ b/tests/unit/sagemaker/workflow/test_fail_step.py
@@ -116,6 +116,6 @@ def test_fail_step_with_properties_ref():
         fail_step.properties()
 
     assert (
-        str(error.value) == "The Properties object is not available for the Fail step "
-        "as it cannot be referenced by other steps."
+        str(error.value)
+        == "FailStep is a terminal step and the Properties object is not available for it."
     )

--- a/tests/unit/sagemaker/workflow/test_fail_step.py
+++ b/tests/unit/sagemaker/workflow/test_fail_step.py
@@ -1,0 +1,121 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from __future__ import absolute_import
+
+import json
+
+import pytest
+
+from sagemaker.workflow.condition_step import ConditionStep
+from sagemaker.workflow.conditions import ConditionEquals
+from sagemaker.workflow.fail_step import FailStep
+from sagemaker.workflow.functions import Join
+from sagemaker.workflow.parameters import ParameterInteger
+from sagemaker.workflow.pipeline import Pipeline
+
+
+def test_fail_step():
+    fail_step = FailStep(
+        name="MyFailStep",
+        depends_on=["TestStep"],
+        error_message="Test error message",
+    )
+    fail_step.add_depends_on(["SecondTestStep"])
+    assert fail_step.to_request() == {
+        "Name": "MyFailStep",
+        "Type": "Fail",
+        "DependsOn": ["TestStep", "SecondTestStep"],
+        "Arguments": {"ErrorMessage": "Test error message"},
+    }
+
+
+def test_fail_step_with_no_error_message():
+    fail_step = FailStep(
+        name="MyFailStep",
+        depends_on=["TestStep"],
+    )
+    fail_step.add_depends_on(["SecondTestStep"])
+    assert fail_step.to_request() == {
+        "Name": "MyFailStep",
+        "Type": "Fail",
+        "DependsOn": ["TestStep", "SecondTestStep"],
+        "Arguments": {"ErrorMessage": ""},
+    }
+
+
+def test_fail_step_with_join_fn_in_error_message():
+    param = ParameterInteger(name="MyInt", default_value=2)
+    cond = ConditionEquals(left=param, right=1)
+    step_cond = ConditionStep(
+        name="CondStep",
+        conditions=[cond],
+        if_steps=[],
+        else_steps=[],
+    )
+    step_fail = FailStep(
+        name="FailStep",
+        error_message=Join(
+            on=": ", values=["Failed due to xxx == yyy returns", step_cond.properties.Outcome]
+        ),
+    )
+    pipeline = Pipeline(
+        name="MyPipeline",
+        steps=[step_cond, step_fail],
+        parameters=[param],
+    )
+
+    _expected_dsl = [
+        {
+            "Name": "CondStep",
+            "Type": "Condition",
+            "Arguments": {
+                "Conditions": [
+                    {"Type": "Equals", "LeftValue": {"Get": "Parameters.MyInt"}, "RightValue": 1}
+                ],
+                "IfSteps": [],
+                "ElseSteps": [],
+            },
+        },
+        {
+            "Name": "FailStep",
+            "Type": "Fail",
+            "Arguments": {
+                "ErrorMessage": {
+                    "Std:Join": {
+                        "On": ": ",
+                        "Values": [
+                            "Failed due to xxx == yyy returns",
+                            {"Get": "Steps.CondStep.Outcome"},
+                        ],
+                    }
+                }
+            },
+        },
+    ]
+
+    assert json.loads(pipeline.definition())["Steps"] == _expected_dsl
+
+
+def test_fail_step_with_properties_ref():
+    fail_step = FailStep(
+        name="MyFailStep",
+        error_message="Test error message",
+    )
+
+    with pytest.raises(Exception) as error:
+        fail_step.properties()
+
+    assert (
+        str(error.value) == "The Properties object is not available for the Fail step "
+        "as it cannot be referenced by other steps."
+    )


### PR DESCRIPTION
*Description of changes:* Add FailStep support for SageMaker model building pipeline.

*Testing done:* unit tests and integ tests

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [X] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [X] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [X] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [X] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [X] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [X] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [X] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [X] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [X] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
