### PR TITLE
update instance types for integ test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -363,7 +363,8 @@ def cpu_instance_type(sagemaker_session, request):
 
 @pytest.fixture(scope="module")
 def gpu_instance_type(request):
-    return "ml.p2.xlarge"
+    return "ml.p3.2xlarge"
+#     return "ml.p2.xlarge"
 
 
 @pytest.fixture(scope="session")
@@ -408,7 +409,8 @@ def pytest_generate_tests(metafunc):
             region in tests.integ.HOSTING_NO_P2_REGIONS
             or region in tests.integ.TRAINING_NO_P2_REGIONS
         ):
-            params.append("ml.p2.xlarge")
+#             params.append("ml.p2.xlarge")
+            params.append("ml.p3.2xlarge")
         metafunc.parametrize("instance_type", params, scope="session")
 
     _generate_all_framework_version_fixtures(metafunc)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -364,6 +364,8 @@ def cpu_instance_type(sagemaker_session, request):
 @pytest.fixture(scope="module")
 def gpu_instance_type(request):
     return "ml.p3.2xlarge"
+
+
 #     return "ml.p2.xlarge"
 
 
@@ -409,7 +411,7 @@ def pytest_generate_tests(metafunc):
             region in tests.integ.HOSTING_NO_P2_REGIONS
             or region in tests.integ.TRAINING_NO_P2_REGIONS
         ):
-#             params.append("ml.p2.xlarge")
+
             params.append("ml.p3.2xlarge")
         metafunc.parametrize("instance_type", params, scope="session")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -366,9 +366,6 @@ def gpu_instance_type(request):
     return "ml.p3.2xlarge"
 
 
-#     return "ml.p2.xlarge"
-
-
 @pytest.fixture(scope="session")
 def inf_instance_type(sagemaker_session, request):
     return "ml.inf1.xlarge"
@@ -411,7 +408,6 @@ def pytest_generate_tests(metafunc):
             region in tests.integ.HOSTING_NO_P2_REGIONS
             or region in tests.integ.TRAINING_NO_P2_REGIONS
         ):
-
             params.append("ml.p3.2xlarge")
         metafunc.parametrize("instance_type", params, scope="session")
 

--- a/tests/integ/test_horovod.py
+++ b/tests/integ/test_horovod.py
@@ -59,7 +59,6 @@ def test_hvd_gpu(
         sagemaker_session,
         tensorflow_training_latest_version,
         tensorflow_training_latest_py_version,
-#         "ml.p2.xlarge",
         "ml.p3.2xlarge",
         tmpdir,
     )

--- a/tests/integ/test_horovod.py
+++ b/tests/integ/test_horovod.py
@@ -59,7 +59,8 @@ def test_hvd_gpu(
         sagemaker_session,
         tensorflow_training_latest_version,
         tensorflow_training_latest_py_version,
-        "ml.p2.xlarge",
+#         "ml.p2.xlarge",
+        "ml.p3.2xlarge",
         tmpdir,
     )
 


### PR DESCRIPTION
*Issue #, if available:*
Due to unavailability of ml.p2.xlarge instances we have updated to ml.p3.2xlarge instance type.
*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
