### PR TITLE
fix: pin pytest-xdist to avoid release failures

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ extras["test"] = (
         "pytest-cov",
         "pytest-rerunfailures",
         "pytest-timeout",
-        "pytest-xdist",
+        "pytest-xdist==2.4.0",
         "coverage<6.2",
         "mock",
         "contextlib2",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Release builds are failing on xdist dependency. Pinning xdist to unblock releases.
```
py36 run-test: commands[1] | pytest --cov=sagemaker --cov-append tests/integ -m release -n 8 --boxed --reruns 4 --boto-config '{"region_name": "us-east-2"}'
INTERNALERROR> Traceback (most recent call last):
INTERNALERROR>   File "/codebuild/output/src863200597/src/.tox/py36/lib/python3.6/site-packages/_pytest/main.py", line 236, in wrap_session
INTERNALERROR>     config._do_configure()
INTERNALERROR>   File "/codebuild/output/src863200597/src/.tox/py36/lib/python3.6/site-packages/_pytest/config/__init__.py", line 911, in _do_configure
INTERNALERROR>     self.hook.pytest_configure.call_historic(kwargs=dict(config=self))
INTERNALERROR>   File "/codebuild/output/src863200597/src/.tox/py36/lib/python3.6/site-packages/pluggy/_hooks.py", line 277, in call_historic
INTERNALERROR>     res = self._hookexec(self.name, self.get_hookimpls(), kwargs, False)
INTERNALERROR>   File "/codebuild/output/src863200597/src/.tox/py36/lib/python3.6/site-packages/pluggy/_manager.py", line 80, in _hookexec
INTERNALERROR>     return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
INTERNALERROR>   File "/codebuild/output/src863200597/src/.tox/py36/lib/python3.6/site-packages/pluggy/_callers.py", line 60, in _multicall
INTERNALERROR>     return outcome.get_result()
INTERNALERROR>   File "/codebuild/output/src863200597/src/.tox/py36/lib/python3.6/site-packages/pluggy/_result.py", line 60, in get_result
INTERNALERROR>     raise ex[1].with_traceback(ex[2])
INTERNALERROR>   File "/codebuild/output/src863200597/src/.tox/py36/lib/python3.6/site-packages/pluggy/_callers.py", line 39, in _multicall
INTERNALERROR>     res = hook_impl.function(*args)
INTERNALERROR>   File "/codebuild/output/src863200597/src/.tox/py36/lib/python3.6/site-packages/xdist/plugin.py", line 205, in pytest_configure
INTERNALERROR>     config.issue_config_time_warning(warning, 2)
INTERNALERROR> AttributeError: 'Config' object has no attribute 'issue_config_time_warning'
ERROR: InvocationError for command /codebuild/output/src863200597/src/.tox/py36/bin/pytest --cov=sagemaker --cov-append tests/integ -m release -n 8 --boxed --reruns 4 --boto-config '{"region_name": "us-east-2"}' (exited with code 3)
```

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
