### PR TITLE
fix: Revert "feature: CompilationStep support for Sagemaker Pipelines…

### DIFF
--- a/doc/workflows/pipelines/sagemaker.workflow.pipelines.rst
+++ b/doc/workflows/pipelines/sagemaker.workflow.pipelines.rst
@@ -140,8 +140,6 @@ Steps
 
 .. autoclass:: sagemaker.workflow.lambda_step.LambdaStep
 
-.. autoclass:: sagemaker.workflow.steps.CompilationStep
-
 .. autoclass:: sagemaker.workflow.quality_check_step.QualityCheckConfig
 
 .. autoclass:: sagemaker.workflow.quality_check_step.QualityCheckStep

--- a/src/sagemaker/inputs.py
+++ b/src/sagemaker/inputs.py
@@ -137,67 +137,6 @@ class CreateModelInput(object):
 
 
 @attr.s
-class CompilationInput(object):
-    """Create a class containing all the parameters.
-
-    It can be used when calling ``sagemaker.model.Model.compile_model()``
-
-    Parameters:
-        target_instance_type(str): Identifies the device that you want to
-                run your model after compilation, for example: ml_c5. For allowed
-                strings see
-                https://docs.aws.amazon.com/sagemaker/latest/dg/API_OutputConfig.html.
-        input_shape(str): Specifies the name and shape of the expected
-                inputs for your trained model in json dictionary form, for
-                example: {'data': [1,3,1024,1024]}, or {'var1': [1,1,28,28],
-                'var2': [1,1,28,28]}
-        output_path(str): Specifies where to store the compiled model
-        framework (str, optional): The framework that is used to train the original
-                model. Allowed values: 'mxnet', 'tensorflow', 'keras', 'pytorch',
-                'onnx', 'xgboost' (default: None)
-        framework_version (str, optional): The version of the framework (default: None)
-        compile_max_run (int, optional): Timeout in seconds for compilation (default:
-            15 * 60). After this amount of time Amazon SageMaker Neo
-            terminates the compilation job regardless of its current status.
-        tags (list[dict], optional): List of tags for labeling a compilation job.
-            For more, see
-            https://docs.aws.amazon.com/sagemaker/latest/dg/API_Tag.html.
-        job_name (str, optional): The name of the compilation job (default: None)
-        target_platform_os (str, optional): Target Platform OS, for example: 'LINUX'.
-            (default: None)
-            For allowed strings see
-            https://docs.aws.amazon.com/sagemaker/latest/dg/API_OutputConfig.html.
-            It can be used instead of target_instance_family.
-        target_platform_arch (str, optional): Target Platform Architecture, for example: 'X86_64'.
-            (default: None)
-            For allowed strings see
-            https://docs.aws.amazon.com/sagemaker/latest/dg/API_OutputConfig.html.
-            It can be used instead of target_instance_family.
-        target_platform_accelerator (str, optional): Target Platform Accelerator,
-            for example: 'NVIDIA'. (default: None)
-            For allowed strings see
-            https://docs.aws.amazon.com/sagemaker/latest/dg/API_OutputConfig.html.
-            It can be used instead of target_instance_family.
-        compiler_options (dict, optional): Additional parameters for compiler. (default: None)
-            Compiler Options are TargetPlatform / target_instance_family specific. See
-            https://docs.aws.amazon.com/sagemaker/latest/dg/API_OutputConfig.html for details.
-    """
-
-    target_instance_type: str = attr.ib(default=None)
-    input_shape: dict = attr.ib(factory=dict)
-    output_path: str = attr.ib(default=None)
-    framework: str = attr.ib(default=None)
-    framework_version: str = attr.ib(default=None)
-    compile_max_run: int = attr.ib(default=15 * 60)
-    tags: list = attr.ib(factory=list)
-    job_name: str = attr.ib(default=None)
-    target_platform_os: str = attr.ib(default=None)
-    target_platform_arch: str = attr.ib(default=None)
-    target_platform_accelerator: str = attr.ib(default=None)
-    compiler_options: dict = attr.ib(default=None)
-
-
-@attr.s
 class TransformInput(object):
     """Create a class containing all the parameters.
 

--- a/src/sagemaker/model.py
+++ b/src/sagemaker/model.py
@@ -30,7 +30,6 @@ from sagemaker import (
     utils,
     git_utils,
 )
-from sagemaker.inputs import CompilationInput
 from sagemaker.deprecations import removed_kwargs
 from sagemaker.predictor import PredictorBase
 from sagemaker.serverless import ServerlessInferenceConfig
@@ -657,58 +656,6 @@ class Model(ModelBase):
             "tags": tags,
             "job_name": job_name,
         }
-
-    def _get_compilation_args(self, estimator, inputs):
-        """Constructs a dict of arguments for an Amazon SageMaker compilation job from estimator.
-
-        Args:
-            estimator (sagemaker.estimator.EstimatorBase): Estimator object
-                created by the user.
-            inputs (CompilationInput): class containing all the parameters that
-                can be used when calling ``sagemaker.model.Model.compile_model()``
-        """
-
-        if not isinstance(inputs, CompilationInput):
-            raise TypeError("Your inputs must be provided as CompilationInput objects.")
-        target_instance_family = inputs.target_instance_type
-        input_shape = inputs.input_shape
-        output_path = inputs.output_path
-        role = estimator.role
-        compile_max_run = inputs.compile_max_run
-        job_name = estimator._compilation_job_name()
-        framework = inputs.framework or self._framework()
-        if framework is None:
-            raise ValueError(
-                "You must specify framework, allowed values {}".format(NEO_ALLOWED_FRAMEWORKS)
-            )
-        if framework not in NEO_ALLOWED_FRAMEWORKS:
-            raise ValueError(
-                "You must provide valid framework, allowed values {}".format(NEO_ALLOWED_FRAMEWORKS)
-            )
-        if self.model_data is None:
-            raise ValueError("You must provide an S3 path to the compressed model artifacts.")
-        tags = inputs.tags
-        target_platform_os = inputs.target_platform_os
-        target_platform_arch = inputs.target_platform_arch
-        target_platform_accelerator = inputs.target_platform_accelerator
-        compiler_options = inputs.compiler_options
-        framework_version = inputs.framework_version or self._get_framework_version()
-
-        return self._compilation_job_config(
-            target_instance_family,
-            input_shape,
-            output_path,
-            role,
-            compile_max_run,
-            job_name,
-            framework,
-            tags,
-            target_platform_os,
-            target_platform_arch,
-            target_platform_accelerator,
-            compiler_options,
-            framework_version,
-        )
 
     def _compilation_image_uri(self, region, target_instance_type, framework, framework_version):
         """Retrieve the Neo or Inferentia image URI.

--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -1845,57 +1845,6 @@ class Session(object):  # pylint: disable=too-many-public-methods
         LOGGER.info("Creating compilation-job with name: %s", job_name)
         self.sagemaker_client.create_compilation_job(**compilation_job_request)
 
-    def _get_compilation_request(
-        self,
-        job_name,
-        input_model_config,
-        output_model_config,
-        role,
-        stop_condition,
-        tags=None,
-        vpc_config=None,
-    ):
-        """Construct CreateCompilationJob request
-
-        Args:
-            input_model_config (dict): the trained model and the Amazon S3 location where it is
-                stored.
-            output_model_config (dict): Identifies the Amazon S3 location where you want Amazon
-                SageMaker Neo to save the results of compilation job
-            role (str): An AWS IAM role (either name or full ARN). The Amazon SageMaker Neo
-                compilation jobs use this role to access model artifacts. You must grant
-                sufficient permissions to this role.
-            job_name (str): Name of the compilation job being created.
-            stop_condition (dict): Defines when compilation job shall finish. Contains entries
-                that can be understood by the service like ``MaxRuntimeInSeconds``.
-            tags (list[dict]): List of tags for labeling a compile model job. For more, see
-                https://docs.aws.amazon.com/sagemaker/latest/dg/API_Tag.html.
-            vpc_config (dict): Contains values for VpcConfig:
-                * subnets (list[str]): List of subnet ids.
-                The key in vpc_config is 'Subnets'.
-                * security_group_ids (list[str]): List of security group ids.
-                The key in vpc_config is 'SecurityGroupIds'.
-        Returns:
-            dict: A dictionary for CreateCompilationJob request
-        """
-
-        compilation_request = {
-            "InputConfig": input_model_config,
-            "OutputConfig": output_model_config,
-            "RoleArn": role,
-            "StoppingCondition": stop_condition,
-            "CompilationJobName": job_name,
-        }
-
-        tags = _append_project_tags(tags)
-        if tags is not None:
-            compilation_request["Tags"] = tags
-
-        if vpc_config is not None:
-            compilation_request["VpcConfig"] = vpc_config
-
-        return compilation_request
-
     def package_model_for_edge(
         self,
         output_model_config,

--- a/tests/unit/sagemaker/workflow/test_steps.py
+++ b/tests/unit/sagemaker/workflow/test_steps.py
@@ -27,7 +27,7 @@ from mock import (
 from sagemaker.debugger import DEBUGGER_FLAG, ProfilerConfig
 from sagemaker.estimator import Estimator
 from sagemaker.tensorflow import TensorFlow
-from sagemaker.inputs import TrainingInput, TransformInput, CreateModelInput, CompilationInput
+from sagemaker.inputs import TrainingInput, TransformInput, CreateModelInput
 from sagemaker.model import Model
 from sagemaker.processing import (
     Processor,
@@ -53,7 +53,6 @@ from sagemaker.workflow.retry import (
 )
 from sagemaker.workflow.steps import (
     ProcessingStep,
-    CompilationStep,
     ConfigurableRetryStep,
     StepTypeEnum,
     TrainingStep,
@@ -1276,52 +1275,5 @@ def test_multi_algo_tuning_step(sagemaker_session):
                     },
                 },
             ],
-        },
-    }
-
-
-def test_compilation_step(sagemaker_session):
-    estimator = Estimator(
-        image_uri=IMAGE_URI,
-        role=ROLE,
-        instance_count=1,
-        instance_type="ml.c5.4xlarge",
-        profiler_config=ProfilerConfig(system_monitor_interval_millis=500),
-        rules=[],
-        sagemaker_session=sagemaker_session,
-    )
-
-    model = Model(
-        image_uri=IMAGE_URI,
-        model_data="s3://output/tensorflow.tar.gz",
-        sagemaker_session=sagemaker_session,
-    )
-
-    compilation_input = CompilationInput(
-        target_instance_type="ml_inf",
-        input_shape={"data": [1, 3, 1024, 1024]},
-        output_path="s3://output",
-        compile_max_run=100,
-        framework="tensorflow",
-        job_name="compile-model",
-        compiler_options=None,
-    )
-    compilation_step = CompilationStep(
-        name="MyCompilationStep", estimator=estimator, model=model, inputs=compilation_input
-    )
-
-    assert compilation_step.to_request() == {
-        "Name": "MyCompilationStep",
-        "Type": "Compilation",
-        "Arguments": {
-            "InputConfig": {
-                "DataInputConfig": '{"data": [1, 3, 1024, 1024]}',
-                "Framework": "TENSORFLOW",
-                "S3Uri": "s3://output/tensorflow.tar.gz",
-            },
-            "OutputConfig": {"S3OutputLocation": "s3://output", "TargetDevice": "ml_inf"},
-            "RoleArn": ROLE,
-            "StoppingCondition": {"MaxRuntimeInSeconds": 100},
-            "Tags": [],
         },
     }


### PR DESCRIPTION
… (#2740)"

This reverts commit eee1d74dbc936184ab22e05cc5c57685a7d76963.

*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
