### PR TITLE
fix: Add CMH to the non-P3 list

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,6 +54,7 @@ NO_P3_REGIONS = [
     "ap-northeast-1",  # it has p3, but not enough
     "ap-south-1",
     "ap-northeast-2",  # it has p3, but not enough
+    "us-east-2",  # it has p3, but not enough
 ]
 
 NO_T2_REGIONS = ["eu-north-1", "ap-east-1", "me-south-1"]

--- a/tests/integ/__init__.py
+++ b/tests/integ/__init__.py
@@ -83,6 +83,7 @@ TRAINING_NO_P3_REGIONS = [
     "ap-northeast-1",  # it has p3, but not enough
     "ap-south-1",
     "ap-northeast-2",  # it has p3, but not enough
+    "us-east-2",  # it has p3, but not enough
 ]
 
 # EI is currently only supported in the following regions


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add CMH to the non-P3 list
Low p3 availability in CMH has caused failures in pipeline release.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
