### PR TITLE
fix: EstimatorTransformer entry point error

### DIFF
--- a/tests/unit/sagemaker/workflow/test_step_collections.py
+++ b/tests/unit/sagemaker/workflow/test_step_collections.py
@@ -825,7 +825,7 @@ def test_estimator_transformer(sagemaker_session):
         repack_model_step_retry_policies=[service_fault_retry_policy],
         image_uri=IMAGE_URI,
         sagemaker_session=sagemaker_session,
-        role=ROLE
+        role=ROLE,
     )
     request_dicts = estimator_transformer.request_dicts()
     assert len(request_dicts) == 2
@@ -868,6 +868,7 @@ def test_estimator_transformer(sagemaker_session):
         else:
             raise Exception("A step exists in the collection of an invalid type.")
 
+
 def test_estimator_transformer_with_model_repack(sagemaker_session):
     model_data = f"s3://{BUCKET}/model.tar.gz"
     model_inputs = CreateModelInput(
@@ -894,7 +895,7 @@ def test_estimator_transformer_with_model_repack(sagemaker_session):
         sagemaker_session=sagemaker_session,
         role=ROLE,
         entry_point=f"{DATA_DIR}/dummy_script.py",
-        dependencies=[dummy_requirements]
+        dependencies=[dummy_requirements],
     )
     request_dicts = estimator_transformer.request_dicts()
     assert len(request_dicts) == 3
@@ -959,11 +960,11 @@ def test_estimator_transformer_with_model_repack(sagemaker_session):
             assert isinstance(arguments["PrimaryContainer"]["ModelDataUrl"], Properties)
             arguments["PrimaryContainer"].pop("ModelDataUrl")
             assert arguments == {
-                    "ExecutionRoleArn": "DummyRole",
-                    "PrimaryContainer": {
-                        "Environment": {},
-                        "Image": "fakeimage",
-                }
+                "ExecutionRoleArn": "DummyRole",
+                "PrimaryContainer": {
+                    "Environment": {},
+                    "Image": "fakeimage",
+                },
             }
 
         elif request_dict["Type"] == "Transform":

--- a/tests/unit/sagemaker/workflow/test_step_collections.py
+++ b/tests/unit/sagemaker/workflow/test_step_collections.py
@@ -802,7 +802,7 @@ def test_register_model_with_model_repack_with_pipeline_model(
             raise Exception("A step exists in the collection of an invalid type.")
 
 
-def test_estimator_transformer(estimator):
+def test_estimator_transformer(sagemaker_session):
     model_data = f"s3://{BUCKET}/model.tar.gz"
     model_inputs = CreateModelInput(
         instance_type="c4.4xlarge",
@@ -814,7 +814,6 @@ def test_estimator_transformer(estimator):
     transform_inputs = TransformInput(data=f"s3://{BUCKET}/transform_manifest")
     estimator_transformer = EstimatorTransformer(
         name="EstimatorTransformerStep",
-        estimator=estimator,
         model_data=model_data,
         model_inputs=model_inputs,
         instance_count=1,
@@ -824,6 +823,9 @@ def test_estimator_transformer(estimator):
         model_step_retry_policies=[service_fault_retry_policy],
         transform_step_retry_policies=[service_fault_retry_policy],
         repack_model_step_retry_policies=[service_fault_retry_policy],
+        image_uri=IMAGE_URI,
+        sagemaker_session=sagemaker_session,
+        role=ROLE
     )
     request_dicts = estimator_transformer.request_dicts()
     assert len(request_dicts) == 2


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
`EstimatorTransformer` currently does not work when `entry_point` argument is provided. Additionally, `EstimatorTransformer` contains a required argument `estimator`, where it is only used to identify `sagemaker_session`, `role`, `subnets` and `security_group_ids`. The docstrings are also not updated.

The proposed change is to: 
1.  Ensure `EstimatorTransformer` works with `entry_point` argument.
2. Remove `estimator` and add `sagemaker_session` and `role` as arguments.
3. Update `EstimatorTransformer` docstrings.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
