### PR TITLE
feature: Adding support for PT 1.10 in SageMaker Training Compiler

### DIFF
--- a/src/sagemaker/image_uri_config/huggingface-training-compiler.json
+++ b/src/sagemaker/image_uri_config/huggingface-training-compiler.json
@@ -7,8 +7,20 @@
         "versions": {
             "4.11.0": {
                 "version_aliases": {
+                    "pytorch1.10": "pytorch1.10.0",
                     "pytorch1.9": "pytorch1.9.0",
                     "tensorflow2.5": "tensorflow2.5.1"
+                },
+                "pytorch1.10.0": {
+                    "py_versions": ["py38"],
+                    "registries": {
+                        "eu-west-1": "763104351884",
+                        "us-east-1": "763104351884",
+                        "us-east-2": "763104351884",
+                        "us-west-2": "763104351884"
+                    },
+                    "repository": "huggingface-pytorch-trcomp-training",
+                    "container_version": {"gpu":"cu113-ubuntu20.04"}
                 },
                 "pytorch1.9.0": {
                     "py_versions": ["py38"],

--- a/src/sagemaker/image_uri_config/huggingface-training-compiler.json
+++ b/src/sagemaker/image_uri_config/huggingface-training-compiler.json
@@ -7,11 +7,11 @@
         "versions": {
             "4.11.0": {
                 "version_aliases": {
-                    "pytorch1.10": "pytorch1.10.0",
+                    "pytorch1.10": "pytorch1.10.2",
                     "pytorch1.9": "pytorch1.9.0",
                     "tensorflow2.5": "tensorflow2.5.1"
                 },
-                "pytorch1.10.0": {
+                "pytorch1.10.2": {
                     "py_versions": ["py38"],
                     "registries": {
                         "eu-west-1": "763104351884",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adding support for PT 1.10 in the HuggingFace estimator (change specific to SageMaker Training Compiler)

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
