### PR TITLE
fix: Add lineage doc

### DIFF
--- a/doc/workflows/index.rst
+++ b/doc/workflows/index.rst
@@ -10,3 +10,4 @@ The SageMaker Python SDK supports managed training and inference for a variety o
     airflow/index
     step_functions/index
     pipelines/index
+    lineage/index

--- a/doc/workflows/lineage/index.rst
+++ b/doc/workflows/lineage/index.rst
@@ -1,0 +1,11 @@
+###################
+SageMaker Lineage
+###################
+Amazon SageMaker ML Lineage Tracking creates and stores information about the steps of a machine learning (ML) workflow from data preparation to model deployment. With the tracking information, you can reproduce the workflow steps, track model and dataset lineage, and establish model governance and audit standards.
+
+SageMaker APIs for creating and managing SageMaker Lineage.
+
+.. toctree::
+    :maxdepth: 2
+
+    sagemaker.lineage

--- a/doc/workflows/lineage/sagemaker.lineage.rst
+++ b/doc/workflows/lineage/sagemaker.lineage.rst
@@ -1,0 +1,70 @@
+Lineage
+=========
+
+
+Artifact
+-------------
+
+.. autoclass:: sagemaker.lineage.artifact.Artifact
+
+.. autoclass:: sagemaker.lineage.artifact.ModelArtifact
+
+.. autoclass:: sagemaker.lineage.artifact.DatasetArtifact
+
+.. autoclass:: sagemaker.lineage.artifact.ImageArtifact
+
+
+Actions
+-------------
+
+.. autoclass:: sagemaker.lineage.action.Action
+
+.. autoclass:: sagemaker.lineage.action.ModelPackageApprovalAction
+
+
+Association
+-------------
+
+.. autoclass:: sagemaker.lineage.association.Association
+
+
+Context
+-------------
+
+.. autoclass:: sagemaker.lineage.context.Context
+
+.. autoclass:: sagemaker.lineage.context.EndpointContext
+
+.. autoclass:: sagemaker.lineage.context.ModelPackageGroup
+
+
+Lineage Trial Component
+--------------------------
+
+.. autoclass:: sagemaker.lineage.lineage_trial_component.LineageTrialComponent
+
+
+Query
+-------------
+
+.. autoclass:: sagemaker.lineage.query.LineageEntityEnum
+
+.. autoclass:: sagemaker.lineage.query.LineageSourceEnum
+
+.. autoclass:: sagemaker.lineage.query.LineageQueryDirectionEnum
+
+.. autoclass:: sagemaker.lineage.query.Edge
+
+.. autoclass:: sagemaker.lineage.query.Vertex
+
+.. autoclass:: sagemaker.lineage.query.LineageQueryResult
+
+.. autoclass:: sagemaker.lineage.query.LineageFilter
+
+.. autoclass:: sagemaker.lineage.query.LineageQuery
+
+
+Visualizer
+-------------
+
+.. autoclass:: sagemaker.lineage.visualizer.LineageTableVisualizer


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add lineage docs in https://sagemaker.readthedocs.io/en/stable/index.html

*Testing done:*
NA

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
