### PR TITLE
fix: update lineage_trial_compoment get pipeline execution arn

### DIFF
--- a/src/sagemaker/lineage/lineage_trial_component.py
+++ b/src/sagemaker/lineage/lineage_trial_component.py
@@ -130,8 +130,15 @@ class LineageTrialComponent(_base_types.Record):
         Returns:
             str: A pipeline execution ARN.
         """
+        trial_component = self.load(
+            trial_component_name=self.trial_component_name, sagemaker_session=self.sagemaker_session
+        )
+
+        if trial_component.source is None or trial_component.source["SourceArn"] is None:
+            return None
+
         tags = self.sagemaker_session.sagemaker_client.list_tags(
-            ResourceArn=self.trial_component_arn
+            ResourceArn=trial_component.source["SourceArn"]
         )["Tags"]
         for tag in tags:
             if tag["Key"] == "sagemaker:pipeline-execution-arn":

--- a/tests/integ/sagemaker/lineage/conftest.py
+++ b/tests/integ/sagemaker/lineage/conftest.py
@@ -233,7 +233,7 @@ def upstream_trial_associated_artifact(
         sagemaker_session=sagemaker_session,
     )
     trial_obj.add_trial_component(trial_component_obj)
-    time.sleep(3)
+    time.sleep(4)
     yield artifact_obj
     trial_obj.remove_trial_component(trial_component_obj)
     assntn.delete()
@@ -561,14 +561,14 @@ def static_approval_action(
 
 
 @pytest.fixture
-def static_model_deployment_action(sagemaker_session, static_endpoint_context):
+def static_model_deployment_action(sagemaker_session, static_processing_job_trial_component):
     query_filter = LineageFilter(
         entities=[LineageEntityEnum.ACTION], sources=[LineageSourceEnum.MODEL_DEPLOYMENT]
     )
     query_result = LineageQuery(sagemaker_session).query(
-        start_arns=[static_endpoint_context.context_arn],
+        start_arns=[static_processing_job_trial_component.trial_component_arn],
         query_filter=query_filter,
-        direction=LineageQueryDirectionEnum.ASCENDANTS,
+        direction=LineageQueryDirectionEnum.DESCENDANTS,
         include_edges=False,
     )
     model_approval_actions = []
@@ -579,14 +579,14 @@ def static_model_deployment_action(sagemaker_session, static_endpoint_context):
 
 @pytest.fixture
 def static_processing_job_trial_component(
-    sagemaker_session, static_endpoint_context
+    sagemaker_session, static_dataset_artifact
 ) -> LineageTrialComponent:
     query_filter = LineageFilter(
         entities=[LineageEntityEnum.TRIAL_COMPONENT], sources=[LineageSourceEnum.PROCESSING_JOB]
     )
 
     query_result = LineageQuery(sagemaker_session).query(
-        start_arns=[static_endpoint_context.context_arn],
+        start_arns=[static_dataset_artifact.artifact_arn],
         query_filter=query_filter,
         direction=LineageQueryDirectionEnum.ASCENDANTS,
         include_edges=False,
@@ -600,14 +600,14 @@ def static_processing_job_trial_component(
 
 @pytest.fixture
 def static_training_job_trial_component(
-    sagemaker_session, static_endpoint_context
+    sagemaker_session, static_model_artifact
 ) -> LineageTrialComponent:
     query_filter = LineageFilter(
         entities=[LineageEntityEnum.TRIAL_COMPONENT], sources=[LineageSourceEnum.TRAINING_JOB]
     )
 
     query_result = LineageQuery(sagemaker_session).query(
-        start_arns=[static_endpoint_context.context_arn],
+        start_arns=[static_model_artifact.artifact_arn],
         query_filter=query_filter,
         direction=LineageQueryDirectionEnum.ASCENDANTS,
         include_edges=False,
@@ -738,12 +738,12 @@ def static_dataset_artifact(static_model_artifact, sagemaker_session):
 
 
 @pytest.fixture
-def static_image_artifact(static_model_artifact, sagemaker_session):
+def static_image_artifact(static_dataset_artifact, sagemaker_session):
     query_filter = LineageFilter(
         entities=[LineageEntityEnum.ARTIFACT], sources=[LineageSourceEnum.IMAGE]
     )
     query_result = LineageQuery(sagemaker_session).query(
-        start_arns=[static_model_artifact.artifact_arn],
+        start_arns=[static_dataset_artifact.artifact_arn],
         query_filter=query_filter,
         direction=LineageQueryDirectionEnum.ASCENDANTS,
         include_edges=False,

--- a/tests/unit/sagemaker/lineage/test_lineage_trial_component.py
+++ b/tests/unit/sagemaker/lineage/test_lineage_trial_component.py
@@ -114,9 +114,28 @@ def test_pipeline_execution_arn(sagemaker_session):
     trial_component_arn = (
         "arn:aws:sagemaker:us-west-2:123456789012:trial_component/lineage-unit-3b05f017-0d87-4c37"
     )
-    obj = lineage_trial_component.LineageTrialComponent(
-        sagemaker_session, trial_component_name="foo", trial_component_arn=trial_component_arn
+    training_job_arn = (
+        "arn:aws:sagemaker:us-west-2:123456789012:training-job/pipelines-bs6gaeln463r-abalonetrain"
     )
+    context = lineage_trial_component.LineageTrialComponent(
+        sagemaker_session,
+        trial_component_name="foo",
+        trial_component_arn=trial_component_arn,
+        source={
+            "SourceArn": training_job_arn,
+            "SourceType": "SageMakerTrainingJob",
+        },
+    )
+    obj = {
+        "TrialComponentName": "pipelines-bs6gaeln463r-AbaloneTrain-A0QiDGuY6z-aws-training-job",
+        "TrialComponentArn": trial_component_arn,
+        "DisplayName": "pipelines-bs6gaeln463r-AbaloneTrain-A0QiDGuY6z-aws-training-job",
+        "Source": {
+            "SourceArn": training_job_arn,
+            "SourceType": "SageMakerTrainingJob",
+        },
+    }
+    sagemaker_session.sagemaker_client.describe_trial_component.return_value = obj
 
     sagemaker_session.sagemaker_client.list_tags.return_value = {
         "Tags": [
@@ -124,9 +143,10 @@ def test_pipeline_execution_arn(sagemaker_session):
         ],
     }
     expected_calls = [
-        unittest.mock.call(ResourceArn=trial_component_arn),
+        unittest.mock.call(ResourceArn=training_job_arn),
     ]
-    pipeline_execution_arn_result = obj.pipeline_execution_arn()
+    pipeline_execution_arn_result = context.pipeline_execution_arn()
+
     assert pipeline_execution_arn_result == "tag1"
     assert expected_calls == sagemaker_session.sagemaker_client.list_tags.mock_calls
 
@@ -135,9 +155,28 @@ def test_no_pipeline_execution_arn(sagemaker_session):
     trial_component_arn = (
         "arn:aws:sagemaker:us-west-2:123456789012:trial_component/lineage-unit-3b05f017-0d87-4c37"
     )
-    obj = lineage_trial_component.LineageTrialComponent(
-        sagemaker_session, trial_component_name="foo", trial_component_arn=trial_component_arn
+    training_job_arn = (
+        "arn:aws:sagemaker:us-west-2:123456789012:training-job/pipelines-bs6gaeln463r-abalonetrain"
     )
+    context = lineage_trial_component.LineageTrialComponent(
+        sagemaker_session,
+        trial_component_name="foo",
+        trial_component_arn=trial_component_arn,
+        source={
+            "SourceArn": training_job_arn,
+            "SourceType": "SageMakerTrainingJob",
+        },
+    )
+    obj = {
+        "TrialComponentName": "pipelines-bs6gaeln463r-AbaloneTrain-A0QiDGuY6z-aws-training-job",
+        "TrialComponentArn": trial_component_arn,
+        "DisplayName": "pipelines-bs6gaeln463r-AbaloneTrain-A0QiDGuY6z-aws-training-job",
+        "Source": {
+            "SourceArn": training_job_arn,
+            "SourceType": "SageMakerTrainingJob",
+        },
+    }
+    sagemaker_session.sagemaker_client.describe_trial_component.return_value = obj
 
     sagemaker_session.sagemaker_client.list_tags.return_value = {
         "Tags": [
@@ -145,9 +184,48 @@ def test_no_pipeline_execution_arn(sagemaker_session):
         ],
     }
     expected_calls = [
-        unittest.mock.call(ResourceArn=trial_component_arn),
+        unittest.mock.call(ResourceArn=training_job_arn),
     ]
-    pipeline_execution_arn_result = obj.pipeline_execution_arn()
+    pipeline_execution_arn_result = context.pipeline_execution_arn()
+    expected_result = None
+    assert pipeline_execution_arn_result == expected_result
+    assert expected_calls == sagemaker_session.sagemaker_client.list_tags.mock_calls
+
+
+def test_no_source_arn_pipeline_execution_arn(sagemaker_session):
+    trial_component_arn = (
+        "arn:aws:sagemaker:us-west-2:123456789012:trial_component/lineage-unit-3b05f017-0d87-4c37"
+    )
+    training_job_arn = (
+        "arn:aws:sagemaker:us-west-2:123456789012:training-job/pipelines-bs6gaeln463r-abalonetrain"
+    )
+    context = lineage_trial_component.LineageTrialComponent(
+        sagemaker_session,
+        trial_component_name="foo",
+        trial_component_arn=trial_component_arn,
+        source={
+            "SourceArn": training_job_arn,
+            "SourceType": "SageMakerTrainingJob",
+        },
+    )
+    obj = {
+        "TrialComponentName": "pipelines-bs6gaeln463r-AbaloneTrain-A0QiDGuY6z-aws-training-job",
+        "TrialComponentArn": trial_component_arn,
+        "DisplayName": "pipelines-bs6gaeln463r-AbaloneTrain-A0QiDGuY6z-aws-training-job",
+        "Source": {
+            "SourceArn": None,
+            "SourceType": None,
+        },
+    }
+    sagemaker_session.sagemaker_client.describe_trial_component.return_value = obj
+
+    sagemaker_session.sagemaker_client.list_tags.return_value = {
+        "Tags": [
+            {"Key": "abcd", "Value": "efg"},
+        ],
+    }
+    expected_calls = []
+    pipeline_execution_arn_result = context.pipeline_execution_arn()
     expected_result = None
     assert pipeline_execution_arn_result == expected_result
     assert expected_calls == sagemaker_session.sagemaker_client.list_tags.mock_calls


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Update lineage_trial_compoment pipeline execution arn method, get the pipeline execution arn by passing source arn instead of trial component arn.
- Update partial integ test to rely on trial component instead of endpoint_context


*Testing done:*
 tox -e py36 -- tests/integ/sagemaker/lineage

```tests/integ/sagemaker/lineage/test_action.py ...........                                                  [ 19%]
tests/integ/sagemaker/lineage/test_artifact.py ............                                               [ 40%]
tests/integ/sagemaker/lineage/test_association.py ....                                                    [ 47%]
tests/integ/sagemaker/lineage/test_context.py ........                                                    [ 61%]
tests/integ/sagemaker/lineage/test_dataset_artifact.py ....                                               [ 68%]
tests/integ/sagemaker/lineage/test_endpoint_context.py ........                                           [ 82%]
tests/integ/sagemaker/lineage/test_image_artifact.py .                                                    [ 84%]
tests/integ/sagemaker/lineage/test_lineage_trial_component.py ...                                         [ 89%]
tests/integ/sagemaker/lineage/test_model_artifact.py .....                                                [ 98%]
tests/integ/sagemaker/lineage/test_model_package_group_context.py .                                       [100%]/

======================================== 57 passed in 686.06s (0:11:26) =========================================

```
## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
