### PR TITLE
fix: jumpstart model table

### DIFF
--- a/doc/doc_utils/jumpstart_doc_utils.py
+++ b/doc/doc_utils/jumpstart_doc_utils.py
@@ -78,7 +78,7 @@ def create_jumpstart_model_table():
     file_content.append("     - Latest Version\n")
     file_content.append("     - Min SDK Version\n")
 
-    for model in sorted(sdk_manifest, key=lambda elt: elt["model_id"]):
+    for model in sdk_manifest_top_versions_for_models.values():
         model_spec = get_jumpstart_sdk_spec(model["spec_key"])
         file_content.append("   * - {}\n".format(model["model_id"]))
         file_content.append("     - {}\n".format(model_spec["training_supported"]))


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR changes the data source used to populate the JumpStart available models table in docs so there are no redundant entries.

*Testing done:*
The doc build script was ran and verified

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
