### PR TITLE
fix: container env generation for S3 URI and add test for the same

### DIFF
--- a/src/sagemaker/model.py
+++ b/src/sagemaker/model.py
@@ -476,7 +476,8 @@ class Model(ModelBase):
             else:
                 dir_name = self.uploaded_code.s3_prefix
         elif self.entry_point is not None:
-            if self.source_dir is not None:
+            script_name = self.entry_point
+        if self.source_dir is not None:
                 dir_name = (
                     self.source_dir
                     if self.source_dir.startswith("s3://")

--- a/src/sagemaker/model.py
+++ b/src/sagemaker/model.py
@@ -466,7 +466,7 @@ class Model(ModelBase):
             )
 
     def _script_mode_env_vars(self):
-        """Placeholder docstring"""
+        """Returns a mapping of environment variables for script mode execution"""
         script_name = None
         dir_name = None
         if self.uploaded_code:
@@ -476,9 +476,12 @@ class Model(ModelBase):
             else:
                 dir_name = self.uploaded_code.s3_prefix
         elif self.entry_point is not None:
-            script_name = self.entry_point
             if self.source_dir is not None:
-                dir_name = "file://" + self.source_dir
+                dir_name = (
+                    self.source_dir
+                    if self.source_dir.startswith("s3://")
+                    else "file://" + self.source_dir
+                )
 
         return {
             SCRIPT_PARAM_NAME.upper(): script_name or str(),

--- a/src/sagemaker/model.py
+++ b/src/sagemaker/model.py
@@ -477,13 +477,12 @@ class Model(ModelBase):
                 dir_name = self.uploaded_code.s3_prefix
         elif self.entry_point is not None:
             script_name = self.entry_point
-        if self.source_dir is not None:
+            if self.source_dir is not None:
                 dir_name = (
                     self.source_dir
                     if self.source_dir.startswith("s3://")
                     else "file://" + self.source_dir
                 )
-
         return {
             SCRIPT_PARAM_NAME.upper(): script_name or str(),
             DIR_PARAM_NAME.upper(): dir_name or str(),

--- a/tests/unit/sagemaker/model/test_framework_model.py
+++ b/tests/unit/sagemaker/model/test_framework_model.py
@@ -112,23 +112,6 @@ def test_prepare_container_def(time, sagemaker_session):
         "ModelDataUrl": MODEL_DATA,
     }
 
-@patch("shutil.rmtree", MagicMock())
-@patch("tarfile.open", MagicMock())
-@patch("os.listdir", MagicMock(return_value=["blah.py"]))
-@patch("time.strftime", return_value=TIMESTAMP)
-def test_prepare_container_def_s3_src(time, sagemaker_session):
-    model = DummyFrameworkModel(sagemaker_session, source_dir=S3_SOURCE_DIR)
-    assert model.prepare_container_def(INSTANCE_TYPE) == {
-        "Environment": {
-            "SAGEMAKER_PROGRAM": ENTRY_POINT,
-            "SAGEMAKER_SUBMIT_DIRECTORY": "s3://somebucket/sourcedir.tar.gz",
-            "SAGEMAKER_CONTAINER_LOG_LEVEL": "20",
-            "SAGEMAKER_REGION": REGION,
-        },
-        "Image": MODEL_IMAGE,
-        "ModelDataUrl": MODEL_DATA,
-    }
-S3_SOURCE_DIR
 
 @patch("shutil.rmtree", MagicMock())
 @patch("tarfile.open", MagicMock())

--- a/tests/unit/sagemaker/model/test_framework_model.py
+++ b/tests/unit/sagemaker/model/test_framework_model.py
@@ -25,6 +25,7 @@ MODEL_DATA = "s3://bucket/model.tar.gz"
 MODEL_IMAGE = "mi"
 ENTRY_POINT = "blah.py"
 ROLE = "some-role"
+S3_SOURCE_DIR = "s3://somebucket/sourcedir.tar.gz"
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), "..", "data")
 SCRIPT_NAME = "dummy_script.py"
@@ -111,6 +112,23 @@ def test_prepare_container_def(time, sagemaker_session):
         "ModelDataUrl": MODEL_DATA,
     }
 
+@patch("shutil.rmtree", MagicMock())
+@patch("tarfile.open", MagicMock())
+@patch("os.listdir", MagicMock(return_value=["blah.py"]))
+@patch("time.strftime", return_value=TIMESTAMP)
+def test_prepare_container_def_s3_src(time, sagemaker_session):
+    model = DummyFrameworkModel(sagemaker_session, source_dir=S3_SOURCE_DIR)
+    assert model.prepare_container_def(INSTANCE_TYPE) == {
+        "Environment": {
+            "SAGEMAKER_PROGRAM": ENTRY_POINT,
+            "SAGEMAKER_SUBMIT_DIRECTORY": "s3://somebucket/sourcedir.tar.gz",
+            "SAGEMAKER_CONTAINER_LOG_LEVEL": "20",
+            "SAGEMAKER_REGION": REGION,
+        },
+        "Image": MODEL_IMAGE,
+        "ModelDataUrl": MODEL_DATA,
+    }
+S3_SOURCE_DIR
 
 @patch("shutil.rmtree", MagicMock())
 @patch("tarfile.open", MagicMock())

--- a/tests/unit/sagemaker/model/test_framework_model.py
+++ b/tests/unit/sagemaker/model/test_framework_model.py
@@ -25,7 +25,6 @@ MODEL_DATA = "s3://bucket/model.tar.gz"
 MODEL_IMAGE = "mi"
 ENTRY_POINT = "blah.py"
 ROLE = "some-role"
-S3_SOURCE_DIR = "s3://somebucket/sourcedir.tar.gz"
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), "..", "data")
 SCRIPT_NAME = "dummy_script.py"


### PR DESCRIPTION
*Description of changes:*
Fixes a bug wherein file:// prefix was wrongly appended even for S3 URI Paths

*Testing done:*
Ran unit tests, integs to follow here

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
