### PR TITLE
feature: Inf-Neuron support for HuggingFace

### DIFF
--- a/src/sagemaker/image_uri_config/huggingface.json
+++ b/src/sagemaker/image_uri_config/huggingface.json
@@ -7,13 +7,13 @@
             "4.6": "4.6.1",
             "4.10": "4.10.2",
             "4.11": "4.11.0",
-            "4.12": "4.12.3"
+            "4.12": "4.12.3",
         },
         "versions": {
             "4.4.2": {
                 "version_aliases": {
                     "pytorch1.6": "pytorch1.6.0",
-                    "tensorflow2.4": "tensorflow2.4.1"
+                    "tensorflow2.4": "tensorflow2.4.1",
                 },
                 "pytorch1.6.0": {
                     "py_versions": ["py36"],
@@ -42,9 +42,9 @@
                         "us-gov-west-1": "442386744353",
                         "us-iso-east-1": "886529160074",
                         "us-west-1": "763104351884",
-                        "us-west-2": "763104351884"
+                        "us-west-2": "763104351884",
                     },
-                    "repository": "huggingface-pytorch-training"
+                    "repository": "huggingface-pytorch-training",
                 },
                 "tensorflow2.4.1": {
                     "py_versions": ["py37"],
@@ -73,15 +73,15 @@
                         "us-gov-west-1": "442386744353",
                         "us-iso-east-1": "886529160074",
                         "us-west-1": "763104351884",
-                        "us-west-2": "763104351884"
+                        "us-west-2": "763104351884",
                     },
-                    "repository": "huggingface-tensorflow-training"
-                }
+                    "repository": "huggingface-tensorflow-training",
+                },
             },
             "4.5.0": {
                 "version_aliases": {
                     "pytorch1.6": "pytorch1.6.0",
-                    "tensorflow2.4": "tensorflow2.4.1"
+                    "tensorflow2.4": "tensorflow2.4.1",
                 },
                 "pytorch1.6.0": {
                     "py_versions": ["py36"],
@@ -110,9 +110,9 @@
                         "us-gov-west-1": "442386744353",
                         "us-iso-east-1": "886529160074",
                         "us-west-1": "763104351884",
-                        "us-west-2": "763104351884"
+                        "us-west-2": "763104351884",
                     },
-                    "repository": "huggingface-pytorch-training"
+                    "repository": "huggingface-pytorch-training",
                 },
                 "tensorflow2.4.1": {
                     "py_versions": ["py37"],
@@ -141,17 +141,17 @@
                         "us-gov-west-1": "442386744353",
                         "us-iso-east-1": "886529160074",
                         "us-west-1": "763104351884",
-                        "us-west-2": "763104351884"
+                        "us-west-2": "763104351884",
                     },
-                    "repository": "huggingface-tensorflow-training"
-                }
+                    "repository": "huggingface-tensorflow-training",
+                },
             },
             "4.6.1": {
                 "version_aliases": {
                     "pytorch1.6": "pytorch1.6.0",
                     "pytorch1.7": "pytorch1.7.1",
                     "pytorch1.8": "pytorch1.8.1",
-                    "tensorflow2.4": "tensorflow2.4.1"
+                    "tensorflow2.4": "tensorflow2.4.1",
                 },
                 "pytorch1.6.0": {
                     "py_versions": ["py36"],
@@ -180,10 +180,10 @@
                         "us-gov-west-1": "442386744353",
                         "us-iso-east-1": "886529160074",
                         "us-west-1": "763104351884",
-                        "us-west-2": "763104351884"
+                        "us-west-2": "763104351884",
                     },
                     "repository": "huggingface-pytorch-training",
-                    "container_version": {"gpu":"cu110-ubuntu18.04"}
+                    "container_version": {"gpu": "cu110-ubuntu18.04"},
                 },
                 "pytorch1.7.1": {
                     "py_versions": ["py36"],
@@ -212,10 +212,10 @@
                         "us-gov-west-1": "442386744353",
                         "us-iso-east-1": "886529160074",
                         "us-west-1": "763104351884",
-                        "us-west-2": "763104351884"
+                        "us-west-2": "763104351884",
                     },
                     "repository": "huggingface-pytorch-training",
-                    "container_version": {"gpu":"cu110-ubuntu18.04"}
+                    "container_version": {"gpu": "cu110-ubuntu18.04"},
                 },
                 "pytorch1.8.1": {
                     "py_versions": ["py36"],
@@ -244,10 +244,10 @@
                         "us-gov-west-1": "442386744353",
                         "us-iso-east-1": "886529160074",
                         "us-west-1": "763104351884",
-                        "us-west-2": "763104351884"
+                        "us-west-2": "763104351884",
                     },
                     "repository": "huggingface-pytorch-training",
-                    "container_version": {"gpu":"cu111-ubuntu18.04"}
+                    "container_version": {"gpu": "cu111-ubuntu18.04"},
                 },
                 "tensorflow2.4.1": {
                     "py_versions": ["py37"],
@@ -276,18 +276,18 @@
                         "us-gov-west-1": "442386744353",
                         "us-iso-east-1": "886529160074",
                         "us-west-1": "763104351884",
-                        "us-west-2": "763104351884"
+                        "us-west-2": "763104351884",
                     },
                     "repository": "huggingface-tensorflow-training",
-                    "container_version": {"gpu":"cu110-ubuntu18.04"}
-                }
+                    "container_version": {"gpu": "cu110-ubuntu18.04"},
+                },
             },
             "4.10.2": {
                 "version_aliases": {
                     "pytorch1.8": "pytorch1.8.1",
                     "pytorch1.9": "pytorch1.9.0",
                     "tensorflow2.4": "tensorflow2.4.1",
-                    "tensorflow2.5": "tensorflow2.5.1"
+                    "tensorflow2.5": "tensorflow2.5.1",
                 },
                 "pytorch1.8.1": {
                     "py_versions": ["py36"],
@@ -316,10 +316,10 @@
                         "us-gov-west-1": "442386744353",
                         "us-iso-east-1": "886529160074",
                         "us-west-1": "763104351884",
-                        "us-west-2": "763104351884"
+                        "us-west-2": "763104351884",
                     },
                     "repository": "huggingface-pytorch-training",
-                    "container_version": {"gpu":"cu110-ubuntu18.04"}
+                    "container_version": {"gpu": "cu110-ubuntu18.04"},
                 },
                 "pytorch1.9.0": {
                     "py_versions": ["py38"],
@@ -348,10 +348,10 @@
                         "us-gov-west-1": "442386744353",
                         "us-iso-east-1": "886529160074",
                         "us-west-1": "763104351884",
-                        "us-west-2": "763104351884"
+                        "us-west-2": "763104351884",
                     },
                     "repository": "huggingface-pytorch-training",
-                    "container_version": {"gpu": "cu111-ubuntu20.04"}
+                    "container_version": {"gpu": "cu111-ubuntu20.04"},
                 },
                 "tensorflow2.4.1": {
                     "py_versions": ["py37"],
@@ -380,10 +380,10 @@
                         "us-gov-west-1": "442386744353",
                         "us-iso-east-1": "886529160074",
                         "us-west-1": "763104351884",
-                        "us-west-2": "763104351884"
+                        "us-west-2": "763104351884",
                     },
                     "repository": "huggingface-tensorflow-training",
-                    "container_version": {"gpu":"cu110-ubuntu18.04"}
+                    "container_version": {"gpu": "cu110-ubuntu18.04"},
                 },
                 "tensorflow2.5.1": {
                     "py_versions": ["py37"],
@@ -412,16 +412,16 @@
                         "us-gov-west-1": "442386744353",
                         "us-iso-east-1": "886529160074",
                         "us-west-1": "763104351884",
-                        "us-west-2": "763104351884"
+                        "us-west-2": "763104351884",
                     },
                     "repository": "huggingface-tensorflow-training",
-                    "container_version": {"gpu": "cu112-ubuntu18.04"}
-                }
+                    "container_version": {"gpu": "cu112-ubuntu18.04"},
+                },
             },
             "4.11.0": {
                 "version_aliases": {
                     "pytorch1.9": "pytorch1.9.0",
-                    "tensorflow2.5": "tensorflow2.5.1"
+                    "tensorflow2.5": "tensorflow2.5.1",
                 },
                 "pytorch1.9.0": {
                     "py_versions": ["py38"],
@@ -450,10 +450,10 @@
                         "us-gov-west-1": "442386744353",
                         "us-iso-east-1": "886529160074",
                         "us-west-1": "763104351884",
-                        "us-west-2": "763104351884"
+                        "us-west-2": "763104351884",
                     },
                     "repository": "huggingface-pytorch-training",
-                    "container_version": {"gpu": "cu111-ubuntu20.04"}
+                    "container_version": {"gpu": "cu111-ubuntu20.04"},
                 },
                 "tensorflow2.5.1": {
                     "py_versions": ["py37"],
@@ -482,16 +482,16 @@
                         "us-gov-west-1": "442386744353",
                         "us-iso-east-1": "886529160074",
                         "us-west-1": "763104351884",
-                        "us-west-2": "763104351884"
+                        "us-west-2": "763104351884",
                     },
                     "repository": "huggingface-tensorflow-training",
-                    "container_version": {"gpu": "cu112-ubuntu18.04"}
-                }
+                    "container_version": {"gpu": "cu112-ubuntu18.04"},
+                },
             },
             "4.12.3": {
                 "version_aliases": {
                     "pytorch1.9": "pytorch1.9.1",
-                    "tensorflow2.5": "tensorflow2.5.1"
+                    "tensorflow2.5": "tensorflow2.5.1",
                 },
                 "pytorch1.9.1": {
                     "py_versions": ["py38"],
@@ -520,10 +520,10 @@
                         "us-gov-west-1": "442386744353",
                         "us-iso-east-1": "886529160074",
                         "us-west-1": "763104351884",
-                        "us-west-2": "763104351884"
+                        "us-west-2": "763104351884",
                     },
                     "repository": "huggingface-pytorch-training",
-                    "container_version": {"gpu": "cu111-ubuntu20.04"}
+                    "container_version": {"gpu": "cu111-ubuntu20.04"},
                 },
                 "tensorflow2.5.1": {
                     "py_versions": ["py37"],
@@ -552,28 +552,22 @@
                         "us-gov-west-1": "442386744353",
                         "us-iso-east-1": "886529160074",
                         "us-west-1": "763104351884",
-                        "us-west-2": "763104351884"
+                        "us-west-2": "763104351884",
                     },
                     "repository": "huggingface-tensorflow-training",
-                    "container_version": {"gpu": "cu112-ubuntu18.04"}
-                }
-            }
-        }
-    },
-
-    "inference": {
-        "processors": ["gpu", "cpu"],
-        "version_aliases": {
-            "4.6": "4.6.1",
-            "4.10": "4.10.2",
-            "4.11": "4.11.0",
-            "4.12": "4.12.3"
+                    "container_version": {"gpu": "cu112-ubuntu18.04"},
+                },
+            },
         },
+    },
+    "inference": {
+        "processors": ["gpu", "cpu", "neuron"],
+        "version_aliases": {"4.6": "4.6.1", "4.10": "4.10.2", "4.11": "4.11.0", "4.12": "4.12.3"},
         "versions": {
             "4.6.1": {
                 "version_aliases": {
                     "pytorch1.7": "pytorch1.7.1",
-                    "tensorflow2.4": "tensorflow2.4.1"
+                    "tensorflow2.4": "tensorflow2.4.1",
                 },
                 "pytorch1.7.1": {
                     "py_versions": ["py36"],
@@ -602,10 +596,10 @@
                         "us-gov-west-1": "442386744353",
                         "us-iso-east-1": "886529160074",
                         "us-west-1": "763104351884",
-                        "us-west-2": "763104351884"
+                        "us-west-2": "763104351884",
                     },
                     "repository": "huggingface-pytorch-inference",
-                    "container_version": {"gpu":"cu110-ubuntu18.04", "cpu":"ubuntu18.04" }
+                    "container_version": {"gpu": "cu110-ubuntu18.04", "cpu": "ubuntu18.04"},
                 },
                 "pytorch1.8.1": {
                     "py_versions": ["py36"],
@@ -634,10 +628,10 @@
                         "us-gov-west-1": "442386744353",
                         "us-iso-east-1": "886529160074",
                         "us-west-1": "763104351884",
-                        "us-west-2": "763104351884"
+                        "us-west-2": "763104351884",
                     },
                     "repository": "huggingface-pytorch-inference",
-                    "container_version": {"gpu":"cu111-ubuntu18.04", "cpu":"ubuntu18.04" }
+                    "container_version": {"gpu": "cu111-ubuntu18.04", "cpu": "ubuntu18.04"},
                 },
                 "tensorflow2.4.1": {
                     "py_versions": ["py37"],
@@ -666,18 +660,18 @@
                         "us-gov-west-1": "442386744353",
                         "us-iso-east-1": "886529160074",
                         "us-west-1": "763104351884",
-                        "us-west-2": "763104351884"
+                        "us-west-2": "763104351884",
                     },
                     "repository": "huggingface-tensorflow-inference",
-                    "container_version": {"gpu":"cu110-ubuntu18.04", "cpu":"ubuntu18.04" }
-                }
+                    "container_version": {"gpu": "cu110-ubuntu18.04", "cpu": "ubuntu18.04"},
+                },
             },
             "4.10.2": {
                 "version_aliases": {
                     "pytorch1.8": "pytorch1.8.1",
                     "pytorch1.9": "pytorch1.9.0",
                     "tensorflow2.4": "tensorflow2.4.1",
-                    "tensorflow2.5": "tensorflow2.5.1"
+                    "tensorflow2.5": "tensorflow2.5.1",
                 },
                 "pytorch1.8.1": {
                     "py_versions": ["py36"],
@@ -706,10 +700,10 @@
                         "us-gov-west-1": "442386744353",
                         "us-iso-east-1": "886529160074",
                         "us-west-1": "763104351884",
-                        "us-west-2": "763104351884"
+                        "us-west-2": "763104351884",
                     },
                     "repository": "huggingface-pytorch-inference",
-                    "container_version": {"gpu":"cu111-ubuntu18.04", "cpu":"ubuntu18.04" }
+                    "container_version": {"gpu": "cu111-ubuntu18.04", "cpu": "ubuntu18.04"},
                 },
                 "pytorch1.9.0": {
                     "py_versions": ["py38"],
@@ -738,10 +732,10 @@
                         "us-gov-west-1": "442386744353",
                         "us-iso-east-1": "886529160074",
                         "us-west-1": "763104351884",
-                        "us-west-2": "763104351884"
+                        "us-west-2": "763104351884",
                     },
                     "repository": "huggingface-pytorch-inference",
-                    "container_version": {"gpu": "cu111-ubuntu20.04", "cpu": "ubuntu20.04" }
+                    "container_version": {"gpu": "cu111-ubuntu20.04", "cpu": "ubuntu20.04"},
                 },
                 "tensorflow2.4.1": {
                     "py_versions": ["py37"],
@@ -770,10 +764,10 @@
                         "us-gov-west-1": "442386744353",
                         "us-iso-east-1": "886529160074",
                         "us-west-1": "763104351884",
-                        "us-west-2": "763104351884"
+                        "us-west-2": "763104351884",
                     },
                     "repository": "huggingface-tensorflow-inference",
-                    "container_version": {"gpu":"cu110-ubuntu18.04", "cpu":"ubuntu18.04" }
+                    "container_version": {"gpu": "cu110-ubuntu18.04", "cpu": "ubuntu18.04"},
                 },
                 "tensorflow2.5.1": {
                     "py_versions": ["py37"],
@@ -802,16 +796,16 @@
                         "us-gov-west-1": "442386744353",
                         "us-iso-east-1": "886529160074",
                         "us-west-1": "763104351884",
-                        "us-west-2": "763104351884"
+                        "us-west-2": "763104351884",
                     },
                     "repository": "huggingface-tensorflow-inference",
-                    "container_version": {"gpu": "cu112-ubuntu18.04", "cpu": "ubuntu18.04" }
-                }
+                    "container_version": {"gpu": "cu112-ubuntu18.04", "cpu": "ubuntu18.04"},
+                },
             },
             "4.11.0": {
                 "version_aliases": {
                     "pytorch1.9": "pytorch1.9.0",
-                    "tensorflow2.5": "tensorflow2.5.1"
+                    "tensorflow2.5": "tensorflow2.5.1",
                 },
                 "pytorch1.9.0": {
                     "py_versions": ["py38"],
@@ -840,10 +834,10 @@
                         "us-gov-west-1": "442386744353",
                         "us-iso-east-1": "886529160074",
                         "us-west-1": "763104351884",
-                        "us-west-2": "763104351884"
+                        "us-west-2": "763104351884",
                     },
                     "repository": "huggingface-pytorch-inference",
-                    "container_version": {"gpu": "cu111-ubuntu20.04", "cpu": "ubuntu20.04" }
+                    "container_version": {"gpu": "cu111-ubuntu20.04", "cpu": "ubuntu20.04"},
                 },
                 "tensorflow2.5.1": {
                     "py_versions": ["py37"],
@@ -872,19 +866,19 @@
                         "us-gov-west-1": "442386744353",
                         "us-iso-east-1": "886529160074",
                         "us-west-1": "763104351884",
-                        "us-west-2": "763104351884"
+                        "us-west-2": "763104351884",
                     },
                     "repository": "huggingface-tensorflow-inference",
-                    "container_version": {"gpu": "cu112-ubuntu18.04", "cpu": "ubuntu18.04" }
-                }
+                    "container_version": {"gpu": "cu112-ubuntu18.04", "cpu": "ubuntu18.04"},
+                },
             },
             "4.12.3": {
                 "version_aliases": {
                     "pytorch1.9": "pytorch1.9.1",
-                    "tensorflow2.5": "tensorflow2.5.1"
+                    "tensorflow2.5": "tensorflow2.5.1",
                 },
                 "pytorch1.9.1": {
-                    "py_versions": ["py38"],
+                    "py_versions": ["py38", "py37"],
                     "registries": {
                         "af-south-1": "626614931356",
                         "ap-east-1": "871362719292",
@@ -910,10 +904,14 @@
                         "us-gov-west-1": "442386744353",
                         "us-iso-east-1": "886529160074",
                         "us-west-1": "763104351884",
-                        "us-west-2": "763104351884"
+                        "us-west-2": "763104351884",
                     },
                     "repository": "huggingface-pytorch-inference",
-                    "container_version": {"gpu": "cu111-ubuntu20.04", "cpu": "ubuntu20.04" }
+                    "container_version": {
+                        "gpu": "cu111-ubuntu20.04",
+                        "cpu": "ubuntu20.04",
+                        "neuron": "sdk1.17.1-ubuntu18.04-v1.0",
+                    },
                 },
                 "tensorflow2.5.1": {
                     "py_versions": ["py37"],
@@ -942,12 +940,12 @@
                         "us-gov-west-1": "442386744353",
                         "us-iso-east-1": "886529160074",
                         "us-west-1": "763104351884",
-                        "us-west-2": "763104351884"
+                        "us-west-2": "763104351884",
                     },
                     "repository": "huggingface-tensorflow-inference",
-                    "container_version": {"gpu": "cu112-ubuntu18.04", "cpu": "ubuntu18.04" }
-                }
-            }
-        }
-    }
+                    "container_version": {"gpu": "cu112-ubuntu18.04", "cpu": "ubuntu18.04"},
+                },
+            },
+        },
+    },
 }

--- a/src/sagemaker/image_uri_config/huggingface.json
+++ b/src/sagemaker/image_uri_config/huggingface.json
@@ -7,13 +7,13 @@
             "4.6": "4.6.1",
             "4.10": "4.10.2",
             "4.11": "4.11.0",
-            "4.12": "4.12.3",
+            "4.12": "4.12.3"
         },
         "versions": {
             "4.4.2": {
                 "version_aliases": {
                     "pytorch1.6": "pytorch1.6.0",
-                    "tensorflow2.4": "tensorflow2.4.1",
+                    "tensorflow2.4": "tensorflow2.4.1"
                 },
                 "pytorch1.6.0": {
                     "py_versions": ["py36"],
@@ -42,9 +42,9 @@
                         "us-gov-west-1": "442386744353",
                         "us-iso-east-1": "886529160074",
                         "us-west-1": "763104351884",
-                        "us-west-2": "763104351884",
+                        "us-west-2": "763104351884"
                     },
-                    "repository": "huggingface-pytorch-training",
+                    "repository": "huggingface-pytorch-training"
                 },
                 "tensorflow2.4.1": {
                     "py_versions": ["py37"],
@@ -73,15 +73,15 @@
                         "us-gov-west-1": "442386744353",
                         "us-iso-east-1": "886529160074",
                         "us-west-1": "763104351884",
-                        "us-west-2": "763104351884",
+                        "us-west-2": "763104351884"
                     },
-                    "repository": "huggingface-tensorflow-training",
-                },
+                    "repository": "huggingface-tensorflow-training"
+                }
             },
             "4.5.0": {
                 "version_aliases": {
                     "pytorch1.6": "pytorch1.6.0",
-                    "tensorflow2.4": "tensorflow2.4.1",
+                    "tensorflow2.4": "tensorflow2.4.1"
                 },
                 "pytorch1.6.0": {
                     "py_versions": ["py36"],
@@ -110,9 +110,9 @@
                         "us-gov-west-1": "442386744353",
                         "us-iso-east-1": "886529160074",
                         "us-west-1": "763104351884",
-                        "us-west-2": "763104351884",
+                        "us-west-2": "763104351884"
                     },
-                    "repository": "huggingface-pytorch-training",
+                    "repository": "huggingface-pytorch-training"
                 },
                 "tensorflow2.4.1": {
                     "py_versions": ["py37"],
@@ -141,17 +141,17 @@
                         "us-gov-west-1": "442386744353",
                         "us-iso-east-1": "886529160074",
                         "us-west-1": "763104351884",
-                        "us-west-2": "763104351884",
+                        "us-west-2": "763104351884"
                     },
-                    "repository": "huggingface-tensorflow-training",
-                },
+                    "repository": "huggingface-tensorflow-training"
+                }
             },
             "4.6.1": {
                 "version_aliases": {
                     "pytorch1.6": "pytorch1.6.0",
                     "pytorch1.7": "pytorch1.7.1",
                     "pytorch1.8": "pytorch1.8.1",
-                    "tensorflow2.4": "tensorflow2.4.1",
+                    "tensorflow2.4": "tensorflow2.4.1"
                 },
                 "pytorch1.6.0": {
                     "py_versions": ["py36"],
@@ -180,10 +180,10 @@
                         "us-gov-west-1": "442386744353",
                         "us-iso-east-1": "886529160074",
                         "us-west-1": "763104351884",
-                        "us-west-2": "763104351884",
+                        "us-west-2": "763104351884"
                     },
                     "repository": "huggingface-pytorch-training",
-                    "container_version": {"gpu": "cu110-ubuntu18.04"},
+                    "container_version": {"gpu":"cu110-ubuntu18.04"}
                 },
                 "pytorch1.7.1": {
                     "py_versions": ["py36"],
@@ -212,10 +212,10 @@
                         "us-gov-west-1": "442386744353",
                         "us-iso-east-1": "886529160074",
                         "us-west-1": "763104351884",
-                        "us-west-2": "763104351884",
+                        "us-west-2": "763104351884"
                     },
                     "repository": "huggingface-pytorch-training",
-                    "container_version": {"gpu": "cu110-ubuntu18.04"},
+                    "container_version": {"gpu":"cu110-ubuntu18.04"}
                 },
                 "pytorch1.8.1": {
                     "py_versions": ["py36"],
@@ -244,10 +244,10 @@
                         "us-gov-west-1": "442386744353",
                         "us-iso-east-1": "886529160074",
                         "us-west-1": "763104351884",
-                        "us-west-2": "763104351884",
+                        "us-west-2": "763104351884"
                     },
                     "repository": "huggingface-pytorch-training",
-                    "container_version": {"gpu": "cu111-ubuntu18.04"},
+                    "container_version": {"gpu":"cu111-ubuntu18.04"}
                 },
                 "tensorflow2.4.1": {
                     "py_versions": ["py37"],
@@ -276,18 +276,18 @@
                         "us-gov-west-1": "442386744353",
                         "us-iso-east-1": "886529160074",
                         "us-west-1": "763104351884",
-                        "us-west-2": "763104351884",
+                        "us-west-2": "763104351884"
                     },
                     "repository": "huggingface-tensorflow-training",
-                    "container_version": {"gpu": "cu110-ubuntu18.04"},
-                },
+                    "container_version": {"gpu":"cu110-ubuntu18.04"}
+                }
             },
             "4.10.2": {
                 "version_aliases": {
                     "pytorch1.8": "pytorch1.8.1",
                     "pytorch1.9": "pytorch1.9.0",
                     "tensorflow2.4": "tensorflow2.4.1",
-                    "tensorflow2.5": "tensorflow2.5.1",
+                    "tensorflow2.5": "tensorflow2.5.1"
                 },
                 "pytorch1.8.1": {
                     "py_versions": ["py36"],
@@ -316,10 +316,10 @@
                         "us-gov-west-1": "442386744353",
                         "us-iso-east-1": "886529160074",
                         "us-west-1": "763104351884",
-                        "us-west-2": "763104351884",
+                        "us-west-2": "763104351884"
                     },
                     "repository": "huggingface-pytorch-training",
-                    "container_version": {"gpu": "cu110-ubuntu18.04"},
+                    "container_version": {"gpu":"cu110-ubuntu18.04"}
                 },
                 "pytorch1.9.0": {
                     "py_versions": ["py38"],
@@ -348,10 +348,10 @@
                         "us-gov-west-1": "442386744353",
                         "us-iso-east-1": "886529160074",
                         "us-west-1": "763104351884",
-                        "us-west-2": "763104351884",
+                        "us-west-2": "763104351884"
                     },
                     "repository": "huggingface-pytorch-training",
-                    "container_version": {"gpu": "cu111-ubuntu20.04"},
+                    "container_version": {"gpu": "cu111-ubuntu20.04"}
                 },
                 "tensorflow2.4.1": {
                     "py_versions": ["py37"],
@@ -380,10 +380,10 @@
                         "us-gov-west-1": "442386744353",
                         "us-iso-east-1": "886529160074",
                         "us-west-1": "763104351884",
-                        "us-west-2": "763104351884",
+                        "us-west-2": "763104351884"
                     },
                     "repository": "huggingface-tensorflow-training",
-                    "container_version": {"gpu": "cu110-ubuntu18.04"},
+                    "container_version": {"gpu":"cu110-ubuntu18.04"}
                 },
                 "tensorflow2.5.1": {
                     "py_versions": ["py37"],
@@ -412,16 +412,16 @@
                         "us-gov-west-1": "442386744353",
                         "us-iso-east-1": "886529160074",
                         "us-west-1": "763104351884",
-                        "us-west-2": "763104351884",
+                        "us-west-2": "763104351884"
                     },
                     "repository": "huggingface-tensorflow-training",
-                    "container_version": {"gpu": "cu112-ubuntu18.04"},
-                },
+                    "container_version": {"gpu": "cu112-ubuntu18.04"}
+                }
             },
             "4.11.0": {
                 "version_aliases": {
                     "pytorch1.9": "pytorch1.9.0",
-                    "tensorflow2.5": "tensorflow2.5.1",
+                    "tensorflow2.5": "tensorflow2.5.1"
                 },
                 "pytorch1.9.0": {
                     "py_versions": ["py38"],
@@ -450,10 +450,10 @@
                         "us-gov-west-1": "442386744353",
                         "us-iso-east-1": "886529160074",
                         "us-west-1": "763104351884",
-                        "us-west-2": "763104351884",
+                        "us-west-2": "763104351884"
                     },
                     "repository": "huggingface-pytorch-training",
-                    "container_version": {"gpu": "cu111-ubuntu20.04"},
+                    "container_version": {"gpu": "cu111-ubuntu20.04"}
                 },
                 "tensorflow2.5.1": {
                     "py_versions": ["py37"],
@@ -482,16 +482,16 @@
                         "us-gov-west-1": "442386744353",
                         "us-iso-east-1": "886529160074",
                         "us-west-1": "763104351884",
-                        "us-west-2": "763104351884",
+                        "us-west-2": "763104351884"
                     },
                     "repository": "huggingface-tensorflow-training",
-                    "container_version": {"gpu": "cu112-ubuntu18.04"},
-                },
+                    "container_version": {"gpu": "cu112-ubuntu18.04"}
+                }
             },
             "4.12.3": {
                 "version_aliases": {
                     "pytorch1.9": "pytorch1.9.1",
-                    "tensorflow2.5": "tensorflow2.5.1",
+                    "tensorflow2.5": "tensorflow2.5.1"
                 },
                 "pytorch1.9.1": {
                     "py_versions": ["py38"],
@@ -520,10 +520,10 @@
                         "us-gov-west-1": "442386744353",
                         "us-iso-east-1": "886529160074",
                         "us-west-1": "763104351884",
-                        "us-west-2": "763104351884",
+                        "us-west-2": "763104351884"
                     },
                     "repository": "huggingface-pytorch-training",
-                    "container_version": {"gpu": "cu111-ubuntu20.04"},
+                    "container_version": {"gpu": "cu111-ubuntu20.04"}
                 },
                 "tensorflow2.5.1": {
                     "py_versions": ["py37"],
@@ -552,22 +552,28 @@
                         "us-gov-west-1": "442386744353",
                         "us-iso-east-1": "886529160074",
                         "us-west-1": "763104351884",
-                        "us-west-2": "763104351884",
+                        "us-west-2": "763104351884"
                     },
                     "repository": "huggingface-tensorflow-training",
-                    "container_version": {"gpu": "cu112-ubuntu18.04"},
-                },
-            },
-        },
+                    "container_version": {"gpu": "cu112-ubuntu18.04"}
+                }
+            }
+        }
     },
+
     "inference": {
         "processors": ["gpu", "cpu", "neuron"],
-        "version_aliases": {"4.6": "4.6.1", "4.10": "4.10.2", "4.11": "4.11.0", "4.12": "4.12.3"},
+        "version_aliases": {
+            "4.6": "4.6.1",
+            "4.10": "4.10.2",
+            "4.11": "4.11.0",
+            "4.12": "4.12.3"
+        },
         "versions": {
             "4.6.1": {
                 "version_aliases": {
                     "pytorch1.7": "pytorch1.7.1",
-                    "tensorflow2.4": "tensorflow2.4.1",
+                    "tensorflow2.4": "tensorflow2.4.1"
                 },
                 "pytorch1.7.1": {
                     "py_versions": ["py36"],
@@ -596,10 +602,10 @@
                         "us-gov-west-1": "442386744353",
                         "us-iso-east-1": "886529160074",
                         "us-west-1": "763104351884",
-                        "us-west-2": "763104351884",
+                        "us-west-2": "763104351884"
                     },
                     "repository": "huggingface-pytorch-inference",
-                    "container_version": {"gpu": "cu110-ubuntu18.04", "cpu": "ubuntu18.04"},
+                    "container_version": {"gpu":"cu110-ubuntu18.04", "cpu":"ubuntu18.04" }
                 },
                 "pytorch1.8.1": {
                     "py_versions": ["py36"],
@@ -628,10 +634,10 @@
                         "us-gov-west-1": "442386744353",
                         "us-iso-east-1": "886529160074",
                         "us-west-1": "763104351884",
-                        "us-west-2": "763104351884",
+                        "us-west-2": "763104351884"
                     },
                     "repository": "huggingface-pytorch-inference",
-                    "container_version": {"gpu": "cu111-ubuntu18.04", "cpu": "ubuntu18.04"},
+                    "container_version": {"gpu":"cu111-ubuntu18.04", "cpu":"ubuntu18.04" }
                 },
                 "tensorflow2.4.1": {
                     "py_versions": ["py37"],
@@ -660,18 +666,18 @@
                         "us-gov-west-1": "442386744353",
                         "us-iso-east-1": "886529160074",
                         "us-west-1": "763104351884",
-                        "us-west-2": "763104351884",
+                        "us-west-2": "763104351884"
                     },
                     "repository": "huggingface-tensorflow-inference",
-                    "container_version": {"gpu": "cu110-ubuntu18.04", "cpu": "ubuntu18.04"},
-                },
+                    "container_version": {"gpu":"cu110-ubuntu18.04", "cpu":"ubuntu18.04" }
+                }
             },
             "4.10.2": {
                 "version_aliases": {
                     "pytorch1.8": "pytorch1.8.1",
                     "pytorch1.9": "pytorch1.9.0",
                     "tensorflow2.4": "tensorflow2.4.1",
-                    "tensorflow2.5": "tensorflow2.5.1",
+                    "tensorflow2.5": "tensorflow2.5.1"
                 },
                 "pytorch1.8.1": {
                     "py_versions": ["py36"],
@@ -700,10 +706,10 @@
                         "us-gov-west-1": "442386744353",
                         "us-iso-east-1": "886529160074",
                         "us-west-1": "763104351884",
-                        "us-west-2": "763104351884",
+                        "us-west-2": "763104351884"
                     },
                     "repository": "huggingface-pytorch-inference",
-                    "container_version": {"gpu": "cu111-ubuntu18.04", "cpu": "ubuntu18.04"},
+                    "container_version": {"gpu":"cu111-ubuntu18.04", "cpu":"ubuntu18.04" }
                 },
                 "pytorch1.9.0": {
                     "py_versions": ["py38"],
@@ -732,10 +738,10 @@
                         "us-gov-west-1": "442386744353",
                         "us-iso-east-1": "886529160074",
                         "us-west-1": "763104351884",
-                        "us-west-2": "763104351884",
+                        "us-west-2": "763104351884"
                     },
                     "repository": "huggingface-pytorch-inference",
-                    "container_version": {"gpu": "cu111-ubuntu20.04", "cpu": "ubuntu20.04"},
+                    "container_version": {"gpu": "cu111-ubuntu20.04", "cpu": "ubuntu20.04" }
                 },
                 "tensorflow2.4.1": {
                     "py_versions": ["py37"],
@@ -764,10 +770,10 @@
                         "us-gov-west-1": "442386744353",
                         "us-iso-east-1": "886529160074",
                         "us-west-1": "763104351884",
-                        "us-west-2": "763104351884",
+                        "us-west-2": "763104351884"
                     },
                     "repository": "huggingface-tensorflow-inference",
-                    "container_version": {"gpu": "cu110-ubuntu18.04", "cpu": "ubuntu18.04"},
+                    "container_version": {"gpu":"cu110-ubuntu18.04", "cpu":"ubuntu18.04" }
                 },
                 "tensorflow2.5.1": {
                     "py_versions": ["py37"],
@@ -796,16 +802,16 @@
                         "us-gov-west-1": "442386744353",
                         "us-iso-east-1": "886529160074",
                         "us-west-1": "763104351884",
-                        "us-west-2": "763104351884",
+                        "us-west-2": "763104351884"
                     },
                     "repository": "huggingface-tensorflow-inference",
-                    "container_version": {"gpu": "cu112-ubuntu18.04", "cpu": "ubuntu18.04"},
-                },
+                    "container_version": {"gpu": "cu112-ubuntu18.04", "cpu": "ubuntu18.04" }
+                }
             },
             "4.11.0": {
                 "version_aliases": {
                     "pytorch1.9": "pytorch1.9.0",
-                    "tensorflow2.5": "tensorflow2.5.1",
+                    "tensorflow2.5": "tensorflow2.5.1"
                 },
                 "pytorch1.9.0": {
                     "py_versions": ["py38"],
@@ -834,10 +840,10 @@
                         "us-gov-west-1": "442386744353",
                         "us-iso-east-1": "886529160074",
                         "us-west-1": "763104351884",
-                        "us-west-2": "763104351884",
+                        "us-west-2": "763104351884"
                     },
                     "repository": "huggingface-pytorch-inference",
-                    "container_version": {"gpu": "cu111-ubuntu20.04", "cpu": "ubuntu20.04"},
+                    "container_version": {"gpu": "cu111-ubuntu20.04", "cpu": "ubuntu20.04" }
                 },
                 "tensorflow2.5.1": {
                     "py_versions": ["py37"],
@@ -866,19 +872,19 @@
                         "us-gov-west-1": "442386744353",
                         "us-iso-east-1": "886529160074",
                         "us-west-1": "763104351884",
-                        "us-west-2": "763104351884",
+                        "us-west-2": "763104351884"
                     },
                     "repository": "huggingface-tensorflow-inference",
-                    "container_version": {"gpu": "cu112-ubuntu18.04", "cpu": "ubuntu18.04"},
-                },
+                    "container_version": {"gpu": "cu112-ubuntu18.04", "cpu": "ubuntu18.04" }
+                }
             },
             "4.12.3": {
                 "version_aliases": {
                     "pytorch1.9": "pytorch1.9.1",
-                    "tensorflow2.5": "tensorflow2.5.1",
+                    "tensorflow2.5": "tensorflow2.5.1"
                 },
                 "pytorch1.9.1": {
-                    "py_versions": ["py38", "py37"],
+                    "py_versions": ["py38","py37"],
                     "registries": {
                         "af-south-1": "626614931356",
                         "ap-east-1": "871362719292",
@@ -904,14 +910,10 @@
                         "us-gov-west-1": "442386744353",
                         "us-iso-east-1": "886529160074",
                         "us-west-1": "763104351884",
-                        "us-west-2": "763104351884",
+                        "us-west-2": "763104351884"
                     },
                     "repository": "huggingface-pytorch-inference",
-                    "container_version": {
-                        "gpu": "cu111-ubuntu20.04",
-                        "cpu": "ubuntu20.04",
-                        "neuron": "sdk1.17.1-ubuntu18.04-v1.0",
-                    },
+                    "container_version": {"gpu": "cu111-ubuntu20.04", "cpu": "ubuntu20.04", "neuron": "sdk1.17.1-ubuntu18.04-v1.0" }
                 },
                 "tensorflow2.5.1": {
                     "py_versions": ["py37"],
@@ -940,12 +942,12 @@
                         "us-gov-west-1": "442386744353",
                         "us-iso-east-1": "886529160074",
                         "us-west-1": "763104351884",
-                        "us-west-2": "763104351884",
+                        "us-west-2": "763104351884"
                     },
                     "repository": "huggingface-tensorflow-inference",
-                    "container_version": {"gpu": "cu112-ubuntu18.04", "cpu": "ubuntu18.04"},
-                },
-            },
-        },
-    },
+                    "container_version": {"gpu": "cu112-ubuntu18.04", "cpu": "ubuntu18.04" }
+                }
+            }
+        }
+    }
 }

--- a/src/sagemaker/image_uris.py
+++ b/src/sagemaker/image_uris.py
@@ -169,8 +169,7 @@ def retrieve(
         ]:
             _version = version
         if processor == "neuron":
-            repo += "-" + processor
-            print("repo: ", repo)
+            repo += "-{0}".format(processor)
 
         tag_prefix = f"{pt_or_tf_version}-transformers{_version}"
 

--- a/src/sagemaker/image_uris.py
+++ b/src/sagemaker/image_uris.py
@@ -325,6 +325,8 @@ def _processor(instance_type, available_processors):
             # 'cpu' or 'gpu'.
             if family in available_processors:
                 processor = family
+            elif family.startswith("inf"):
+                processor = "inf"
             elif family[0] in ("g", "p"):
                 processor = "gpu"
             else:
@@ -334,6 +336,7 @@ def _processor(instance_type, available_processors):
                 "Invalid SageMaker instance type: {}. For options, see: "
                 "https://aws.amazon.com/sagemaker/pricing/instance-types".format(instance_type)
             )
+        
     _validate_arg(processor, available_processors, "processor")
     return processor
 

--- a/src/sagemaker/image_uris.py
+++ b/src/sagemaker/image_uris.py
@@ -168,6 +168,9 @@ def retrieve(
             "huggingface-tensorflow-trcomp-training",
         ]:
             _version = version
+        if processor == "neuron":
+            repo += "-" + processor
+            print("repo: ", repo)
 
         tag_prefix = f"{pt_or_tf_version}-transformers{_version}"
 
@@ -310,6 +313,8 @@ def _processor(instance_type, available_processors):
 
     if instance_type.startswith("local"):
         processor = "cpu" if instance_type == "local" else "gpu"
+    elif instance_type.startswith("neuron"):
+        processor = "neuron"
     else:
         # looks for either "ml.<family>.<size>" or "ml_<family>"
         match = re.match(r"^ml[\._]([a-z\d]+)\.?\w*$", instance_type)
@@ -321,8 +326,6 @@ def _processor(instance_type, available_processors):
             # 'cpu' or 'gpu'.
             if family in available_processors:
                 processor = family
-            elif family.startswith("inf"):
-                processor = "inf"
             elif family[0] in ("g", "p"):
                 processor = "gpu"
             else:
@@ -332,7 +335,6 @@ def _processor(instance_type, available_processors):
                 "Invalid SageMaker instance type: {}. For options, see: "
                 "https://aws.amazon.com/sagemaker/pricing/instance-types".format(instance_type)
             )
-
     _validate_arg(processor, available_processors, "processor")
     return processor
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Added the necessary changes to incorporate the inf-neuron/hf image into the huggigface framework

*Testing done:*

- Locally tested the feature to extract image string with the following code:
```
import sagemaker
image = sagemaker.image_uris.retrieve(framework="huggingface",region=boto3.Session().region_name,version="4.12.3",py_version="py37",base_framework_version="pytorch1.9.1",instance_type="neuron",image_scope="inference")
```
- Tested the changes in this PR locally, where it passed all the tests (attached the local output below)

```
JT:sagemaker-python-sdk jeniyat$ ./.githooks/pre-push
GLOB sdist-make: /Users/jeniyat/Desktop/HuggingFace/source_repo/sagemaker-python-sdk/setup.py
✔ OK black-check in 8.605 seconds
✔ OK twine in 11.449 seconds
✔ OK pylint in 21.92 seconds
✔ OK docstyle in 24.015 seconds
✔ OK flake8 in 41.267 seconds
__________________________________________________________________________________________________________________________________________________________ summary ___________________________________________________________________________________________________________________________________________________________
  flake8: commands succeeded
  pylint: commands succeeded
  docstyle: commands succeeded
  black-check: commands succeeded
  twine: commands succeeded
  congratulations :)
=================== flake8,pylint,docstyle,black-check,twine execution time ===================
44 seconds

GLOB sdist-make: /Users/jeniyat/Desktop/HuggingFace/source_repo/sagemaker-python-sdk/setup.py
✔ OK doc8 in 8.755 seconds
✔ OK sphinx in 4 minutes, 46.133 seconds
__________________________________________________________________________________________________________________________________________________________ summary ___________________________________________________________________________________________________________________________________________________________
  sphinx: commands succeeded
  doc8: commands succeeded
  congratulations :)
=================== sphinx,doc8 execution time ===================
4 minutes and 49 seconds


```
## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
