### PR TITLE
fix: gpu integs CapacityError - fallback to available compute

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,12 +4,18 @@
 
 version: 2
 
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.9"
+
+
 python:
-  version: 3.9
   install:
     - method: pip
       path: .
     - requirements: doc/requirements.txt
+
 
 sphinx:
   configuration: doc/conf.py

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -406,6 +406,15 @@ def gpu_instance_type(sagemaker_session, request):
 
 
 @pytest.fixture(scope="session")
+def gpu_instance_type_list(sagemaker_session, request):
+    region = sagemaker_session.boto_session.region_name
+    if region in NO_P3_REGIONS:
+        return ["ml.p2.xlarge"]
+    else:
+        return ["ml.p3.2xlarge", "ml.p2.xlarge"]
+
+
+@pytest.fixture(scope="session")
 def inf_instance_type(sagemaker_session, request):
     return "ml.inf1.xlarge"
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. With Capacity crunch in PDX in daytime for p3.2x instances, falling back on p2 instances and retry.
Note: that I would fix the code redundancy here later after finding a better way but currently the PR checks are blocked.
3. Update readthedocs build version to v2

*Testing done:*
1. Tested integ runs locally. 

2. `tox -e sphinx` on py39 env
```The HTML pages are in _build/html.
_______________________________________________________________ summary _______________________________________________________________
  sphinx: commands succeeded
  congratulations :)
```

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
