### PR TITLE
feat: enable EnableInterContainerTrafficEncryption for model monitoring

### DIFF
--- a/src/sagemaker/model_monitor/clarify_model_monitoring.py
+++ b/src/sagemaker/model_monitor/clarify_model_monitoring.py
@@ -397,7 +397,6 @@ class ClarifyModelMonitor(mm.ModelMonitor):
 
         if network_config is not None:
             network_config_dict = network_config._to_request_dict()
-            self._validate_network_config(network_config_dict)
             request_dict["NetworkConfig"] = network_config_dict
         elif existing_network_config is not None:
             request_dict["NetworkConfig"] = existing_network_config

--- a/src/sagemaker/model_monitor/model_monitoring.py
+++ b/src/sagemaker/model_monitor/model_monitoring.py
@@ -295,7 +295,6 @@ class ModelMonitor(object):
         network_config_dict = None
         if self.network_config is not None:
             network_config_dict = self.network_config._to_request_dict()
-            self._validate_network_config(network_config_dict)
 
         self.sagemaker_session.create_monitoring_schedule(
             monitoring_schedule_name=self.monitoring_schedule_name,
@@ -448,7 +447,6 @@ class ModelMonitor(object):
         network_config_dict = None
         if self.network_config is not None:
             network_config_dict = self.network_config._to_request_dict()
-            self._validate_network_config(network_config_dict)
 
         self.sagemaker_session.update_monitoring_schedule(
             monitoring_schedule_name=self.monitoring_schedule_name,
@@ -708,6 +706,9 @@ class ModelMonitor(object):
         if network_config_dict:
             network_config = NetworkConfig(
                 enable_network_isolation=network_config_dict["EnableNetworkIsolation"],
+                encrypt_inter_container_traffic=network_config_dict[
+                    "EnableInterContainerTrafficEncryption"
+                ],
                 security_group_ids=security_group_ids,
                 subnets=subnets,
             )
@@ -784,6 +785,9 @@ class ModelMonitor(object):
         if network_config_dict:
             network_config = NetworkConfig(
                 enable_network_isolation=network_config_dict["EnableNetworkIsolation"],
+                encrypt_inter_container_traffic=network_config_dict[
+                    "EnableInterContainerTrafficEncryption"
+                ],
                 security_group_ids=security_group_ids,
                 subnets=subnets,
             )
@@ -1163,31 +1167,6 @@ class ModelMonitor(object):
             schedule_desc = self.describe_schedule()
             if schedule_desc["MonitoringScheduleStatus"] != "Pending":
                 break
-
-    def _validate_network_config(self, network_config_dict):
-        """Function to validate EnableInterContainerTrafficEncryption.
-
-        It validates EnableInterContainerTrafficEncryption is not set in the provided
-        NetworkConfig request dictionary.
-
-        Args:
-            network_config_dict (dict): NetworkConfig request dictionary.
-                Contains parameters from :class:`~sagemaker.network.NetworkConfig` object
-                that configures network isolation, encryption of
-                inter-container traffic, security group IDs, and subnets.
-
-        """
-        if "EnableInterContainerTrafficEncryption" in network_config_dict:
-            message = (
-                "EnableInterContainerTrafficEncryption is not supported in Model Monitor. "
-                "Please ensure that encrypt_inter_container_traffic=None "
-                "when creating your NetworkConfig object. "
-                "Current encrypt_inter_container_traffic value: {}".format(
-                    self.network_config.encrypt_inter_container_traffic
-                )
-            )
-            _LOGGER.info(message)
-            raise ValueError(message)
 
     @classmethod
     def monitoring_type(cls):
@@ -1781,7 +1760,6 @@ class DefaultModelMonitor(ModelMonitor):
         network_config_dict = None
         if self.network_config is not None:
             network_config_dict = self.network_config._to_request_dict()
-            super(DefaultModelMonitor, self)._validate_network_config(network_config_dict)
 
         if role is not None:
             self.role = role
@@ -2034,6 +2012,9 @@ class DefaultModelMonitor(ModelMonitor):
             subnets = vpc_config.get("Subnets")
             network_config = NetworkConfig(
                 enable_network_isolation=network_config_dict["EnableNetworkIsolation"],
+                encrypt_inter_container_traffic=network_config_dict[
+                    "EnableInterContainerTrafficEncryption"
+                ],
                 security_group_ids=security_group_ids,
                 subnets=subnets,
             )
@@ -2304,7 +2285,6 @@ class DefaultModelMonitor(ModelMonitor):
 
         if network_config is not None:
             network_config_dict = network_config._to_request_dict()
-            self._validate_network_config(network_config_dict)
             request_dict["NetworkConfig"] = network_config_dict
         elif existing_network_config is not None:
             request_dict["NetworkConfig"] = existing_network_config
@@ -3007,7 +2987,6 @@ class ModelQualityMonitor(ModelMonitor):
 
         if network_config is not None:
             network_config_dict = network_config._to_request_dict()
-            self._validate_network_config(network_config_dict)
             request_dict["NetworkConfig"] = network_config_dict
         elif existing_network_config is not None:
             request_dict["NetworkConfig"] = existing_network_config

--- a/tests/integ/test_model_monitor.py
+++ b/tests/integ/test_model_monitor.py
@@ -53,7 +53,10 @@ ENVIRONMENT = {ENV_KEY_1: ENV_VALUE_1}
 TAG_KEY_1 = "tag_key_1"
 TAG_VALUE_1 = "tag_value_1"
 TAGS = [{"Key": TAG_KEY_1, "Value": TAG_VALUE_1}]
-NETWORK_CONFIG = NetworkConfig(enable_network_isolation=True)
+NETWORK_CONFIG = NetworkConfig(
+    enable_network_isolation=True,
+    encrypt_inter_container_traffic=True,
+)
 ENABLE_CLOUDWATCH_METRICS = True
 
 DEFAULT_BASELINING_MAX_RUNTIME_IN_SECONDS = 86400

--- a/tests/unit/sagemaker/monitor/test_clarify_model_monitor.py
+++ b/tests/unit/sagemaker/monitor/test_clarify_model_monitor.py
@@ -81,6 +81,7 @@ SECURITY_GROUP_IDS = ["test_security_group_ids"]
 SUBNETS = ["test_subnets"]
 NETWORK_CONFIG = NetworkConfig(
     enable_network_isolation=False,
+    encrypt_inter_container_traffic=False,
     security_group_ids=SECURITY_GROUP_IDS,
     subnets=SUBNETS,
 )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Enable `InterContainerTrafficEncryption`  for create monitoring schedule.

*Testing done:*

unit and integ

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
