### PR TITLE
fix: local mode printing of credentials during docker login closes #2180

### DIFF
--- a/src/sagemaker/local/image.py
+++ b/src/sagemaker/local/image.py
@@ -112,7 +112,11 @@ class _SageMakerContainer(object):
         self.container = None
 
     def process(
-        self, processing_inputs, processing_output_config, environment, processing_job_name
+        self,
+        processing_inputs,
+        processing_output_config,
+        environment,
+        processing_job_name,
     ):
         """Run a processing job locally using docker-compose.
 
@@ -139,7 +143,11 @@ class _SageMakerContainer(object):
         for host in self.hosts:
             _create_processing_config_file_directories(self.container_root, host)
             self.write_processing_config_files(
-                host, environment, processing_inputs, processing_output_config, processing_job_name
+                host,
+                environment,
+                processing_inputs,
+                processing_output_config,
+                processing_job_name,
             )
 
         self._generate_compose_file(
@@ -381,7 +389,12 @@ class _SageMakerContainer(object):
         return os.path.join(output_data, "model.tar.gz")
 
     def write_processing_config_files(
-        self, host, environment, processing_inputs, processing_output_config, processing_job_name
+        self,
+        host,
+        environment,
+        processing_inputs,
+        processing_output_config,
+        processing_job_name,
     ):
         """Write the config files for the processing containers.
 
@@ -1080,8 +1093,14 @@ def _ecr_login_if_needed(boto_session, image):
     token = raw_token.decode("utf-8").strip("AWS:")
     ecr_url = auth["authorizationData"][0]["proxyEndpoint"]
 
-    cmd = "docker login -u AWS -p %s %s" % (token, ecr_url)
-    subprocess.check_output(cmd.split())
+    # Log in to ecr, but use communicate to not print creds to the console
+    cmd = f"docker login {ecr_url} -u AWS --password-stdin".split()
+    proc = subprocess.Popen(
+        cmd,
+        stdin=subprocess.PIPE,
+    )
+
+    proc.communicate(input=token.encode())
 
     return True
 

--- a/tests/unit/test_image.py
+++ b/tests/unit/test_image.py
@@ -753,8 +753,9 @@ def test_ecr_login_image_exists(_check_output, image):
     assert result is False
 
 
-@patch("subprocess.check_output", return_value="".encode("utf-8"))
-def test_ecr_login_needed(check_output):
+@patch("subprocess.Popen", return_value=Mock(autospec=subprocess.Popen))
+@patch("sagemaker.local.image._check_output", return_value="")
+def test_ecr_login_needed(mock_check_output, popen):
     session_mock = Mock()
 
     token = "very-secure-token"
@@ -775,13 +776,22 @@ def test_ecr_login_needed(check_output):
     }
     session_mock.client("ecr").get_authorization_token.return_value = response
     image = "520713654638.dkr.ecr.us-east-1.amazonaws.com/image-i-need:1.1"
+    # What a sucessful login would look like
+    popen.return_value.communicate.return_value = (None, None)
+
     result = sagemaker.local.image._ecr_login_if_needed(session_mock, image)
 
-    expected_command = (
-        "docker login -u AWS -p %s https://520713654638.dkr.ecr.us-east-1.amazonaws.com" % token
-    )
-
-    check_output.assert_called_with(expected_command.split())
+    mock_check_output.assert_called_with(f"docker images -q {image}")
+    expected_command = [
+        "docker",
+        "login",
+        "https://520713654638.dkr.ecr.us-east-1.amazonaws.com",
+        "-u",
+        "AWS",
+        "--password-stdin",
+    ]
+    popen.assert_called_with(expected_command, stdin=subprocess.PIPE)
+    popen.return_value.communicate.assert_called_with(input=token.encode())
     session_mock.client("ecr").get_authorization_token.assert_called_with(
         registryIds=["520713654638"]
     )


### PR DESCRIPTION
*Issue #, if available:*
#2180

*Description of changes:*
No longer print token during login. Feel free to make any changes needed directly.

Sorry about the formatting changes, black really wanted those unrelated lines formatted and it seems to be right with `-l 100`.

*Testing done:*
Tested locally, this likely should be validated in notebook environments to ensure docker behaves the same there. It should, since docker warns about passing of credentials in an insecure manner and recommends doing this. I frequently docker login this way when testing images in ci. 

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
