### PR TITLE
feature: Retrieve data configuration

### DIFF
--- a/src/sagemaker/utils.py
+++ b/src/sagemaker/utils.py
@@ -652,34 +652,25 @@ def _module_import_error(py_module, feature, extras):
 
 
 class NotebooksDataConfig(abc.ABC):
-    """Abstract base class for creation of mechanisms for accessing data related to Example Notebooks.
+    """Abstract base class for creation for accessing data related to Example Notebooks.
 
-    Provides a skeleton for customization requiring the overriding of the method fetch_data_config.
+    Provides a skeleton for customization by overriding of method fetch_data_config.
     """
 
     @abc.abstractmethod
     def fetch_data_config(self, sagemaker_session):
-        """An abstract method that implements mechanisms to extract notebooks data config from a pre-configured
-         data source.
+        """Abstract method implementing retrieval of data config from a pre-configured data source.
 
         Args:
             sagemaker_session (Session): SageMaker session instance to use for boto configuration
 
         Returns:
             object: The data configuration object for Example Notebooks
-
         """
 
 
 class S3DataConfig(NotebooksDataConfig):
-
-    """
-    This class extends the NotebooksDataConfig class to fetch a data config file hosted on S3
-    """
-
-    def __init__(self):
-        """Initialize a ``S3DataConfig`` instance."""
-        super(S3DataConfig, self).__init__()
+    """This class extends the NotebooksDataConfig class to fetch a data config file hosted on S3"""
 
     @staticmethod
     def fetch_data_config(sagemaker_session):
@@ -689,11 +680,11 @@ class S3DataConfig(NotebooksDataConfig):
             sagemaker_session (Session): SageMaker session instance to use for boto configuration.
 
         Returns:
-            object: The JSON object containing data configuration object for Example Notebooks from S3.
+            object: The JSON object containing data configuration.
         """
 
-        bucket_name = 'example-notebooks-data-config'
-        prefix = 'config/data_config.json'
+        bucket_name = "example-notebooks-data-config"
+        prefix = "config/data_config.json"
         json_string = sagemaker_session.read_s3_file(bucket_name, prefix)
         return json.loads(json_string)
 
@@ -705,12 +696,16 @@ class S3DataConfig(NotebooksDataConfig):
             sagemaker_session (Session): SageMaker session instance to use for boto configuration.
 
         Returns:
-            str: The name of the S3 bucket containing datasets for Example Notebooks in the specified region.
+            str: The S3 bucket containing datasets for Example Notebooks in the specified region.
         """
 
         config = S3DataConfig.fetch_data_config(sagemaker_session)
         region = sagemaker_session.boto_region_name
-        return config[sagemaker_session.boto_region_name] if region in config.keys() else config["default"]
+        return (
+            config[sagemaker_session.boto_region_name]
+            if region in config.keys()
+            else config["default"]
+        )
 
 
 get_ecr_image_uri_prefix = deprecations.removed_function("get_ecr_image_uri_prefix")

--- a/src/sagemaker/utils.py
+++ b/src/sagemaker/utils.py
@@ -661,7 +661,6 @@ class DataConfig(abc.ABC):
     def fetch_data_config(self):
         """Abstract method implementing retrieval of data config from a pre-configured data source.
 
-
         Returns:
             object: The data configuration object for Example Notebooks
         """

--- a/src/sagemaker/utils.py
+++ b/src/sagemaker/utils.py
@@ -679,7 +679,7 @@ class S3DataConfig(DataConfig):
 
         Args:
             sagemaker_session (Session): SageMaker session instance to use for boto configuration.
-            bucket_name (str): Required. Name of the bucket from which data config needs to be fetched.
+            bucket_name (str): Required. Bucket name from which data config needs to be fetched.
             prefix (str): Required. The object prefix for the hosted data config.
 
         """

--- a/src/sagemaker/utils.py
+++ b/src/sagemaker/utils.py
@@ -658,11 +658,9 @@ class DataConfig(abc.ABC):
     """
 
     @abc.abstractmethod
-    def fetch_data_config(self, sagemaker_session):
+    def fetch_data_config(self):
         """Abstract method implementing retrieval of data config from a pre-configured data source.
 
-        Args:
-            sagemaker_session (Session): SageMaker session instance to use for boto configuration
 
         Returns:
             object: The data configuration object for Example Notebooks
@@ -681,9 +679,9 @@ class S3DataConfig(DataConfig):
         """Initialize a ``S3DataConfig`` instance.
 
         Args:
-            bucket_name (str): Name of the bucket from which data config needs to be fetched
-            prefix (str): The object prefix for the hosted data config
             sagemaker_session (Session): SageMaker session instance to use for boto configuration.
+            bucket_name (str): Name of the bucket from which data config needs to be fetched.
+            prefix (str): The object prefix for the hosted data config.
 
         """
         super(S3DataConfig, self).__init__()
@@ -691,11 +689,8 @@ class S3DataConfig(DataConfig):
         self.prefix = prefix
         self.sagemaker_session = sagemaker_session
 
-    def fetch_data_config(self, sagemaker_session):
+    def fetch_data_config(self):
         """Fetches data configuration for Example Notebooks from a S3 bucket.
-
-        Args:
-            sagemaker_session (Session): SageMaker session instance to use for boto configuration.
 
         Returns:
             object: The JSON object containing data configuration.
@@ -705,10 +700,7 @@ class S3DataConfig(DataConfig):
         return json.loads(json_string)
 
     def get_data_bucket(self):
-        """Returns the bucket containing the data for specified region.
-
-        Args:
-            sagemaker_session (Session): SageMaker session instance to use for boto configuration.
+        """Provides the bucket containing the data for specified region.
 
         Returns:
             str: The S3 bucket containing datasets for Example Notebooks in the specified region.

--- a/src/sagemaker/utils.py
+++ b/src/sagemaker/utils.py
@@ -672,18 +672,24 @@ class S3DataConfig(DataConfig):
     def __init__(
         self,
         sagemaker_session,
-        bucket_name="example-notebooks-data-config",
-        prefix="config/data_config.json",
+        bucket_name,
+        prefix,
     ):
         """Initialize a ``S3DataConfig`` instance.
 
         Args:
             sagemaker_session (Session): SageMaker session instance to use for boto configuration.
-            bucket_name (str): Name of the bucket from which data config needs to be fetched.
-            prefix (str): The object prefix for the hosted data config.
+            bucket_name (str): Required. Name of the bucket from which data config needs to be fetched.
+            prefix (str): Required. The object prefix for the hosted data config.
 
         """
+        if bucket_name is None or prefix is None:
+            raise ValueError(
+                "Bucket Name and S3 file Prefix are required arguments and must be provided."
+            )
+
         super(S3DataConfig, self).__init__()
+
         self.bucket_name = bucket_name
         self.prefix = prefix
         self.sagemaker_session = sagemaker_session

--- a/src/sagemaker/utils.py
+++ b/src/sagemaker/utils.py
@@ -23,6 +23,8 @@ import shutil
 import tarfile
 import tempfile
 import time
+import json
+import abc
 from datetime import datetime
 
 import botocore
@@ -647,6 +649,68 @@ def _module_import_error(py_module, feature, extras):
         "to install all required dependencies."
     )
     return error_msg.format(py_module, feature, extras)
+
+
+class NotebooksDataConfig(abc.ABC):
+    """Abstract base class for creation of mechanisms for accessing data related to Example Notebooks.
+
+    Provides a skeleton for customization requiring the overriding of the method fetch_data_config.
+    """
+
+    @abc.abstractmethod
+    def fetch_data_config(self, sagemaker_session):
+        """An abstract method that implements mechanisms to extract notebooks data config from a pre-configured
+         data source.
+
+        Args:
+            sagemaker_session (Session): SageMaker session instance to use for boto configuration
+
+        Returns:
+            object: The data configuration object for Example Notebooks
+
+        """
+
+
+class S3DataConfig(NotebooksDataConfig):
+
+    """
+    This class extends the NotebooksDataConfig class to fetch a data config file hosted on S3
+    """
+
+    def __init__(self):
+        """Initialize a ``S3DataConfig`` instance."""
+        super(S3DataConfig, self).__init__()
+
+    @staticmethod
+    def fetch_data_config(sagemaker_session):
+        """Fetches data configuration for Example Notebooks from a S3 bucket.
+
+        Args:
+            sagemaker_session (Session): SageMaker session instance to use for boto configuration.
+
+        Returns:
+            object: The JSON object containing data configuration object for Example Notebooks from S3.
+        """
+
+        bucket_name = 'example-notebooks-data-config'
+        prefix = 'config/data_config.json'
+        json_string = sagemaker_session.read_s3_file(bucket_name, prefix)
+        return json.loads(json_string)
+
+    @staticmethod
+    def get_data_bucket(sagemaker_session):
+        """Returns the bucket containing the data for specified region.
+
+        Args:
+            sagemaker_session (Session): SageMaker session instance to use for boto configuration.
+
+        Returns:
+            str: The name of the S3 bucket containing datasets for Example Notebooks in the specified region.
+        """
+
+        config = S3DataConfig.fetch_data_config(sagemaker_session)
+        region = sagemaker_session.boto_region_name
+        return config[sagemaker_session.boto_region_name] if region in config.keys() else config["default"]
 
 
 get_ecr_image_uri_prefix = deprecations.removed_function("get_ecr_image_uri_prefix")

--- a/src/sagemaker/utils.py
+++ b/src/sagemaker/utils.py
@@ -662,7 +662,7 @@ class DataConfig(abc.ABC):
         """Abstract method implementing retrieval of data config from a pre-configured data source.
 
         Returns:
-            object: The data configuration object for Example Notebooks
+            object: The data configuration object.
         """
 
 
@@ -695,7 +695,7 @@ class S3DataConfig(DataConfig):
         self.sagemaker_session = sagemaker_session
 
     def fetch_data_config(self):
-        """Fetches data configuration for Example Notebooks from a S3 bucket.
+        """Fetches data configuration from a S3 bucket.
 
         Returns:
             object: The JSON object containing data configuration.
@@ -704,20 +704,19 @@ class S3DataConfig(DataConfig):
         json_string = self.sagemaker_session.read_s3_file(self.bucket_name, self.prefix)
         return json.loads(json_string)
 
-    def get_data_bucket(self):
+    def get_data_bucket(self, region_requested=None):
         """Provides the bucket containing the data for specified region.
 
+        Args:
+            region_requested (str): The region for which the data is beig requested.
+
         Returns:
-            str: The S3 bucket containing datasets for Example Notebooks in the specified region.
+            str: Name of the S3 bucket containing datasets in the requested region.
         """
 
         config = self.fetch_data_config()
-        region = self.sagemaker_session.boto_region_name
-        return (
-            config[self.sagemaker_session.boto_region_name]
-            if region in config.keys()
-            else config["default"]
-        )
+        region = region_requested if region_requested else self.sagemaker_session.boto_region_name
+        return config[region] if region in config.keys() else config["default"]
 
 
 get_ecr_image_uri_prefix = deprecations.removed_function("get_ecr_image_uri_prefix")

--- a/src/sagemaker/utils.py
+++ b/src/sagemaker/utils.py
@@ -652,7 +652,7 @@ def _module_import_error(py_module, feature, extras):
 
 
 class DataConfig(abc.ABC):
-    """Abstract base class for creation for accessing data config hosted in AWS resourcs.
+    """Abstract base class for accessing data config hosted in AWS resources.
 
     Provides a skeleton for customization by overriding of method fetch_data_config.
     """

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -207,36 +207,27 @@ def test_secondary_training_status_message_prev_missing():
     )
 
 
-SAMPLE_DATA_CONFIG = {
-    "us-west-2": "sagemaker-hosted-datasets",
-    "default": "sagemaker-sample-files"
-}
+SAMPLE_DATA_CONFIG = {"us-west-2": "sagemaker-hosted-datasets", "default": "sagemaker-sample-files"}
 
 
 def test_notebooks_data_config_if_region_not_present():
 
     sample_data_config = json.dumps(SAMPLE_DATA_CONFIG)
 
-    boto_mock = MagicMock(name="boto_session",  region_name="ap-northeast-1")
+    boto_mock = MagicMock(name="boto_session", region_name="ap-northeast-1")
     session = sagemaker.Session(boto_session=boto_mock, sagemaker_client=MagicMock())
     session.read_s3_file = Mock(return_value=sample_data_config)
-    assert (
-            sagemaker.utils.S3DataConfig.get_data_bucket(session)
-            == "sagemaker-sample-files"
-    )
+    assert sagemaker.utils.S3DataConfig.get_data_bucket(session) == "sagemaker-sample-files"
 
 
 def test_notebooks_data_config_if_region_present():
 
     sample_data_config = json.dumps(SAMPLE_DATA_CONFIG)
 
-    boto_mock = MagicMock(name="boto_session",  region_name="us-west-2")
+    boto_mock = MagicMock(name="boto_session", region_name="us-west-2")
     session = sagemaker.Session(boto_session=boto_mock, sagemaker_client=MagicMock())
     session.read_s3_file = Mock(return_value=sample_data_config)
-    assert (
-            sagemaker.utils.S3DataConfig.get_data_bucket(session)
-            == "sagemaker-hosted-datasets"
-    )
+    assert sagemaker.utils.S3DataConfig.get_data_bucket(session) == "sagemaker-hosted-datasets"
 
 
 @patch("os.makedirs")

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -217,7 +217,12 @@ def test_notebooks_data_config_if_region_not_present():
     boto_mock = MagicMock(name="boto_session", region_name="ap-northeast-1")
     session = sagemaker.Session(boto_session=boto_mock, sagemaker_client=MagicMock())
     session.read_s3_file = Mock(return_value=sample_data_config)
-    assert sagemaker.utils.S3DataConfig(session).get_data_bucket() == "sagemaker-sample-files"
+    assert (
+        sagemaker.utils.S3DataConfig(
+            session, "example-notebooks-data-config", "config/data_config.json"
+        ).get_data_bucket()
+        == "sagemaker-sample-files"
+    )
 
 
 def test_notebooks_data_config_if_region_present():
@@ -227,7 +232,12 @@ def test_notebooks_data_config_if_region_present():
     boto_mock = MagicMock(name="boto_session", region_name="us-west-2")
     session = sagemaker.Session(boto_session=boto_mock, sagemaker_client=MagicMock())
     session.read_s3_file = Mock(return_value=sample_data_config)
-    assert sagemaker.utils.S3DataConfig(session).get_data_bucket() == "sagemaker-hosted-datasets"
+    assert (
+        sagemaker.utils.S3DataConfig(
+            session, "example-notebooks-data-config", "config/data_config.json"
+        ).get_data_bucket()
+        == "sagemaker-hosted-datasets"
+    )
 
 
 @patch("os.makedirs")

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -217,7 +217,7 @@ def test_notebooks_data_config_if_region_not_present():
     boto_mock = MagicMock(name="boto_session", region_name="ap-northeast-1")
     session = sagemaker.Session(boto_session=boto_mock, sagemaker_client=MagicMock())
     session.read_s3_file = Mock(return_value=sample_data_config)
-    assert sagemaker.utils.S3DataConfig.get_data_bucket(session) == "sagemaker-sample-files"
+    assert sagemaker.utils.S3DataConfig(session).get_data_bucket() == "sagemaker-sample-files"
 
 
 def test_notebooks_data_config_if_region_present():
@@ -227,7 +227,7 @@ def test_notebooks_data_config_if_region_present():
     boto_mock = MagicMock(name="boto_session", region_name="us-west-2")
     session = sagemaker.Session(boto_session=boto_mock, sagemaker_client=MagicMock())
     session.read_s3_file = Mock(return_value=sample_data_config)
-    assert sagemaker.utils.S3DataConfig.get_data_bucket(session) == "sagemaker-hosted-datasets"
+    assert sagemaker.utils.S3DataConfig(session).get_data_bucket() == "sagemaker-hosted-datasets"
 
 
 @patch("os.makedirs")

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -20,6 +20,7 @@ from datetime import datetime
 import os
 import re
 import time
+import json
 
 from boto3 import exceptions
 import botocore
@@ -203,6 +204,38 @@ def test_secondary_training_status_message_prev_missing():
     assert (
         sagemaker.utils.secondary_training_status_message(TRAINING_JOB_DESCRIPTION_1, {})
         == expected
+    )
+
+
+SAMPLE_DATA_CONFIG = {
+    "us-west-2": "sagemaker-hosted-datasets",
+    "default": "sagemaker-sample-files"
+}
+
+
+def test_notebooks_data_config_if_region_not_present():
+
+    sample_data_config = json.dumps(SAMPLE_DATA_CONFIG)
+
+    boto_mock = MagicMock(name="boto_session",  region_name="ap-northeast-1")
+    session = sagemaker.Session(boto_session=boto_mock, sagemaker_client=MagicMock())
+    session.read_s3_file = Mock(return_value=sample_data_config)
+    assert (
+            sagemaker.utils.S3DataConfig.get_data_bucket(session)
+            == "sagemaker-sample-files"
+    )
+
+
+def test_notebooks_data_config_if_region_present():
+
+    sample_data_config = json.dumps(SAMPLE_DATA_CONFIG)
+
+    boto_mock = MagicMock(name="boto_session",  region_name="us-west-2")
+    session = sagemaker.Session(boto_session=boto_mock, sagemaker_client=MagicMock())
+    session.read_s3_file = Mock(return_value=sample_data_config)
+    assert (
+            sagemaker.utils.S3DataConfig.get_data_bucket(session)
+            == "sagemaker-hosted-datasets"
     )
 
 


### PR DESCRIPTION
*Description of changes:*
Add APIs to allow retrieval of data configuration for Example Notebooks.

*Testing done:*
Added unit tests

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license