### PR TITLE
fix: local mode deletion of temp files on job end

### DIFF
--- a/tests/unit/sagemaker/local/test_local_utils.py
+++ b/tests/unit/sagemaker/local/test_local_utils.py
@@ -13,6 +13,7 @@
 from __future__ import absolute_import
 
 import os
+import errno
 import pytest
 from mock import patch, Mock
 
@@ -165,3 +166,20 @@ def test_get_using_dot_notation_key_error():
 def test_get_using_dot_notation_index_error():
     with pytest.raises(ValueError):
         sagemaker.local.utils.get_using_dot_notation({"foo": ["bar"]}, "foo[1]")
+
+
+def raise_os_error(args):
+    err = OSError()
+    err.errno = errno.EACCES
+    raise err
+
+
+@patch("shutil.rmtree", side_effect=raise_os_error)
+@patch("sagemaker.local.utils.recursive_copy")
+def test_move_to_destination_local_root_failure(recursive_copy, mock_rmtree):
+    # This should not raise, in case root owns files, make sure it doesn't
+    sagemaker.local.utils.move_to_destination("/tmp/data", "file:///target/dir/", "job", None)
+    mock_rmtree.assert_called_once()
+    recursive_copy.assert_called_with(
+        "/tmp/data", os.path.abspath(os.path.join(os.sep, "target", "dir"))
+    )


### PR DESCRIPTION
*Issue #, if available:*
closes [#2527](https://github.com/aws/sagemaker-python-sdk/issues/2647)

This is a clone of https://github.com/aws/sagemaker-python-sdk/pull/2644 but has allow commits from maintainers on so should be easier to merge. 

Description of changes:

Add try except around file cleanup in sagemaker.local.utils.copy_directory_structure. This was causing local mode to fail when docker (running as root) writes files to a mounted dir and the user does not have permission to remove the files.

The same pattern is followed [here](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/local/image.py#L956).

Testing done:

Add test for failed removal, behaves as expected.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
