### PR TITLE
feature: pluggable instance fallback mechanism, add CapacityError

### DIFF
--- a/src/sagemaker/exceptions.py
+++ b/src/sagemaker/exceptions.py
@@ -23,6 +23,10 @@ class UnexpectedStatusException(ValueError):
         super(UnexpectedStatusException, self).__init__(message)
 
 
+class CapacityError(UnexpectedStatusException):
+    """Raised when resource status is not expected and fails with a reason of CapacityError"""
+
+
 class AsyncInferenceError(Exception):
     """The base exception class for Async Inference exceptions."""
 

--- a/tests/integ/test_huggingface.py
+++ b/tests/integ/test_huggingface.py
@@ -15,15 +15,14 @@ from __future__ import absolute_import
 import os
 
 import pytest
-import logging
 
 from sagemaker.huggingface import HuggingFace, HuggingFaceProcessor
 from sagemaker.huggingface.model import HuggingFaceModel, HuggingFacePredictor
 from sagemaker.utils import unique_name_from_base
 from tests import integ
+from tests.integ.utils import gpu_list, retry_with_instance_list
 from tests.integ import DATA_DIR, TRAINING_DEFAULT_TIMEOUT_MINUTES
 from tests.integ.timeout import timeout, timeout_and_delete_endpoint_by_name
-from sagemaker.exceptions import UnexpectedStatusException
 
 ROLE = "SageMakerRole"
 
@@ -34,43 +33,34 @@ ROLE = "SageMakerRole"
     and integ.test_region() in integ.TRAINING_NO_P3_REGIONS,
     reason="no ml.p2 or ml.p3 instances in this region",
 )
+@retry_with_instance_list(gpu_list(integ.test_region()))
 def test_framework_processing_job_with_deps(
     sagemaker_session,
-    gpu_instance_type_list,
     huggingface_training_latest_version,
     huggingface_training_pytorch_latest_version,
     huggingface_pytorch_latest_training_py_version,
+    **kwargs,
 ):
-    for i_type in gpu_instance_type_list:
-        logging.info("Using the instance type: {}".format(i_type))
-        with timeout(minutes=TRAINING_DEFAULT_TIMEOUT_MINUTES):
-            code_path = os.path.join(DATA_DIR, "dummy_code_bundle_with_reqs")
-            entry_point = "main_script.py"
+    with timeout(minutes=TRAINING_DEFAULT_TIMEOUT_MINUTES):
+        code_path = os.path.join(DATA_DIR, "dummy_code_bundle_with_reqs")
+        entry_point = "main_script.py"
 
-            processor = HuggingFaceProcessor(
-                transformers_version=huggingface_training_latest_version,
-                pytorch_version=huggingface_training_pytorch_latest_version,
-                py_version=huggingface_pytorch_latest_training_py_version,
-                role=ROLE,
-                instance_count=1,
-                instance_type=i_type,
-                sagemaker_session=sagemaker_session,
-                base_job_name="test-huggingface",
-            )
-            try:
-                processor.run(
-                    code=entry_point,
-                    source_dir=code_path,
-                    inputs=[],
-                    wait=True,
-                )
-            except UnexpectedStatusException as e:
-                if "CapacityError" in str(e) and i_type != gpu_instance_type_list[-1]:
-                    logging.warning("Failure using instance type: {}. {}".format(i_type, str(e)))
-                    continue
-                else:
-                    raise
-        break
+        processor = HuggingFaceProcessor(
+            transformers_version=huggingface_training_latest_version,
+            pytorch_version=huggingface_training_pytorch_latest_version,
+            py_version=huggingface_pytorch_latest_training_py_version,
+            role=ROLE,
+            instance_count=1,
+            instance_type=kwargs["instance_type"],
+            sagemaker_session=sagemaker_session,
+            base_job_name="test-huggingface",
+        )
+        processor.run(
+            code=entry_point,
+            source_dir=code_path,
+            inputs=[],
+            wait=True,
+        )
 
 
 @pytest.mark.release

--- a/tests/integ/test_tf.py
+++ b/tests/integ/test_tf.py
@@ -15,7 +15,6 @@ from __future__ import absolute_import
 import numpy as np
 import os
 import time
-import logging
 
 import pytest
 
@@ -25,8 +24,8 @@ from sagemaker.utils import unique_name_from_base, sagemaker_timestamp
 import tests.integ
 from tests.integ import DATA_DIR, TRAINING_DEFAULT_TIMEOUT_MINUTES, kms_utils, timeout
 from tests.integ.retry import retries
+from tests.integ.utils import gpu_list, retry_with_instance_list
 from tests.integ.s3_utils import assert_s3_file_patterns_exist
-from sagemaker.exceptions import UnexpectedStatusException
 
 
 ROLE = "SageMakerRole"
@@ -48,41 +47,32 @@ ENV_INPUT = {"env_key1": "env_val1", "env_key2": "env_val2", "env_key3": "env_va
     and tests.integ.test_region() in tests.integ.TRAINING_NO_P3_REGIONS,
     reason="no ml.p2 or ml.p3 instances in this region",
 )
+@retry_with_instance_list(gpu_list(tests.integ.test_region()))
 def test_framework_processing_job_with_deps(
     sagemaker_session,
-    gpu_instance_type_list,
     tensorflow_training_latest_version,
     tensorflow_training_latest_py_version,
+    **kwargs,
 ):
-    for i_type in gpu_instance_type_list:
-        logging.info("Using the instance type: {}".format(i_type))
-        with timeout.timeout(minutes=TRAINING_DEFAULT_TIMEOUT_MINUTES):
-            code_path = os.path.join(DATA_DIR, "dummy_code_bundle_with_reqs")
-            entry_point = "main_script.py"
+    with timeout.timeout(minutes=TRAINING_DEFAULT_TIMEOUT_MINUTES):
+        code_path = os.path.join(DATA_DIR, "dummy_code_bundle_with_reqs")
+        entry_point = "main_script.py"
 
-            processor = TensorFlowProcessor(
-                framework_version=tensorflow_training_latest_version,
-                py_version=tensorflow_training_latest_py_version,
-                role=ROLE,
-                instance_count=1,
-                instance_type=i_type,
-                sagemaker_session=sagemaker_session,
-                base_job_name="test-tensorflow",
-            )
-            try:
-                processor.run(
-                    code=entry_point,
-                    source_dir=code_path,
-                    inputs=[],
-                    wait=True,
-                )
-            except UnexpectedStatusException as e:
-                if "CapacityError" in str(e) and i_type != gpu_instance_type_list[-1]:
-                    logging.warning("Failure using instance type: {}. {}".format(i_type, str(e)))
-                    continue
-                else:
-                    raise
-        break
+        processor = TensorFlowProcessor(
+            framework_version=tensorflow_training_latest_version,
+            py_version=tensorflow_training_latest_py_version,
+            role=ROLE,
+            instance_count=1,
+            instance_type=kwargs["instance_type"],
+            sagemaker_session=sagemaker_session,
+            base_job_name="test-tensorflow",
+        )
+        processor.run(
+            code=entry_point,
+            source_dir=code_path,
+            inputs=[],
+            wait=True,
+        )
 
 
 def test_mnist_with_checkpoint_config(

--- a/tests/integ/utils.py
+++ b/tests/integ/utils.py
@@ -1,0 +1,71 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from __future__ import absolute_import
+import logging
+from functools import wraps
+
+from tests.conftest import NO_P3_REGIONS, NO_M4_REGIONS
+from sagemaker.exceptions import CapacityError
+
+
+def gpu_list(region):
+    if region in NO_P3_REGIONS:
+        return ["ml.p2.xlarge"]
+    else:
+        return ["ml.p3.2xlarge", "ml.p2.xlarge"]
+
+
+def cpu_list(region):
+    if region in NO_M4_REGIONS:
+        return ["ml.m5.xlarge"]
+    else:
+        return ["ml.m4.xlarge", "ml.m5.xlarge"]
+
+
+def retry_with_instance_list(instance_list):
+    """Decorator for running an Integ test with an instance_list and
+    break on first success
+
+    Args:
+        instance_list (list): List of Compute instances for integ test.
+    Usage:
+        @retry_with_instance_list(instance_list=["ml.g3.2", "ml.g2"])
+        def sample_function():
+            print("xxxx....")
+    """
+
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            if not (instance_list and isinstance(instance_list, list)):
+                error_string = f"Parameter instance_list = {instance_list} \
+                is expected to be a non-empty list of instance types."
+                raise Exception(error_string)
+            for i_type in instance_list:
+                logging.info(f"Using the instance type: {i_type} for {func.__name__}")
+                try:
+                    kwargs.update({"instance_type": i_type})
+                    func(*args, **kwargs)
+                except CapacityError as e:
+                    if i_type != instance_list[-1]:
+                        logging.warning(
+                            "Failure using instance type: {}. {}".format(i_type, str(e))
+                        )
+                        continue
+                    else:
+                        raise
+                break
+
+        return wrapper
+
+    return decorator

--- a/tests/unit/test_exception_on_bad_status.py
+++ b/tests/unit/test_exception_on_bad_status.py
@@ -84,6 +84,26 @@ def test_does_raise_when_incorrect_job_status():
         assert "Stopped" in e.allowed_statuses
 
 
+def test_does_raise_capacity_error_when_incorrect_job_status():
+    try:
+        job = Mock()
+        sagemaker_session = get_sagemaker_session(returns_status="Failed")
+        sagemaker_session._check_job_status(
+            job,
+            {
+                "TransformationJobStatus": "Failed",
+                "FailureReason": "CapacityError: Unable to provision requested ML compute capacity",
+            },
+            "TransformationJobStatus",
+        )
+        assert False, "sagemaker.exceptions.CapacityError should have been raised but was not"
+    except Exception as e:
+        assert type(e) == sagemaker.exceptions.CapacityError
+        assert e.actual_status == "Failed"
+        assert "Completed" in e.allowed_statuses
+        assert "Stopped" in e.allowed_statuses
+
+
 def test_does_not_raise_when_successfully_deployed_endpoint():
     try:
         sagemaker_session = get_sagemaker_session(returns_status="InService")


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Raise CapacityError in case the failure reason for job failure is Capacity issue from EC2.
2. Provide a pluggable instance fallback mechanism which can be used with integ test.

*Testing done:*
Added unit test.
Made sure tests pass locally for backwards compatibility.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
