### PR TITLE
Update black-check version, add support for Spark 3.1 Processing

### DIFF
--- a/src/sagemaker/image_uri_config/spark.json
+++ b/src/sagemaker/image_uri_config/spark.json
@@ -59,6 +59,35 @@
                         "us-gov-west-1": "271483468897"
                     },
                     "repository": "sagemaker-spark-processing"
+            },
+            "3.1": {
+                "py_versions": ["py37"],
+                "registries": {
+                    "me-south-1": "750251592176",
+                    "ap-south-1": "105495057255",
+                    "eu-north-1": "330188676905",
+                    "eu-west-3": "136845547031",
+                    "us-east-2": "314815235551",
+                    "eu-west-1": "571004829621",
+                    "eu-central-1": "906073651304",
+                    "sa-east-1": "737130764395",
+                    "ap-east-1": "732049463269",
+                    "us-east-1": "173754725891",
+                    "ap-northeast-2": "860869212795",
+                    "eu-west-2": "836651553127",
+                    "ap-northeast-1": "411782140378",
+                    "us-west-2": "153931337802",
+                    "us-west-1": "667973535471",
+                    "ap-southeast-1": "759080221371",
+                    "ap-southeast-2": "440695851116",
+                    "ca-central-1": "446299261295",
+                    "cn-north-1": "671472414489",
+                    "cn-northwest-1": "844356804704",
+                    "eu-south-1": "753923664805",
+                    "af-south-1": "309385258863",
+                    "us-gov-west-1": "271483468897"
+                },
+                "repository": "sagemaker-spark-processing"
             }
         }
     }

--- a/tests/integ/test_spark_processing.py
+++ b/tests/integ/test_spark_processing.py
@@ -88,6 +88,19 @@ def spark_py_processor(sagemaker_session, cpu_instance_type):
 
 
 @pytest.fixture(scope="module")
+def spark_v3_py_processor(sagemaker_session, cpu_instance_type):
+    spark_py_processor = PySparkProcessor(
+        role="SageMakerRole",
+        instance_count=2,
+        instance_type=cpu_instance_type,
+        sagemaker_session=sagemaker_session,
+        framework_version="3.1",
+    )
+
+    return spark_py_processor
+
+
+@pytest.fixture(scope="module")
 def spark_jar_processor(sagemaker_session, cpu_instance_type):
     spark_jar_processor = SparkJarProcessor(
         role="SageMakerRole",
@@ -95,6 +108,19 @@ def spark_jar_processor(sagemaker_session, cpu_instance_type):
         instance_type=cpu_instance_type,
         sagemaker_session=sagemaker_session,
         framework_version="2.4",
+    )
+
+    return spark_jar_processor
+
+
+@pytest.fixture(scope="module")
+def spark_v3_jar_processor(sagemaker_session, cpu_instance_type):
+    spark_jar_processor = SparkJarProcessor(
+        role="SageMakerRole",
+        instance_count=2,
+        instance_type=cpu_instance_type,
+        sagemaker_session=sagemaker_session,
+        framework_version="3.1",
     )
 
     return spark_jar_processor
@@ -178,6 +204,15 @@ def configuration() -> list:
         },
     ]
     return configuration
+
+
+def test_sagemaker_pyspark_v3(
+    spark_v3_py_processor, spark_v3_jar_processor, sagemaker_session, configuration, build_jar
+):
+    test_sagemaker_pyspark_multinode(spark_v3_py_processor, sagemaker_session, configuration)
+    test_sagemaker_java_jar_multinode(
+        spark_v3_jar_processor, sagemaker_session, configuration, build_jar
+    )
 
 
 def test_sagemaker_pyspark_multinode(spark_py_processor, sagemaker_session, configuration):

--- a/tox.ini
+++ b/tox.ini
@@ -134,7 +134,7 @@ commands = doc8
 setenv =
     LC_ALL=C.UTF-8
     LANG=C.UTF-8
-deps = black==22.1.0
+deps = black==22.3.0
 commands =
     black -l 100 ./
 
@@ -143,7 +143,7 @@ commands =
 setenv =
     LC_ALL=C.UTF-8
     LANG=C.UTF-8
-deps = black==22.1.0
+deps = black==22.3.0
 commands =
     black -l 100 --check ./
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update black-check version, add support for Spark 3.1 Processing

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
