### PR TITLE
fix: Refactor repack_model script injection, fixes tar.gz error

### DIFF
--- a/src/sagemaker/workflow/_utils.py
+++ b/src/sagemaker/workflow/_utils.py
@@ -20,10 +20,6 @@ import tempfile
 from typing import List, Union
 from sagemaker import image_uris
 from sagemaker.inputs import TrainingInput
-from sagemaker.s3 import (
-    S3Downloader,
-    S3Uploader,
-)
 from sagemaker.estimator import EstimatorBase
 from sagemaker.sklearn.estimator import SKLearn
 from sagemaker.workflow.entities import RequestType
@@ -35,6 +31,7 @@ from sagemaker.workflow.steps import (
     Step,
     ConfigurableRetryStep,
 )
+from sagemaker.utils import _save_model, download_file_from_url
 from sagemaker.workflow.retry import RetryPolicy
 
 FRAMEWORK_VERSION = "0.23-1"
@@ -203,12 +200,14 @@ class _RepackModelStep(TrainingStep):
         self._entry_point = self._entry_point_basename
 
     def _inject_repack_script(self):
-        """Injects the _repack_model.py script where it belongs.
+        """Injects the _repack_model.py script into S3 or local source directory.
 
         If the source_dir is an S3 path:
             1) downloads the source_dir tar.gz
-            2) copies the _repack_model.py script where it belongs
-            3) uploads the mutated source_dir
+            2) extracts it
+            3) copies the _repack_model.py script into the extracted directory
+            4) rezips the directory
+            5) overwrites the S3 source_dir with the new tar.gz
 
         If the source_dir is a local path:
             1) copies the _repack_model.py script into the source dir
@@ -216,27 +215,21 @@ class _RepackModelStep(TrainingStep):
         fname = os.path.join(os.path.dirname(__file__), REPACK_SCRIPT)
         if self._source_dir.lower().startswith("s3://"):
             with tempfile.TemporaryDirectory() as tmp:
-                local_path = os.path.join(tmp, "local.tar.gz")
+                targz_contents_dir = os.path.join(tmp, "extracted")
 
-                S3Downloader.download(
-                    s3_uri=self._source_dir,
-                    local_path=local_path,
-                    sagemaker_session=self.sagemaker_session,
-                )
+                old_targz_path = os.path.join(tmp, "old.tar.gz")
+                download_file_from_url(self._source_dir, old_targz_path, self.sagemaker_session)
 
-                src_dir = os.path.join(tmp, "src")
-                with tarfile.open(name=local_path, mode="r:gz") as tf:
-                    tf.extractall(path=src_dir)
+                with tarfile.open(name=old_targz_path, mode="r:gz") as t:
+                    t.extractall(path=targz_contents_dir)
 
-                shutil.copy2(fname, os.path.join(src_dir, REPACK_SCRIPT))
-                with tarfile.open(name=local_path, mode="w:gz") as tf:
-                    tf.add(src_dir, arcname=".")
+                shutil.copy2(fname, os.path.join(targz_contents_dir, REPACK_SCRIPT))
 
-                S3Uploader.upload(
-                    local_path=local_path,
-                    desired_s3_uri=self._source_dir,
-                    sagemaker_session=self.sagemaker_session,
-                )
+                new_targz_path = os.path.join(tmp, "new.tar.gz")
+                with tarfile.open(new_targz_path, mode="w:gz") as t:
+                    t.add(targz_contents_dir, arcname=os.path.sep)
+
+                _save_model(self._source_dir, new_targz_path, self.sagemaker_session, kms_key=None)
         else:
             shutil.copy2(fname, os.path.join(self._source_dir, REPACK_SCRIPT))
 


### PR DESCRIPTION
…gz error

*Issue #, if available:*
[3038](https://github.com/aws/sagemaker-python-sdk/issues/3038)

*Description of changes:*
Repack model injection is not working for S3 source directories. Refactor this to follow logic similar to Model's repack method.

*Testing done:*
Manual, unit

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
