### PR TITLE
feat: add Tensorflow and Pytorch version for SM Training Compiler and expand to regular regions

### DIFF
--- a/src/sagemaker/image_uri_config/huggingface-training-compiler.json
+++ b/src/sagemaker/image_uri_config/huggingface-training-compiler.json
@@ -36,7 +36,7 @@
             },
             "4.17.0": {
                 "version_aliases": {
-                    "pytorch1.10.2": "pytorch1.10.2",
+                    "pytorch1.10": "pytorch1.10.2",
                     "tensorflow2.6": "tensorflow2.6.3"
                 },
                 "pytorch1.10.2": {

--- a/src/sagemaker/image_uri_config/huggingface-training-compiler.json
+++ b/src/sagemaker/image_uri_config/huggingface-training-compiler.json
@@ -2,7 +2,8 @@
     "training": {
         "processors": ["gpu"],
         "version_aliases": {
-            "4.11": "4.11.0"
+            "4.11": "4.11.0",
+            "4.17": "4.17.0"
         },
         "versions": {
             "4.11.0": {
@@ -31,6 +32,72 @@
                     },
                     "repository": "huggingface-tensorflow-trcomp-training",
                     "container_version": {"gpu":"cu112-ubuntu18.04"}
+                }
+            },
+            "4.17.0": {
+                "version_aliases": {
+                    "pytorch1.10.2": "pytorch1.10.2",
+                    "tensorflow2.6": "tensorflow2.6.3"
+                },
+                "pytorch1.10.2": {
+                    "py_versions": ["py38"],
+                    "registries": {
+						"af-south-1": "626614931356",
+                        "ap-east-1": "871362719292",
+                        "ap-northeast-1": "763104351884",
+                        "ap-northeast-2": "763104351884",
+                        "ap-northeast-3": "364406365360",
+                        "ap-south-1": "763104351884",
+                        "ap-southeast-1": "763104351884",
+                        "ap-southeast-2": "763104351884",
+                        "ca-central-1": "763104351884",
+                        "eu-central-1": "763104351884",
+                        "eu-north-1": "763104351884",
+                        "eu-south-1": "692866216735",
+                        "eu-west-1": "763104351884",
+                        "eu-west-2": "763104351884",
+                        "eu-west-3": "763104351884",
+                        "me-south-1": "217643126080",
+                        "sa-east-1": "763104351884",
+                        "us-east-1": "763104351884",
+                        "us-east-2": "763104351884",
+                        "us-gov-west-1": "442386744353",
+                        "us-iso-east-1": "886529160074",
+                        "us-west-1": "763104351884",
+                        "us-west-2": "763104351884"
+                    },
+                    "repository": "huggingface-pytorch-trcomp-training",
+                    "container_version": {"gpu":"cu112-ubuntu20.04"}
+                },
+                "tensorflow2.6.3": {
+                    "py_versions": ["py38"],
+                    "registries": {
+						"af-south-1": "626614931356",
+                        "ap-east-1": "871362719292",
+                        "ap-northeast-1": "763104351884",
+                        "ap-northeast-2": "763104351884",
+                        "ap-northeast-3": "364406365360",
+                        "ap-south-1": "763104351884",
+                        "ap-southeast-1": "763104351884",
+                        "ap-southeast-2": "763104351884",
+                        "ca-central-1": "763104351884",
+                        "eu-central-1": "763104351884",
+                        "eu-north-1": "763104351884",
+                        "eu-south-1": "692866216735",
+                        "eu-west-1": "763104351884",
+                        "eu-west-2": "763104351884",
+                        "eu-west-3": "763104351884",
+                        "me-south-1": "217643126080",
+                        "sa-east-1": "763104351884",
+                        "us-east-1": "763104351884",
+                        "us-east-2": "763104351884",
+                        "us-gov-west-1": "442386744353",
+                        "us-iso-east-1": "886529160074",
+                        "us-west-1": "763104351884",
+                        "us-west-2": "763104351884"
+                    },
+                    "repository": "huggingface-tensorflow-trcomp-training",
+                    "container_version": {"gpu":"cu112-ubuntu20.04"}
                 }
             }
         }

--- a/src/sagemaker/image_uri_config/huggingface-training-compiler.json
+++ b/src/sagemaker/image_uri_config/huggingface-training-compiler.json
@@ -42,7 +42,7 @@
                 "pytorch1.10.2": {
                     "py_versions": ["py38"],
                     "registries": {
-						"af-south-1": "626614931356",
+					    "af-south-1": "626614931356",
                         "ap-east-1": "871362719292",
                         "ap-northeast-1": "763104351884",
                         "ap-northeast-2": "763104351884",
@@ -61,18 +61,16 @@
                         "sa-east-1": "763104351884",
                         "us-east-1": "763104351884",
                         "us-east-2": "763104351884",
-                        "us-gov-west-1": "442386744353",
-                        "us-iso-east-1": "886529160074",
                         "us-west-1": "763104351884",
                         "us-west-2": "763104351884"
                     },
                     "repository": "huggingface-pytorch-trcomp-training",
-                    "container_version": {"gpu":"cu112-ubuntu20.04"}
+                    "container_version": {"gpu":"cu113-ubuntu20.04"}
                 },
                 "tensorflow2.6.3": {
                     "py_versions": ["py38"],
                     "registries": {
-						"af-south-1": "626614931356",
+					    "af-south-1": "626614931356",
                         "ap-east-1": "871362719292",
                         "ap-northeast-1": "763104351884",
                         "ap-northeast-2": "763104351884",
@@ -91,8 +89,6 @@
                         "sa-east-1": "763104351884",
                         "us-east-1": "763104351884",
                         "us-east-2": "763104351884",
-                        "us-gov-west-1": "442386744353",
-                        "us-iso-east-1": "886529160074",
                         "us-west-1": "763104351884",
                         "us-west-2": "763104351884"
                     },

--- a/src/sagemaker/image_uri_config/huggingface-training-compiler.json
+++ b/src/sagemaker/image_uri_config/huggingface-training-compiler.json
@@ -42,7 +42,7 @@
                 "pytorch1.10.2": {
                     "py_versions": ["py38"],
                     "registries": {
-					    "af-south-1": "626614931356",
+                        "af-south-1": "626614931356",
                         "ap-east-1": "871362719292",
                         "ap-northeast-1": "763104351884",
                         "ap-northeast-2": "763104351884",
@@ -70,7 +70,7 @@
                 "tensorflow2.6.3": {
                     "py_versions": ["py38"],
                     "registries": {
-					    "af-south-1": "626614931356",
+                        "af-south-1": "626614931356",
                         "ap-east-1": "871362719292",
                         "ap-northeast-1": "763104351884",
                         "ap-northeast-2": "763104351884",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -249,6 +249,15 @@ def huggingface_training_compiler_tensorflow_version(huggingface_training_compil
 
 
 @pytest.fixture(scope="module")
+def huggingface_training_compiler_py_version(huggingface_training_compiler_tensorflow_version):
+    return (
+        "py37"
+        if Version(huggingface_training_compiler_tensorflow_version) < Version("2.6")
+        else "py38"
+    )
+
+
+@pytest.fixture(scope="module")
 def huggingface_pytorch_latest_training_py_version(huggingface_training_pytorch_latest_version):
     return (
         "py38" if Version(huggingface_training_pytorch_latest_version) >= Version("1.9") else "py36"

--- a/tests/integ/__init__.py
+++ b/tests/integ/__init__.py
@@ -158,6 +158,26 @@ EDGE_PACKAGING_SUPPORTED_REGIONS = [
 ]
 # TODO: SM Training Compiler team to add all supported regions.
 TRAINING_COMPILER_SUPPORTED_REGIONS = [
+    "af-south-1",
+    "ap-east-1",
+    "ap-northeast-1",
+    "ap-northeast-2",
+    "ap-northeast-3",
+    "ap-south-1",
+    "ap-southeast-1",
+    "ap-southeast-2",
+    "ca-central-1",
+    "eu-central-1",
+    "eu-north-1",
+    "eu-south-1",
+    "eu-west-1",
+    "eu-west-2",
+    "eu-west-3",
+    "me-south-1",
+    "sa-east-1",
+    "us-east-1",
+    "us-east-2",
+    "us-west-1",
     "us-west-2",
 ]
 # Data parallelism need to be tested with p3.16xlarge.

--- a/tests/integ/test_training_compiler.py
+++ b/tests/integ/test_training_compiler.py
@@ -88,7 +88,7 @@ def test_huggingface_tensorflow(
         data_path = os.path.join(DATA_DIR, "huggingface")
 
         hf = HuggingFace(
-            py_version="py37",
+            py_version="py38",
             entry_point=os.path.join(data_path, "run_tf.py"),
             role="SageMakerRole",
             transformers_version=huggingface_training_compiler_latest_version,

--- a/tests/unit/sagemaker/training_compiler/test_huggingface_pytorch_compiler.py
+++ b/tests/unit/sagemaker/training_compiler/test_huggingface_pytorch_compiler.py
@@ -1,0 +1,508 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from __future__ import absolute_import
+import logging
+
+import json
+import os
+
+import pytest
+from mock import MagicMock, Mock, patch
+
+from sagemaker import image_uris
+from sagemaker.huggingface import HuggingFace, TrainingCompilerConfig
+
+from tests.unit.sagemaker.training_compiler import EC2_GPU_INSTANCE_CLASSES
+
+
+DATA_DIR = os.path.join(os.path.dirname(__file__), "..", "data")
+SCRIPT_PATH = os.path.join(DATA_DIR, "dummy_script.py")
+SERVING_SCRIPT_FILE = "another_dummy_script.py"
+MODEL_DATA = "s3://some/data.tar.gz"
+ENV = {"DUMMY_ENV_VAR": "dummy_value"}
+TIMESTAMP = "2017-11-06-14:14:15.672"
+TIME = 1510006209.073025
+BUCKET_NAME = "mybucket"
+INSTANCE_COUNT = 1
+INSTANCE_TYPE = "ml.p3.2xlarge"
+IMAGE_URI = "huggingface"
+JOB_NAME = "{}-{}".format(IMAGE_URI, TIMESTAMP)
+ROLE = "Dummy"
+REGION = "us-east-1"
+GPU = "ml.p3.2xlarge"
+SUPPORTED_GPU_INSTANCE_CLASSES = {"p3", "p3dn", "g4dn", "p4dn"}
+UNSUPPORTED_GPU_INSTANCE_CLASSES = EC2_GPU_INSTANCE_CLASSES - SUPPORTED_GPU_INSTANCE_CLASSES
+
+LIST_TAGS_RESULT = {"Tags": [{"Key": "TagtestKey", "Value": "TagtestValue"}]}
+
+EXPERIMENT_CONFIG = {
+    "ExperimentName": "exp",
+    "TrialName": "trial",
+    "TrialComponentDisplayName": "tc",
+}
+
+
+@pytest.fixture(scope="module")
+def cpu_instance_type():
+    return "ml.m5.xlarge"
+
+
+@pytest.fixture(name="sagemaker_session", scope="function")
+def fixture_sagemaker_session():
+    boto_mock = Mock(name="boto_session", region_name=REGION)
+    session = Mock(
+        name="sagemaker_session",
+        boto_session=boto_mock,
+        boto_region_name=REGION,
+        config=None,
+        local_mode=False,
+        s3_resource=None,
+        s3_client=None,
+    )
+
+    describe = {"ModelArtifacts": {"S3ModelArtifacts": "s3://m/m.tar.gz"}}
+    session.sagemaker_client.describe_training_job = Mock(return_value=describe)
+    session.sagemaker_client.list_tags = Mock(return_value=LIST_TAGS_RESULT)
+    session.default_bucket = Mock(name="default_bucket", return_value=BUCKET_NAME)
+    session.expand_role = Mock(name="expand_role", return_value=ROLE)
+    return session
+
+
+def _get_full_gpu_image_uri(
+    version, base_framework_version, instance_type, training_compiler_config
+):
+    return image_uris.retrieve(
+        "huggingface",
+        REGION,
+        version=version,
+        py_version="py38",
+        instance_type=instance_type,
+        image_scope="training",
+        base_framework_version=base_framework_version,
+        container_version="cu111-ubuntu20.04",
+        training_compiler_config=training_compiler_config,
+    )
+
+
+def _create_train_job(version, base_framework_version, instance_type, training_compiler_config):
+    return {
+        "image_uri": _get_full_gpu_image_uri(
+            version, base_framework_version, instance_type, training_compiler_config
+        ),
+        "input_mode": "File",
+        "input_config": [
+            {
+                "ChannelName": "training",
+                "DataSource": {
+                    "S3DataSource": {
+                        "S3DataDistributionType": "FullyReplicated",
+                        "S3DataType": "S3Prefix",
+                    }
+                },
+            }
+        ],
+        "role": ROLE,
+        "job_name": JOB_NAME,
+        "output_config": {"S3OutputPath": "s3://{}/".format(BUCKET_NAME)},
+        "resource_config": {
+            "InstanceType": instance_type,
+            "InstanceCount": 1,
+            "VolumeSizeInGB": 30,
+        },
+        "hyperparameters": {
+            "sagemaker_program": json.dumps("dummy_script.py"),
+            "sagemaker_container_log_level": str(logging.INFO),
+            "sagemaker_job_name": json.dumps(JOB_NAME),
+            "sagemaker_submit_directory": json.dumps(
+                "s3://{}/{}/source/sourcedir.tar.gz".format(BUCKET_NAME, JOB_NAME)
+            ),
+            "sagemaker_region": '"us-east-1"',
+        },
+        "stop_condition": {"MaxRuntimeInSeconds": 24 * 60 * 60},
+        "tags": None,
+        "vpc_config": None,
+        "metric_definitions": None,
+        "environment": None,
+        "retry_strategy": None,
+        "experiment_config": EXPERIMENT_CONFIG,
+        "debugger_hook_config": {
+            "CollectionConfigurations": [],
+            "S3OutputPath": "s3://{}/".format(BUCKET_NAME),
+        },
+        "profiler_rule_configs": [
+            {
+                "RuleConfigurationName": "ProfilerReport-1510006209",
+                "RuleEvaluatorImage": "503895931360.dkr.ecr.us-east-1.amazonaws.com/sagemaker-debugger-rules:latest",
+                "RuleParameters": {"rule_to_invoke": "ProfilerReport"},
+            }
+        ],
+        "profiler_config": {
+            "S3OutputPath": "s3://{}/".format(BUCKET_NAME),
+        },
+    }
+
+
+def test_unsupported_BYOC(
+    huggingface_training_compiler_version,
+    huggingface_training_compiler_pytorch_version,
+):
+    byoc = (
+        "1.dkr.ecr.us-east-1.amazonaws.com/huggingface-pytorch-trcomp-training:"
+        "1.10.2-"
+        "transformers4.17.0-gpu-"
+        "py38-cu113-ubuntu20.04"
+    )
+    with pytest.raises(ValueError):
+        HuggingFace(
+            image_uri=byoc,
+            py_version="py38",
+            entry_point=SCRIPT_PATH,
+            role=ROLE,
+            instance_count=INSTANCE_COUNT,
+            instance_type=INSTANCE_TYPE,
+            transformers_version=huggingface_training_compiler_version,
+            pytorch_version=huggingface_training_compiler_pytorch_version,
+            enable_sagemaker_metrics=False,
+            compiler_config=TrainingCompilerConfig(),
+        ).fit()
+
+
+def test_unsupported_cpu_instance(
+    cpu_instance_type,
+    huggingface_training_compiler_version,
+    huggingface_training_compiler_pytorch_version,
+):
+    with pytest.raises(ValueError):
+        HuggingFace(
+            py_version="py38",
+            entry_point=SCRIPT_PATH,
+            role=ROLE,
+            instance_count=INSTANCE_COUNT,
+            instance_type=cpu_instance_type,
+            transformers_version=huggingface_training_compiler_version,
+            pytorch_version=huggingface_training_compiler_pytorch_version,
+            enable_sagemaker_metrics=False,
+            compiler_config=TrainingCompilerConfig(),
+        ).fit()
+
+
+@pytest.mark.parametrize("unsupported_gpu_instance_class", UNSUPPORTED_GPU_INSTANCE_CLASSES)
+def test_unsupported_gpu_instance(
+    unsupported_gpu_instance_class,
+    huggingface_training_compiler_version,
+    huggingface_training_compiler_pytorch_version,
+):
+    with pytest.raises(ValueError):
+        HuggingFace(
+            py_version="py38",
+            entry_point=SCRIPT_PATH,
+            role=ROLE,
+            instance_count=INSTANCE_COUNT,
+            instance_type=f"ml.{unsupported_gpu_instance_class}.xlarge",
+            transformers_version=huggingface_training_compiler_version,
+            pytorch_version=huggingface_training_compiler_pytorch_version,
+            enable_sagemaker_metrics=False,
+            compiler_config=TrainingCompilerConfig(),
+        ).fit()
+
+
+def test_unsupported_framework_version(
+    huggingface_training_compiler_version,
+):
+    with pytest.raises(ValueError):
+        HuggingFace(
+            py_version="py38",
+            entry_point=SCRIPT_PATH,
+            role=ROLE,
+            instance_count=INSTANCE_COUNT,
+            instance_type=INSTANCE_TYPE,
+            transformers_version=huggingface_training_compiler_version,
+            pytorch_version=".".join(
+                ["99"] * len(huggingface_training_compiler_version.split("."))
+            ),
+            enable_sagemaker_metrics=False,
+            compiler_config=TrainingCompilerConfig(),
+        ).fit()
+
+
+def test_unsupported_framework_mxnet(
+    huggingface_training_compiler_version,
+):
+    with pytest.raises(ValueError):
+        HuggingFace(
+            py_version="py38",
+            entry_point=SCRIPT_PATH,
+            role=ROLE,
+            instance_count=INSTANCE_COUNT,
+            instance_type=INSTANCE_TYPE,
+            transformers_version=huggingface_training_compiler_version,
+            mxnet_version=".".join(["99"] * len(huggingface_training_compiler_version.split("."))),
+            enable_sagemaker_metrics=False,
+            compiler_config=TrainingCompilerConfig(),
+        ).fit()
+
+
+def test_unsupported_python_2(
+    huggingface_training_compiler_version,
+    huggingface_training_compiler_pytorch_version,
+):
+    with pytest.raises(ValueError):
+        HuggingFace(
+            py_version="py27",
+            entry_point=SCRIPT_PATH,
+            role=ROLE,
+            instance_count=INSTANCE_COUNT,
+            instance_type=INSTANCE_TYPE,
+            transformers_version=huggingface_training_compiler_version,
+            pytorch_version=huggingface_training_compiler_pytorch_version,
+            enable_sagemaker_metrics=False,
+            compiler_config=TrainingCompilerConfig(),
+        ).fit()
+
+
+@patch("sagemaker.utils.repack_model", MagicMock())
+@patch("sagemaker.utils.create_tar_file", MagicMock())
+@patch("sagemaker.estimator.name_from_base", return_value=JOB_NAME)
+@patch("time.time", return_value=TIME)
+@pytest.mark.parametrize("instance_class", SUPPORTED_GPU_INSTANCE_CLASSES)
+def test_default_compiler_config(
+    time,
+    name_from_base,
+    sagemaker_session,
+    huggingface_training_compiler_version,
+    huggingface_training_compiler_pytorch_version,
+    instance_class,
+):
+    compiler_config = TrainingCompilerConfig()
+    instance_type = f"ml.{instance_class}.xlarge"
+
+    hf = HuggingFace(
+        py_version="py38",
+        entry_point=SCRIPT_PATH,
+        role=ROLE,
+        sagemaker_session=sagemaker_session,
+        instance_count=INSTANCE_COUNT,
+        instance_type=instance_type,
+        transformers_version=huggingface_training_compiler_version,
+        pytorch_version=huggingface_training_compiler_pytorch_version,
+        enable_sagemaker_metrics=False,
+        compiler_config=compiler_config,
+    )
+
+    inputs = "s3://mybucket/train"
+
+    hf.fit(inputs=inputs, experiment_config=EXPERIMENT_CONFIG)
+
+    sagemaker_call_names = [c[0] for c in sagemaker_session.method_calls]
+    assert sagemaker_call_names == ["train", "logs_for_job"]
+    boto_call_names = [c[0] for c in sagemaker_session.boto_session.method_calls]
+    assert boto_call_names == ["resource"]
+
+    expected_train_args = _create_train_job(
+        huggingface_training_compiler_version,
+        f"pytorch{huggingface_training_compiler_pytorch_version}",
+        instance_type,
+        compiler_config,
+    )
+    expected_train_args["input_config"][0]["DataSource"]["S3DataSource"]["S3Uri"] = inputs
+    expected_train_args["enable_sagemaker_metrics"] = False
+    expected_train_args["hyperparameters"][TrainingCompilerConfig.HP_ENABLE_COMPILER] = json.dumps(
+        True
+    )
+    expected_train_args["hyperparameters"][TrainingCompilerConfig.HP_ENABLE_DEBUG] = json.dumps(
+        False
+    )
+
+    actual_train_args = sagemaker_session.method_calls[0][2]
+    assert (
+        actual_train_args == expected_train_args
+    ), f"{json.dumps(actual_train_args, indent=2)} != {json.dumps(expected_train_args, indent=2)}"
+
+
+@patch("sagemaker.utils.repack_model", MagicMock())
+@patch("sagemaker.utils.create_tar_file", MagicMock())
+@patch("sagemaker.estimator.name_from_base", return_value=JOB_NAME)
+@patch("time.time", return_value=TIME)
+def test_debug_compiler_config(
+    time,
+    name_from_base,
+    sagemaker_session,
+    huggingface_training_compiler_version,
+    huggingface_training_compiler_pytorch_version,
+):
+    compiler_config = TrainingCompilerConfig(debug=True)
+
+    hf = HuggingFace(
+        py_version="py38",
+        entry_point=SCRIPT_PATH,
+        role=ROLE,
+        sagemaker_session=sagemaker_session,
+        instance_count=INSTANCE_COUNT,
+        instance_type=INSTANCE_TYPE,
+        transformers_version=huggingface_training_compiler_version,
+        pytorch_version=huggingface_training_compiler_pytorch_version,
+        enable_sagemaker_metrics=False,
+        compiler_config=compiler_config,
+    )
+
+    inputs = "s3://mybucket/train"
+
+    hf.fit(inputs=inputs, experiment_config=EXPERIMENT_CONFIG)
+
+    sagemaker_call_names = [c[0] for c in sagemaker_session.method_calls]
+    assert sagemaker_call_names == ["train", "logs_for_job"]
+    boto_call_names = [c[0] for c in sagemaker_session.boto_session.method_calls]
+    assert boto_call_names == ["resource"]
+
+    expected_train_args = _create_train_job(
+        huggingface_training_compiler_version,
+        f"pytorch{huggingface_training_compiler_pytorch_version}",
+        INSTANCE_TYPE,
+        compiler_config,
+    )
+    expected_train_args["input_config"][0]["DataSource"]["S3DataSource"]["S3Uri"] = inputs
+    expected_train_args["enable_sagemaker_metrics"] = False
+    expected_train_args["hyperparameters"][TrainingCompilerConfig.HP_ENABLE_COMPILER] = json.dumps(
+        True
+    )
+    expected_train_args["hyperparameters"][TrainingCompilerConfig.HP_ENABLE_DEBUG] = json.dumps(
+        True
+    )
+
+    actual_train_args = sagemaker_session.method_calls[0][2]
+    assert (
+        actual_train_args == expected_train_args
+    ), f"{json.dumps(actual_train_args, indent=2)} != {json.dumps(expected_train_args, indent=2)}"
+
+
+@patch("sagemaker.utils.repack_model", MagicMock())
+@patch("sagemaker.utils.create_tar_file", MagicMock())
+@patch("sagemaker.estimator.name_from_base", return_value=JOB_NAME)
+@patch("time.time", return_value=TIME)
+def test_disable_compiler_config(
+    time,
+    name_from_base,
+    sagemaker_session,
+    huggingface_training_compiler_version,
+    huggingface_training_compiler_pytorch_version,
+):
+    compiler_config = TrainingCompilerConfig(enabled=False)
+
+    hf = HuggingFace(
+        py_version="py38",
+        entry_point=SCRIPT_PATH,
+        role=ROLE,
+        sagemaker_session=sagemaker_session,
+        instance_count=INSTANCE_COUNT,
+        instance_type=INSTANCE_TYPE,
+        transformers_version=huggingface_training_compiler_version,
+        pytorch_version=huggingface_training_compiler_pytorch_version,
+        enable_sagemaker_metrics=False,
+        compiler_config=TrainingCompilerConfig(enabled=False),
+    )
+
+    inputs = "s3://mybucket/train"
+
+    hf.fit(inputs=inputs, experiment_config=EXPERIMENT_CONFIG)
+
+    sagemaker_call_names = [c[0] for c in sagemaker_session.method_calls]
+    assert sagemaker_call_names == ["train", "logs_for_job"]
+    boto_call_names = [c[0] for c in sagemaker_session.boto_session.method_calls]
+    assert boto_call_names == ["resource"]
+
+    expected_train_args = _create_train_job(
+        huggingface_training_compiler_version,
+        f"pytorch{huggingface_training_compiler_pytorch_version}",
+        INSTANCE_TYPE,
+        compiler_config,
+    )
+    expected_train_args["input_config"][0]["DataSource"]["S3DataSource"]["S3Uri"] = inputs
+    expected_train_args["enable_sagemaker_metrics"] = False
+    expected_train_args["hyperparameters"][TrainingCompilerConfig.HP_ENABLE_COMPILER] = json.dumps(
+        False
+    )
+    expected_train_args["hyperparameters"][TrainingCompilerConfig.HP_ENABLE_DEBUG] = json.dumps(
+        False
+    )
+
+    actual_train_args = sagemaker_session.method_calls[0][2]
+    assert (
+        actual_train_args == expected_train_args
+    ), f"{json.dumps(actual_train_args, indent=2)} != {json.dumps(expected_train_args, indent=2)}"
+
+
+@pytest.mark.parametrize(
+    ["compiler_enabled", "debug_enabled"], [(True, False), (True, True), (False, False)]
+)
+def test_attach(
+    sagemaker_session,
+    compiler_enabled,
+    debug_enabled,
+):
+    training_image = (
+        "1.dkr.ecr.us-east-1.amazonaws.com/huggingface-pytorch-trcomp-training:"
+        "1.10.2-"
+        "transformers4.17.0-gpu-"
+        "py38-cu113-ubuntu20.04"
+    )
+    returned_job_description = {
+        "AlgorithmSpecification": {"TrainingInputMode": "File", "TrainingImage": training_image},
+        "HyperParameters": {
+            "sagemaker_submit_directory": '"s3://some/sourcedir.tar.gz"',
+            "sagemaker_program": '"iris-dnn-classifier.py"',
+            "sagemaker_s3_uri_training": '"sagemaker-3/integ-test-data/tf_iris"',
+            "sagemaker_container_log_level": '"logging.INFO"',
+            "sagemaker_job_name": '"hopper"',
+            "training_steps": "100",
+            "sagemaker_region": '"us-east-1"',
+            TrainingCompilerConfig.HP_ENABLE_COMPILER: json.dumps(compiler_enabled),
+            TrainingCompilerConfig.HP_ENABLE_DEBUG: json.dumps(debug_enabled),
+        },
+        "RoleArn": "arn:aws:iam::366:role/SageMakerRole",
+        "ResourceConfig": {
+            "VolumeSizeInGB": 30,
+            "InstanceCount": 1,
+            "InstanceType": "ml.p3.2xlarge",
+        },
+        "StoppingCondition": {"MaxRuntimeInSeconds": 24 * 60 * 60},
+        "TrainingJobName": "hopper",
+        "TrainingJobStatus": "Completed",
+        "TrainingJobArn": "arn:aws:sagemaker:us-west-2:336:training-job/hopper",
+        "OutputDataConfig": {"KmsKeyId": "", "S3OutputPath": "s3://place/output/hopper"},
+        "TrainingJobOutput": {"S3TrainingJobOutput": "s3://here/output.tar.gz"},
+    }
+    sagemaker_session.sagemaker_client.describe_training_job = Mock(
+        name="describe_training_job", return_value=returned_job_description
+    )
+
+    estimator = HuggingFace.attach(training_job_name="hopper", sagemaker_session=sagemaker_session)
+    assert estimator.latest_training_job.job_name == "hopper"
+    assert estimator.py_version == "py38"
+    assert estimator.framework_version == "4.17.0"
+    assert estimator.pytorch_version == "1.10.2"
+    assert estimator.role == "arn:aws:iam::366:role/SageMakerRole"
+    assert estimator.instance_count == 1
+    assert estimator.max_run == 24 * 60 * 60
+    assert estimator.input_mode == "File"
+    assert estimator.base_job_name == "hopper"
+    assert estimator.output_path == "s3://place/output/hopper"
+    assert estimator.output_kms_key == ""
+    assert estimator.hyperparameters()["training_steps"] == "100"
+    assert estimator.hyperparameters()[TrainingCompilerConfig.HP_ENABLE_COMPILER] == json.dumps(
+        compiler_enabled
+    )
+    assert estimator.hyperparameters()[TrainingCompilerConfig.HP_ENABLE_DEBUG] == json.dumps(
+        debug_enabled
+    )
+    assert estimator.source_dir == "s3://some/sourcedir.tar.gz"
+    assert estimator.entry_point == "iris-dnn-classifier.py"

--- a/tests/unit/sagemaker/training_compiler/test_huggingface_pytorch_compiler.py
+++ b/tests/unit/sagemaker/training_compiler/test_huggingface_pytorch_compiler.py
@@ -462,7 +462,7 @@ def test_attach(
             "sagemaker_program": '"iris-dnn-classifier.py"',
             "sagemaker_s3_uri_training": '"sagemaker-3/integ-test-data/tf_iris"',
             "sagemaker_container_log_level": '"logging.INFO"',
-            "sagemaker_job_name": '"hopper"',
+            "sagemaker_job_name": '"trcomp"',
             "training_steps": "100",
             "sagemaker_region": '"us-east-1"',
             TrainingCompilerConfig.HP_ENABLE_COMPILER: json.dumps(compiler_enabled),
@@ -475,18 +475,18 @@ def test_attach(
             "InstanceType": "ml.p3.2xlarge",
         },
         "StoppingCondition": {"MaxRuntimeInSeconds": 24 * 60 * 60},
-        "TrainingJobName": "hopper",
+        "TrainingJobName": "trcomp",
         "TrainingJobStatus": "Completed",
-        "TrainingJobArn": "arn:aws:sagemaker:us-west-2:336:training-job/hopper",
-        "OutputDataConfig": {"KmsKeyId": "", "S3OutputPath": "s3://place/output/hopper"},
+        "TrainingJobArn": "arn:aws:sagemaker:us-west-2:336:training-job/trcomp",
+        "OutputDataConfig": {"KmsKeyId": "", "S3OutputPath": "s3://place/output/trcomp"},
         "TrainingJobOutput": {"S3TrainingJobOutput": "s3://here/output.tar.gz"},
     }
     sagemaker_session.sagemaker_client.describe_training_job = Mock(
         name="describe_training_job", return_value=returned_job_description
     )
 
-    estimator = HuggingFace.attach(training_job_name="hopper", sagemaker_session=sagemaker_session)
-    assert estimator.latest_training_job.job_name == "hopper"
+    estimator = HuggingFace.attach(training_job_name="trcomp", sagemaker_session=sagemaker_session)
+    assert estimator.latest_training_job.job_name == "trcomp"
     assert estimator.py_version == "py38"
     assert estimator.framework_version == "4.17.0"
     assert estimator.pytorch_version == "1.10.2"
@@ -494,8 +494,8 @@ def test_attach(
     assert estimator.instance_count == 1
     assert estimator.max_run == 24 * 60 * 60
     assert estimator.input_mode == "File"
-    assert estimator.base_job_name == "hopper"
-    assert estimator.output_path == "s3://place/output/hopper"
+    assert estimator.base_job_name == "trcomp"
+    assert estimator.output_path == "s3://place/output/trcomp"
     assert estimator.output_kms_key == ""
     assert estimator.hyperparameters()["training_steps"] == "100"
     assert estimator.hyperparameters()[TrainingCompilerConfig.HP_ENABLE_COMPILER] == json.dumps(

--- a/tests/unit/sagemaker/training_compiler/test_huggingface_tensorflow_compiler.py
+++ b/tests/unit/sagemaker/training_compiler/test_huggingface_tensorflow_compiler.py
@@ -473,7 +473,7 @@ def test_attach(
             "sagemaker_program": '"iris-dnn-classifier.py"',
             "sagemaker_s3_uri_training": '"sagemaker-3/integ-test-data/tf_iris"',
             "sagemaker_container_log_level": '"logging.INFO"',
-            "sagemaker_job_name": '"hopper"',
+            "sagemaker_job_name": '"trcomp"',
             "training_steps": "100",
             "sagemaker_region": '"us-east-1"',
             TrainingCompilerConfig.HP_ENABLE_COMPILER: json.dumps(compiler_enabled),
@@ -486,18 +486,18 @@ def test_attach(
             "InstanceType": "ml.p3.2xlarge",
         },
         "StoppingCondition": {"MaxRuntimeInSeconds": 24 * 60 * 60},
-        "TrainingJobName": "hopper",
+        "TrainingJobName": "trcomp",
         "TrainingJobStatus": "Completed",
-        "TrainingJobArn": "arn:aws:sagemaker:us-west-2:336:training-job/hopper",
-        "OutputDataConfig": {"KmsKeyId": "", "S3OutputPath": "s3://place/output/hopper"},
+        "TrainingJobArn": "arn:aws:sagemaker:us-west-2:336:training-job/trcomp",
+        "OutputDataConfig": {"KmsKeyId": "", "S3OutputPath": "s3://place/output/trcomp"},
         "TrainingJobOutput": {"S3TrainingJobOutput": "s3://here/output.tar.gz"},
     }
     sagemaker_session.sagemaker_client.describe_training_job = Mock(
         name="describe_training_job", return_value=returned_job_description
     )
 
-    estimator = HuggingFace.attach(training_job_name="hopper", sagemaker_session=sagemaker_session)
-    assert estimator.latest_training_job.job_name == "hopper"
+    estimator = HuggingFace.attach(training_job_name="trcomp", sagemaker_session=sagemaker_session)
+    assert estimator.latest_training_job.job_name == "trcomp"
     assert estimator.py_version == huggingface_training_compiler_py_version
     assert estimator.framework_version == "4.17.0"
     assert estimator.tensorflow_version == "2.6.3"
@@ -505,8 +505,8 @@ def test_attach(
     assert estimator.instance_count == 1
     assert estimator.max_run == 24 * 60 * 60
     assert estimator.input_mode == "File"
-    assert estimator.base_job_name == "hopper"
-    assert estimator.output_path == "s3://place/output/hopper"
+    assert estimator.base_job_name == "trcomp"
+    assert estimator.output_path == "s3://place/output/trcomp"
     assert estimator.output_kms_key == ""
     assert estimator.hyperparameters()["training_steps"] == "100"
     assert estimator.hyperparameters()[TrainingCompilerConfig.HP_ENABLE_COMPILER] == json.dumps(

--- a/tests/unit/sagemaker/training_compiler/test_huggingface_tensorflow_compiler.py
+++ b/tests/unit/sagemaker/training_compiler/test_huggingface_tensorflow_compiler.py
@@ -154,13 +154,13 @@ def _create_train_job(version, base_framework_version, instance_type, training_c
 
 def test_unsupported_BYOC(
     huggingface_training_compiler_version,
-    huggingface_training_compiler_pytorch_version,
+    huggingface_training_compiler_tensorflow_version,
 ):
     byoc = (
-        "1.dkr.ecr.us-east-1.amazonaws.com/huggingface-pytorch-trcomp-training:"
-        "1.9.0-"
-        "transformers4.10.2-gpu-"
-        "py38-cu111-ubuntu20.04"
+        "1.dkr.ecr.us-east-1.amazonaws.com/huggingface-tensorflow-trcomp-training:"
+        "2.6.3-"
+        "transformers4.17.0-gpu-"
+        "py38-cu112-ubuntu20.04"
     )
     with pytest.raises(ValueError):
         HuggingFace(
@@ -171,7 +171,7 @@ def test_unsupported_BYOC(
             instance_count=INSTANCE_COUNT,
             instance_type=INSTANCE_TYPE,
             transformers_version=huggingface_training_compiler_version,
-            pytorch_version=huggingface_training_compiler_pytorch_version,
+            tensorflow_version=huggingface_training_compiler_tensorflow_version,
             enable_sagemaker_metrics=False,
             compiler_config=TrainingCompilerConfig(),
         ).fit()
@@ -180,7 +180,7 @@ def test_unsupported_BYOC(
 def test_unsupported_cpu_instance(
     cpu_instance_type,
     huggingface_training_compiler_version,
-    huggingface_training_compiler_pytorch_version,
+    huggingface_training_compiler_tensorflow_version,
 ):
     with pytest.raises(ValueError):
         HuggingFace(
@@ -190,7 +190,7 @@ def test_unsupported_cpu_instance(
             instance_count=INSTANCE_COUNT,
             instance_type=cpu_instance_type,
             transformers_version=huggingface_training_compiler_version,
-            pytorch_version=huggingface_training_compiler_pytorch_version,
+            tensorflow_version=huggingface_training_compiler_tensorflow_version,
             enable_sagemaker_metrics=False,
             compiler_config=TrainingCompilerConfig(),
         ).fit()
@@ -200,7 +200,7 @@ def test_unsupported_cpu_instance(
 def test_unsupported_gpu_instance(
     unsupported_gpu_instance_class,
     huggingface_training_compiler_version,
-    huggingface_training_compiler_pytorch_version,
+    huggingface_training_compiler_tensorflow_version,
 ):
     with pytest.raises(ValueError):
         HuggingFace(
@@ -210,7 +210,7 @@ def test_unsupported_gpu_instance(
             instance_count=INSTANCE_COUNT,
             instance_type=f"ml.{unsupported_gpu_instance_class}.xlarge",
             transformers_version=huggingface_training_compiler_version,
-            pytorch_version=huggingface_training_compiler_pytorch_version,
+            tensorflow_version=huggingface_training_compiler_tensorflow_version,
             enable_sagemaker_metrics=False,
             compiler_config=TrainingCompilerConfig(),
         ).fit()
@@ -227,7 +227,7 @@ def test_unsupported_framework_version(
             instance_count=INSTANCE_COUNT,
             instance_type=INSTANCE_TYPE,
             transformers_version=huggingface_training_compiler_version,
-            pytorch_version=".".join(
+            tensorflow_version=".".join(
                 ["99"] * len(huggingface_training_compiler_version.split("."))
             ),
             enable_sagemaker_metrics=False,
@@ -254,7 +254,7 @@ def test_unsupported_framework_mxnet(
 
 def test_unsupported_python_2(
     huggingface_training_compiler_version,
-    huggingface_training_compiler_pytorch_version,
+    huggingface_training_compiler_tensorflow_version,
 ):
     with pytest.raises(ValueError):
         HuggingFace(
@@ -264,7 +264,7 @@ def test_unsupported_python_2(
             instance_count=INSTANCE_COUNT,
             instance_type=INSTANCE_TYPE,
             transformers_version=huggingface_training_compiler_version,
-            pytorch_version=huggingface_training_compiler_pytorch_version,
+            tensorflow_version=huggingface_training_compiler_tensorflow_version,
             enable_sagemaker_metrics=False,
             compiler_config=TrainingCompilerConfig(),
         ).fit()
@@ -280,7 +280,7 @@ def test_default_compiler_config(
     name_from_base,
     sagemaker_session,
     huggingface_training_compiler_version,
-    huggingface_training_compiler_pytorch_version,
+    huggingface_training_compiler_tensorflow_version,
     instance_class,
 ):
     compiler_config = TrainingCompilerConfig()
@@ -294,7 +294,7 @@ def test_default_compiler_config(
         instance_count=INSTANCE_COUNT,
         instance_type=instance_type,
         transformers_version=huggingface_training_compiler_version,
-        pytorch_version=huggingface_training_compiler_pytorch_version,
+        tensorflow_version=huggingface_training_compiler_tensorflow_version,
         enable_sagemaker_metrics=False,
         compiler_config=compiler_config,
     )
@@ -310,7 +310,7 @@ def test_default_compiler_config(
 
     expected_train_args = _create_train_job(
         huggingface_training_compiler_version,
-        f"pytorch{huggingface_training_compiler_pytorch_version}",
+        f"tensorflow{huggingface_training_compiler_tensorflow_version}",
         instance_type,
         compiler_config,
     )
@@ -338,7 +338,7 @@ def test_debug_compiler_config(
     name_from_base,
     sagemaker_session,
     huggingface_training_compiler_version,
-    huggingface_training_compiler_pytorch_version,
+    huggingface_training_compiler_tensorflow_version,
 ):
     compiler_config = TrainingCompilerConfig(debug=True)
 
@@ -350,7 +350,7 @@ def test_debug_compiler_config(
         instance_count=INSTANCE_COUNT,
         instance_type=INSTANCE_TYPE,
         transformers_version=huggingface_training_compiler_version,
-        pytorch_version=huggingface_training_compiler_pytorch_version,
+        tensorflow_version=huggingface_training_compiler_tensorflow_version,
         enable_sagemaker_metrics=False,
         compiler_config=compiler_config,
     )
@@ -366,7 +366,7 @@ def test_debug_compiler_config(
 
     expected_train_args = _create_train_job(
         huggingface_training_compiler_version,
-        f"pytorch{huggingface_training_compiler_pytorch_version}",
+        f"tensorflow{huggingface_training_compiler_tensorflow_version}",
         INSTANCE_TYPE,
         compiler_config,
     )
@@ -394,7 +394,7 @@ def test_disable_compiler_config(
     name_from_base,
     sagemaker_session,
     huggingface_training_compiler_version,
-    huggingface_training_compiler_pytorch_version,
+    huggingface_training_compiler_tensorflow_version,
 ):
     compiler_config = TrainingCompilerConfig(enabled=False)
 
@@ -406,7 +406,7 @@ def test_disable_compiler_config(
         instance_count=INSTANCE_COUNT,
         instance_type=INSTANCE_TYPE,
         transformers_version=huggingface_training_compiler_version,
-        pytorch_version=huggingface_training_compiler_pytorch_version,
+        tensorflow_version=huggingface_training_compiler_tensorflow_version,
         enable_sagemaker_metrics=False,
         compiler_config=TrainingCompilerConfig(enabled=False),
     )
@@ -422,7 +422,7 @@ def test_disable_compiler_config(
 
     expected_train_args = _create_train_job(
         huggingface_training_compiler_version,
-        f"pytorch{huggingface_training_compiler_pytorch_version}",
+        f"tensorflow{huggingface_training_compiler_tensorflow_version}",
         INSTANCE_TYPE,
         compiler_config,
     )
@@ -450,10 +450,10 @@ def test_attach(
     debug_enabled,
 ):
     training_image = (
-        "1.dkr.ecr.us-east-1.amazonaws.com/huggingface-pytorch-trcomp-training:"
-        "1.9.0-"
-        "transformers4.10.2-gpu-"
-        "py38-cu111-ubuntu20.04"
+        "1.dkr.ecr.us-east-1.amazonaws.com/huggingface-tensorflow-trcomp-training:"
+        "2.6.3-"
+        "transformers4.17.0-gpu-"
+        "py38-cu112-ubuntu20.04"
     )
     returned_job_description = {
         "AlgorithmSpecification": {"TrainingInputMode": "File", "TrainingImage": training_image},
@@ -488,8 +488,8 @@ def test_attach(
     estimator = HuggingFace.attach(training_job_name="hopper", sagemaker_session=sagemaker_session)
     assert estimator.latest_training_job.job_name == "hopper"
     assert estimator.py_version == "py38"
-    assert estimator.framework_version == "4.10.2"
-    assert estimator.pytorch_version == "1.9.0"
+    assert estimator.framework_version == "4.17.0"
+    assert estimator.tensorflow_version == "2.6.3"
     assert estimator.role == "arn:aws:iam::366:role/SageMakerRole"
     assert estimator.instance_count == 1
     assert estimator.max_run == 24 * 60 * 60

--- a/tests/unit/sagemaker/training_compiler/test_huggingface_tensorflow_compiler.py
+++ b/tests/unit/sagemaker/training_compiler/test_huggingface_tensorflow_compiler.py
@@ -79,11 +79,7 @@ def fixture_sagemaker_session():
 
 
 def _get_full_gpu_image_uri(
-    version,
-    base_framework_version,
-    instance_type,
-    training_compiler_config,
-    py_version
+    version, base_framework_version, instance_type, training_compiler_config, py_version
 ):
     return image_uris.retrieve(
         "huggingface",
@@ -98,7 +94,9 @@ def _get_full_gpu_image_uri(
     )
 
 
-def _create_train_job(version, base_framework_version, instance_type, training_compiler_config, py_version):
+def _create_train_job(
+    version, base_framework_version, instance_type, training_compiler_config, py_version
+):
     return {
         "image_uri": _get_full_gpu_image_uri(
             version, base_framework_version, instance_type, training_compiler_config, py_version
@@ -159,7 +157,7 @@ def _create_train_job(version, base_framework_version, instance_type, training_c
 def test_unsupported_BYOC(
     huggingface_training_compiler_version,
     huggingface_training_compiler_tensorflow_version,
-    huggingface_training_compiler_py_version
+    huggingface_training_compiler_py_version,
 ):
     byoc = (
         f"1.dkr.ecr.us-east-1.amazonaws.com/huggingface-tensorflow-trcomp-training:"
@@ -186,7 +184,7 @@ def test_unsupported_cpu_instance(
     cpu_instance_type,
     huggingface_training_compiler_version,
     huggingface_training_compiler_tensorflow_version,
-    huggingface_training_compiler_py_version
+    huggingface_training_compiler_py_version,
 ):
     with pytest.raises(ValueError):
         HuggingFace(
@@ -207,7 +205,7 @@ def test_unsupported_gpu_instance(
     unsupported_gpu_instance_class,
     huggingface_training_compiler_version,
     huggingface_training_compiler_tensorflow_version,
-    huggingface_training_compiler_py_version
+    huggingface_training_compiler_py_version,
 ):
     with pytest.raises(ValueError):
         HuggingFace(
@@ -225,7 +223,7 @@ def test_unsupported_gpu_instance(
 
 def test_unsupported_framework_version(
     huggingface_training_compiler_version,
-    huggingface_training_compiler_py_version
+    huggingface_training_compiler_py_version,
 ):
     with pytest.raises(ValueError):
         HuggingFace(
@@ -245,7 +243,7 @@ def test_unsupported_framework_version(
 
 def test_unsupported_framework_mxnet(
     huggingface_training_compiler_version,
-    huggingface_training_compiler_py_version
+    huggingface_training_compiler_py_version,
 ):
     with pytest.raises(ValueError):
         HuggingFace(
@@ -263,7 +261,7 @@ def test_unsupported_framework_mxnet(
 
 def test_unsupported_python_2(
     huggingface_training_compiler_version,
-    huggingface_training_compiler_tensorflow_version
+    huggingface_training_compiler_tensorflow_version,
 ):
     with pytest.raises(ValueError):
         HuggingFace(
@@ -291,7 +289,7 @@ def test_default_compiler_config(
     huggingface_training_compiler_version,
     huggingface_training_compiler_tensorflow_version,
     instance_class,
-    huggingface_training_compiler_py_version
+    huggingface_training_compiler_py_version,
 ):
     compiler_config = TrainingCompilerConfig()
     instance_type = f"ml.{instance_class}.xlarge"
@@ -323,7 +321,7 @@ def test_default_compiler_config(
         f"tensorflow{huggingface_training_compiler_tensorflow_version}",
         instance_type,
         compiler_config,
-        huggingface_training_compiler_py_version
+        huggingface_training_compiler_py_version,
     )
     expected_train_args["input_config"][0]["DataSource"]["S3DataSource"]["S3Uri"] = inputs
     expected_train_args["enable_sagemaker_metrics"] = False
@@ -350,7 +348,7 @@ def test_debug_compiler_config(
     sagemaker_session,
     huggingface_training_compiler_version,
     huggingface_training_compiler_tensorflow_version,
-    huggingface_training_compiler_py_version
+    huggingface_training_compiler_py_version,
 ):
     compiler_config = TrainingCompilerConfig(debug=True)
 
@@ -381,7 +379,7 @@ def test_debug_compiler_config(
         f"tensorflow{huggingface_training_compiler_tensorflow_version}",
         INSTANCE_TYPE,
         compiler_config,
-        huggingface_training_compiler_py_version
+        huggingface_training_compiler_py_version,
     )
     expected_train_args["input_config"][0]["DataSource"]["S3DataSource"]["S3Uri"] = inputs
     expected_train_args["enable_sagemaker_metrics"] = False
@@ -408,7 +406,7 @@ def test_disable_compiler_config(
     sagemaker_session,
     huggingface_training_compiler_version,
     huggingface_training_compiler_tensorflow_version,
-    huggingface_training_compiler_py_version
+    huggingface_training_compiler_py_version,
 ):
     compiler_config = TrainingCompilerConfig(enabled=False)
 
@@ -439,7 +437,7 @@ def test_disable_compiler_config(
         f"tensorflow{huggingface_training_compiler_tensorflow_version}",
         INSTANCE_TYPE,
         compiler_config,
-        huggingface_training_compiler_py_version
+        huggingface_training_compiler_py_version,
     )
     expected_train_args["input_config"][0]["DataSource"]["S3DataSource"]["S3Uri"] = inputs
     expected_train_args["enable_sagemaker_metrics"] = False
@@ -460,10 +458,7 @@ def test_disable_compiler_config(
     ["compiler_enabled", "debug_enabled"], [(True, False), (True, True), (False, False)]
 )
 def test_attach(
-    sagemaker_session,
-    compiler_enabled,
-    debug_enabled,
-    huggingface_training_compiler_py_version
+    sagemaker_session, compiler_enabled, debug_enabled, huggingface_training_compiler_py_version
 ):
     training_image = (
         f"1.dkr.ecr.us-east-1.amazonaws.com/huggingface-tensorflow-trcomp-training:"
@@ -503,7 +498,7 @@ def test_attach(
 
     estimator = HuggingFace.attach(training_job_name="hopper", sagemaker_session=sagemaker_session)
     assert estimator.latest_training_job.job_name == "hopper"
-    assert estimator.py_version == "py38"
+    assert estimator.py_version == huggingface_training_compiler_py_version
     assert estimator.framework_version == "4.17.0"
     assert estimator.tensorflow_version == "2.6.3"
     assert estimator.role == "arn:aws:iam::366:role/SageMakerRole"


### PR DESCRIPTION
*Description of changes:* 
- Update tensorflow version for Training Compiler to 2.6.3 and Pytorch to 1.10.2
- Added unit test for Tensorflow. 
- Added all supported regions for integration tests

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
