### PR TITLE
#using uuid to randomize, otherwise system timestamp is used

### DIFF
--- a/src/sagemaker/utils.py
+++ b/src/sagemaker/utils.py
@@ -25,6 +25,7 @@ import tempfile
 import time
 import json
 import abc
+import uuid
 from datetime import datetime
 
 import botocore
@@ -32,8 +33,6 @@ from six.moves.urllib import parse
 
 from sagemaker import deprecations
 from sagemaker.session_settings import SessionSettings
-
-import uuid
 
 
 ECR_URI_PATTERN = r"^(\d+)(\.)dkr(\.)ecr(\.)(.+)(\.)(.*)(/)(.*:.*)$"

--- a/src/sagemaker/utils.py
+++ b/src/sagemaker/utils.py
@@ -33,6 +33,8 @@ from six.moves.urllib import parse
 from sagemaker import deprecations
 from sagemaker.session_settings import SessionSettings
 
+import uuid
+
 
 ECR_URI_PATTERN = r"^(\d+)(\.)dkr(\.)ecr(\.)(.+)(\.)(.*)(/)(.*:.*)$"
 MAX_BUCKET_PATHS_COUNT = 5
@@ -81,6 +83,7 @@ def name_from_base(base, max_length=63, short=False):
 
 def unique_name_from_base(base, max_length=63):
     """Placeholder Docstring"""
+    random.seed(int(uuid.uuid4())) #using uuid to randomize, otherwise system timestamp is used. 
     unique = "%04x" % random.randrange(16**4)  # 4-digit hex
     ts = str(int(time.time()))
     available_length = max_length - 2 - len(ts) - len(unique)

--- a/src/sagemaker/utils.py
+++ b/src/sagemaker/utils.py
@@ -83,7 +83,7 @@ def name_from_base(base, max_length=63, short=False):
 
 def unique_name_from_base(base, max_length=63):
     """Placeholder Docstring"""
-    random.seed(int(uuid.uuid4())) #using uuid to randomize, otherwise system timestamp is used. 
+    random.seed(int(uuid.uuid4()))  # using uuid to randomize, otherwise system timestamp is used.
     unique = "%04x" % random.randrange(16**4)  # 4-digit hex
     ts = str(int(time.time()))
     available_length = max_length - 2 - len(ts) - len(unique)


### PR DESCRIPTION
*Issue #, if available:*
Customer reported issue when load-testing multiple notebooks:

"While executing AutoGluon Notebook, 5/20 users encountered failures while creating a model and endpoint. We modified our examples to create a unique resource name using sagemaker util below. Looks like, collision seems high with this tool.
model_name = sagemaker.utils.unique_name_from_base("inf-pipeline-model")
As the seed for random by default is timestamp it is creating same unique 4-digit hex when accessed around same time"

*Description of changes:*
#using uuid to randomize random.seed(), otherwise system timestamp is used. 

*Testing done:*
Modified sagemaker sdk locally, tested changes. 

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
