### PR TITLE
change: update modelparallel config validation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,6 +80,7 @@ setup(
     package_dir={"": "src"},
     py_modules=[os.path.splitext(os.path.basename(path))[0] for path in glob("src/*.py")],
     include_package_data=True,
+    package_data={"sagemaker": ["mp_config.yaml"]},
     long_description=read("README.rst"),
     author="Amazon Web Services",
     url="https://github.com/aws/sagemaker-python-sdk/",

--- a/src/sagemaker/fw_utils.py
+++ b/src/sagemaker/fw_utils.py
@@ -238,71 +238,10 @@ def validate_mp_config(config):
     Raises:
         ValueError: If any of the keys have incorrect values.
     """
-
-    if "partitions" not in config:
-        raise ValueError("'partitions' is a required parameter.")
-
-    def validate_positive(key):
-        try:
-            if not isinstance(config[key], int) or config[key] < 1:
-                raise ValueError(f"The number of {key} must be a positive integer.")
-        except KeyError:
-            pass
-
-    def validate_in(key, vals):
-        try:
-            if config[key] not in vals:
-                raise ValueError(f"{key} must be a value in: {vals}.")
-        except KeyError:
-            pass
-
-    def validate_bool(keys):
-        validate_in(keys, [True, False])
-
-    validate_in("pipeline", ["simple", "interleaved", "_only_forward"])
-    validate_in("placement_strategy", ["spread", "cluster"])
-    validate_in("optimize", ["speed", "memory"])
-
-    for key in ["microbatches", "partitions", "active_microbatches"]:
-        validate_positive(key)
-
-    for key in [
-        "auto_partition",
-        "contiguous",
-        "load_partition",
-        "horovod",
-        "ddp",
-        "deterministic_server",
-    ]:
-        validate_bool(key)
-
-    if "partition_file" in config and not isinstance(config.get("partition_file"), str):
-        raise ValueError("'partition_file' must be a str.")
-
-    if config.get("auto_partition") is False and "default_partition" not in config:
-        raise ValueError("default_partition must be supplied if auto_partition is set to False!")
-
-    if "default_partition" in config and config["default_partition"] >= config["partitions"]:
-        raise ValueError("default_partition must be less than the number of partitions!")
-
-    if "memory_weight" in config and (
-        config["memory_weight"] > 1.0 or config["memory_weight"] < 0.0
-    ):
-        raise ValueError("memory_weight must be between 0.0 and 1.0!")
-
-    if "ddp_port" in config and "ddp" not in config:
-        raise ValueError("`ddp_port` needs `ddp` to be set as well")
-
-    if "ddp_dist_backend" in config and "ddp" not in config:
-        raise ValueError("`ddp_dist_backend` needs `ddp` to be set as well")
-
-    if "ddp_port" in config:
-        if not isinstance(config["ddp_port"], int) or config["ddp_port"] < 0:
-            value = config["ddp_port"]
-            raise ValueError(f"Invalid port number {value}.")
-
-    if config.get("horovod", False) and config.get("ddp", False):
-        raise ValueError("'ddp' and 'horovod' cannot be simultaneously enabled.")
+    from sagemaker.mp_config import ModelParallelConfig
+    
+    # the constructor runs validation on config parameters
+    ModelParallelConfig(config)
 
 
 def tar_and_upload_dir(

--- a/src/sagemaker/fw_utils.py
+++ b/src/sagemaker/fw_utils.py
@@ -239,7 +239,7 @@ def validate_mp_config(config):
         ValueError: If any of the keys have incorrect values.
     """
     from sagemaker.mp_config import ModelParallelConfig
-    
+
     # the constructor runs validation on config parameters
     ModelParallelConfig(config)
 

--- a/src/sagemaker/mp_config.py
+++ b/src/sagemaker/mp_config.py
@@ -1,0 +1,233 @@
+# Standard Library
+import json
+import os
+import re
+from pydoc import locate
+
+# Third Party
+import yaml
+
+# NOTE: this file is duplicated across smp and SageMaker Python SDK.
+# any changes to this file requires an update of the corresponding file
+# in SageMaker Python SDK upon release.
+
+try:
+    from smdistributed.modelparallel.backend.logger import get_logger
+
+    logger = get_logger()
+    info_func = logger.info
+    warn_func = logger.warning
+    py_sdk = False
+except ImportError:
+    # the case where this file runs on Python SDK for config validation
+    info_func = print
+    warn_func = print
+    py_sdk = True
+
+
+def int_or_float_if_possible(s):
+    try:
+        float_s = float(s)
+        int_s = int(float_s)
+        return int_s if int_s == float_s else float_s
+    except ValueError:
+        return s
+
+
+class ConfigParam:
+    def __init__(self, name, input_value, cfg_dict, existing_params, provided=False):
+        self.name = name
+        self.cfg_dict = cfg_dict
+        self.existing_params = existing_params
+        self.provided = provided
+        self._value = self._set_value(input_value)
+
+    def get_value(self):
+        return self._value
+
+    def _get_default(self):
+        default = self._handle_dependencies(self.cfg_dict["default"])
+        if isinstance(default, (float, int)):
+            # should explicitly enforce upper and lower bounds for dynamic formulas in case
+            # the default evaluates out of bounds
+            if "upper_bound" in self.cfg_dict:
+                default = min(default, self._handle_dependencies(self.cfg_dict["upper_bound"]))
+            if "lower_bound" in self.cfg_dict:
+                default = max(default, self._handle_dependencies(self.cfg_dict["lower_bound"]))
+
+        return default
+
+    def _set_value(self, input_value):
+        if not self.provided:
+            if "default" not in self.cfg_dict:
+                raise ValueError(f"Config parameter {self.name} is required.")
+
+            return self._get_default()
+
+        if "type" in self.cfg_dict:
+            expected_type = locate(self.cfg_dict["type"])
+            if expected_type != type(input_value):
+                raise TypeError(
+                    f"Config parameter {self.name} needs to be of type {expected_type.__name__}. Found: {type(input_value)}"
+                )
+
+        if "options" in self.cfg_dict:
+            options = self._handle_dependencies(self.cfg_dict["options"])
+            if input_value not in options:
+                raise ValueError(
+                    f"Config parameter {self.name} must be one of {self.cfg_dict['options']}. Found: {input_value}."
+                )
+
+        if "lower_bound" in self.cfg_dict:
+            lower_bound = self._handle_dependencies(self.cfg_dict["lower_bound"])
+            if input_value < lower_bound:
+                raise ValueError(
+                    f"Config parameter {self.name} ({input_value}) cannot be less than {self.cfg_dict['lower_bound']} ({lower_bound})."
+                )
+
+        if "upper_bound" in self.cfg_dict:
+            upper_bound = self._handle_dependencies(self.cfg_dict["upper_bound"])
+            if input_value > upper_bound:
+                raise ValueError(
+                    f"Config parameter {self.name} ({input_value}) cannot be larger than {self.cfg_dict['upper_bound']} ({upper_bound})."
+                )
+
+        if "requires" in self.cfg_dict:
+            default = self._get_default()
+            for k, v in self.cfg_dict["requires"].items():
+                if self.existing_params[k].get_value() != v and input_value != default:
+                    raise ValueError(
+                        f"Setting config parameter {self.name} to non-default value {input_value} requires {k} to be set to {v}. Found: {self.existing_params[k].get_value()}"
+                    )
+
+        if "requires_not" in self.cfg_dict:
+            default = self._get_default()
+            for k, v in self.cfg_dict["requires_not"].items():
+                if self.existing_params[k].get_value() == v and input_value != default:
+                    raise ValueError(
+                        f"Setting config parameter {self.name} to non-default value {input_value} requires {k} to not be {v}."
+                    )
+
+        return input_value
+
+    def _maybe_convert(self, value):
+        if value[0] == "(" and value[-1] == ")" and value[1:-1] in self.existing_params:
+            value = self.existing_params[value[1:-1]].get_value()
+
+        return int_or_float_if_possible(value)
+
+    def _handle_dependencies(self, value):
+        if isinstance(value, str):
+            tokens = re.split("\\+|\\-|\\*|\\/", value)
+            ops = [c for c in value if c in ["+", "-", "*", "/"]]
+
+            assert len(tokens) == len(ops) + 1, f"Malformed formula: {value}"
+
+            # if there are operations, all terms must be convertible to float or int
+            # if not, cur_value can be a string
+            tokens = [self._maybe_convert(token.strip()) for token in tokens]
+            cur_value = tokens[0]
+            for op, val in zip(ops, tokens[1:]):
+                if op == "+":
+                    cur_value += val
+                elif op == "-":
+                    cur_value -= val
+                elif op == "*":
+                    cur_value *= val
+                elif op == "/":
+                    cur_value /= val
+            return cur_value
+        else:
+            return value
+
+
+class DependencyIterator:
+    def __init__(self, config):
+        self.config = config
+        self.seen = set()
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        for k in self.config:
+            if k not in self.seen:
+                if "dependencies" not in self.config[k]:
+                    self.seen.add(k)
+                    return k
+
+                if all([(d in self.seen) for d in self.config[k]["dependencies"]]):
+                    self.seen.add(k)
+                    return k
+
+        raise StopIteration
+
+
+class ModelParallelConfig:
+    """Structure that holds the user-defined parameters for SMP."""
+
+    def __init__(self, config):
+        if not py_sdk:
+            SM_CONFIG = json.loads(os.environ.get("SM_HP_MP_PARAMETERS", default="{}"))
+            for each_sm_config in SM_CONFIG:
+                config[each_sm_config] = SM_CONFIG[each_sm_config]
+
+        # load the schema from yaml file
+        dir_path = os.path.dirname(os.path.realpath(__file__))
+        config_path = os.path.join(dir_path, "config.yaml")
+        with open(config_path, "r") as f:
+            schema = yaml.safe_load(f)
+
+        # handle aliases - note below logic assumes at most one alias per config parameter
+        aliases = {v["alias"]: k for k, v in schema.items() if "alias" in v}
+        for alias, orig in aliases.items():
+            if alias in config:
+                if orig in config and config[alias] != config[orig]:
+                    raise ValueError(
+                        f"Conflicting values {config[orig]} and {config[alias]} are provided for config parameter {orig} and its alias {alias}."
+                    )
+                config[orig] = config[alias]
+                del config[alias]
+
+        # make sure there are no invalid config parameters
+        for k in config:
+            if k not in schema:
+                raise ValueError(f"Unrecognized config parameter {k}.")
+
+        # parse and validate the inputs
+        params = {}
+        for k in DependencyIterator(schema):
+            provided = k in config
+            input_value = config[k] if provided else None
+            params[k] = ConfigParam(k, input_value, schema[k], params, provided)
+
+        # set the attributes
+        for k in params:
+            setattr(self, k, params[k].get_value())
+
+        self._input_config = config
+        self._config_dict = params
+
+        # enforce additional constraints - need to be careful here to make sure these do not conflict with the
+        # existing constraints
+        if self.active_microbatches != self.microbatches and self.pipeline != "interleaved":
+            # PT limitation right now
+            self.pipeline = "interleaved"
+            info_func(
+                "Simple pipeline is only supported when 'active_microbatches' is equal to 'microbatches'. Using interleaved pipeline instead."
+            )
+
+        if self.pipeline_parallel_degree > 1 and self.checkpoint_attentions:
+            warn_func(
+                f"Cannot checkpoint attentions when pipeline-parallel degree is more than 1, disabling attention checkpointing."
+            )
+            self.checkpoint_attentions = False
+
+    def display_config(self):
+        assert hasattr(self, "_config_dict")
+
+        if not py_sdk:
+            info_func("Configuration parameters:")
+            for k, v in self._config_dict.items():
+                if "internal" not in v.cfg_dict or not v.cfg_dict["internal"]:
+                    info_func(f"  {k}: {v.get_value()}")

--- a/src/sagemaker/mp_config.py
+++ b/src/sagemaker/mp_config.py
@@ -174,7 +174,7 @@ class ModelParallelConfig:
 
         # load the schema from yaml file
         dir_path = os.path.dirname(os.path.realpath(__file__))
-        config_path = os.path.join(dir_path, "config.yaml")
+        config_path = os.path.join(dir_path, "mp_config.yaml")
         with open(config_path, "r") as f:
             schema = yaml.safe_load(f)
 

--- a/src/sagemaker/mp_config.yaml
+++ b/src/sagemaker/mp_config.yaml
@@ -1,0 +1,177 @@
+---
+ pipeline_parallel_degree:
+   type: int
+   default: 1
+   lower_bound: 1
+   alias: partitions
+ tensor_parallel_degree:
+   type: int
+   default: 1
+   lower_bound: 1
+   requires:
+     ddp: True
+   dependencies:
+     - ddp
+ microbatches:
+   type: int
+   default: 1
+   lower_bound: 1
+ pipeline:
+   type: str
+   default: interleaved
+   options:
+     - simple
+     - interleaved
+     - _only_forward
+ horovod:
+   type: bool
+   default: False
+ ddp:
+   type: bool
+   default: False
+   requires:
+     horovod: False
+   dependencies:
+     - horovod
+ ddp_port:
+   type: int
+   default: null
+   lower_bound: 0
+   requires:
+     ddp: True
+   dependencies:
+     - ddp
+ ddp_dist_backend:
+   type: str
+   default: nccl
+   requires:
+     ddp: True
+   options:
+     - nccl
+   dependencies:
+     - ddp
+ contiguous:
+   type: bool
+   default: True
+ placement_strategy:
+   type: str
+   default: cluster
+   options:
+     - cluster
+     - spread
+     - PDT
+     - PTD
+     - DPT
+     - DTP
+     - TPD
+     - TDP
+ optimize:
+   type: str
+   default: speed
+   options:
+     - speed
+     - memory
+ auto_partition:
+   type: bool
+   default: True
+   requires_not:
+     default_partition: null
+   dependencies:
+     - default_partition
+ default_partition:
+   type: int
+   default: null
+   lower_bound: 0
+   upper_bound: (pipeline_parallel_degree) - 1
+   dependencies:
+     - pipeline_parallel_degree
+ prescaled_batch:
+   type: bool
+   default: False
+   requires:
+     optimize: speed
+   dependencies:
+     - optimize
+ memory_weight:
+   type: float
+   default: 0.8
+   lower_bound: 0.0
+   upper_bound: 1.0
+ active_microbatches:
+   type: int
+   default: (pipeline_parallel_degree) + 2
+   lower_bound: 1
+   upper_bound: (microbatches)
+   dependencies:
+     - microbatches
+     - pipeline_parallel_degree
+ fast_mode:
+   type: bool
+   default: False
+   internal: True
+ static_mode:
+   type: bool
+   default: False
+   internal: True
+ fp16_params:
+   type: bool
+   default: False
+ tensor_parallel_seed:
+   type: int
+   default: 0
+   lower_bound: 0
+ offload_activations:
+   type: bool
+   default: False
+ _shard_offloaded_activations:
+   type: bool
+   default: True
+   requires:
+    offload_activations: True
+   internal: True
+   dependencies:
+     - offload_activations
+ shard_optimizer_state:
+   type: bool
+   default: False
+ skip_tracing:
+   type: bool
+   default: False
+ activation_loading_horizon:
+   type: int
+   default: 4
+   lower_bound: 1
+ herring:
+   type: bool
+   default: False
+   requires:
+     ddp: False
+     horovod: False
+   dependencies:
+     - ddp
+     - horovod
+   internal: True
+ _match_weights:
+   type: bool
+   default: False
+   internal: True
+ _fp32_grad_accumulation:
+   type: bool
+   default: False
+   internal: True
+   requires:
+     fp16_params: True
+   dependencies:
+     - fp16_params
+ checkpoint_attentions:
+   type: bool
+   default: False
+   internal: True
+ load_partition:
+   type: bool
+   default: False
+   internal: True
+ partition_file:
+   type: str
+   default: null
+   internal: True

--- a/tests/unit/test_fw_utils.py
+++ b/tests/unit/test_fw_utils.py
@@ -129,29 +129,22 @@ def test_tar_and_upload_dir_s3_without_kms_with_overridden_settings(utils, sagem
     obj.upload_file.assert_called_with(utils.create_tar_file(), ExtraArgs=None)
 
 
-def test_mp_config_partition_exists():
-    mp_parameters = {}
-    with pytest.raises(ValueError):
-        fw_utils.validate_mp_config(mp_parameters)
-
-
 @pytest.mark.parametrize(
-    "pipeline, placement_strategy, optimize, trace_device",
+    "pipeline, placement_strategy, optimize",
     [
-        ("simple", "spread", "speed", "cpu"),
-        ("interleaved", "cluster", "memory", "gpu"),
-        ("_only_forward", "spread", "speed", "gpu"),
+        ("simple", "spread", "speed"),
+        ("interleaved", "cluster", "memory"),
+        ("_only_forward", "spread", "speed"),
     ],
 )
-def test_mp_config_string_names(pipeline, placement_strategy, optimize, trace_device):
+def test_mp_config_string_names(pipeline, placement_strategy, optimize):
     mp_parameters = {
         "partitions": 2,
         "pipeline": pipeline,
         "placement_strategy": placement_strategy,
         "optimize": optimize,
-        "trace_device": trace_device,
-        "active_microbatches": 8,
-        "deterministic_server": True,
+        "active_microbatches": 4,
+        "microbatches": 8,
     }
     fw_utils.validate_mp_config(mp_parameters)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Updating the config validation for the modelparallel library, based on the latest release.

*Testing done:* Ran GPT-2 example script with the updated SageMaker Python SDK.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
