### PR TITLE
fix: added PipelineValidation class to validate processingStep input length

### DIFF
--- a/src/sagemaker/workflow/pipeline_validation.py
+++ b/src/sagemaker/workflow/pipeline_validation.py
@@ -1,0 +1,55 @@
+
+from __future__ import absolute_import
+
+from typing import Dict, Union, List
+
+import attr
+
+import botocore.loaders
+from botocore.exceptions import ClientError, ValidationError
+from typing import Any, Dict, List, Sequence, Union, Optional
+
+# from sagemaker.workflow.pipeline import Pipeline
+from sagemaker.workflow.steps import StepTypeEnum
+from sagemaker.workflow.steps import Step
+from sagemaker.workflow.step_collections import StepCollection
+
+class PipelineValidation:
+    """
+
+    Extends pipeline for client-side validation
+
+    Attributes:
+        _shapes_map dict(): dictionary of botocore model restrictions to check at compile time
+
+    """
+
+    _shapes_map = dict()
+
+    def __init__(self,
+                 steps: Sequence[Union[Step, StepCollection]] = attr.ib(factory=list)
+                 ):
+        """ Loads up the shapes from the botocore service model. """
+        loader = botocore.loaders.Loader()
+        sagemaker_model = loader.load_service_model("sagemaker", "service-2")
+        self._shapes_map = sagemaker_model["shapes"]
+        self._steps = steps
+
+    def validate_pipeline_inputs(self):
+        """ Validate pipeline definition as a series of method checks """
+        try:
+            self._validate_processing_steps()
+        except ClientError as e:
+            raise
+
+    def _validate_processing_steps(self):
+        """ Validate that ProcessingInputs size is less than 10 (as defined in botocore) """
+        max_processing_inputs = self._shapes_map["ProcessingInputs"]["max"]
+        for step in self._steps:
+            if step.step_type is StepTypeEnum.PROCESSING and len(step.inputs) > max_processing_inputs:
+                raise ValidationError(value=len(step.inputs), param=step.inputs, type_name=StepTypeEnum.PROCESSING)
+
+
+
+
+

--- a/tests/integ/sagemaker/workflow/test_pipeline_validation_steps.py
+++ b/tests/integ/sagemaker/workflow/test_pipeline_validation_steps.py
@@ -1,0 +1,146 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from __future__ import absolute_import
+
+import pytest
+import sagemaker
+
+from mock import (
+    Mock,
+    PropertyMock,
+    patch,
+)
+
+from sagemaker.workflow.parameters import ParameterInteger, ParameterString
+from sagemaker.workflow.pipeline import Pipeline
+from sagemaker.workflow.properties import Properties, PropertyFile
+from sagemaker import get_execution_role, utils
+
+from sagemaker.processing import Processor
+from sagemaker.processing import ProcessingInput
+from sagemaker.workflow.steps import (
+    ProcessingStep,
+    CacheConfig,
+)
+
+from botocore.exceptions import ClientError, ValidationError
+
+REGION = "us-west-2"
+BUCKET = "my-bucket"
+IMAGE_URI = "fakeimage"
+ROLE = "DummyRole"
+MODEL_NAME = "gisele"
+
+
+@pytest.fixture
+def boto_session():
+    role_mock = Mock()
+    type(role_mock).arn = PropertyMock(return_value=ROLE)
+
+    resource_mock = Mock()
+    resource_mock.Role.return_value = role_mock
+
+    session_mock = Mock(region_name=REGION)
+    session_mock.resource.return_value = resource_mock
+
+    return session_mock
+
+
+@pytest.fixture
+def client():
+    """Mock client.
+
+    Considerations when appropriate:
+
+        * utilize botocore.stub.Stubber
+        * separate runtime client from client
+    """
+    client_mock = Mock()
+    client_mock._client_config.user_agent = (
+        "Boto3/1.14.24 Python/3.8.5 Linux/5.4.0-42-generic Botocore/1.17.24 Resource"
+    )
+    return client_mock
+
+
+@pytest.fixture
+def sagemaker_session(boto_session, client):
+    return sagemaker.session.Session(
+        boto_session=boto_session,
+        sagemaker_client=client,
+        sagemaker_runtime_client=client,
+        default_bucket=BUCKET,
+    )
+
+@pytest.fixture
+def role(sagemaker_session):
+    return get_execution_role(sagemaker_session)
+
+
+def test_processing_step_inputs_exceeds_limit_on_pipeline_create(sagemaker_session):
+    processing_input_data_uri_parameter = ParameterString(
+        name="ProcessingInputDataUri", default_value=f"s3://{BUCKET}/processing_manifest"
+    )
+    instance_type_parameter = ParameterString(name="InstanceType", default_value="ml.m4.4xlarge")
+    instance_count_parameter = ParameterInteger(name="InstanceCount", default_value=1)
+    processor = Processor(
+        image_uri=IMAGE_URI,
+        role=ROLE,
+        instance_count=instance_count_parameter,
+        instance_type=instance_type_parameter,
+        sagemaker_session=sagemaker_session,
+    )
+    # Botocore supports max of 10 processing inputs. Throw error at compile time.
+    inputs = []
+    for _ in range(11):
+        inputs.append(
+            ProcessingInput(
+                source="",
+                destination="processing_manifest"
+            )
+        )
+    cache_config = CacheConfig(enable_caching=True, expire_after="PT1H")
+    evaluation_report = PropertyFile(
+        name="EvaluationReport", output_name="evaluation", path="evaluation.json"
+    )
+    step = ProcessingStep(
+        name="OverloadedProcessing Step",
+        description="ProcessingStep description",
+        display_name="MyProcessingStep",
+        depends_on=["TestStep", "SecondTestStep"],
+        processor=processor,
+        inputs=inputs,
+        outputs=[],
+        cache_config=cache_config,
+        property_files=[evaluation_report],
+    )
+    step.add_depends_on(["ThirdTestStep"])
+    pipeline = Pipeline(
+        name="OverloadedProcessingStep_Pipeline",
+        parameters=[
+            processing_input_data_uri_parameter,
+            instance_type_parameter,
+            instance_count_parameter,
+        ],
+        steps=[step],
+        sagemaker_session=sagemaker_session,
+    )
+
+    try:
+        with pytest.raises(ValidationError):
+            response = pipeline.create(role)
+    finally:
+        try:
+            pipeline.delete()
+        except Exception:
+            pass
+

--- a/tests/unit/sagemaker/workflow/test_pipeline_validation.py
+++ b/tests/unit/sagemaker/workflow/test_pipeline_validation.py
@@ -1,0 +1,84 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+# language governing permissions and limitations under the License.
+from __future__ import absolute_import
+
+import json
+
+import pytest
+
+from botocore.exceptions import ClientError, ValidationError
+
+from mock import Mock
+
+from sagemaker.workflow.parameters import ParameterString
+from sagemaker.workflow.properties import Properties
+from sagemaker.workflow.steps import (
+    Step,
+    ProcessingStep
+)
+from sagemaker.workflow.steps import StepTypeEnum
+from sagemaker.processing import ProcessingInput
+from sagemaker.workflow.pipeline_validation import PipelineValidation
+
+
+class DummyStep(Step):
+    def __init__(self, name, input_data, step_type, display_name=None, description=None, inputs=None):
+        self.input_data = input_data
+        self.step_type = step_type
+        self.inputs = inputs
+
+        super(DummyStep, self).__init__(name, display_name, description, step_type, StepTypeEnum.TRAINING)
+        path = f"Steps.{name}"
+        prop = Properties(path=path)
+        prop.__dict__["S3Uri"] = Properties(f"{path}.S3Uri")
+        self._properties = prop
+
+    @property
+    def arguments(self):
+        return {"input_data": self.input_data}
+
+    @property
+    def properties(self):
+        return self._properties
+
+
+@pytest.fixture
+def role_arn():
+    return "arn:role"
+
+
+@pytest.fixture
+def sagemaker_session_mock():
+    session_mock = Mock()
+    session_mock.default_bucket = Mock(name="default_bucket", return_value="s3_bucket")
+    return session_mock
+
+
+def test_processing_step_inputs_exceeds_limit(sagemaker_session_mock, role_arn):
+    parameter = ParameterString("MyStr")
+    inputs = []
+    for _ in range(11):
+        inputs.append(
+            ProcessingInput(
+                source="",
+                destination="processing_manifest"
+            )
+        )
+    # print(inputs)
+    steps = DummyStep("DummyStep1", parameter, StepTypeEnum.PROCESSING, inputs=inputs)
+    ppv = PipelineValidation([steps])
+    with pytest.raises(ValidationError):
+        ppv._validate_processing_steps()
+
+


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/sagemaker-python-sdk/issues/2554

*Description of changes:*

- New validator attribute to pipeline objects which validates pipeline parameters
- Fix the issue above by throwing an error to enforce max input length for processingStep/processingInput s

*Testing done:*

one unit/integ

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x ] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
