### PR TITLE
fix: Support file URIs in ProcessingStep's code parameter

### DIFF
--- a/src/sagemaker/workflow/utilities.py
+++ b/src/sagemaker/workflow/utilities.py
@@ -15,6 +15,7 @@ from __future__ import absolute_import
 
 from typing import List, Sequence, Union
 import hashlib
+from urllib.parse import unquote, urlparse
 
 from sagemaker.workflow.entities import (
     Entity,
@@ -50,6 +51,8 @@ def hash_file(path: str) -> str:
     """
     BUF_SIZE = 65536  # read in 64KiB chunks
     md5 = hashlib.md5()
+    if path.lower().startswith("file://"):
+        path = unquote(urlparse(path).path.strip('/'))
     with open(path, "rb") as f:
         while True:
             data = f.read(BUF_SIZE)

--- a/src/sagemaker/workflow/utilities.py
+++ b/src/sagemaker/workflow/utilities.py
@@ -52,7 +52,7 @@ def hash_file(path: str) -> str:
     BUF_SIZE = 65536  # read in 64KiB chunks
     md5 = hashlib.md5()
     if path.lower().startswith("file://"):
-        path = unquote(urlparse(path).path.strip('/'))
+        path = unquote(urlparse(path).path)
     with open(path, "rb") as f:
         while True:
             data = f.read(BUF_SIZE)

--- a/tests/unit/sagemaker/workflow/test_utilities.py
+++ b/tests/unit/sagemaker/workflow/test_utilities.py
@@ -1,0 +1,31 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+# language governing permissions and limitations under the License.
+from __future__ import absolute_import
+
+import tempfile
+from sagemaker.workflow.utilities import hash_file
+
+
+def test_hash_file():
+    with tempfile.NamedTemporaryFile() as tmp:
+        tmp.write("hashme".encode())
+        hash = hash_file(tmp.name)
+        assert hash == "d41d8cd98f00b204e9800998ecf8427e"
+
+
+def test_hash_file_uri():
+    with tempfile.NamedTemporaryFile() as tmp:
+        tmp.write("hashme".encode())
+        hash = hash_file(f"file://{tmp.name}")
+        assert hash == "d41d8cd98f00b204e9800998ecf8427e"

--- a/tests/unit/sagemaker/workflow/test_utilities.py
+++ b/tests/unit/sagemaker/workflow/test_utilities.py
@@ -27,5 +27,5 @@ def test_hash_file():
 def test_hash_file_uri():
     with tempfile.NamedTemporaryFile() as tmp:
         tmp.write("hashme".encode())
-        hash = hash_file(f"file://{tmp.name}")
+        hash = hash_file(f"file:///{tmp.name}")
         assert hash == "d41d8cd98f00b204e9800998ecf8427e"


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
ProcessingStep hashes the contents of local files passed to `code` to fix cache miss issues. Update the hash function to support file URIs.

*Testing done:*
Unit, manual

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
