### PR TITLE
WIP: add validation specification feature to allow pushing models to marketplace without using boto3

### DIFF
--- a/src/sagemaker/model.py
+++ b/src/sagemaker/model.py
@@ -305,6 +305,7 @@ class Model(ModelBase):
         description=None,
         drift_check_baselines=None,
         customer_metadata_properties=None,
+        validation_specification=None
     ):
         """Creates a model package for creating SageMaker models or listing on Marketplace.
 
@@ -360,6 +361,7 @@ class Model(ModelBase):
             container_def_list=[container_def],
             drift_check_baselines=drift_check_baselines,
             customer_metadata_properties=customer_metadata_properties,
+            validation_specification=validation_specification
         )
         model_package = self.sagemaker_session.create_model_package_from_containers(
             **model_pkg_args

--- a/src/sagemaker/model.py
+++ b/src/sagemaker/model.py
@@ -305,7 +305,7 @@ class Model(ModelBase):
         description=None,
         drift_check_baselines=None,
         customer_metadata_properties=None,
-        validation_specification=None
+        validation_specification=None,
     ):
         """Creates a model package for creating SageMaker models or listing on Marketplace.
 
@@ -361,7 +361,7 @@ class Model(ModelBase):
             container_def_list=[container_def],
             drift_check_baselines=drift_check_baselines,
             customer_metadata_properties=customer_metadata_properties,
-            validation_specification=validation_specification
+            validation_specification=validation_specification,
         )
         model_package = self.sagemaker_session.create_model_package_from_containers(
             **model_pkg_args

--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -2787,7 +2787,7 @@ class Session(object):  # pylint: disable=too-many-public-methods
         description=None,
         drift_check_baselines=None,
         customer_metadata_properties=None,
-        validation_specification=None
+        validation_specification=None,
     ):
         """Get request dictionary for CreateModelPackage API.
 
@@ -2833,7 +2833,7 @@ class Session(object):  # pylint: disable=too-many-public-methods
             description,
             drift_check_baselines=drift_check_baselines,
             customer_metadata_properties=customer_metadata_properties,
-            validation_specification=validation_specification
+            validation_specification=validation_specification,
         )
         if model_package_group_name is not None:
             try:
@@ -4182,7 +4182,7 @@ def get_model_package_args(
     container_def_list=None,
     drift_check_baselines=None,
     customer_metadata_properties=None,
-    validation_specification=None
+    validation_specification=None,
 ):
     """Get arguments for create_model_package method.
 
@@ -4273,7 +4273,7 @@ def get_create_model_package_request(
     tags=None,
     drift_check_baselines=None,
     customer_metadata_properties=None,
-    validation_specification=None
+    validation_specification=None,
 ):
     """Get request dictionary for CreateModelPackage API.
 

--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -2787,6 +2787,7 @@ class Session(object):  # pylint: disable=too-many-public-methods
         description=None,
         drift_check_baselines=None,
         customer_metadata_properties=None,
+        validation_specification=None
     ):
         """Get request dictionary for CreateModelPackage API.
 
@@ -2832,6 +2833,7 @@ class Session(object):  # pylint: disable=too-many-public-methods
             description,
             drift_check_baselines=drift_check_baselines,
             customer_metadata_properties=customer_metadata_properties,
+            validation_specification=validation_specification
         )
         if model_package_group_name is not None:
             try:
@@ -4180,6 +4182,7 @@ def get_model_package_args(
     container_def_list=None,
     drift_check_baselines=None,
     customer_metadata_properties=None,
+    validation_specification=None
 ):
     """Get arguments for create_model_package method.
 
@@ -4249,6 +4252,8 @@ def get_model_package_args(
         model_package_args["tags"] = tags
     if customer_metadata_properties is not None:
         model_package_args["customer_metadata_properties"] = customer_metadata_properties
+    if validation_specification is not None:
+        model_package_args["validation_specification"] = validation_specification
     return model_package_args
 
 
@@ -4268,6 +4273,7 @@ def get_create_model_package_request(
     tags=None,
     drift_check_baselines=None,
     customer_metadata_properties=None,
+    validation_specification=None
 ):
     """Get request dictionary for CreateModelPackage API.
 
@@ -4319,6 +4325,8 @@ def get_create_model_package_request(
         request_dict["MetadataProperties"] = metadata_properties
     if customer_metadata_properties is not None:
         request_dict["CustomerMetadataProperties"] = customer_metadata_properties
+    if validation_specification:
+        request_dict["ValidationSpecification"] = validation_specification
     if containers is not None:
         if not all([content_types, response_types, inference_instances, transform_instances]):
             raise ValueError(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
