### PR TITLE
fix: xgboost, sklearn network isolation for jumpstart

### DIFF
--- a/src/sagemaker/model.py
+++ b/src/sagemaker/model.py
@@ -478,7 +478,7 @@ class Model(ModelBase):
         dir_name = None
         if self.uploaded_code:
             script_name = self.uploaded_code.script_name
-            if self.enable_network_isolation():
+            if self.repacked_model_data or self.enable_network_isolation():
                 dir_name = "/opt/ml/model/code"
             else:
                 dir_name = self.uploaded_code.s3_prefix

--- a/tests/unit/sagemaker/model/test_model.py
+++ b/tests/unit/sagemaker/model/test_model.py
@@ -665,3 +665,25 @@ def test_all_framework_models_add_jumpstart_base_name(
 
         sagemaker_session.create_model.reset_mock()
         sagemaker_session.endpoint_from_production_variants.reset_mock()
+
+
+@patch("sagemaker.utils.repack_model")
+def test_script_mode_model_uses_proper_sagemaker_submit_dir(repack_model, sagemaker_session):
+
+    source_dir = "s3://blah/blah/blah"
+    t = Model(
+        entry_point=ENTRY_POINT_INFERENCE,
+        role=ROLE,
+        sagemaker_session=sagemaker_session,
+        source_dir=source_dir,
+        image_uri=IMAGE_URI,
+        model_data=MODEL_DATA,
+    )
+    t.deploy(instance_type=INSTANCE_TYPE, initial_instance_count=INSTANCE_COUNT)
+
+    assert (
+        sagemaker_session.create_model.call_args_list[0][0][2]["Environment"][
+            "SAGEMAKER_SUBMIT_DIRECTORY"
+        ]
+        == "/opt/ml/model/code"
+    )


### PR DESCRIPTION
*Issue #, if available:*
V542026104

*Description of changes:*
This PR fixes the inference host environment variable for `SAGEMAKER_SUBMIT_DIRECTORY`, so that it gets the proper value when the script/model artifacts get repackaged. 

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
