### PR TITLE
documentation: fix minor typo

### DIFF
--- a/doc/frameworks/tensorflow/deploying_tensorflow_serving.rst
+++ b/doc/frameworks/tensorflow/deploying_tensorflow_serving.rst
@@ -273,7 +273,7 @@ refer to TensorFlow's `Save and Restore <https://www.tensorflow.org/guide/saved_
 inference-time behavior of your SavedModels.
 
 Providing Python scripts for pre/post-processing
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can add your customized Python code to process your input and output data.
 This customized Python code must be named ``inference.py`` and specified through the ``entry_point`` parameter:

--- a/doc/frameworks/tensorflow/deploying_tensorflow_serving.rst
+++ b/doc/frameworks/tensorflow/deploying_tensorflow_serving.rst
@@ -272,7 +272,7 @@ More information on how to create ``export_outputs`` can be found in `specifying
 refer to TensorFlow's `Save and Restore <https://www.tensorflow.org/guide/saved_model>`_ documentation for other ways to control the
 inference-time behavior of your SavedModels.
 
-Providing Python scripts for pre/pos-processing
+Providing Python scripts for pre/post-processing
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can add your customized Python code to process your input and output data.


### PR DESCRIPTION
*Issue #, if available:*
n/a
*Description of changes:*
Change prefix "pos" to "post" before "processing".
*Testing done:*
n/a
## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
