### PR TITLE
doc: sm model parallel 1.8.0 release notes

### DIFF
--- a/doc/api/training/distributed.rst
+++ b/doc/api/training/distributed.rst
@@ -10,7 +10,7 @@ The SageMaker Distributed Data Parallel Library
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. toctree::
-    :maxdepth: 3
+    :maxdepth: 2
 
     smd_data_parallel
     sdp_versions/latest
@@ -23,7 +23,7 @@ The SageMaker Distributed Model Parallel Library
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. toctree::
-   :maxdepth: 3
+   :maxdepth: 2
 
    smd_model_parallel
    smp_versions/latest

--- a/doc/api/training/smd_model_parallel_release_notes/smd_model_parallel_change_log.rst
+++ b/doc/api/training/smd_model_parallel_release_notes/smd_model_parallel_change_log.rst
@@ -5,8 +5,47 @@ Release Notes
 New features, bug fixes, and improvements are regularly made to the SageMaker
 distributed model parallel library.
 
-SageMaker Distributed Model Parallel 1.7.0 Release Notes
+SageMaker Distributed Model Parallel 1.8.0 Release Notes
 ========================================================
+
+*Date: March. 23. 2022*
+
+**New Features**
+
+* Added tensor parallelism support for the `GPT-J model
+  <https://huggingface.co/docs/transformers/model_doc/gptj>`_.
+  When using the GPT-J model of Hugging Face Transformers v4.17.0 with
+  tensor parallelism, the SageMaker model parallel library automatically
+  replaces the model with a tensor parallel distributed GPT-J model.
+  For more information, see `Support for Hugging Face Transformer Models
+  <https://docs.aws.amazon.com/sagemaker/latest/dg/model-parallel-extended-features-pytorch-hugging-face.html>`_
+  in the *Amazon SageMaker Model Parallel Training developer guide*.
+
+**Migration to AWS Deep Learning Containers**
+
+This version passed benchmark testing and is migrated to the following AWS Deep Learning Containers:
+
+* HuggingFace 4.17.0 DLC with PyTorch 1.10.2
+
+    .. code::
+
+      763104351884.dkr.ecr.us-west-2.amazonaws.com/huggingface-pytorch-training:1.10.2-transformers4.17.0-gpu-py38-cu113-ubuntu20.04
+
+
+    The binary file of this version of the library for custom container users:
+
+    .. code::
+
+      https://sagemaker-distributed-model-parallel.s3.us-west-2.amazonaws.com/pytorch-1.10.0/build-artifacts/2022-03-12-00-33/smdistributed_modelparallel-1.8.0-cp38-cp38-linux_x86_64.whl
+
+
+----
+
+Release History
+===============
+
+SageMaker Distributed Model Parallel 1.7.0 Release Notes
+--------------------------------------------------------
 
 *Date: March. 07. 2022*
 
@@ -48,11 +87,6 @@ This version passed benchmark testing and is migrated to the following AWS Deep 
 
     763104351884.dkr.ecr.<region>.amazonaws.com/pytorch-training:1.10.2-gpu-py38-cu113-ubuntu20.04-sagemaker
 
-
-----
-
-Release History
-===============
 
 SageMaker Distributed Model Parallel 1.6.0 Release Notes
 --------------------------------------------------------

--- a/doc/api/training/smp_versions/latest.rst
+++ b/doc/api/training/smp_versions/latest.rst
@@ -10,8 +10,8 @@ depending on which version of the library you need to use.
 To use the library, reference the
 **Common API** documentation alongside the framework specific API documentation.
 
-Version 1.7.0 (Latest)
-======================
+Version 1.7.0, 1.8.0 (Latest)
+=============================
 
 To use the library, reference the Common API documentation alongside the framework specific API documentation.
 


### PR DESCRIPTION
*Description of changes:*

- SageMaker distributed model parallel library v1.8.0 release note

*Testing done:*

- Doc build tested locally.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
