### PR TITLE
fix: integs for training compiler in non-PDX regions

### DIFF
--- a/tests/integ/test_training_compiler.py
+++ b/tests/integ/test_training_compiler.py
@@ -32,6 +32,10 @@ def gpu_instance_type(request):
     integ.test_region() not in integ.TRAINING_COMPILER_SUPPORTED_REGIONS,
     reason="SageMaker Training Compiler is not supported in this region",
 )
+@pytest.mark.skipif(
+    integ.test_region() in integ.TRAINING_NO_P3_REGIONS,
+    reason="no ml.p3 instances in this region",
+)
 def test_huggingface_pytorch(
     sagemaker_session,
     gpu_instance_type,
@@ -77,6 +81,10 @@ def test_huggingface_pytorch(
 @pytest.mark.skipif(
     integ.test_region() not in integ.TRAINING_COMPILER_SUPPORTED_REGIONS,
     reason="SageMaker Training Compiler is not supported in this region",
+)
+@pytest.mark.skipif(
+    integ.test_region() in integ.TRAINING_NO_P3_REGIONS,
+    reason="no ml.p3 instances in this region",
 )
 def test_huggingface_tensorflow(
     sagemaker_session,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
https://github.com/aws/sagemaker-python-sdk/pull/3045 introduced a breaking change to our release regional tests as new region support was added. This PR Fixes this.

*Testing done:*
Tested in personal account in some regions like - GRU, BOM.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
