### PR TITLE
change: turn off Pipeline Parameter inheritance from python primitives

### DIFF
--- a/src/sagemaker/estimator.py
+++ b/src/sagemaker/estimator.py
@@ -483,6 +483,7 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):  # pylint: disable=too-man
         if (
             not self.sagemaker_session.local_mode
             and output_path
+            and not is_pipeline_variable(output_path)
             and output_path.startswith("file://")
         ):
             raise RuntimeError("file:// output paths are only supported in Local Mode")

--- a/src/sagemaker/fw_utils.py
+++ b/src/sagemaker/fw_utils.py
@@ -428,6 +428,10 @@ def warn_if_parameter_server_with_multi_gpu(training_instance_type, distribution
     """
     if training_instance_type == "local" or distribution is None:
         return
+    if is_pipeline_variable(training_instance_type):
+        # The training_instance_type is not available in compile time.
+        # Rather, it's given in Pipeline execution time
+        return
 
     is_multi_gpu_instance = (
         training_instance_type == "local_gpu"
@@ -484,6 +488,10 @@ def validate_smdistributed(
     """
     if "smdistributed" not in distribution:
         # Distribution strategy other than smdistributed is selected
+        return
+    if is_pipeline_variable(instance_type):
+        # The instance_type is not available in compile time.
+        # Rather, it's given in Pipeline execution time
         return
 
     # distribution contains smdistributed

--- a/src/sagemaker/workflow/__init__.py
+++ b/src/sagemaker/workflow/__init__.py
@@ -12,14 +12,8 @@
 # language governing permissions and limitations under the License.
 """Defines Types etc. used in workflow."""
 from __future__ import absolute_import
-from typing import Union
 
 from sagemaker.workflow.entities import Expression
-from sagemaker.workflow.execution_variables import ExecutionVariable
-from sagemaker.workflow.parameters import Parameter
-from sagemaker.workflow.properties import Properties
-
-PipelineNonPrimitiveInputTypes = Union[ExecutionVariable, Expression, Parameter, Properties]
 
 
 def is_pipeline_variable(var: object) -> bool:

--- a/src/sagemaker/workflow/clarify_check_step.py
+++ b/src/sagemaker/workflow/clarify_check_step.py
@@ -37,8 +37,8 @@ from sagemaker.model_monitor import BiasAnalysisConfig, ExplainabilityAnalysisCo
 from sagemaker.model_monitor.model_monitoring import _MODEL_MONITOR_S3_PATH
 from sagemaker.processing import ProcessingInput, ProcessingOutput, ProcessingJob
 from sagemaker.utils import name_from_base
-from sagemaker.workflow import PipelineNonPrimitiveInputTypes, is_pipeline_variable
-from sagemaker.workflow.entities import RequestType
+from sagemaker.workflow import is_pipeline_variable
+from sagemaker.workflow.entities import RequestType, PipelineVariable
 from sagemaker.workflow.properties import Properties
 from sagemaker.workflow.step_collections import StepCollection
 from sagemaker.workflow.steps import Step, StepTypeEnum, CacheConfig
@@ -59,7 +59,7 @@ class ClarifyCheckConfig(ABC):
         data_config (DataConfig): Config of the input/output data.
         kms_key (str): The ARN of the KMS key that is used to encrypt the
             user code file (default: None).
-            This field CANNOT be any of PipelineNonPrimitiveInputTypes.
+            This field CANNOT be any type of the `PipelineVariable`.
         monitoring_analysis_config_uri: (str): The uri of monitoring analysis config.
             This field does not take input.
             It will be generated once uploading the created analysis config file.
@@ -86,7 +86,7 @@ class DataBiasCheckConfig(ClarifyCheckConfig):
             "`KS <https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-data-bias-metric-kolmogorov-smirnov.html>`_",
             "`CDDL <https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-data-bias-metric-cddl.html>`_"].
             Defaults to computing all.
-            This field CANNOT be any of PipelineNonPrimitiveInputTypes.
+            This field CANNOT be any type of the `PipelineVariable`.
     """  # noqa E501
 
     data_bias_config: BiasConfig = attr.ib()
@@ -115,7 +115,7 @@ class ModelBiasCheckConfig(ClarifyCheckConfig):
             ", "`TE <https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-post-training-bias-metric-te.html>`_",
             "`FT <https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-post-training-bias-metric-ft.html>`_"].
             Defaults to computing all.
-            This field CANNOT be any of PipelineNonPrimitiveInputTypes.
+            This field CANNOT be any type of the `PipelineVariable`.
     """
 
     data_bias_config: BiasConfig = attr.ib()
@@ -136,7 +136,7 @@ class ModelExplainabilityCheckConfig(ClarifyCheckConfig):
             in the model output for the predicted scores to be explained (default: None).
             This is not required if the model output is a single score. Alternatively,
             an instance of ModelPredictedLabelConfig can be provided
-            but this field CANNOT be any of PipelineNonPrimitiveInputTypes.
+            but this field CANNOT be any type of the `PipelineVariable`.
     """
 
     model_config: ModelConfig = attr.ib()
@@ -152,10 +152,10 @@ class ClarifyCheckStep(Step):
         name: str,
         clarify_check_config: ClarifyCheckConfig,
         check_job_config: CheckJobConfig,
-        skip_check: Union[bool, PipelineNonPrimitiveInputTypes] = False,
-        register_new_baseline: Union[bool, PipelineNonPrimitiveInputTypes] = False,
-        model_package_group_name: Union[str, PipelineNonPrimitiveInputTypes] = None,
-        supplied_baseline_constraints: Union[str, PipelineNonPrimitiveInputTypes] = None,
+        skip_check: Union[bool, PipelineVariable] = False,
+        register_new_baseline: Union[bool, PipelineVariable] = False,
+        model_package_group_name: Union[str, PipelineVariable] = None,
+        supplied_baseline_constraints: Union[str, PipelineVariable] = None,
         display_name: str = None,
         description: str = None,
         cache_config: CacheConfig = None,
@@ -167,14 +167,14 @@ class ClarifyCheckStep(Step):
             name (str): The name of the ClarifyCheckStep step.
             clarify_check_config (ClarifyCheckConfig): A ClarifyCheckConfig instance.
             check_job_config (CheckJobConfig): A CheckJobConfig instance.
-            skip_check (bool or PipelineNonPrimitiveInputTypes): Whether the check
+            skip_check (bool or PipelineVariable): Whether the check
                 should be skipped (default: False).
-            register_new_baseline (bool or PipelineNonPrimitiveInputTypes): Whether
+            register_new_baseline (bool or PipelineVariable): Whether
                 the new baseline should be registered (default: False).
-            model_package_group_name (str or PipelineNonPrimitiveInputTypes): The name of a
+            model_package_group_name (str or PipelineVariable): The name of a
                 registered model package group, among which the baseline will be fetched
                 from the latest approved model (default: None).
-            supplied_baseline_constraints (str or PipelineNonPrimitiveInputTypes): The S3 path
+            supplied_baseline_constraints (str or PipelineVariable): The S3 path
                 to the supplied constraints object representing the constraints JSON file
                 which will be used for drift to check (default: None).
             display_name (str): The display name of the ClarifyCheckStep step (default: None).

--- a/src/sagemaker/workflow/entities.py
+++ b/src/sagemaker/workflow/entities.py
@@ -16,7 +16,7 @@ from __future__ import absolute_import
 import abc
 
 from enum import EnumMeta
-from typing import Any, Dict, List, Union, Optional
+from typing import Any, Dict, List, Union
 
 PrimitiveType = Union[str, int, bool, float, None]
 RequestType = Union[Dict[str, Any], List[Dict[str, Any]]]
@@ -102,39 +102,3 @@ class PipelineVariable(Expression):
     @abc.abstractmethod
     def expr(self) -> RequestType:
         """Get the expression structure for workflow service calls."""
-
-    def startswith(
-        self,
-        prefix: Union[str, tuple],  # pylint: disable=unused-argument
-        start: Optional[int] = None,  # pylint: disable=unused-argument
-        end: Optional[int] = None,  # pylint: disable=unused-argument
-    ) -> bool:
-        """Simulate the Python string's built-in method: startswith
-
-        Args:
-            prefix (str, tuple): The (tuple of) string to be checked.
-            start (int): To set the start index of the matching boundary (default: None).
-            end (int): To set the end index of the matching boundary (default: None).
-
-        Return:
-            bool: Always return False as Pipeline variables are parsed during execution runtime
-        """
-        return False
-
-    def endswith(
-        self,
-        suffix: Union[str, tuple],  # pylint: disable=unused-argument
-        start: Optional[int] = None,  # pylint: disable=unused-argument
-        end: Optional[int] = None,  # pylint: disable=unused-argument
-    ) -> bool:
-        """Simulate the Python string's built-in method: endswith
-
-        Args:
-            suffix (str, tuple): The (tuple of) string to be checked.
-            start (int): To set the start index of the matching boundary (default: None).
-            end (int): To set the end index of the matching boundary (default: None).
-
-        Return:
-            bool: Always return False as Pipeline variables are parsed during execution runtime
-        """
-        return False

--- a/src/sagemaker/workflow/fail_step.py
+++ b/src/sagemaker/workflow/fail_step.py
@@ -15,9 +15,9 @@ from __future__ import absolute_import
 
 from typing import List, Union, Optional
 
-from sagemaker.workflow import PipelineNonPrimitiveInputTypes
 from sagemaker.workflow.entities import (
     RequestType,
+    PipelineVariable,
 )
 from sagemaker.workflow.step_collections import StepCollection
 from sagemaker.workflow.steps import Step, StepTypeEnum
@@ -29,7 +29,7 @@ class FailStep(Step):
     def __init__(
         self,
         name: str,
-        error_message: Union[str, PipelineNonPrimitiveInputTypes] = None,
+        error_message: Union[str, PipelineVariable] = None,
         display_name: str = None,
         description: str = None,
         depends_on: Optional[List[Union[str, Step, StepCollection]]] = None,
@@ -39,7 +39,7 @@ class FailStep(Step):
         Args:
             name (str): The name of the `FailStep`. A name is required and must be
                 unique within a pipeline.
-            error_message (str or PipelineNonPrimitiveInputTypes):
+            error_message (str or PipelineVariable):
                 An error message defined by the user.
                 Once the `FailStep` is reached, the execution fails and the
                 error message is set as the failure reason (default: None).

--- a/src/sagemaker/workflow/parameters.py
+++ b/src/sagemaker/workflow/parameters.py
@@ -100,29 +100,6 @@ class Parameter(PipelineVariable, Entity):
         return {"Get": f"Parameters.{name}"}
 
     @classmethod
-    def _implicit_value(cls, value, python_type, args, kwargs):
-        """Determine the implicit value from the arguments.
-
-        The implicit value of the instance should be the default_value if present.
-
-        Args:
-            value: The default implicit value.
-            python_type: The Python type the implicit value should be.
-            args: The list of positional arguments.
-            kwargs: The dict of keyword arguments.
-
-        Returns:
-            The implicit value that should be used.
-        """
-        if len(args) == 2:
-            value = args[1] or value
-        elif kwargs:
-            value = kwargs.get("default_value", value)
-        cls._check_default_value_type(value, python_type)
-
-        return value
-
-    @classmethod
     def _check_default_value_type(cls, value, python_type):
         """Check whether the default value is compatible with the parameter type.
 
@@ -143,13 +120,8 @@ class Parameter(PipelineVariable, Entity):
 ParameterBoolean = partial(Parameter, parameter_type=ParameterTypeEnum.BOOLEAN)
 
 
-class ParameterString(Parameter, str):
+class ParameterString(Parameter):
     """String parameter for pipelines."""
-
-    def __new__(cls, *args, **kwargs):  # pylint: disable=unused-argument
-        """Subclass str"""
-        val = cls._implicit_value("", str, args, kwargs)
-        return str.__new__(cls, val)
 
     def __init__(self, name: str, default_value: str = None, enum_values: List[str] = None):
         """Create a pipeline string parameter.
@@ -186,13 +158,8 @@ class ParameterString(Parameter, str):
         return request_dict
 
 
-class ParameterInteger(Parameter, int):
+class ParameterInteger(Parameter):
     """Integer parameter for pipelines."""
-
-    def __new__(cls, *args, **kwargs):
-        """Subclass int"""
-        val = cls._implicit_value(0, int, args, kwargs)
-        return int.__new__(cls, val)
 
     def __init__(self, name: str, default_value: int = None):
         """Create a pipeline integer parameter.
@@ -209,13 +176,8 @@ class ParameterInteger(Parameter, int):
         )
 
 
-class ParameterFloat(Parameter, float):
+class ParameterFloat(Parameter):
     """Float parameter for pipelines."""
-
-    def __new__(cls, *args, **kwargs):
-        """Subclass float"""
-        val = cls._implicit_value(0.0, float, args, kwargs)
-        return float.__new__(cls, val)
 
     def __init__(self, name: str, default_value: float = None):
         """Create a pipeline float parameter.

--- a/src/sagemaker/workflow/quality_check_step.py
+++ b/src/sagemaker/workflow/quality_check_step.py
@@ -22,9 +22,9 @@ import attr
 from sagemaker import s3
 from sagemaker.model_monitor import ModelMonitor
 from sagemaker.processing import ProcessingOutput, ProcessingJob, Processor, ProcessingInput
-from sagemaker.workflow import PipelineNonPrimitiveInputTypes, is_pipeline_variable
+from sagemaker.workflow import is_pipeline_variable
 
-from sagemaker.workflow.entities import RequestType
+from sagemaker.workflow.entities import RequestType, PipelineVariable
 from sagemaker.workflow.properties import (
     Properties,
 )
@@ -51,21 +51,21 @@ class QualityCheckConfig(ABC):
     """Quality Check Config.
 
     Attributes:
-        baseline_dataset (str or PipelineNonPrimitiveInputTypes): The path to the
+        baseline_dataset (str or PipelineVariable): The path to the
             baseline_dataset file. This can be a local path or an S3 uri string
         dataset_format (dict): The format of the baseline_dataset.
-        output_s3_uri (str or PipelineNonPrimitiveInputTypes): Desired S3 destination of
+        output_s3_uri (str or PipelineVariable): Desired S3 destination of
             the constraint_violations and statistics json files (default: None).
             If not specified an auto generated path will be used:
             "s3://<default_session_bucket>/model-monitor/baselining/<job_name>/results"
         post_analytics_processor_script (str): The path to the record post-analytics
             processor script (default: None). This can be a local path or an S3 uri string
-            but CANNOT be any of PipelineNonPrimitiveInputTypes.
+            but CANNOT be any type of the PipelineVariable.
     """
 
-    baseline_dataset: Union[str, PipelineNonPrimitiveInputTypes] = attr.ib()
+    baseline_dataset: Union[str, PipelineVariable] = attr.ib()
     dataset_format: dict = attr.ib()
-    output_s3_uri: Union[str, PipelineNonPrimitiveInputTypes] = attr.ib(kw_only=True, default=None)
+    output_s3_uri: Union[str, PipelineVariable] = attr.ib(kw_only=True, default=None)
     post_analytics_processor_script: str = attr.ib(kw_only=True, default=None)
 
 
@@ -77,7 +77,7 @@ class DataQualityCheckConfig(QualityCheckConfig):
         record_preprocessor_script (str): The path to the record preprocessor script
             (default: None).
             This can be a local path or an S3 uri string
-            but CANNOT be any of PipelineNonPrimitiveInputTypes.
+            but CANNOT be any type of the PipelineVariable.
     """
 
     record_preprocessor_script: str = attr.ib(default=None)
@@ -88,26 +88,24 @@ class ModelQualityCheckConfig(QualityCheckConfig):
     """Model Quality Check Config.
 
     Attributes:
-        problem_type (str or PipelineNonPrimitiveInputTypes): The type of problem of this model
+        problem_type (str or PipelineVariable): The type of problem of this model
             quality monitoring.
             Valid values are "Regression", "BinaryClassification", "MulticlassClassification".
-        inference_attribute (str or PipelineNonPrimitiveInputTypes): Index or JSONpath to
+        inference_attribute (str or PipelineVariable): Index or JSONpath to
             locate predicted label(s) (default: None).
-        probability_attribute (str or PipelineNonPrimitiveInputTypes): Index or JSONpath to
+        probability_attribute (str or PipelineVariable): Index or JSONpath to
             locate probabilities (default: None).
-        ground_truth_attribute (str or PipelineNonPrimitiveInputTypes: Index or JSONpath to
+        ground_truth_attribute (str or PipelineVariable: Index or JSONpath to
             locate actual label(s) (default: None).
-        probability_threshold_attribute (str or PipelineNonPrimitiveInputTypes): Threshold to
+        probability_threshold_attribute (str or PipelineVariable): Threshold to
             convert probabilities to binaries (default: None).
     """
 
-    problem_type: Union[str, PipelineNonPrimitiveInputTypes] = attr.ib()
-    inference_attribute: Union[str, PipelineNonPrimitiveInputTypes] = attr.ib(default=None)
-    probability_attribute: Union[str, PipelineNonPrimitiveInputTypes] = attr.ib(default=None)
-    ground_truth_attribute: Union[str, PipelineNonPrimitiveInputTypes] = attr.ib(default=None)
-    probability_threshold_attribute: Union[str, PipelineNonPrimitiveInputTypes] = attr.ib(
-        default=None
-    )
+    problem_type: Union[str, PipelineVariable] = attr.ib()
+    inference_attribute: Union[str, PipelineVariable] = attr.ib(default=None)
+    probability_attribute: Union[str, PipelineVariable] = attr.ib(default=None)
+    ground_truth_attribute: Union[str, PipelineVariable] = attr.ib(default=None)
+    probability_threshold_attribute: Union[str, PipelineVariable] = attr.ib(default=None)
 
 
 class QualityCheckStep(Step):
@@ -118,11 +116,11 @@ class QualityCheckStep(Step):
         name: str,
         quality_check_config: QualityCheckConfig,
         check_job_config: CheckJobConfig,
-        skip_check: Union[bool, PipelineNonPrimitiveInputTypes] = False,
-        register_new_baseline: Union[bool, PipelineNonPrimitiveInputTypes] = False,
-        model_package_group_name: Union[str, PipelineNonPrimitiveInputTypes] = None,
-        supplied_baseline_statistics: Union[str, PipelineNonPrimitiveInputTypes] = None,
-        supplied_baseline_constraints: Union[str, PipelineNonPrimitiveInputTypes] = None,
+        skip_check: Union[bool, PipelineVariable] = False,
+        register_new_baseline: Union[bool, PipelineVariable] = False,
+        model_package_group_name: Union[str, PipelineVariable] = None,
+        supplied_baseline_statistics: Union[str, PipelineVariable] = None,
+        supplied_baseline_constraints: Union[str, PipelineVariable] = None,
         display_name: str = None,
         description: str = None,
         cache_config: CacheConfig = None,
@@ -134,17 +132,17 @@ class QualityCheckStep(Step):
             name (str): The name of the QualityCheckStep step.
             quality_check_config (QualityCheckConfig): A QualityCheckConfig instance.
             check_job_config (CheckJobConfig): A CheckJobConfig instance.
-            skip_check (bool or PipelineNonPrimitiveInputTypes): Whether the check
+            skip_check (bool or PipelineVariable): Whether the check
                 should be skipped (default: False).
-            register_new_baseline (bool or PipelineNonPrimitiveInputTypes): Whether
+            register_new_baseline (bool or PipelineVariable): Whether
                 the new baseline should be registered (default: False).
-            model_package_group_name (str or PipelineNonPrimitiveInputTypes): The name of a
+            model_package_group_name (str or PipelineVariable): The name of a
                 registered model package group, among which the baseline will be fetched
                 from the latest approved model (default: None).
-            supplied_baseline_statistics (str or PipelineNonPrimitiveInputTypes): The S3 path
+            supplied_baseline_statistics (str or PipelineVariable): The S3 path
                 to the supplied statistics object representing the statistics JSON file
                 which will be used for drift to check (default: None).
-            supplied_baseline_constraints (str or PipelineNonPrimitiveInputTypes): The S3 path
+            supplied_baseline_constraints (str or PipelineVariable): The S3 path
                 to the supplied constraints object representing the constraints JSON file
                 which will be used for drift to check (default: None).
             display_name (str): The display name of the QualityCheckStep step (default: None).

--- a/src/sagemaker/workflow/steps.py
+++ b/src/sagemaker/workflow/steps.py
@@ -34,6 +34,7 @@ from sagemaker.processing import (
 )
 from sagemaker.transformer import Transformer, _TransformJob
 from sagemaker.tuner import HyperparameterTuner, _TuningJob
+from sagemaker.workflow import is_pipeline_variable
 from sagemaker.workflow.entities import (
     DefaultEnumMeta,
     Entity,
@@ -663,6 +664,11 @@ class ProcessingStep(ConfigurableRetryStep):
             self.processor.arguments = job_arguments
 
             if code:
+                if is_pipeline_variable(code):
+                    raise ValueError(
+                        "code argument has to be a valid S3 URI or local file path "
+                        + "rather than a pipeline variable"
+                    )
                 code_url = urlparse(code)
                 if code_url.scheme == "" or code_url.scheme == "file":
                     # By default, `Processor` will upload the local code to an S3 path

--- a/tests/unit/sagemaker/workflow/helpers.py
+++ b/tests/unit/sagemaker/workflow/helpers.py
@@ -14,7 +14,7 @@
 """Helper methods for testing."""
 from __future__ import absolute_import
 
-from sagemaker.workflow import Properties
+from sagemaker.workflow.properties import Properties
 from sagemaker.workflow.steps import Step, StepTypeEnum
 
 

--- a/tests/unit/sagemaker/workflow/test_execution_variables.py
+++ b/tests/unit/sagemaker/workflow/test_execution_variables.py
@@ -44,13 +44,6 @@ def test_implicit_value():
     assert str(error.value) == "Pipeline variables do not support __float__ operation."
 
 
-def test_string_builtin_funcs_that_return_bool():
-    prop = ExecutionVariables.PIPELINE_NAME
-    # The execution var will only be parsed in runtime (Pipeline backend) so not able to tell in SDK
-    assert not prop.startswith("MyPipeline")
-    assert not prop.endswith("MyPipeline")
-
-
 def test_add_func():
     var_start_datetime = ExecutionVariables.START_DATETIME
     var_current_datetime = ExecutionVariables.CURRENT_DATETIME

--- a/tests/unit/sagemaker/workflow/test_functions.py
+++ b/tests/unit/sagemaker/workflow/test_functions.py
@@ -92,13 +92,6 @@ def test_implicit_value_on_join():
     assert str(error.value) == "Pipeline variables do not support __float__ operation."
 
 
-def test_string_builtin_funcs_that_return_bool_on_join():
-    func = Join(on=",", values=["s3:/", "my-bucket", "a"])
-    # The func will only be parsed in runtime (Pipeline backend) so not able to tell in SDK
-    assert not func.startswith("s3")
-    assert not func.endswith("s3")
-
-
 def test_add_func_of_join():
     func_join1 = Join(values=[1, "a"])
     param = ParameterInteger(name="MyInteger", default_value=3)
@@ -198,17 +191,6 @@ def test_implicit_value_on_json_get():
     with pytest.raises(TypeError) as error:
         float(func)
     assert str(error.value) == "Pipeline variables do not support __float__ operation."
-
-
-def test_string_builtin_funcs_that_return_bool_on_json_get():
-    func = JsonGet(
-        step_name="my-step",
-        property_file="my-property-file",
-        json_path="my-json-path",
-    )
-    # The func will only be parsed in runtime (Pipeline backend) so not able to tell in SDK
-    assert not func.startswith("s3")
-    assert not func.endswith("s3")
 
 
 def test_add_func_of_json_get():

--- a/tests/unit/sagemaker/workflow/test_parameters.py
+++ b/tests/unit/sagemaker/workflow/test_parameters.py
@@ -13,8 +13,6 @@
 # language governing permissions and limitations under the License.
 from __future__ import absolute_import
 
-from urllib.parse import urlparse
-
 import pytest
 
 from sagemaker.workflow.parameters import (
@@ -95,18 +93,6 @@ def test_parameter_float_implicit_value():
         float(param)
 
     assert str(error.value) == "Pipeline variables do not support __float__ operation."
-
-
-def test_parsable_parameter_string():
-    param = ParameterString("MyString", default_value="s3://foo/bar/baz.csv")
-    assert urlparse(param).scheme == "s3"
-
-
-def test_string_builtin_funcs_that_return_bool_on_parameter_string():
-    param = ParameterString("MyString", default_value="s3://foo/bar/baz.csv")
-    # The param will only be parsed in runtime (Pipeline backend) so not able to tell in SDK
-    assert not param.startswith("s3")
-    assert not param.endswith("s3")
 
 
 def test_add_func():

--- a/tests/unit/sagemaker/workflow/test_properties.py
+++ b/tests/unit/sagemaker/workflow/test_properties.py
@@ -122,13 +122,6 @@ def test_implicit_value():
     assert str(error.value) == "Pipeline variables do not support __float__ operation."
 
 
-def test_string_builtin_funcs_that_return_bool():
-    prop = Properties("Steps.MyStep", "DescribeModelPackageOutput")
-    # The prop will only be parsed in runtime (Pipeline backend) so not able to tell in SDK
-    assert not prop.startswith("s3")
-    assert not prop.endswith("s3")
-
-
 def test_add_func():
     prop_train = Properties("Steps.MyStepTrain", "DescribeTrainingJobResponse")
     prop_model = Properties("Steps.MyStepModel", "DescribeModelPackageOutput")

--- a/tests/unit/sagemaker/workflow/test_steps.py
+++ b/tests/unit/sagemaker/workflow/test_steps.py
@@ -416,12 +416,10 @@ def test_training_step_tensorflow(sagemaker_session):
         instance_count=instance_count_parameter,
         instance_type=instance_type_parameter,
         sagemaker_session=sagemaker_session,
-        # subnets=subnets,
         hyperparameters={
             "batch-size": training_batch_size_parameter,
             "epochs": training_epochs_parameter,
         },
-        # security_group_ids=security_group_ids,
         debugger_hook_config=False,
         # Training using SMDataParallel Distributed Training Framework
         distribution={"smdistributed": {"dataparallel": {"enabled": True}}},
@@ -725,22 +723,22 @@ def test_processing_step_normalizes_args_with_param_str_local_code(
             destination="processing_manifest",
         )
     ]
-    step = ProcessingStep(
-        name="MyProcessingStep",
-        processor=script_processor,
-        code=code_param,
-        inputs=inputs,
-        outputs=outputs,
-        job_arguments=["arg1", "arg2"],
-        cache_config=cache_config,
-    )
-    pipeline = Pipeline(
-        name="MyPipeline",
-        parameters=[code_param],
-        steps=[step],
-        sagemaker_session=sagemaker_session,
-    )
     with pytest.raises(ValueError) as error:
+        step = ProcessingStep(
+            name="MyProcessingStep",
+            processor=script_processor,
+            code=code_param,
+            inputs=inputs,
+            outputs=outputs,
+            job_arguments=["arg1", "arg2"],
+            cache_config=cache_config,
+        )
+        pipeline = Pipeline(
+            name="MyPipeline",
+            parameters=[code_param],
+            steps=[step],
+            sagemaker_session=sagemaker_session,
+        )
         pipeline.definition()
 
     assert "has to be a valid S3 URI or local file path" in str(error.value)

--- a/tests/unit/sagemaker/workflow/test_utils.py
+++ b/tests/unit/sagemaker/workflow/test_utils.py
@@ -26,8 +26,8 @@ from mock import (
 )
 
 from sagemaker.estimator import Estimator
-from sagemaker.workflow import Properties
 from sagemaker.workflow._utils import _RepackModelStep, _RegisterModelStep
+from sagemaker.workflow.properties import Properties
 from tests.unit.test_utils import FakeS3, list_tar_files
 from tests.unit import DATA_DIR
 

--- a/tests/unit/test_tuner.py
+++ b/tests/unit/test_tuner.py
@@ -1187,7 +1187,7 @@ def test_integer_parameter_ranges_with_pipeline_parameter():
     min = ParameterInteger(name="p", default_value=2)
     max = JsonGet(step_name="sn", property_file="pf", json_path="jp")
     scale = ParameterString(name="scale", default_value="Auto")
-    int_param = IntegerParameter(min, max)
+    int_param = IntegerParameter(min, max, scale)
     ranges = int_param.as_tuning_range("some")
 
     assert len(ranges.keys()) == 4
@@ -1213,7 +1213,7 @@ def test_integer_parameter_ranges_with_pipeline_parameter():
             ],
         }
     }
-    assert ranges["ScalingType"] == scale
+    assert ranges["ScalingType"].expr == {"Get": "Parameters.scale"}
 
 
 def test_integer_parameter_scaling_type():


### PR DESCRIPTION
*Issues:* https://github.com/aws/sagemaker-python-sdk/issues/3091

*Description of changes:*
- Turn off Pipeline Parameter inheritance from python primitives as this has brought many hidden problems
- Clean up `PipelineNonPrimitiveInputTypes`  type collection as it's duplicate with `PipelineVariable`
- Change the behavior of `startswith` and `endswith` of `PipelineVariable`. Instead of always return false, we should throw exceptions explicitly here as the return false can hide some problems.

*Testing done:* unit tests

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
