### PR TITLE
fix: Automl integ describe job check

### DIFF
--- a/tests/integ/test_auto_ml.py
+++ b/tests/integ/test_auto_ml.py
@@ -170,7 +170,7 @@ def test_auto_ml_describe_auto_ml_job(sagemaker_session):
             },
             "TargetAttributeName": TARGET_ATTRIBUTE_NAME,
             "ContentType": "text/csv;header=present",
-            'ChannelType': 'training',
+            "ChannelType": "training",
         }
     ]
     expected_default_output_config = {
@@ -208,7 +208,7 @@ def test_auto_ml_attach(sagemaker_session):
             },
             "TargetAttributeName": TARGET_ATTRIBUTE_NAME,
             "ContentType": "text/csv;header=present",
-            'ChannelType': 'training',
+            "ChannelType": "training",
         }
     ]
     expected_default_output_config = {

--- a/tests/integ/test_auto_ml.py
+++ b/tests/integ/test_auto_ml.py
@@ -170,6 +170,7 @@ def test_auto_ml_describe_auto_ml_job(sagemaker_session):
             },
             "TargetAttributeName": TARGET_ATTRIBUTE_NAME,
             "ContentType": "text/csv;header=present",
+            'ChannelType': 'training',
         }
     ]
     expected_default_output_config = {
@@ -207,6 +208,7 @@ def test_auto_ml_attach(sagemaker_session):
             },
             "TargetAttributeName": TARGET_ATTRIBUTE_NAME,
             "ContentType": "text/csv;header=present",
+            'ChannelType': 'training',
         }
     ]
     expected_default_output_config = {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fixing the PR integ automl integ tests. It seems like the [describe_auto_ml_job](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sagemaker.html#SageMaker.Client.describe_auto_ml_job) InputDataConfig response has been updated.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
