### PR TITLE
fix: repack model locally when local_code local mode

### DIFF
--- a/src/sagemaker/model.py
+++ b/src/sagemaker/model.py
@@ -17,6 +17,7 @@ import abc
 import json
 import logging
 import os
+import pdb
 import re
 import copy
 
@@ -454,9 +455,15 @@ class Model(ModelBase):
             if is_pipeline_variable(self.model_data):
                 # model is not yet there, defer repacking to later during pipeline execution
                 return
-
-            bucket = self.bucket or self.sagemaker_session.default_bucket()
-            repacked_model_data = "s3://" + "/".join([bucket, key_prefix, "model.tar.gz"])
+            pdb.set_trace()
+            if local_code and self.model_data.startswith("file://"):
+                repacked_model_data = self.model_data
+            else:
+                bucket = self.bucket or self.sagemaker_session.default_bucket()
+                repacked_model_data = "s3://" + "/".join([bucket, key_prefix, "model.tar.gz"])
+                self.uploaded_code = fw_utils.UploadedCode(
+                    s3_prefix=repacked_model_data, script_name=os.path.basename(self.entry_point)
+                )
 
             utils.repack_model(
                 inference_script=self.entry_point,
@@ -469,9 +476,6 @@ class Model(ModelBase):
             )
 
             self.repacked_model_data = repacked_model_data
-            self.uploaded_code = fw_utils.UploadedCode(
-                s3_prefix=self.repacked_model_data, script_name=os.path.basename(self.entry_point)
-            )
 
     def _script_mode_env_vars(self):
         """Returns a mapping of environment variables for script mode execution"""

--- a/src/sagemaker/model.py
+++ b/src/sagemaker/model.py
@@ -17,7 +17,6 @@ import abc
 import json
 import logging
 import os
-import pdb
 import re
 import copy
 
@@ -455,7 +454,6 @@ class Model(ModelBase):
             if is_pipeline_variable(self.model_data):
                 # model is not yet there, defer repacking to later during pipeline execution
                 return
-            pdb.set_trace()
             if local_code and self.model_data.startswith("file://"):
                 repacked_model_data = self.model_data
             else:


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/sagemaker-python-sdk/issues/3031
https://github.com/aws/sagemaker-python-sdk/issues/3084

*Description of changes:*
`sagemaker.model.Model` uploads data to S3 when repacking, regardless and despite of local mode settings being specific to use local_code.

*Testing done:*
Locally tested, added test for checking botosession.resource('s3') and botosession.client('s3') calls are not getting made.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
