### PR TITLE
change: Support Properties for StepCollection

### DIFF
--- a/src/sagemaker/workflow/_utils.py
+++ b/src/sagemaker/workflow/_utils.py
@@ -17,7 +17,7 @@ import os
 import shutil
 import tarfile
 import tempfile
-from typing import List, Union, Optional
+from typing import List, Union, Optional, TYPE_CHECKING
 from sagemaker import image_uris
 from sagemaker.inputs import TrainingInput
 from sagemaker.estimator import EstimatorBase
@@ -33,6 +33,9 @@ from sagemaker.workflow.steps import (
 )
 from sagemaker.utils import _save_model, download_file_from_url
 from sagemaker.workflow.retry import RetryPolicy
+
+if TYPE_CHECKING:
+    from sagemaker.workflow.step_collections import StepCollection
 
 FRAMEWORK_VERSION = "0.23-1"
 INSTANCE_TYPE = "ml.m5.large"
@@ -57,7 +60,7 @@ class _RepackModelStep(TrainingStep):
         description: str = None,
         source_dir: str = None,
         dependencies: List = None,
-        depends_on: Union[List[str], List[Step]] = None,
+        depends_on: Optional[List[Union[str, Step, "StepCollection"]]] = None,
         retry_policies: List[RetryPolicy] = None,
         subnets=None,
         security_group_ids=None,
@@ -124,8 +127,9 @@ class _RepackModelStep(TrainingStep):
                         >>>     |------ virtual-env
 
                     This is not supported with "local code" in Local Mode.
-            depends_on (List[str] or List[Step]): A list of step names or instances
-                    this step depends on (default: None).
+            depends_on (List[Union[str, Step, StepCollection]]): The list of `Step`/`StepCollection`
+                names or `Step` instances or `StepCollection` instances that the current `Step`
+                depends on (default: None).
             retry_policies (List[RetryPolicy]): The list of retry policies for the current step
                 (default: None).
             subnets (list[str]): List of subnet ids. If not specified, the re-packing
@@ -274,7 +278,7 @@ class _RegisterModelStep(ConfigurableRetryStep):
         compile_model_family=None,
         display_name: str = None,
         description=None,
-        depends_on: Optional[Union[List[str], List[Step]]] = None,
+        depends_on: Optional[List[Union[str, Step, "StepCollection"]]] = None,
         retry_policies: Optional[List[RetryPolicy]] = None,
         tags=None,
         container_def_list=None,
@@ -311,8 +315,9 @@ class _RegisterModelStep(ConfigurableRetryStep):
                 if specified, a compiled model will be used (default: None).
             display_name (str): The display name of this `_RegisterModelStep` step (default: None).
             description (str): Model Package description (default: None).
-            depends_on (List[str] or List[Step]): A list of step names or instances
-                this step depends on (default: None).
+            depends_on (List[Union[str, Step, StepCollection]]): The list of `Step`/`StepCollection`
+                names or `Step` instances or `StepCollection` instances that the current `Step`
+                depends on (default: None).
             retry_policies (List[RetryPolicy]): The list of retry policies for the current step
                 (default: None).
             tags (List[dict[str, str]]): A list of dictionaries containing key-value pairs used to

--- a/src/sagemaker/workflow/callback_step.py
+++ b/src/sagemaker/workflow/callback_step.py
@@ -13,7 +13,7 @@
 """The step definitions for workflow."""
 from __future__ import absolute_import
 
-from typing import List, Dict, Union
+from typing import List, Dict, Union, Optional
 from enum import Enum
 
 import attr
@@ -27,6 +27,7 @@ from sagemaker.workflow.properties import (
 from sagemaker.workflow.entities import (
     DefaultEnumMeta,
 )
+from sagemaker.workflow.step_collections import StepCollection
 from sagemaker.workflow.steps import Step, StepTypeEnum, CacheConfig
 
 
@@ -86,7 +87,7 @@ class CallbackStep(Step):
         display_name: str = None,
         description: str = None,
         cache_config: CacheConfig = None,
-        depends_on: Union[List[str], List[Step]] = None,
+        depends_on: Optional[List[Union[str, Step, StepCollection]]] = None,
     ):
         """Constructs a CallbackStep.
 
@@ -99,8 +100,9 @@ class CallbackStep(Step):
             display_name (str): The display name of the callback step.
             description (str): The description of the callback step.
             cache_config (CacheConfig):  A `sagemaker.workflow.steps.CacheConfig` instance.
-            depends_on (List[str] or List[Step]): A list of step names or step instances
-                this `sagemaker.workflow.steps.CallbackStep` depends on
+            depends_on (List[Union[str, Step, StepCollection]]): A list of `Step`/`StepCollection`
+                names or `Step` instances or `StepCollection` instances that this `CallbackStep`
+                depends on.
         """
         super(CallbackStep, self).__init__(
             name, display_name, description, StepTypeEnum.CALLBACK, depends_on

--- a/src/sagemaker/workflow/clarify_check_step.py
+++ b/src/sagemaker/workflow/clarify_check_step.py
@@ -18,7 +18,7 @@ import json
 import os
 import tempfile
 from abc import ABC
-from typing import List, Union
+from typing import List, Union, Optional
 
 import attr
 
@@ -40,6 +40,7 @@ from sagemaker.utils import name_from_base
 from sagemaker.workflow import PipelineNonPrimitiveInputTypes, is_pipeline_variable
 from sagemaker.workflow.entities import RequestType
 from sagemaker.workflow.properties import Properties
+from sagemaker.workflow.step_collections import StepCollection
 from sagemaker.workflow.steps import Step, StepTypeEnum, CacheConfig
 from sagemaker.workflow.check_job_config import CheckJobConfig
 
@@ -158,7 +159,7 @@ class ClarifyCheckStep(Step):
         display_name: str = None,
         description: str = None,
         cache_config: CacheConfig = None,
-        depends_on: Union[List[str], List[Step]] = None,
+        depends_on: Optional[List[Union[str, Step, StepCollection]]] = None,
     ):
         """Constructs a ClarifyCheckStep.
 
@@ -180,8 +181,9 @@ class ClarifyCheckStep(Step):
             description (str): The description of the ClarifyCheckStep step (default: None).
             cache_config (CacheConfig):  A `sagemaker.workflow.steps.CacheConfig` instance
                 (default: None).
-            depends_on (List[str] or List[Step]): A list of step names or step instances
-                this `sagemaker.workflow.steps.ClarifyCheckStep` depends on (default: None).
+            depends_on (List[Union[str, Step, StepCollection]]): A list of `Step`/`StepCollection`
+                names or `Step` instances or `StepCollection` instances that this `ClarifyCheckStep`
+                depends on (default: None).
         """
         if (
             not isinstance(clarify_check_config, DataBiasCheckConfig)

--- a/src/sagemaker/workflow/condition_step.py
+++ b/src/sagemaker/workflow/condition_step.py
@@ -13,17 +13,17 @@
 """The step definitions for workflow."""
 from __future__ import absolute_import
 
-from typing import List, Union
+from typing import List, Union, Optional
 
 import attr
 
 from sagemaker.deprecations import deprecated_class
 from sagemaker.workflow.conditions import Condition
+from sagemaker.workflow.step_collections import StepCollection
 from sagemaker.workflow.steps import (
     Step,
     StepTypeEnum,
 )
-from sagemaker.workflow.step_collections import StepCollection
 from sagemaker.workflow.utilities import list_to_request
 from sagemaker.workflow.entities import (
     RequestType,
@@ -41,7 +41,7 @@ class ConditionStep(Step):
     def __init__(
         self,
         name: str,
-        depends_on: Union[List[str], List[Step]] = None,
+        depends_on: Optional[List[Union[str, Step, StepCollection]]] = None,
         display_name: str = None,
         description: str = None,
         conditions: List[Condition] = None,
@@ -56,6 +56,9 @@ class ConditionStep(Step):
 
         Args:
             name (str): The name of the condition step.
+            depends_on (List[Union[str, Step, StepCollection]]): The list of `Step`/StepCollection`
+                names or `Step` instances or `StepCollection` instances that the current `Step`
+                depends on.
             display_name (str): The display name of the condition step.
             description (str): The description of the condition step.
             conditions (List[Condition]): A list of `sagemaker.workflow.conditions.Condition`

--- a/src/sagemaker/workflow/emr_step.py
+++ b/src/sagemaker/workflow/emr_step.py
@@ -13,7 +13,7 @@
 """The step definitions for workflow."""
 from __future__ import absolute_import
 
-from typing import List
+from typing import List, Union, Optional
 
 from sagemaker.workflow.entities import (
     RequestType,
@@ -21,6 +21,7 @@ from sagemaker.workflow.entities import (
 from sagemaker.workflow.properties import (
     Properties,
 )
+from sagemaker.workflow.step_collections import StepCollection
 from sagemaker.workflow.steps import Step, StepTypeEnum, CacheConfig
 
 
@@ -70,7 +71,7 @@ class EMRStep(Step):
         description: str,
         cluster_id: str,
         step_config: EMRStepConfig,
-        depends_on: List[str] = None,
+        depends_on: Optional[List[Union[str, Step, StepCollection]]] = None,
         cache_config: CacheConfig = None,
     ):
         """Constructs a EMRStep.
@@ -81,8 +82,9 @@ class EMRStep(Step):
             description(str): The description of the EMR step.
             cluster_id(str): The ID of the running EMR cluster.
             step_config(EMRStepConfig): One StepConfig to be executed by the job flow.
-            depends_on(List[str]):
-                A list of step names this `sagemaker.workflow.steps.EMRStep` depends on
+            depends_on (List[Union[str, Step, StepCollection]]): A list of `Step`/`StepCollection`
+                names or `Step` instances or `StepCollection` instances that this `EMRStep`
+                depends on.
             cache_config(CacheConfig):  A `sagemaker.workflow.steps.CacheConfig` instance.
 
         """

--- a/src/sagemaker/workflow/fail_step.py
+++ b/src/sagemaker/workflow/fail_step.py
@@ -13,12 +13,13 @@
 """The `Step` definitions for SageMaker Pipelines Workflows."""
 from __future__ import absolute_import
 
-from typing import List, Union
+from typing import List, Union, Optional
 
 from sagemaker.workflow import PipelineNonPrimitiveInputTypes
 from sagemaker.workflow.entities import (
     RequestType,
 )
+from sagemaker.workflow.step_collections import StepCollection
 from sagemaker.workflow.steps import Step, StepTypeEnum
 
 
@@ -31,7 +32,7 @@ class FailStep(Step):
         error_message: Union[str, PipelineNonPrimitiveInputTypes] = None,
         display_name: str = None,
         description: str = None,
-        depends_on: Union[List[str], List[Step]] = None,
+        depends_on: Optional[List[Union[str, Step, StepCollection]]] = None,
     ):
         """Constructs a `FailStep`.
 
@@ -45,8 +46,9 @@ class FailStep(Step):
             display_name (str): The display name of the `FailStep`.
                 The display name provides better UI readability. (default: None).
             description (str): The description of the `FailStep` (default: None).
-            depends_on (List[str] or List[Step]): A list of `Step` names or `Step` instances
-                that this `FailStep` depends on.
+            depends_on (List[Union[str, Step, StepCollection]]): A list of `Step`/`StepCollection`
+                names or `Step` instances or `StepCollection` instances that this `FailStep`
+                depends on.
                 If a listed `Step` name does not exist, an error is returned (default: None).
         """
         super(FailStep, self).__init__(

--- a/src/sagemaker/workflow/lambda_step.py
+++ b/src/sagemaker/workflow/lambda_step.py
@@ -13,7 +13,7 @@
 """The step definitions for workflow."""
 from __future__ import absolute_import
 
-from typing import List, Dict
+from typing import List, Dict, Optional, Union
 from enum import Enum
 
 import attr
@@ -27,6 +27,7 @@ from sagemaker.workflow.properties import (
 from sagemaker.workflow.entities import (
     DefaultEnumMeta,
 )
+from sagemaker.workflow.step_collections import StepCollection
 from sagemaker.workflow.steps import Step, StepTypeEnum, CacheConfig
 from sagemaker.lambda_helper import Lambda
 
@@ -87,7 +88,7 @@ class LambdaStep(Step):
         inputs: dict = None,
         outputs: List[LambdaOutput] = None,
         cache_config: CacheConfig = None,
-        depends_on: List[str] = None,
+        depends_on: Optional[List[Union[str, Step, StepCollection]]] = None,
     ):
         """Constructs a LambdaStep.
 
@@ -102,8 +103,9 @@ class LambdaStep(Step):
                 to the lambda function.
             outputs (List[LambdaOutput]): List of outputs from the lambda function.
             cache_config (CacheConfig):  A `sagemaker.workflow.steps.CacheConfig` instance.
-            depends_on (List[str]): A list of step names this `sagemaker.workflow.steps.LambdaStep`
-                depends on
+            depends_on (List[Union[str, Step, StepCollection]]): A list of `Step`/`StepCollection`
+                names or `Step` instances or `StepCollection` instances that this `LambdaStep`
+                depends on.
         """
         super(LambdaStep, self).__init__(
             name, display_name, description, StepTypeEnum.LAMBDA, depends_on

--- a/src/sagemaker/workflow/model_step.py
+++ b/src/sagemaker/workflow/model_step.py
@@ -40,7 +40,7 @@ class ModelStep(StepCollection):
         self,
         name: str,
         step_args: _ModelStepArguments,
-        depends_on: Optional[Union[List[str], List[Step]]] = None,
+        depends_on: Optional[List[Union[str, Step, StepCollection]]] = None,
         retry_policies: Optional[Union[List[RetryPolicy], Dict[str, List[RetryPolicy]]]] = None,
         display_name: Optional[str] = None,
         description: Optional[str] = None,
@@ -51,8 +51,9 @@ class ModelStep(StepCollection):
             name (str): The name of the `ModelStep`. A name is required and must be
                 unique within a pipeline.
             step_args (_ModelStepArguments): The arguments for the `ModelStep` definition.
-            depends_on (List[str] or List[Step]): A list of `Step` names or `Step` instances
-                that this `ModelStep` depends on.
+            depends_on (List[Union[str, Step, StepCollection]]): A list of `Step`/`StepCollection`
+                names or `Step` instances or `StepCollection` instances that the first step,
+                in this `ModelStep` collection, depends on.
                 If a listed `Step` name does not exist, an error is returned (default: None).
             retry_policies (List[RetryPolicy] or Dict[str, List[RetryPolicy]]): The list of retry
                 policies for the `ModelStep` (default: None).

--- a/src/sagemaker/workflow/quality_check_step.py
+++ b/src/sagemaker/workflow/quality_check_step.py
@@ -14,7 +14,7 @@
 from __future__ import absolute_import
 
 from abc import ABC
-from typing import List, Union
+from typing import List, Union, Optional
 import os
 import pathlib
 import attr
@@ -28,6 +28,7 @@ from sagemaker.workflow.entities import RequestType
 from sagemaker.workflow.properties import (
     Properties,
 )
+from sagemaker.workflow.step_collections import StepCollection
 from sagemaker.workflow.steps import Step, StepTypeEnum, CacheConfig
 from sagemaker.workflow.check_job_config import CheckJobConfig
 
@@ -125,7 +126,7 @@ class QualityCheckStep(Step):
         display_name: str = None,
         description: str = None,
         cache_config: CacheConfig = None,
-        depends_on: Union[List[str], List[Step]] = None,
+        depends_on: Optional[List[Union[str, Step, StepCollection]]] = None,
     ):
         """Constructs a QualityCheckStep.
 
@@ -150,8 +151,9 @@ class QualityCheckStep(Step):
             description (str): The description of the QualityCheckStep step (default: None).
             cache_config (CacheConfig):  A `sagemaker.workflow.steps.CacheConfig` instance
                 (default: None).
-            depends_on (List[str] or List[Step]): A list of step names or step instances
-                this `sagemaker.workflow.steps.QualityCheckStep` depends on (default: None).
+            depends_on (List[Union[str, Step, StepCollection]]): A list of `Step`/`StepCollection`
+                names or `Step` instances or `StepCollection` instances that this `QualityCheckStep`
+                depends on (default: None).
         """
         if not isinstance(quality_check_config, DataQualityCheckConfig) and not isinstance(
             quality_check_config, ModelQualityCheckConfig

--- a/tests/unit/sagemaker/workflow/helpers.py
+++ b/tests/unit/sagemaker/workflow/helpers.py
@@ -14,6 +14,9 @@
 """Helper methods for testing."""
 from __future__ import absolute_import
 
+from sagemaker.workflow import Properties
+from sagemaker.workflow.steps import Step, StepTypeEnum
+
 
 def ordered(obj):
     """Helper function for dict comparison.
@@ -32,3 +35,19 @@ def ordered(obj):
         return sorted(ordered(x) for x in obj)
     else:
         return obj
+
+
+class CustomStep(Step):
+    def __init__(self, name, display_name=None, description=None, depends_on=None):
+        super(CustomStep, self).__init__(
+            name, display_name, description, StepTypeEnum.TRAINING, depends_on
+        )
+        self._properties = Properties(path=f"Steps.{name}")
+
+    @property
+    def arguments(self):
+        return dict()
+
+    @property
+    def properties(self):
+        return self._properties

--- a/tests/unit/sagemaker/workflow/test_callback_step.py
+++ b/tests/unit/sagemaker/workflow/test_callback_step.py
@@ -21,6 +21,7 @@ from mock import Mock
 from sagemaker.workflow.parameters import ParameterInteger, ParameterString
 from sagemaker.workflow.pipeline import Pipeline
 from sagemaker.workflow.callback_step import CallbackStep, CallbackOutput, CallbackOutputTypeEnum
+from tests.unit.sagemaker.workflow.helpers import CustomStep
 
 
 @pytest.fixture
@@ -98,6 +99,7 @@ def test_callback_step_output_expr():
 
 def test_pipeline_interpolates_callback_outputs():
     parameter = ParameterString("MyStr")
+    custom_step = CustomStep("TestStep")
     outputParam1 = CallbackOutput(output_name="output1", output_type=CallbackOutputTypeEnum.String)
     outputParam2 = CallbackOutput(output_name="output2", output_type=CallbackOutputTypeEnum.String)
     cb_step1 = CallbackStep(
@@ -118,7 +120,7 @@ def test_pipeline_interpolates_callback_outputs():
     pipeline = Pipeline(
         name="MyPipeline",
         parameters=[parameter],
-        steps=[cb_step1, cb_step2],
+        steps=[cb_step1, cb_step2, custom_step],
         sagemaker_session=sagemaker_session_mock,
     )
 
@@ -146,6 +148,11 @@ def test_pipeline_interpolates_callback_outputs():
                 "DependsOn": ["TestStep"],
                 "SqsQueueUrl": "https://sqs.us-east-2.amazonaws.com/123456789012/MyQueue",
                 "OutputParameters": [{"OutputName": "output2", "OutputType": "String"}],
+            },
+            {
+                "Name": "TestStep",
+                "Type": "Training",
+                "Arguments": {},
             },
         ],
     }

--- a/tests/unit/sagemaker/workflow/test_condition_step.py
+++ b/tests/unit/sagemaker/workflow/test_condition_step.py
@@ -10,31 +10,12 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-# language governing permissions and limitations under the License.
 from __future__ import absolute_import
 
 from sagemaker.workflow.conditions import ConditionEquals
 from sagemaker.workflow.parameters import ParameterInteger
-from sagemaker.workflow.steps import (
-    Step,
-    StepTypeEnum,
-)
-from sagemaker.workflow.properties import Properties
 from sagemaker.workflow.condition_step import ConditionStep
-
-
-class CustomStep(Step):
-    def __init__(self, name, display_name=None, description=None):
-        super(CustomStep, self).__init__(name, display_name, description, StepTypeEnum.TRAINING)
-        self._properties = Properties(path=f"Steps.{name}")
-
-    @property
-    def arguments(self):
-        return dict()
-
-    @property
-    def properties(self):
-        return self._properties
+from tests.unit.sagemaker.workflow.helpers import CustomStep
 
 
 def test_condition_step():

--- a/tests/unit/sagemaker/workflow/test_emr_step.py
+++ b/tests/unit/sagemaker/workflow/test_emr_step.py
@@ -22,6 +22,7 @@ from sagemaker.workflow.emr_step import EMRStep, EMRStepConfig
 from sagemaker.workflow.steps import CacheConfig
 from sagemaker.workflow.pipeline import Pipeline
 from sagemaker.workflow.parameters import ParameterString
+from tests.unit.sagemaker.workflow.helpers import CustomStep
 
 
 @pytest.fixture()
@@ -92,6 +93,7 @@ def test_emr_step_with_one_step_config(sagemaker_session):
 
 
 def test_pipeline_interpolates_emr_outputs(sagemaker_session):
+    custom_step = CustomStep("TestStep")
     parameter = ParameterString("MyStr")
 
     emr_step_config_1 = EMRStepConfig(
@@ -124,7 +126,7 @@ def test_pipeline_interpolates_emr_outputs(sagemaker_session):
     pipeline = Pipeline(
         name="MyPipeline",
         parameters=[parameter],
-        steps=[step_emr_1, step_emr_2],
+        steps=[step_emr_1, step_emr_2, custom_step],
         sagemaker_session=sagemaker_session,
     )
 
@@ -170,6 +172,11 @@ def test_pipeline_interpolates_emr_outputs(sagemaker_session):
                 "Description": "MyEMRStepDescription",
                 "DisplayName": "emr_step_2",
                 "DependsOn": ["TestStep"],
+            },
+            {
+                "Name": "TestStep",
+                "Type": "Training",
+                "Arguments": {},
             },
         ],
     }

--- a/tests/unit/sagemaker/workflow/test_lambda_step.py
+++ b/tests/unit/sagemaker/workflow/test_lambda_step.py
@@ -23,6 +23,7 @@ from sagemaker.workflow.pipeline import Pipeline
 from sagemaker.workflow.lambda_step import LambdaStep, LambdaOutput, LambdaOutputTypeEnum
 from sagemaker.lambda_helper import Lambda
 from sagemaker.workflow.steps import CacheConfig
+from tests.unit.sagemaker.workflow.helpers import CustomStep
 
 
 @pytest.fixture()
@@ -54,6 +55,8 @@ def sagemaker_session_cn():
 
 
 def test_lambda_step(sagemaker_session):
+    custom_step1 = CustomStep("TestStep")
+    custom_step2 = CustomStep("SecondTestStep")
     param = ParameterInteger(name="MyInt")
     output_param1 = LambdaOutput(output_name="output1", output_type=LambdaOutputTypeEnum.String)
     output_param2 = LambdaOutput(output_name="output2", output_type=LambdaOutputTypeEnum.Boolean)
@@ -75,7 +78,7 @@ def test_lambda_step(sagemaker_session):
     pipeline = Pipeline(
         name="MyPipeline",
         parameters=[param],
-        steps=[lambda_step],
+        steps=[lambda_step, custom_step1, custom_step2],
         sagemaker_session=sagemaker_session,
     )
     assert json.loads(pipeline.definition())["Steps"][0] == {
@@ -118,6 +121,7 @@ def test_lambda_step_output_expr(sagemaker_session):
 
 
 def test_pipeline_interpolates_lambda_outputs(sagemaker_session):
+    custom_step = CustomStep("TestStep")
     parameter = ParameterString("MyStr")
     output_param1 = LambdaOutput(output_name="output1", output_type=LambdaOutputTypeEnum.String)
     output_param2 = LambdaOutput(output_name="output2", output_type=LambdaOutputTypeEnum.String)
@@ -145,7 +149,7 @@ def test_pipeline_interpolates_lambda_outputs(sagemaker_session):
     pipeline = Pipeline(
         name="MyPipeline",
         parameters=[parameter],
-        steps=[lambda_step1, lambda_step2],
+        steps=[lambda_step1, lambda_step2, custom_step],
         sagemaker_session=sagemaker_session,
     )
 
@@ -173,6 +177,11 @@ def test_pipeline_interpolates_lambda_outputs(sagemaker_session):
                 "DependsOn": ["TestStep"],
                 "FunctionArn": "arn:aws:lambda:us-west-2:123456789012:function:sagemaker_test_lambda",
                 "OutputParameters": [{"OutputName": "output2", "OutputType": "String"}],
+            },
+            {
+                "Name": "TestStep",
+                "Type": "Training",
+                "Arguments": {},
             },
         ],
     }

--- a/tests/unit/sagemaker/workflow/test_processing_step.py
+++ b/tests/unit/sagemaker/workflow/test_processing_step.py
@@ -49,7 +49,7 @@ from sagemaker.clarify import (
     ModelPredictedLabelConfig,
     SHAPConfig,
 )
-
+from tests.unit.sagemaker.workflow.helpers import CustomStep
 
 REGION = "us-west-2"
 IMAGE_URI = "fakeimage"
@@ -89,6 +89,8 @@ def network_config():
 
 
 def test_processing_step_with_processor(pipeline_session, processing_input):
+    custom_step1 = CustomStep("TestStep")
+    custom_step2 = CustomStep("SecondTestStep")
     processor = Processor(
         image_uri=IMAGE_URI,
         role=sagemaker.get_execution_role(),
@@ -122,7 +124,7 @@ def test_processing_step_with_processor(pipeline_session, processing_input):
 
     pipeline = Pipeline(
         name="MyPipeline",
-        steps=[step],
+        steps=[step, custom_step1, custom_step2],
         sagemaker_session=pipeline_session,
     )
     assert json.loads(pipeline.definition())["Steps"][0] == {

--- a/tests/unit/sagemaker/workflow/test_step_collections.py
+++ b/tests/unit/sagemaker/workflow/test_step_collections.py
@@ -13,12 +13,21 @@
 # language governing permissions and limitations under the License.
 from __future__ import absolute_import
 
+import json
 import os
 import tempfile
 import shutil
 import pytest
 
 from sagemaker.drift_check_baselines import DriftCheckBaselines
+from sagemaker.workflow.model_step import (
+    ModelStep,
+    _CREATE_MODEL_NAME_BASE,
+    _REPACK_MODEL_NAME_BASE,
+)
+from sagemaker.workflow.parameters import ParameterString
+from sagemaker.workflow.pipeline import Pipeline
+from sagemaker.workflow.pipeline_context import PipelineSession
 from sagemaker.workflow.utilities import list_to_request
 from tests.unit import DATA_DIR
 
@@ -39,17 +48,14 @@ from sagemaker.model_metrics import (
     ModelMetrics,
 )
 from sagemaker.workflow.properties import Properties
-from sagemaker.workflow.steps import (
-    Step,
-    StepTypeEnum,
-)
+from sagemaker.workflow.steps import CreateModelStep
 from sagemaker.workflow.step_collections import (
     EstimatorTransformer,
     StepCollection,
     RegisterModel,
 )
 from sagemaker.workflow.retry import StepRetryPolicy, StepExceptionTypeEnum
-from tests.unit.sagemaker.workflow.helpers import ordered
+from tests.unit.sagemaker.workflow.helpers import ordered, CustomStep
 
 REGION = "us-west-2"
 BUCKET = "my-bucket"
@@ -59,34 +65,6 @@ MODEL_NAME = "gisele"
 MODEL_REPACKING_IMAGE_URI = (
     "246618743249.dkr.ecr.us-west-2.amazonaws.com/sagemaker-scikit-learn:0.23-1-cpu-py3"
 )
-
-
-class CustomStep(Step):
-    def __init__(self, name, display_name=None, description=None):
-        super(CustomStep, self).__init__(name, display_name, description, StepTypeEnum.TRAINING)
-        self._properties = Properties(path=f"Steps.{name}")
-
-    @property
-    def arguments(self):
-        return dict()
-
-    @property
-    def properties(self):
-        return self._properties
-
-
-@pytest.fixture
-def boto_session():
-    role_mock = Mock()
-    type(role_mock).arn = PropertyMock(return_value=ROLE)
-
-    resource_mock = Mock()
-    resource_mock.Role.return_value = role_mock
-
-    session_mock = Mock(region_name=REGION)
-    session_mock.resource.return_value = resource_mock
-
-    return session_mock
 
 
 @pytest.fixture
@@ -106,11 +84,35 @@ def client():
 
 
 @pytest.fixture
+def boto_session(client):
+    role_mock = Mock()
+    type(role_mock).arn = PropertyMock(return_value=ROLE)
+
+    resource_mock = Mock()
+    resource_mock.Role.return_value = role_mock
+
+    session_mock = Mock(region_name=REGION)
+    session_mock.resource.return_value = resource_mock
+    session_mock.client.return_value = client
+
+    return session_mock
+
+
+@pytest.fixture
 def sagemaker_session(boto_session, client):
     return sagemaker.session.Session(
         boto_session=boto_session,
         sagemaker_client=client,
         sagemaker_runtime_client=client,
+        default_bucket=BUCKET,
+    )
+
+
+@pytest.fixture
+def pipeline_session(boto_session, client):
+    return PipelineSession(
+        boto_session=boto_session,
+        sagemaker_client=client,
         default_bucket=BUCKET,
     )
 
@@ -200,7 +202,9 @@ def source_dir(request):
 
 
 def test_step_collection():
-    step_collection = StepCollection(steps=[CustomStep("MyStep1"), CustomStep("MyStep2")])
+    step_collection = StepCollection(
+        name="MyStepCollection", steps=[CustomStep("MyStep1"), CustomStep("MyStep2")]
+    )
     assert step_collection.request_dicts() == [
         {"Name": "MyStep1", "Type": "Training", "Arguments": dict()},
         {"Name": "MyStep2", "Type": "Training", "Arguments": dict()},
@@ -208,13 +212,141 @@ def test_step_collection():
 
 
 def test_step_collection_with_list_to_request():
-    step_collection = StepCollection(steps=[CustomStep("MyStep1"), CustomStep("MyStep2")])
+    step_collection = StepCollection(
+        name="MyStepCollection", steps=[CustomStep("MyStep1"), CustomStep("MyStep2")]
+    )
     custom_step = CustomStep("MyStep3")
     assert list_to_request([step_collection, custom_step]) == [
         {"Name": "MyStep1", "Type": "Training", "Arguments": dict()},
         {"Name": "MyStep2", "Type": "Training", "Arguments": dict()},
         {"Name": "MyStep3", "Type": "Training", "Arguments": dict()},
     ]
+
+
+def test_step_collection_properties(pipeline_session, sagemaker_session):
+    # ModelStep
+    model = Model(
+        name="MyModel",
+        image_uri=IMAGE_URI,
+        model_data=ParameterString(name="ModelData", default_value="s3://my-bucket/file"),
+        sagemaker_session=pipeline_session,
+        entry_point=f"{DATA_DIR}/dummy_script.py",
+        source_dir=f"{DATA_DIR}",
+        role=ROLE,
+    )
+    step_args = model.create(
+        instance_type="c4.4xlarge",
+        accelerator_type="ml.eia1.medium",
+    )
+    model_step_name = "MyModelStep"
+    model_step = ModelStep(
+        name=model_step_name,
+        step_args=step_args,
+    )
+    steps = model_step.steps
+    assert len(steps) == 2
+    assert isinstance(steps[1], CreateModelStep)
+    assert model_step.properties.ModelName.expr == {
+        "Get": f"Steps.{model_step_name}-{_CREATE_MODEL_NAME_BASE}.ModelName"
+    }
+
+    # RegisterModel
+    model.sagemaker_session = sagemaker_session
+    model.entry_point = None
+    model.source_dir = None
+    register_model_step_name = "RegisterModelStep"
+    register_model = RegisterModel(
+        name=register_model_step_name,
+        model=model,
+        model_data="s3://",
+        content_types=["content_type"],
+        response_types=["response_type"],
+        inference_instances=["inference_instance"],
+        transform_instances=["transform_instance"],
+        model_package_group_name="mpg",
+    )
+    steps = register_model.steps
+    assert len(steps) == 1
+    assert register_model.properties.ModelPackageName.expr == {
+        "Get": f"Steps.{register_model_step_name}.ModelPackageName"
+    }
+
+    # Custom StepCollection
+    step_collection = StepCollection(name="MyStepCollection")
+    steps = step_collection.steps
+    assert len(steps) == 0
+    assert not step_collection.properties
+
+
+def test_step_collection_is_depended_on(pipeline_session, sagemaker_session):
+    custom_step1 = CustomStep(name="MyStep1")
+    model_name = "MyModel"
+    model = Model(
+        name=model_name,
+        image_uri=IMAGE_URI,
+        model_data=ParameterString(name="ModelData", default_value="s3://my-bucket/file"),
+        sagemaker_session=pipeline_session,
+        entry_point=f"{DATA_DIR}/dummy_script.py",
+        source_dir=f"{DATA_DIR}",
+        role=ROLE,
+    )
+    step_args = model.create(
+        instance_type="c4.4xlarge",
+        accelerator_type="ml.eia1.medium",
+    )
+    model_step_name = "MyModelStep"
+    model_step = ModelStep(
+        name=model_step_name,
+        step_args=step_args,
+    )
+
+    # StepCollection object is depended on by another StepCollection object
+    model.sagemaker_session = sagemaker_session
+    register_model_name = "RegisterModelStep"
+    register_model = RegisterModel(
+        name=register_model_name,
+        model=model,
+        model_data="s3://",
+        content_types=["content_type"],
+        response_types=["response_type"],
+        inference_instances=["inference_instance"],
+        transform_instances=["transform_instance"],
+        model_package_group_name="mpg",
+        depends_on=["MyStep1", model_step],
+    )
+
+    # StepCollection objects are depended on by a step
+    custom_step2 = CustomStep(
+        name="MyStep2", depends_on=["MyStep1", model_step, register_model_name]
+    )
+    custom_step3 = CustomStep(
+        name="MyStep3", depends_on=[custom_step1, model_step_name, register_model]
+    )
+
+    pipeline = Pipeline(
+        name="MyPipeline",
+        steps=[custom_step1, model_step, custom_step2, custom_step3, register_model],
+    )
+    step_list = json.loads(pipeline.definition())["Steps"]
+    assert len(step_list) == 7
+    for step in step_list:
+        if step["Name"] not in ["MyStep2", "MyStep3", f"{model_name}RepackModel"]:
+            assert "DependsOn" not in step
+            continue
+        if step["Name"] == f"{model_name}RepackModel":
+            assert set(step["DependsOn"]) == {
+                "MyStep1",
+                f"{model_step_name}-{_REPACK_MODEL_NAME_BASE}-{model_name}",
+                f"{model_step_name}-{_CREATE_MODEL_NAME_BASE}",
+            }
+        else:
+            assert set(step["DependsOn"]) == {
+                "MyStep1",
+                f"{model_step_name}-{_REPACK_MODEL_NAME_BASE}-{model_name}",
+                f"{model_step_name}-{_CREATE_MODEL_NAME_BASE}",
+                f"{model_name}RepackModel",
+                register_model_name,
+            }
 
 
 def test_register_model(estimator, model_metrics, drift_check_baselines):

--- a/tests/unit/sagemaker/workflow/test_steps.py
+++ b/tests/unit/sagemaker/workflow/test_steps.py
@@ -289,6 +289,8 @@ def test_custom_step_with_retry_policy():
 
 
 def test_training_step_base_estimator(sagemaker_session):
+    custom_step1 = CustomStep("TestStep")
+    custom_step2 = CustomStep("AnotherTestStep")
     instance_type_parameter = ParameterString(name="InstanceType", default_value="c4.4xlarge")
     instance_count_parameter = ParameterInteger(name="InstanceCount", default_value=1)
     data_source_uri_parameter = ParameterString(
@@ -335,7 +337,7 @@ def test_training_step_base_estimator(sagemaker_session):
             training_batch_size_parameter,
             use_spot_instances,
         ],
-        steps=[step],
+        steps=[step, custom_step1, custom_step2],
         sagemaker_session=sagemaker_session,
     )
 
@@ -573,6 +575,9 @@ def test_training_step_no_profiler_warning(sagemaker_session):
 
 
 def test_processing_step(sagemaker_session):
+    custom_step1 = CustomStep("TestStep")
+    custom_step2 = CustomStep("SecondTestStep")
+    custom_step3 = CustomStep("ThirdTestStep")
     processing_input_data_uri_parameter = ParameterString(
         name="ProcessingInputDataUri", default_value=f"s3://{BUCKET}/processing_manifest"
     )
@@ -619,7 +624,7 @@ def test_processing_step(sagemaker_session):
             instance_type_parameter,
             instance_count_parameter,
         ],
-        steps=[step],
+        steps=[step, custom_step1, custom_step2, custom_step3],
         sagemaker_session=sagemaker_session,
     )
     assert json.loads(pipeline.definition())["Steps"][0] == {

--- a/tests/unit/sagemaker/workflow/test_training_step.py
+++ b/tests/unit/sagemaker/workflow/test_training_step.py
@@ -48,6 +48,7 @@ from sagemaker.amazon.object2vec import Object2Vec
 
 
 from sagemaker.inputs import TrainingInput
+from tests.unit.sagemaker.workflow.helpers import CustomStep
 
 REGION = "us-west-2"
 IMAGE_URI = "fakeimage"
@@ -78,6 +79,8 @@ def hyperparameters():
 
 
 def test_training_step_with_estimator(pipeline_session, training_input, hyperparameters):
+    custom_step1 = CustomStep("TestStep")
+    custom_step2 = CustomStep("SecondTestStep")
     estimator = Estimator(
         role=sagemaker.get_execution_role(),
         instance_count=1,
@@ -105,7 +108,7 @@ def test_training_step_with_estimator(pipeline_session, training_input, hyperpar
 
     pipeline = Pipeline(
         name="MyPipeline",
-        steps=[step],
+        steps=[step, custom_step1, custom_step2],
         sagemaker_session=pipeline_session,
     )
     assert json.loads(pipeline.definition())["Steps"][0] == {


### PR DESCRIPTION
*Description of changes:*
- Support Properties for StepCollection
- Support dependency declaration of StepCollection (i.e. depended by other steps)

*Testing done:* unit tests and integ tests

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
