### PR TITLE
fix: Add script mode env vars to model packages created from Register…

### DIFF
--- a/src/sagemaker/workflow/_utils.py
+++ b/src/sagemaker/workflow/_utils.py
@@ -272,6 +272,7 @@ class _RegisterModelStep(ConfigurableRetryStep):
         compile_model_family (str): Instance family for compiled model, if specified, a compiled
             model will be used (default: None).
         container_def_list (list): A list of container definitions.
+        entry_point (str): The path (absolute or relative) to the custom entry point.
         **kwargs: additional arguments to `create_model`.
     """
 
@@ -298,6 +299,7 @@ class _RegisterModelStep(ConfigurableRetryStep):
         container_def_list=None,
         drift_check_baselines=None,
         customer_metadata_properties=None,
+        entry_point=None,
         **kwargs,
     ):
         """Constructor of a register model step.
@@ -361,6 +363,7 @@ class _RegisterModelStep(ConfigurableRetryStep):
         self.tags = tags
         self.kwargs = kwargs
         self.container_def_list = container_def_list
+        self.entry_point = entry_point
 
         self._properties = Properties(path=f"Steps.{name}", shape_name="DescribeModelPackageOutput")
 
@@ -427,6 +430,7 @@ class _RegisterModelStep(ConfigurableRetryStep):
             tags=self.tags,
             container_def_list=self.container_def_list,
             customer_metadata_properties=self.customer_metadata_properties,
+            entry_point=self.entry_point,
         )
 
         request_dict = get_create_model_package_request(**model_package_args)

--- a/src/sagemaker/workflow/step_collections.py
+++ b/src/sagemaker/workflow/step_collections.py
@@ -133,6 +133,7 @@ class RegisterModel(StepCollection):
             subnets = model.vpc_config["Subnets"]
             security_group_ids = model.vpc_config["SecurityGroupIds"]
 
+        entry_point = None
         if "entry_point" in kwargs:
             repack_model = True
             entry_point = kwargs.pop("entry_point", None)
@@ -234,6 +235,7 @@ class RegisterModel(StepCollection):
             container_def_list=self.container_def_list,
             retry_policies=register_model_step_retry_policies,
             customer_metadata_properties=customer_metadata_properties,
+            entry_point=entry_point,
             **kwargs,
         )
         if not repack_model:

--- a/tests/unit/sagemaker/workflow/test_repack_model_script.py
+++ b/tests/unit/sagemaker/workflow/test_repack_model_script.py
@@ -171,4 +171,10 @@ def create_file_tree(root, tree):
 
 @pytest.fixture()
 def tmp(tmpdir):
+    # cleanup test folders
+    if os.path.exists("/opt/ml/code"):
+        shutil.rmtree("/opt/ml/code")
+    if os.path.exists("/opt/ml/model"):
+        shutil.rmtree("/opt/ml/model")
+
     yield str(tmpdir)

--- a/tests/unit/sagemaker/workflow/test_step_collections.py
+++ b/tests/unit/sagemaker/workflow/test_step_collections.py
@@ -514,9 +514,25 @@ def test_register_model_with_model_repack_with_estimator(
                 arguments["InferenceSpecification"]["Containers"][0]["Image"]
                 == estimator.training_image_uri()
             )
+
+            # Confirm that model container env vars were set correctly.
+            # These env vars are necessary for script mode to work
             assert isinstance(
                 arguments["InferenceSpecification"]["Containers"][0]["ModelDataUrl"], Properties
             )
+            assert (
+                arguments["InferenceSpecification"]["Containers"][0]["Environment"][
+                    "SAGEMAKER_SUBMIT_DIRECTORY"
+                ]
+                == "/opt/ml/model/code"
+            )
+            assert (
+                arguments["InferenceSpecification"]["Containers"][0]["Environment"][
+                    "SAGEMAKER_PROGRAM"
+                ]
+                == "dummy_script.py"
+            )
+
             del arguments["InferenceSpecification"]["Containers"]
             assert ordered(arguments) == ordered(
                 {
@@ -636,10 +652,26 @@ def test_register_model_with_model_repack_with_model(model, model_metrics, drift
             arguments = request_dict["Arguments"]
             assert len(arguments["InferenceSpecification"]["Containers"]) == 1
             assert arguments["InferenceSpecification"]["Containers"][0]["Image"] == model.image_uri
+
+            # Confirm that model container env vars were set correctly.
+            # These env vars are necessary for script mode to work
             assert isinstance(
                 arguments["InferenceSpecification"]["Containers"][0]["ModelDataUrl"], Properties
             )
+            assert (
+                arguments["InferenceSpecification"]["Containers"][0]["Environment"][
+                    "SAGEMAKER_SUBMIT_DIRECTORY"
+                ]
+                == "s3://my-bucket/modelName/sourcedir.tar.gz"
+            )
+            assert (
+                arguments["InferenceSpecification"]["Containers"][0]["Environment"][
+                    "SAGEMAKER_PROGRAM"
+                ]
+                == "dummy_script.py"
+            )
             del arguments["InferenceSpecification"]["Containers"]
+
             assert ordered(arguments) == ordered(
                 {
                     "InferenceSpecification": {


### PR DESCRIPTION
…ModelStep

*Description of changes:*
When an `estimator` is passed to `RegisterModelStep`, the resulting `CreateModelPackage` args will be missing the environment variables needed for script mode to work. Add those env vars to the default container definition.

*Testing done:*
Unit, manual

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
