### PR TITLE
Add DeepAR ap-northeast-3 repository.

### DIFF
--- a/tests/unit/sagemaker/image_uris/test_algos.py
+++ b/tests/unit/sagemaker/image_uris/test_algos.py
@@ -104,6 +104,7 @@ ALGO_REGIONS_AND_ACCOUNTS = (
             "ap-east-1": "286214385809",
             "ap-northeast-1": "633353088612",
             "ap-northeast-2": "204372634319",
+            "ap-northeast-3": "867004704886",
             "ap-south-1": "991648021394",
             "ap-southeast-1": "475088953585",
             "ap-southeast-2": "514117268639",


### PR DESCRIPTION
DeepAR's repository for `ap-northeast-3` was missing (see screenshot).
![Screenshot 2022-05-19 at 20 25 24](https://user-images.githubusercontent.com/133732/169374312-f58b517e-e60f-4baf-b4a8-23500fe22a4a.png)

