### PR TITLE
feature: add helper method to generate pipeline adjacency list

### DIFF
--- a/src/sagemaker/workflow/_utils.py
+++ b/src/sagemaker/workflow/_utils.py
@@ -369,7 +369,7 @@ class _RegisterModelStep(ConfigurableRetryStep):
         self.kwargs = kwargs
         self.container_def_list = container_def_list
 
-        self._properties = Properties(path=f"Steps.{name}", shape_name="DescribeModelPackageOutput")
+        self._properties = Properties(step_name=name, shape_name="DescribeModelPackageOutput")
 
     @property
     def arguments(self) -> RequestType:

--- a/src/sagemaker/workflow/callback_step.py
+++ b/src/sagemaker/workflow/callback_step.py
@@ -112,13 +112,12 @@ class CallbackStep(Step):
         self.cache_config = cache_config
         self.inputs = inputs
 
-        root_path = f"Steps.{name}"
-        root_prop = Properties(path=root_path)
+        root_prop = Properties(step_name=name)
 
         property_dict = {}
         for output in outputs:
             property_dict[output.output_name] = Properties(
-                f"{root_path}.OutputParameters['{output.output_name}']"
+                step_name=name, path=f"OutputParameters['{output.output_name}']"
             )
 
         root_prop.__dict__["Outputs"] = property_dict

--- a/src/sagemaker/workflow/clarify_check_step.py
+++ b/src/sagemaker/workflow/clarify_check_step.py
@@ -236,13 +236,12 @@ class ClarifyCheckStep(Step):
             self._generate_processing_job_analysis_config(), self._baselining_processor
         )
 
-        root_path = f"Steps.{name}"
-        root_prop = Properties(path=root_path)
+        root_prop = Properties(step_name=name)
         root_prop.__dict__["CalculatedBaselineConstraints"] = Properties(
-            f"{root_path}.CalculatedBaselineConstraints"
+            step_name=name, path="CalculatedBaselineConstraints"
         )
         root_prop.__dict__["BaselineUsedForDriftCheckConstraints"] = Properties(
-            f"{root_path}.BaselineUsedForDriftCheckConstraints"
+            step_name=name, path="BaselineUsedForDriftCheckConstraints"
         )
         self._properties = root_prop
 

--- a/src/sagemaker/workflow/condition_step.py
+++ b/src/sagemaker/workflow/condition_step.py
@@ -77,9 +77,8 @@ class ConditionStep(Step):
         self.if_steps = if_steps or []
         self.else_steps = else_steps or []
 
-        root_path = f"Steps.{name}"
-        root_prop = Properties(path=root_path)
-        root_prop.__dict__["Outcome"] = Properties(f"{root_path}.Outcome")
+        root_prop = Properties(step_name=name)
+        root_prop.__dict__["Outcome"] = Properties(step_name=name, path="Outcome")
         self._properties = root_prop
 
     @property
@@ -90,6 +89,11 @@ class ConditionStep(Step):
             IfSteps=list_to_request(self.if_steps),
             ElseSteps=list_to_request(self.else_steps),
         )
+
+    @property
+    def step_only_arguments(self):
+        """Argument dict pertaining to the step only, and not the `if_steps` or `else_steps`."""
+        return self.conditions
 
     @property
     def properties(self):
@@ -125,6 +129,11 @@ class JsonGet(PipelineVariable):  # pragma: no cover
                 "Path": self.json_path,
             }
         }
+
+    @property
+    def _referenced_steps(self) -> List[str]:
+        """List of step names that this function depends on."""
+        return [self.step.name]
 
 
 JsonGet = deprecated_class(JsonGet, "JsonGet")

--- a/src/sagemaker/workflow/emr_step.py
+++ b/src/sagemaker/workflow/emr_step.py
@@ -94,7 +94,7 @@ class EMRStep(Step):
         self.args = emr_step_args
         self.cache_config = cache_config
 
-        root_property = Properties(path=f"Steps.{name}", shape_name="Step", service_name="emr")
+        root_property = Properties(step_name=name, shape_name="Step", service_name="emr")
         root_property.__dict__["ClusterId"] = cluster_id
         self._properties = root_property
 

--- a/src/sagemaker/workflow/entities.py
+++ b/src/sagemaker/workflow/entities.py
@@ -102,3 +102,8 @@ class PipelineVariable(Expression):
     @abc.abstractmethod
     def expr(self) -> RequestType:
         """Get the expression structure for workflow service calls."""
+
+    @property
+    @abc.abstractmethod
+    def _referenced_steps(self) -> List[str]:
+        """List of step names that this function depends on."""

--- a/src/sagemaker/workflow/execution_variables.py
+++ b/src/sagemaker/workflow/execution_variables.py
@@ -13,6 +13,7 @@
 """Pipeline parameters and conditions for workflow."""
 from __future__ import absolute_import
 
+from typing import List
 from sagemaker.workflow.entities import (
     RequestType,
     PipelineVariable,
@@ -41,6 +42,11 @@ class ExecutionVariable(PipelineVariable):
     def expr(self) -> RequestType:
         """The 'Get' expression dict for an `ExecutionVariable`."""
         return {"Get": f"Execution.{self.name}"}
+
+    @property
+    def _referenced_steps(self) -> List[str]:
+        """List of step names that this function depends on."""
+        return []
 
 
 class ExecutionVariables:

--- a/src/sagemaker/workflow/functions.py
+++ b/src/sagemaker/workflow/functions.py
@@ -64,6 +64,15 @@ class Join(PipelineVariable):
             },
         }
 
+    @property
+    def _referenced_steps(self) -> List[str]:
+        """List of step names that this function depends on."""
+        steps = []
+        for value in self.values:
+            if isinstance(value, PipelineVariable):
+                steps.extend(value._referenced_steps)
+        return steps
+
 
 @attr.s
 class JsonGet(PipelineVariable):
@@ -96,3 +105,8 @@ class JsonGet(PipelineVariable):
                 "Path": self.json_path,
             }
         }
+
+    @property
+    def _referenced_steps(self) -> List[str]:
+        """List of step names that this function depends on."""
+        return [self.step_name]

--- a/src/sagemaker/workflow/lambda_step.py
+++ b/src/sagemaker/workflow/lambda_step.py
@@ -115,13 +115,12 @@ class LambdaStep(Step):
         self.cache_config = cache_config
         self.inputs = inputs if inputs is not None else {}
 
-        root_path = f"Steps.{name}"
-        root_prop = Properties(path=root_path)
+        root_prop = Properties(step_name=name)
 
         property_dict = {}
         for output in self.outputs:
             property_dict[output.output_name] = Properties(
-                f"{root_path}.OutputParameters['{output.output_name}']"
+                step_name=name, path=f"OutputParameters['{output.output_name}']"
             )
 
         root_prop.__dict__["Outputs"] = property_dict

--- a/src/sagemaker/workflow/parameters.py
+++ b/src/sagemaker/workflow/parameters.py
@@ -90,6 +90,11 @@ class Parameter(PipelineVariable, Entity):
         """The 'Get' expression dict for a `Parameter`."""
         return Parameter._expr(self.name)
 
+    @property
+    def _referenced_steps(self) -> List[str]:
+        """List of step names that this function depends on."""
+        return []
+
     @classmethod
     def _expr(cls, name):
         """An internal classmethod for the 'Get' expression dict for a `Parameter`.

--- a/src/sagemaker/workflow/quality_check_step.py
+++ b/src/sagemaker/workflow/quality_check_step.py
@@ -203,19 +203,18 @@ class QualityCheckStep(Step):
             ],
         )
 
-        root_path = f"Steps.{name}"
-        root_prop = Properties(path=root_path)
+        root_prop = Properties(step_name=name)
         root_prop.__dict__["CalculatedBaselineConstraints"] = Properties(
-            f"{root_path}.CalculatedBaselineConstraints"
+            step_name=name, path="CalculatedBaselineConstraints"
         )
         root_prop.__dict__["CalculatedBaselineStatistics"] = Properties(
-            f"{root_path}.CalculatedBaselineStatistics"
+            step_name=name, path="CalculatedBaselineStatistics"
         )
         root_prop.__dict__["BaselineUsedForDriftCheckStatistics"] = Properties(
-            f"{root_path}.BaselineUsedForDriftCheckStatistics"
+            step_name=name, path="BaselineUsedForDriftCheckStatistics"
         )
         root_prop.__dict__["BaselineUsedForDriftCheckConstraints"] = Properties(
-            f"{root_path}.BaselineUsedForDriftCheckConstraints"
+            step_name=name, path="BaselineUsedForDriftCheckConstraints"
         )
         self._properties = root_prop
 

--- a/src/sagemaker/workflow/step_collections.py
+++ b/src/sagemaker/workflow/step_collections.py
@@ -51,8 +51,7 @@ class StepCollection:
         """The properties of the particular `StepCollection`."""
         if not self.steps:
             return None
-        size = len(self.steps)
-        return self.steps[size - 1].properties
+        return self.steps[-1].properties
 
 
 class RegisterModel(StepCollection):  # pragma: no cover

--- a/tests/unit/sagemaker/workflow/helpers.py
+++ b/tests/unit/sagemaker/workflow/helpers.py
@@ -15,6 +15,7 @@ from __future__ import absolute_import
 
 from sagemaker.workflow.properties import Properties
 from sagemaker.workflow.steps import Step, StepTypeEnum
+from sagemaker.workflow.step_collections import StepCollection
 
 
 def ordered(obj):
@@ -37,19 +38,32 @@ def ordered(obj):
 
 
 class CustomStep(Step):
-    def __init__(self, name, display_name=None, description=None, depends_on=None):
+    def __init__(self, name, input_data=None, display_name=None, description=None, depends_on=None):
+        self.input_data = input_data
         super(CustomStep, self).__init__(
             name, display_name, description, StepTypeEnum.TRAINING, depends_on
         )
         # for testing property reference, we just use DescribeTrainingJobResponse shape here.
-        self._properties = Properties(
-            path=f"Steps.{name}", shape_name="DescribeTrainingJobResponse"
-        )
+        self._properties = Properties(name, shape_name="DescribeTrainingJobResponse")
 
     @property
     def arguments(self):
+        if self.input_data:
+            return {"input_data": self.input_data}
         return dict()
 
     @property
     def properties(self):
         return self._properties
+
+
+class CustomStepCollection(StepCollection):
+    def __init__(self, name, num_steps=2, depends_on=None):
+        steps = []
+        previous_step = None
+        for i in range(num_steps):
+            step_depends_on = depends_on if not previous_step else [previous_step]
+            step = CustomStep(name=f"{name}-{i}", depends_on=step_depends_on)
+            steps.append(step)
+            previous_step = step
+        super(CustomStepCollection, self).__init__(name, steps)

--- a/tests/unit/sagemaker/workflow/test_callback_step.py
+++ b/tests/unit/sagemaker/workflow/test_callback_step.py
@@ -19,9 +19,9 @@ import pytest
 from mock import Mock
 
 from sagemaker.workflow.parameters import ParameterInteger, ParameterString
-from sagemaker.workflow.pipeline import Pipeline
+from sagemaker.workflow.pipeline import Pipeline, PipelineGraph
 from sagemaker.workflow.callback_step import CallbackStep, CallbackOutput, CallbackOutputTypeEnum
-from tests.unit.sagemaker.workflow.helpers import CustomStep
+from tests.unit.sagemaker.workflow.helpers import CustomStep, ordered
 
 
 @pytest.fixture
@@ -156,3 +156,11 @@ def test_pipeline_interpolates_callback_outputs():
             },
         ],
     }
+    adjacency_list = PipelineGraph.from_pipeline(pipeline).adjacency_list
+    assert ordered(adjacency_list) == ordered(
+        {
+            "MyCallbackStep1": [],
+            "MyCallbackStep2": [],
+            "TestStep": ["MyCallbackStep1", "MyCallbackStep2"],
+        }
+    )

--- a/tests/unit/sagemaker/workflow/test_conditions.py
+++ b/tests/unit/sagemaker/workflow/test_conditions.py
@@ -112,7 +112,7 @@ def test_condition_in_mixed():
     assert cond_in.to_request() == {
         "Type": "In",
         "QueryValue": {"Get": "Parameters.MyStr"},
-        "Values": ["abc", {"Get": "foo"}, {"Get": "Execution.StartDateTime"}],
+        "Values": ["abc", {"Get": "Steps.foo"}, {"Get": "Execution.StartDateTime"}],
     }
 
 

--- a/tests/unit/sagemaker/workflow/test_entities.py
+++ b/tests/unit/sagemaker/workflow/test_entities.py
@@ -121,7 +121,7 @@ def test_pipeline_variable_in_pipeline_definition(sagemaker_session):
         property_file=property_file,
         json_path="my-json-path",
     )
-    prop = Properties("Steps.MyStep", "DescribeProcessingJobResponse")
+    prop = Properties(step_name="MyStep", shape_name="DescribeProcessingJobResponse")
 
     cond = ConditionGreaterThan(left=param_str, right=param_int.to_string())
     step_fail = FailStep(

--- a/tests/unit/sagemaker/workflow/test_fail_step.py
+++ b/tests/unit/sagemaker/workflow/test_fail_step.py
@@ -21,7 +21,8 @@ from sagemaker.workflow.conditions import ConditionEquals
 from sagemaker.workflow.fail_step import FailStep
 from sagemaker.workflow.functions import Join
 from sagemaker.workflow.parameters import ParameterInteger
-from sagemaker.workflow.pipeline import Pipeline
+from sagemaker.workflow.pipeline import Pipeline, PipelineGraph
+from tests.unit.sagemaker.workflow.helpers import ordered
 
 
 def test_fail_step():
@@ -104,6 +105,8 @@ def test_fail_step_with_join_fn_in_error_message():
     ]
 
     assert json.loads(pipeline.definition())["Steps"] == _expected_dsl
+    adjacency_list = PipelineGraph.from_pipeline(pipeline).adjacency_list
+    assert ordered(adjacency_list) == ordered({"CondStep": ["FailStep"], "FailStep": []})
 
 
 def test_fail_step_with_properties_ref():

--- a/tests/unit/sagemaker/workflow/test_functions.py
+++ b/tests/unit/sagemaker/workflow/test_functions.py
@@ -50,7 +50,7 @@ def test_join_expressions():
             ParameterFloat(name="MyFloat"),
             ParameterInteger(name="MyInt"),
             ParameterString(name="MyStr"),
-            Properties(path="Steps.foo.OutputPath.S3Uri"),
+            Properties(step_name="foo", path="OutputPath.S3Uri"),
             ExecutionVariables.PIPELINE_EXECUTION_ID,
             Join(on=",", values=[1, "a", False, 1.1]),
         ]

--- a/tests/unit/sagemaker/workflow/test_lambda_step.py
+++ b/tests/unit/sagemaker/workflow/test_lambda_step.py
@@ -19,11 +19,11 @@ import pytest
 from mock import Mock, MagicMock
 
 from sagemaker.workflow.parameters import ParameterInteger, ParameterString
-from sagemaker.workflow.pipeline import Pipeline
+from sagemaker.workflow.pipeline import Pipeline, PipelineGraph
 from sagemaker.workflow.lambda_step import LambdaStep, LambdaOutput, LambdaOutputTypeEnum
 from sagemaker.lambda_helper import Lambda
 from sagemaker.workflow.steps import CacheConfig
-from tests.unit.sagemaker.workflow.helpers import CustomStep
+from tests.unit.sagemaker.workflow.helpers import CustomStep, ordered
 
 
 @pytest.fixture()
@@ -63,7 +63,7 @@ def test_lambda_step(sagemaker_session):
     cache_config = CacheConfig(enable_caching=True, expire_after="PT1H")
     lambda_step = LambdaStep(
         name="MyLambdaStep",
-        depends_on=["TestStep"],
+        depends_on=[custom_step1],
         lambda_func=Lambda(
             function_arn="arn:aws:lambda:us-west-2:123456789012:function:sagemaker_test_lambda",
             session=sagemaker_session,
@@ -74,7 +74,7 @@ def test_lambda_step(sagemaker_session):
         outputs=[output_param1, output_param2],
         cache_config=cache_config,
     )
-    lambda_step.add_depends_on(["SecondTestStep"])
+    lambda_step.add_depends_on([custom_step2])
     pipeline = Pipeline(
         name="MyPipeline",
         parameters=[param],
@@ -95,6 +95,10 @@ def test_lambda_step(sagemaker_session):
         "Arguments": {"arg1": "foo", "arg2": 5, "arg3": {"Get": "Parameters.MyInt"}},
         "CacheConfig": {"Enabled": True, "ExpireAfter": "PT1H"},
     }
+    adjacency_list = PipelineGraph.from_pipeline(pipeline).adjacency_list
+    assert ordered(adjacency_list) == ordered(
+        {"MyLambdaStep": [], "TestStep": ["MyLambdaStep"], "SecondTestStep": ["MyLambdaStep"]}
+    )
 
 
 def test_lambda_step_output_expr(sagemaker_session):
@@ -127,7 +131,7 @@ def test_pipeline_interpolates_lambda_outputs(sagemaker_session):
     output_param2 = LambdaOutput(output_name="output2", output_type=LambdaOutputTypeEnum.String)
     lambda_step1 = LambdaStep(
         name="MyLambdaStep1",
-        depends_on=["TestStep"],
+        depends_on=[custom_step],
         lambda_func=Lambda(
             function_arn="arn:aws:lambda:us-west-2:123456789012:function:sagemaker_test_lambda",
             session=sagemaker_session,
@@ -137,7 +141,7 @@ def test_pipeline_interpolates_lambda_outputs(sagemaker_session):
     )
     lambda_step2 = LambdaStep(
         name="MyLambdaStep2",
-        depends_on=["TestStep"],
+        depends_on=[custom_step],
         lambda_func=Lambda(
             function_arn="arn:aws:lambda:us-west-2:123456789012:function:sagemaker_test_lambda",
             session=sagemaker_session,
@@ -185,6 +189,10 @@ def test_pipeline_interpolates_lambda_outputs(sagemaker_session):
             },
         ],
     }
+    adjacency_list = PipelineGraph.from_pipeline(pipeline).adjacency_list
+    assert ordered(adjacency_list) == ordered(
+        {"MyLambdaStep1": [], "MyLambdaStep2": [], "TestStep": ["MyLambdaStep1", "MyLambdaStep2"]}
+    )
 
 
 def test_lambda_step_no_inputs_outputs(sagemaker_session):

--- a/tests/unit/sagemaker/workflow/test_model_step.py
+++ b/tests/unit/sagemaker/workflow/test_model_step.py
@@ -41,7 +41,7 @@ from sagemaker.workflow.model_step import (
     _REPACK_MODEL_NAME_BASE,
 )
 from sagemaker.workflow.parameters import ParameterString, ParameterInteger
-from sagemaker.workflow.pipeline import Pipeline
+from sagemaker.workflow.pipeline import Pipeline, PipelineGraph
 from sagemaker.workflow.pipeline_context import PipelineSession
 from sagemaker.workflow.retry import (
     StepRetryPolicy,
@@ -53,7 +53,7 @@ from sagemaker.xgboost import XGBoostModel
 from sagemaker.lambda_helper import Lambda
 from sagemaker.workflow.lambda_step import LambdaStep, LambdaOutput, LambdaOutputTypeEnum
 from tests.unit import DATA_DIR
-from tests.unit.sagemaker.workflow.helpers import CustomStep
+from tests.unit.sagemaker.workflow.helpers import CustomStep, ordered
 
 _IMAGE_URI = "fakeimage"
 _REGION = "us-west-2"
@@ -146,7 +146,7 @@ def test_register_model_with_runtime_repack(pipeline_session, model_data_param, 
         transform_instances=["ml.m5.xlarge"],
         model_package_group_name="MyModelPackageGroup",
     )
-    model_steps = ModelStep(
+    model_step = ModelStep(
         name="MyModelStep",
         step_args=step_args,
         retry_policies=dict(
@@ -162,17 +162,18 @@ def test_register_model_with_runtime_repack(pipeline_session, model_data_param, 
         depends_on=["TestStep"],
         description="my model step description",
     )
+    custom_step2 = CustomStep("TestStep2", depends_on=[model_step])
     pipeline = Pipeline(
         name="MyPipeline",
         parameters=[model_data_param],
-        steps=[model_steps, custom_step],
+        steps=[custom_step, model_step, custom_step2],
         sagemaker_session=pipeline_session,
     )
     step_dsl_list = json.loads(pipeline.definition())["Steps"]
-    assert len(step_dsl_list) == 3
+    assert len(step_dsl_list) == 4
     expected_repack_step_name = f"MyModelStep-{_REPACK_MODEL_NAME_BASE}-MyModel"
     # Filter out the dummy custom step
-    step_dsl_list = list(filter(lambda s: s["Name"] != "TestStep", step_dsl_list))
+    step_dsl_list = list(filter(lambda s: not s["Name"].startswith("TestStep"), step_dsl_list))
     for step in step_dsl_list[0:2]:
         if step["Type"] == "Training":
             assert step["Name"] == expected_repack_step_name
@@ -222,6 +223,16 @@ def test_register_model_with_runtime_repack(pipeline_session, model_data_param, 
             assert "my model step description" in step["Description"]
         else:
             raise Exception("A step exists in the collection of an invalid type.")
+
+    adjacency_list = PipelineGraph.from_pipeline(pipeline).adjacency_list
+    assert ordered(adjacency_list) == ordered(
+        {
+            "TestStep": ["MyModelStep-RepackModel-MyModel"],
+            "MyModelStep-RepackModel-MyModel": ["MyModelStep-RegisterModel"],
+            "MyModelStep-RegisterModel": ["TestStep2"],
+            "TestStep2": [],
+        }
+    )
 
 
 def test_create_model_with_runtime_repack(pipeline_session, model_data_param, model):
@@ -289,6 +300,13 @@ def test_create_model_with_runtime_repack(pipeline_session, model_data_param, mo
             ]
         else:
             raise Exception("A step exists in the collection of an invalid type.")
+    adjacency_list = PipelineGraph.from_pipeline(pipeline).adjacency_list
+    assert ordered(adjacency_list) == ordered(
+        {
+            "MyModelStep-CreateModel": [],
+            "MyModelStep-RepackModel-MyModel": ["MyModelStep-CreateModel"],
+        }
+    )
 
 
 def test_create_pipeline_model_with_runtime_repack(pipeline_session, model_data_param, model):
@@ -376,6 +394,13 @@ def test_create_pipeline_model_with_runtime_repack(pipeline_session, model_data_
             ]
         else:
             raise Exception("A step exists in the collection of an invalid type.")
+    adjacency_list = PipelineGraph.from_pipeline(pipeline).adjacency_list
+    assert ordered(adjacency_list) == ordered(
+        {
+            "MyModelStep-CreateModel": [],
+            "MyModelStep-RepackModel-MyModel": ["MyModelStep-CreateModel"],
+        }
+    )
 
 
 def test_register_pipeline_model_with_runtime_repack(pipeline_session, model_data_param):
@@ -411,14 +436,17 @@ def test_register_pipeline_model_with_runtime_repack(pipeline_session, model_dat
         name="MyModelStep",
         step_args=step_args,
     )
+    custom_step = CustomStep("TestStep", input_data=model_steps.properties.ModelApprovalStatus)
     pipeline = Pipeline(
         name="MyPipeline",
         parameters=[model_data_param],
-        steps=[model_steps],
+        steps=[model_steps, custom_step],
         sagemaker_session=pipeline_session,
     )
     step_dsl_list = json.loads(pipeline.definition())["Steps"]
-    assert len(step_dsl_list) == 2
+    assert len(step_dsl_list) == 3
+    # Filter out the dummy custom step
+    step_dsl_list = list(filter(lambda s: not s["Name"].startswith("TestStep"), step_dsl_list))
     expected_repack_step_name = f"MyModelStep-{_REPACK_MODEL_NAME_BASE}-1"
     for step in step_dsl_list:
         if step["Type"] == "Training":
@@ -453,6 +481,14 @@ def test_register_pipeline_model_with_runtime_repack(pipeline_session, model_dat
             assert containers[1]["Environment"]["k"] == "v"
         else:
             raise Exception("A step exists in the collection of an invalid type.")
+    adjacency_list = PipelineGraph.from_pipeline(pipeline).adjacency_list
+    assert ordered(adjacency_list) == ordered(
+        {
+            "MyModelStep-RegisterModel": ["TestStep"],
+            "MyModelStep-RepackModel-1": ["MyModelStep-RegisterModel"],
+            "TestStep": [],
+        }
+    )
 
 
 def test_register_model_without_repack(pipeline_session):
@@ -501,6 +537,8 @@ def test_register_model_without_repack(pipeline_session):
         containers[0]["Environment"][_SAGEMAKER_SUBMIT_DIRECTORY]
         == f"s3://{_BUCKET}/{model_name}/sourcedir.tar.gz"
     )
+    adjacency_list = PipelineGraph.from_pipeline(pipeline).adjacency_list
+    assert ordered(adjacency_list) == ordered({"MyModelStep-RegisterModel": []})
 
 
 @patch("sagemaker.utils.repack_model")
@@ -538,6 +576,10 @@ def test_create_model_with_compile_time_repack(mock_repack, pipeline_session):
     assert arguments["PrimaryContainer"]["Environment"][_SAGEMAKER_SUBMIT_DIRECTORY] == _DIR_NAME
     assert len(step_dsl_list[0]["DependsOn"]) == 1
     assert step_dsl_list[0]["DependsOn"][0] == "TestStep"
+    adjacency_list = PipelineGraph.from_pipeline(pipeline).adjacency_list
+    assert ordered(adjacency_list) == ordered(
+        {"MyModelStep-CreateModel": [], "TestStep": ["MyModelStep-CreateModel"]}
+    )
 
 
 def test_conditional_model_create_and_regis(
@@ -555,7 +597,7 @@ def test_conditional_model_create_and_regis(
         model_package_group_name="MyModelPackageGroup",
     )
     step_model_regis = ModelStep(
-        name="MyModelStep",
+        name="MyModelStepRegis",
         step_args=step_args,
     )
     # create model without runtime repack
@@ -566,7 +608,7 @@ def test_conditional_model_create_and_regis(
         accelerator_type="ml.eia1.medium",
     )
     step_model_create = ModelStep(
-        name="MyModelStep",
+        name="MyModelStepCreate",
         step_args=step_args,
     )
     step_cond = ConditionStep(
@@ -586,7 +628,7 @@ def test_conditional_model_create_and_regis(
     cond_step_dsl = json.loads(pipeline.definition())["Steps"][0]
     step_dsl_list = cond_step_dsl["Arguments"]["IfSteps"] + cond_step_dsl["Arguments"]["ElseSteps"]
     assert len(step_dsl_list) == 3
-    expected_repack_step_name = f"MyModelStep-{_REPACK_MODEL_NAME_BASE}-MyModel"
+    expected_repack_step_name = f"MyModelStepRegis-{_REPACK_MODEL_NAME_BASE}-MyModel"
     for step in step_dsl_list:
         if step["Type"] == "Training":
             assert step["Name"] == expected_repack_step_name
@@ -601,7 +643,7 @@ def test_conditional_model_create_and_regis(
             assert "s3://" in arguments["HyperParameters"]["sagemaker_submit_directory"]
             assert arguments["HyperParameters"]["dependencies"] == "null"
         elif step["Type"] == "RegisterModel":
-            assert step["Name"] == f"MyModelStep-{_REGISTER_MODEL_NAME_BASE}"
+            assert step["Name"] == f"MyModelStepRegis-{_REGISTER_MODEL_NAME_BASE}"
             arguments = step["Arguments"]
             assert arguments["ModelApprovalStatus"] == "PendingManualApproval"
             assert len(arguments["InferenceSpecification"]["Containers"]) == 1
@@ -613,7 +655,7 @@ def test_conditional_model_create_and_regis(
             assert container["Environment"][_SAGEMAKER_PROGRAM] == _SCRIPT_NAME
             assert container["Environment"][_SAGEMAKER_SUBMIT_DIRECTORY] == _DIR_NAME
         elif step["Type"] == "Model":
-            assert step["Name"] == f"MyModelStep-{_CREATE_MODEL_NAME_BASE}"
+            assert step["Name"] == f"MyModelStepCreate-{_CREATE_MODEL_NAME_BASE}"
             arguments = step["Arguments"]
             container = arguments["PrimaryContainer"]
             assert container["Image"] == _IMAGE_URI
@@ -621,6 +663,18 @@ def test_conditional_model_create_and_regis(
             assert not container.get("Environment", {})
         else:
             raise Exception("A step exists in the collection of an invalid type.")
+    adjacency_list = PipelineGraph.from_pipeline(pipeline).adjacency_list
+    assert ordered(adjacency_list) == ordered(
+        {
+            "MyModelStepCreate-CreateModel": [],
+            "MyModelStepRegis-RegisterModel": [],
+            "MyModelStepRegis-RepackModel-MyModel": ["MyModelStepRegis-RegisterModel"],
+            "cond-good-enough": [
+                "MyModelStepCreate-CreateModel",
+                "MyModelStepRegis-RepackModel-MyModel",
+            ],
+        }
+    )
 
 
 @pytest.mark.parametrize(
@@ -918,6 +972,14 @@ def test_model_step_with_lambda_property_reference(pipeline_session):
     assert register_step["Arguments"]["PrimaryContainer"]["Image"] == {
         "Get": "Steps.MyLambda.OutputParameters['model_image']"
     }
+    adjacency_list = PipelineGraph.from_pipeline(pipeline).adjacency_list
+    assert ordered(adjacency_list) == ordered(
+        {
+            "MyLambda": ["mymodelstep-CreateModel", "mymodelstep-RepackModel-MyModel"],
+            "mymodelstep-CreateModel": [],
+            "mymodelstep-RepackModel-MyModel": ["mymodelstep-CreateModel"],
+        }
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/sagemaker/workflow/test_pipeline.py
+++ b/tests/unit/sagemaker/workflow/test_pipeline.py
@@ -22,37 +22,13 @@ from mock import Mock
 from sagemaker import s3
 from sagemaker.workflow.execution_variables import ExecutionVariables
 from sagemaker.workflow.parameters import ParameterString
-from sagemaker.workflow.pipeline import Pipeline
+from sagemaker.workflow.pipeline import Pipeline, PipelineGraph
 from sagemaker.workflow.parallelism_config import ParallelismConfiguration
 from sagemaker.workflow.pipeline_experiment_config import (
     PipelineExperimentConfig,
     PipelineExperimentConfigProperties,
 )
-from sagemaker.workflow.properties import Properties
-from sagemaker.workflow.steps import (
-    Step,
-    StepTypeEnum,
-)
-from tests.unit.sagemaker.workflow.helpers import ordered
-
-
-class CustomStep(Step):
-    def __init__(self, name, input_data, display_name=None, description=None):
-        self.input_data = input_data
-        super(CustomStep, self).__init__(name, display_name, description, StepTypeEnum.TRAINING)
-
-        path = f"Steps.{name}"
-        prop = Properties(path=path)
-        prop.__dict__["S3Uri"] = Properties(f"{path}.S3Uri")
-        self._properties = prop
-
-    @property
-    def arguments(self):
-        return {"input_data": self.input_data}
-
-    @property
-    def properties(self):
-        return self._properties
+from tests.unit.sagemaker.workflow.helpers import ordered, CustomStep
 
 
 @pytest.fixture
@@ -314,7 +290,9 @@ def test_pipeline_two_step(sagemaker_session_mock):
             PipelineExperimentConfigProperties.EXPERIMENT_NAME,  # experiment config property
         ],
     )
-    step2 = CustomStep(name="MyStep2", input_data=[step1.properties.S3Uri])  # step property
+    step2 = CustomStep(
+        name="MyStep2", input_data=[step1.properties.ModelArtifacts.S3ModelArtifacts]
+    )  # step property
     pipeline = Pipeline(
         name="MyPipeline",
         parameters=[parameter],
@@ -344,7 +322,7 @@ def test_pipeline_two_step(sagemaker_session_mock):
             {
                 "Name": "MyStep2",
                 "Type": "Training",
-                "Arguments": {"input_data": [step1.properties.S3Uri]},
+                "Arguments": {"input_data": [step1.properties.ModelArtifacts.S3ModelArtifacts]},
             },
         ],
     }
@@ -372,11 +350,16 @@ def test_pipeline_two_step(sagemaker_session_mock):
                 {
                     "Name": "MyStep2",
                     "Type": "Training",
-                    "Arguments": {"input_data": [{"Get": "Steps.MyStep1.S3Uri"}]},
+                    "Arguments": {
+                        "input_data": [{"Get": "Steps.MyStep1.ModelArtifacts.S3ModelArtifacts"}]
+                    },
                 },
             ],
         }
     )
+
+    adjacency_list = PipelineGraph.from_pipeline(pipeline).adjacency_list
+    assert ordered(adjacency_list) == ordered({"MyStep1": ["MyStep2"], "MyStep2": []})
 
 
 def test_pipeline_override_experiment_config():

--- a/tests/unit/sagemaker/workflow/test_pipeline_graph.py
+++ b/tests/unit/sagemaker/workflow/test_pipeline_graph.py
@@ -1,0 +1,342 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from __future__ import absolute_import
+
+import pytest
+
+from mock import Mock
+
+from sagemaker.workflow.pipeline import Pipeline, PipelineGraph
+from sagemaker.workflow.condition_step import ConditionStep
+from sagemaker.workflow.conditions import (
+    ConditionEquals,
+    ConditionIn,
+    ConditionNot,
+    ConditionOr,
+    ConditionGreaterThan,
+)
+from sagemaker.workflow.execution_variables import ExecutionVariables
+from sagemaker.workflow.parameters import ParameterInteger, ParameterString
+from tests.unit.sagemaker.workflow.helpers import ordered, CustomStep, CustomStepCollection
+
+
+@pytest.fixture
+def sagemaker_session_mock():
+    session_mock = Mock()
+    session_mock.default_bucket = Mock(name="default_bucket", return_value="s3_bucket")
+    return session_mock
+
+
+@pytest.fixture
+def role_arn():
+    return "arn:role"
+
+
+def test_pipeline_duplicate_step_name(sagemaker_session_mock):
+    step1 = CustomStep(name="foo")
+    step2 = CustomStep(name="foo")
+    pipeline = Pipeline(
+        name="MyPipeline", steps=[step1, step2], sagemaker_session=sagemaker_session_mock
+    )
+    with pytest.raises(ValueError) as error:
+        PipelineGraph.from_pipeline(pipeline)
+    assert "Pipeline steps cannot have duplicate names." in str(error.value)
+
+
+def test_pipeline_duplicate_step_name_in_condition_step(sagemaker_session_mock):
+    param = ParameterInteger(name="MyInt", default_value=2)
+    cond = ConditionEquals(left=param, right=1)
+    custom_step = CustomStep(name="foo")
+    custom_step2 = CustomStep(name="foo")
+    condition_step = ConditionStep(
+        name="condStep", conditions=[cond], depends_on=[custom_step], if_steps=[custom_step2]
+    )
+    pipeline = Pipeline(
+        name="MyPipeline",
+        steps=[custom_step, condition_step],
+        sagemaker_session=sagemaker_session_mock,
+    )
+    with pytest.raises(ValueError) as error:
+        PipelineGraph.from_pipeline(pipeline)
+    assert "Pipeline steps cannot have duplicate names." in str(error.value)
+
+
+def test_pipeline_duplicate_step_name_in_step_collection(sagemaker_session_mock):
+    custom_step = CustomStep(name="foo-1")
+    custom_step_collection = CustomStepCollection(name="foo", depends_on=[custom_step])
+    pipeline = Pipeline(
+        name="MyPipeline",
+        steps=[custom_step, custom_step_collection],
+        sagemaker_session=sagemaker_session_mock,
+    )
+    with pytest.raises(ValueError) as error:
+        PipelineGraph.from_pipeline(pipeline)
+    assert "Pipeline steps cannot have duplicate names." in str(error.value)
+
+
+def test_pipeline_graph_acyclic(sagemaker_session_mock):
+    step_a = CustomStep(name="stepA")
+    step_b = CustomStep(name="stepB")
+    step_c = CustomStep(name="stepC", depends_on=[step_a])
+    step_d = CustomStep(name="stepD", depends_on=[step_c])
+    step_e = CustomStep(name="stepE", depends_on=[step_a, step_b, step_d])
+
+    pipeline = Pipeline(
+        name="MyPipeline",
+        steps=[step_a, step_b, step_c, step_d, step_e],
+        sagemaker_session=sagemaker_session_mock,
+    )
+
+    pipeline_graph = PipelineGraph.from_pipeline(pipeline)
+    adjacency_list = pipeline_graph.adjacency_list
+    assert ordered(adjacency_list) == ordered(
+        {
+            "stepA": ["stepC", "stepE"],
+            "stepB": ["stepE"],
+            "stepC": ["stepD"],
+            "stepD": ["stepE"],
+            "stepE": [],
+        }
+    )
+    _verify_pipeline_graph_traversal(pipeline_graph)
+
+
+def test_pipeline_graph_acyclic_with_condition_step_explicit_dependency(sagemaker_session_mock):
+    custom_step = CustomStep(name="TestStep")
+    if_step = CustomStep(name="IfStep")
+    else_step = CustomStep(name="ElseStep")
+    param = ParameterInteger(name="MyInt", default_value=2)
+    cond = ConditionEquals(left=param, right=1)
+    condition_step = ConditionStep(
+        name="condStep",
+        conditions=[cond],
+        depends_on=[custom_step],
+        if_steps=[if_step],
+        else_steps=[else_step],
+    )
+    pipeline = Pipeline(
+        name="MyPipeline",
+        steps=[custom_step, condition_step],
+        sagemaker_session=sagemaker_session_mock,
+    )
+
+    pipeline_graph = PipelineGraph.from_pipeline(pipeline)
+    adjacency_list = pipeline_graph.adjacency_list
+    assert ordered(adjacency_list) == ordered(
+        {"condStep": ["ElseStep", "IfStep"], "ElseStep": [], "IfStep": [], "TestStep": ["condStep"]}
+    )
+    _verify_pipeline_graph_traversal(pipeline_graph)
+
+
+def test_pipeline_graph_acyclic_with_condition_step_property_reference_dependency(
+    sagemaker_session_mock,
+):
+    custom_step = CustomStep(name="TestStep")
+    if_step = CustomStep(name="IfStep")
+    else_step = CustomStep(name="ElseStep")
+    cond = ConditionEquals(left=custom_step.properties.TrainingJobStatus, right="Succeeded")
+    condition_step = ConditionStep(
+        name="condStep", conditions=[cond], if_steps=[if_step], else_steps=[else_step]
+    )
+    pipeline = Pipeline(
+        name="MyPipeline",
+        steps=[custom_step, condition_step],
+        sagemaker_session=sagemaker_session_mock,
+    )
+
+    pipeline_graph = PipelineGraph.from_pipeline(pipeline)
+    adjacency_list = pipeline_graph.adjacency_list
+    assert ordered(adjacency_list) == ordered(
+        {"condStep": ["ElseStep", "IfStep"], "ElseStep": [], "IfStep": [], "TestStep": ["condStep"]}
+    )
+    _verify_pipeline_graph_traversal(pipeline_graph)
+
+
+def test_pipeline_graph_acyclic_with_step_collection_explicit_dependency(sagemaker_session_mock):
+    custom_step1 = CustomStep(name="TestStep")
+    custom_step_collection = CustomStepCollection(
+        name="TestStepCollection", depends_on=[custom_step1]
+    )
+    custom_step2 = CustomStep(name="TestStep2", depends_on=[custom_step_collection])
+    pipeline = Pipeline(
+        name="MyPipeline",
+        steps=[custom_step1, custom_step_collection, custom_step2],
+        sagemaker_session=sagemaker_session_mock,
+    )
+
+    pipeline_graph = PipelineGraph.from_pipeline(pipeline)
+    adjacency_list = pipeline_graph.adjacency_list
+    assert ordered(adjacency_list) == ordered(
+        {
+            "TestStep": ["TestStepCollection-0"],
+            "TestStep2": [],
+            "TestStepCollection-0": ["TestStepCollection-1"],
+            "TestStepCollection-1": ["TestStep2"],
+        }
+    )
+    _verify_pipeline_graph_traversal(pipeline_graph)
+
+
+def test_pipeline_graph_acyclic_with_step_collection_property_reference_dependency(
+    sagemaker_session_mock,
+):
+    custom_step_collection = CustomStepCollection(name="TestStepCollection")
+    custom_step = CustomStep(
+        name="TestStep",
+        input_data=custom_step_collection.properties.AlgorithmSpecification.AlgorithmName,
+    )
+    pipeline = Pipeline(
+        name="MyPipeline",
+        steps=[custom_step_collection, custom_step],
+        sagemaker_session=sagemaker_session_mock,
+    )
+
+    pipeline_graph = PipelineGraph.from_pipeline(pipeline)
+    adjacency_list = pipeline_graph.adjacency_list
+    assert ordered(adjacency_list) == ordered(
+        {
+            "TestStep": [],
+            "TestStepCollection-0": ["TestStepCollection-1"],
+            "TestStepCollection-1": ["TestStep"],
+        }
+    )
+    _verify_pipeline_graph_traversal(pipeline_graph)
+
+
+def test_pipeline_graph_cyclic(sagemaker_session_mock):
+    step_a = CustomStep(name="stepA", depends_on=["stepC"])
+    step_b = CustomStep(name="stepB", depends_on=["stepA"])
+    step_c = CustomStep(name="stepC", depends_on=["stepB"])
+
+    pipeline = Pipeline(
+        name="MyPipeline", steps=[step_a, step_b, step_c], sagemaker_session=sagemaker_session_mock
+    )
+
+    with pytest.raises(ValueError) as error:
+        PipelineGraph.from_pipeline(pipeline)
+    assert "Cycle detected in pipeline step graph." in str(error.value)
+
+
+def test_condition_comparison(sagemaker_session):
+    param = ParameterInteger(name="MyInt")
+    cond = ConditionEquals(left=param, right=1)
+    if_step = CustomStep(name="IfStep")
+    else_step = CustomStep(name="ElseStep")
+    cond_step = ConditionStep(
+        name="MyConditionStep",
+        conditions=[cond],
+        if_steps=[if_step],
+        else_steps=[else_step],
+    )
+    pipeline = Pipeline(
+        name="MyPipeline",
+        steps=[cond_step],
+        sagemaker_session=sagemaker_session,
+        parameters=[param],
+    )
+    adjacency_list = PipelineGraph.from_pipeline(pipeline).adjacency_list
+    assert ordered(adjacency_list) == ordered(
+        {"MyConditionStep": ["ElseStep", "IfStep"], "ElseStep": [], "IfStep": []}
+    )
+
+
+def test_condition_not(sagemaker_session):
+    param = ParameterInteger(name="MyInt")
+    cond = ConditionEquals(left=param, right=1)
+    cond_not = ConditionNot(expression=cond)
+    if_step = CustomStep(name="IfStep")
+    else_step = CustomStep(name="ElseStep")
+    cond_step = ConditionStep(
+        name="MyConditionStep",
+        conditions=[cond_not],
+        if_steps=[if_step],
+        else_steps=[else_step],
+    )
+    pipeline = Pipeline(
+        name="MyPipeline",
+        steps=[cond_step],
+        sagemaker_session=sagemaker_session,
+        parameters=[param],
+    )
+    adjacency_list = PipelineGraph.from_pipeline(pipeline).adjacency_list
+    assert ordered(adjacency_list) == ordered(
+        {"MyConditionStep": ["ElseStep", "IfStep"], "ElseStep": [], "IfStep": []}
+    )
+
+
+def test_condition_in(sagemaker_session):
+    param = ParameterString(name="MyStr")
+    cond_in = ConditionIn(value=param, in_values=["abc", "def"])
+    if_step = CustomStep(name="IfStep")
+    else_step = CustomStep(name="ElseStep")
+    cond_step = ConditionStep(
+        name="MyConditionStep",
+        conditions=[cond_in],
+        if_steps=[if_step],
+        else_steps=[else_step],
+    )
+    pipeline = Pipeline(
+        name="MyPipeline",
+        steps=[cond_step],
+        sagemaker_session=sagemaker_session,
+        parameters=[param],
+    )
+    adjacency_list = PipelineGraph.from_pipeline(pipeline).adjacency_list
+    assert ordered(adjacency_list) == ordered(
+        {
+            "MyConditionStep": ["ElseStep", "IfStep"],
+            "ElseStep": [],
+            "IfStep": [],
+        }
+    )
+
+
+def test_condition_or(sagemaker_session):
+    param = ParameterString(name="MyStr")
+    cond1 = ConditionGreaterThan(left=ExecutionVariables.START_DATETIME, right="2020-12-01")
+    cond2 = ConditionEquals(left=param, right="Success")
+    cond_or = ConditionOr(conditions=[cond1, cond2])
+    if_step = CustomStep(name="IfStep")
+    else_step = CustomStep(name="ElseStep")
+    cond_step = ConditionStep(
+        name="MyConditionStep",
+        conditions=[cond_or],
+        if_steps=[if_step],
+        else_steps=[else_step],
+    )
+    pipeline = Pipeline(
+        name="MyPipeline",
+        steps=[cond_step],
+        sagemaker_session=sagemaker_session,
+        parameters=[param],
+    )
+    adjacency_list = PipelineGraph.from_pipeline(pipeline).adjacency_list
+    assert ordered(adjacency_list) == ordered(
+        {
+            "MyConditionStep": ["ElseStep", "IfStep"],
+            "ElseStep": [],
+            "IfStep": [],
+        }
+    )
+
+
+def _verify_pipeline_graph_traversal(pipeline_graph):
+    adjacency_list = pipeline_graph.adjacency_list
+    traversed_steps = []
+    for step in pipeline_graph:
+        # the traversal order of a PipelineGraph needs to be a topological sort traversal
+        # i.e. parent steps are always traversed before their children steps
+        assert step not in traversed_steps
+        for children_steps in adjacency_list[step.name]:
+            assert children_steps not in traversed_steps
+        traversed_steps.append(step)

--- a/tests/unit/sagemaker/workflow/test_processing_step.py
+++ b/tests/unit/sagemaker/workflow/test_processing_step.py
@@ -42,7 +42,7 @@ from sagemaker.spark.processing import SparkJarProcessor, PySparkProcessor
 
 
 from sagemaker.workflow.steps import CacheConfig, ProcessingStep
-from sagemaker.workflow.pipeline import Pipeline
+from sagemaker.workflow.pipeline import Pipeline, PipelineGraph
 from sagemaker.workflow.properties import PropertyFile
 from sagemaker.workflow.parameters import ParameterString
 from sagemaker.workflow.functions import Join
@@ -59,7 +59,7 @@ from sagemaker.clarify import (
     ModelPredictedLabelConfig,
     SHAPConfig,
 )
-from tests.unit.sagemaker.workflow.helpers import CustomStep
+from tests.unit.sagemaker.workflow.helpers import CustomStep, ordered
 
 REGION = "us-west-2"
 BUCKET = "my-bucket"
@@ -326,6 +326,14 @@ def test_processing_step_with_processor(pipeline_session, processing_input):
     assert step.properties.ProcessingJobName.expr == {
         "Get": "Steps.MyProcessingStep.ProcessingJobName"
     }
+    adjacency_list = PipelineGraph.from_pipeline(pipeline).adjacency_list
+    assert ordered(adjacency_list) == ordered(
+        {
+            "TestStep": ["MyProcessingStep"],
+            "SecondTestStep": ["MyProcessingStep"],
+            "MyProcessingStep": [],
+        }
+    )
 
 
 def test_processing_step_with_processor_and_step_args(pipeline_session, processing_input):
@@ -491,7 +499,7 @@ def test_processing_step_with_clarify_processor(pipeline_session):
             seed=123,
         )
 
-    def verfiy(step_args):
+    def verify(step_args):
         step = ProcessingStep(
             name="MyProcessingStep",
             step_args=step_args,
@@ -531,13 +539,13 @@ def test_processing_step_with_clarify_processor(pipeline_session):
         bias_config=data_bias_config(),
         model_config=model_config("1st-model-rpyndy0uyo"),
     )
-    verfiy(run_bias_args)
+    verify(run_bias_args)
 
     run_pre_training_bias_args = clarify_processor.run_pre_training_bias(
         data_config=data_config,
         data_bias_config=data_bias_config(),
     )
-    verfiy(run_pre_training_bias_args)
+    verify(run_pre_training_bias_args)
 
     run_post_training_bias_args = clarify_processor.run_post_training_bias(
         data_config=data_config,
@@ -545,14 +553,14 @@ def test_processing_step_with_clarify_processor(pipeline_session):
         model_config=model_config("1st-model-rpyndy0uyo"),
         model_predicted_label_config=ModelPredictedLabelConfig(probability_threshold=0.9),
     )
-    verfiy(run_post_training_bias_args)
+    verify(run_post_training_bias_args)
 
     run_explainability_args = clarify_processor.run_explainability(
         data_config=data_config,
         model_config=model_config("1st-model-rpyndy0uyo"),
         explainability_config=shap_config(),
     )
-    verfiy(run_explainability_args)
+    verify(run_explainability_args)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/sagemaker/workflow/test_properties.py
+++ b/tests/unit/sagemaker/workflow/test_properties.py
@@ -18,7 +18,7 @@ from sagemaker.workflow.properties import Properties
 
 
 def test_properties_describe_training_job_response():
-    prop = Properties("Steps.MyStep", "DescribeTrainingJobResponse")
+    prop = Properties(step_name="MyStep", shape_name="DescribeTrainingJobResponse")
     some_prop_names = ["TrainingJobName", "TrainingJobArn", "HyperParameters", "OutputDataConfig"]
     for name in some_prop_names:
         assert name in prop.__dict__.keys()
@@ -30,7 +30,7 @@ def test_properties_describe_training_job_response():
 
 
 def test_properties_describe_processing_job_response():
-    prop = Properties("Steps.MyStep", "DescribeProcessingJobResponse")
+    prop = Properties(step_name="MyStep", shape_name="DescribeProcessingJobResponse")
     some_prop_names = ["ProcessingInputs", "ProcessingOutputConfig", "ProcessingEndTime"]
     for name in some_prop_names:
         assert name in prop.__dict__.keys()
@@ -42,7 +42,7 @@ def test_properties_describe_processing_job_response():
 
 def test_properties_tuning_job():
     prop = Properties(
-        "Steps.MyStep",
+        step_name="MyStep",
         shape_names=[
             "DescribeHyperParameterTuningJobResponse",
             "ListTrainingJobsForHyperParameterTuningJobResponse",
@@ -72,7 +72,7 @@ def test_properties_tuning_job():
 
 
 def test_properties_emr_step():
-    prop = Properties("Steps.MyStep", "Step", service_name="emr")
+    prop = Properties("MyStep", shape_name="Step", service_name="emr")
     some_prop_names = ["Id", "Name", "Config", "ActionOnFailure", "Status"]
     for name in some_prop_names:
         assert name in prop.__dict__.keys()
@@ -85,7 +85,7 @@ def test_properties_emr_step():
 
 
 def test_properties_describe_model_package_output():
-    prop = Properties("Steps.MyStep", "DescribeModelPackageOutput")
+    prop = Properties(step_name="MyStep", shape_name="DescribeModelPackageOutput")
     some_prop_names = ["ModelPackageName", "ModelPackageGroupName", "ModelPackageArn"]
     for name in some_prop_names:
         assert name in prop.__dict__.keys()
@@ -96,7 +96,7 @@ def test_properties_describe_model_package_output():
 
 
 def test_to_string():
-    prop = Properties("Steps.MyStep", "DescribeTrainingJobResponse")
+    prop = Properties("MyStep", shape_name="DescribeTrainingJobResponse")
 
     assert prop.CreationTime.to_string().expr == {
         "Std:Join": {
@@ -107,7 +107,7 @@ def test_to_string():
 
 
 def test_implicit_value():
-    prop = Properties("Steps.MyStep", "DescribeTrainingJobResponse")
+    prop = Properties("MyStep", shape_name="DescribeTrainingJobResponse")
 
     with pytest.raises(TypeError) as error:
         str(prop.CreationTime)
@@ -123,8 +123,8 @@ def test_implicit_value():
 
 
 def test_add_func():
-    prop_train = Properties("Steps.MyStepTrain", "DescribeTrainingJobResponse")
-    prop_model = Properties("Steps.MyStepModel", "DescribeModelPackageOutput")
+    prop_train = Properties("MyStepTrain", shape_name="DescribeTrainingJobResponse")
+    prop_model = Properties("MyStepModel", shape_name="DescribeModelPackageOutput")
 
     with pytest.raises(TypeError) as error:
         prop_train + prop_model

--- a/tests/unit/sagemaker/workflow/test_steps.py
+++ b/tests/unit/sagemaker/workflow/test_steps.py
@@ -46,7 +46,7 @@ from sagemaker.tuner import (
 from sagemaker.network import NetworkConfig
 from sagemaker.transformer import Transformer
 from sagemaker.workflow.functions import Join
-from sagemaker.workflow.pipeline import Pipeline
+from sagemaker.workflow.pipeline import Pipeline, PipelineGraph
 from sagemaker.workflow.properties import Properties, PropertyFile
 from sagemaker.workflow.parameters import ParameterString, ParameterInteger, ParameterBoolean
 from sagemaker.workflow.retry import (
@@ -70,6 +70,7 @@ from sagemaker.sparkml import SparkMLModel
 from sagemaker.predictor import Predictor
 from sagemaker.model import FrameworkModel
 from tests.unit import DATA_DIR
+from tests.unit.sagemaker.workflow.helpers import ordered
 
 DUMMY_SCRIPT_PATH = os.path.join(DATA_DIR, "dummy_script.py")
 
@@ -85,7 +86,7 @@ class CustomStep(ConfigurableRetryStep):
         super(CustomStep, self).__init__(
             name, StepTypeEnum.TRAINING, display_name, description, None, retry_policies
         )
-        self._properties = Properties(path=f"Steps.{name}")
+        self._properties = Properties(name)
 
     @property
     def arguments(self):
@@ -395,6 +396,14 @@ def test_training_step_base_estimator(sagemaker_session):
     }
     assert step.properties.TrainingJobName.expr == {"Get": "Steps.MyTrainingStep.TrainingJobName"}
     assert step.properties.HyperParameters.expr == {"Get": "Steps.MyTrainingStep.HyperParameters"}
+    adjacency_list = PipelineGraph.from_pipeline(pipeline).adjacency_list
+    assert ordered(adjacency_list) == ordered(
+        {
+            "AnotherTestStep": ["MyTrainingStep"],
+            "MyTrainingStep": [],
+            "TestStep": ["MyTrainingStep"],
+        }
+    )
 
 
 def test_training_step_tensorflow(sagemaker_session):
@@ -668,6 +677,15 @@ def test_processing_step(sagemaker_session):
     assert step.properties.ProcessingJobName.expr == {
         "Get": "Steps.MyProcessingStep.ProcessingJobName"
     }
+    adjacency_list = PipelineGraph.from_pipeline(pipeline).adjacency_list
+    assert ordered(adjacency_list) == ordered(
+        {
+            "SecondTestStep": ["MyProcessingStep"],
+            "TestStep": ["MyProcessingStep"],
+            "ThirdTestStep": ["MyProcessingStep"],
+            "MyProcessingStep": [],
+        }
+    )
 
 
 @patch("sagemaker.processing.ScriptProcessor._normalize_args")
@@ -979,7 +997,7 @@ def test_transform_step(sagemaker_session):
 
 
 def test_properties_describe_training_job_response():
-    prop = Properties("Steps.MyStep", "DescribeTrainingJobResponse")
+    prop = Properties(step_name="MyStep", shape_name="DescribeTrainingJobResponse")
     some_prop_names = ["TrainingJobName", "TrainingJobArn", "HyperParameters", "OutputDataConfig"]
     for name in some_prop_names:
         assert name in prop.__dict__.keys()
@@ -990,7 +1008,7 @@ def test_properties_describe_training_job_response():
 
 
 def test_properties_describe_processing_job_response():
-    prop = Properties("Steps.MyStep", "DescribeProcessingJobResponse")
+    prop = Properties(step_name="MyStep", shape_name="DescribeProcessingJobResponse")
     some_prop_names = ["ProcessingInputs", "ProcessingOutputConfig", "ProcessingEndTime"]
     for name in some_prop_names:
         assert name in prop.__dict__.keys()

--- a/tests/unit/sagemaker/workflow/test_training_step.py
+++ b/tests/unit/sagemaker/workflow/test_training_step.py
@@ -27,7 +27,7 @@ from sagemaker.workflow.pipeline_context import PipelineSession
 from sagemaker.workflow.parameters import ParameterString
 
 from sagemaker.workflow.steps import TrainingStep
-from sagemaker.workflow.pipeline import Pipeline
+from sagemaker.workflow.pipeline import Pipeline, PipelineGraph
 from sagemaker.workflow.functions import Join
 
 from sagemaker.estimator import Estimator
@@ -55,7 +55,7 @@ from sagemaker.amazon.object2vec import Object2Vec
 from tests.unit import DATA_DIR
 
 from sagemaker.inputs import TrainingInput
-from tests.unit.sagemaker.workflow.helpers import CustomStep
+from tests.unit.sagemaker.workflow.helpers import CustomStep, ordered
 
 REGION = "us-west-2"
 BUCKET = "my-bucket"
@@ -242,6 +242,10 @@ def test_training_step_with_estimator(pipeline_session, training_input, hyperpar
         "Arguments": step_args.args,
     }
     assert step.properties.TrainingJobName.expr == {"Get": "Steps.MyTrainingStep.TrainingJobName"}
+    adjacency_list = PipelineGraph.from_pipeline(pipeline).adjacency_list
+    assert ordered(adjacency_list) == ordered(
+        {"MyTrainingStep": [], "SecondTestStep": ["MyTrainingStep"], "TestStep": ["MyTrainingStep"]}
+    )
 
 
 @pytest.mark.parametrize("estimator", ESTIMATOR_LISTS)

--- a/tests/unit/sagemaker/workflow/test_transform_step.py
+++ b/tests/unit/sagemaker/workflow/test_transform_step.py
@@ -26,7 +26,7 @@ from sagemaker.workflow.pipeline_context import PipelineSession
 from tests.unit.sagemaker.workflow.helpers import CustomStep
 
 from sagemaker.workflow.steps import TransformStep, TransformInput
-from sagemaker.workflow.pipeline import Pipeline
+from sagemaker.workflow.pipeline import Pipeline, PipelineGraph
 from sagemaker.workflow.parameters import ParameterString
 from sagemaker.workflow.functions import Join
 from sagemaker.workflow import is_pipeline_variable
@@ -174,6 +174,8 @@ def test_transform_step_with_transformer(model_name, data, output_path, pipeline
         step_def["Arguments"]["TransformOutput"]["S3OutputPath"],
     )
     assert step_def == {"Name": "MyTransformStep", "Type": "Transform", "Arguments": step_args}
+    adjacency_list = PipelineGraph.from_pipeline(pipeline).adjacency_list
+    assert adjacency_list == {"MyTransformStep": []}
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/sagemaker/workflow/test_tuning_step.py
+++ b/tests/unit/sagemaker/workflow/test_tuning_step.py
@@ -25,7 +25,7 @@ from sagemaker.workflow.pipeline_context import PipelineSession
 
 from sagemaker.workflow.steps import TuningStep
 from sagemaker.inputs import TrainingInput
-from sagemaker.workflow.pipeline import Pipeline
+from sagemaker.workflow.pipeline import Pipeline, PipelineGraph
 from sagemaker.workflow.parameters import ParameterString
 from sagemaker.workflow.functions import Join
 
@@ -33,7 +33,6 @@ from sagemaker.tuner import HyperparameterTuner, IntegerParameter
 from sagemaker.pytorch.estimator import PyTorch
 
 from tests.unit import DATA_DIR
-
 
 REGION = "us-west-2"
 BUCKET = "my-bucket"
@@ -166,6 +165,8 @@ def test_tuning_step_with_single_algo_tuner(pipeline_session, training_input, en
         "Type": "Tuning",
         "Arguments": step_args,
     }
+    adjacency_list = PipelineGraph.from_pipeline(pipeline).adjacency_list
+    assert adjacency_list == {"MyTuningStep": []}
 
 
 def test_tuning_step_with_multi_algo_tuner(pipeline_session, entry_point):
@@ -229,6 +230,8 @@ def test_tuning_step_with_multi_algo_tuner(pipeline_session, entry_point):
         "Type": "Tuning",
         "Arguments": step_args.args,
     }
+    adjacency_list = PipelineGraph.from_pipeline(pipeline).adjacency_list
+    assert adjacency_list == {"MyTuningStep": []}
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/sagemaker/workflow/test_utils.py
+++ b/tests/unit/sagemaker/workflow/test_utils.py
@@ -184,7 +184,7 @@ def test_repack_model_step_with_invalid_input():
 
 
 def test_repack_model_step_with_source_dir(estimator, source_dir):
-    model_data = Properties(path="Steps.MyStep", shape_name="DescribeModelOutput")
+    model_data = Properties(step_name="MyStep", shape_name="DescribeModelOutput")
     entry_point = "inference.py"
     step = _RepackModelStep(
         name="MyRepackModelStep",
@@ -259,7 +259,7 @@ def test_inject_repack_script_s3(estimator, tmp, fake_s3):
         ],
     )
 
-    model_data = Properties(path="Steps.MyStep", shape_name="DescribeModelOutput")
+    model_data = Properties(step_name="MyStep", shape_name="DescribeModelOutput")
     entry_point = "inference.py"
     source_dir_path = "s3://fake/location"
     step = _RepackModelStep(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Added a helper method to create adjacency list representing the step dependency DAG within a sagemaker pipeline

*Testing done:* unit tests

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
