### PR TITLE
Fix: fix pipeline doc code example where process.run only accepts argument

### DIFF
--- a/doc/amazon_sagemaker_model_building_pipeline.rst
+++ b/doc/amazon_sagemaker_model_building_pipeline.rst
@@ -239,7 +239,7 @@ Referable Property List:
                 ProcessingOutput(output_name="train", source="/opt/ml/processing/train"),
             ],
             code="./local/preprocess.py",
-            job_arguments=["--input-data", "s3://my-input"]
+            arguments=["--input-data", "s3://my-input"]
         ),
     )
 
@@ -496,7 +496,7 @@ A :class:`sagemaker.workflow.properties.PropertyFile` is designed to store infor
             ProcessingOutput(output_name="hyperparam", source="/opt/ml/processing/evaluation"),
         ],
         code="./local/preprocess.py",
-        job_arguments=["--input-data", "s3://my-input"],
+        arguments=["--input-data", "s3://my-input"],
     )
 
     hyperparam_report = PropertyFile(
@@ -577,7 +577,7 @@ There are eight types of condition are supported, they are:
             ProcessingOutput(output_name="hyperparam", source="/opt/ml/processing/evaluation"),
         ],
         code="./local/preprocess.py",
-        job_arguments=["--input-data", "s3://my-input"],
+        arguments=["--input-data", "s3://my-input"],
     )
 
     eval_report = PropertyFile(
@@ -668,7 +668,7 @@ Use :class:`sagemaker.workflow.functions.JsonGet` to extract a Json property fro
             ProcessingOutput(output_name="hyperparam", source="/opt/ml/processing/evaluation"),
         ],
         code="./local/preprocess.py",
-        job_arguments=["--input-data", "s3://my-input"],
+        arguments=["--input-data", "s3://my-input"],
     )
 
     hyperparam_report = PropertyFile(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

doc fix

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
