### PR TITLE
feature: AutoGluon 0.4.2 image_uris support

### DIFF
--- a/src/sagemaker/image_uri_config/autogluon.json
+++ b/src/sagemaker/image_uri_config/autogluon.json
@@ -3,7 +3,7 @@
         "processors": ["cpu", "gpu"],
         "version_aliases": {
             "0.3": "0.3.2",
-            "0.4": "0.4.0"
+            "0.4": "0.4.2"
         },
         "versions": {
             "0.3.1": {
@@ -65,6 +65,35 @@
                 "py_versions": ["py38"]
             },
             "0.4.0": {
+                "registries": {
+                    "af-south-1": "626614931356",
+                    "ap-east-1": "871362719292",
+                    "ap-northeast-1": "763104351884",
+                    "ap-northeast-2": "763104351884",
+                    "ap-northeast-3": "364406365360",
+                    "ap-south-1": "763104351884",
+                    "ap-southeast-1": "763104351884",
+                    "ap-southeast-2": "763104351884",
+                    "ca-central-1": "763104351884",
+                    "eu-central-1": "763104351884",
+                    "eu-north-1": "763104351884",
+                    "eu-west-1": "763104351884",
+                    "eu-west-2": "763104351884",
+                    "eu-west-3": "763104351884",
+                    "eu-south-1": "692866216735",
+                    "me-south-1": "217643126080",
+                    "sa-east-1": "763104351884",
+                    "us-east-1": "763104351884",
+                    "us-east-2": "763104351884",
+                    "us-gov-west-1": "442386744353",
+                    "us-iso-east-1": "886529160074",
+                    "us-west-1": "763104351884",
+                    "us-west-2": "763104351884"
+                },
+                "repository": "autogluon-training",
+                "py_versions": ["py38"]
+            },
+            "0.4.2": {
                 "registries": {
                     "af-south-1": "626614931356",
                     "ap-east-1": "871362719292",
@@ -96,10 +125,9 @@
         }
     },
     "inference": {
-        "processors": ["cpu"],
         "version_aliases": {
             "0.3": "0.3.2",
-            "0.4": "0.4.0"
+            "0.4": "0.4.2"
         },
         "versions": {
             "0.3.1": {
@@ -131,6 +159,7 @@
                     "us-west-2": "763104351884"
                 },
                 "repository": "autogluon-inference",
+                "processors": ["cpu"],
                 "py_versions": ["py37"]
             },
             "0.3.2": {
@@ -162,6 +191,7 @@
                     "us-west-2": "763104351884"
                 },
                 "repository": "autogluon-inference",
+                "processors": ["cpu"],
                 "py_versions": ["py38"]
             },
             "0.4.0": {
@@ -193,6 +223,39 @@
                     "us-west-2": "763104351884"
                 },
                 "repository": "autogluon-inference",
+                "processors": ["cpu"],
+                "py_versions": ["py38"]
+            },
+            "0.4.2": {
+                "registries": {
+                    "af-south-1": "626614931356",
+                    "ap-east-1": "871362719292",
+                    "ap-northeast-1": "763104351884",
+                    "ap-northeast-2": "763104351884",
+                    "ap-northeast-3": "364406365360",
+                    "ap-south-1": "763104351884",
+                    "ap-southeast-1": "763104351884",
+                    "ap-southeast-2": "763104351884",
+                    "ca-central-1": "763104351884",
+                    "cn-north-1": "727897471807",
+                    "cn-northwest-1": "727897471807",
+                    "eu-central-1": "763104351884",
+                    "eu-north-1": "763104351884",
+                    "eu-west-1": "763104351884",
+                    "eu-west-2": "763104351884",
+                    "eu-west-3": "763104351884",
+                    "eu-south-1": "692866216735",
+                    "me-south-1": "217643126080",
+                    "sa-east-1": "763104351884",
+                    "us-east-1": "763104351884",
+                    "us-east-2": "763104351884",
+                    "us-gov-west-1": "442386744353",
+                    "us-iso-east-1": "886529160074",
+                    "us-west-1": "763104351884",
+                    "us-west-2": "763104351884"
+                },
+                "repository": "autogluon-inference",
+                "processors": ["cpu", "gpu"],
                 "py_versions": ["py38"]
             }
         }


### PR DESCRIPTION
*Description of changes:*
Added image_uri metadata for AutoGluon 0.4.2

*Testing done:*
tox

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
