### PR TITLE
fix: bucket exists check for session.default_bucket

### DIFF
--- a/tests/unit/test_default_bucket.py
+++ b/tests/unit/test_default_bucket.py
@@ -14,7 +14,7 @@ from __future__ import absolute_import
 
 import pytest
 from botocore.exceptions import ClientError
-from mock import MagicMock
+from mock import MagicMock, patch
 import sagemaker
 
 ACCOUNT_ID = "123"
@@ -32,6 +32,11 @@ def sagemaker_session():
 
 
 def test_default_bucket_s3_create_call(sagemaker_session):
+    error = ClientError(
+        error_response={"Error": {"Code": "404", "Message": "Not Found"}},
+        operation_name="foo",
+    )
+    sagemaker_session.boto_session.resource("s3").meta.client.head_bucket.side_effect = error
     bucket_name = sagemaker_session.default_bucket()
 
     create_calls = sagemaker_session.boto_session.resource().create_bucket.mock_calls
@@ -43,6 +48,25 @@ def test_default_bucket_s3_create_call(sagemaker_session):
         "Bucket": bucket_name,
     }
     assert sagemaker_session._default_bucket == bucket_name
+
+
+def test_default_bucket_s3_needs_access(sagemaker_session):
+    with patch("logging.Logger.error") as mocked_error_log:
+        with pytest.raises(ClientError):
+            error = ClientError(
+                error_response={"Error": {"Code": "403", "Message": "Forbidden"}},
+                operation_name="foo",
+            )
+            sagemaker_session.boto_session.resource(
+                "s3"
+            ).meta.client.head_bucket.side_effect = error
+            sagemaker_session.default_bucket()
+            mocked_error_log.assert_called_once_with(
+                "Bucket %s exists, but access is forbidden. Please try again after "
+                "adding appropriate access.",
+                DEFAULT_BUCKET_NAME,
+            )
+        assert sagemaker_session._default_bucket is None
 
 
 def test_default_already_cached(sagemaker_session):
@@ -57,11 +81,9 @@ def test_default_already_cached(sagemaker_session):
 
 
 def test_default_bucket_exists(sagemaker_session):
-    error = ClientError(
-        error_response={"Error": {"Code": "BucketAlreadyOwnedByYou", "Message": "message"}},
-        operation_name="foo",
-    )
-    sagemaker_session.boto_session.resource().create_bucket.side_effect = error
+    sagemaker_session.boto_session.resource("s3").meta.client.head_bucket.return_value = {
+        "ResponseMetadata": {"RequestId": "xxx", "HTTPStatusCode": 200, "RetryAttempts": 0}
+    }
 
     bucket_name = sagemaker_session.default_bucket()
     assert bucket_name == DEFAULT_BUCKET_NAME
@@ -70,7 +92,7 @@ def test_default_bucket_exists(sagemaker_session):
 def test_concurrent_bucket_modification(sagemaker_session):
     message = "A conflicting conditional operation is currently in progress against this resource. Please try again"
     error = ClientError(
-        error_response={"Error": {"Code": "BucketAlreadyOwnedByYou", "Message": message}},
+        error_response={"Error": {"Code": "OperationAborted", "Message": message}},
         operation_name="foo",
     )
     sagemaker_session.boto_session.resource().create_bucket.side_effect = error
@@ -80,6 +102,11 @@ def test_concurrent_bucket_modification(sagemaker_session):
 
 
 def test_bucket_creation_client_error(sagemaker_session):
+    error = ClientError(
+        error_response={"Error": {"Code": "404", "Message": "Not Found"}},
+        operation_name="foo",
+    )
+    sagemaker_session.boto_session.resource("s3").meta.client.head_bucket.side_effect = error
     with pytest.raises(ClientError):
         error = ClientError(
             error_response={"Error": {"Code": "SomethingWrong", "Message": "message"}},
@@ -92,6 +119,11 @@ def test_bucket_creation_client_error(sagemaker_session):
 
 
 def test_bucket_creation_other_error(sagemaker_session):
+    error = ClientError(
+        error_response={"Error": {"Code": "404", "Message": "Not Found"}},
+        operation_name="foo",
+    )
+    sagemaker_session.boto_session.resource("s3").meta.client.head_bucket.side_effect = error
     with pytest.raises(RuntimeError):
         error = RuntimeError()
         sagemaker_session.boto_session.resource().create_bucket.side_effect = error


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/sagemaker-python-sdk/issues/2910

*Description of changes:*
Current check for bucket existence in `session.py` requires `s3:ListAllMyBuckets`. This permission shouldn't be necessary and is often not allowed in environments following the least privileges principle. Also Without `s3:ListAllMyBuckets` permissions the case of bucket existence, still requires `s3:CreateBucket` perms otherwise the check doesn't work properly.

Expected behavior
Users should be able to create a Sagemaker jobs without having to assign s3:ListAllMyBuckets or s3:CreateBucket to the IAM role. 

With this change users can now use a `s3:ListBucket` on a specific bucket, which can support the case of same or cross account specific bucket access.

*Testing done:*
For backwards compatibility the creation_date check for `s3:ListAllMyBuckets` would also be supported.
Added units

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
