### PR TITLE
fix: integs fallback from p3 to p2 instance

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,6 +46,7 @@ NO_P3_REGIONS = [
     "ca-central-1",  # it has p3, but not enough
     "eu-central-1",  # it has p3, but not enough
     "eu-north-1",
+    "eu-west-1",  # it has p3, but not enough
     "eu-west-2",  # it has p3, but not enough
     "eu-west-3",
     "eu-south-1",

--- a/tests/integ/__init__.py
+++ b/tests/integ/__init__.py
@@ -74,6 +74,7 @@ TRAINING_NO_P3_REGIONS = [
     "ca-central-1",  # it has p3, but not enough
     "eu-central-1",  # it has p3, but not enough
     "eu-north-1",
+    "eu-west-1",  # it has p3, but not enough
     "eu-west-2",  # it has p3, but not enough
     "eu-west-3",
     "eu-south-1",

--- a/tests/integ/test_horovod.py
+++ b/tests/integ/test_horovod.py
@@ -22,6 +22,7 @@ from six.moves.urllib.parse import urlparse
 
 import sagemaker.utils
 import tests.integ as integ
+from tests.integ.utils import gpu_list, retry_with_instance_list
 from sagemaker.tensorflow import TensorFlow
 from tests.integ import timeout
 
@@ -51,18 +52,19 @@ def test_hvd_cpu(
     and integ.test_region() in integ.TRAINING_NO_P3_REGIONS,
     reason="no ml.p2 or ml.p3 instances in this region",
 )
+@retry_with_instance_list(gpu_list(integ.test_region()))
 def test_hvd_gpu(
     sagemaker_session,
     tensorflow_training_latest_version,
     tensorflow_training_latest_py_version,
-    gpu_instance_type,
     tmpdir,
+    **kwargs,
 ):
     _create_and_fit_estimator(
         sagemaker_session,
         tensorflow_training_latest_version,
         tensorflow_training_latest_py_version,
-        gpu_instance_type,
+        kwargs["instance_type"],
         tmpdir,
     )
 

--- a/tests/integ/test_horovod_mx.py
+++ b/tests/integ/test_horovod_mx.py
@@ -24,6 +24,7 @@ import sagemaker.utils
 import tests.integ as integ
 from sagemaker.mxnet import MXNet
 from tests.integ import timeout
+from tests.integ.utils import gpu_list, retry_with_instance_list
 
 horovod_dir = os.path.join(os.path.dirname(__file__), "..", "data", "horovod")
 
@@ -51,18 +52,19 @@ def test_hvd_cpu(
     and integ.test_region() in integ.TRAINING_NO_P3_REGIONS,
     reason="no ml.p2 or ml.p3 instances in this region",
 )
+@retry_with_instance_list(gpu_list(integ.test_region()))
 def test_hvd_gpu(
     mxnet_training_latest_version,
     mxnet_training_latest_py_version,
     sagemaker_session,
-    gpu_instance_type,
     tmpdir,
+    **kwargs,
 ):
     _create_and_fit_estimator(
         mxnet_training_latest_version,
         mxnet_training_latest_py_version,
         sagemaker_session,
-        gpu_instance_type,
+        kwargs["instance_type"],
         tmpdir,
     )
 

--- a/tests/integ/test_huggingface.py
+++ b/tests/integ/test_huggingface.py
@@ -69,12 +69,13 @@ def test_framework_processing_job_with_deps(
     and integ.test_region() in integ.TRAINING_NO_P3_REGIONS,
     reason="no ml.p2 or ml.p3 instances in this region",
 )
+@retry_with_instance_list(gpu_list(integ.test_region()))
 def test_huggingface_training(
     sagemaker_session,
-    gpu_instance_type,
     huggingface_training_latest_version,
     huggingface_training_pytorch_latest_version,
     huggingface_pytorch_latest_training_py_version,
+    **kwargs,
 ):
     with timeout(minutes=TRAINING_DEFAULT_TIMEOUT_MINUTES):
         data_path = os.path.join(DATA_DIR, "huggingface")
@@ -86,7 +87,7 @@ def test_huggingface_training(
             transformers_version=huggingface_training_latest_version,
             pytorch_version=huggingface_training_pytorch_latest_version,
             instance_count=1,
-            instance_type=gpu_instance_type,
+            instance_type=kwargs["instance_type"],
             hyperparameters={
                 "model_name_or_path": "distilbert-base-cased",
                 "task_name": "wnli",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
