### PR TITLE
pass `default_bucket` to `Session` object in `LocalSession` class construct

### DIFF
--- a/src/sagemaker/local/local_session.py
+++ b/src/sagemaker/local/local_session.py
@@ -491,7 +491,7 @@ class LocalSession(Session):
     :class:`~sagemaker.session.Session`.
     """
 
-    def __init__(self, boto_session=None, s3_endpoint_url=None, disable_local_code=False):
+    def __init__(self, boto_session=None, s3_endpoint_url=None, disable_local_code=False, default_bucket=None):
         """Create a Local SageMaker Session.
 
         Args:
@@ -503,6 +503,12 @@ class LocalSession(Session):
             disable_local_code (bool): Set ``True`` to override the default AWS configuration
                 chain to disable the ``local.local_code`` setting, which may not be supported for
                 some SDK features (default: False).
+            default_bucket (str): The default Amazon S3 bucket to be used by this session.
+                This will be created the next time an Amazon S3 bucket is needed (by calling
+                :func:`default_bucket`).
+                If not provided, a default bucket will be created based on the following format:
+                "sagemaker-{region}-{aws-account-id}".
+                Example: "sagemaker-my-custom-bucket".
         """
         self.s3_endpoint_url = s3_endpoint_url
         # We use this local variable to avoid disrupting the __init__->_initialize API of the
@@ -510,7 +516,7 @@ class LocalSession(Session):
         # discourage external use:
         self._disable_local_code = disable_local_code
 
-        super(LocalSession, self).__init__(boto_session)
+        super(LocalSession, self).__init__(boto_session, default_bucket=default_bucket)
 
         if platform.system() == "Windows":
             logger.warning("Windows Support for Local Mode is Experimental")


### PR DESCRIPTION
LocalSession class to accept default_bucket as argument instead of falling back to `sagemaker-{region}-{aws-account-id}` bucket.

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
