### PR TITLE
feature: include fields to work with inference recommender

### DIFF
--- a/src/sagemaker/estimator.py
+++ b/src/sagemaker/estimator.py
@@ -1301,6 +1301,8 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):  # pylint: disable=too-man
         drift_check_baselines=None,
         customer_metadata_properties=None,
         domain=None,
+        sample_payload_url=None,
+        task=None,
         **kwargs,
     ):
         """Creates a model package for creating SageMaker models or listing on Marketplace.
@@ -1334,6 +1336,11 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):  # pylint: disable=too-man
                 metadata properties (default: None).
             domain (str): Domain values can be "COMPUTER_VISION", "NATURAL_LANGUAGE_PROCESSING",
                 "MACHINE_LEARNING" (default: None).
+            sample_payload_url (str): The S3 path where the sample payload is stored
+                (default: None).
+            task (str): Task values which are supported by Inference Recommender are "FILL_MASK",
+                "IMAGE_CLASSIFICATION", "OBJECT_DETECTION", "TEXT_GENERATION", "IMAGE_SEGMENTATION",
+                "CLASSIFICATION", "REGRESSION", "OTHER" (default: None).
             **kwargs: Passed to invocation of ``create_model()``. Implementations may customize
                 ``create_model()`` to accept ``**kwargs`` to customize model creation during
                 deploy. For more, see the implementation docs.
@@ -1371,6 +1378,8 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):  # pylint: disable=too-man
             drift_check_baselines=drift_check_baselines,
             customer_metadata_properties=customer_metadata_properties,
             domain=domain,
+            sample_payload_url=sample_payload_url,
+            task=task,
         )
 
     @property

--- a/src/sagemaker/huggingface/model.py
+++ b/src/sagemaker/huggingface/model.py
@@ -306,6 +306,12 @@ class HuggingFaceModel(FrameworkModel):
         drift_check_baselines=None,
         customer_metadata_properties=None,
         domain=None,
+        sample_payload_url=None,
+        task=None,
+        framework=None,
+        framework_version=None,
+        nearest_model_name=None,
+        data_input_configuration=None,
     ):
         """Creates a model package for creating SageMaker models or listing on Marketplace.
 
@@ -337,6 +343,18 @@ class HuggingFaceModel(FrameworkModel):
                 metadata properties (default: None).
             domain (str): Domain values can be "COMPUTER_VISION", "NATURAL_LANGUAGE_PROCESSING",
                 "MACHINE_LEARNING" (default: None).
+            sample_payload_url (str): The S3 path where the sample payload is stored
+                (default: None).
+            task (str): Task values which are supported by Inference Recommender are "FILL_MASK",
+                "IMAGE_CLASSIFICATION", "OBJECT_DETECTION", "TEXT_GENERATION", "IMAGE_SEGMENTATION",
+                "CLASSIFICATION", "REGRESSION", "OTHER" (default: None).
+            framework (str): Machine learning framework of the model package container image
+                (default: None).
+            framework_version (str): Framework version of the Model Package Container Image
+                (default: None).
+            nearest_model_name (str): Name of a pre-trained machine learning benchmarked by
+                Amazon SageMaker Inference Recommender (default: None).
+            data_input_configuration (str): Input object for the model (default: None).
 
         Returns:
             A `sagemaker.model.ModelPackage` instance.
@@ -367,6 +385,12 @@ class HuggingFaceModel(FrameworkModel):
             drift_check_baselines=drift_check_baselines,
             customer_metadata_properties=customer_metadata_properties,
             domain=domain,
+            sample_payload_url=sample_payload_url,
+            task=task,
+            framework=framework,
+            framework_version=framework_version,
+            nearest_model_name=nearest_model_name,
+            data_input_configuration=data_input_configuration,
         )
 
     def prepare_container_def(

--- a/src/sagemaker/model.py
+++ b/src/sagemaker/model.py
@@ -310,6 +310,12 @@ class Model(ModelBase):
         customer_metadata_properties=None,
         validation_specification=None,
         domain=None,
+        task=None,
+        sample_payload_url=None,
+        framework=None,
+        framework_version=None,
+        nearest_model_name=None,
+        data_input_configuration=None,
     ):
         """Creates a model package for creating SageMaker models or listing on Marketplace.
 
@@ -339,6 +345,18 @@ class Model(ModelBase):
                 metadata properties (default: None).
             domain (str): Domain values can be "COMPUTER_VISION", "NATURAL_LANGUAGE_PROCESSING",
                 "MACHINE_LEARNING" (default: None).
+            sample_payload_url (str): The S3 path where the sample payload is stored
+                (default: None).
+            task (str): Task values which are supported by Inference Recommender are "FILL_MASK",
+                "IMAGE_CLASSIFICATION", "OBJECT_DETECTION", "TEXT_GENERATION", "IMAGE_SEGMENTATION",
+                "CLASSIFICATION", "REGRESSION", "OTHER" (default: None).
+            framework (str): Machine learning framework of the model package container image
+                (default: None).
+            framework_version (str): Framework version of the Model Package Container Image
+                (default: None).
+            nearest_model_name (str): Name of a pre-trained machine learning benchmarked by
+                Amazon SageMaker Inference Recommender (default: None).
+            data_input_configuration (str): Input object for the model (default: None).
 
         Returns:
             A `sagemaker.model.ModelPackage` instance or pipeline step arguments
@@ -352,7 +370,20 @@ class Model(ModelBase):
         if model_package_group_name is not None:
             container_def = self.prepare_container_def()
         else:
-            container_def = {"Image": self.image_uri, "ModelDataUrl": self.model_data}
+            container_def = {
+                "Image": self.image_uri,
+                "ModelDataUrl": self.model_data,
+            }
+        container_def.update(
+            {
+                "Framework": framework,
+                "FrameworkVersion": framework_version,
+                "NearestModelName": nearest_model_name,
+                "ModelInput": {
+                    "DataInputConfig": data_input_configuration,
+                },
+            }
+        )
         model_pkg_args = sagemaker.get_model_package_args(
             content_types,
             response_types,
@@ -370,6 +401,8 @@ class Model(ModelBase):
             customer_metadata_properties=customer_metadata_properties,
             validation_specification=validation_specification,
             domain=domain,
+            sample_payload_url=sample_payload_url,
+            task=task,
         )
         model_package = self.sagemaker_session.create_model_package_from_containers(
             **model_pkg_args

--- a/src/sagemaker/mxnet/model.py
+++ b/src/sagemaker/mxnet/model.py
@@ -159,6 +159,12 @@ class MXNetModel(FrameworkModel):
         drift_check_baselines=None,
         customer_metadata_properties=None,
         domain=None,
+        sample_payload_url=None,
+        task=None,
+        framework=None,
+        framework_version=None,
+        nearest_model_name=None,
+        data_input_configuration=None,
     ):
         """Creates a model package for creating SageMaker models or listing on Marketplace.
 
@@ -188,6 +194,18 @@ class MXNetModel(FrameworkModel):
                 metadata properties (default: None).
             domain (str): Domain values can be "COMPUTER_VISION", "NATURAL_LANGUAGE_PROCESSING",
                 "MACHINE_LEARNING" (default: None).
+            sample_payload_url (str): The S3 path where the sample payload is stored
+                (default: None).
+            task (str): Task values which are supported by Inference Recommender are "FILL_MASK",
+                "IMAGE_CLASSIFICATION", "OBJECT_DETECTION", "TEXT_GENERATION", "IMAGE_SEGMENTATION",
+                "CLASSIFICATION", "REGRESSION", "OTHER" (default: None).
+            framework (str): Machine learning framework of the model package container image
+                (default: None).
+            framework_version (str): Framework version of the Model Package Container Image
+                (default: None).
+            nearest_model_name (str): Name of a pre-trained machine learning benchmarked by
+                Amazon SageMaker Inference Recommender (default: None).
+            data_input_configuration (str): Input object for the model (default: None).
 
         Returns:
             A `sagemaker.model.ModelPackage` instance.
@@ -218,6 +236,12 @@ class MXNetModel(FrameworkModel):
             drift_check_baselines=drift_check_baselines,
             customer_metadata_properties=customer_metadata_properties,
             domain=domain,
+            sample_payload_url=sample_payload_url,
+            task=task,
+            framework=framework,
+            framework_version=framework_version,
+            nearest_model_name=nearest_model_name,
+            data_input_configuration=data_input_configuration,
         )
 
     def prepare_container_def(

--- a/src/sagemaker/pytorch/model.py
+++ b/src/sagemaker/pytorch/model.py
@@ -160,6 +160,12 @@ class PyTorchModel(FrameworkModel):
         drift_check_baselines=None,
         customer_metadata_properties=None,
         domain=None,
+        sample_payload_url=None,
+        task=None,
+        framework=None,
+        framework_version=None,
+        nearest_model_name=None,
+        data_input_configuration=None,
     ):
         """Creates a model package for creating SageMaker models or listing on Marketplace.
 
@@ -189,6 +195,18 @@ class PyTorchModel(FrameworkModel):
                 metadata properties (default: None).
             domain (str): Domain values can be "COMPUTER_VISION", "NATURAL_LANGUAGE_PROCESSING",
                 "MACHINE_LEARNING" (default: None).
+            sample_payload_url (str): The S3 path where the sample payload is stored
+                (default: None).
+            task (str): Task values which are supported by Inference Recommender are "FILL_MASK",
+                "IMAGE_CLASSIFICATION", "OBJECT_DETECTION", "TEXT_GENERATION", "IMAGE_SEGMENTATION",
+                "CLASSIFICATION", "REGRESSION", "OTHER" (default: None).
+            framework (str): Machine learning framework of the model package container image
+                (default: None).
+            framework_version (str): Framework version of the Model Package Container Image
+                (default: None).
+            nearest_model_name (str): Name of a pre-trained machine learning benchmarked by
+                Amazon SageMaker Inference Recommender (default: None).
+            data_input_configuration (str): Input object for the model (default: None).
 
         Returns:
             A `sagemaker.model.ModelPackage` instance.
@@ -219,6 +237,12 @@ class PyTorchModel(FrameworkModel):
             drift_check_baselines=drift_check_baselines,
             customer_metadata_properties=customer_metadata_properties,
             domain=domain,
+            sample_payload_url=sample_payload_url,
+            task=task,
+            framework=framework,
+            framework_version=framework_version,
+            nearest_model_name=nearest_model_name,
+            data_input_configuration=data_input_configuration,
         )
 
     def prepare_container_def(

--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -2822,6 +2822,8 @@ class Session(object):  # pylint: disable=too-many-public-methods
         customer_metadata_properties=None,
         validation_specification=None,
         domain=None,
+        sample_payload_url=None,
+        task=None,
     ):
         """Get request dictionary for CreateModelPackage API.
 
@@ -2851,6 +2853,11 @@ class Session(object):  # pylint: disable=too-many-public-methods
                 metadata properties (default: None).
             domain (str): Domain values can be "COMPUTER_VISION", "NATURAL_LANGUAGE_PROCESSING",
                 "MACHINE_LEARNING" (default: None).
+            sample_payload_url (str): The S3 path where the sample payload is stored
+                (default: None).
+            task (str): Task values which are supported by Inference Recommender are "FILL_MASK",
+                "IMAGE_CLASSIFICATION", "OBJECT_DETECTION", "TEXT_GENERATION", "IMAGE_SEGMENTATION",
+                "CLASSIFICATION", "REGRESSION", "OTHER" (default: None).
         """
 
         model_pkg_request = get_create_model_package_request(
@@ -2870,6 +2877,8 @@ class Session(object):  # pylint: disable=too-many-public-methods
             customer_metadata_properties=customer_metadata_properties,
             validation_specification=validation_specification,
             domain=domain,
+            sample_payload_url=sample_payload_url,
+            task=task,
         )
 
         def submit(request):
@@ -4241,6 +4250,8 @@ def get_model_package_args(
     customer_metadata_properties=None,
     validation_specification=None,
     domain=None,
+    sample_payload_url=None,
+    task=None,
 ):
     """Get arguments for create_model_package method.
 
@@ -4273,15 +4284,42 @@ def get_model_package_args(
             metadata properties (default: None).
         domain (str): Domain values can be "COMPUTER_VISION", "NATURAL_LANGUAGE_PROCESSING",
             "MACHINE_LEARNING" (default: None).
+        sample_payload_url (str): The S3 path where the sample payload is stored (default: None).
+        task (str): Task values which are supported by Inference Recommender are "FILL_MASK",
+            "IMAGE_CLASSIFICATION", "OBJECT_DETECTION", "TEXT_GENERATION", "IMAGE_SEGMENTATION",
+            "CLASSIFICATION", "REGRESSION", "OTHER" (default: None).
+        framework (str): Machine learning framework of the model package container image
+            (default: None).
+        framework_version (str): Framework version of the Model Package Container Image
+            (default: None).
+        nearest_model_name (str): Name of a pre-trained machine learning benchmarked by
+            Amazon SageMaker Inference Recommender (default: None).
+        data_input_configuration (str): Input object for the model (default: None).
     Returns:
         dict: A dictionary of method argument names and values.
     """
     if container_def_list is not None:
+        container_def_list[0].update(
+            {
+                "Framework": container_def_list[0]["Framework"],
+                "FrameworkVersion": container_def_list[0]["FrameworkVersion"],
+                "NearestModelName": container_def_list[0]["NearestModelName"],
+                "ModelInput": {
+                    "DataInputConfig": container_def_list[0]["ModelInput"]["DataInputConfig"],
+                },
+            }
+        )
         containers = container_def_list
     else:
         container = {
             "Image": image_uri,
             "ModelDataUrl": model_data,
+            "Framework": container_def_list[0]["Framework"],
+            "FrameworkVersion": container_def_list[0]["FrameworkVersion"],
+            "NearestModelName": container_def_list[0]["NearestModelName"],
+            "ModelInput": {
+                "DataInputConfig": container_def_list[0]["ModelInput"]["DataInputConfig"],
+            },
         }
         containers = [container]
 
@@ -4316,6 +4354,10 @@ def get_model_package_args(
         model_package_args["validation_specification"] = validation_specification
     if domain is not None:
         model_package_args["domain"] = domain
+    if sample_payload_url is not None:
+        model_package_args["sample_payload_url"] = sample_payload_url
+    if task is not None:
+        model_package_args["task"] = task
     return model_package_args
 
 
@@ -4337,6 +4379,8 @@ def get_create_model_package_request(
     customer_metadata_properties=None,
     validation_specification=None,
     domain=None,
+    sample_payload_url=None,
+    task=None,
 ):
     """Get request dictionary for CreateModelPackage API.
 
@@ -4367,6 +4411,10 @@ def get_create_model_package_request(
             metadata properties (default: None).
         domain (str): Domain values can be "COMPUTER_VISION", "NATURAL_LANGUAGE_PROCESSING",
             "MACHINE_LEARNING" (default: None).
+        sample_payload_url (str): The S3 path where the sample payload is stored (default: None).
+        task (str): Task values which are supported by Inference Recommender are "FILL_MASK",
+            "IMAGE_CLASSIFICATION", "OBJECT_DETECTION", "TEXT_GENERATION", "IMAGE_SEGMENTATION",
+            "CLASSIFICATION", "REGRESSION", "OTHER" (default: None).
     """
 
     if all([model_package_name, model_package_group_name]):
@@ -4394,6 +4442,10 @@ def get_create_model_package_request(
         request_dict["ValidationSpecification"] = validation_specification
     if domain is not None:
         request_dict["Domain"] = domain
+    if sample_payload_url is not None:
+        request_dict["SamplePayloadUrl"] = sample_payload_url
+    if task is not None:
+        request_dict["Task"] = task
     if containers is not None:
         if not all([content_types, response_types]):
             raise ValueError(

--- a/src/sagemaker/sklearn/model.py
+++ b/src/sagemaker/sklearn/model.py
@@ -154,6 +154,12 @@ class SKLearnModel(FrameworkModel):
         drift_check_baselines=None,
         customer_metadata_properties=None,
         domain=None,
+        sample_payload_url=None,
+        task=None,
+        framework=None,
+        framework_version=None,
+        nearest_model_name=None,
+        data_input_configuration=None,
     ):
         """Creates a model package for creating SageMaker models or listing on Marketplace.
 
@@ -183,6 +189,18 @@ class SKLearnModel(FrameworkModel):
                 metadata properties (default: None).
             domain (str): Domain values can be "COMPUTER_VISION", "NATURAL_LANGUAGE_PROCESSING",
                 "MACHINE_LEARNING" (default: None).
+            sample_payload_url (str): The S3 path where the sample payload is stored
+                (default: None).
+            task (str): Task values which are supported by Inference Recommender are "FILL_MASK",
+                "IMAGE_CLASSIFICATION", "OBJECT_DETECTION", "TEXT_GENERATION", "IMAGE_SEGMENTATION",
+                "CLASSIFICATION", "REGRESSION", "OTHER" (default: None).
+            framework (str): Machine learning framework of the model package container image
+                (default: None).
+            framework_version (str): Framework version of the Model Package Container Image
+                (default: None).
+            nearest_model_name (str): Name of a pre-trained machine learning benchmarked by
+                Amazon SageMaker Inference Recommender (default: None).
+            data_input_configuration (str): Input object for the model (default: None).
 
         Returns:
             A `sagemaker.model.ModelPackage` instance.
@@ -213,6 +231,12 @@ class SKLearnModel(FrameworkModel):
             drift_check_baselines=drift_check_baselines,
             customer_metadata_properties=customer_metadata_properties,
             domain=domain,
+            sample_payload_url=sample_payload_url,
+            task=task,
+            framework=framework,
+            framework_version=framework_version,
+            nearest_model_name=nearest_model_name,
+            data_input_configuration=data_input_configuration,
         )
 
     def prepare_container_def(

--- a/src/sagemaker/tensorflow/model.py
+++ b/src/sagemaker/tensorflow/model.py
@@ -206,6 +206,12 @@ class TensorFlowModel(sagemaker.model.FrameworkModel):
         drift_check_baselines=None,
         customer_metadata_properties=None,
         domain=None,
+        sample_payload_url=None,
+        task=None,
+        framework=None,
+        framework_version=None,
+        nearest_model_name=None,
+        data_input_configuration=None,
     ):
         """Creates a model package for creating SageMaker models or listing on Marketplace.
 
@@ -235,6 +241,18 @@ class TensorFlowModel(sagemaker.model.FrameworkModel):
                 metadata properties (default: None).
             domain (str): Domain values can be "COMPUTER_VISION", "NATURAL_LANGUAGE_PROCESSING",
                 "MACHINE_LEARNING" (default: None).
+            sample_payload_url (str): The S3 path where the sample payload is stored
+                (default: None).
+            task (str): Task values which are supported by Inference Recommender are "FILL_MASK",
+                "IMAGE_CLASSIFICATION", "OBJECT_DETECTION", "TEXT_GENERATION", "IMAGE_SEGMENTATION",
+                "CLASSIFICATION", "REGRESSION", "OTHER" (default: None).
+            framework (str): Machine learning framework of the model package container image
+                (default: None).
+            framework_version (str): Framework version of the Model Package Container Image
+                (default: None).
+            nearest_model_name (str): Name of a pre-trained machine learning benchmarked by
+                Amazon SageMaker Inference Recommender (default: None).
+            data_input_configuration (str): Input object for the model (default: None).
 
         Returns:
             A `sagemaker.model.ModelPackage` instance.
@@ -265,6 +283,12 @@ class TensorFlowModel(sagemaker.model.FrameworkModel):
             drift_check_baselines=drift_check_baselines,
             customer_metadata_properties=customer_metadata_properties,
             domain=domain,
+            sample_payload_url=sample_payload_url,
+            task=task,
+            framework=framework,
+            framework_version=framework_version,
+            nearest_model_name=nearest_model_name,
+            data_input_configuration=data_input_configuration,
         )
 
     def deploy(

--- a/src/sagemaker/workflow/_utils.py
+++ b/src/sagemaker/workflow/_utils.py
@@ -285,6 +285,8 @@ class _RegisterModelStep(ConfigurableRetryStep):
         drift_check_baselines=None,
         customer_metadata_properties=None,
         domain=None,
+        sample_payload_url=None,
+        task=None,
         **kwargs,
     ):
         """Constructor of a register model step.
@@ -329,6 +331,11 @@ class _RegisterModelStep(ConfigurableRetryStep):
                 metadata properties (default: None).
             domain (str): Domain values can be "COMPUTER_VISION", "NATURAL_LANGUAGE_PROCESSING",
                 "MACHINE_LEARNING" (default: None).
+            sample_payload_url (str): The S3 path where the sample payload is stored
+                (default: None).
+            task (str): Task values which are supported by Inference Recommender are "FILL_MASK",
+                "IMAGE_CLASSIFICATION", "OBJECT_DETECTION", "TEXT_GENERATION", "IMAGE_SEGMENTATION",
+                "CLASSIFICATION", "REGRESSION", "OTHER" (default: None).
             **kwargs: additional arguments to `create_model`.
         """
         super(_RegisterModelStep, self).__init__(
@@ -360,6 +367,8 @@ class _RegisterModelStep(ConfigurableRetryStep):
         self.drift_check_baselines = drift_check_baselines
         self.customer_metadata_properties = customer_metadata_properties
         self.domain = domain
+        self.sample_payload_url = sample_payload_url
+        self.task = task
         self.metadata_properties = metadata_properties
         self.approval_status = approval_status
         self.image_uri = image_uri
@@ -438,6 +447,8 @@ class _RegisterModelStep(ConfigurableRetryStep):
                 container_def_list=self.container_def_list,
                 customer_metadata_properties=self.customer_metadata_properties,
                 domain=self.domain,
+                sample_payload_url=self.sample_payload_url,
+                task=self.task,
             )
 
             request_dict = get_create_model_package_request(**model_package_args)

--- a/src/sagemaker/workflow/step_collections.py
+++ b/src/sagemaker/workflow/step_collections.py
@@ -81,6 +81,12 @@ class RegisterModel(StepCollection):  # pragma: no cover
         drift_check_baselines=None,
         customer_metadata_properties=None,
         domain=None,
+        sample_payload_url=None,
+        task=None,
+        framework=None,
+        framework_version=None,
+        nearest_model_name=None,
+        data_input_configuration=None,
         **kwargs,
     ):
         """Construct steps `_RepackModelStep` and `_RegisterModelStep` based on the estimator.
@@ -124,6 +130,18 @@ class RegisterModel(StepCollection):  # pragma: no cover
                 metadata properties (default: None).
             domain (str): Domain values can be "COMPUTER_VISION", "NATURAL_LANGUAGE_PROCESSING",
                 "MACHINE_LEARNING" (default: None).
+            sample_payload_url (str): The S3 path where the sample payload is stored
+                (default: None).
+            task (str): Task values which are supported by Inference Recommender are "FILL_MASK",
+                "IMAGE_CLASSIFICATION", "OBJECT_DETECTION", "TEXT_GENERATION", "IMAGE_SEGMENTATION",
+                "CLASSIFICATION", "REGRESSION", "OTHER" (default: None).
+            framework (str): Machine learning framework of the model package container image
+                (default: None).
+            framework_version (str): Framework version of the Model Package Container Image
+                (default: None).
+            nearest_model_name (str): Name of a pre-trained machine learning benchmarked by
+                Amazon SageMaker Inference Recommender (default: None).
+            data_input_configuration (str): Input object for the model (default: None).
 
             **kwargs: additional arguments to `create_model`.
         """
@@ -228,6 +246,16 @@ class RegisterModel(StepCollection):  # pragma: no cover
                         inference_instances[0] if inference_instances else None
                     )
                 ]
+            self.container_def_list[0].update(
+                {
+                    "Framework": framework,
+                    "FrameworkVersion": framework_version,
+                    "NearestModelName": nearest_model_name,
+                    "ModelInput": {
+                        "DataInputConfig": data_input_configuration,
+                    },
+                }
+            )
 
         register_model_step = _RegisterModelStep(
             name=name,
@@ -250,6 +278,8 @@ class RegisterModel(StepCollection):  # pragma: no cover
             retry_policies=register_model_step_retry_policies,
             customer_metadata_properties=customer_metadata_properties,
             domain=domain,
+            sample_payload_url=sample_payload_url,
+            task=task,
             **kwargs,
         )
         if not repack_model:

--- a/tests/unit/sagemaker/workflow/test_pipeline_session.py
+++ b/tests/unit/sagemaker/workflow/test_pipeline_session.py
@@ -116,6 +116,12 @@ def test_pipeline_session_context_for_model_step(pipeline_session_mock):
         inference_instances=["ml.t2.medium", "ml.m5.xlarge"],
         transform_instances=["ml.m5.xlarge"],
         model_package_group_name="MyModelPackageGroup",
+        task="IMAGE_CLASSIFICATION",
+        sample_payload_url="s3://test-bucket/model",
+        framework="TENSORFLOW",
+        framework_version="2.9",
+        nearest_model_name="resnet50",
+        data_input_configuration='{"input_1":[1,224,224,3]}',
     )
     # The context should be cleaned up before return
     assert not pipeline_session_mock.context
@@ -136,11 +142,16 @@ def test_pipeline_session_context_for_model_step_without_instance_types(
         source_dir=f"{DATA_DIR}",
         role=_ROLE,
     )
-
     register_step_args = model.register(
         content_types=["text/csv"],
         response_types=["text/csv"],
         model_package_group_name="MyModelPackageGroup",
+        task="IMAGE_CLASSIFICATION",
+        sample_payload_url="s3://test-bucket/model",
+        framework="TENSORFLOW",
+        framework_version="2.9",
+        nearest_model_name="resnet50",
+        data_input_configuration='{"input_1":[1,224,224,3]}',
     )
 
     expected_output = {
@@ -159,6 +170,12 @@ def test_pipeline_session_context_for_model_step_without_instance_types(
                         name="ModelData",
                         default_value="s3://my-bucket/file",
                     ),
+                    "Framework": "TENSORFLOW",
+                    "FrameworkVersion": "2.9",
+                    "NearestModelName": "resnet50",
+                    "ModelInput": {
+                        "DataInputConfig": '{"input_1":[1,224,224,3]}',
+                    },
                 }
             ],
             "SupportedContentTypes": ["text/csv"],
@@ -168,6 +185,8 @@ def test_pipeline_session_context_for_model_step_without_instance_types(
         },
         "CertifyForMarketplace": False,
         "ModelApprovalStatus": "PendingManualApproval",
+        "SamplePayloadUrl": "s3://test-bucket/model",
+        "Task": "IMAGE_CLASSIFICATION",
     }
 
     assert register_step_args.create_model_package_request == expected_output

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -1705,6 +1705,12 @@ CONTAINERS = [
         "Environment": {"SAGEMAKER_DEFAULT_INVOCATIONS_ACCEPT": "application/json"},
         "Image": "mi-1",
         "ModelDataUrl": "s3://bucket/model_1.tar.gz",
+        "Framework": "TENSORFLOW",
+        "FrameworkVersion": "2.9",
+        "NearestModelName": "resnet50",
+        "ModelInput": {
+            "DataInputConfig": '{"input_1":[1,224,224,3]}',
+        },
     },
     {"Environment": {}, "Image": "mi-2", "ModelDataUrl": "s3://bucket/model_2.tar.gz"},
 ]
@@ -2387,6 +2393,8 @@ def test_create_model_package_from_containers_all_args(sagemaker_session):
     description = "description"
     customer_metadata_properties = {"key1": "value1"}
     domain = "COMPUTER_VISION"
+    task = "IMAGE_CLASSIFICATION"
+    sample_payload_url = "s3://test-bucket/model"
     sagemaker_session.create_model_package_from_containers(
         containers=containers,
         content_types=content_types,
@@ -2402,6 +2410,8 @@ def test_create_model_package_from_containers_all_args(sagemaker_session):
         drift_check_baselines=drift_check_baselines,
         customer_metadata_properties=customer_metadata_properties,
         domain=domain,
+        sample_payload_url=sample_payload_url,
+        task=task,
     )
     expected_args = {
         "ModelPackageName": model_package_name,
@@ -2420,6 +2430,8 @@ def test_create_model_package_from_containers_all_args(sagemaker_session):
         "DriftCheckBaselines": drift_check_baselines,
         "CustomerMetadataProperties": customer_metadata_properties,
         "Domain": domain,
+        "SamplePayloadUrl": sample_payload_url,
+        "Task": task,
     }
     sagemaker_session.sagemaker_client.create_model_package.assert_called_with(**expected_args)
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Include fields to enable working with inference recommender.
The fields include: 
Framework, FrameworkVersion, NearestModelName, DataInputConfiguration, SamplePayloadUrl, Task

*Testing done:* Unit
tox -e py38 tests/unit/sagemaker/workflow/test_pipeline_session.py::test_pipeline_session_context_for_model_step_without_instance_types

tox -e py38 -- -s -vv tests/unit/test_session.py::test_create_model_package_from_containers_all_args

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
