### PR TITLE
fix: changing trcomp integ tests to be able to run in all regions

### DIFF
--- a/tests/integ/test_training_compiler.py
+++ b/tests/integ/test_training_compiler.py
@@ -31,8 +31,39 @@ def gpu_instance_type(request):
     return "ml.p3.2xlarge"
 
 
+@pytest.fixture(scope="module")
+def imagenet_val_set(request, sagemaker_session, tmpdir):
+    """
+    Copies the dataset from the bucket it's hosted in to the local bucket in the test region
+    """
+    sagemaker_session.download_data(
+        path=tmpdir, bucket="collection-of-ml-datasets", key_prefix="Imagenet/TFRecords/validation"
+    )
+    train_input = sagemaker_session.upload_data(
+        path=tmpdir,
+        key_prefix="integ-test-data/trcomp/tensorflow/imagenet/val",
+    )
+    return train_input
+
+
+@pytest.fixture(scope="module")
+def huggingface_dummy_dataset(request, sagemaker_session, tmpdir):
+    """
+    Copies the dataset from the local disk to the local bucket in the test region
+    """
+    data_path = os.path.join(DATA_DIR, "huggingface")
+    train_input = sagemaker_session.upload_data(
+        path=os.path.join(data_path, "train"),
+        key_prefix="integ-test-data/trcomp/huggingface/dummy/train",
+    )
+    return train_input
+
+
 @pytest.fixture(scope="module", autouse=True)
 def skip_if_incompatible(request):
+    """
+    These tests are for training compiler enabled images/estimators only.
+    """
     if integ.test_region() not in integ.TRAINING_COMPILER_SUPPORTED_REGIONS:
         pytest.skip("SageMaker Training Compiler is not supported in this region")
     if integ.test_region() in integ.TRAINING_NO_P3_REGIONS:
@@ -45,7 +76,11 @@ def test_huggingface_pytorch(
     gpu_instance_type,
     huggingface_training_compiler_latest_version,
     huggingface_training_compiler_pytorch_latest_version,
+    huggingface_dummy_dataset,
 ):
+    """
+    Test the HuggingFace estimator with PyTorch
+    """
     with timeout(minutes=TRAINING_DEFAULT_TIMEOUT_MINUTES):
         data_path = os.path.join(DATA_DIR, "huggingface")
 
@@ -73,12 +108,7 @@ def test_huggingface_pytorch(
             compiler_config=HFTrainingCompilerConfig(),
         )
 
-        train_input = hf.sagemaker_session.upload_data(
-            path=os.path.join(data_path, "train"),
-            key_prefix="integ-test-data/huggingface/train",
-        )
-
-        hf.fit(train_input)
+        hf.fit(huggingface_dummy_dataset)
 
 
 @pytest.mark.release
@@ -87,7 +117,11 @@ def test_huggingface_tensorflow(
     gpu_instance_type,
     huggingface_training_compiler_latest_version,
     huggingface_training_compiler_tensorflow_latest_version,
+    huggingface_dummy_dataset,
 ):
+    """
+    Test the HuggingFace estimator with TensorFlow
+    """
     with timeout(minutes=TRAINING_DEFAULT_TIMEOUT_MINUTES):
         data_path = os.path.join(DATA_DIR, "huggingface")
 
@@ -112,11 +146,7 @@ def test_huggingface_tensorflow(
             compiler_config=HFTrainingCompilerConfig(),
         )
 
-        train_input = hf.sagemaker_session.upload_data(
-            path=os.path.join(data_path, "train"), key_prefix="integ-test-data/huggingface/train"
-        )
-
-        hf.fit(train_input)
+        hf.fit(huggingface_dummy_dataset)
 
 
 @pytest.mark.release
@@ -124,7 +154,11 @@ def test_tensorflow(
     sagemaker_session,
     gpu_instance_type,
     tensorflow_training_latest_version,
+    imagenet_val_set,
 ):
+    """
+    Test the TensorFlow estimator
+    """
     if version.parse(tensorflow_training_latest_version) < version.parse("2.9"):
         pytest.skip("Training Compiler only supports TF >= 2.9")
     with timeout(minutes=TRAINING_DEFAULT_TIMEOUT_MINUTES):
@@ -173,7 +207,7 @@ def test_tensorflow(
         )
 
         tf.fit(
-            inputs="s3://collection-of-ml-datasets/Imagenet/TFRecords/validation",
+            inputs=imagenet_val_set,
             logs=True,
             wait=True,
         )

--- a/tests/integ/test_training_compiler.py
+++ b/tests/integ/test_training_compiler.py
@@ -32,22 +32,25 @@ def gpu_instance_type(request):
 
 
 @pytest.fixture(scope="module")
-def imagenet_val_set(request, sagemaker_session, tmpdir):
+def imagenet_val_set(request, sagemaker_session, tmpdir_factory):
     """
     Copies the dataset from the bucket it's hosted in to the local bucket in the test region
     """
+    local_path = tmpdir_factory.mktemp("trcomp_imagenet_val_set")
     sagemaker_session.download_data(
-        path=tmpdir, bucket="collection-of-ml-datasets", key_prefix="Imagenet/TFRecords/validation"
+        path=local_path,
+        bucket="collection-of-ml-datasets",
+        key_prefix="Imagenet/TFRecords/validation",
     )
     train_input = sagemaker_session.upload_data(
-        path=tmpdir,
+        path=local_path,
         key_prefix="integ-test-data/trcomp/tensorflow/imagenet/val",
     )
     return train_input
 
 
 @pytest.fixture(scope="module")
-def huggingface_dummy_dataset(request, sagemaker_session, tmpdir):
+def huggingface_dummy_dataset(request, sagemaker_session):
     """
     Copies the dataset from the local disk to the local bucket in the test region
     """


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
As title

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
