### PR TITLE
change: Add override_pipeline_parameter_var decorator to give grace period to update invalid pipeline var args

### DIFF
--- a/src/sagemaker/image_uris.py
+++ b/src/sagemaker/image_uris.py
@@ -24,6 +24,7 @@ from sagemaker.jumpstart.utils import is_jumpstart_model_input
 from sagemaker.spark import defaults
 from sagemaker.jumpstart import artifacts
 from sagemaker.workflow import is_pipeline_variable
+from sagemaker.workflow.utilities import override_pipeline_parameter_var
 
 logger = logging.getLogger(__name__)
 
@@ -31,6 +32,8 @@ ECR_URI_TEMPLATE = "{registry}.dkr.{hostname}/{repository}"
 HUGGING_FACE_FRAMEWORK = "huggingface"
 
 
+# TODO: we should remove this decorator later
+@override_pipeline_parameter_var
 def retrieve(
     framework,
     region,

--- a/src/sagemaker/processing.py
+++ b/src/sagemaker/processing.py
@@ -1195,7 +1195,9 @@ class ProcessingOutput(object):
             source (str): The source for the output.
             destination (str): The destination of the output. If a destination
                 is not provided, one will be generated:
-                "s3://<default-bucket-name>/<job-name>/output/<output-name>".
+                "s3://<default-bucket-name>/<job-name>/output/<output-name>"
+                (Note: this does not apply when used with
+                :class:`~sagemaker.workflow.steps.ProcessingStep`).
             output_name (str): The name of the output. If a name
                 is not provided, one will be generated (eg. "output-1").
             s3_upload_mode (str): Valid options are "EndOfJob" or "Continuous".

--- a/src/sagemaker/workflow/utilities.py
+++ b/src/sagemaker/workflow/utilities.py
@@ -13,23 +13,29 @@
 """Utilities to support workflow."""
 from __future__ import absolute_import
 
+import inspect
+import logging
+from functools import wraps
 from pathlib import Path
-from typing import List, Sequence, Union, Set
+from typing import List, Sequence, Union, Set, TYPE_CHECKING
 import hashlib
 from urllib.parse import unquote, urlparse
 from _hashlib import HASH as Hash
 
+from sagemaker.workflow.parameters import Parameter
 from sagemaker.workflow.pipeline_context import _StepArguments
-from sagemaker.workflow.step_collections import StepCollection
 from sagemaker.workflow.entities import (
     Entity,
     RequestType,
 )
 
+if TYPE_CHECKING:
+    from sagemaker.workflow.step_collections import StepCollection
+
 BUF_SIZE = 65536  # 64KiB
 
 
-def list_to_request(entities: Sequence[Union[Entity, StepCollection]]) -> List[RequestType]:
+def list_to_request(entities: Sequence[Union[Entity, "StepCollection"]]) -> List[RequestType]:
     """Get the request structure for list of entities.
 
     Args:
@@ -37,6 +43,8 @@ def list_to_request(entities: Sequence[Union[Entity, StepCollection]]) -> List[R
     Returns:
         list: A request structure for a workflow service call.
     """
+    from sagemaker.workflow.step_collections import StepCollection
+
     request_dicts = []
     for entity in entities:
         if isinstance(entity, Entity):
@@ -151,3 +159,41 @@ def validate_step_args_input(
         raise TypeError(error_message)
     if step_args.caller_name not in expected_caller:
         raise ValueError(error_message)
+
+
+def override_pipeline_parameter_var(func):
+    """A decorator to override pipeline Parameters passed into a function
+
+    This is a temporary decorator to override pipeline Parameter objects with their default value
+    and display warning information to instruct users to update their code.
+
+    This decorator can help to give a grace period for users to update their code when
+    we make changes to explicitly prevent passing any pipeline variables to a function.
+
+    We should remove this decorator after the grace period.
+    """
+    warning_msg_template = (
+        "%s should not be a pipeline variable (%s). "
+        "The default_value of this Parameter object will be used to override it. "
+        "Please remove this pipeline variable and use python primitives instead."
+    )
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        params = inspect.signature(func).parameters
+        args = list(args)
+        for i, (arg_name, _) in enumerate(params.items()):
+            if i >= len(args):
+                break
+            if isinstance(args[i], Parameter):
+                logging.warning(warning_msg_template, arg_name, type(args[i]))
+                args[i] = args[i].default_value
+        args = tuple(args)
+
+        for arg_name, value in kwargs.items():
+            if isinstance(value, Parameter):
+                logging.warning(warning_msg_template, arg_name, type(value))
+                kwargs[arg_name] = value.default_value
+        return func(*args, **kwargs)
+
+    return wrapper

--- a/tests/unit/sagemaker/image_uris/test_retrieve.py
+++ b/tests/unit/sagemaker/image_uris/test_retrieve.py
@@ -19,6 +19,7 @@ import pytest
 from mock import patch
 
 from sagemaker import image_uris
+from sagemaker.workflow.functions import Join
 from sagemaker.workflow.parameters import ParameterString
 
 BASE_CONFIG = {
@@ -721,16 +722,50 @@ def test_retrieve_huggingface(config_for_framework):
 
 
 def test_retrieve_with_pipeline_variable():
+    kwargs = dict(
+        framework="tensorflow",
+        version="1.15",
+        py_version="py3",
+        instance_type="ml.m5.xlarge",
+        region="us-east-1",
+        image_scope="training",
+    )
+    # instance_type is plain string which should not break anything
+    image_uris.retrieve(**kwargs)
+
+    # instance_type is parameter string with not None default value
+    # which should not break anything
+    kwargs["instance_type"] = ParameterString(
+        name="TrainingInstanceType",
+        default_value="ml.m5.xlarge",
+    )
+    image_uris.retrieve(**kwargs)
+
+    # instance_type is parameter string without default value
+    # (equivalent to pass in None to instance_type field)
+    # which should fail due to empty instance type check
+    kwargs["instance_type"] = ParameterString(name="TrainingInstanceType")
     with pytest.raises(Exception) as error:
-        image_uris.retrieve(
-            framework="tensorflow",
-            version="1.15",
-            py_version="py3",
-            instance_type=ParameterString(
-                name="TrainingInstanceType",
-                default_value="ml.m5.xlarge",
-            ),
-            region="us-east-1",
-            image_scope="training",
-        )
+        image_uris.retrieve(**kwargs)
+    assert "Empty SageMaker instance type" in str(error.value)
+
+    # instance_type is other types of pipeline variable
+    # which should break loudly
+    kwargs["instance_type"] = Join(on="", values=["a", "b"])
+    with pytest.raises(Exception) as error:
+        image_uris.retrieve(**kwargs)
     assert "instance_type should not be a pipeline variable" in str(error.value)
+
+    # instance_type (ParameterString) is given as args rather than kwargs
+    # which should not break anything
+    image_uris.retrieve(
+        "tensorflow",
+        "us-east-1",
+        "1.15",
+        "py3",
+        ParameterString(
+            name="TrainingInstanceType",
+            default_value="ml.m5.xlarge",
+        ),
+        image_scope="training",
+    )


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/sagemaker-python-sdk/issues/3141

*Description of changes:*
- Add `override_pipeline_parameter_var` decorator to `image_uris.retrieve` to give grace period for users to remove passing pipeline variables to this method
  - Note this only provides grace period to passing `ParameterString` with default value to the `image_uris.retrieve` which are all the issue reports we've received. And for other types of pipeline variables, they did not work previously so should not be impacted by the Git issue 3141.
- Update the doc string of the `definition` field of `ProcessingOutput` as it's not correct in Pipeline context.

*Testing done:* Unit tests

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
