### PR TITLE
change: Update model name from 'compiled.pt' to 'model.pth' for neo

### DIFF
--- a/tests/data/pytorch_neo/code/inference.py
+++ b/tests/data/pytorch_neo/code/inference.py
@@ -71,8 +71,8 @@ def model_fn(model_dir):
     logger.info("model_fn")
     neopytorch.config(model_dir=model_dir, neo_runtime=True)
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    # The compiled model is saved as "compiled.pt"
-    model = torch.jit.load(os.path.join(model_dir, "compiled.pt"), map_location=device)
+    # The compiled model is saved as "model.pth"
+    model = torch.jit.load(os.path.join(model_dir, "model.pth"), map_location=device)
 
     # It is recommended to run warm-up inference during model load
     sample_input_path = os.path.join(model_dir, "sample_input.pkl")


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
