### PR TITLE
change: remove primitive_or_expr() from conditions

### DIFF
--- a/src/sagemaker/workflow/condition_step.py
+++ b/src/sagemaker/workflow/condition_step.py
@@ -15,20 +15,17 @@ from __future__ import absolute_import
 
 from typing import List, Union, Optional
 
-import attr
 
 from sagemaker.deprecations import deprecated_class
 from sagemaker.workflow.conditions import Condition
 from sagemaker.workflow.step_collections import StepCollection
+from sagemaker.workflow.functions import JsonGet as NewJsonGet
 from sagemaker.workflow.steps import (
     Step,
     StepTypeEnum,
 )
 from sagemaker.workflow.utilities import list_to_request
-from sagemaker.workflow.entities import (
-    RequestType,
-    PipelineVariable,
-)
+from sagemaker.workflow.entities import RequestType
 from sagemaker.workflow.properties import (
     Properties,
     PropertyFile,
@@ -93,7 +90,7 @@ class ConditionStep(Step):
     @property
     def step_only_arguments(self):
         """Argument dict pertaining to the step only, and not the `if_steps` or `else_steps`."""
-        return self.conditions
+        return [condition.to_request() for condition in self.conditions]
 
     @property
     def properties(self):
@@ -101,8 +98,7 @@ class ConditionStep(Step):
         return self._properties
 
 
-@attr.s
-class JsonGet(PipelineVariable):  # pragma: no cover
+class JsonGet(NewJsonGet):  # pragma: no cover
     """Get JSON properties from PropertyFiles.
 
     Attributes:
@@ -112,28 +108,8 @@ class JsonGet(PipelineVariable):  # pragma: no cover
         json_path (str): The JSON path expression to the requested value.
     """
 
-    step: Step = attr.ib()
-    property_file: Union[PropertyFile, str] = attr.ib()
-    json_path: str = attr.ib()
-
-    @property
-    def expr(self):
-        """The expression dict for a `JsonGet` function."""
-        if isinstance(self.property_file, PropertyFile):
-            name = self.property_file.name
-        else:
-            name = self.property_file
-        return {
-            "Std:JsonGet": {
-                "PropertyFile": {"Get": f"Steps.{self.step.name}.PropertyFiles.{name}"},
-                "Path": self.json_path,
-            }
-        }
-
-    @property
-    def _referenced_steps(self) -> List[str]:
-        """List of step names that this function depends on."""
-        return [self.step.name]
+    def __init__(self, step: Step, property_file: Union[PropertyFile, str], json_path: str):
+        super().__init__(step_name=step.name, property_file=property_file, json_path=json_path)
 
 
 JsonGet = deprecated_class(JsonGet, "JsonGet")

--- a/src/sagemaker/workflow/conditions.py
+++ b/src/sagemaker/workflow/conditions.py
@@ -20,15 +20,13 @@ from __future__ import absolute_import
 import abc
 
 from enum import Enum
-from typing import Dict, List, Union
+from typing import List, Union
 
 import attr
 
-from sagemaker.workflow import is_pipeline_variable
 from sagemaker.workflow.entities import (
     DefaultEnumMeta,
     Entity,
-    Expression,
     PrimitiveType,
     RequestType,
 )
@@ -88,8 +86,8 @@ class ConditionComparison(Condition):
         """Get the request structure for workflow service calls."""
         return {
             "Type": self.condition_type.value,
-            "LeftValue": primitive_or_expr(self.left),
-            "RightValue": primitive_or_expr(self.right),
+            "LeftValue": self.left,
+            "RightValue": self.right,
         }
 
     @property
@@ -227,8 +225,8 @@ class ConditionIn(Condition):
         """Get the request structure for workflow service calls."""
         return {
             "Type": self.condition_type.value,
-            "QueryValue": self.value.expr,
-            "Values": [primitive_or_expr(in_value) for in_value in self.in_values],
+            "QueryValue": self.value,
+            "Values": self.in_values,
         }
 
     @property
@@ -291,19 +289,3 @@ class ConditionOr(Condition):
         for condition in self.conditions:
             steps.extend(condition._referenced_steps)
         return steps
-
-
-def primitive_or_expr(
-    value: Union[ExecutionVariable, Expression, PrimitiveType, Parameter, Properties]
-) -> Union[Dict[str, str], PrimitiveType]:
-    """Provide the expression of the value or return value if it is a primitive.
-
-    Args:
-        value (Union[ConditionValueType, PrimitiveType]): The value to evaluate.
-
-    Returns:
-        Either the expression of the value or the primitive value.
-    """
-    if is_pipeline_variable(value):
-        return value.expr
-    return value

--- a/tests/unit/sagemaker/workflow/test_condition_step.py
+++ b/tests/unit/sagemaker/workflow/test_condition_step.py
@@ -11,13 +11,25 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 from __future__ import absolute_import
+import json
 
 import pytest
 from mock import Mock, MagicMock
-from sagemaker.workflow.conditions import ConditionEquals
-from sagemaker.workflow.parameters import ParameterInteger
+from sagemaker.workflow.conditions import (
+    ConditionEquals,
+    ConditionGreaterThan,
+    ConditionGreaterThanOrEqualTo,
+    ConditionIn,
+    ConditionLessThan,
+    ConditionLessThanOrEqualTo,
+    ConditionNot,
+    ConditionOr,
+)
+from sagemaker.workflow.execution_variables import ExecutionVariables
+from sagemaker.workflow.parameters import ParameterInteger, ParameterString
 from sagemaker.workflow.condition_step import ConditionStep
 from sagemaker.workflow.pipeline import Pipeline, PipelineGraph
+from sagemaker.workflow.properties import Properties
 from tests.unit.sagemaker.workflow.helpers import CustomStep, ordered
 
 
@@ -56,7 +68,7 @@ def test_condition_step():
             "Conditions": [
                 {
                     "Type": "Equals",
-                    "LeftValue": {"Get": "Parameters.MyInt"},
+                    "LeftValue": param,
                     "RightValue": 1,
                 },
             ],
@@ -77,6 +89,147 @@ def test_condition_step():
         },
     }
     assert cond_step.properties.Outcome.expr == {"Get": "Steps.MyConditionStep.Outcome"}
+
+
+def test_pipeline_condition_step_interpolated(sagemaker_session):
+    param1 = ParameterInteger(name="MyInt1")
+    param2 = ParameterInteger(name="MyInt2")
+    param3 = ParameterString(name="MyStr")
+    var = ExecutionVariables.START_DATETIME
+    prop = Properties("foo")
+
+    cond_eq = ConditionEquals(left=param1, right=param2)
+    cond_gt = ConditionGreaterThan(left=var, right="2020-12-01")
+    cond_gte = ConditionGreaterThanOrEqualTo(left=var, right=param3)
+    cond_lt = ConditionLessThan(left=var, right="2020-12-01")
+    cond_lte = ConditionLessThanOrEqualTo(left=var, right=param3)
+    cond_in = ConditionIn(value=param3, in_values=["abc", "def"])
+    cond_in_mixed = ConditionIn(value=param3, in_values=["abc", prop, var])
+    cond_not_eq = ConditionNot(expression=cond_eq)
+    cond_not_in = ConditionNot(expression=cond_in)
+    cond_or = ConditionOr(conditions=[cond_gt, cond_in])
+
+    step1 = CustomStep(name="MyStep1")
+    step2 = CustomStep(name="MyStep2")
+    cond_step = ConditionStep(
+        name="MyConditionStep",
+        conditions=[
+            cond_eq,
+            cond_gt,
+            cond_gte,
+            cond_lt,
+            cond_lte,
+            cond_in,
+            cond_in_mixed,
+            cond_not_eq,
+            cond_not_in,
+            cond_or,
+        ],
+        if_steps=[step1],
+        else_steps=[step2],
+    )
+
+    pipeline = Pipeline(
+        name="MyPipeline",
+        parameters=[param1, param2, param3],
+        steps=[cond_step],
+        sagemaker_session=sagemaker_session,
+    )
+    assert json.loads(pipeline.definition()) == {
+        "Version": "2020-12-01",
+        "Metadata": {},
+        "Parameters": [
+            {"Name": "MyInt1", "Type": "Integer"},
+            {"Name": "MyInt2", "Type": "Integer"},
+            {"Name": "MyStr", "Type": "String"},
+        ],
+        "PipelineExperimentConfig": {
+            "ExperimentName": {"Get": "Execution.PipelineName"},
+            "TrialName": {"Get": "Execution.PipelineExecutionId"},
+        },
+        "Steps": [
+            {
+                "Name": "MyConditionStep",
+                "Type": "Condition",
+                "Arguments": {
+                    "Conditions": [
+                        {
+                            "Type": "Equals",
+                            "LeftValue": {"Get": "Parameters.MyInt1"},
+                            "RightValue": {"Get": "Parameters.MyInt2"},
+                        },
+                        {
+                            "Type": "GreaterThan",
+                            "LeftValue": {"Get": "Execution.StartDateTime"},
+                            "RightValue": "2020-12-01",
+                        },
+                        {
+                            "Type": "GreaterThanOrEqualTo",
+                            "LeftValue": {"Get": "Execution.StartDateTime"},
+                            "RightValue": {"Get": "Parameters.MyStr"},
+                        },
+                        {
+                            "Type": "LessThan",
+                            "LeftValue": {"Get": "Execution.StartDateTime"},
+                            "RightValue": "2020-12-01",
+                        },
+                        {
+                            "Type": "LessThanOrEqualTo",
+                            "LeftValue": {"Get": "Execution.StartDateTime"},
+                            "RightValue": {"Get": "Parameters.MyStr"},
+                        },
+                        {
+                            "Type": "In",
+                            "QueryValue": {"Get": "Parameters.MyStr"},
+                            "Values": ["abc", "def"],
+                        },
+                        {
+                            "Type": "In",
+                            "QueryValue": {"Get": "Parameters.MyStr"},
+                            "Values": [
+                                "abc",
+                                {"Get": "Steps.foo"},
+                                {"Get": "Execution.StartDateTime"},
+                            ],
+                        },
+                        {
+                            "Type": "Not",
+                            "Expression": {
+                                "Type": "Equals",
+                                "LeftValue": {"Get": "Parameters.MyInt1"},
+                                "RightValue": {"Get": "Parameters.MyInt2"},
+                            },
+                        },
+                        {
+                            "Type": "Not",
+                            "Expression": {
+                                "Type": "In",
+                                "QueryValue": {"Get": "Parameters.MyStr"},
+                                "Values": ["abc", "def"],
+                            },
+                        },
+                        {
+                            "Type": "Or",
+                            "Conditions": [
+                                {
+                                    "Type": "GreaterThan",
+                                    "LeftValue": {"Get": "Execution.StartDateTime"},
+                                    "RightValue": "2020-12-01",
+                                },
+                                {
+                                    "Type": "In",
+                                    "QueryValue": {"Get": "Parameters.MyStr"},
+                                    "Values": ["abc", "def"],
+                                },
+                            ],
+                        },
+                    ],
+                    "IfSteps": [{"Name": "MyStep1", "Type": "Training", "Arguments": {}}],
+                    "ElseSteps": [{"Name": "MyStep2", "Type": "Training", "Arguments": {}}],
+                },
+            }
+        ],
+    }
 
 
 def test_pipeline(sagemaker_session):

--- a/tests/unit/sagemaker/workflow/test_conditions.py
+++ b/tests/unit/sagemaker/workflow/test_conditions.py
@@ -36,7 +36,7 @@ def test_condition_equals():
     cond = ConditionEquals(left=param, right=1)
     assert cond.to_request() == {
         "Type": "Equals",
-        "LeftValue": {"Get": "Parameters.MyInt"},
+        "LeftValue": param,
         "RightValue": 1,
     }
 
@@ -47,8 +47,8 @@ def test_condition_equals_parameter():
     cond = ConditionEquals(left=param1, right=param2)
     assert cond.to_request() == {
         "Type": "Equals",
-        "LeftValue": {"Get": "Parameters.MyInt1"},
-        "RightValue": {"Get": "Parameters.MyInt2"},
+        "LeftValue": param1,
+        "RightValue": param2,
     }
 
 
@@ -57,7 +57,7 @@ def test_condition_greater_than():
     cond = ConditionGreaterThan(left=var, right="2020-12-01")
     assert cond.to_request() == {
         "Type": "GreaterThan",
-        "LeftValue": {"Get": "Execution.StartDateTime"},
+        "LeftValue": var,
         "RightValue": "2020-12-01",
     }
 
@@ -68,8 +68,8 @@ def test_condition_greater_than_or_equal_to():
     cond = ConditionGreaterThanOrEqualTo(left=var, right=param)
     assert cond.to_request() == {
         "Type": "GreaterThanOrEqualTo",
-        "LeftValue": {"Get": "Execution.StartDateTime"},
-        "RightValue": {"Get": "Parameters.StartDateTime"},
+        "LeftValue": var,
+        "RightValue": param,
     }
 
 
@@ -78,7 +78,7 @@ def test_condition_less_than():
     cond = ConditionLessThan(left=var, right="2020-12-01")
     assert cond.to_request() == {
         "Type": "LessThan",
-        "LeftValue": {"Get": "Execution.StartDateTime"},
+        "LeftValue": var,
         "RightValue": "2020-12-01",
     }
 
@@ -89,8 +89,8 @@ def test_condition_less_than_or_equal_to():
     cond = ConditionLessThanOrEqualTo(left=var, right=param)
     assert cond.to_request() == {
         "Type": "LessThanOrEqualTo",
-        "LeftValue": {"Get": "Execution.StartDateTime"},
-        "RightValue": {"Get": "Parameters.StartDateTime"},
+        "LeftValue": var,
+        "RightValue": param,
     }
 
 
@@ -99,7 +99,7 @@ def test_condition_in():
     cond_in = ConditionIn(value=param, in_values=["abc", "def"])
     assert cond_in.to_request() == {
         "Type": "In",
-        "QueryValue": {"Get": "Parameters.MyStr"},
+        "QueryValue": param,
         "Values": ["abc", "def"],
     }
 
@@ -111,8 +111,8 @@ def test_condition_in_mixed():
     cond_in = ConditionIn(value=param, in_values=["abc", prop, var])
     assert cond_in.to_request() == {
         "Type": "In",
-        "QueryValue": {"Get": "Parameters.MyStr"},
-        "Values": ["abc", {"Get": "Steps.foo"}, {"Get": "Execution.StartDateTime"}],
+        "QueryValue": param,
+        "Values": ["abc", prop, var],
     }
 
 
@@ -124,7 +124,7 @@ def test_condition_not():
         "Type": "Not",
         "Expression": {
             "Type": "Equals",
-            "LeftValue": {"Get": "Parameters.MyStr"},
+            "LeftValue": param,
             "RightValue": "foo",
         },
     }
@@ -138,7 +138,7 @@ def test_condition_not_in():
         "Type": "Not",
         "Expression": {
             "Type": "In",
-            "QueryValue": {"Get": "Parameters.MyStr"},
+            "QueryValue": param,
             "Values": ["abc", "def"],
         },
     }
@@ -155,12 +155,12 @@ def test_condition_or():
         "Conditions": [
             {
                 "Type": "GreaterThan",
-                "LeftValue": {"Get": "Execution.StartDateTime"},
+                "LeftValue": var,
                 "RightValue": "2020-12-01",
             },
             {
                 "Type": "In",
-                "QueryValue": {"Get": "Parameters.MyStr"},
+                "QueryValue": param,
                 "Values": ["abc", "def"],
             },
         ],


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Remove redundant `primitive_or_expr()` which is used in `to_request()` in some Pipeline conditions. This behavior is redundant since PropertyReferences or other PipelineVariables are interpolated when creating pipeline definition, early interpolation results in plain request dict (PipelineVariables are converted into dictionary) returned by ConditionStep.to_request(), which lose PipelineVariable information. Preserving PipelineVariable information is required by Pipeline local mode. 

*Testing done:*
Updated related unit test cases and ran locally

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
