### PR TITLE
feat: Add target_model to support multi-model endpoints

### DIFF
--- a/src/sagemaker/clarify.py
+++ b/src/sagemaker/clarify.py
@@ -200,6 +200,7 @@ class ModelConfig:
         custom_attributes=None,
         accelerator_type=None,
         endpoint_name_prefix=None,
+        target_model=None,
     ):
         r"""Initializes a configuration of a model and the endpoint to be created for it.
 
@@ -234,6 +235,9 @@ class ModelConfig:
                 for making inferences to the model.
             endpoint_name_prefix (str): The endpoint name prefix of a new endpoint. Must follow
                 pattern ``^[a-zA-Z0-9](-\*[a-zA-Z0-9]``.
+            target_model (str): Sets the target model name when using a multi-model endpoint. For
+                more information about multi-model endpoints, see
+                https://docs.aws.amazon.com/sagemaker/latest/dg/multi-model-endpoints.html
 
         Raises:
             ValueError: when the ``endpoint_name_prefix`` is invalid, ``accept_type`` is invalid,
@@ -281,6 +285,7 @@ class ModelConfig:
             self.predictor_config["content_template"] = content_template
         _set(custom_attributes, "custom_attributes", self.predictor_config)
         _set(accelerator_type, "accelerator_type", self.predictor_config)
+        _set(target_model, "target_model", self.predictor_config)
 
     def get_predictor_config(self):
         """Returns part of the predictor dictionary of the analysis config."""

--- a/tests/unit/test_clarify.py
+++ b/tests/unit/test_clarify.py
@@ -240,6 +240,7 @@ def test_model_config():
     accept_type = "text/csv"
     content_type = "application/jsonlines"
     custom_attributes = "c000b4f9-df62-4c85-a0bf-7c525f9104a4"
+    target_model = "target_model_name"
     accelerator_type = "ml.eia1.medium"
     model_config = ModelConfig(
         model_name=model_name,
@@ -249,6 +250,7 @@ def test_model_config():
         content_type=content_type,
         custom_attributes=custom_attributes,
         accelerator_type=accelerator_type,
+        target_model=target_model,
     )
     expected_config = {
         "model_name": model_name,
@@ -258,6 +260,7 @@ def test_model_config():
         "content_type": content_type,
         "custom_attributes": custom_attributes,
         "accelerator_type": accelerator_type,
+        "target_model": target_model,
     }
     assert expected_config == model_config.get_predictor_config()
 


### PR DESCRIPTION
*Issue #, if available:*
Add `target_model` to support multi-model endpoints in Clarify processing jobs. 

*Testing done:*
Added unit tests. 

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
