### PR TITLE
Using logger instead of print

### DIFF
--- a/src/sagemaker/processing.py
+++ b/src/sagemaker/processing.py
@@ -16,7 +16,7 @@ which is used for Amazon SageMaker Processing Jobs. These jobs let users perform
 data pre-processing, post-processing, feature engineering, data validation, and model evaluation,
 and interpretation on Amazon SageMaker.
 """
-from __future__ import print_function, absolute_import
+from __future__ import absolute_import
 
 import os
 import pathlib
@@ -787,10 +787,9 @@ class ProcessingJob(_Job):
         process_args = cls._get_process_args(processor, inputs, outputs, experiment_config)
 
         # Print the job name and the user's inputs and outputs as lists of dictionaries.
-        print()
-        print("Job Name: ", process_args["job_name"])
-        print("Inputs: ", process_args["inputs"])
-        print("Outputs: ", process_args["output_config"]["Outputs"])
+        logger.info("Job Name: ", process_args["job_name"])
+        logger.info("Inputs: ", process_args["inputs"])
+        logger.info("Outputs: ", process_args["output_config"]["Outputs"])
 
         # Call sagemaker_session.process using the arguments dictionary.
         processor.sagemaker_session.process(**process_args)

--- a/src/sagemaker/processing.py
+++ b/src/sagemaker/processing.py
@@ -787,9 +787,9 @@ class ProcessingJob(_Job):
         process_args = cls._get_process_args(processor, inputs, outputs, experiment_config)
 
         # Print the job name and the user's inputs and outputs as lists of dictionaries.
-        logger.info("Job Name: ", process_args["job_name"])
-        logger.info("Inputs: ", process_args["inputs"])
-        logger.info("Outputs: ", process_args["output_config"]["Outputs"])
+        logger.info("Job Name: {0}".format(process_args["job_name"]))
+        logger.info("Inputs: {0}".format(process_args["inputs"]))
+        logger.info("Outputs: {0}".format(process_args["output_config"]["Outputs"]))
 
         # Call sagemaker_session.process using the arguments dictionary.
         processor.sagemaker_session.process(**process_args)


### PR DESCRIPTION
*Description of changes:*

Instead of using `print` function use the `logger`.

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
