### PR TITLE
feature: Allow customizing trial component display names for pipeline launched jobs

### DIFF
--- a/doc/amazon_sagemaker_model_building_pipeline.rst
+++ b/doc/amazon_sagemaker_model_building_pipeline.rst
@@ -741,6 +741,8 @@ There are a number of properties for a pipeline execution that can only be resol
 - :class:`sagemaker.workflow.execution_variables.ExecutionVariables.PIPELINE_EXECUTION_ARN`: The execution ARN for an execution.
 - :class:`sagemaker.workflow.execution_variables.ExecutionVariables.PIPELINE_NAME`: The name of the pipeline.
 - :class:`sagemaker.workflow.execution_variables.ExecutionVariables.PIPELINE_ARN`: The ARN of the pipeline.
+- :class:`sagemaker.workflow.execution_variables.ExecutionVariables.TRAINING_JOB_NAME`: The name of the training job launched by the training step.
+- :class:`sagemaker.workflow.execution_variables.ExecutionVariables.PROCESSING_JOB_NAME`: The name of the processing job launched by the processing step.
 
 You can use these execution variables as you see fit. The following example uses the :code:`START_DATETIME` execution variable to construct a processing output path:
 

--- a/doc/workflows/pipelines/sagemaker.workflow.pipelines.rst
+++ b/doc/workflows/pipelines/sagemaker.workflow.pipelines.rst
@@ -52,7 +52,7 @@ Execution Variables
 .. autoclass:: sagemaker.workflow.execution_variables.ExecutionVariable
 
 .. autoclass:: sagemaker.workflow.execution_variables.ExecutionVariables
-    :members: START_DATETIME, CURRENT_DATETIME, PIPELINE_EXECUTION_ID, PIPELINE_EXECUTION_ARN, PIPELINE_NAME, PIPELINE_ARN
+    :members: START_DATETIME, CURRENT_DATETIME, PIPELINE_EXECUTION_ID, PIPELINE_EXECUTION_ARN, PIPELINE_NAME, PIPELINE_ARN, TRAINING_JOB_NAME, PROCESSING_JOB_NAME
 
 Functions
 ---------

--- a/src/sagemaker/estimator.py
+++ b/src/sagemaker/estimator.py
@@ -1025,6 +1025,12 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):  # pylint: disable=too-man
                 * If both `ExperimentName` and `TrialName` are not supplied the trial component
                 will be unassociated.
                 * `TrialComponentDisplayName` is used for display in Studio.
+                * Both `ExperimentName` and `TrialName` will be ignored if the Estimator instance
+                is built with :class:`~sagemaker.workflow.pipeline_context.PipelineSession`.
+                However, the value of `TrialComponentDisplayName` is honored for display in Studio.
+        Returns:
+            None or pipeline step arguments in case the Estimator instance is built with
+            :class:`~sagemaker.workflow.pipeline_context.PipelineSession`
         """
         self._prepare_for_training(job_name=job_name)
 

--- a/src/sagemaker/processing.py
+++ b/src/sagemaker/processing.py
@@ -173,9 +173,14 @@ class Processor(object):
                 * If both `ExperimentName` and `TrialName` are not supplied the trial component
                 will be unassociated.
                 * `TrialComponentDisplayName` is used for display in Studio.
+                * Both `ExperimentName` and `TrialName` will be ignored if the Processor instance
+                is built with :class:`~sagemaker.workflow.pipeline_context.PipelineSession`.
+                However, the value of `TrialComponentDisplayName` is honored for display in Studio.
             kms_key (str): The ARN of the KMS key that is used to encrypt the
                 user code file (default: None).
-
+        Returns:
+            None or pipeline step arguments in case the Processor instance is built with
+            :class:`~sagemaker.workflow.pipeline_context.PipelineSession`
         Raises:
             ValueError: if ``logs`` is True but ``wait`` is False.
         """
@@ -543,8 +548,14 @@ class ScriptProcessor(Processor):
                 * If both `ExperimentName` and `TrialName` are not supplied the trial component
                 will be unassociated.
                 * `TrialComponentDisplayName` is used for display in Studio.
+                * Both `ExperimentName` and `TrialName` will be ignored if the Processor instance
+                is built with :class:`~sagemaker.workflow.pipeline_context.PipelineSession`.
+                However, the value of `TrialComponentDisplayName` is honored for display in Studio.
             kms_key (str): The ARN of the KMS key that is used to encrypt the
                 user code file (default: None).
+        Returns:
+            None or pipeline step arguments in case the Processor instance is built with
+            :class:`~sagemaker.workflow.pipeline_context.PipelineSession`
         """
         normalized_inputs, normalized_outputs = self._normalize_args(
             job_name=job_name,
@@ -1601,8 +1612,14 @@ class FrameworkProcessor(ScriptProcessor):
                 * If both `ExperimentName` and `TrialName` are not supplied the trial component
                 will be unassociated.
                 * `TrialComponentDisplayName` is used for display in Studio.
+                * Both `ExperimentName` and `TrialName` will be ignored if the Processor instance
+                is built with :class:`~sagemaker.workflow.pipeline_context.PipelineSession`.
+                However, the value of `TrialComponentDisplayName` is honored for display in Studio.
             kms_key (str): The ARN of the KMS key that is used to encrypt the
                 user code file (default: None).
+        Returns:
+            None or pipeline step arguments in case the Processor instance is built with
+            :class:`~sagemaker.workflow.pipeline_context.PipelineSession`
         """
         s3_runproc_sh, inputs, job_name = self._pack_and_upload_code(
             code, source_dir, dependencies, git_config, job_name, inputs

--- a/src/sagemaker/transformer.py
+++ b/src/sagemaker/transformer.py
@@ -186,6 +186,9 @@ class Transformer(object):
                 * If both `ExperimentName` and `TrialName` are not supplied the trial component
                 will be unassociated.
                 * `TrialComponentDisplayName` is used for display in Studio.
+                * Both `ExperimentName` and `TrialName` will be ignored if the Transformer instance
+                is built with :class:`~sagemaker.workflow.pipeline_context.PipelineSession`.
+                However, the value of `TrialComponentDisplayName` is honored for display in Studio.
             model_client_config (dict[str, str]): Model configuration.
                 Dictionary contains two optional keys,
                 'InvocationsTimeoutInSeconds', and 'InvocationsMaxRetries'.
@@ -194,6 +197,9 @@ class Transformer(object):
                 (default: ``True``).
             logs (bool): Whether to show the logs produced by the job.
                 Only meaningful when wait is ``True`` (default: ``True``).
+        Returns:
+            None or pipeline step arguments in case the Transformer instance is built with
+            :class:`~sagemaker.workflow.pipeline_context.PipelineSession`
         """
         local_mode = self.sagemaker_session.local_mode
         if not local_mode and not is_pipeline_variable(data) and not data.startswith("s3://"):

--- a/src/sagemaker/workflow/execution_variables.py
+++ b/src/sagemaker/workflow/execution_variables.py
@@ -58,6 +58,8 @@ class ExecutionVariables:
     - ExecutionVariables.PIPELINE_ARN
     - ExecutionVariables.PIPELINE_EXECUTION_ID
     - ExecutionVariables.PIPELINE_EXECUTION_ARN
+    - ExecutionVariables.TRAINING_JOB_NAME
+    - ExecutionVariables.PROCESSING_JOB_NAME
     """
 
     START_DATETIME = ExecutionVariable("StartDateTime")
@@ -66,3 +68,5 @@ class ExecutionVariables:
     PIPELINE_ARN = ExecutionVariable("PipelineArn")
     PIPELINE_EXECUTION_ID = ExecutionVariable("PipelineExecutionId")
     PIPELINE_EXECUTION_ARN = ExecutionVariable("PipelineExecutionArn")
+    TRAINING_JOB_NAME = ExecutionVariable("TrainingJobName")
+    PROCESSING_JOB_NAME = ExecutionVariable("ProcessingJobName")

--- a/src/sagemaker/workflow/steps.py
+++ b/src/sagemaker/workflow/steps.py
@@ -223,6 +223,18 @@ class Step(Entity):
             return step_map[str_input].steps[-1].name
         return str_input
 
+    @staticmethod
+    def _trim_experiment_config(request_dict: Dict):
+        """For job steps, trim the experiment config to keep the trial component display name."""
+        if request_dict.get("ExperimentConfig", {}).get("TrialComponentDisplayName"):
+            request_dict["ExperimentConfig"] = {
+                "TrialComponentDisplayName": request_dict["ExperimentConfig"][
+                    "TrialComponentDisplayName"
+                ]
+            }
+        else:
+            request_dict.pop("ExperimentConfig", None)
+
 
 @attr.s
 class CacheConfig:
@@ -432,7 +444,7 @@ class TrainingStep(ConfigurableRetryStep):
             request_dict["HyperParameters"].pop("sagemaker_job_name", None)
 
         request_dict.pop("TrainingJobName", None)
-        request_dict.pop("ExperimentConfig", None)
+        Step._trim_experiment_config(request_dict)
 
         return request_dict
 
@@ -663,7 +675,8 @@ class TransformStep(ConfigurableRetryStep):
             )
 
         request_dict.pop("TransformJobName", None)
-        request_dict.pop("ExperimentConfig", None)
+        Step._trim_experiment_config(request_dict)
+
         return request_dict
 
     @property
@@ -811,7 +824,8 @@ class ProcessingStep(ConfigurableRetryStep):
             request_dict = self.processor.sagemaker_session._get_process_request(**process_args)
 
         request_dict.pop("ProcessingJobName", None)
-        request_dict.pop("ExperimentConfig", None)
+        Step._trim_experiment_config(request_dict)
+
         return request_dict
 
     @property

--- a/tests/unit/sagemaker/workflow/test_training_step.py
+++ b/tests/unit/sagemaker/workflow/test_training_step.py
@@ -19,6 +19,8 @@ from mock import Mock, PropertyMock
 import pytest
 import warnings
 
+from copy import deepcopy
+
 from sagemaker import Processor, Model
 from sagemaker.parameter import IntegerParameter
 from sagemaker.transformer import Transformer
@@ -207,7 +209,34 @@ def hyperparameters():
     return {"test-key": "test-val"}
 
 
-def test_training_step_with_estimator(pipeline_session, training_input, hyperparameters):
+@pytest.mark.parametrize(
+    "experiment_config, expected_experiment_config",
+    [
+        (
+            {
+                "ExperimentName": "experiment-name",
+                "TrialName": "trial-name",
+                "TrialComponentDisplayName": "display-name",
+            },
+            {"TrialComponentDisplayName": "display-name"},
+        ),
+        (
+            {"TrialComponentDisplayName": "display-name"},
+            {"TrialComponentDisplayName": "display-name"},
+        ),
+        (
+            {
+                "ExperimentName": "experiment-name",
+                "TrialName": "trial-name",
+            },
+            None,
+        ),
+        (None, None),
+    ],
+)
+def test_training_step_with_estimator(
+    pipeline_session, training_input, hyperparameters, experiment_config, expected_experiment_config
+):
     custom_step1 = CustomStep("TestStep")
     custom_step2 = CustomStep("SecondTestStep")
     enable_network_isolation = ParameterBoolean(name="enable_network_isolation")
@@ -226,7 +255,9 @@ def test_training_step_with_estimator(pipeline_session, training_input, hyperpar
     with warnings.catch_warnings(record=True) as w:
         # TODO: remove job_name once we merge
         # https://github.com/aws/sagemaker-python-sdk/pull/3158/files
-        step_args = estimator.fit(inputs=training_input, job_name="TestJob")
+        step_args = estimator.fit(
+            inputs=training_input, job_name="TestJob", experiment_config=experiment_config
+        )
         assert len(w) == 1
         assert issubclass(w[-1].category, UserWarning)
         assert "Running within a PipelineSession" in str(w[-1].message)
@@ -247,17 +278,28 @@ def test_training_step_with_estimator(pipeline_session, training_input, hyperpar
         parameters=[enable_network_isolation, encrypt_container_traffic],
         sagemaker_session=pipeline_session,
     )
-    step_args.args["EnableInterContainerTrafficEncryption"] = {
+
+    expected_step_arguments = deepcopy(step_args.args)
+
+    expected_step_arguments["EnableInterContainerTrafficEncryption"] = {
         "Get": "Parameters.encrypt_container_traffic"
     }
-    step_args.args["EnableNetworkIsolation"] = {"Get": "Parameters.encrypt_container_traffic"}
+    expected_step_arguments["EnableNetworkIsolation"] = {
+        "Get": "Parameters.enable_network_isolation"
+    }
+    if expected_experiment_config is None:
+        expected_step_arguments.pop("ExperimentConfig", None)
+    else:
+        expected_step_arguments["ExperimentConfig"] = expected_experiment_config
+    del expected_step_arguments["TrainingJobName"]
+
     assert json.loads(pipeline.definition())["Steps"][0] == {
         "Name": "MyTrainingStep",
         "Description": "TrainingStep description",
         "DisplayName": "MyTrainingStep",
         "Type": "Training",
         "DependsOn": ["TestStep", "SecondTestStep"],
-        "Arguments": step_args.args,
+        "Arguments": expected_step_arguments,
     }
     assert step.properties.TrainingJobName.expr == {"Get": "Steps.MyTrainingStep.TrainingJobName"}
     adjacency_list = PipelineGraph.from_pipeline(pipeline).adjacency_list

--- a/tests/unit/sagemaker/workflow/test_transform_step.py
+++ b/tests/unit/sagemaker/workflow/test_transform_step.py
@@ -18,6 +18,8 @@ from mock import Mock, PropertyMock
 import pytest
 import warnings
 
+from copy import deepcopy
+
 from sagemaker import Model, Processor
 from sagemaker.estimator import Estimator
 from sagemaker.parameter import IntegerParameter
@@ -153,27 +155,108 @@ def test_transform_step_with_transformer(model_name, data, output_path, pipeline
         parameters=[model_name, data],
         sagemaker_session=pipeline_session,
     )
-    step_args = step_args.args
-    step_def = json.loads(pipeline.definition())["Steps"][0]
-    step_args["ModelName"] = model_name.expr if is_pipeline_variable(model_name) else model_name
-    step_args["TransformInput"]["DataSource"]["S3DataSource"]["S3Uri"] = (
+
+    expected_step_arguments = deepcopy(step_args.args)
+    expected_step_arguments["ModelName"] = (
+        model_name.expr if is_pipeline_variable(model_name) else model_name
+    )
+    expected_step_arguments["TransformInput"]["DataSource"]["S3DataSource"]["S3Uri"] = (
         data.expr if is_pipeline_variable(data) else data
     )
-    step_args["TransformOutput"]["S3OutputPath"] = (
+    expected_step_arguments["TransformOutput"]["S3OutputPath"] = (
         output_path.expr if is_pipeline_variable(output_path) else output_path
     )
+    del expected_step_arguments["TransformJobName"]
 
-    del (
-        step_args["ModelName"],
-        step_args["TransformInput"]["DataSource"]["S3DataSource"]["S3Uri"],
-        step_args["TransformOutput"]["S3OutputPath"],
+    step_def = json.loads(pipeline.definition())["Steps"][0]
+    assert step_def == {
+        "Name": "MyTransformStep",
+        "Type": "Transform",
+        "Arguments": expected_step_arguments,
+    }
+
+
+@pytest.mark.parametrize(
+    "experiment_config, expected_experiment_config",
+    [
+        (
+            {
+                "ExperimentName": "experiment-name",
+                "TrialName": "trial-name",
+                "TrialComponentDisplayName": "display-name",
+            },
+            {"TrialComponentDisplayName": "display-name"},
+        ),
+        (
+            {"TrialComponentDisplayName": "display-name"},
+            {"TrialComponentDisplayName": "display-name"},
+        ),
+        (
+            {
+                "ExperimentName": "experiment-name",
+                "TrialName": "trial-name",
+            },
+            None,
+        ),
+        (None, None),
+    ],
+)
+def test_transform_step_with_transformer_experiment_config(
+    experiment_config, expected_experiment_config, pipeline_session
+):
+    transformer = Transformer(
+        model_name="my_model",
+        instance_type="ml.m5.xlarge",
+        instance_count=1,
+        output_path="s3://my-bucket/my-output-path",
+        sagemaker_session=pipeline_session,
     )
-    del (
-        step_def["Arguments"]["ModelName"],
-        step_def["Arguments"]["TransformInput"]["DataSource"]["S3DataSource"]["S3Uri"],
-        step_def["Arguments"]["TransformOutput"]["S3OutputPath"],
+    transform_inputs = TransformInput(data="s3://my-bucket/my-data")
+
+    with warnings.catch_warnings(record=True) as w:
+        step_args = transformer.transform(
+            data=transform_inputs.data,
+            data_type=transform_inputs.data_type,
+            content_type=transform_inputs.content_type,
+            compression_type=transform_inputs.compression_type,
+            split_type=transform_inputs.split_type,
+            input_filter=transform_inputs.input_filter,
+            output_filter=transform_inputs.output_filter,
+            join_source=transform_inputs.join_source,
+            model_client_config=transform_inputs.model_client_config,
+            experiment_config=experiment_config,
+        )
+        assert len(w) == 1
+        assert issubclass(w[-1].category, UserWarning)
+        assert "Running within a PipelineSession" in str(w[-1].message)
+
+    with warnings.catch_warnings(record=True) as w:
+        step = TransformStep(
+            name="MyTransformStep",
+            step_args=step_args,
+        )
+        assert len(w) == 0
+
+    pipeline = Pipeline(
+        name="MyPipeline",
+        steps=[step],
+        sagemaker_session=pipeline_session,
     )
-    assert step_def == {"Name": "MyTransformStep", "Type": "Transform", "Arguments": step_args}
+
+    expected_step_arguments = deepcopy(step_args.args)
+    if expected_experiment_config is None:
+        expected_step_arguments.pop("ExperimentConfig", None)
+    else:
+        expected_step_arguments["ExperimentConfig"] = expected_experiment_config
+    del expected_step_arguments["TransformJobName"]
+
+    step_def = json.loads(pipeline.definition())["Steps"][0]
+    assert step_def == {
+        "Name": "MyTransformStep",
+        "Type": "Transform",
+        "Arguments": expected_step_arguments,
+    }
+
     adjacency_list = PipelineGraph.from_pipeline(pipeline).adjacency_list
     assert adjacency_list == {"MyTransformStep": []}
 


### PR DESCRIPTION
…aunched jobs

*Issue #, if available:*

*Description of changes:* Allow users to customize trial component display names for pipeline launched jobs

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
