### PR TITLE
fix: rename RegisterModel inner steps to prevent duplicate step names

### DIFF
--- a/src/sagemaker/workflow/step_collections.py
+++ b/src/sagemaker/workflow/step_collections.py
@@ -57,6 +57,9 @@ class StepCollection:
 class RegisterModel(StepCollection):  # pragma: no cover
     """Register Model step collection for workflow."""
 
+    _REGISTER_MODEL_NAME_BASE = "RegisterModel"
+    _REPACK_MODEL_NAME_BASE = "RepackModel"
+
     def __init__(
         self,
         name: str,
@@ -168,7 +171,7 @@ class RegisterModel(StepCollection):  # pragma: no cover
             kwargs = dict(**kwargs, output_kms_key=kwargs.pop("model_kms_key", None))
 
             repack_model_step = _RepackModelStep(
-                name=f"{name}RepackModel",
+                name="{}-{}".format(self.name, self._REPACK_MODEL_NAME_BASE),
                 depends_on=depends_on,
                 retry_policies=repack_model_step_retry_policies,
                 sagemaker_session=estimator.sagemaker_session,
@@ -212,7 +215,7 @@ class RegisterModel(StepCollection):  # pragma: no cover
                     model_name = model_entity.name or model_entity._framework_name
 
                     repack_model_step = _RepackModelStep(
-                        name=f"{model_name}RepackModel",
+                        name="{}-{}".format(model_name, self._REPACK_MODEL_NAME_BASE),
                         depends_on=depends_on,
                         retry_policies=repack_model_step_retry_policies,
                         sagemaker_session=sagemaker_session,
@@ -256,7 +259,7 @@ class RegisterModel(StepCollection):  # pragma: no cover
             )
 
         register_model_step = _RegisterModelStep(
-            name=name,
+            name="{}-{}".format(self.name, self._REGISTER_MODEL_NAME_BASE),
             estimator=estimator,
             model_data=model_data,
             content_types=content_types,

--- a/tests/integ/sagemaker/workflow/test_model_create_and_registration.py
+++ b/tests/integ/sagemaker/workflow/test_model_create_and_registration.py
@@ -123,8 +123,8 @@ def test_conditional_pytorch_training_model_registration(
         model_data=step_train.properties.ModelArtifacts.S3ModelArtifacts,
         content_types=["*"],
         response_types=["*"],
-        inference_instances=["*"],
-        transform_instances=["*"],
+        inference_instances=["ml.m5.xlarge"],
+        transform_instances=["ml.m5.xlarge"],
         description="test-description",
         sample_payload_url=sample_payload_url,
         task=task,
@@ -234,7 +234,7 @@ def test_mxnet_model_registration(
         content_types=["*"],
         response_types=["*"],
         inference_instances=["ml.m5.xlarge"],
-        transform_instances=["*"],
+        transform_instances=["ml.m5.xlarge"],
         description="test-description",
         sample_payload_url=sample_payload_url,
         task=task,
@@ -670,7 +670,7 @@ def test_model_registration_with_drift_check_baselines(
                 )
                 continue
             assert execution_steps[0]["StepStatus"] == "Succeeded"
-            assert execution_steps[0]["StepName"] == "MyRegisterModelStep"
+            assert execution_steps[0]["StepName"] == "MyRegisterModelStep-RegisterModel"
 
             response = sagemaker_session.sagemaker_client.describe_model_package(
                 ModelPackageName=execution_steps[0]["Metadata"]["RegisterModel"]["Arn"]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Rename RegisterModel inner steps to prevent duplicate step names while building a PipelineGraph

*Testing done:*
added unit tests

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
