### PR TITLE
Add validation to EMRStepConfig.properties to ensure key/value pair

### DIFF
--- a/src/sagemaker/workflow/emr_step.py
+++ b/src/sagemaker/workflow/emr_step.py
@@ -15,6 +15,8 @@ from __future__ import absolute_import
 
 from typing import List, Union, Optional
 
+from botocore.exceptions import MissingParametersError
+
 from sagemaker.workflow.entities import (
     RequestType,
 )
@@ -47,6 +49,7 @@ class EMRStepConfig:
         self.args = args
         self.main_class = main_class
         self.properties = properties
+        self.validate_prop_dicts()
 
     def to_request(self) -> RequestType:
         """Convert EMRStepConfig object to request dict."""
@@ -59,6 +62,20 @@ class EMRStepConfig:
             config["HadoopJarStep"]["Properties"] = self.properties
 
         return config
+
+    def validate_prop_dicts(self):
+        """Validate k,v structure of properties dictionaries, err if not provided"""
+        if isinstance(self.properties, list) and self.properties:
+            for field_dict in self.properties:
+                try:
+                    if "key" in field_dict.keys():
+                        field_dict["Key"] = field_dict.pop("key")
+                    if "value" in field_dict.keys():
+                        field_dict["Value"] = field_dict.pop("value")
+                except KeyError:
+                    raise MissingParametersError(
+                        object_name=EMRStepConfig, missing=["Key", "Value"]
+                    )
 
 
 class EMRStep(Step):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add validation to k/v pair for EMRStepConfig properties dicts

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
