### PR TITLE
documentation: heterogeneous cluster api doc fix

### DIFF
--- a/src/sagemaker/inputs.py
+++ b/src/sagemaker/inputs.py
@@ -67,10 +67,16 @@ class TrainingInput(object):
                 AugmentedManifestFile formats are described at `S3DataSource
                 <https://docs.aws.amazon.com/sagemaker/latest/dg/API_S3DataSource.html>`_
                 in the `Amazon SageMaker API reference`.
-            instance_groups (list[str]): Optional. A list of ``instance_group_name``\ s
-                of a heterogeneous cluster that's configured using the
+            instance_groups (list[str]): Optional. A list of instance group names in string format
+                that you specified while configuring a heterogeneous cluster using the
                 :class:`sagemaker.instance_group.InstanceGroup`.
                 S3 data will be sent to all instance groups in the specified list.
+                For instructions on how to use InstanceGroup objects
+                to configure a heterogeneous cluster
+                through the SageMaker generic and framework estimator classes, see
+                `Train Using a Heterogeneous Cluster
+                <https://docs.aws.amazon.com/sagemaker/latest/dg/train-heterogeneous-cluster.html>`_
+                in the *Amazon SageMaker developer guide*.
                 (default: None)
             input_mode (str): Optional override for this channel's input mode (default: None).
                 By default, channels will use the input mode defined on


### PR DESCRIPTION
*Description of changes:*

- a quick fix for heterogeneous-related docstrings

*Testing done:*

passed `tox -e black-check,flake8,docstyle,sphinx,doc8,twine --parallel all`

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
