### PR TITLE
feature: add warnings for xgboost specific rules in debugger rules

### DIFF
--- a/src/sagemaker/estimator.py
+++ b/src/sagemaker/estimator.py
@@ -779,6 +779,8 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):  # pylint: disable=too-man
         if self.rules is not None:
             for rule in self.rules:
                 if isinstance(rule, Rule):
+                    # Add check for xgboost rules
+                    self._check_debugger_rule(rule)
                     self.debugger_rules.append(rule)
                 elif isinstance(rule, ProfilerRule):
                     self.profiler_rules.append(rule)
@@ -787,6 +789,16 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):  # pylint: disable=too-man
                         "Rules list can only contain sagemaker.debugger.Rule "
                         + "and sagemaker.debugger.ProfilerRule"
                     )
+
+    def _check_debugger_rule(self, rule):
+        """Add warning for incorrectly used xgboost rules."""
+        _xgboost_specific_rules = ["FeatureImportanceOverweight", "TreeDepth"]
+        if rule.name in _xgboost_specific_rules:
+            logger.warning(
+                "TreeDepth and FeatureImportanceOverweight rules are valid "
+                "only for the XGBoost algorithm. Please make sure this estimator "
+                "is used for XGBoost algorithm. "
+            )
 
     def _prepare_debugger_for_training(self):
         """Prepare debugger rules and debugger configs for training."""


### PR DESCRIPTION
fix: fix that failing in certain debugger rules leads to end training jobs with no description.

*Issue #, if available:*  There are debugger rules that are valid only for XGBoost algorithms, but there is no warning or error message for users when the rules are incorrectly used.

*Description of changes:* Add warning for using XBGoost debugger rules outside of XGBoost algorithms. 

*Testing done:* Passed all unit tests.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
