### PR TITLE
change: Make repack step output path align with model repack path

### DIFF
--- a/src/sagemaker/image_uris.py
+++ b/src/sagemaker/image_uris.py
@@ -32,7 +32,6 @@ ECR_URI_TEMPLATE = "{registry}.dkr.{hostname}/{repository}"
 HUGGING_FACE_FRAMEWORK = "huggingface"
 
 
-# TODO: we should remove this decorator later
 @override_pipeline_parameter_var
 def retrieve(
     framework,
@@ -117,7 +116,11 @@ def retrieve(
     args = dict(locals())
     for name, val in args.items():
         if is_pipeline_variable(val):
-            raise ValueError("%s should not be a pipeline variable (%s)" % (name, type(val)))
+            raise ValueError(
+                "When retrieving the image_uri, the argument %s should not be a pipeline variable "
+                "(%s) since pipeline variables are only interpreted in the pipeline execution time."
+                % (name, type(val))
+            )
 
     if is_jumpstart_model_input(model_id, model_version):
         return artifacts._retrieve_image_uri(
@@ -487,6 +490,9 @@ def get_training_image_uri(
     if image_uri:
         return image_uri
 
+    logger.info(
+        "image_uri is not presented, retrieving image_uri based on instance_type, framework etc."
+    )
     base_framework_version: Optional[str] = None
 
     if tensorflow_version is not None or pytorch_version is not None:

--- a/src/sagemaker/rl/estimator.py
+++ b/src/sagemaker/rl/estimator.py
@@ -280,6 +280,11 @@ class RLEstimator(Framework):
         """
         if self.image_uri:
             return self.image_uri
+
+        logger.info(
+            "image_uri is not presented, retrieving image_uri based on instance_type, "
+            "framework etc."
+        )
         return image_uris.retrieve(
             self._image_framework(),
             self.sagemaker_session.boto_region_name,

--- a/src/sagemaker/workflow/model_step.py
+++ b/src/sagemaker/workflow/model_step.py
@@ -23,8 +23,6 @@ from sagemaker.workflow.retry import RetryPolicy, SageMakerJobStepRetryPolicy
 from sagemaker.workflow.step_collections import StepCollection
 from sagemaker.workflow.steps import Step, CreateModelStep
 
-NEED_RUNTIME_REPACK = "need_runtime_repack"
-
 _CREATE_MODEL_RETRY_POLICIES = "create_model_retry_policies"
 _REGISTER_MODEL_RETRY_POLICIES = "register_model_retry_policies"
 _REPACK_MODEL_RETRY_POLICIES = "repack_model_retry_policies"
@@ -155,6 +153,7 @@ class ModelStep(StepCollection):
         self._create_model_args = self.step_args.create_model_request
         self._register_model_args = self.step_args.create_model_package_request
         self._need_runtime_repack = self.step_args.need_runtime_repack
+        self._runtime_repack_output_prefix = self.step_args.runtime_repack_output_prefix
         self._assign_and_validate_retry_policies(retry_policies)
 
         if self._need_runtime_repack:
@@ -268,6 +267,7 @@ class ModelStep(StepCollection):
                     ),
                     depends_on=self.depends_on,
                     retry_policies=self._repack_model_retry_policies,
+                    output_path=self._runtime_repack_output_prefix,
                 )
                 self.steps.append(repack_model_step)
 

--- a/src/sagemaker/workflow/pipeline_context.py
+++ b/src/sagemaker/workflow/pipeline_context.py
@@ -67,6 +67,7 @@ class _ModelStepArguments(_StepArguments):
         self.create_model_package_request = None
         self.create_model_request = None
         self.need_runtime_repack = set()
+        self.runtime_repack_output_prefix = None
 
 
 class PipelineSession(Session):
@@ -139,14 +140,14 @@ class PipelineSession(Session):
         else:
             self.context = _JobStepArguments(func_name, request)
 
-    def init_step_arguments(self, model):
+    def init_model_step_arguments(self, model):
         """Create a `_ModelStepArguments` (if not exist) as pipeline context
 
         Args:
             model (Model or PipelineModel): A `sagemaker.model.Model`
                 or `sagemaker.pipeline.PipelineModel` instance
         """
-        if not self._context or not isinstance(self._context, _ModelStepArguments):
+        if not isinstance(self._context, _ModelStepArguments):
             self._context = _ModelStepArguments(model)
 
 
@@ -197,7 +198,7 @@ def runnable_by_pipeline(run_func):
                 UserWarning,
             )
             if run_func.__name__ in ["register", "create"]:
-                self_instance.sagemaker_session.init_step_arguments(self_instance)
+                self_instance.sagemaker_session.init_model_step_arguments(self_instance)
                 run_func(*args, **kwargs)
                 context = self_instance.sagemaker_session.context
                 self_instance.sagemaker_session.context = None

--- a/tests/integ/sagemaker/workflow/test_model_steps.py
+++ b/tests/integ/sagemaker/workflow/test_model_steps.py
@@ -836,6 +836,7 @@ def test_tensorflow_model_register_and_deploy_with_runtime_repack(
         sagemaker_session=pipeline_session,
         entry_point=os.path.join(_TENSORFLOW_PATH, "inference.py"),
         dependencies=[os.path.join(_TENSORFLOW_PATH, "dependency.py")],
+        code_location=f"s3://{pipeline_session.default_bucket()}/model-code",
     )
     step_args = tf_model.register(
         content_types=["application/json"],

--- a/tests/unit/sagemaker/image_uris/test_retrieve.py
+++ b/tests/unit/sagemaker/image_uris/test_retrieve.py
@@ -754,7 +754,7 @@ def test_retrieve_with_pipeline_variable():
     kwargs["instance_type"] = Join(on="", values=["a", "b"])
     with pytest.raises(Exception) as error:
         image_uris.retrieve(**kwargs)
-    assert "instance_type should not be a pipeline variable" in str(error.value)
+    assert "the argument instance_type should not be a pipeline variable" in str(error.value)
 
     # instance_type (ParameterString) is given as args rather than kwargs
     # which should not break anything

--- a/tests/unit/sagemaker/workflow/test_model_step.py
+++ b/tests/unit/sagemaker/workflow/test_model_step.py
@@ -67,6 +67,8 @@ _SCRIPT_NAME = "dummy_script.py"
 _DIR_NAME = "/opt/ml/model/code"
 _XGBOOST_PATH = os.path.join(DATA_DIR, "xgboost_abalone")
 _TENSORFLOW_PATH = os.path.join(DATA_DIR, "tfs/tfs-test-entrypoint-and-dependencies")
+_REPACK_OUTPUT_KEY_PREFIX = "code-output"
+_MODEL_CODE_LOCATION = f"s3://{_BUCKET}/{_REPACK_OUTPUT_KEY_PREFIX}"
 
 
 @pytest.fixture
@@ -688,6 +690,7 @@ def test_conditional_model_create_and_regis(
                 entry_point=f"{DATA_DIR}/{_SCRIPT_NAME}",
                 role=_ROLE,
                 enable_network_isolation=True,
+                code_location=_MODEL_CODE_LOCATION,
             ),
             2,
         ),
@@ -711,6 +714,7 @@ def test_conditional_model_create_and_regis(
                 entry_point=f"{DATA_DIR}/{_SCRIPT_NAME}",
                 role=_ROLE,
                 framework_version="1.5.0",
+                code_location=_MODEL_CODE_LOCATION,
             ),
             2,
         ),
@@ -742,6 +746,7 @@ def test_conditional_model_create_and_regis(
                 image_uri=_IMAGE_URI,
                 entry_point=f"{DATA_DIR}/{_SCRIPT_NAME}",
                 role=_ROLE,
+                code_location=_MODEL_CODE_LOCATION,
             ),
             2,
         ),
@@ -758,21 +763,45 @@ def test_conditional_model_create_and_regis(
     ],
 )
 def test_create_model_among_different_model_types(test_input, pipeline_session, model_data_param):
+    def assert_test_result(steps: list):
+        # If expected_step_num is 2, it means a runtime repack step is appended
+        # If expected_step_num is 1, it means no runtime repack is needed
+        assert len(steps) == expected_step_num
+        if expected_step_num == 2:
+            assert steps[0]["Type"] == "Training"
+            if model.key_prefix == _REPACK_OUTPUT_KEY_PREFIX:
+                assert steps[0]["Arguments"]["OutputDataConfig"]["S3OutputPath"] == (
+                    f"{_MODEL_CODE_LOCATION}/{model.name}"
+                )
+            else:
+                assert steps[0]["Arguments"]["OutputDataConfig"]["S3OutputPath"] == (
+                    f"s3://{_BUCKET}/{model.name}"
+                )
+
     model, expected_step_num = test_input
     model.sagemaker_session = pipeline_session
     model.model_data = model_data_param
-    step_args = model.create(
+    create_model_step_args = model.create(
         instance_type="c4.4xlarge",
     )
-    model_steps = ModelStep(
+    create_model_steps = ModelStep(
         name="MyModelStep",
-        step_args=step_args,
+        step_args=create_model_step_args,
     )
-    steps = model_steps.request_dicts()
+    assert_test_result(create_model_steps.request_dicts())
 
-    # If expected_step_num is 2, it means a runtime repack step is appended
-    # If expected_step_num is 1, it means no runtime repack is needed
-    assert len(steps) == expected_step_num
+    register_model_step_args = model.register(
+        content_types=["text/csv"],
+        response_types=["text/csv"],
+        inference_instances=["ml.t2.medium", "ml.m5.xlarge"],
+        transform_instances=["ml.m5.xlarge"],
+        model_package_group_name="MyModelPackageGroup",
+    )
+    register_model_steps = ModelStep(
+        name="MyModelStep",
+        step_args=register_model_step_args,
+    )
+    assert_test_result(register_model_steps.request_dicts())
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
*Description of changes:* 
- Issue 1:
The repack step is doing model repack in pipeline execution time and currently the output path of the repacked model is the default path generated by the repack step (a training job under the hood). 
This output path is not aligned with the compile time model repack path (generated in Python SDK) and consequently it is not able to be customized via the `code_location` argument in model class.
This PR makes the repack step output path to be aligned with the compile time model repack path:
  - If `code_location` is given, the runtime repack output path should be: `s3://<bucket_name>/<code_location>/<model_name>/......`
  - If `code_location` is None, the runtime repack output path is: `s3://<bucket_name>/<model_name>/......`

- Issue 2: https://github.com/aws/sagemaker-python-sdk/issues/3201
As customer pointed out, the warning message given by image_uris.retrieve is confusing. This PR also add more information in the warning message to clarify.

*Testing done:* unit tests and integ test

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
