### PR TITLE
change: add a check to prevent launching a modelparallel job on CPU only instances

### DIFF
--- a/src/sagemaker/pytorch/estimator.py
+++ b/src/sagemaker/pytorch/estimator.py
@@ -25,6 +25,7 @@ from sagemaker.fw_utils import (
     python_deprecation_warning,
     validate_version_or_image_args,
     validate_distribution,
+    validate_distribution_instance,
 )
 from sagemaker.pytorch import defaults
 from sagemaker.pytorch.model import PyTorchModel
@@ -220,6 +221,12 @@ class PyTorch(Framework):
             entry_point, source_dir, hyperparameters, image_uri=image_uri, **kwargs
         )
         if distribution is not None:
+            instance_type = self._get_instance_type()
+            # remove "ml." prefix
+            if instance_type[:3] == "ml.":
+                instance_type = instance_type[3:]
+            validate_distribution_instance(self.sagemaker_session, distribution, instance_type)
+
             distribution = validate_distribution(
                 distribution,
                 self.instance_groups,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes: Added a check to prevent launching a modelparallel job on CPU only instances.

*Testing done:
- All unit tests passed after the change (We ran unit tests in a conda environment with `python=3.8`. Please find the following results). **Since we only add a check by directly using an existing API, we would like to discuss with the reviewers to see if a new unit test is necessary.**
```
$ tox tests/unit
...
_________________________________________________________________________________________________________________ summary __________________________________________________________________________________________________________________
  black-format: commands succeeded
  flake8: commands succeeded
  pylint: commands succeeded
  docstyle: commands succeeded
  sphinx: commands succeeded
  doc8: commands succeeded
  twine: commands succeeded
  py37: commands succeeded
  py38: commands succeeded
ERROR:  py39: InterpreterNotFound: python3.9
ERROR:  py310: InterpreterNotFound: python3.10
```
- Live tests
-- Failure case
```
% python sagemaker_train_script.py --model pytorch-gpt2-precision --ddp 1 --tag pytorch_cur_testtp-preview-0-1 --partitions 2 --instance_type t2.nano --processes_per_host 8 --tensor_parallel_degree 2 --instance_count 2 --microbatches 2
INFO:botocore.credentials:Found credentials in shared credentials file: ~/.aws/credentials
AWS account:…
AWS region:…
Training image:  …
INFO:botocore.credentials:Found credentials in shared credentials file: ~/.aws/credentials
WARNING:sagemaker.deprecations:The class sagemaker.session.s3_input has been renamed in sagemaker>=2.
See: https://sagemaker.readthedocs.io/en/stable/v2.html for details.
WARNING:sagemaker.deprecations:The class sagemaker.session.s3_input has been renamed in sagemaker>=2.
See: https://sagemaker.readthedocs.io/en/stable/v2.html for details.
Creating trial pt-gpt2-pytorch-cur-testtp-preview-0-1-t2-nano-2-seq-1-ddp-cluster-tp2--shard0--partial0-2022-07-19-01-48-40 under experiment rubik-pipeline
checkpoint s3 bucket: s3://rubik-mp-benchmarks/output/pytorch_gpt2/logits_shard_0_pytorch-cur-testtp-preview-0-1-t2-nano-2-seq-1-ddp/
Traceback (most recent call last):
  File "sagemaker_train_script.py", line 1982, in <module>
    main()
  File "sagemaker_train_script.py", line 1966, in main
    pytorch_gpt2_precision(args.tensor_parallel_degree, args.shard_optimizer_state)
  File "sagemaker_train_script.py", line 740, in pytorch_gpt2_precision
    pytorch_estimator = PyTorch(
  File "/Users/…/miniconda3/envs/test_sagemaker/lib/python3.8/site-packages/sagemaker/pytorch/estimator.py", line 211, in __init__
    validate_distribution_instance(self.sagemaker_session, distribution, instance_type)
  File "/Users/…/miniconda3/envs/test_sagemaker/lib/python3.8/site-packages/sagemaker/fw_utils.py", line 732, in validate_distribution_instance
    raise ValueError(
ValueError: modelparallel only runs on GPU-enabled instances. t2.nano does not support GPU.
```
-- Success case
```
% python sagemaker_train_script.py --model pytorch-gpt2-precision --ddp 1 --tag pytorch_cur_testtp-preview-0-1 --partitions 2 --instance_type p4d.24xlarge --processes_per_host 8 --tensor_parallel_degree 2 --instance_count 2 --microbatches 2
INFO:botocore.credentials:Found credentials in shared credentials file: ~/.aws/credentials
AWS account:...
AWS region:...
Training image:  ...
INFO:botocore.credentials:Found credentials in shared credentials file: ~/.aws/credentials
WARNING:sagemaker.deprecations:The class sagemaker.session.s3_input has been renamed in sagemaker>=2.
See: https://sagemaker.readthedocs.io/en/stable/v2.html for details.
WARNING:sagemaker.deprecations:The class sagemaker.session.s3_input has been renamed in sagemaker>=2.
See: https://sagemaker.readthedocs.io/en/stable/v2.html for details.
Creating trial pt-gpt2-pytorch-cur-testtp-preview-0-1-p4d-24xlarge-2-seq-1-ddp-cluster-tp2--shard0--partial0-2022-07-19-02-18-56 under experiment rubik-pipeline
checkpoint s3 bucket: s3://rubik-mp-benchmarks/output/pytorch_gpt2/logits_shard_0_pytorch-cur-testtp-preview-0-1-p4d-24xlarge-2-seq-1-ddp/
INFO:sagemaker.image_uris:Defaulting to the only supported framework/algorithm version: latest.
INFO:sagemaker.image_uris:Ignoring unnecessary instance type: None.
INFO:sagemaker:Creating training-job with name: rubik-pytorch-cur-testtp-preview-0-1-p4d-24xlar-1658197137-2b71
2022-07-19 02:18:59 Starting - Starting the training job..
```
## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
