### PR TITLE
feature: make estimator accept json file as modelparallel config

### DIFF
--- a/src/sagemaker/fw_utils.py
+++ b/src/sagemaker/fw_utils.py
@@ -13,6 +13,7 @@
 """Utility methods used by framework classes"""
 from __future__ import absolute_import
 
+import json
 import logging
 import os
 import re
@@ -21,6 +22,7 @@ import shutil
 import tempfile
 from collections import namedtuple
 from typing import Optional, Union, Dict
+import yaml
 
 import sagemaker.image_uris
 from sagemaker.session_settings import SessionSettings
@@ -234,6 +236,45 @@ def validate_source_code_input_against_pipeline_variables(
         )
 
 
+def parse_mp_parameters(params):
+    """Parse the model parallelism parameters provided by the user.
+
+    Args:
+        params: a string representing path to an existing config, or
+                a config dict.
+
+    Returns:
+        parsed: a dict of parsed config.
+
+    Raises:
+        ValueError: if params is not a string or a dict, or
+                    the config file cannot be parsed as json or yaml.
+    """
+    parsed = None
+    if isinstance(params, dict):
+        parsed = params
+    elif os.path.exists(params):
+        try:
+            with open(params, "r") as fp:
+                parsed = json.load(fp)
+        except json.decoder.JSONDecodeError:
+            try:
+                with open(params, "r") as fp:
+                    parsed = yaml.load(fp)
+            except yaml.YAMLError:
+                pass
+    else:
+        raise ValueError(
+            f"Expected a string path to an existing modelparallel config, or a dictionary. "
+            f"Received: {params}."
+        )
+
+    if parsed is None:
+        raise ValueError(f"Cannot parse {params} as a json or yaml file.")
+
+    return parsed
+
+
 def get_mp_parameters(distribution):
     """Get the model parallelism parameters provided by the user.
 
@@ -250,6 +291,7 @@ def get_mp_parameters(distribution):
         mp_dict = {}
     if mp_dict.get("enabled", False) is True:
         params = mp_dict.get("parameters", {})
+        params = parse_mp_parameters(params)
         validate_mp_config(params)
         return params
     return None

--- a/src/sagemaker/fw_utils.py
+++ b/src/sagemaker/fw_utils.py
@@ -22,7 +22,6 @@ import shutil
 import tempfile
 from collections import namedtuple
 from typing import Optional, Union, Dict
-import yaml
 
 import sagemaker.image_uris
 from sagemaker.session_settings import SessionSettings
@@ -248,7 +247,7 @@ def parse_mp_parameters(params):
 
     Raises:
         ValueError: if params is not a string or a dict, or
-                    the config file cannot be parsed as json or yaml.
+                    the config file cannot be parsed as json.
     """
     parsed = None
     if isinstance(params, dict):
@@ -258,11 +257,7 @@ def parse_mp_parameters(params):
             with open(params, "r") as fp:
                 parsed = json.load(fp)
         except json.decoder.JSONDecodeError:
-            try:
-                with open(params, "r") as fp:
-                    parsed = yaml.load(fp)
-            except yaml.YAMLError:
-                pass
+            pass
     else:
         raise ValueError(
             f"Expected a string path to an existing modelparallel config, or a dictionary. "
@@ -270,7 +265,7 @@ def parse_mp_parameters(params):
         )
 
     if parsed is None:
-        raise ValueError(f"Cannot parse {params} as a json or yaml file.")
+        raise ValueError(f"Cannot parse {params} as a json file.")
 
     return parsed
 

--- a/tests/unit/test_fw_utils.py
+++ b/tests/unit/test_fw_utils.py
@@ -13,10 +13,12 @@
 from __future__ import absolute_import
 
 import inspect
+import json
 import os
 import tarfile
 from contextlib import contextmanager
 from itertools import product
+import yaml
 
 import pytest
 
@@ -190,6 +192,61 @@ def test_validate_source_dir_file_not_in_dir():
     directory = "."
     with pytest.raises(ValueError):
         fw_utils.validate_source_dir(script, directory)
+
+
+def test_parse_mp_parameters_input_dict():
+    mp_parameters = {
+        "partitions": 1,
+        "tensor_parallel_degree": 2,
+        "microbatches": 1,
+        "optimize": "speed",
+        "pipeline": "interleaved",
+        "ddp": 1,
+        "auto_partition": False,
+        "default_partition": 0,
+    }
+    assert mp_parameters == fw_utils.parse_mp_parameters(mp_parameters)
+
+
+def test_parse_mp_parameters_input_str_json():
+    mp_parameters = {
+        "partitions": 1,
+        "tensor_parallel_degree": 2,
+        "microbatches": 1,
+        "optimize": "speed",
+        "pipeline": "interleaved",
+        "ddp": 1,
+        "auto_partition": False,
+        "default_partition": 0,
+    }
+    json_file_path = "./params.json"
+    with open(json_file_path, "x") as fp:
+        json.dump(mp_parameters, fp)
+    assert mp_parameters == fw_utils.parse_mp_parameters(json_file_path)
+    os.remove(json_file_path)
+
+
+def test_parse_mp_parameters_input_str_yaml():
+    mp_parameters = {
+        "partitions": 1,
+        "tensor_parallel_degree": 2,
+        "microbatches": 1,
+        "optimize": "speed",
+        "pipeline": "interleaved",
+        "ddp": 1,
+        "auto_partition": False,
+        "default_partition": 0,
+    }
+    yaml_file_path = "./params.yaml"
+    with open(yaml_file_path, "x") as fp:
+        yaml.dump(mp_parameters, fp)
+    assert mp_parameters == fw_utils.parse_mp_parameters(yaml_file_path)
+    os.remove(yaml_file_path)
+
+
+def test_parse_mp_parameters_input_not_exit():
+    with pytest.raises(ValueError):
+        fw_utils.parse_mp_parameters(" !@#$%^&*()path probably in not there.!@#$%^&*()")
 
 
 def test_tar_and_upload_dir_not_s3(sagemaker_session):

--- a/tests/unit/test_fw_utils.py
+++ b/tests/unit/test_fw_utils.py
@@ -18,7 +18,6 @@ import os
 import tarfile
 from contextlib import contextmanager
 from itertools import product
-import yaml
 
 import pytest
 
@@ -224,24 +223,6 @@ def test_parse_mp_parameters_input_str_json():
         json.dump(mp_parameters, fp)
     assert mp_parameters == fw_utils.parse_mp_parameters(json_file_path)
     os.remove(json_file_path)
-
-
-def test_parse_mp_parameters_input_str_yaml():
-    mp_parameters = {
-        "partitions": 1,
-        "tensor_parallel_degree": 2,
-        "microbatches": 1,
-        "optimize": "speed",
-        "pipeline": "interleaved",
-        "ddp": 1,
-        "auto_partition": False,
-        "default_partition": 0,
-    }
-    yaml_file_path = "./params.yaml"
-    with open(yaml_file_path, "x") as fp:
-        yaml.dump(mp_parameters, fp)
-    assert mp_parameters == fw_utils.parse_mp_parameters(yaml_file_path)
-    os.remove(yaml_file_path)
 
 
 def test_parse_mp_parameters_input_not_exit():


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* When passing distribution dict to estimator API PyTorch, we can let smp_config be either a dict (current behavior) or a string representing a config file.
```
            distribution = {
                "smdistributed": {
                    "modelparallel": {
                        "enabled": True,
                        "parameters": smp_config,
                    },
                },
                ...
            }
```
The config file needs to be a json file. e.g., `params.json`
```
{"partitions": 1, "tensor_parallel_degree": 2, "microbatches": 1, "optimize": "speed", "pipeline": "interleaved", "ddp": 1, "auto_partition": false, "default_partition": 0}
```

*Testing done:* local unit tests

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
