### PR TITLE
feature: added _AnalysisConfigGenerator for clarify

### DIFF
--- a/src/sagemaker/clarify.py
+++ b/src/sagemaker/clarify.py
@@ -1088,11 +1088,8 @@ class SageMakerClarifyProcessor(Processor):
             bias_config,
             methods
         )
-        if job_name is None:
-            if self.job_name_prefix:
-                job_name = utils.name_from_base(self.job_name_prefix)
-            else:
-                job_name = utils.name_from_base("Clarify-Pretraining-Bias")
+        # when name is either not provided (is None) or an empty string ("")
+        job_name = job_name or utils.name_from_base(self.job_name_prefix or "Clarify-Pretraining-Bias")
         return self._run(
             data_config,
             analysis_config,
@@ -1174,11 +1171,8 @@ class SageMakerClarifyProcessor(Processor):
             methods,
             model_config
         )
-        if job_name is None:
-            if self.job_name_prefix:
-                job_name = utils.name_from_base(self.job_name_prefix)
-            else:
-                job_name = utils.name_from_base("Clarify-Posttraining-Bias")
+        # when name is either not provided (is None) or an empty string ("")
+        job_name = job_name or utils.name_from_base(self.job_name_prefix or "Clarify-Posttraining-Bias")
         return self._run(
             data_config,
             analysis_config,
@@ -1271,11 +1265,8 @@ class SageMakerClarifyProcessor(Processor):
             pre_training_methods,
             post_training_methods,
         )
-        if job_name is None:
-            if self.job_name_prefix:
-                job_name = utils.name_from_base(self.job_name_prefix)
-            else:
-                job_name = utils.name_from_base("Clarify-Bias")
+        # when name is either not provided (is None) or an empty string ("")
+        job_name = job_name or utils.name_from_base(self.job_name_prefix or "Clarify-Bias")
         return self._run(
             data_config,
             analysis_config,
@@ -1366,11 +1357,8 @@ class SageMakerClarifyProcessor(Processor):
             model_scores,
             explainability_config
         )
-        if job_name is None:
-            if self.job_name_prefix:
-                job_name = utils.name_from_base(self.job_name_prefix)
-            else:
-                job_name = utils.name_from_base("Clarify-Explainability")
+        # when name is either not provided (is None) or an empty string ("")
+        job_name = job_name or utils.name_from_base(self.job_name_prefix or "Clarify-Explainability")
         return self._run(
             data_config,
             analysis_config,

--- a/src/sagemaker/clarify.py
+++ b/src/sagemaker/clarify.py
@@ -983,6 +983,10 @@ class SageMakerClarifyProcessor(Processor):
                   the Trial Component will be unassociated.
                 * ``'TrialComponentDisplayName'`` is used for display in Amazon SageMaker Studio.
         """
+        # for debugging: to access locally, i.e. without a need to look for it in an S3 bucket
+        self._last_analysis_config = analysis_config
+        logger.info("Analysis Config: ", analysis_config)
+
         with tempfile.TemporaryDirectory() as tmpdirname:
             analysis_config_file = os.path.join(tmpdirname, "analysis_config.json")
             with open(analysis_config_file, "w") as f:

--- a/src/sagemaker/clarify.py
+++ b/src/sagemaker/clarify.py
@@ -983,10 +983,6 @@ class SageMakerClarifyProcessor(Processor):
                   the Trial Component will be unassociated.
                 * ``'TrialComponentDisplayName'`` is used for display in Amazon SageMaker Studio.
         """
-        analysis_config["methods"]["report"] = {
-            "name": "report",
-            "title": "Analysis Report",
-        }
         with tempfile.TemporaryDirectory() as tmpdirname:
             analysis_config_file = os.path.join(tmpdirname, "analysis_config.json")
             with open(analysis_config_file, "w") as f:
@@ -1371,8 +1367,9 @@ class SageMakerClarifyProcessor(Processor):
 
 
 class _AnalysisConfigGenerator:
-    @staticmethod
+    @classmethod
     def explainability(
+        cls,
         data_config,
         model_config,
         model_scores,
@@ -1414,22 +1411,23 @@ class _AnalysisConfigGenerator:
             explainability_methods = explainability_config.get_explainability_config()
         analysis_config["methods"] = explainability_methods
         analysis_config["predictor"] = predictor_config
-        return analysis_config
+        return cls._common(analysis_config)
 
-    @staticmethod
-    def bias_pre_training(data_config, bias_config, methods):
+    @classmethod
+    def bias_pre_training(cls, data_config, bias_config, methods):
         analysis_config = data_config.get_config()
         analysis_config.update(bias_config.get_config())
         analysis_config["methods"] = {"pre_training_bias": {"methods": methods}}
-        return analysis_config
+        return cls._common(analysis_config)
 
-    @staticmethod
+    @classmethod
     def bias_post_training(
-            data_config,
-            bias_config,
-            model_predicted_label_config,
-            methods,
-            model_config
+        cls,
+        data_config,
+        bias_config,
+        model_predicted_label_config,
+        methods,
+        model_config
     ):
         analysis_config = data_config.get_config()
         analysis_config.update(bias_config.get_config())
@@ -1441,10 +1439,11 @@ class _AnalysisConfigGenerator:
         predictor_config.update(model_config.get_predictor_config())
         analysis_config["predictor"] = predictor_config
         _set(probability_threshold, "probability_threshold", analysis_config)
-        return analysis_config
+        return cls._common(analysis_config)
 
-    @staticmethod
+    @classmethod
     def bias(
+        cls,
         data_config,
         bias_config,
         model_config,
@@ -1469,7 +1468,7 @@ class _AnalysisConfigGenerator:
             "pre_training_bias": {"methods": pre_training_methods},
             "post_training_bias": {"methods": post_training_methods},
         }
-        return analysis_config
+        return cls._common(analysis_config)
 
     @staticmethod
     def _common(analysis_config):

--- a/src/sagemaker/clarify.py
+++ b/src/sagemaker/clarify.py
@@ -1167,16 +1167,13 @@ class SageMakerClarifyProcessor(Processor):
                   the Trial Component will be unassociated.
                 * ``'TrialComponentDisplayName'`` is used for display in Amazon SageMaker Studio.
         """  # noqa E501  # pylint: disable=c0301
-        analysis_config = data_config.get_config()
-        analysis_config.update(data_bias_config.get_config())
-        (
-            probability_threshold,
-            predictor_config,
-        ) = model_predicted_label_config.get_predictor_config()
-        predictor_config.update(model_config.get_predictor_config())
-        analysis_config["methods"] = {"post_training_bias": {"methods": methods}}
-        analysis_config["predictor"] = predictor_config
-        _set(probability_threshold, "probability_threshold", analysis_config)
+        analysis_config = _AnalysisConfigGenerator.bias_post_training(
+            data_config,
+            data_bias_config,
+            model_predicted_label_config,
+            methods,
+            model_config
+        )
         if job_name is None:
             if self.job_name_prefix:
                 job_name = utils.name_from_base(self.job_name_prefix)
@@ -1445,6 +1442,26 @@ class _AnalysisConfigGenerator:
         analysis_config = data_config.get_config()
         analysis_config.update(data_bias_config.get_config())
         analysis_config["methods"] = {"pre_training_bias": {"methods": methods}}
+        return analysis_config
+
+    @staticmethod
+    def bias_post_training(
+            data_config,
+            data_bias_config,
+            model_predicted_label_config,
+            methods,
+            model_config
+    ):
+        analysis_config = data_config.get_config()
+        analysis_config.update(data_bias_config.get_config())
+        analysis_config["methods"] = {"post_training_bias": {"methods": methods}}
+        (
+            probability_threshold,
+            predictor_config,
+        ) = model_predicted_label_config.get_predictor_config()
+        predictor_config.update(model_config.get_predictor_config())
+        analysis_config["predictor"] = predictor_config
+        _set(probability_threshold, "probability_threshold", analysis_config)
         return analysis_config
 
     @staticmethod

--- a/src/sagemaker/clarify.py
+++ b/src/sagemaker/clarify.py
@@ -1083,9 +1083,11 @@ class SageMakerClarifyProcessor(Processor):
                   the Trial Component will be unassociated.
                 * ``'TrialComponentDisplayName'`` is used for display in Amazon SageMaker Studio.
         """  # noqa E501  # pylint: disable=c0301
-        analysis_config = data_config.get_config()
-        analysis_config.update(data_bias_config.get_config())
-        analysis_config["methods"] = {"pre_training_bias": {"methods": methods}}
+        analysis_config = _AnalysisConfigGenerator.bias_pre_training(
+            data_config,
+            data_bias_config,
+            methods
+        )
         if job_name is None:
             if self.job_name_prefix:
                 job_name = utils.name_from_base(self.job_name_prefix)
@@ -1436,6 +1438,21 @@ class _AnalysisConfigGenerator:
             explainability_methods = explainability_config.get_explainability_config()
         analysis_config["methods"] = explainability_methods
         analysis_config["predictor"] = predictor_config
+        return analysis_config
+
+    @staticmethod
+    def bias_pre_training(data_config, data_bias_config, methods):
+        analysis_config = data_config.get_config()
+        analysis_config.update(data_bias_config.get_config())
+        analysis_config["methods"] = {"pre_training_bias": {"methods": methods}}
+        return analysis_config
+
+    @staticmethod
+    def _common(analysis_config):
+        analysis_config["methods"]["report"] = {
+            "name": "report",
+            "title": "Analysis Report",
+        }
         return analysis_config
 
 

--- a/src/sagemaker/clarify.py
+++ b/src/sagemaker/clarify.py
@@ -25,6 +25,8 @@ import re
 
 import tempfile
 from abc import ABC, abstractmethod
+from typing import List, Union
+
 from sagemaker import image_uris, s3, utils
 from sagemaker.processing import ProcessingInput, ProcessingOutput, Processor
 
@@ -1034,7 +1036,7 @@ class SageMakerClarifyProcessor(Processor):
     def run_pre_training_bias(
         self,
         data_config,
-        bias_config,
+        data_bias_config,
         methods="all",
         wait=True,
         logs=True,
@@ -1049,7 +1051,7 @@ class SageMakerClarifyProcessor(Processor):
 
         Args:
             data_config (:class:`~sagemaker.clarify.DataConfig`): Config of the input/output data.
-            bias_config (:class:`~sagemaker.clarify.BiasConfig`): Config of sensitive groups.
+            data_bias_config (:class:`~sagemaker.clarify.BiasConfig`): Config of sensitive groups.
             methods (str or list[str]): Selects a subset of potential metrics:
                 ["`CI <https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-bias-metric-class-imbalance.html>`_",
                 "`DPL <https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-data-bias-metric-true-label-imbalance.html>`_",
@@ -1085,7 +1087,7 @@ class SageMakerClarifyProcessor(Processor):
         """  # noqa E501  # pylint: disable=c0301
         analysis_config = _AnalysisConfigGenerator.bias_pre_training(
             data_config,
-            bias_config,
+            data_bias_config,
             methods
         )
         # when name is either not provided (is None) or an empty string ("")
@@ -1103,7 +1105,7 @@ class SageMakerClarifyProcessor(Processor):
     def run_post_training_bias(
         self,
         data_config,
-        bias_config,
+        data_bias_config,
         model_config,
         model_predicted_label_config,
         methods="all",
@@ -1123,7 +1125,7 @@ class SageMakerClarifyProcessor(Processor):
 
         Args:
             data_config (:class:`~sagemaker.clarify.DataConfig`): Config of the input/output data.
-            bias_config (:class:`~sagemaker.clarify.BiasConfig`): Config of sensitive groups.
+            data_bias_config (:class:`~sagemaker.clarify.BiasConfig`): Config of sensitive groups.
             model_config (:class:`~sagemaker.clarify.ModelConfig`): Config of the model and its
                 endpoint to be created.
             model_predicted_label_config (:class:`~sagemaker.clarify.ModelPredictedLabelConfig`):
@@ -1166,7 +1168,7 @@ class SageMakerClarifyProcessor(Processor):
         """  # noqa E501  # pylint: disable=c0301
         analysis_config = _AnalysisConfigGenerator.bias_post_training(
             data_config,
-            bias_config,
+            data_bias_config,
             model_predicted_label_config,
             methods,
             model_config
@@ -1377,10 +1379,10 @@ class _AnalysisConfigGenerator:
     @classmethod
     def explainability(
         cls,
-        data_config,
-        model_config,
-        model_scores,
-        explainability_config
+        data_config: DataConfig,
+        model_config: ModelConfig,
+        model_scores: ModelPredictedLabelConfig,
+        explainability_config: ExplainabilityConfig,
     ):
         analysis_config = data_config.get_config()
         predictor_config = model_config.get_predictor_config()
@@ -1421,7 +1423,7 @@ class _AnalysisConfigGenerator:
         return cls._common(analysis_config)
 
     @classmethod
-    def bias_pre_training(cls, data_config, bias_config, methods):
+    def bias_pre_training(cls, data_config: DataConfig, bias_config: BiasConfig, methods: Union[str, List[str]]):
         analysis_config = {
             **data_config.get_config(),
             **bias_config.get_config(),
@@ -1432,11 +1434,11 @@ class _AnalysisConfigGenerator:
     @classmethod
     def bias_post_training(
         cls,
-        data_config,
-        bias_config,
-        model_predicted_label_config,
-        methods,
-        model_config
+        data_config: DataConfig,
+        bias_config: BiasConfig,
+        model_predicted_label_config: ModelPredictedLabelConfig,
+        methods: Union[str, List[str]],
+        model_config: ModelConfig,
     ):
         analysis_config = {
             **data_config.get_config(),
@@ -1454,12 +1456,12 @@ class _AnalysisConfigGenerator:
     @classmethod
     def bias(
         cls,
-        data_config,
-        bias_config,
-        model_config,
-        model_predicted_label_config,
-        pre_training_methods="all",
-        post_training_methods="all",
+        data_config: DataConfig,
+        bias_config: BiasConfig,
+        model_config: ModelConfig,
+        model_predicted_label_config: ModelPredictedLabelConfig,
+        pre_training_methods: Union[str, List[str]] = "all",
+        post_training_methods: Union[str, List[str]] = "all",
     ):
         analysis_config = {
             **data_config.get_config(),

--- a/tests/unit/test_clarify.py
+++ b/tests/unit/test_clarify.py
@@ -766,8 +766,8 @@ def test_pre_training_bias(
             "facet": [{"name_or_index": "F1"}],
             "group_variable": "F2",
             "methods": {
-                'report': {'name': 'report', 'title': 'Analysis Report'},
-                "pre_training_bias": {"methods": "all"}
+                "report": {"name": "report", "title": "Analysis Report"},
+                "pre_training_bias": {"methods": "all"},
             },
         }
         mock_method.assert_called_with(
@@ -832,8 +832,8 @@ def test_post_training_bias(
             "facet": [{"name_or_index": "F1"}],
             "group_variable": "F2",
             "methods": {
-                'report': {'name': 'report', 'title': 'Analysis Report'},
-                "post_training_bias": {"methods": "all"}
+                "report": {"name": "report", "title": "Analysis Report"},
+                "post_training_bias": {"methods": "all"},
             },
             "predictor": {
                 "model_name": "xgboost-model",
@@ -993,7 +993,7 @@ def _run_test_explain(
                 "top_k_features": 10,
             }
         expected_analysis_config["methods"] = {
-            'report': {'name': 'report', 'title': 'Analysis Report'},
+            "report": {"name": "report", "title": "Analysis Report"},
             **expected_explanation_configs,
         }
         mock_method.assert_called_with(
@@ -1300,43 +1300,49 @@ def test_analysis_config_generator_for_explainability(data_config, model_config)
         model_scores,
         SHAPConfig(),
     )
-    expected = {'dataset_type': 'text/csv',
-                'headers': ['Label', 'F1', 'F2', 'F3', 'F4'],
-                'joinsource_name_or_index': 'F4',
-                'label': 'Label',
-                'methods': {
-                    'report': {'name': 'report', 'title': 'Analysis Report'},
-                    'shap': {'save_local_shap_values': True, 'use_logit': False}
-                },
-                'predictor': {'initial_instance_count': 1,
-                              'instance_type': 'ml.c5.xlarge',
-                              'label_headers': ['success'],
-                              'model_name': 'xgboost-model',
-                              'probability': 'pr'}}
+    expected = {
+        "dataset_type": "text/csv",
+        "headers": ["Label", "F1", "F2", "F3", "F4"],
+        "joinsource_name_or_index": "F4",
+        "label": "Label",
+        "methods": {
+            "report": {"name": "report", "title": "Analysis Report"},
+            "shap": {"save_local_shap_values": True, "use_logit": False},
+        },
+        "predictor": {
+            "initial_instance_count": 1,
+            "instance_type": "ml.c5.xlarge",
+            "label_headers": ["success"],
+            "model_name": "xgboost-model",
+            "probability": "pr",
+        },
+    }
     assert actual == expected
 
 
 def test_analysis_config_generator_for_bias_pre_training(data_config, data_bias_config):
     actual = _AnalysisConfigGenerator.bias_pre_training(
-        data_config,
-        data_bias_config,
-        methods="all"
+        data_config, data_bias_config, methods="all"
     )
-    expected = {'dataset_type': 'text/csv',
-                'facet': [{'name_or_index': 'F1'}],
-                'group_variable': 'F2',
-                'headers': ['Label', 'F1', 'F2', 'F3', 'F4'],
-                'joinsource_name_or_index': 'F4',
-                'label': 'Label',
-                'label_values_or_threshold': [1],
-                'methods': {
-                    'report': {'name': 'report', 'title': 'Analysis Report'},
-                    'pre_training_bias': {'methods': 'all'}}
-                }
+    expected = {
+        "dataset_type": "text/csv",
+        "facet": [{"name_or_index": "F1"}],
+        "group_variable": "F2",
+        "headers": ["Label", "F1", "F2", "F3", "F4"],
+        "joinsource_name_or_index": "F4",
+        "label": "Label",
+        "label_values_or_threshold": [1],
+        "methods": {
+            "report": {"name": "report", "title": "Analysis Report"},
+            "pre_training_bias": {"methods": "all"},
+        },
+    }
     assert actual == expected
 
 
-def test_analysis_config_generator_for_bias_post_training(data_config, data_bias_config, model_config):
+def test_analysis_config_generator_for_bias_post_training(
+    data_config, data_bias_config, model_config
+):
     model_predicted_label_config = ModelPredictedLabelConfig(
         probability="pr",
         label_headers=["success"],
@@ -1348,22 +1354,26 @@ def test_analysis_config_generator_for_bias_post_training(data_config, data_bias
         methods="all",
         model_config=model_config,
     )
-    expected = {'dataset_type': 'text/csv',
-                'facet': [{'name_or_index': 'F1'}],
-                'group_variable': 'F2',
-                'headers': ['Label', 'F1', 'F2', 'F3', 'F4'],
-                'joinsource_name_or_index': 'F4',
-                'label': 'Label',
-                'label_values_or_threshold': [1],
-                'methods': {
-                    'report': {'name': 'report', 'title': 'Analysis Report'},
-                    'post_training_bias': {'methods': 'all'}
-                },
-                'predictor': {'initial_instance_count': 1,
-                              'instance_type': 'ml.c5.xlarge',
-                              'label_headers': ['success'],
-                              'model_name': 'xgboost-model',
-                              'probability': 'pr'}}
+    expected = {
+        "dataset_type": "text/csv",
+        "facet": [{"name_or_index": "F1"}],
+        "group_variable": "F2",
+        "headers": ["Label", "F1", "F2", "F3", "F4"],
+        "joinsource_name_or_index": "F4",
+        "label": "Label",
+        "label_values_or_threshold": [1],
+        "methods": {
+            "report": {"name": "report", "title": "Analysis Report"},
+            "post_training_bias": {"methods": "all"},
+        },
+        "predictor": {
+            "initial_instance_count": 1,
+            "instance_type": "ml.c5.xlarge",
+            "label_headers": ["success"],
+            "model_name": "xgboost-model",
+            "probability": "pr",
+        },
+    }
     assert actual == expected
 
 
@@ -1380,20 +1390,25 @@ def test_analysis_config_generator_for_bias(data_config, data_bias_config, model
         pre_training_methods="all",
         post_training_methods="all",
     )
-    expected = {'dataset_type': 'text/csv',
-                'facet': [{'name_or_index': 'F1'}],
-                'group_variable': 'F2',
-                'headers': ['Label', 'F1', 'F2', 'F3', 'F4'],
-                'joinsource_name_or_index': 'F4',
-                'label': 'Label',
-                'label_values_or_threshold': [1],
-                'methods': {
-                    'report': {'name': 'report', 'title': 'Analysis Report'},
-                    'post_training_bias': {'methods': 'all'},
-                    'pre_training_bias': {'methods': 'all'}},
-                'predictor': {'initial_instance_count': 1,
-                              'instance_type': 'ml.c5.xlarge',
-                              'label_headers': ['success'],
-                              'model_name': 'xgboost-model',
-                              'probability': 'pr'}}
+    expected = {
+        "dataset_type": "text/csv",
+        "facet": [{"name_or_index": "F1"}],
+        "group_variable": "F2",
+        "headers": ["Label", "F1", "F2", "F3", "F4"],
+        "joinsource_name_or_index": "F4",
+        "label": "Label",
+        "label_values_or_threshold": [1],
+        "methods": {
+            "report": {"name": "report", "title": "Analysis Report"},
+            "post_training_bias": {"methods": "all"},
+            "pre_training_bias": {"methods": "all"},
+        },
+        "predictor": {
+            "initial_instance_count": 1,
+            "instance_type": "ml.c5.xlarge",
+            "label_headers": ["success"],
+            "model_name": "xgboost-model",
+            "probability": "pr",
+        },
+    }
     assert actual == expected

--- a/tests/unit/test_clarify.py
+++ b/tests/unit/test_clarify.py
@@ -1319,3 +1319,31 @@ def test_analysis_config_generator_for_bias_pre_training(data_config, data_bias_
                 'label_values_or_threshold': [1],
                 'methods': {'pre_training_bias': {'methods': 'all'}}}
     assert actual == expected
+
+
+def test_analysis_config_generator_for_bias_post_training(data_config, data_bias_config, model_config):
+    model_predicted_label_config = ModelPredictedLabelConfig(
+        probability="pr",
+        label_headers=["success"],
+    )
+    actual = _AnalysisConfigGenerator.bias_post_training(
+        data_config,
+        data_bias_config,
+        model_predicted_label_config,
+        methods="all",
+        model_config=model_config,
+    )
+    expected = {'dataset_type': 'text/csv',
+                'facet': [{'name_or_index': 'F1'}],
+                'group_variable': 'F2',
+                'headers': ['Label', 'F1', 'F2', 'F3', 'F4'],
+                'joinsource_name_or_index': 'F4',
+                'label': 'Label',
+                'label_values_or_threshold': [1],
+                'methods': {'post_training_bias': {'methods': 'all'}},
+                'predictor': {'initial_instance_count': 1,
+                              'instance_type': 'ml.c5.xlarge',
+                              'label_headers': ['success'],
+                              'model_name': 'xgboost-model',
+                              'probability': 'pr'}}
+    assert actual == expected

--- a/tests/unit/test_clarify.py
+++ b/tests/unit/test_clarify.py
@@ -1303,3 +1303,19 @@ def test_analysis_config_generator_for_explainability(data_config, model_config)
                               'probability': 'pr'}}
     assert actual == expected
 
+
+def test_analysis_config_generator_for_bias_pre_training(data_config, data_bias_config):
+    actual = _AnalysisConfigGenerator.bias_pre_training(
+        data_config,
+        data_bias_config,
+        methods="all"
+    )
+    expected = {'dataset_type': 'text/csv',
+                'facet': [{'name_or_index': 'F1'}],
+                'group_variable': 'F2',
+                'headers': ['Label', 'F1', 'F2', 'F3', 'F4'],
+                'joinsource_name_or_index': 'F4',
+                'label': 'Label',
+                'label_values_or_threshold': [1],
+                'methods': {'pre_training_bias': {'methods': 'all'}}}
+    assert actual == expected

--- a/tests/unit/test_clarify.py
+++ b/tests/unit/test_clarify.py
@@ -1347,3 +1347,33 @@ def test_analysis_config_generator_for_bias_post_training(data_config, data_bias
                               'model_name': 'xgboost-model',
                               'probability': 'pr'}}
     assert actual == expected
+
+
+def test_analysis_config_generator_for_bias(data_config, data_bias_config, model_config):
+    model_predicted_label_config = ModelPredictedLabelConfig(
+        probability="pr",
+        label_headers=["success"],
+    )
+    actual = _AnalysisConfigGenerator.bias(
+        data_config,
+        data_bias_config,
+        model_config,
+        model_predicted_label_config,
+        pre_training_methods="all",
+        post_training_methods="all",
+    )
+    expected = {'dataset_type': 'text/csv',
+                'facet': [{'name_or_index': 'F1'}],
+                           'group_variable': 'F2',
+                           'headers': ['Label', 'F1', 'F2', 'F3', 'F4'],
+                           'joinsource_name_or_index': 'F4',
+                           'label': 'Label',
+                           'label_values_or_threshold': [1],
+                           'methods': {'post_training_bias': {'methods': 'all'},
+                                       'pre_training_bias': {'methods': 'all'}},
+                           'predictor': {'initial_instance_count': 1,
+                                         'instance_type': 'ml.c5.xlarge',
+                                         'label_headers': ['success'],
+                                         'model_name': 'xgboost-model',
+                                         'probability': 'pr'}}
+    assert actual == expected

--- a/tests/unit/test_clarify.py
+++ b/tests/unit/test_clarify.py
@@ -1382,18 +1382,18 @@ def test_analysis_config_generator_for_bias(data_config, data_bias_config, model
     )
     expected = {'dataset_type': 'text/csv',
                 'facet': [{'name_or_index': 'F1'}],
-                           'group_variable': 'F2',
-                           'headers': ['Label', 'F1', 'F2', 'F3', 'F4'],
-                           'joinsource_name_or_index': 'F4',
-                           'label': 'Label',
-                           'label_values_or_threshold': [1],
-                           'methods': {
-                               'report': {'name': 'report', 'title': 'Analysis Report'},
-                               'post_training_bias': {'methods': 'all'},
-                               'pre_training_bias': {'methods': 'all'}},
-                           'predictor': {'initial_instance_count': 1,
-                                         'instance_type': 'ml.c5.xlarge',
-                                         'label_headers': ['success'],
-                                         'model_name': 'xgboost-model',
-                                         'probability': 'pr'}}
+                'group_variable': 'F2',
+                'headers': ['Label', 'F1', 'F2', 'F3', 'F4'],
+                'joinsource_name_or_index': 'F4',
+                'label': 'Label',
+                'label_values_or_threshold': [1],
+                'methods': {
+                    'report': {'name': 'report', 'title': 'Analysis Report'},
+                    'post_training_bias': {'methods': 'all'},
+                    'pre_training_bias': {'methods': 'all'}},
+                'predictor': {'initial_instance_count': 1,
+                              'instance_type': 'ml.c5.xlarge',
+                              'label_headers': ['success'],
+                              'model_name': 'xgboost-model',
+                              'probability': 'pr'}}
     assert actual == expected

--- a/tests/unit/test_clarify.py
+++ b/tests/unit/test_clarify.py
@@ -29,6 +29,7 @@ from sagemaker.clarify import (
     SHAPConfig,
     TextConfig,
     ImageConfig,
+    _AnalysisConfigGenerator,
 )
 
 JOB_NAME_PREFIX = "my-prefix"
@@ -1277,3 +1278,28 @@ def test_shap_with_image_config(
         expected_predictor_config,
         expected_image_config=expected_image_config,
     )
+
+
+def test_analysis_config_generator_for_explainability(data_config, model_config):
+    model_scores = ModelPredictedLabelConfig(
+        probability="pr",
+        label_headers=["success"],
+    )
+    actual = _AnalysisConfigGenerator.explainability(
+        data_config,
+        model_config,
+        model_scores,
+        SHAPConfig(),
+    )
+    expected = {'dataset_type': 'text/csv',
+                'headers': ['Label', 'F1', 'F2', 'F3', 'F4'],
+                'joinsource_name_or_index': 'F4',
+                'label': 'Label',
+                'methods': {'shap': {'save_local_shap_values': True, 'use_logit': False}},
+                'predictor': {'initial_instance_count': 1,
+                              'instance_type': 'ml.c5.xlarge',
+                              'label_headers': ['success'],
+                              'model_name': 'xgboost-model',
+                              'probability': 'pr'}}
+    assert actual == expected
+

--- a/tests/unit/test_clarify.py
+++ b/tests/unit/test_clarify.py
@@ -765,7 +765,10 @@ def test_pre_training_bias(
             "label_values_or_threshold": [1],
             "facet": [{"name_or_index": "F1"}],
             "group_variable": "F2",
-            "methods": {"pre_training_bias": {"methods": "all"}},
+            "methods": {
+                'report': {'name': 'report', 'title': 'Analysis Report'},
+                "pre_training_bias": {"methods": "all"}
+            },
         }
         mock_method.assert_called_with(
             data_config,
@@ -828,7 +831,10 @@ def test_post_training_bias(
             "joinsource_name_or_index": "F4",
             "facet": [{"name_or_index": "F1"}],
             "group_variable": "F2",
-            "methods": {"post_training_bias": {"methods": "all"}},
+            "methods": {
+                'report': {'name': 'report', 'title': 'Analysis Report'},
+                "post_training_bias": {"methods": "all"}
+            },
             "predictor": {
                 "model_name": "xgboost-model",
                 "instance_type": "ml.c5.xlarge",
@@ -986,7 +992,10 @@ def _run_test_explain(
                 "grid_resolution": 20,
                 "top_k_features": 10,
             }
-        expected_analysis_config["methods"] = expected_explanation_configs
+        expected_analysis_config["methods"] = {
+            'report': {'name': 'report', 'title': 'Analysis Report'},
+            **expected_explanation_configs,
+        }
         mock_method.assert_called_with(
             data_config,
             expected_analysis_config,
@@ -1295,7 +1304,10 @@ def test_analysis_config_generator_for_explainability(data_config, model_config)
                 'headers': ['Label', 'F1', 'F2', 'F3', 'F4'],
                 'joinsource_name_or_index': 'F4',
                 'label': 'Label',
-                'methods': {'shap': {'save_local_shap_values': True, 'use_logit': False}},
+                'methods': {
+                    'report': {'name': 'report', 'title': 'Analysis Report'},
+                    'shap': {'save_local_shap_values': True, 'use_logit': False}
+                },
                 'predictor': {'initial_instance_count': 1,
                               'instance_type': 'ml.c5.xlarge',
                               'label_headers': ['success'],
@@ -1317,7 +1329,10 @@ def test_analysis_config_generator_for_bias_pre_training(data_config, data_bias_
                 'joinsource_name_or_index': 'F4',
                 'label': 'Label',
                 'label_values_or_threshold': [1],
-                'methods': {'pre_training_bias': {'methods': 'all'}}}
+                'methods': {
+                    'report': {'name': 'report', 'title': 'Analysis Report'},
+                    'pre_training_bias': {'methods': 'all'}}
+                }
     assert actual == expected
 
 
@@ -1340,7 +1355,10 @@ def test_analysis_config_generator_for_bias_post_training(data_config, data_bias
                 'joinsource_name_or_index': 'F4',
                 'label': 'Label',
                 'label_values_or_threshold': [1],
-                'methods': {'post_training_bias': {'methods': 'all'}},
+                'methods': {
+                    'report': {'name': 'report', 'title': 'Analysis Report'},
+                    'post_training_bias': {'methods': 'all'}
+                },
                 'predictor': {'initial_instance_count': 1,
                               'instance_type': 'ml.c5.xlarge',
                               'label_headers': ['success'],
@@ -1369,8 +1387,10 @@ def test_analysis_config_generator_for_bias(data_config, data_bias_config, model
                            'joinsource_name_or_index': 'F4',
                            'label': 'Label',
                            'label_values_or_threshold': [1],
-                           'methods': {'post_training_bias': {'methods': 'all'},
-                                       'pre_training_bias': {'methods': 'all'}},
+                           'methods': {
+                               'report': {'name': 'report', 'title': 'Analysis Report'},
+                               'post_training_bias': {'methods': 'all'},
+                               'pre_training_bias': {'methods': 'all'}},
                            'predictor': {'initial_instance_count': 1,
                                          'instance_type': 'ml.c5.xlarge',
                                          'label_headers': ['success'],


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Added `_AnalysisConfigGenerator` class to simplify maintainability of the config creation. 
    - Also, with this generator, customers may reproduce the state of the config locally during debugging (i.e. without a need to opening it in the S3 bucket)
- Simplified `job_name` creation part
- Added a private method `_last_analysis_config`) to store last analysis_config used for a run (to be useful in case of debugging)
- Extended the std out with the analysis config used for a run. Currently it already prints other values, like Job Name, Inputs, and Outputs:

```
Job Name:  Clarify-Bias-2022-07-22-09-00-31-294
Inputs:  [{...}]
Outputs:  [...}]
```

*Testing done:*
Unit Tests

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
