### PR TITLE
documentation: Fix tensorflow and pytorch supported version in HuggingFaceProcessor

### DIFF
--- a/src/sagemaker/huggingface/processing.py
+++ b/src/sagemaker/huggingface/processing.py
@@ -68,10 +68,10 @@ class HuggingFaceProcessor(FrameworkProcessor):
                 ``image_uri`` is provided. The current supported version is ``4.4.2``.
             tensorflow_version (str): TensorFlow version you want to use for
                 executing your model training code. Defaults to ``None``. Required unless
-                ``pytorch_version`` is provided. The current supported version is ``1.6.0``.
+                ``pytorch_version`` is provided. The current supported version is ``2.4.1``.
             pytorch_version (str): PyTorch version you want to use for
                 executing your model training code. Defaults to ``None``. Required unless
-                ``tensorflow_version`` is provided. The current supported version is ``2.4.1``.
+                ``tensorflow_version`` is provided. The current supported version is ``1.6.0``.
             py_version (str): Python version you want to use for executing your model training
                 code. Defaults to ``None``. Required unless ``image_uri`` is provided.  If
                 using PyTorch, the current supported version is ``py36``. If using TensorFlow,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

![image](https://user-images.githubusercontent.com/25279765/183023275-2c5a0ecd-5884-40e9-ba98-d5826096371a.png)

There are conflicts between the specified version in docstring and the actual implementation. This PR fixes the docstring of the HuggingFaceProcessor to match actual implementation.

*Testing done:*



## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
