### PR TITLE
documentation: Correct documentation error

### DIFF
--- a/src/sagemaker/clarify.py
+++ b/src/sagemaker/clarify.py
@@ -63,7 +63,6 @@ class DataConfig:
             label (str): Target attribute of the model required by bias metrics.
                 Specified as column name or index for CSV dataset or as JSONPath for JSONLines.
                 *Required parameter* except for when the input dataset does not contain the label.
-                Cannot be used at the same time as ``predicted_label``.
             features (str): JSONPath for locating the feature columns for bias metrics if the
                 dataset format is JSONLines.
             dataset_type (str): Format of the dataset. Valid values are ``"text/csv"`` for CSV,
@@ -103,7 +102,7 @@ class DataConfig:
             predicted_label (str or int): Predicted label of the target attribute of the model
                 required for running bias analysis. Specified as column name or index for CSV data.
                 Clarify uses the predicted labels directly instead of making model inference API
-                calls. Cannot be used at the same time as ``label``.
+                calls.
             excluded_columns (list[int] or list[str]): A list of names or indices of the columns
                 which are to be excluded from making model inference API calls.
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Correct documentation error - `label` and `predicted_label` can be used together. 

*Testing done:* No tests. Just a documentation change

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
