### PR TITLE
fix: Update localmode code to decode urllib response as UTF8

### DIFF
--- a/src/sagemaker/local/entities.py
+++ b/src/sagemaker/local/entities.py
@@ -314,7 +314,7 @@ class _LocalTransformJob(object):
         endpoint_url = "http://%s:%d/execution-parameters" % (get_docker_host(), serving_port)
         response, code = _perform_request(endpoint_url)
         if code == 200:
-            execution_parameters = json.loads(response.read())
+            execution_parameters = json.loads(response.data.decode("utf-8"))
             # MaxConcurrentTransforms is ignored because we currently only support 1
             for setting in ("BatchStrategy", "MaxPayloadInMB"):
                 if setting not in kwargs and setting in execution_parameters:

--- a/tests/unit/test_local_entities.py
+++ b/tests/unit/test_local_entities.py
@@ -106,7 +106,7 @@ def test_start_local_transform_job(_perform_batch_inference, _perform_request, l
 
     response = Mock()
     _perform_request.return_value = (response, 200)
-    response.read.return_value = '{"BatchStrategy": "SingleRecord"}'
+    response.data = '{"BatchStrategy": "SingleRecord"}'.encode("UTF-8")
     local_transform_job.primary_container["ModelDataUrl"] = "file:///some/model"
     local_transform_job.start(input_data, output_data, transform_resources, Environment={})
 
@@ -176,9 +176,9 @@ def test_start_local_transform_job_from_remote_docker_host(
     output_data = {}
     transform_resources = {"InstanceType": "local"}
     m_get_docker_host.return_value = "some_host"
-    perform_request_mock = Mock()
-    m_perform_request.return_value = (perform_request_mock, 200)
-    perform_request_mock.read.return_value = '{"BatchStrategy": "SingleRecord"}'
+    response = Mock()
+    m_perform_request.return_value = (response, 200)
+    response.data = '{"BatchStrategy": "SingleRecord"}'.encode("UTF-8")
     local_transform_job.primary_container["ModelDataUrl"] = "file:///some/model"
     local_transform_job.start(input_data, output_data, transform_resources, Environment={})
     endpoints = [


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
