### PR TITLE
change: update validation for pytorchddp distribution

### DIFF
--- a/doc/frameworks/pytorch/using_pytorch.rst
+++ b/doc/frameworks/pytorch/using_pytorch.rst
@@ -212,7 +212,8 @@ with the ``pytorchddp`` option as the distribution strategy.
 .. note::
 
   This PyTorch DDP support is available
-  in the SageMaker PyTorch Deep Learning Containers v1.12 and later.
+  in the SageMaker PyTorch Deep Learning Containers v1.11 and later
+  on GPU instances.
 
 Adapt Your Training Script
 --------------------------
@@ -238,7 +239,6 @@ but you can also overwrite them.
 
 **Supported backends:**
 
--  ``gloo`` and ``tcp`` for CPU instances
 -  ``gloo`` and ``nccl`` for GPU instances
 
 Launching a Distributed Training Job

--- a/tests/unit/test_fw_utils.py
+++ b/tests/unit/test_fw_utils.py
@@ -855,6 +855,7 @@ def test_validate_smdataparallel_args_not_raises():
 def test_validate_pytorchddp_not_raises():
     # Case 1: Framework is not PyTorch
     fw_utils.validate_pytorch_distribution(
+        instance_type="ml.p4d.24xlarge",
         distribution=None,
         framework_name="tensorflow",
         framework_version="2.9.1",
@@ -864,18 +865,17 @@ def test_validate_pytorchddp_not_raises():
     # Case 2: Framework is PyTorch, but distribution is not PyTorchDDP
     pytorchddp_disabled = {"pytorchddp": {"enabled": False}}
     fw_utils.validate_pytorch_distribution(
+        instance_type="ml.p4d.24xlarge",
         distribution=pytorchddp_disabled,
         framework_name="pytorch",
-        framework_version="1.10",
+        framework_version="1.11",
         py_version="py3",
         image_uri="custom-container",
     )
-    # Case 3: Framework is PyTorch, Distribution is PyTorchDDP enabled, supported framework and py versions
+    # Case 3: Framework is PyTorch, Distribution is PyTorchDDP enabled,
+    # Framework version, py version and instance_type are supported
     pytorchddp_enabled = {"pytorchddp": {"enabled": True}}
     pytorchddp_supported_fw_versions = [
-        "1.10",
-        "1.10.0",
-        "1.10.2",
         "1.11",
         "1.11.0",
         "1.12",
@@ -883,6 +883,7 @@ def test_validate_pytorchddp_not_raises():
     ]
     for framework_version in pytorchddp_supported_fw_versions:
         fw_utils.validate_pytorch_distribution(
+            instance_type="local_gpu",
             distribution=pytorchddp_enabled,
             framework_name="pytorch",
             framework_version=framework_version,
@@ -896,6 +897,7 @@ def test_validate_pytorchddp_raises():
     # Case 1: Unsupported framework version
     with pytest.raises(ValueError):
         fw_utils.validate_pytorch_distribution(
+            instance_type="ml.p4d.24xlarge",
             distribution=pytorchddp_enabled,
             framework_name="pytorch",
             framework_version="1.8",
@@ -906,9 +908,21 @@ def test_validate_pytorchddp_raises():
     # Case 2: Unsupported Py version
     with pytest.raises(ValueError):
         fw_utils.validate_pytorch_distribution(
+            instance_type="ml.p4d.24xlarge",
             distribution=pytorchddp_enabled,
             framework_name="pytorch",
             framework_version="1.10",
             py_version="py2",
+            image_uri=None,
+        )
+
+    # Case 3: Unsupported instance type
+    with pytest.raises(ValueError):
+        fw_utils.validate_pytorch_distribution(
+            instance_type="ml.c5.xlarge",
+            distribution=pytorchddp_enabled,
+            framework_name="pytorch",
+            framework_version="1.12",
+            py_version="py3",
             image_uri=None,
         )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update validation and documentation for pytorchddp distribution.
* Framework version: 1.11+
* Instance type: local_gpu, g/p-based GPU instances

*Testing done:*
* Unit tests updated
* Tested custom whl in Jupyter throws validation error

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
