### PR TITLE
Add CGK in config for Spark Image

### DIFF
--- a/src/sagemaker/image_uri_config/spark.json
+++ b/src/sagemaker/image_uri_config/spark.json
@@ -27,7 +27,8 @@
                     "cn-northwest-1": "844356804704",
                     "eu-south-1": "753923664805",
                     "af-south-1": "309385258863",
-                    "us-gov-west-1": "271483468897"
+                    "us-gov-west-1": "271483468897",
+                    "ap-southeast-3": "732049463269"
                 },
                 "repository": "sagemaker-spark-processing"
             },
@@ -56,7 +57,8 @@
                         "cn-northwest-1": "844356804704",
                         "eu-south-1": "753923664805",
                         "af-south-1": "309385258863",
-                        "us-gov-west-1": "271483468897"
+                        "us-gov-west-1": "271483468897",
+                        "ap-southeast-3": "732049463269"
                     },
                     "repository": "sagemaker-spark-processing"
             },
@@ -85,7 +87,8 @@
                     "cn-northwest-1": "844356804704",
                     "eu-south-1": "753923664805",
                     "af-south-1": "309385258863",
-                    "us-gov-west-1": "271483468897"
+                    "us-gov-west-1": "271483468897",
+                    "ap-southeast-3": "732049463269"
                 },
                 "repository": "sagemaker-spark-processing"
             }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adding CGK region for Spark Image.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x ] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
