### PR TITLE
change: Add PipelineVariable annotation to framework estimators

### DIFF
--- a/src/sagemaker/algorithm.py
+++ b/src/sagemaker/algorithm.py
@@ -13,15 +13,22 @@
 """Test docstring"""
 from __future__ import absolute_import
 
+from typing import Optional, Union, Dict, List
+
 import sagemaker
 import sagemaker.parameter
 from sagemaker import vpc_utils
 from sagemaker.deserializers import BytesDeserializer
 from sagemaker.deprecations import removed_kwargs
 from sagemaker.estimator import EstimatorBase
+from sagemaker.inputs import TrainingInput, FileSystemInput
 from sagemaker.serializers import IdentitySerializer
 from sagemaker.transformer import Transformer
 from sagemaker.predictor import Predictor
+from sagemaker.session import Session
+from sagemaker.workflow.entities import PipelineVariable
+
+from sagemaker.workflow import is_pipeline_variable
 
 
 class AlgorithmEstimator(EstimatorBase):
@@ -37,28 +44,28 @@ class AlgorithmEstimator(EstimatorBase):
 
     def __init__(
         self,
-        algorithm_arn,
-        role,
-        instance_count,
-        instance_type,
-        volume_size=30,
-        volume_kms_key=None,
-        max_run=24 * 60 * 60,
-        input_mode="File",
-        output_path=None,
-        output_kms_key=None,
-        base_job_name=None,
-        sagemaker_session=None,
-        hyperparameters=None,
-        tags=None,
-        subnets=None,
-        security_group_ids=None,
-        model_uri=None,
-        model_channel_name="model",
-        metric_definitions=None,
-        encrypt_inter_container_traffic=False,
-        use_spot_instances=False,
-        max_wait=None,
+        algorithm_arn: str,
+        role: str,
+        instance_count: Optional[Union[int, PipelineVariable]] = None,
+        instance_type: Optional[Union[str, PipelineVariable]] = None,
+        volume_size: Union[int, PipelineVariable] = 30,
+        volume_kms_key: Optional[Union[str, PipelineVariable]] = None,
+        max_run: Union[int, PipelineVariable] = 24 * 60 * 60,
+        input_mode: Union[str, PipelineVariable] = "File",
+        output_path: Optional[Union[str, PipelineVariable]] = None,
+        output_kms_key: Optional[Union[str, PipelineVariable]] = None,
+        base_job_name: Optional[str] = None,
+        sagemaker_session: Optional[Session] = None,
+        hyperparameters: Optional[Dict[str, Union[str, PipelineVariable]]] = None,
+        tags: Optional[List[Dict[str, Union[str, PipelineVariable]]]] = None,
+        subnets: Optional[List[Union[str, PipelineVariable]]] = None,
+        security_group_ids: Optional[List[Union[str, PipelineVariable]]] = None,
+        model_uri: Optional[str] = None,
+        model_channel_name: Union[str, PipelineVariable] = "model",
+        metric_definitions: Optional[List[Dict[str, Union[str, PipelineVariable]]]] = None,
+        encrypt_inter_container_traffic: Union[bool, PipelineVariable] = False,
+        use_spot_instances: Union[bool, PipelineVariable] = False,
+        max_wait: Optional[Union[int, PipelineVariable]] = None,
         **kwargs  # pylint: disable=W0613
     ):
         """Initialize an ``AlgorithmEstimator`` instance.
@@ -71,18 +78,21 @@ class AlgorithmEstimator(EstimatorBase):
                 access training data and model artifacts. After the endpoint
                 is created, the inference code might use the IAM role, if it
                 needs to access an AWS resource.
-            instance_count (int): Number of Amazon EC2 instances to use for training.
-            instance_type (str): Type of EC2 instance to use for training, for example, 'ml.c4.xlarge'.
-            volume_size (int): Size in GB of the EBS volume to use for
+            instance_count (int or PipelineVariable): Number of Amazon EC2 instances to use
+                for training.
+            instance_type (str or PipelineVariable): Type of EC2 instance to use for training,
+                for example, 'ml.c4.xlarge'.
+            volume_size (int or PipelineVariable): Size in GB of the EBS volume to use for
                 storing input data during training (default: 30). Must be large enough to store
                 training data if File Mode is used (which is the default).
-            volume_kms_key (str): Optional. KMS key ID for encrypting EBS volume attached
-                to the training instance (default: None).
-            max_run (int): Timeout in seconds for training (default: 24 * 60 * 60).
+            volume_kms_key (str or PipelineVariable): Optional. KMS key ID for encrypting
+                EBS volume attached to the training instance (default: None).
+            max_run (int or PipelineVariable): Timeout in seconds for training
+                (default: 24 * 60 * 60).
                 After this amount of time Amazon SageMaker terminates the
                 job regardless of its current status.
-            input_mode (str): The input mode that the algorithm supports
-            (default: 'File'). Valid modes:
+            input_mode (str or PipelineVariable): The input mode that the algorithm supports
+                (default: 'File'). Valid modes:
 
                 * 'File' - Amazon SageMaker copies the training dataset from
                   the S3 location to a local directory.
@@ -92,13 +102,14 @@ class AlgorithmEstimator(EstimatorBase):
                 This argument can be overriden on a per-channel basis using
                 ``sagemaker.inputs.TrainingInput.input_mode``.
 
-            output_path (str): S3 location for saving the training result (model artifacts and
-                output files). If not specified, results are stored to a default bucket. If
+            output_path (str or PipelineVariable): S3 location for saving the training result
+                (model artifacts and output files). If not specified,
+                results are stored to a default bucket. If
                 the bucket with the specific name does not exist, the
                 estimator creates the bucket during the
                 :meth:`~sagemaker.estimator.EstimatorBase.fit` method
                 execution.
-            output_kms_key (str): Optional. KMS key ID for encrypting the
+            output_kms_key (str or PipelineVariable): Optional. KMS key ID for encrypting the
                 training output (default: None). base_job_name (str): Prefix for
                 training job name when the
                 :meth:`~sagemaker.estimator.EstimatorBase.fit`
@@ -109,9 +120,10 @@ class AlgorithmEstimator(EstimatorBase):
                 interactions with Amazon SageMaker APIs and any other AWS services needed. If
                 not specified, the estimator creates one using the default
                 AWS configuration chain.
-            tags (list[dict]): List of tags for labeling a training job. For more, see
+            tags (list[dict[str, str] or list[dict[str, PipelineVariable]]): List of tags for
+                labeling a training job. For more, see
                 https://docs.aws.amazon.com/sagemaker/latest/dg/API_Tag.html.
-            subnets (list[str]): List of subnet ids. If not specified
+            subnets (list[str] or list[PipelineVariable]): List of subnet ids. If not specified
                 training job will be created without VPC config.
                 security_group_ids (list[str]): List of security group ids. If
                 not specified training job will be created without VPC config.
@@ -122,22 +134,22 @@ class AlgorithmEstimator(EstimatorBase):
                 other artifacts coming from a different source.
                 More information:
                 https://docs.aws.amazon.com/sagemaker/latest/dg/cdf-training.html#td-deserialization
-            model_channel_name (str): Name of the channel where 'model_uri'
+            model_channel_name (str or PipelineVariable): Name of the channel where 'model_uri'
                 will be downloaded (default: 'model'). metric_definitions
                 (list[dict]): A list of dictionaries that defines the metric(s)
                 used to evaluate the training jobs. Each dictionary contains two keys: 'Name' for
                 the name of the metric, and 'Regex' for the regular
                 expression used to extract the metric from the logs.
-            encrypt_inter_container_traffic (bool): Specifies whether traffic between training
-                containers is encrypted for the training job (default: ``False``).
-            use_spot_instances (bool): Specifies whether to use SageMaker
+            encrypt_inter_container_traffic (bool or PipelineVariable): Specifies whether traffic
+                between training containers is encrypted for the training job (default: ``False``).
+            use_spot_instances (bool or PipelineVariable): Specifies whether to use SageMaker
                 Managed Spot instances for training. If enabled then the
                 `max_wait` arg should also be set.
 
                 More information:
                 https://docs.aws.amazon.com/sagemaker/latest/dg/model-managed-spot-training.html
                 (default: ``False``).
-            max_wait (int): Timeout in seconds waiting for spot training
+            max_wait (int or PipelineVariable): Timeout in seconds waiting for spot training
                 instances (default: None). After this amount of time Amazon
                 SageMaker will stop waiting for Spot instances to become
                 available (default: ``None``).
@@ -186,7 +198,7 @@ class AlgorithmEstimator(EstimatorBase):
         # Check that the input mode provided is compatible with the training input modes for the
         # algorithm.
         input_modes = self._algorithm_training_input_modes(train_spec["TrainingChannels"])
-        if self.input_mode not in input_modes:
+        if not is_pipeline_variable(self.input_mode) and self.input_mode not in input_modes:
             raise ValueError(
                 "Invalid input mode: %s. %s only supports: %s"
                 % (self.input_mode, algorithm_name, input_modes)
@@ -194,14 +206,17 @@ class AlgorithmEstimator(EstimatorBase):
 
         # Check that the training instance type is compatible with the algorithm.
         supported_instances = train_spec["SupportedTrainingInstanceTypes"]
-        if self.instance_type not in supported_instances:
+        if (
+            not is_pipeline_variable(self.instance_type)
+            and self.instance_type not in supported_instances
+        ):
             raise ValueError(
                 "Invalid instance_type: %s. %s supports the following instance types: %s"
                 % (self.instance_type, algorithm_name, supported_instances)
             )
 
         # Verify if distributed training is supported by the algorithm
-        if (
+        if not is_pipeline_variable(self.instance_count) and (
             self.instance_count > 1
             and "SupportsDistributedTraining" in train_spec
             and not train_spec["SupportsDistributedTraining"]
@@ -414,12 +429,18 @@ class AlgorithmEstimator(EstimatorBase):
 
         super(AlgorithmEstimator, self)._prepare_for_training(job_name)
 
-    def fit(self, inputs=None, wait=True, logs=True, job_name=None):
+    def fit(
+        self,
+        inputs: Optional[Union[str, Dict, TrainingInput, FileSystemInput]] = None,
+        wait: bool = True,
+        logs: bool = True,
+        job_name: Optional[str] = None,
+    ):
         """Placeholder docstring"""
         if inputs:
             self._validate_input_channels(inputs)
 
-        super(AlgorithmEstimator, self).fit(inputs, wait, logs, job_name)
+        return super(AlgorithmEstimator, self).fit(inputs, wait, logs, job_name)
 
     def _validate_input_channels(self, channels):
         """Placeholder docstring"""

--- a/src/sagemaker/chainer/estimator.py
+++ b/src/sagemaker/chainer/estimator.py
@@ -14,7 +14,7 @@
 from __future__ import absolute_import
 
 import logging
-from typing import Union, Optional
+from typing import Union, Optional, Dict
 
 from sagemaker.estimator import Framework, EstimatorBase
 from sagemaker.fw_utils import (
@@ -34,26 +34,26 @@ logger = logging.getLogger("sagemaker")
 class Chainer(Framework):
     """Handle end-to-end training and deployment of custom Chainer code."""
 
-    _framework_name = "chainer"
+    _framework_name: str = "chainer"
 
     # Hyperparameters
-    _use_mpi = "sagemaker_use_mpi"
-    _num_processes = "sagemaker_num_processes"
-    _process_slots_per_host = "sagemaker_process_slots_per_host"
-    _additional_mpi_options = "sagemaker_additional_mpi_options"
+    _use_mpi: str = "sagemaker_use_mpi"
+    _num_processes: str = "sagemaker_num_processes"
+    _process_slots_per_host: str = "sagemaker_process_slots_per_host"
+    _additional_mpi_options: str = "sagemaker_additional_mpi_options"
 
     def __init__(
         self,
         entry_point: Union[str, PipelineVariable],
-        use_mpi=None,
-        num_processes=None,
-        process_slots_per_host=None,
-        additional_mpi_options=None,
+        use_mpi: Optional[Union[bool, PipelineVariable]] = None,
+        num_processes: Optional[Union[int, PipelineVariable]] = None,
+        process_slots_per_host: Optional[Union[int, PipelineVariable]] = None,
+        additional_mpi_options: Optional[Union[str, PipelineVariable]] = None,
         source_dir: Optional[Union[str, PipelineVariable]] = None,
-        hyperparameters=None,
-        framework_version=None,
-        py_version=None,
-        image_uri=None,
+        hyperparameters: Optional[Dict[str, Union[str, PipelineVariable]]] = None,
+        framework_version: Optional[str] = None,
+        py_version: Optional[str] = None,
+        image_uri: Optional[Union[str, PipelineVariable]] = None,
         **kwargs
     ):
         """This ``Estimator`` executes an Chainer script in a managed execution environment.
@@ -78,17 +78,17 @@ class Chainer(Framework):
                 file which should be executed as the entry point to training.
                 If ``source_dir`` is specified, then ``entry_point``
                 must point to a file located at the root of ``source_dir``.
-            use_mpi (bool): If true, entry point is run as an MPI script. By
+            use_mpi (bool or PipelineVariable): If true, entry point is run as an MPI script. By
                 default, the Chainer Framework runs the entry point with
                 'mpirun' if more than one instance is used.
-            num_processes (int): Total number of processes to run the entry
+            num_processes (int or PipelineVariable): Total number of processes to run the entry
                 point with. By default, the Chainer Framework runs one process
                 per GPU (on GPU instances), or one process per host (on CPU
                 instances).
-            process_slots_per_host (int): The number of processes that can run
+            process_slots_per_host (int or PipelineVariable): The number of processes that can run
                 on each instance. By default, this is set to the number of GPUs
                 on the instance (on GPU instances), or one (on CPU instances).
-            additional_mpi_options (str): String of options to the 'mpirun'
+            additional_mpi_options (str or PipelineVariable): String of options to the 'mpirun'
                 command used to run the entry point. For example, '-X
                 NCCL_DEBUG=WARN' will pass that option string to the mpirun
                 command.
@@ -96,8 +96,8 @@ class Chainer(Framework):
                 any other training source code dependencies aside from the entry
                 point file (default: None). Structure within this directory are
                 preserved when training on Amazon SageMaker.
-            hyperparameters (dict): Hyperparameters that will be used for
-                training (default: None). The hyperparameters are made
+            hyperparameters (dict[str, str] or dict[str, PipelineVariable]): Hyperparameters
+                that will be used for training (default: None). The hyperparameters are made
                 accessible as a dict[str, str] to the training code on
                 SageMaker. For convenience, this accepts other types for keys
                 and values, but ``str()`` will be called to convert them before

--- a/src/sagemaker/pytorch/estimator.py
+++ b/src/sagemaker/pytorch/estimator.py
@@ -14,7 +14,7 @@
 from __future__ import absolute_import
 
 import logging
-from typing import Union, Optional
+from typing import Union, Optional, Dict
 
 from packaging.version import Version
 
@@ -44,12 +44,12 @@ class PyTorch(Framework):
     def __init__(
         self,
         entry_point: Union[str, PipelineVariable],
-        framework_version=None,
-        py_version=None,
+        framework_version: Optional[str] = None,
+        py_version: Optional[str] = None,
         source_dir: Optional[Union[str, PipelineVariable]] = None,
-        hyperparameters=None,
-        image_uri=None,
-        distribution=None,
+        hyperparameters: Optional[Dict[str, Union[str, PipelineVariable]]] = None,
+        image_uri: Optional[Union[str, PipelineVariable]] = None,
+        distribution: Optional[Dict] = None,
         **kwargs
     ):
         """This ``Estimator`` executes a PyTorch script in a managed PyTorch execution environment.
@@ -86,13 +86,13 @@ class PyTorch(Framework):
                 point file (default: None). If ``source_dir`` is an S3 URI, it must
                 point to a tar.gz file. Structure within this directory are preserved
                 when training on Amazon SageMaker.
-            hyperparameters (dict): Hyperparameters that will be used for
-                training (default: None). The hyperparameters are made
+            hyperparameters (dict[str, str] or dict[str, PipelineVariable]): Hyperparameters
+                that will be used for training (default: None). The hyperparameters are made
                 accessible as a dict[str, str] to the training code on
                 SageMaker. For convenience, this accepts other types for keys
                 and values, but ``str()`` will be called to convert them before
                 training.
-            image_uri (str): If specified, the estimator will use this image
+            image_uri (str or PipelineVariable): If specified, the estimator will use this image
                 for training and hosting, instead of selecting the appropriate
                 SageMaker official image based on framework_version and
                 py_version. It can be an ECR url or dockerhub image and tag.

--- a/src/sagemaker/rl/estimator.py
+++ b/src/sagemaker/rl/estimator.py
@@ -16,7 +16,7 @@ from __future__ import absolute_import
 import enum
 import logging
 import re
-from typing import Union, Optional
+from typing import Union, Optional, List, Dict
 
 from sagemaker import image_uris, fw_utils
 from sagemaker.estimator import Framework, EstimatorBase
@@ -77,13 +77,13 @@ class RLEstimator(Framework):
     def __init__(
         self,
         entry_point: Union[str, PipelineVariable],
-        toolkit=None,
-        toolkit_version=None,
-        framework=None,
+        toolkit: Optional[RLToolkit] = None,
+        toolkit_version: Optional[str] = None,
+        framework: Optional[Framework] = None,
         source_dir: Optional[Union[str, PipelineVariable]] = None,
-        hyperparameters=None,
-        image_uri=None,
-        metric_definitions=None,
+        hyperparameters: Optional[Dict[str, Union[str, PipelineVariable]]] = None,
+        image_uri: Optional[Union[str, PipelineVariable]] = None,
+        metric_definitions: Optional[List[Dict[str, Union[str, PipelineVariable]]]] = None,
         **kwargs
     ):
         """Creates an RLEstimator for managed Reinforcement Learning (RL).
@@ -122,19 +122,19 @@ class RLEstimator(Framework):
                 the entry point file (default: None). If ``source_dir`` is an S3 URI, it must
                 point to a tar.gz file. Structure within this directory are preserved
                 when training on Amazon SageMaker.
-            hyperparameters (dict): Hyperparameters that will be used for
-                training (default: None). The hyperparameters are made
+            hyperparameters (dict[str, str] or dict[str, PipelineVariable]): Hyperparameters
+                that will be used for training (default: None). The hyperparameters are made
                 accessible as a dict[str, str] to the training code on
                 SageMaker. For convenience, this accepts other types for keys
                 and values.
-            image_uri (str): An ECR url. If specified, the estimator will use
+            image_uri (str or PipelineVariable): An ECR url. If specified, the estimator will use
                 this image for training and hosting, instead of selecting the
                 appropriate SageMaker official image based on framework_version
                 and py_version. Example:
                 123.dkr.ecr.us-west-2.amazonaws.com/my-custom-image:1.0
-            metric_definitions (list[dict]): A list of dictionaries that defines
-                the metric(s) used to evaluate the training jobs. Each
-                dictionary contains two keys: 'Name' for the name of the metric,
+            metric_definitions (list[dict[str, str] or list[dict[str, PipelineVariable]]):
+                A list of dictionaries that defines the metric(s) used to evaluate the
+                training jobs. Each dictionary contains two keys: 'Name' for the name of the metric,
                 and 'Regex' for the regular expression used to extract the
                 metric from the logs. This should be defined only for jobs that
                 don't use an Amazon algorithm.

--- a/src/sagemaker/sklearn/estimator.py
+++ b/src/sagemaker/sklearn/estimator.py
@@ -14,7 +14,7 @@
 from __future__ import absolute_import
 
 import logging
-from typing import Union, Optional
+from typing import Union, Optional, Dict
 
 from sagemaker import image_uris
 from sagemaker.deprecations import renamed_kwargs
@@ -28,6 +28,7 @@ from sagemaker.sklearn import defaults
 from sagemaker.sklearn.model import SKLearnModel
 from sagemaker.vpc_utils import VPC_CONFIG_DEFAULT
 from sagemaker.workflow.entities import PipelineVariable
+from sagemaker.workflow import is_pipeline_variable
 
 logger = logging.getLogger("sagemaker")
 
@@ -40,12 +41,12 @@ class SKLearn(Framework):
     def __init__(
         self,
         entry_point: Union[str, PipelineVariable],
-        framework_version=None,
-        py_version="py3",
+        framework_version: Optional[str] = None,
+        py_version: str = "py3",
         source_dir: Optional[Union[str, PipelineVariable]] = None,
-        hyperparameters=None,
-        image_uri=None,
-        image_uri_region=None,
+        hyperparameters: Optional[Dict[str, Union[str, PipelineVariable]]] = None,
+        image_uri: Optional[Union[str, PipelineVariable]] = None,
+        image_uri_region: Optional[str] = None,
         **kwargs
     ):
         """Creates a SKLearn Estimator for Scikit-learn environment.
@@ -84,13 +85,13 @@ class SKLearn(Framework):
                 point file (default: None). If ``source_dir`` is an S3 URI, it must
                 point to a tar.gz file. Structure within this directory are preserved
                 when training on Amazon SageMaker.
-            hyperparameters (dict): Hyperparameters that will be used for
-                training (default: None). The hyperparameters are made
+            hyperparameters (dict[str, str] or dict[str, PipelineVariable]): Hyperparameters
+                that will be used for training (default: None). The hyperparameters are made
                 accessible as a dict[str, str] to the training code on
                 SageMaker. For convenience, this accepts other types for keys
                 and values, but ``str()`` will be called to convert them before
                 training.
-            image_uri (str): If specified, the estimator will use this image
+            image_uri (str or PipelineVariable)): If specified, the estimator will use this image
                 for training and hosting, instead of selecting the appropriate
                 SageMaker official image based on framework_version and
                 py_version. It can be an ECR url or dockerhub image and tag.
@@ -133,11 +134,20 @@ class SKLearn(Framework):
         _validate_not_gpu_instance_type(instance_type)
 
         if instance_count:
-            if instance_count != 1:
-                raise AttributeError(
-                    "Scikit-Learn does not support distributed training. Please remove the "
-                    "'instance_count' argument or set 'instance_count=1' when initializing SKLearn."
+            instance_cnt_err_msg = (
+                "Scikit-Learn does not support distributed training. Please remove the "
+                "'instance_count' argument or set 'instance_count=1' when initializing SKLearn."
+            )
+            if is_pipeline_variable(instance_count):
+                raise TypeError(
+                    "Invalid type of instance_count (PipelineVariable - {}). ".format(
+                        type(instance_count)
+                    )
+                    + instance_cnt_err_msg
                 )
+
+            if instance_count != 1:
+                raise AttributeError(instance_cnt_err_msg)
 
         super(SKLearn, self).__init__(
             entry_point,
@@ -275,9 +285,18 @@ def _validate_not_gpu_instance_type(training_instance_type):
         "ml.p3.16xlarge",
     ]
 
+    if is_pipeline_variable(training_instance_type):
+        warn_msg = (
+            "instance_type is a PipelineVariable (%s). "
+            "Its interpreted value in execution time should not be of GPU types "
+            "since GPU training is not supported for Scikit-Learn."
+        )
+        logger.warning(warn_msg, type(training_instance_type))
+        return
+
     if training_instance_type in gpu_instance_types:
         raise ValueError(
-            "GPU training in not supported for Scikit-Learn. "
+            "GPU training is not supported for Scikit-Learn. "
             "Please pick a different instance type from here: "
             "https://aws.amazon.com/ec2/instance-types/"
         )

--- a/src/sagemaker/training_compiler/config.py
+++ b/src/sagemaker/training_compiler/config.py
@@ -14,6 +14,8 @@
 from __future__ import absolute_import
 import logging
 
+from sagemaker.workflow import is_pipeline_variable
+
 logger = logging.getLogger(__name__)
 
 
@@ -132,7 +134,14 @@ class TrainingCompilerConfig(object):
             ValueError: Raised if the requested configuration is not compatible
                         with SageMaker Training Compiler.
         """
-        if estimator.instance_type:
+        if is_pipeline_variable(estimator.instance_type):
+            warn_msg = (
+                "Estimator instance_type is a PipelineVariable (%s), "
+                "which has to be interpreted as one of the "
+                "[p3, g4dn, p4d, g5] classes in execution time."
+            )
+            logger.warning(warn_msg, type(estimator.instance_type))
+        elif estimator.instance_type:
             if "local" not in estimator.instance_type:
                 requested_instance_class = estimator.instance_type.split(".")[
                     1

--- a/src/sagemaker/workflow/pipeline.py
+++ b/src/sagemaker/workflow/pipeline.py
@@ -486,7 +486,10 @@ def _generate_step_map(
     """Helper method to create a mapping from Step/Step Collection name to itself."""
     for step in steps:
         if step.name in step_map:
-            raise ValueError("Pipeline steps cannot have duplicate names.")
+            raise ValueError(
+                "Pipeline steps cannot have duplicate names. In addition, steps added in "
+                "the ConditionStep cannot be added in the Pipeline steps list."
+            )
         step_map[step.name] = step
         if isinstance(step, ConditionStep):
             _generate_step_map(step.if_steps + step.else_steps, step_map)

--- a/src/sagemaker/workflow/utilities.py
+++ b/src/sagemaker/workflow/utilities.py
@@ -176,7 +176,8 @@ def override_pipeline_parameter_var(func):
     """
     warning_msg_template = (
         "The input argument %s of function (%s) is a pipeline variable (%s), which is not allowed. "
-        "The default_value of this Parameter object will be used to override it."
+        "The default_value of this Parameter object will be used to override it. "
+        "Please make sure the default_value is valid."
     )
 
     @wraps(func)

--- a/src/sagemaker/xgboost/estimator.py
+++ b/src/sagemaker/xgboost/estimator.py
@@ -14,7 +14,7 @@
 from __future__ import absolute_import
 
 import logging
-from typing import Union, Optional
+from typing import Union, Optional, Dict
 
 from sagemaker import image_uris
 from sagemaker.deprecations import renamed_kwargs
@@ -45,12 +45,12 @@ class XGBoost(Framework):
     def __init__(
         self,
         entry_point: Union[str, PipelineVariable],
-        framework_version,
+        framework_version: str,
         source_dir: Optional[Union[str, PipelineVariable]] = None,
-        hyperparameters=None,
-        py_version="py3",
-        image_uri=None,
-        image_uri_region=None,
+        hyperparameters: Optional[Dict[str, Union[str, PipelineVariable]]] = None,
+        py_version: str = "py3",
+        image_uri: Optional[Union[str, PipelineVariable]] = None,
+        image_uri_region: Optional[str] = None,
         **kwargs
     ):
         """An estimator that executes an XGBoost-based SageMaker Training Job.
@@ -80,15 +80,16 @@ class XGBoost(Framework):
                 point file (default: None). If ``source_dir`` is an S3 URI, it must
                 point to a tar.gz file. Structure within this directory are preserved
                 when training on Amazon SageMaker.
-            hyperparameters (dict): Hyperparameters that will be used for training (default: None).
+            hyperparameters (dict[str, str] or dict[str, PipelineVariable]): Hyperparameters
+                that will be used for training (default: None).
                 The hyperparameters are made accessible as a dict[str, str] to the training code
                 on SageMaker. For convenience, this accepts other types for keys and values, but
                 ``str()`` will be called to convert them before training.
             py_version (str): Python version you want to use for executing your model
                 training code (default: 'py3').
-            image_uri (str): If specified, the estimator will use this image for training and
-                hosting, instead of selecting the appropriate SageMaker official image
-                based on framework_version and py_version. It can be an ECR url or
+            image_uri (str or PipelineVariable): If specified, the estimator will use this image
+                for training and hosting, instead of selecting the appropriate SageMaker official
+                image based on framework_version and py_version. It can be an ECR url or
                 dockerhub image and tag.
                 Examples:
                     123.dkr.ecr.us-west-2.amazonaws.com/my-custom-image:1.0

--- a/tests/unit/test_sklearn.py
+++ b/tests/unit/test_sklearn.py
@@ -406,7 +406,7 @@ def test_fail_gpu_training(sagemaker_session, sklearn_version):
             py_version=PYTHON_VERSION,
             framework_version=sklearn_version,
         )
-    assert "GPU training in not supported for Scikit-Learn." in str(error)
+    assert "GPU training is not supported for Scikit-Learn." in str(error)
 
 
 def test_model(sagemaker_session, sklearn_version):


### PR DESCRIPTION
*Description of changes:*
- Add PipelineVariable annotation in framework Estimator subclasses. The PipelineVariable annotation will be leveraged by a test mechanism: https://github.com/aws/sagemaker-python-sdk/pull/3163 to scan and check the incompatible issues between Pipeline steps and downstream classes caused by pipeline variables.
- Fix issues figured out by the test mechanism.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
