### PR TITLE
fix: support kms key in processor pack local code

### DIFF
--- a/src/sagemaker/processing.py
+++ b/src/sagemaker/processing.py
@@ -392,6 +392,7 @@ class Processor(object):
                     output.destination = s3_uri
                 normalized_outputs.append(output)
         return normalized_outputs
+        return normalized_outputs
 
 
 class ScriptProcessor(Processor):
@@ -1622,7 +1623,7 @@ class FrameworkProcessor(ScriptProcessor):
             :class:`~sagemaker.workflow.pipeline_context.PipelineSession`
         """
         s3_runproc_sh, inputs, job_name = self._pack_and_upload_code(
-            code, source_dir, dependencies, git_config, job_name, inputs
+            code, source_dir, dependencies, git_config, job_name, inputs, kms_key
         )
 
         # Submit a processing job.
@@ -1638,7 +1639,9 @@ class FrameworkProcessor(ScriptProcessor):
             kms_key=kms_key,
         )
 
-    def _pack_and_upload_code(self, code, source_dir, dependencies, git_config, job_name, inputs):
+    def _pack_and_upload_code(
+        self, code, source_dir, dependencies, git_config, job_name, inputs, kms_key=None
+    ):
         """Pack local code bundle and upload to Amazon S3."""
         if code.startswith("s3://"):
             return code, inputs, job_name
@@ -1676,6 +1679,7 @@ class FrameworkProcessor(ScriptProcessor):
         s3_runproc_sh = S3Uploader.upload_string_as_file_body(
             self._generate_framework_script(script),
             desired_s3_uri=entrypoint_s3_uri,
+            kms_key=kms_key,
             sagemaker_session=self.sagemaker_session,
         )
         logger.info("runproc.sh uploaded to %s", s3_runproc_sh)

--- a/src/sagemaker/processing.py
+++ b/src/sagemaker/processing.py
@@ -392,7 +392,6 @@ class Processor(object):
                     output.destination = s3_uri
                 normalized_outputs.append(output)
         return normalized_outputs
-        return normalized_outputs
 
 
 class ScriptProcessor(Processor):

--- a/tests/unit/sagemaker/workflow/test_pipeline_session.py
+++ b/tests/unit/sagemaker/workflow/test_pipeline_session.py
@@ -50,7 +50,7 @@ def test_pipeline_session_init(sagemaker_client_config, boto_session):
         sagemaker_client=sagemaker_client,
     )
     assert sess.sagemaker_client is not None
-    assert sess.default_bucket() is not None
+    assert sess.default_bucket is not None
     assert sess.context is None
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
support kms key in processor pack local code

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
