### PR TITLE
fix: StepTypeEnum couldn't be instantiated correctly

### DIFF
--- a/doc/workflows/pipelines/sagemaker.workflow.pipelines.rst
+++ b/doc/workflows/pipelines/sagemaker.workflow.pipelines.rst
@@ -40,11 +40,7 @@ CheckJobConfig
 Entities
 --------
 
-.. autoclass:: sagemaker.workflow.entities.Entity
-
-.. autoclass:: sagemaker.workflow.entities.DefaultEnumMeta
-
-.. autoclass:: sagemaker.workflow.entities.Expression
+.. autoclass:: sagemaker.workflow.entities.PipelineVariable
 
 .. autoclass:: sagemaker.workflow.entities.PipelineVariable
 

--- a/src/sagemaker/workflow/callback_step.py
+++ b/src/sagemaker/workflow/callback_step.py
@@ -24,14 +24,11 @@ from sagemaker.workflow.entities import (
 from sagemaker.workflow.properties import (
     Properties,
 )
-from sagemaker.workflow.entities import (
-    DefaultEnumMeta,
-)
 from sagemaker.workflow.step_collections import StepCollection
 from sagemaker.workflow.steps import Step, StepTypeEnum, CacheConfig
 
 
-class CallbackOutputTypeEnum(Enum, metaclass=DefaultEnumMeta):
+class CallbackOutputTypeEnum(Enum):
     """CallbackOutput type enum."""
 
     String = "String"

--- a/src/sagemaker/workflow/conditions.py
+++ b/src/sagemaker/workflow/conditions.py
@@ -26,7 +26,6 @@ import attr
 
 from sagemaker.workflow import is_pipeline_variable
 from sagemaker.workflow.entities import (
-    DefaultEnumMeta,
     Entity,
     Expression,
     PrimitiveType,
@@ -41,7 +40,7 @@ from sagemaker.workflow.entities import PipelineVariable
 ConditionValueType = Union[ExecutionVariable, Parameter, Properties]
 
 
-class ConditionTypeEnum(Enum, metaclass=DefaultEnumMeta):
+class ConditionTypeEnum(Enum):
     """Condition type enum."""
 
     EQ = "Equals"
@@ -62,7 +61,7 @@ class Condition(Entity):
         condition_type (ConditionTypeEnum): The type of condition.
     """
 
-    condition_type: ConditionTypeEnum = attr.ib(factory=ConditionTypeEnum.factory)
+    condition_type: ConditionTypeEnum = attr.ib(default=None)
 
     @property
     @abc.abstractmethod

--- a/src/sagemaker/workflow/entities.py
+++ b/src/sagemaker/workflow/entities.py
@@ -15,7 +15,6 @@ from __future__ import absolute_import
 
 import abc
 
-from enum import EnumMeta
 from typing import Any, Dict, List, Union
 
 PrimitiveType = Union[str, int, bool, float, None]
@@ -31,20 +30,6 @@ class Entity(abc.ABC):
     @abc.abstractmethod
     def to_request(self) -> RequestType:
         """Get the request structure for workflow service calls."""
-
-
-class DefaultEnumMeta(EnumMeta):
-    """An EnumMeta which defaults to the first value in the Enum list."""
-
-    default = object()
-
-    def __call__(cls, *args, value=default, **kwargs):
-        """Defaults to the first value in the Enum list."""
-        if value is DefaultEnumMeta.default:
-            return next(iter(cls))
-        return super().__call__(value, *args, **kwargs)
-
-    factory = __call__
 
 
 class Expression(abc.ABC):

--- a/src/sagemaker/workflow/lambda_step.py
+++ b/src/sagemaker/workflow/lambda_step.py
@@ -24,15 +24,12 @@ from sagemaker.workflow.entities import (
 from sagemaker.workflow.properties import (
     Properties,
 )
-from sagemaker.workflow.entities import (
-    DefaultEnumMeta,
-)
 from sagemaker.workflow.step_collections import StepCollection
 from sagemaker.workflow.steps import Step, StepTypeEnum, CacheConfig
 from sagemaker.lambda_helper import Lambda
 
 
-class LambdaOutputTypeEnum(Enum, metaclass=DefaultEnumMeta):
+class LambdaOutputTypeEnum(Enum):
     """LambdaOutput type enum."""
 
     String = "String"

--- a/src/sagemaker/workflow/parameters.py
+++ b/src/sagemaker/workflow/parameters.py
@@ -20,7 +20,6 @@ from typing import Dict, List, Type
 import attr
 
 from sagemaker.workflow.entities import (
-    DefaultEnumMeta,
     Entity,
     PrimitiveType,
     RequestType,
@@ -28,7 +27,7 @@ from sagemaker.workflow.entities import (
 )
 
 
-class ParameterTypeEnum(Enum, metaclass=DefaultEnumMeta):
+class ParameterTypeEnum(Enum):
     """Parameter type enum."""
 
     STRING = "String"
@@ -59,7 +58,7 @@ class Parameter(PipelineVariable, Entity):
     """
 
     name: str = attr.ib(factory=str)
-    parameter_type: ParameterTypeEnum = attr.ib(factory=ParameterTypeEnum.factory)
+    parameter_type: ParameterTypeEnum = attr.ib(default=None)
     default_value: PrimitiveType = attr.ib(default=None)
 
     @default_value.validator

--- a/src/sagemaker/workflow/retry.py
+++ b/src/sagemaker/workflow/retry.py
@@ -17,7 +17,7 @@ from enum import Enum
 from typing import List
 import attr
 
-from sagemaker.workflow.entities import Entity, DefaultEnumMeta, RequestType
+from sagemaker.workflow.entities import Entity, RequestType
 
 
 DEFAULT_BACKOFF_RATE = 2.0
@@ -26,14 +26,14 @@ MAX_ATTEMPTS_CAP = 20
 MAX_EXPIRE_AFTER_MIN = 14400
 
 
-class StepExceptionTypeEnum(Enum, metaclass=DefaultEnumMeta):
+class StepExceptionTypeEnum(Enum):
     """Step ExceptionType enum."""
 
     SERVICE_FAULT = "Step.SERVICE_FAULT"
     THROTTLING = "Step.THROTTLING"
 
 
-class SageMakerJobExceptionTypeEnum(Enum, metaclass=DefaultEnumMeta):
+class SageMakerJobExceptionTypeEnum(Enum):
     """SageMaker Job ExceptionType enum."""
 
     INTERNAL_ERROR = "SageMaker.JOB_INTERNAL_ERROR"

--- a/src/sagemaker/workflow/steps.py
+++ b/src/sagemaker/workflow/steps.py
@@ -38,7 +38,6 @@ from sagemaker.tuner import HyperparameterTuner, _TuningJob
 from sagemaker.workflow.conditions import Condition
 from sagemaker.workflow import is_pipeline_variable
 from sagemaker.workflow.entities import (
-    DefaultEnumMeta,
     Entity,
     RequestType,
 )
@@ -55,7 +54,7 @@ if TYPE_CHECKING:
     from sagemaker.workflow.step_collections import StepCollection
 
 
-class StepTypeEnum(Enum, metaclass=DefaultEnumMeta):
+class StepTypeEnum(Enum):
     """Enum of `Step` types."""
 
     CONDITION = "Condition"
@@ -91,7 +90,7 @@ class Step(Entity):
     name: str = attr.ib(factory=str)
     display_name: Optional[str] = attr.ib(default=None)
     description: Optional[str] = attr.ib(default=None)
-    step_type: StepTypeEnum = attr.ib(factory=StepTypeEnum.factory)
+    step_type: StepTypeEnum = attr.ib(default=None)
     depends_on: Optional[List[Union[str, "Step", "StepCollection"]]] = attr.ib(default=None)
 
     @property

--- a/tests/unit/sagemaker/workflow/test_entities.py
+++ b/tests/unit/sagemaker/workflow/test_entities.py
@@ -17,14 +17,9 @@ import json
 
 import pytest
 
-from enum import Enum
-
 from sagemaker.workflow.condition_step import ConditionStep
 from sagemaker.workflow.conditions import ConditionGreaterThan
-from sagemaker.workflow.entities import (
-    DefaultEnumMeta,
-    Entity,
-)
+from sagemaker.workflow.entities import Entity
 from sagemaker.workflow.fail_step import FailStep
 from sagemaker.workflow.functions import Join, JsonGet
 from sagemaker.workflow.parameters import ParameterString, ParameterInteger
@@ -40,11 +35,6 @@ class CustomEntity(Entity):
         return {"foo": self.foo}
 
 
-class CustomEnum(Enum, metaclass=DefaultEnumMeta):
-    A = 1
-    B = 2
-
-
 @pytest.fixture
 def custom_entity():
     return CustomEntity(1)
@@ -58,10 +48,6 @@ def custom_entity_list():
 def test_entity(custom_entity):
     request_struct = {"foo": 1}
     assert custom_entity.to_request() == request_struct
-
-
-def test_default_enum_meta():
-    assert CustomEnum().value == 1
 
 
 def test_pipeline_variable_in_pipeline_definition(sagemaker_session):


### PR DESCRIPTION
*Issue #, if available:*

#3272

*Description of changes:*

The `DefaultEnumMeta` metaclass is malfunctioned. Enum types defined with this couldn't be instantiated correctly.
For example, `StepTypeEnum('Processing')` leads to `StepTypeEnum.CONDITION`
    
Removed this metaclass altogether instead of fixing it because the target behavior "defaulting to the first value in the Enum list" is not particularly useful in the pipeline SDK implementation and can be misleading even implemented correctly.


*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
