### PR TITLE
documentation: fix links according to the app security scan

### DIFF
--- a/doc/frameworks/sklearn/using_sklearn.rst
+++ b/doc/frameworks/sklearn/using_sklearn.rst
@@ -7,7 +7,7 @@ With Scikit-learn Estimators, you can train and host Scikit-learn models on Amaz
 For information about supported versions of Scikit-learn, see the `AWS documentation <https://docs.aws.amazon.com/sagemaker/latest/dg/sklearn.html>`__.
 We recommend that you use the latest supported version because that's where we focus most of our development efforts.
 
-You can visit the Scikit-learn repository at https://github.com/scikit-learn/scikit-learn.
+For more information about the framework, see the `Sciket-Learn <https://github.com/scikit-learn/scikit-learn>`_ repository.
 For general information about using the SageMaker Python SDK, see :ref:`overview:Using the SageMaker Python SDK`.
 
 .. contents::
@@ -82,7 +82,8 @@ Because the SageMaker imports your training script, you should put your training
 (``if __name__=='__main__':``) if you are using the same script to host your model, so that SageMaker does not
 inadvertently run your training code at the wrong point in execution.
 
-For more on training environment variables, please visit https://github.com/aws/sagemaker-containers.
+For more on training environment variables, please visit
+`SageMaker Training Toolkit <https://github.com/aws/sagemaker-training-toolkit>`_.
 
 .. important::
     The sagemaker-containers repository has been deprecated,
@@ -124,7 +125,7 @@ Both ``requirements.txt`` and your training script should be put in the same fol
 You must specify this folder in ``source_dir`` argument when creating a Scikit-learn estimator.
 A ``requirements.txt`` file is a text file that contains a list of items that are installed by using ``pip install``.
 You can also specify the version of an item to install.
-For information about the format of a ``requirements.txt`` file, see `Requirements Files <https://pip.pypa.io/en/stable/user_guide/#requirements-files>`__ in the pip documentation.
+For information about the format of a ``requirements.txt`` file, see `Requirements Files <https://pip.pypa.io/en/stable/user_guide#requirements-files>`__ in the pip documentation.
 
 Create an Estimator
 ===================
@@ -241,7 +242,8 @@ Before a model can be served, it must be loaded. The SageMaker Scikit-learn mode
 
 .. code:: python
 
-    def model_fn(model_dir)
+    def model_fn(model_dir):
+        ...
 
 SageMaker will inject the directory where your model files and sub-directories, saved by ``save``, have been mounted.
 Your model function should return a model object that can be used for model serving.
@@ -334,14 +336,16 @@ it should return an object that can be passed to ``predict_fn`` and have the fol
 
 .. code:: python
 
-    def input_fn(request_body, request_content_type)
+  def input_fn(request_body, request_content_type):
+      ...
 
-Where ``request_body`` is a byte buffer and ``request_content_type`` is a Python string
+where ``request_body`` is a byte buffer and ``request_content_type`` is a Python string.
 
 The SageMaker Scikit-learn model server provides a default implementation of ``input_fn``.
 This function deserializes JSON, CSV, or NPY encoded data into a NumPy array.
 
-Default NPY deserialization requires ``request_body`` to follow the `NPY <https://docs.scipy.org/doc/numpy/neps/npy-format.html>`_ format. For Scikit-learn, the Python SDK
+Default NPY deserialization requires ``request_body`` to follow the
+`NPY <https://docs.scipy.org/doc/numpy/neps/npy-format.html>`_ format. For Scikit-learn, the Python SDK
 defaults to sending prediction requests with this format.
 
 Default json deserialization requires ``request_body`` contain a single json list.
@@ -383,7 +387,8 @@ The ``predict_fn`` function has the following signature:
 
 .. code:: python
 
-    def predict_fn(input_object, model)
+    def predict_fn(input_object, model):
+        ...
 
 Where ``input_object`` is the object returned from ``input_fn`` and
 ``model`` is the model loaded by ``model_fn``.
@@ -426,7 +431,8 @@ The ``output_fn`` has the following signature:
 
 .. code:: python
 
-    def output_fn(prediction, content_type)
+    def output_fn(prediction, content_type):
+        ...
 
 Where ``prediction`` is the result of invoking ``predict_fn`` and
 ``content_type`` is the InvokeEndpoint requested response content-type.
@@ -481,10 +487,10 @@ To see what arguments are accepted by the ``SKLearnModel`` constructor, see :cla
 Your model data must be a .tar.gz file in S3. SageMaker Training Job model data is saved to .tar.gz files in S3,
 however if you have local data you want to deploy, you can prepare the data yourself.
 
-Assuming you have a local directory containg your model data named "my_model" you can tar and gzip compress the file and
+Assuming you have a local directory containing your model data named "my_model", you can tar and gzip compress the file and
 upload to S3 using the following commands:
 
-::
+.. code::
 
     tar -czf model.tar.gz my_model
     aws s3 cp model.tar.gz s3://my-bucket/my-path/model.tar.gz
@@ -492,27 +498,28 @@ upload to S3 using the following commands:
 This uploads the contents of my_model to a gzip compressed tar file to S3 in the bucket "my-bucket", with the key
 "my-path/model.tar.gz".
 
-To run this command, you'll need the aws cli tool installed. Please refer to our `FAQ <#FAQ>`__ for more information on
+To run this command, you'll need the AWS CLI tool installed. Please refer to our `FAQ <#FAQ>`__ for more information on
 installing this.
 
 ******************************
 Scikit-learn Training Examples
 ******************************
 
-Amazon provides an example Jupyter notebook that demonstrate end-to-end training on Amazon SageMaker using Scikit-learn:
-
-https://github.com/awslabs/amazon-sagemaker-examples/tree/master/sagemaker-python-sdk
+To find example notebooks that demonstrate end-to-end training on Amazon SageMaker using Scikit-learn,
+see the `Amazon SageMaker example notebooks repository
+<https://github.com/awslabs/amazon-sagemaker-examples/tree/master/sagemaker-python-sdk>`_.
 
 These are also available in SageMaker Notebook Instance hosted Jupyter notebooks under the "sample notebooks" folder.
 
 ******************************
-SageMaker scikit-learn Classes
+SageMaker Scikit-learn Classes
 ******************************
 
-For information about the different scikit-learn classes in the SageMaker Python SDK, see https://sagemaker.readthedocs.io/en/stable/frameworks/sklearn/sagemaker.sklearn.html.
+For information about the different Scikit-learn classes in the SageMaker Python SDK, see https://sagemaker.readthedocs.io/en/stable/frameworks/sklearn/sagemaker.sklearn.html.
 
 ****************************************
 SageMaker Scikit-learn Docker Containers
 ****************************************
 
-You can visit the SageMaker Scikit-Learn containers repository here: https://github.com/aws/sagemaker-scikit-learn-container
+To find the SageMaker-managed Scikit-learn containers,
+visit the `SageMaker Scikit-Learn containers repository <https://github.com/aws/sagemaker-scikit-learn-container>`_.


### PR DESCRIPTION
*Description of changes:*

Properly formatting some links + nit style fixes

*Testing done:*

`tox -e black-check,flake8,docstyle,sphinx,doc8,twine --parallel all`

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
