### PR TITLE
fix: local pipeline step argument parsing bug

### DIFF
--- a/src/sagemaker/local/pipeline.py
+++ b/src/sagemaker/local/pipeline.py
@@ -89,16 +89,15 @@ class LocalPipelineExecutor(object):
         if isinstance(obj, dict):
             obj_copy = deepcopy(obj)
             for k, v in obj.items():
-                if isinstance(v, dict):
-                    obj_copy[k] = self._parse_arguments(v, step_name)
-                elif isinstance(v, list):
-                    list_copy = []
-                    for item in v:
-                        list_copy.append(self._parse_arguments(item, step_name))
-                    obj_copy[k] = list_copy
-                elif isinstance(v, PipelineVariable):
-                    obj_copy[k] = self.evaluate_pipeline_variable(v, step_name)
+                obj_copy[k] = self._parse_arguments(v, step_name)
             return obj_copy
+        if isinstance(obj, list):
+            list_copy = []
+            for item in obj:
+                list_copy.append(self._parse_arguments(item, step_name))
+            return list_copy
+        if isinstance(obj, PipelineVariable):
+            return self.evaluate_pipeline_variable(obj, step_name)
         return obj
 
     def evaluate_pipeline_variable(self, pipeline_variable, step_name):

--- a/tests/integ/test_local_mode.py
+++ b/tests/integ/test_local_mode.py
@@ -35,7 +35,7 @@ from sagemaker.sklearn.processing import SKLearnProcessor
 from sagemaker.workflow.pipeline import Pipeline
 from sagemaker.workflow.steps import TrainingStep, ProcessingStep, TransformStep
 from sagemaker.workflow.model_step import ModelStep
-from sagemaker.workflow.parameters import ParameterInteger
+from sagemaker.workflow.parameters import ParameterInteger, ParameterString
 from sagemaker.workflow.condition_step import ConditionStep
 from sagemaker.workflow.fail_step import FailStep
 from sagemaker.workflow.conditions import ConditionLessThanOrEqualTo
@@ -496,6 +496,7 @@ def test_local_processing_script_processor(sagemaker_local_session, sklearn_imag
 
 @pytest.mark.local_mode
 def test_local_pipeline_with_processing_step(sklearn_latest_version, local_pipeline_session):
+    string_container_arg = ParameterString(name="ProcessingContainerArg", default_value="foo")
     sklearn_processor = SKLearnProcessor(
         framework_version=sklearn_latest_version,
         role="SageMakerRole",
@@ -509,6 +510,7 @@ def test_local_pipeline_with_processing_step(sklearn_latest_version, local_pipel
     processing_args = sklearn_processor.run(
         code=script_path,
         inputs=[ProcessingInput(source=input_file_path, destination="/opt/ml/processing/inputs/")],
+        arguments=["--container_arg", string_container_arg],
     )
     processing_step = ProcessingStep(
         name="sklearn_processor_local_pipeline", step_args=processing_args
@@ -517,6 +519,7 @@ def test_local_pipeline_with_processing_step(sklearn_latest_version, local_pipel
         name="local_pipeline_processing",
         steps=[processing_step],
         sagemaker_session=local_pipeline_session,
+        parameters=[string_container_arg],
     )
     pipeline.create("SageMakerRole", "pipeline for sdk integ testing")
 


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/sagemaker-python-sdk/issues/3323

*Description of changes:* Fixed local pipeline argument parsing logic to account for lists of PipelineVariables

*Testing done:* Edited integ test to cover this case

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
