### PR TITLE
fix: Add regex for short-form sagemaker-xgboost tags

### DIFF
--- a/tests/unit/test_fw_utils.py
+++ b/tests/unit/test_fw_utils.py
@@ -511,6 +511,33 @@ def test_framework_version_from_tag_other():
     assert version is None
 
 
+def test_xgboost_version_from_tag():
+    tags = (
+        "1.5-1-cpu-py3",
+        "1.5-1",
+    )
+
+    for tag in tags:
+        version = fw_utils.framework_version_from_tag(tag)
+        assert "1.5-1" == version
+
+
+def test_framework_name_from_xgboost_image_short_tag():
+    ecr_uri = "246618743249.dkr.ecr.us-west-2.amazonaws.com/sagemaker-xgboost"
+    image_tag = "1.5-1"
+    image_uri = f"{ecr_uri}:{image_tag}"
+    expected_result = ("xgboost", "py3", "1.5-1", None)
+    assert expected_result == fw_utils.framework_name_from_image(image_uri)
+
+
+def test_framework_name_from_xgboost_image_long_tag():
+    ecr_uri = "246618743249.dkr.ecr.us-west-2.amazonaws.com/sagemaker-xgboost"
+    image_tag = "1.5-1-cpu-py3"
+    image_uri = f"{ecr_uri}:{image_tag}"
+    expected_result = ("xgboost", "py3", "1.5-1-cpu-py3", None)
+    assert expected_result == fw_utils.framework_name_from_image(image_uri)
+
+
 def test_model_code_key_prefix_with_all_values_present():
     key_prefix = fw_utils.model_code_key_prefix("prefix", "model_name", "image_uri")
     assert key_prefix == "prefix/model_name"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The json schemas for `sagemaker-xgboost` versions `1.2-1`, `1.2-2`, `1.3-1`, and `1.5-1` do not have the fields `processors` and `py_versions`. This causes the function `sagemaker.image_uris.retrieve` to return an ECR URI that is incorrectly parsed in the XGB estimator because the format does not match what is expected: https://github.com/aws/sagemaker-python-sdk/blob/v2.105.0/src/sagemaker/xgboost/estimator.py#L268-L277

The following lines of code demonstrate the difference between `1.0-1` - which has these fields - and `1.5-1`, which does not:

```python3
import sagemaker

print(sagemaker.image_uris.retrieve("xgboost", "us-west-2", "1.0-1"))
print(sagemaker.image_uris.retrieve("xgboost", "us-west-2", "1.5-1"))
>>> 246618743249.dkr.ecr.us-west-2.amazonaws.com/sagemaker-xgboost:1.0-1-cpu-py3
>>> 246618743249.dkr.ecr.us-west-2.amazonaws.com/sagemaker-xgboost:1.5-1
``` 

```python3
In [6]: framework_name_from_image("246618743249.dkr.ecr.us-west-2.amazonaws.com/sagemaker-xgboost:1.5-1")
Out[6]: (None, None, None, None)

In [7]: framework_name_from_image("246618743249.dkr.ecr.us-west-2.amazonaws.com/sagemaker-xgboost:1.5-1-cpu-py3")
Out[7]: ('xgboost', 'py3', '1.5-1-cpu-py3', None)
```

Note: All `sagemaker-xgboost` images are published to production ECRs with the tags `<xgboost_version>-1` and `<xgboost_version>-1-cpu-py3`. These tags are aliases for each other and the images they return are identical.

The `processors` and `py_versions` fields cannot just be added to the schemas for `1.2-1`, `1.2-2`, `1.3-1`, and `1.5-1` because the images `-cpu-py3` also have GPU capabilities. Adding a processors field with only CPU as the value causes validation errors if a GPU instance is used with one of these images. Therefore, this change instead modifies `framework_name_from_image` and `framework_version_from_tag` to accommodate the short-form alias if it is passed. 

*Testing done:*

```
conda create -n sm_sdk python=3.8
pip install --upgrade .[test]
tox tests/unit
```

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
