### PR TITLE
change: Upgrade attrs>=20.3.0,<23

### DIFF
--- a/requirements/extras/test_requirements.txt
+++ b/requirements/extras/test_requirements.txt
@@ -13,7 +13,7 @@ black==22.3.0
 stopit==1.1.2
 apache-airflow==2.3.4
 apache-airflow-providers-amazon==4.0.0
-attrs==20.3.0
+attrs==22.1.0
 fabric==2.6.0
 requests==2.27.1
 sagemaker-experiments==0.1.35

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ def read_requirements(filename):
 
 # Declare minimal set for installation
 required_packages = [
-    "attrs>=20.3.0,<22",
+    "attrs>=20.3.0,<23",
     "boto3>=1.20.21,<2.0",
     "google-pasta",
     "numpy>=1.9.0,<2.0",


### PR DESCRIPTION
Expand version of `attrs` to allow `attrs==22.*` installation

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
