### PR TITLE
fix: huggingface release test

### DIFF
--- a/tests/integ/test_training_compiler.py
+++ b/tests/integ/test_training_compiler.py
@@ -81,7 +81,6 @@ def skip_if_incompatible(gpu_instance_type, request):
         pytest.skip("no ml.p3 instances in this region")
 
 
-@pytest.mark.release
 @pytest.mark.parametrize(
     "gpu_instance_type,instance_count",
     [
@@ -125,6 +124,46 @@ def test_huggingface_pytorch(
             disable_profiler=True,
             compiler_config=HFTrainingCompilerConfig(),
             distribution={"pytorchxla": {"enabled": True}} if instance_count > 1 else None,
+        )
+
+        hf.fit(huggingface_dummy_dataset)
+
+
+@pytest.mark.release
+def test_huggingface_pytorch_release(
+    sagemaker_session,
+    gpu_instance_type,
+    huggingface_training_compiler_latest_version,
+    huggingface_training_compiler_pytorch_latest_version,
+    huggingface_dummy_dataset,
+):
+    """
+    Test the HuggingFace estimator with PyTorch
+    """
+    with timeout(minutes=TRAINING_DEFAULT_TIMEOUT_MINUTES):
+        data_path = os.path.join(DATA_DIR, "huggingface")
+
+        hf = HuggingFace(
+            py_version="py38",
+            entry_point=os.path.join(data_path, "run_glue.py"),
+            role="SageMakerRole",
+            transformers_version=huggingface_training_compiler_latest_version,
+            pytorch_version=huggingface_training_compiler_pytorch_latest_version,
+            instance_count=1,
+            instance_type=gpu_instance_type,
+            hyperparameters={
+                "model_name_or_path": "distilbert-base-cased",
+                "task_name": "wnli",
+                "do_train": True,
+                "do_eval": True,
+                "max_seq_length": 128,
+                "fp16": True,
+                "per_device_train_batch_size": 128,
+                "output_dir": "/opt/ml/model",
+            },
+            sagemaker_session=sagemaker_session,
+            disable_profiler=True,
+            compiler_config=HFTrainingCompilerConfig(),
         )
 
         hf.fit(huggingface_dummy_dataset)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Dub has low availability of p3.16 instances, causing release tests to fail in DUB. Reverting the related test changes made in https://github.com/aws/sagemaker-python-sdk/commit/01fd66a37a8fe78889cd680379235d36b6554ad6

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
