### PR TITLE
fix: fix ml_inf to ml_inf1 in Neo multi-version support

### DIFF
--- a/src/sagemaker/model.py
+++ b/src/sagemaker/model.py
@@ -789,7 +789,7 @@ api/latest/reference/services/sagemaker.html#SageMaker.Client.add_tags>`_
                 }
                 if target_instance_type in NEO_IOC_TARGET_DEVICES:
                     return framework in multi_version_frameworks_support_mapping["neo_ioc_targets"]
-                if target_instance_type == "ml_inf":
+                if target_instance_type == "ml_inf1":
                     return framework in multi_version_frameworks_support_mapping["inferentia"]
             return False
 

--- a/tests/unit/sagemaker/model/test_neo.py
+++ b/tests/unit/sagemaker/model/test_neo.py
@@ -47,7 +47,7 @@ def test_compile_model_for_inferentia(sagemaker_session):
     )
     model = _create_model(sagemaker_session)
     model.compile(
-        target_instance_family="ml_inf",
+        target_instance_family="ml_inf1",
         input_shape={"data": [1, 3, 1024, 1024]},
         output_path="s3://output",
         role="role",
@@ -313,7 +313,7 @@ def test_compile_with_pytorch_neo_in_ml_inf(session):
 
     model = _create_model()
     model.compile(
-        target_instance_family="ml_inf",
+        target_instance_family="ml_inf1",
         input_shape={"data": [1, 3, 1024, 1024]},
         output_path="s3://output",
         role="role",
@@ -336,7 +336,7 @@ def test_compile_with_tensorflow_neo_in_ml_inf(session):
 
     model = _create_model()
     model.compile(
-        target_instance_family="ml_inf",
+        target_instance_family="ml_inf1",
         input_shape={"data": [1, 3, 1024, 1024]},
         output_path="s3://output",
         role="role",


### PR DESCRIPTION
*Issue #, if available:*
There was a typo "ml_inf" which should be "ml_inf1"

*Description of changes:*
Fixed the typo

*Testing done:*
Unit tests

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
