### PR TITLE
feature: Trainium Neuron support for PyTorch

### DIFF
--- a/src/sagemaker/estimator.py
+++ b/src/sagemaker/estimator.py
@@ -44,6 +44,7 @@ from sagemaker.fw_utils import (
     UploadedCode,
     _region_supports_debugger,
     _region_supports_profiler,
+    _instance_type_supports_profiler,
     get_mp_parameters,
     tar_and_upload_dir,
     validate_source_dir,
@@ -592,7 +593,9 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):  # pylint: disable=too-man
 
         self.max_retry_attempts = max_retry_attempts
 
-        if not _region_supports_profiler(self.sagemaker_session.boto_region_name):
+        if not _region_supports_profiler(
+            self.sagemaker_session.boto_region_name
+        ) or not _instance_type_supports_profiler(self.instance_type):
             self.disable_profiler = True
 
         self.profiler_rule_configs = None

--- a/src/sagemaker/fw_utils.py
+++ b/src/sagemaker/fw_utils.py
@@ -904,6 +904,21 @@ def _region_supports_profiler(region_name):
     return region_name.lower() not in PROFILER_UNSUPPORTED_REGIONS
 
 
+def _instance_type_supports_profiler(instance_type):
+    """Returns bool indicating whether instance_type supports Amazon SageMaker Debugger profiling feature.
+
+    Args:
+        instance_type (str): Name of the instance_type to check against.
+
+    Returns:
+        bool: Whether or not the region supports Amazon SageMaker Debugger profiling feature.
+    """
+    match = re.match(r"^ml[\._]([a-z\d]+)\.?\w*$", instance_type)
+    if match and match[1].startswith("trn"):
+        return False
+    return True
+
+
 def validate_version_or_image_args(framework_version, py_version, image_uri):
     """Checks if version or image arguments are specified.
 

--- a/src/sagemaker/fw_utils.py
+++ b/src/sagemaker/fw_utils.py
@@ -905,7 +905,7 @@ def _region_supports_profiler(region_name):
 
 
 def _instance_type_supports_profiler(instance_type):
-    """Returns bool indicating whether instance_type supports Amazon SageMaker Debugger profiling feature.
+    """Returns bool indicating whether instance_type supports SageMaker Debugger profiling feature.
 
     Args:
         instance_type (str): Name of the instance_type to check against.

--- a/src/sagemaker/image_uri_config/pytorch-neuron.json
+++ b/src/sagemaker/image_uri_config/pytorch-neuron.json
@@ -1,9 +1,9 @@
 {
     "training": {
         "processors": ["trn"],
-        "version_aliases": {"1.10": "1.10.2"},
+        "version_aliases": {"1.11": "1.11.0"},
         "versions": {
-                "1.10.2": {
+                "1.11.0": {
                     "py_versions": ["py38"],
                     "repository": "pytorch-training-neuron",
                     "registries": {
@@ -33,7 +33,7 @@
                         "us-west-1": "763104351884",
                         "us-west-2": "763104351884"
                     },
-                    "container_version": {"trn": "ubuntu18.04"},
+                    "container_version": {"trn": "ubuntu20.04"},
                     "sdk_versions": ["sdk2.3.0"]
                 }
             }

--- a/src/sagemaker/image_uri_config/pytorch-neuron.json
+++ b/src/sagemaker/image_uri_config/pytorch-neuron.json
@@ -1,0 +1,41 @@
+{
+    "training": {
+        "processors": ["trn"],
+        "version_aliases": {"1.10": "1.10.2"},
+        "versions": {
+                "1.10.2": {
+                    "py_versions": ["py38"],
+                    "repository": "pytorch-training-neuron",
+                    "registries": {
+                        "af-south-1": "626614931356",
+                        "ap-east-1": "871362719292",
+                        "ap-northeast-1": "763104351884",
+                        "ap-northeast-2": "763104351884",
+                        "ap-northeast-3": "364406365360",
+                        "ap-south-1": "763104351884",
+                        "ap-southeast-1": "763104351884",
+                        "ap-southeast-2": "763104351884",
+                        "ca-central-1": "763104351884",
+                        "cn-north-1": "727897471807",
+                        "cn-northwest-1": "727897471807",
+                        "eu-central-1": "763104351884",
+                        "eu-north-1": "763104351884",
+                        "eu-west-1": "763104351884",
+                        "eu-west-2": "763104351884",
+                        "eu-west-3": "763104351884",
+                        "eu-south-1": "692866216735",
+                        "me-south-1": "217643126080",
+                        "sa-east-1": "763104351884",
+                        "us-east-1": "763104351884",
+                        "us-east-2": "763104351884",
+                        "us-gov-west-1": "442386744353",
+                        "us-iso-east-1": "886529160074",
+                        "us-west-1": "763104351884",
+                        "us-west-2": "763104351884"
+                    },
+                    "container_version": {"trn": "ubuntu18.04"},
+                    "sdk_versions": ["sdk2.2.1"]
+                }
+            }
+        }
+    }

--- a/src/sagemaker/image_uri_config/pytorch-neuron.json
+++ b/src/sagemaker/image_uri_config/pytorch-neuron.json
@@ -34,7 +34,7 @@
                         "us-west-2": "763104351884"
                     },
                     "container_version": {"trn": "ubuntu18.04"},
-                    "sdk_versions": ["sdk2.2.1"]
+                    "sdk_versions": ["sdk2.3.0"]
                 }
             }
         }

--- a/src/sagemaker/image_uris.py
+++ b/src/sagemaker/image_uris.py
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 
 ECR_URI_TEMPLATE = "{registry}.dkr.{hostname}/{repository}"
 HUGGING_FACE_FRAMEWORK = "huggingface"
-TRAINIUM_ALLOWED_FRAMEWORKS = ("pytorch")
+TRAINIUM_ALLOWED_FRAMEWORKS = "pytorch"
 
 
 @override_pipeline_parameter_var
@@ -282,7 +282,7 @@ def _config_for_framework_and_scope(framework, image_scope, accelerator_type=Non
             available_scopes[0],
         )
         image_scope = available_scopes[0]
-        
+
     if image_scope is None and framework not in TRAINIUM_ALLOWED_FRAMEWORKS:
         _validate_framework(framework, TRAINIUM_ALLOWED_FRAMEWORKS, "framework")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -330,7 +330,7 @@ def huggingface_neuron_latest_inference_py_version():
 
 @pytest.fixture(scope="module")
 def pytorch_neuron_version():
-    return "1.10"
+    return "1.11"
 
 
 @pytest.fixture(scope="module")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -329,6 +329,11 @@ def huggingface_neuron_latest_inference_py_version():
 
 
 @pytest.fixture(scope="module")
+def pytorch_neuron_version():
+    return "1.10"
+    
+
+@pytest.fixture(scope="module")
 def pytorch_eia_py_version():
     return "py3"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -331,7 +331,7 @@ def huggingface_neuron_latest_inference_py_version():
 @pytest.fixture(scope="module")
 def pytorch_neuron_version():
     return "1.10"
-    
+
 
 @pytest.fixture(scope="module")
 def pytorch_eia_py_version():

--- a/tests/unit/sagemaker/image_uris/expected_uris.py
+++ b/tests/unit/sagemaker/image_uris/expected_uris.py
@@ -38,7 +38,7 @@ def neuron_framework_uri(
     inference_tool="neuron",
     region=REGION,
     sdk_version="sdk2.3.0",
-    container_version="ubuntu18.04",
+    container_version="ubuntu20.04",
 ):
     domain = ALTERNATE_DOMAINS.get(region, DOMAIN)
     tag = "-".join(

--- a/tests/unit/sagemaker/image_uris/expected_uris.py
+++ b/tests/unit/sagemaker/image_uris/expected_uris.py
@@ -11,7 +11,6 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 from __future__ import absolute_import
-import re
 
 ALTERNATE_DOMAINS = {
     "cn-north-1": "amazonaws.com.cn",
@@ -30,11 +29,22 @@ def framework_uri(repo, fw_version, account, py_version=None, processor="cpu", r
 
     return IMAGE_URI_FORMAT.format(account, region, domain, repo, tag)
 
-def neuron_framework_uri(repo, fw_version, account, py_version=None, instance_type="ml_trn", inference_tool="neuron", region=REGION, sdk_version="sdk2.2.1", container_version="ubuntu18.04"):
-    domain = ALTERNATE_DOMAINS.get(region, DOMAIN) 
+
+def neuron_framework_uri(
+        repo, 
+        fw_version, 
+        account, 
+        py_version=None, 
+        inference_tool="neuron", 
+        region=REGION, 
+        sdk_version="sdk2.2.1", 
+        container_version="ubuntu18.04"
+    ):
+    domain = ALTERNATE_DOMAINS.get(region, DOMAIN)
     tag = "-".join(x for x in (fw_version, inference_tool, py_version, sdk_version, container_version) if x)
 
     return IMAGE_URI_FORMAT.format(account, region, domain, repo, tag)
+
 
 def algo_uri(algo, account, region, version=1):
     domain = ALTERNATE_DOMAINS.get(region, DOMAIN)

--- a/tests/unit/sagemaker/image_uris/expected_uris.py
+++ b/tests/unit/sagemaker/image_uris/expected_uris.py
@@ -31,17 +31,19 @@ def framework_uri(repo, fw_version, account, py_version=None, processor="cpu", r
 
 
 def neuron_framework_uri(
-        repo, 
-        fw_version, 
-        account, 
-        py_version=None, 
-        inference_tool="neuron", 
-        region=REGION, 
-        sdk_version="sdk2.2.1", 
-        container_version="ubuntu18.04"
-    ):
+    repo,
+    fw_version,
+    account,
+    py_version=None,
+    inference_tool="neuron",
+    region=REGION,
+    sdk_version="sdk2.2.1",
+    container_version="ubuntu18.04",
+):
     domain = ALTERNATE_DOMAINS.get(region, DOMAIN)
-    tag = "-".join(x for x in (fw_version, inference_tool, py_version, sdk_version, container_version) if x)
+    tag = "-".join(
+        x for x in (fw_version, inference_tool, py_version, sdk_version, container_version) if x
+    )
 
     return IMAGE_URI_FORMAT.format(account, region, domain, repo, tag)
 

--- a/tests/unit/sagemaker/image_uris/expected_uris.py
+++ b/tests/unit/sagemaker/image_uris/expected_uris.py
@@ -11,6 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 from __future__ import absolute_import
+import re
 
 ALTERNATE_DOMAINS = {
     "cn-north-1": "amazonaws.com.cn",
@@ -29,6 +30,11 @@ def framework_uri(repo, fw_version, account, py_version=None, processor="cpu", r
 
     return IMAGE_URI_FORMAT.format(account, region, domain, repo, tag)
 
+def neuron_framework_uri(repo, fw_version, account, py_version=None, instance_type="ml_trn", inference_tool="neuron", region=REGION, sdk_version="sdk2.2.1", container_version="ubuntu18.04"):
+    domain = ALTERNATE_DOMAINS.get(region, DOMAIN) 
+    tag = "-".join(x for x in (fw_version, inference_tool, py_version, sdk_version, container_version) if x)
+
+    return IMAGE_URI_FORMAT.format(account, region, domain, repo, tag)
 
 def algo_uri(algo, account, region, version=1):
     domain = ALTERNATE_DOMAINS.get(region, DOMAIN)

--- a/tests/unit/sagemaker/image_uris/expected_uris.py
+++ b/tests/unit/sagemaker/image_uris/expected_uris.py
@@ -37,7 +37,7 @@ def neuron_framework_uri(
     py_version=None,
     inference_tool="neuron",
     region=REGION,
-    sdk_version="sdk2.2.1",
+    sdk_version="sdk2.3.0",
     container_version="ubuntu18.04",
 ):
     domain = ALTERNATE_DOMAINS.get(region, DOMAIN)

--- a/tests/unit/sagemaker/image_uris/test_trainium.py
+++ b/tests/unit/sagemaker/image_uris/test_trainium.py
@@ -12,8 +12,6 @@
 # language governing permissions and limitations under the License.
 from __future__ import absolute_import
 
-import pytest
-
 from sagemaker import image_uris
 from tests.unit.sagemaker.image_uris import expected_uris
 
@@ -48,14 +46,14 @@ ACCOUNTS = {
 TRAINIUM_REGIONS = ACCOUNTS.keys()
 
 
-def _expected_trainium_framework_uri(framework, version, region="us-west-2", instance_type="ml_trn"):
+def _expected_trainium_framework_uri(framework, version, region="us-west-2", inference_tool="neuron"):
     return expected_uris.neuron_framework_uri(
         "{}-neuron".format(framework),
         fw_version=version,
         py_version="py38",
         account=ACCOUNTS[region],
         region=region,
-        instance_type=instance_type,
+        inference_tool=inference_tool,
     )
 
 
@@ -65,7 +63,7 @@ def _test_trainium_framework_uris(framework, version):
             framework, region, instance_type="ml.trn1.xlarge", version=version
         )
         expected = _expected_trainium_framework_uri(
-            "{}-training".format(framework), version, region=region, instance_type="ml.trn1.xlarge"
+            "{}-training".format(framework), version, region=region, inference_tool="neuron"
         )
         assert expected == uri
 

--- a/tests/unit/sagemaker/image_uris/test_trainium.py
+++ b/tests/unit/sagemaker/image_uris/test_trainium.py
@@ -1,0 +1,74 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from __future__ import absolute_import
+
+import pytest
+
+from sagemaker import image_uris
+from tests.unit.sagemaker.image_uris import expected_uris
+
+ACCOUNTS = {
+    "af-south-1": "626614931356",
+    "ap-east-1": "871362719292",
+    "ap-northeast-1": "763104351884",
+    "ap-northeast-2": "763104351884",
+    "ap-northeast-3": "364406365360",
+    "ap-south-1": "763104351884",
+    "ap-southeast-1": "763104351884",
+    "ap-southeast-2": "763104351884",
+    "ca-central-1": "763104351884",
+    "cn-north-1": "727897471807",
+    "cn-northwest-1": "727897471807",
+    "eu-central-1": "763104351884",
+    "eu-north-1": "763104351884",
+    "eu-west-1": "763104351884",
+    "eu-west-2": "763104351884",
+    "eu-west-3": "763104351884",
+    "eu-south-1": "692866216735",
+    "me-south-1": "217643126080",
+    "sa-east-1": "763104351884",
+    "us-east-1": "763104351884",
+    "us-east-2": "763104351884",
+    "us-gov-west-1": "442386744353",
+    "us-iso-east-1": "886529160074",
+    "us-west-1": "763104351884",
+    "us-west-2": "763104351884",
+}
+
+TRAINIUM_REGIONS = ACCOUNTS.keys()
+
+
+def _expected_trainium_framework_uri(framework, version, region="us-west-2", instance_type="ml_trn"):
+    return expected_uris.neuron_framework_uri(
+        "{}-neuron".format(framework),
+        fw_version=version,
+        py_version="py38",
+        account=ACCOUNTS[region],
+        region=region,
+        instance_type=instance_type,
+    )
+
+
+def _test_trainium_framework_uris(framework, version):
+    for region in TRAINIUM_REGIONS:
+        uri = image_uris.retrieve(
+            framework, region, instance_type="ml.trn1.xlarge", version=version
+        )
+        expected = _expected_trainium_framework_uri(
+            "{}-training".format(framework), version, region=region, instance_type="ml.trn1.xlarge"
+        )
+        assert expected == uri
+
+
+def test_trainium_pytorch(pytorch_neuron_version):
+    _test_trainium_framework_uris("pytorch", pytorch_neuron_version)

--- a/tests/unit/sagemaker/image_uris/test_trainium.py
+++ b/tests/unit/sagemaker/image_uris/test_trainium.py
@@ -46,7 +46,9 @@ ACCOUNTS = {
 TRAINIUM_REGIONS = ACCOUNTS.keys()
 
 
-def _expected_trainium_framework_uri(framework, version, region="us-west-2", inference_tool="neuron"):
+def _expected_trainium_framework_uri(
+    framework, version, region="us-west-2", inference_tool="neuron"
+):
     return expected_uris.neuron_framework_uri(
         "{}-neuron".format(framework),
         fw_version=version,

--- a/tests/unit/test_fw_utils.py
+++ b/tests/unit/test_fw_utils.py
@@ -949,6 +949,6 @@ def test_validate_pytorchddp_raises():
 
 
 def test_instance_type_supports_profiler():
-    assert fw_utils._instance_type_supports_profiler("ml.trn1.xlarge") == False
-    assert fw_utils._instance_type_supports_profiler("ml.m4.xlarge") == True
-    assert fw_utils._instance_type_supports_profiler("local") == True
+    assert fw_utils._instance_type_supports_profiler("ml.trn1.xlarge") is False
+    assert fw_utils._instance_type_supports_profiler("ml.m4.xlarge") is True
+    assert fw_utils._instance_type_supports_profiler("local") is True

--- a/tests/unit/test_fw_utils.py
+++ b/tests/unit/test_fw_utils.py
@@ -946,3 +946,9 @@ def test_validate_pytorchddp_raises():
             py_version="py2",
             image_uri=None,
         )
+
+
+def test_instance_type_supports_profiler():
+    assert fw_utils._instance_type_supports_profiler("ml.trn1.xlarge") == False
+    assert fw_utils._instance_type_supports_profiler("ml.m4.xlarge") == True
+    assert fw_utils._instance_type_supports_profiler("local") == True


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added the necessary changes to incorporate the `v1.0-pt-1.11.0-tr-neuron-sdk2.3.0-py38` image into the `PyTorch` framework.

*Testing done:*

Locally tested the feature to extract image string with the following code, where the output matched with the [released DLC image](https://github.com/aws/deep-learning-containers/releases/tag/v1.0-pt-1.11.0-tr-neuron-sdk2.3.0-py38)

```bash
import sagemaker, boto3

sagemaker.image_uris.retrieve(framework="pytorch",
    region=boto3.Session().region_name,
    instance_type="ml.trn1.xlarge")

'763104351884.dkr.ecr.us-west-2.amazonaws.com/pytorch-training-neuron:1.11.0-neuron-py38-sdk2.3.0-ubuntu20.04'
```

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
