### PR TITLE
Add SDK support for SparkML Model Serving Container v3.3

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -214,7 +214,7 @@ In order to host a SparkML model in SageMaker, it should be serialized with ``ML
 
 For more information on MLeap, see https://github.com/combust/mleap .
 
-Supported major version of Spark: 2.4 (MLeap version - 0.9.6)
+Supported major version of Spark: 3.3 (MLeap version - 0.20.0)
 
 Here is an example on how to create an instance of  ``SparkMLModel`` class and use ``deploy()`` method to create an
 endpoint which can be used to perform prediction against your trained SparkML Model.

--- a/src/sagemaker/sparkml/model.py
+++ b/src/sagemaker/sparkml/model.py
@@ -78,7 +78,7 @@ class SparkMLModel(Model):
         self,
         model_data: Union[str, PipelineVariable],
         role: Optional[str] = None,
-        spark_version: str = "2.4",
+        spark_version: str = "3.3",
         sagemaker_session: Optional[Session] = None,
         **kwargs,
     ):
@@ -95,7 +95,7 @@ class SparkMLModel(Model):
                 artifacts. After the endpoint is created, the inference code
                 might use the IAM role, if it needs to access an AWS resource.
             spark_version (str): Spark version you want to use for executing the
-                inference (default: '2.4').
+                inference (default: '3.3').
             sagemaker_session (sagemaker.session.Session): Session object which
                 manages interactions with Amazon SageMaker APIs and any other
                 AWS services needed. If not specified, the estimator creates one

--- a/tests/unit/sagemaker/image_uris/test_sparkml.py
+++ b/tests/unit/sagemaker/image_uris/test_sparkml.py
@@ -43,7 +43,7 @@ ACCOUNTS = {
     "us-west-1": "746614075791",
     "us-west-2": "246618743249",
 }
-VERSIONS = ["2.2", "2.4"]
+VERSIONS = ["2.2", "2.4", "3.3"]
 
 
 @pytest.mark.parametrize("version", VERSIONS)

--- a/tests/unit/sagemaker/workflow/test_steps.py
+++ b/tests/unit/sagemaker/workflow/test_steps.py
@@ -920,7 +920,7 @@ def test_create_model_step_with_model_pipeline(tfo, time, sagemaker_session):
                 },
                 {
                     "Environment": {"SAGEMAKER_DEFAULT_INVOCATIONS_ACCEPT": "text/csv"},
-                    "Image": "246618743249.dkr.ecr.us-west-2.amazonaws.com/sagemaker-sparkml-serving:2.4",
+                    "Image": "246618743249.dkr.ecr.us-west-2.amazonaws.com/sagemaker-sparkml-serving:3.3",
                     "ModelDataUrl": "s3://bucket/model_2.tar.gz",
                 },
             ],

--- a/tests/unit/test_pipeline_model.py
+++ b/tests/unit/test_pipeline_model.py
@@ -97,7 +97,7 @@ def test_prepare_container_def(tfo, time, sagemaker_session):
         {
             "Environment": {"SAGEMAKER_DEFAULT_INVOCATIONS_ACCEPT": "text/csv"},
             "Image": "246618743249.dkr.ecr.us-west-2.amazonaws.com"
-            + "/sagemaker-sparkml-serving:2.4",
+            + "/sagemaker-sparkml-serving:3.3",
             "ModelDataUrl": "s3://bucket/model_2.tar.gz",
         },
     ]
@@ -335,7 +335,7 @@ def test_network_isolation(tfo, time, sagemaker_session):
                 "ModelDataUrl": "s3://bucket/model_1.tar.gz",
             },
             {
-                "Image": "246618743249.dkr.ecr.us-west-2.amazonaws.com/sagemaker-sparkml-serving:2.4",
+                "Image": "246618743249.dkr.ecr.us-west-2.amazonaws.com/sagemaker-sparkml-serving:3.3",
                 "Environment": {},
                 "ModelDataUrl": "s3://bucket/model_2.tar.gz",
             },

--- a/tests/unit/test_sparkml_serving.py
+++ b/tests/unit/test_sparkml_serving.py
@@ -49,7 +49,7 @@ def sagemaker_session():
 
 def test_sparkml_model(sagemaker_session):
     sparkml = SparkMLModel(sagemaker_session=sagemaker_session, model_data=MODEL_DATA, role=ROLE)
-    assert sparkml.image_uri == image_uris.retrieve("sparkml-serving", REGION, version="2.4")
+    assert sparkml.image_uri == image_uris.retrieve("sparkml-serving", REGION, version="3.3")
 
 
 def test_predictor_type(sagemaker_session):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
