### PR TITLE
fix: Fix bug forcing uploaded tar to be named sourcedir

### DIFF
--- a/src/sagemaker/processing.py
+++ b/src/sagemaker/processing.py
@@ -1730,16 +1730,14 @@ class FrameworkProcessor(ScriptProcessor):
                 "sagemaker_session unspecified when creating your Processor to have one set up "
                 "automatically."
             )
-        if ("/sourcedir.tar.gz" in estimator.uploaded_code.s3_prefix):
+        if "/sourcedir.tar.gz" in estimator.uploaded_code.s3_prefix:
             # Upload the bootstrapping code as s3://.../jobname/source/runproc.sh.
             entrypoint_s3_uri = estimator.uploaded_code.s3_prefix.replace(
                 "sourcedir.tar.gz",
                 "runproc.sh",
             )
         else:
-            raise RuntimeError(
-                "S3 source_dir file must be named `sourcedir.tar.gz.`"
-            )
+            raise RuntimeError("S3 source_dir file must be named `sourcedir.tar.gz.`")
 
         script = estimator.uploaded_code.script_name
         s3_runproc_sh = S3Uploader.upload_string_as_file_body(

--- a/src/sagemaker/processing.py
+++ b/src/sagemaker/processing.py
@@ -1732,10 +1732,8 @@ class FrameworkProcessor(ScriptProcessor):
             )
 
         # Upload the bootstrapping code as s3://.../jobname/source/runproc.sh.
-        entrypoint_s3_uri = estimator.uploaded_code.s3_prefix.replace(
-            "sourcedir.tar.gz",
-            "runproc.sh",
-        )
+        entrypoint_s3_uri = estimator.uploaded_code.s3_prefix.rsplit('/', 1)[0] + '/runproc.sh'
+
         script = estimator.uploaded_code.script_name
         s3_runproc_sh = S3Uploader.upload_string_as_file_body(
             self._generate_framework_script(script),

--- a/src/sagemaker/processing.py
+++ b/src/sagemaker/processing.py
@@ -1587,13 +1587,13 @@ class FrameworkProcessor(ScriptProcessor):
                 framework script to run.Path (absolute or relative) to the local
                 Python source file which should be executed as the entry point
                 to training. When `code` is an S3 URI, ignore `source_dir`,
-                `dependencies, and `git_config`. If ``source_dir`` is specified,
+                `dependencies`, and `git_config`. If ``source_dir`` is specified,
                 then ``code`` must point to a file located at the root of ``source_dir``.
             source_dir (str): Path (absolute, relative or an S3 URI) to a directory
                 with any other processing source code dependencies aside from the entry
                 point file (default: None). If ``source_dir`` is an S3 URI, it must
-                point to a tar.gz file. Structure within this directory are preserved
-                when processing on Amazon SageMaker (default: None).
+                point to a file named `sourcedir.tar.gz`. Structure within this directory
+                are preserved when processing on Amazon SageMaker (default: None).
             dependencies (list[str]): A list of paths to directories (absolute
                 or relative) with any additional libraries that will be exported
                 to the container (default: []). The library folders will be
@@ -1730,9 +1730,16 @@ class FrameworkProcessor(ScriptProcessor):
                 "sagemaker_session unspecified when creating your Processor to have one set up "
                 "automatically."
             )
-
-        # Upload the bootstrapping code as s3://.../jobname/source/runproc.sh.
-        entrypoint_s3_uri = estimator.uploaded_code.s3_prefix.rsplit("/", 1)[0] + "/runproc.sh"
+        if ("sourcedir.tar.gz" in estimator.uploaded_code.s3_prefix):
+            # Upload the bootstrapping code as s3://.../jobname/source/runproc.sh.
+            entrypoint_s3_uri = estimator.uploaded_code.s3_prefix.replace(
+                "sourcedir.tar.gz",
+                "runproc.sh",
+            )
+        else:
+            raise RuntimeError(
+                "S3 source_dir file must be named `sourcedir.tar.gz.`"
+            )
 
         script = estimator.uploaded_code.script_name
         s3_runproc_sh = S3Uploader.upload_string_as_file_body(

--- a/src/sagemaker/processing.py
+++ b/src/sagemaker/processing.py
@@ -1732,7 +1732,7 @@ class FrameworkProcessor(ScriptProcessor):
             )
 
         # Upload the bootstrapping code as s3://.../jobname/source/runproc.sh.
-        entrypoint_s3_uri = estimator.uploaded_code.s3_prefix.rsplit('/', 1)[0] + '/runproc.sh'
+        entrypoint_s3_uri = estimator.uploaded_code.s3_prefix.rsplit("/", 1)[0] + "/runproc.sh"
 
         script = estimator.uploaded_code.script_name
         s3_runproc_sh = S3Uploader.upload_string_as_file_body(

--- a/src/sagemaker/processing.py
+++ b/src/sagemaker/processing.py
@@ -1730,7 +1730,7 @@ class FrameworkProcessor(ScriptProcessor):
                 "sagemaker_session unspecified when creating your Processor to have one set up "
                 "automatically."
             )
-        if ("sourcedir.tar.gz" in estimator.uploaded_code.s3_prefix):
+        if ("/sourcedir.tar.gz" in estimator.uploaded_code.s3_prefix):
             # Upload the bootstrapping code as s3://.../jobname/source/runproc.sh.
             entrypoint_s3_uri = estimator.uploaded_code.s3_prefix.replace(
                 "sourcedir.tar.gz",

--- a/tests/integ/test_xgboost.py
+++ b/tests/integ/test_xgboost.py
@@ -40,6 +40,26 @@ def xgboost_training_job(
     )
 
 
+def test_sourcedir_naming(
+    sagemaker_session,
+    xgboost_latest_version,
+    xgboost_latest_py_version,
+    cpu_instance_type,
+):
+    with pytest.raises(RuntimeError):
+        processor = XGBoostProcessor(
+            framework_version=xgboost_latest_version,
+            role=ROLE,
+            instance_count=1,
+            instance_type=cpu_instance_type,
+            sagemaker_session=sagemaker_session,
+        )
+        processor.run(
+            source_dir="s3://bucket/deps.tar.gz",
+            code="main_script.py",
+        )
+
+
 @pytest.mark.release
 def test_framework_processing_job_with_deps(
     sagemaker_session,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Bug was found which would upload bootstrapping code to override the source directory if it was named anything other than 'sourcedir.tar.gz'. Fix allows source directory to have any name.

EDIT 11/30 - It seems there are several places in the background which require the source directory to be named `sourcedir.tar.gz`. Rather than trying to refactor everything, I added documentation clarifying the requirement and validation which raises an error when misnamed. Also added testing of validation.

*Testing done:* Ran customer workflow using new update, confirmed that the uploaded source directory was not replaced, and bootstrapping code was separately uploaded as 'runproc.sh'. Also ran tox tests.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
