### PR TITLE
feature: added support for batch transform with model monitoring

### DIFF
--- a/src/sagemaker/inputs.py
+++ b/src/sagemaker/inputs.py
@@ -176,6 +176,7 @@ class TransformInput(object):
     output_filter: str = attr.ib(default=None)
     join_source: str = attr.ib(default=None)
     model_client_config: dict = attr.ib(default=None)
+    batch_data_capture_config: dict = attr.ib(default=None)
 
 
 class FileSystemInput(object):
@@ -232,3 +233,45 @@ class FileSystemInput(object):
 
         if content_type:
             self.config["ContentType"] = content_type
+
+
+class BatchDataCaptureConfig(object):
+    """Configuration object passed in when create a batch transform job.
+
+    Specifies configuration related to batch transform job data capture for use with
+    Amazon SageMaker Model Monitoring
+    """
+
+    def __init__(
+        self,
+        destination_s3_uri: str,
+        kms_key_id: str = None,
+        generate_inference_id: bool = None,
+    ):
+        """Create new BatchDataCaptureConfig
+
+        Args:
+            destination_s3_uri (str): S3 Location to store the captured data
+            kms_key_id (str): The KMS key to use when writing to S3.
+                KmsKeyId can be an ID of a KMS key, ARN of a KMS key, alias of a KMS key,
+                or alias of a KMS key. The KmsKeyId is applied to all outputs.
+                (default: None)
+            generate_inference_id (bool): Flag to generate an inference id
+                (default: None)
+        """
+        self.destination_s3_uri = destination_s3_uri
+        self.kms_key_id = kms_key_id
+        self.generate_inference_id = generate_inference_id
+
+    def _to_request_dict(self):
+        """Generates a request dictionary using the parameters provided to the class."""
+        batch_data_capture_config = {
+            "DestinationS3Uri": self.destination_s3_uri,
+        }
+
+        if self.kms_key_id is not None:
+            batch_data_capture_config["KmsKeyId"] = self.kms_key_id
+        if self.generate_inference_id is not None:
+            batch_data_capture_config["GenerateInferenceId"] = self.generate_inference_id
+
+        return batch_data_capture_config

--- a/src/sagemaker/model_monitor/__init__.py
+++ b/src/sagemaker/model_monitor/__init__.py
@@ -23,6 +23,7 @@ from sagemaker.model_monitor.model_monitoring import DefaultModelMonitor  # noqa
 from sagemaker.model_monitor.model_monitoring import BaseliningJob  # noqa: F401
 from sagemaker.model_monitor.model_monitoring import MonitoringExecution  # noqa: F401
 from sagemaker.model_monitor.model_monitoring import EndpointInput  # noqa: F401
+from sagemaker.model_monitor.model_monitoring import BatchTransformInput  # noqa: F401
 from sagemaker.model_monitor.model_monitoring import MonitoringOutput  # noqa: F401
 from sagemaker.model_monitor.model_monitoring import ModelQualityMonitor  # noqa: F401
 
@@ -42,5 +43,6 @@ from sagemaker.model_monitor.monitoring_files import ConstraintViolations  # noq
 
 from sagemaker.model_monitor.data_capture_config import DataCaptureConfig  # noqa: F401
 from sagemaker.model_monitor.dataset_format import DatasetFormat  # noqa: F401
+from sagemaker.model_monitor.dataset_format import MonitoringDatasetFormat  # noqa: F401
 
 from sagemaker.network import NetworkConfig  # noqa: F401

--- a/src/sagemaker/model_monitor/clarify_model_monitoring.py
+++ b/src/sagemaker/model_monitor/clarify_model_monitoring.py
@@ -227,6 +227,7 @@ class ClarifyModelMonitor(mm.ModelMonitor):
         env=None,
         tags=None,
         network_config=None,
+        batch_transform_input=None,
     ):
         """Build the request for job definition creation API
 
@@ -270,6 +271,8 @@ class ClarifyModelMonitor(mm.ModelMonitor):
             network_config (sagemaker.network.NetworkConfig): A NetworkConfig
                 object that configures network isolation, encryption of
                 inter-container traffic, security group IDs, and subnets.
+            batch_transform_input (sagemaker.model_monitor.BatchTransformInput): Inputs to run
+                the monitoring schedule on the batch transform
 
         Returns:
             dict: request parameters to create job definition.
@@ -366,6 +369,27 @@ class ClarifyModelMonitor(mm.ModelMonitor):
                         latest_baselining_job_config.probability_threshold_attribute
                     )
             job_input = normalized_endpoint_input._to_request_dict()
+        elif batch_transform_input is not None:
+            # backfill attributes to batch transform input
+            if latest_baselining_job_config is not None:
+                if batch_transform_input.features_attribute is None:
+                    batch_transform_input.features_attribute = (
+                        latest_baselining_job_config.features_attribute
+                    )
+                if batch_transform_input.inference_attribute is None:
+                    batch_transform_input.inference_attribute = (
+                        latest_baselining_job_config.inference_attribute
+                    )
+                if batch_transform_input.probability_attribute is None:
+                    batch_transform_input.probability_attribute = (
+                        latest_baselining_job_config.probability_attribute
+                    )
+                if batch_transform_input.probability_threshold_attribute is None:
+                    batch_transform_input.probability_threshold_attribute = (
+                        latest_baselining_job_config.probability_threshold_attribute
+                    )
+            job_input = batch_transform_input._to_request_dict()
+
         if ground_truth_input is not None:
             job_input["GroundTruthS3Input"] = dict(S3Uri=ground_truth_input)
 
@@ -500,42 +524,55 @@ class ModelBiasMonitor(ClarifyModelMonitor):
     # noinspection PyMethodOverriding
     def create_monitoring_schedule(
         self,
-        endpoint_input,
         ground_truth_input,
+        endpoint_input=None,
         analysis_config=None,
         output_s3_uri=None,
         constraints=None,
         monitor_schedule_name=None,
         schedule_cron_expression=None,
         enable_cloudwatch_metrics=True,
+        batch_transform_input=None,
     ):
         """Creates a monitoring schedule.
 
         Args:
-            endpoint_input (str or sagemaker.model_monitor.EndpointInput): The endpoint to monitor.
-                This can either be the endpoint name or an EndpointInput.
             ground_truth_input (str): S3 URI to ground truth dataset.
+            endpoint_input (str or sagemaker.model_monitor.EndpointInput): The endpoint to monitor.
+                This can either be the endpoint name or an EndpointInput. (default: None)
             analysis_config (str or BiasAnalysisConfig): URI to analysis_config for the bias job.
                 If it is None then configuration of the latest baselining job will be reused, but
-                if no baselining job then fail the call.
+                if no baselining job then fail the call. (default: None)
             output_s3_uri (str): S3 destination of the constraint_violations and analysis result.
-                Default: "s3://<default_session_bucket>/<job_name>/output"
+                Default: "s3://<default_session_bucket>/<job_name>/output" (default: None)
             constraints (sagemaker.model_monitor.Constraints or str): If provided it will be used
                 for monitoring the endpoint. It can be a Constraints object or an S3 uri pointing
-                to a constraints JSON file.
+                to a constraints JSON file. (default: None)
             monitor_schedule_name (str): Schedule name. If not specified, the processor generates
                 a default job name, based on the image name and current timestamp.
+                (default: None)
             schedule_cron_expression (str): The cron expression that dictates the frequency that
                 this job run. See sagemaker.model_monitor.CronExpressionGenerator for valid
-                expressions. Default: Daily.
+                expressions. Default: Daily. (default: None)
             enable_cloudwatch_metrics (bool): Whether to publish cloudwatch metrics as part of
-                the baselining or monitoring jobs.
+                the baselining or monitoring jobs. (default: True)
+            batch_transform_input (sagemaker.model_monitor.BatchTransformInput): Inputs to run
+                the monitoring schedule on the batch transform (default: None)
         """
         if self.job_definition_name is not None or self.monitoring_schedule_name is not None:
             message = (
                 "It seems that this object was already used to create an Amazon Model "
                 "Monitoring Schedule. To create another, first delete the existing one "
                 "using my_monitor.delete_monitoring_schedule()."
+            )
+            _LOGGER.error(message)
+            raise ValueError(message)
+
+        if (batch_transform_input is not None) ^ (endpoint_input is None):
+            message = (
+                "Need to have either batch_transform_input or endpoint_input to create an "
+                "Amazon Model Monitoring Schedule. "
+                "Please provide only one of the above required inputs"
             )
             _LOGGER.error(message)
             raise ValueError(message)
@@ -569,6 +606,7 @@ class ModelBiasMonitor(ClarifyModelMonitor):
             env=self.env,
             tags=self.tags,
             network_config=self.network_config,
+            batch_transform_input=batch_transform_input,
         )
         self.sagemaker_session.sagemaker_client.create_model_bias_job_definition(**request_dict)
 
@@ -612,6 +650,7 @@ class ModelBiasMonitor(ClarifyModelMonitor):
         max_runtime_in_seconds=None,
         env=None,
         network_config=None,
+        batch_transform_input=None,
     ):
         """Updates the existing monitoring schedule.
 
@@ -651,6 +690,8 @@ class ModelBiasMonitor(ClarifyModelMonitor):
             network_config (sagemaker.network.NetworkConfig): A NetworkConfig
                 object that configures network isolation, encryption of
                 inter-container traffic, security group IDs, and subnets.
+            batch_transform_input (sagemaker.model_monitor.BatchTransformInput): Inputs to run
+                the monitoring schedule on the batch transform
         """
         valid_args = {
             arg: value for arg, value in locals().items() if arg != "self" and value is not None
@@ -659,6 +700,15 @@ class ModelBiasMonitor(ClarifyModelMonitor):
         # Nothing to update
         if len(valid_args) <= 0:
             return
+
+        if batch_transform_input is not None and endpoint_input is not None:
+            message = (
+                "Need to have either batch_transform_input or endpoint_input to create an "
+                "Amazon Model Monitoring Schedule. "
+                "Please provide only one of the above required inputs"
+            )
+            _LOGGER.error(message)
+            raise ValueError(message)
 
         # Only need to update schedule expression
         if len(valid_args) == 1 and schedule_cron_expression is not None:
@@ -691,6 +741,7 @@ class ModelBiasMonitor(ClarifyModelMonitor):
             env=env,
             tags=self.tags,
             network_config=network_config,
+            batch_transform_input=batch_transform_input,
         )
         self.sagemaker_session.sagemaker_client.create_model_bias_job_definition(**request_dict)
         try:
@@ -895,13 +946,14 @@ class ModelExplainabilityMonitor(ClarifyModelMonitor):
     # noinspection PyMethodOverriding
     def create_monitoring_schedule(
         self,
-        endpoint_input,
+        endpoint_input=None,
         analysis_config=None,
         output_s3_uri=None,
         constraints=None,
         monitor_schedule_name=None,
         schedule_cron_expression=None,
         enable_cloudwatch_metrics=True,
+        batch_transform_input=None,
     ):
         """Creates a monitoring schedule.
 
@@ -923,12 +975,23 @@ class ModelExplainabilityMonitor(ClarifyModelMonitor):
                 expressions. Default: Daily.
             enable_cloudwatch_metrics (bool): Whether to publish cloudwatch metrics as part of
                 the baselining or monitoring jobs.
+            batch_transform_input (sagemaker.model_monitor.BatchTransformInput): Inputs to
+            run the monitoring schedule on the batch transform
         """
         if self.job_definition_name is not None or self.monitoring_schedule_name is not None:
             message = (
                 "It seems that this object was already used to create an Amazon Model "
                 "Monitoring Schedule. To create another, first delete the existing one "
                 "using my_monitor.delete_monitoring_schedule()."
+            )
+            _LOGGER.error(message)
+            raise ValueError(message)
+
+        if (batch_transform_input is not None) ^ (endpoint_input is None):
+            message = (
+                "Need to have either batch_transform_input or endpoint_input to create an "
+                "Amazon Model Monitoring Schedule."
+                "Please provide only one of the above required inputs"
             )
             _LOGGER.error(message)
             raise ValueError(message)
@@ -961,6 +1024,7 @@ class ModelExplainabilityMonitor(ClarifyModelMonitor):
             env=self.env,
             tags=self.tags,
             network_config=self.network_config,
+            batch_transform_input=batch_transform_input,
         )
         self.sagemaker_session.sagemaker_client.create_model_explainability_job_definition(
             **request_dict
@@ -1005,6 +1069,7 @@ class ModelExplainabilityMonitor(ClarifyModelMonitor):
         max_runtime_in_seconds=None,
         env=None,
         network_config=None,
+        batch_transform_input=None,
     ):
         """Updates the existing monitoring schedule.
 
@@ -1043,6 +1108,8 @@ class ModelExplainabilityMonitor(ClarifyModelMonitor):
             network_config (sagemaker.network.NetworkConfig): A NetworkConfig
                 object that configures network isolation, encryption of
                 inter-container traffic, security group IDs, and subnets.
+            batch_transform_input (sagemaker.model_monitor.BatchTransformInput): Inputs to
+                run the monitoring schedule on the batch transform
         """
         valid_args = {
             arg: value for arg, value in locals().items() if arg != "self" and value is not None
@@ -1051,6 +1118,15 @@ class ModelExplainabilityMonitor(ClarifyModelMonitor):
         # Nothing to update
         if len(valid_args) <= 0:
             raise ValueError("Nothing to update.")
+
+        if batch_transform_input is not None and endpoint_input is not None:
+            message = (
+                "Need to have either batch_transform_input or endpoint_input to create an "
+                "Amazon Model Monitoring Schedule. "
+                "Please provide only one of the above required inputs"
+            )
+            _LOGGER.error(message)
+            raise ValueError(message)
 
         # Only need to update schedule expression
         if len(valid_args) == 1 and schedule_cron_expression is not None:
@@ -1084,6 +1160,7 @@ class ModelExplainabilityMonitor(ClarifyModelMonitor):
             env=env,
             tags=self.tags,
             network_config=network_config,
+            batch_transform_input=batch_transform_input,
         )
         self.sagemaker_session.sagemaker_client.create_model_explainability_job_definition(
             **request_dict

--- a/src/sagemaker/model_monitor/dataset_format.py
+++ b/src/sagemaker/model_monitor/dataset_format.py
@@ -59,3 +59,46 @@ class DatasetFormat(object):
 
         """
         return {"sagemakerCaptureJson": {}}
+
+
+class MonitoringDatasetFormat(object):
+    """Represents a Dataset Format that is used when calling a DefaultModelMonitor."""
+
+    @staticmethod
+    def csv(header=True):
+        """Returns a DatasetFormat JSON string for use with a DefaultModelMonitor.
+
+        Args:
+            header (bool): Whether the csv dataset to baseline and monitor has a header.
+                Default: True.
+            output_columns_position (str): The position of the output columns.
+                Must be one of ("START", "END"). Default: "START".
+
+        Returns:
+            dict: JSON string containing DatasetFormat to be used by DefaultModelMonitor.
+
+        """
+        return {"Csv": {"Header": header}}
+
+    @staticmethod
+    def json(lines=True):
+        """Returns a DatasetFormat JSON string for use with a DefaultModelMonitor.
+
+        Args:
+            lines (bool): Whether the file should be read as a json object per line. Default: True.
+
+        Returns:
+            dict: JSON string containing DatasetFormat to be used by DefaultModelMonitor.
+
+        """
+        return {"Json": {"Line": lines}}
+
+    @staticmethod
+    def parquet():
+        """Returns a DatasetFormat SageMaker Capture Json string for use with a DefaultModelMonitor.
+
+        Returns:
+            dict: JSON string containing DatasetFormat to be used by DefaultModelMonitor.
+
+        """
+        return {"Parquet": {}}

--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -34,7 +34,7 @@ from sagemaker import vpc_utils
 
 from sagemaker._studio import _append_project_tags
 from sagemaker.deprecations import deprecated_class
-from sagemaker.inputs import ShuffleConfig, TrainingInput
+from sagemaker.inputs import ShuffleConfig, TrainingInput, BatchDataCaptureConfig
 from sagemaker.user_agent import prepend_user_agent
 from sagemaker.utils import (
     name_from_image,
@@ -2454,6 +2454,7 @@ class Session(object):  # pylint: disable=too-many-public-methods
         tags,
         data_processing,
         model_client_config=None,
+        batch_data_capture_config: BatchDataCaptureConfig = None,
     ):
         """Construct an dict can be used to create an Amazon SageMaker transform job.
 
@@ -2489,6 +2490,9 @@ class Session(object):  # pylint: disable=too-many-public-methods
             model_client_config (dict): A dictionary describing the model configuration for the
                 job. Dictionary contains two optional keys,
                 'InvocationsTimeoutInSeconds', and 'InvocationsMaxRetries'.
+            batch_data_capture_config (BatchDataCaptureConfig): Configuration object which
+                specifies the configurations related to the batch data capture for the transform job
+                (default: None)
 
         Returns:
             Dict: a create transform job request dict
@@ -2525,6 +2529,9 @@ class Session(object):  # pylint: disable=too-many-public-methods
         if model_client_config and len(model_client_config) > 0:
             transform_request["ModelClientConfig"] = model_client_config
 
+        if batch_data_capture_config is not None:
+            transform_request["DataCaptureConfig"] = batch_data_capture_config._to_request_dict()
+
         return transform_request
 
     def transform(
@@ -2542,6 +2549,7 @@ class Session(object):  # pylint: disable=too-many-public-methods
         tags,
         data_processing,
         model_client_config=None,
+        batch_data_capture_config: BatchDataCaptureConfig = None,
     ):
         """Create an Amazon SageMaker transform job.
 
@@ -2577,6 +2585,8 @@ class Session(object):  # pylint: disable=too-many-public-methods
             model_client_config (dict): A dictionary describing the model configuration for the
                 job. Dictionary contains two optional keys,
                 'InvocationsTimeoutInSeconds', and 'InvocationsMaxRetries'.
+            batch_data_capture_config (BatchDataCaptureConfig): Configuration object which
+                specifies the configurations related to the batch data capture for the transform job
         """
         tags = _append_project_tags(tags)
         transform_request = self._get_transform_request(
@@ -2593,6 +2603,7 @@ class Session(object):  # pylint: disable=too-many-public-methods
             tags=tags,
             data_processing=data_processing,
             model_client_config=model_client_config,
+            batch_data_capture_config=batch_data_capture_config,
         )
 
         def submit(request):

--- a/src/sagemaker/transformer.py
+++ b/src/sagemaker/transformer.py
@@ -14,11 +14,11 @@
 from __future__ import absolute_import
 
 from typing import Union, Optional, List, Dict
-
 from botocore import exceptions
 
 from sagemaker.job import _Job
 from sagemaker.session import Session
+from sagemaker.inputs import BatchDataCaptureConfig
 from sagemaker.workflow.entities import PipelineVariable
 from sagemaker.workflow.pipeline_context import runnable_by_pipeline
 from sagemaker.workflow import is_pipeline_variable
@@ -127,6 +127,7 @@ class Transformer(object):
         join_source: Optional[Union[str, PipelineVariable]] = None,
         experiment_config: Optional[Dict[str, str]] = None,
         model_client_config: Optional[Dict[str, Union[str, PipelineVariable]]] = None,
+        batch_data_capture_config: BatchDataCaptureConfig = None,
         wait: bool = True,
         logs: bool = True,
     ):
@@ -193,6 +194,9 @@ class Transformer(object):
                 configuration. Dictionary contains two optional keys,
                 'InvocationsTimeoutInSeconds', and 'InvocationsMaxRetries'.
                 (default: ``None``).
+            batch_data_capture_config (BatchDataCaptureConfig): Configuration object which
+                specifies the configurations related to the batch data capture for the transform job
+                (default: ``None``).
             wait (bool): Whether the call should wait until the job completes
                 (default: ``True``).
             logs (bool): Whether to show the logs produced by the job.
@@ -237,6 +241,7 @@ class Transformer(object):
             join_source,
             experiment_config,
             model_client_config,
+            batch_data_capture_config,
         )
 
         if wait:
@@ -372,6 +377,7 @@ class _TransformJob(_Job):
         join_source,
         experiment_config,
         model_client_config,
+        batch_data_capture_config,
     ):
         """Placeholder docstring"""
 
@@ -387,6 +393,7 @@ class _TransformJob(_Job):
             join_source,
             experiment_config,
             model_client_config,
+            batch_data_capture_config,
         )
 
         transformer.sagemaker_session.transform(**transform_args)
@@ -407,6 +414,7 @@ class _TransformJob(_Job):
         join_source,
         experiment_config,
         model_client_config,
+        batch_data_capture_config,
     ):
         """Placeholder docstring"""
 
@@ -430,6 +438,7 @@ class _TransformJob(_Job):
                 "model_client_config": model_client_config,
                 "tags": transformer.tags,
                 "data_processing": data_processing,
+                "batch_data_capture_config": batch_data_capture_config,
             }
         )
 

--- a/src/sagemaker/workflow/steps.py
+++ b/src/sagemaker/workflow/steps.py
@@ -710,6 +710,7 @@ class TransformStep(ConfigurableRetryStep):
                 join_source=self.inputs.join_source,
                 model_client_config=self.inputs.model_client_config,
                 experiment_config=dict(),
+                batch_data_capture_config=self.inputs.batch_data_capture_config,
             )
             request_dict = self.transformer.sagemaker_session._get_transform_request(
                 **transform_args

--- a/tests/integ/test_transformer.py
+++ b/tests/integ/test_transformer.py
@@ -18,12 +18,13 @@ import time
 
 import pytest
 
-from sagemaker import KMeans, s3
+from sagemaker import KMeans, s3, get_execution_role
 from sagemaker.mxnet import MXNet
 from sagemaker.pytorch import PyTorchModel
 from sagemaker.tensorflow import TensorFlow
 from sagemaker.transformer import Transformer
 from sagemaker.estimator import Estimator
+from sagemaker.inputs import BatchDataCaptureConfig
 from sagemaker.utils import unique_name_from_base
 from tests.integ import (
     datasets,
@@ -35,7 +36,44 @@ from tests.integ.kms_utils import bucket_with_encryption, get_or_create_kms_key
 from tests.integ.timeout import timeout, timeout_and_delete_model_with_transformer
 from tests.integ.vpc_test_utils import get_or_create_vpc_resources
 
+from sagemaker.model_monitor import DatasetFormat, Statistics
+
+from sagemaker.workflow.check_job_config import CheckJobConfig
+from sagemaker.workflow.quality_check_step import (
+    DataQualityCheckConfig,
+    ModelQualityCheckConfig,
+)
+from sagemaker.workflow.parameters import ParameterString
+from sagemaker.s3 import S3Uploader
+from sagemaker.clarify import (
+    BiasConfig,
+    DataConfig,
+)
+from sagemaker.workflow.clarify_check_step import (
+    DataBiasCheckConfig,
+)
+
+_INSTANCE_COUNT = 1
+_INSTANCE_TYPE = "ml.c5.xlarge"
+_HEADERS = ["Label", "F1", "F2", "F3", "F4"]
+_CHECK_FAIL_ERROR_MSG_CLARIFY = "ClientError: Clarify check failed. See violation report"
+_PROBLEM_TYPE = "Regression"
+_HEADER_OF_LABEL = "Label"
+_HEADER_OF_PREDICTED_LABEL = "Prediction"
+_CHECK_FAIL_ERROR_MSG_QUALITY = "ClientError: Quality check failed. See violation report"
+
+
 MXNET_MNIST_PATH = os.path.join(DATA_DIR, "mxnet_mnist")
+
+
+@pytest.fixture(scope="module")
+def role(sagemaker_session):
+    return get_execution_role(sagemaker_session)
+
+
+@pytest.fixture
+def pipeline_name():
+    return unique_name_from_base("my-pipeline-transform")
 
 
 @pytest.fixture(scope="module")
@@ -76,6 +114,131 @@ def mxnet_transform_input(sagemaker_session):
     return sagemaker_session.upload_data(
         path=transform_input_path, key_prefix=transform_input_key_prefix
     )
+
+
+@pytest.fixture
+def check_job_config(role, pipeline_session):
+    return CheckJobConfig(
+        role=role,
+        instance_count=_INSTANCE_COUNT,
+        instance_type=_INSTANCE_TYPE,
+        volume_size_in_gb=60,
+        sagemaker_session=pipeline_session,
+    )
+
+
+@pytest.fixture
+def supplied_baseline_statistics_uri_param():
+    return ParameterString(name="SuppliedBaselineStatisticsUri", default_value="")
+
+
+@pytest.fixture
+def supplied_baseline_constraints_uri_param():
+    return ParameterString(name="SuppliedBaselineConstraintsUri", default_value="")
+
+
+@pytest.fixture
+def dataset(pipeline_session):
+    dataset_local_path = os.path.join(DATA_DIR, "pipeline/clarify_check_step/dataset.csv")
+    dataset_s3_uri = "s3://{}/{}/{}/{}/{}".format(
+        pipeline_session.default_bucket(),
+        "clarify_check_step",
+        "input",
+        "dataset",
+        unique_name_from_base("dataset"),
+    )
+    return S3Uploader.upload(dataset_local_path, dataset_s3_uri, sagemaker_session=pipeline_session)
+
+
+@pytest.fixture
+def data_config(pipeline_session, dataset):
+    output_path = "s3://{}/{}/{}/{}".format(
+        pipeline_session.default_bucket(),
+        "clarify_check_step",
+        "analysis_result",
+        unique_name_from_base("result"),
+    )
+    analysis_cfg_output_path = "s3://{}/{}/{}/{}".format(
+        pipeline_session.default_bucket(),
+        "clarify_check_step",
+        "analysis_cfg",
+        unique_name_from_base("analysis_cfg"),
+    )
+    return DataConfig(
+        s3_data_input_path=dataset,
+        s3_output_path=output_path,
+        s3_analysis_config_output_path=analysis_cfg_output_path,
+        label="Label",
+        headers=_HEADERS,
+        dataset_type="text/csv",
+    )
+
+
+@pytest.fixture
+def bias_config():
+    return BiasConfig(
+        label_values_or_threshold=[1],
+        facet_name="F1",
+        facet_values_or_threshold=[0.5],
+        group_name="F2",
+    )
+
+
+@pytest.fixture
+def data_bias_check_config(data_config, bias_config):
+    return DataBiasCheckConfig(
+        data_config=data_config,
+        data_bias_config=bias_config,
+    )
+
+
+@pytest.fixture
+def data_quality_baseline_dataset():
+    return os.path.join(DATA_DIR, "pipeline/quality_check_step/data_quality/baseline_dataset.csv")
+
+
+@pytest.fixture
+def data_quality_check_config(data_quality_baseline_dataset):
+    return DataQualityCheckConfig(
+        baseline_dataset=data_quality_baseline_dataset,
+        dataset_format=DatasetFormat.csv(header=False),
+    )
+
+
+@pytest.fixture
+def data_quality_supplied_baseline_statistics(sagemaker_session):
+    return Statistics.from_file_path(
+        statistics_file_path=os.path.join(
+            DATA_DIR, "pipeline/quality_check_step/data_quality/statistics.json"
+        ),
+        sagemaker_session=sagemaker_session,
+    ).file_s3_uri
+
+
+@pytest.fixture
+def model_quality_baseline_dataset():
+    return os.path.join(DATA_DIR, "pipeline/quality_check_step/model_quality/baseline_dataset.csv")
+
+
+@pytest.fixture
+def model_quality_check_config(model_quality_baseline_dataset):
+    return ModelQualityCheckConfig(
+        baseline_dataset=model_quality_baseline_dataset,
+        dataset_format=DatasetFormat.csv(),
+        problem_type=_PROBLEM_TYPE,
+        inference_attribute=_HEADER_OF_LABEL,
+        ground_truth_attribute=_HEADER_OF_PREDICTED_LABEL,
+    )
+
+
+@pytest.fixture
+def model_quality_supplied_baseline_statistics(sagemaker_session):
+    return Statistics.from_file_path(
+        statistics_file_path=os.path.join(
+            DATA_DIR, "pipeline/quality_check_step/model_quality/statistics.json"
+        ),
+        sagemaker_session=sagemaker_session,
+    ).file_s3_uri
 
 
 @pytest.mark.release
@@ -246,6 +409,37 @@ def test_transform_model_client_config(
         )
 
         assert model_client_config == transform_job_desc["ModelClientConfig"]
+
+
+def test_transform_data_capture_config(
+    mxnet_estimator, mxnet_transform_input, sagemaker_session, cpu_instance_type
+):
+    destination_s3_uri = os.path.join("s3://", sagemaker_session.default_bucket(), "data_capture")
+    batch_data_capture_config = BatchDataCaptureConfig(
+        destination_s3_uri=destination_s3_uri, kms_key_id="", generate_inference_id=False
+    )
+    transformer = mxnet_estimator.transformer(1, cpu_instance_type)
+
+    # we extract the S3Prefix from the input
+    filename = mxnet_transform_input.split("/")[-1]
+    input_prefix = mxnet_transform_input.replace(f"/{filename}", "")
+    transformer.transform(
+        input_prefix,
+        content_type="text/csv",
+        batch_data_capture_config=batch_data_capture_config,
+    )
+
+    with timeout_and_delete_model_with_transformer(
+        transformer, sagemaker_session, minutes=TRANSFORM_DEFAULT_TIMEOUT_MINUTES
+    ):
+        transformer.wait()
+        transform_job_desc = sagemaker_session.sagemaker_client.describe_transform_job(
+            TransformJobName=transformer.latest_transform_job.name
+        )
+
+        assert (
+            batch_data_capture_config._to_request_dict() == transform_job_desc["DataCaptureConfig"]
+        )
 
 
 def test_transform_byo_estimator(sagemaker_session, cpu_instance_type):

--- a/tests/unit/sagemaker/monitor/test_model_monitoring.py
+++ b/tests/unit/sagemaker/monitor/test_model_monitoring.py
@@ -23,12 +23,13 @@ from sagemaker.model_monitor import (
     CronExpressionGenerator,
     DefaultModelMonitor,
     EndpointInput,
+    BatchTransformInput,
     ModelQualityMonitor,
     Statistics,
 )
 
-from sagemaker.model_monitor.dataset_format import DatasetFormat
 from sagemaker.network import NetworkConfig
+from sagemaker.model_monitor.dataset_format import MonitoringDatasetFormat, DatasetFormat
 
 REGION = "us-west-2"
 BUCKET_NAME = "mybucket"
@@ -101,6 +102,7 @@ SCHEDULE_NAME = "schedule"
 SCHEDULE_ARN = "arn:aws:sagemaker:us-west-2:012345678901:monitoring-schedule/" + SCHEDULE_NAME
 OUTPUT_LOCAL_PATH = "/opt/ml/processing/output"
 ENDPOINT_INPUT_LOCAL_PATH = "/opt/ml/processing/input/endpoint"
+SCHEDULE_DESTINATION = "/opt/ml/processing/data"
 SCHEDULE_NAME = "schedule"
 CRON_HOURLY = CronExpressionGenerator.hourly()
 S3_INPUT_MODE = "File"
@@ -119,6 +121,8 @@ PROBABILITY_ATTRIBUTE = "probabilities"
 PROBABILITY_THRESHOLD_ATTRIBUTE = 0.6
 PREPROCESSOR_URI = "s3://my_bucket/preprocessor.py"
 POSTPROCESSOR_URI = "s3://my_bucket/postprocessor.py"
+DATA_CAPTURED_S3_URI = "s3://my-bucket/batch-fraud-detection/on-schedule-monitoring/in/"
+DATASET_FORMAT = MonitoringDatasetFormat.csv(header=False)
 JOB_OUTPUT_CONFIG = {
     "MonitoringOutputs": [
         {
@@ -148,6 +152,15 @@ DATA_QUALITY_JOB_INPUT = {
         "S3DataDistributionType": S3_DATA_DISTRIBUTION_TYPE,
     },
 }
+DATA_QUALITY_BATCH_TRANSFORM_INPUT = {
+    "BatchTransformInput": {
+        "DataCapturedDestinationS3Uri": DATA_CAPTURED_S3_URI,
+        "LocalPath": SCHEDULE_DESTINATION,
+        "S3DataDistributionType": S3_DATA_DISTRIBUTION_TYPE,
+        "S3InputMode": S3_INPUT_MODE,
+        "DatasetFormat": DATASET_FORMAT,
+    }
+}
 DATA_QUALITY_APP_SPECIFICATION = {
     "ImageUri": DEFAULT_IMAGE_URI,
     "Environment": ENVIRONMENT,
@@ -162,6 +175,16 @@ DATA_QUALITY_JOB_DEFINITION = {
     "DataQualityAppSpecification": DATA_QUALITY_APP_SPECIFICATION,
     "DataQualityBaselineConfig": DATA_QUALITY_BASELINE_CONFIG,
     "DataQualityJobInput": DATA_QUALITY_JOB_INPUT,
+    "DataQualityJobOutputConfig": JOB_OUTPUT_CONFIG,
+    "JobResources": JOB_RESOURCES,
+    "RoleArn": ROLE,
+    "NetworkConfig": NETWORK_CONFIG._to_request_dict(),
+    "StoppingCondition": STOP_CONDITION,
+}
+DATA_QUALITY_BATCH_TRANSFORM_JOB_DEFINITION = {
+    "DataQualityAppSpecification": DATA_QUALITY_APP_SPECIFICATION,
+    "DataQualityBaselineConfig": DATA_QUALITY_BASELINE_CONFIG,
+    "DataQualityJobInput": DATA_QUALITY_BATCH_TRANSFORM_INPUT,
     "DataQualityJobOutputConfig": JOB_OUTPUT_CONFIG,
     "JobResources": JOB_RESOURCES,
     "RoleArn": ROLE,
@@ -191,9 +214,38 @@ MODEL_QUALITY_JOB_INPUT = {
     },
     "GroundTruthS3Input": {"S3Uri": GROUND_TRUTH_S3_URI},
 }
+
+MODEL_QUALITY_BATCH_TRANSFORM_INPUT_JOB_INPUT = {
+    "BatchTransformInput": {
+        "DataCapturedDestinationS3Uri": DATA_CAPTURED_S3_URI,
+        "LocalPath": SCHEDULE_DESTINATION,
+        "S3InputMode": S3_INPUT_MODE,
+        "S3DataDistributionType": S3_DATA_DISTRIBUTION_TYPE,
+        "StartTimeOffset": START_TIME_OFFSET,
+        "EndTimeOffset": END_TIME_OFFSET,
+        "FeaturesAttribute": FEATURES_ATTRIBUTE,
+        "InferenceAttribute": INFERENCE_ATTRIBUTE,
+        "ProbabilityAttribute": PROBABILITY_ATTRIBUTE,
+        "ProbabilityThresholdAttribute": PROBABILITY_THRESHOLD_ATTRIBUTE,
+        "DatasetFormat": DATASET_FORMAT,
+    },
+    "GroundTruthS3Input": {"S3Uri": GROUND_TRUTH_S3_URI},
+}
+
 MODEL_QUALITY_JOB_DEFINITION = {
     "ModelQualityAppSpecification": MODEL_QUALITY_APP_SPECIFICATION,
     "ModelQualityJobInput": MODEL_QUALITY_JOB_INPUT,
+    "ModelQualityJobOutputConfig": JOB_OUTPUT_CONFIG,
+    "JobResources": JOB_RESOURCES,
+    "RoleArn": ROLE,
+    "ModelQualityBaselineConfig": MODEL_QUALITY_BASELINE_CONFIG,
+    "NetworkConfig": NETWORK_CONFIG._to_request_dict(),
+    "StoppingCondition": STOP_CONDITION,
+}
+
+MODEL_QUALITY_BATCH_TRANSFORM_INPUT_JOB_DEFINITION = {
+    "ModelQualityAppSpecification": MODEL_QUALITY_APP_SPECIFICATION,
+    "ModelQualityJobInput": MODEL_QUALITY_BATCH_TRANSFORM_INPUT_JOB_INPUT,
     "ModelQualityJobOutputConfig": JOB_OUTPUT_CONFIG,
     "JobResources": JOB_RESOURCES,
     "RoleArn": ROLE,
@@ -480,6 +532,28 @@ def test_data_quality_monitor(data_quality_monitor, sagemaker_session):
     )
 
 
+def test_data_quality_batch_transform_monitor(data_quality_monitor, sagemaker_session):
+    # create schedule
+    _test_data_quality_batch_transform_monitor_create_schedule(
+        data_quality_monitor=data_quality_monitor,
+        sagemaker_session=sagemaker_session,
+        constraints=CONSTRAINTS,
+        statistics=STATISTICS,
+    )
+
+    # update schedule
+    _test_data_quality_monitor_update_schedule(
+        data_quality_monitor=data_quality_monitor,
+        sagemaker_session=sagemaker_session,
+    )
+
+    # delete schedule
+    _test_data_quality_monitor_delete_schedule(
+        data_quality_monitor=data_quality_monitor,
+        sagemaker_session=sagemaker_session,
+    )
+
+
 def test_data_quality_monitor_created_by_attach(sagemaker_session):
     # attach and validate
     sagemaker_session.sagemaker_client.describe_data_quality_job_definition = MagicMock()
@@ -600,6 +674,7 @@ def _test_data_quality_monitor_create_schedule(
         endpoint_name=ENDPOINT_NAME, destination=ENDPOINT_INPUT_LOCAL_PATH
     ),
 ):
+    # for endpoint input
     data_quality_monitor.create_monitoring_schedule(
         endpoint_input=endpoint_input,
         record_preprocessor_script=PREPROCESSOR_URI,
@@ -615,6 +690,45 @@ def _test_data_quality_monitor_create_schedule(
     expected_arguments = {
         "JobDefinitionName": data_quality_monitor.job_definition_name,
         **copy.deepcopy(DATA_QUALITY_JOB_DEFINITION),
+        "Tags": TAGS,
+    }
+    if baseline_job_name:
+        baseline_config = expected_arguments.get("DataQualityBaselineConfig", {})
+        baseline_config["BaseliningJobName"] = baseline_job_name
+
+    sagemaker_session.sagemaker_client.create_data_quality_job_definition.assert_called_with(
+        **expected_arguments
+    )
+
+
+def _test_data_quality_batch_transform_monitor_create_schedule(
+    data_quality_monitor,
+    sagemaker_session,
+    constraints=None,
+    statistics=None,
+    baseline_job_name=None,
+    batch_transform_input=BatchTransformInput(
+        data_captured_destination_s3_uri=DATA_CAPTURED_S3_URI,
+        destination=SCHEDULE_DESTINATION,
+        dataset_format=MonitoringDatasetFormat.csv(header=False),
+    ),
+):
+    # for batch transform input
+    data_quality_monitor.create_monitoring_schedule(
+        batch_transform_input=batch_transform_input,
+        record_preprocessor_script=PREPROCESSOR_URI,
+        post_analytics_processor_script=POSTPROCESSOR_URI,
+        output_s3_uri=OUTPUT_S3_URI,
+        constraints=constraints,
+        statistics=statistics,
+        monitor_schedule_name=SCHEDULE_NAME,
+        schedule_cron_expression=CRON_HOURLY,
+    )
+
+    # validation
+    expected_arguments = {
+        "JobDefinitionName": data_quality_monitor.job_definition_name,
+        **copy.deepcopy(DATA_QUALITY_BATCH_TRANSFORM_JOB_DEFINITION),
         "Tags": TAGS,
     }
     if baseline_job_name:
@@ -881,6 +995,27 @@ def test_model_quality_monitor(model_quality_monitor, sagemaker_session):
     )
 
 
+def test_model_quality_batch_transform_monitor(model_quality_monitor, sagemaker_session):
+    # create schedule
+    _test_model_quality_monitor_batch_transform_create_schedule(
+        model_quality_monitor=model_quality_monitor,
+        sagemaker_session=sagemaker_session,
+        constraints=CONSTRAINTS,
+    )
+
+    # update schedule
+    _test_model_quality_monitor_update_schedule(
+        model_quality_monitor=model_quality_monitor,
+        sagemaker_session=sagemaker_session,
+    )
+
+    # delete schedule
+    _test_model_quality_monitor_delete_schedule(
+        model_quality_monitor=model_quality_monitor,
+        sagemaker_session=sagemaker_session,
+    )
+
+
 def test_model_quality_monitor_created_by_attach(sagemaker_session):
     # attach and validate
     sagemaker_session.sagemaker_client.describe_model_quality_job_definition = MagicMock()
@@ -1022,6 +1157,65 @@ def _test_model_quality_monitor_create_schedule(
     expected_arguments = {
         "JobDefinitionName": model_quality_monitor.job_definition_name,
         **copy.deepcopy(MODEL_QUALITY_JOB_DEFINITION),
+        "Tags": TAGS,
+    }
+    if constraints:
+        expected_arguments["ModelQualityBaselineConfig"] = {
+            "ConstraintsResource": {"S3Uri": constraints.file_s3_uri}
+        }
+    if baseline_job_name:
+        expected_arguments["ModelQualityBaselineConfig"] = {
+            "BaseliningJobName": baseline_job_name,
+        }
+
+    sagemaker_session.sagemaker_client.create_model_quality_job_definition.assert_called_with(
+        **expected_arguments
+    )
+
+    sagemaker_session.sagemaker_client.create_monitoring_schedule.assert_called_with(
+        MonitoringScheduleName=SCHEDULE_NAME,
+        MonitoringScheduleConfig={
+            "MonitoringJobDefinitionName": model_quality_monitor.job_definition_name,
+            "MonitoringType": "ModelQuality",
+            "ScheduleConfig": {"ScheduleExpression": CRON_HOURLY},
+        },
+        Tags=TAGS,
+    )
+
+
+def _test_model_quality_monitor_batch_transform_create_schedule(
+    model_quality_monitor,
+    sagemaker_session,
+    constraints=None,
+    baseline_job_name=None,
+    batch_transform_input=BatchTransformInput(
+        data_captured_destination_s3_uri=DATA_CAPTURED_S3_URI,
+        destination=SCHEDULE_DESTINATION,
+        start_time_offset=START_TIME_OFFSET,
+        end_time_offset=END_TIME_OFFSET,
+        features_attribute=FEATURES_ATTRIBUTE,
+        inference_attribute=INFERENCE_ATTRIBUTE,
+        probability_attribute=PROBABILITY_ATTRIBUTE,
+        probability_threshold_attribute=PROBABILITY_THRESHOLD_ATTRIBUTE,
+        dataset_format=MonitoringDatasetFormat.csv(header=False),
+    ),
+):
+    model_quality_monitor.create_monitoring_schedule(
+        batch_transform_input=batch_transform_input,
+        ground_truth_input=GROUND_TRUTH_S3_URI,
+        problem_type=PROBLEM_TYPE,
+        record_preprocessor_script=PREPROCESSOR_URI,
+        post_analytics_processor_script=POSTPROCESSOR_URI,
+        output_s3_uri=OUTPUT_S3_URI,
+        constraints=constraints,
+        monitor_schedule_name=SCHEDULE_NAME,
+        schedule_cron_expression=CRON_HOURLY,
+    )
+
+    # validation
+    expected_arguments = {
+        "JobDefinitionName": model_quality_monitor.job_definition_name,
+        **copy.deepcopy(MODEL_QUALITY_BATCH_TRANSFORM_INPUT_JOB_DEFINITION),
         "Tags": TAGS,
     }
     if constraints:
@@ -1248,3 +1442,42 @@ def _test_model_quality_monitor_delete_schedule(model_quality_monitor, sagemaker
     sagemaker_session.sagemaker_client.delete_model_quality_job_definition.assert_called_once_with(
         JobDefinitionName=job_definition_name
     )
+
+
+def test_batch_transform_and_endpoint_input_simultaneous_failure(
+    data_quality_monitor,
+    sagemaker_session,
+    constraints=None,
+    statistics=None,
+    baseline_job_name=None,
+    batch_transform_input=BatchTransformInput(
+        data_captured_destination_s3_uri=DATA_CAPTURED_S3_URI,
+        destination=SCHEDULE_DESTINATION,
+        dataset_format=MonitoringDatasetFormat.csv(header=False),
+    ),
+    endpoint_input=EndpointInput(
+        endpoint_name=ENDPOINT_NAME,
+        destination=ENDPOINT_INPUT_LOCAL_PATH,
+        start_time_offset=START_TIME_OFFSET,
+        end_time_offset=END_TIME_OFFSET,
+        features_attribute=FEATURES_ATTRIBUTE,
+        inference_attribute=INFERENCE_ATTRIBUTE,
+        probability_attribute=PROBABILITY_ATTRIBUTE,
+        probability_threshold_attribute=PROBABILITY_THRESHOLD_ATTRIBUTE,
+    ),
+):
+    try:
+        # for batch transform input
+        data_quality_monitor.create_monitoring_schedule(
+            batch_transform_input=batch_transform_input,
+            record_preprocessor_script=PREPROCESSOR_URI,
+            post_analytics_processor_script=POSTPROCESSOR_URI,
+            output_s3_uri=OUTPUT_S3_URI,
+            constraints=constraints,
+            statistics=statistics,
+            monitor_schedule_name=SCHEDULE_NAME,
+            schedule_cron_expression=CRON_HOURLY,
+            endpoint_input=endpoint_input,
+        )
+    except Exception as e:
+        assert "Need to have either batch_transform_input or endpoint_input" in str(e)

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -32,6 +32,7 @@ from sagemaker.session import (
     NOTEBOOK_METADATA_FILE,
 )
 from sagemaker.tuner import WarmStartConfig, WarmStartTypes
+from sagemaker.inputs import BatchDataCaptureConfig
 
 STATIC_HPs = {"feature_dim": "784"}
 
@@ -1373,6 +1374,7 @@ def test_transform_pack_to_request(sagemaker_session):
         model_client_config=None,
         tags=None,
         data_processing=data_processing,
+        batch_data_capture_config=None,
     )
 
     _, _, actual_args = sagemaker_session.sagemaker_client.method_calls[0]
@@ -1384,6 +1386,12 @@ def test_transform_pack_to_request_with_optional_params(sagemaker_session):
     max_concurrent_transforms = 1
     max_payload = 0
     env = {"FOO": "BAR"}
+
+    batch_data_capture_config = BatchDataCaptureConfig(
+        destination_s3_uri="test_uri",
+        kms_key_id="",
+        generate_inference_id=False,
+    )
 
     sagemaker_session.transform(
         job_name=JOB_NAME,
@@ -1399,6 +1407,7 @@ def test_transform_pack_to_request_with_optional_params(sagemaker_session):
         model_client_config=MODEL_CLIENT_CONFIG,
         tags=TAGS,
         data_processing=None,
+        batch_data_capture_config=batch_data_capture_config,
     )
 
     _, _, actual_args = sagemaker_session.sagemaker_client.method_calls[0]
@@ -1409,6 +1418,7 @@ def test_transform_pack_to_request_with_optional_params(sagemaker_session):
     assert actual_args["Tags"] == TAGS
     assert actual_args["ExperimentConfig"] == EXPERIMENT_CONFIG
     assert actual_args["ModelClientConfig"] == MODEL_CLIENT_CONFIG
+    assert actual_args["DataCaptureConfig"] == batch_data_capture_config._to_request_dict()
 
 
 @patch("sys.stdout", new_callable=io.BytesIO if six.PY2 else io.StringIO)

--- a/tests/unit/test_transformer.py
+++ b/tests/unit/test_transformer.py
@@ -16,6 +16,7 @@ import pytest
 from mock import MagicMock, Mock, patch
 
 from sagemaker.transformer import _TransformJob, Transformer
+from sagemaker.inputs import BatchDataCaptureConfig
 from tests.integ import test_local_mode
 
 MODEL_NAME = "model"
@@ -168,6 +169,9 @@ def test_transform_with_all_params(start_new_job, transformer):
         "TrialComponentDisplayName": "tc",
     }
     model_client_config = {"InvocationsTimeoutInSeconds": 60, "InvocationsMaxRetries": 2}
+    batch_data_capture_config = BatchDataCaptureConfig(
+        destination_s3_uri=OUTPUT_PATH, kms_key_id=KMS_KEY_ID, generate_inference_id=False
+    )
 
     transformer.transform(
         DATA,
@@ -181,6 +185,7 @@ def test_transform_with_all_params(start_new_job, transformer):
         join_source=join_source,
         experiment_config=experiment_config,
         model_client_config=model_client_config,
+        batch_data_capture_config=batch_data_capture_config,
     )
 
     assert transformer._current_job_name == JOB_NAME
@@ -197,6 +202,7 @@ def test_transform_with_all_params(start_new_job, transformer):
         join_source,
         experiment_config,
         model_client_config,
+        batch_data_capture_config,
     )
 
 
@@ -433,6 +439,10 @@ def test_start_new(prepare_data_processing, load_config, sagemaker_session):
     join_source = "Input"
     model_client_config = {"InvocationsTimeoutInSeconds": 60, "InvocationsMaxRetries": 2}
 
+    batch_data_capture_config = BatchDataCaptureConfig(
+        destination_s3_uri=OUTPUT_PATH, kms_key_id=KMS_KEY_ID, generate_inference_id=False
+    )
+
     job = _TransformJob.start_new(
         transformer=transformer,
         data=DATA,
@@ -445,6 +455,7 @@ def test_start_new(prepare_data_processing, load_config, sagemaker_session):
         join_source=join_source,
         experiment_config={"ExperimentName": "exp"},
         model_client_config=model_client_config,
+        batch_data_capture_config=batch_data_capture_config,
     )
 
     assert job.sagemaker_session == sagemaker_session
@@ -469,6 +480,7 @@ def test_start_new(prepare_data_processing, load_config, sagemaker_session):
         model_client_config=model_client_config,
         tags=tags,
         data_processing=prepare_data_processing.return_value,
+        batch_data_capture_config=batch_data_capture_config,
     )
 
 


### PR DESCRIPTION
*Issue #, if available:*

This is the same PR as https://github.com/aws/sagemaker-python-sdk/pull/3418

*Description of changes:*

Addressed the reviewer comments on adding defaults.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
