### PR TITLE
fix: Add retry for airflow ParsingError

### DIFF
--- a/tests/integ/test_airflow_config.py
+++ b/tests/integ/test_airflow_config.py
@@ -16,10 +16,9 @@ import os
 
 import pytest
 import numpy as np
-from airflow import utils
-from airflow import DAG
-from airflow.providers.amazon.aws.operators.sagemaker import SageMakerTrainingOperator
-from airflow.providers.amazon.aws.operators.sagemaker_transform import SageMakerTransformOperator
+from configparser import ParsingError
+from sagemaker.utils import retries
+
 from six.moves.urllib.parse import urlparse
 
 import tests.integ
@@ -48,6 +47,23 @@ from sagemaker.xgboost import XGBoost
 from tests.integ import datasets, DATA_DIR
 from tests.integ.record_set import prepare_record_set_from_local_files
 from tests.integ.timeout import timeout
+
+for _ in retries(
+    max_retry_count=10,  # 10*6 = 1min
+    exception_message_prefix="airflow import ",
+    seconds_to_sleep=6,
+):
+    try:
+        from airflow import utils
+        from airflow import DAG
+        from airflow.providers.amazon.aws.operators.sagemaker import SageMakerTrainingOperator
+        from airflow.providers.amazon.aws.operators.sagemaker_transform import (
+            SageMakerTransformOperator,
+        )
+
+        break
+    except ParsingError:
+        pass
 
 PYTORCH_MNIST_DIR = os.path.join(DATA_DIR, "pytorch_mnist")
 PYTORCH_MNIST_SCRIPT = os.path.join(PYTORCH_MNIST_DIR, "mnist.py")


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Workaround to try any add retries for ConfigParser Failures.

*Testing done:*
Ran integ tests locally

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
