### PR TITLE
fix: Update Graviton supported instance families

### DIFF
--- a/src/sagemaker/fw_utils.py
+++ b/src/sagemaker/fw_utils.py
@@ -144,7 +144,16 @@ TRAINIUM_SUPPORTED_DISTRIBUTION_STRATEGIES = ["torch_distributed"]
 SMDISTRIBUTED_SUPPORTED_STRATEGIES = ["dataparallel", "modelparallel"]
 
 
-GRAVITON_ALLOWED_TARGET_INSTANCE_FAMILY = ["c6g", "t4g", "r6g", "m6g"]
+GRAVITON_ALLOWED_TARGET_INSTANCE_FAMILY = [
+    "m6g",
+    "m6gd",
+    "c6g",
+    "c6gd",
+    "c6gn",
+    "c7g",
+    "r6g",
+    "r6gd",
+]
 
 
 GRAVITON_ALLOWED_FRAMEWORKS = set(["tensorflow", "pytorch", "xgboost", "sklearn"])

--- a/tests/unit/sagemaker/image_uris/test_graviton.py
+++ b/tests/unit/sagemaker/image_uris/test_graviton.py
@@ -17,12 +17,26 @@ from tests.unit.sagemaker.image_uris import expected_uris
 
 import pytest
 
+GRAVITON_ALLOWED_TARGET_INSTANCE_FAMILY = [
+    "m6g",
+    "m6gd",
+    "c6g",
+    "c6gd",
+    "c6gn",
+    "c7g",
+    "r6g",
+    "r6gd",
+]
 GRAVITON_ALGOS = ("tensorflow", "pytotch")
 GRAVITON_INSTANCE_TYPES = [
-    "ml.c6g.4xlarge",
-    "ml.t4g.2xlarge",
-    "ml.r6g.2xlarge",
     "ml.m6g.4xlarge",
+    "ml.m6gd.2xlarge",
+    "ml.c6g.2xlarge",
+    "ml.c6gd.4xlarge",
+    "ml.c6gn.4xlarge",
+    "ml.c7g.2xlarge",
+    "ml.r6g.2xlarge",
+    "ml.r6gd.4xlarge",
 ]
 
 ACCOUNTS = {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update instance families list supported by Graviton instances in SageMaker.

*Testing done:*
Tested changes using unit tests.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
