### PR TITLE
fix: Fixing type hints for Spark processor that has instance type/count params in reverse order

### DIFF
--- a/src/sagemaker/spark/processing.py
+++ b/src/sagemaker/spark/processing.py
@@ -700,8 +700,8 @@ class PySparkProcessor(_SparkProcessorBase):
     def __init__(
         self,
         role: str,
-        instance_type: Union[int, PipelineVariable],
-        instance_count: Union[str, PipelineVariable],
+        instance_type: Union[str, PipelineVariable],
+        instance_count: Union[int, PipelineVariable],
         framework_version: Optional[str] = None,
         py_version: Optional[str] = None,
         container_version: Optional[str] = None,
@@ -960,8 +960,8 @@ class SparkJarProcessor(_SparkProcessorBase):
     def __init__(
         self,
         role: str,
-        instance_type: Union[int, PipelineVariable],
-        instance_count: Union[str, PipelineVariable],
+        instance_type: Union[str, PipelineVariable],
+        instance_count: Union[int, PipelineVariable],
         framework_version: Optional[str] = None,
         py_version: Optional[str] = None,
         container_version: Optional[str] = None,


### PR DESCRIPTION
*Issue #, if available:*
#3167

*Description of changes:*

SparkProcessor and SparkJarProcessor, unlike all other processors, have instance_type and instance_count in constructor in reverse order. When the type hints were added in #3167, they were probably copy-pasted from other processors, hence str and int type hints got assigned in reverse order by mistake.

This is the fix to get correct type hints only, without changing the order of parameters and without breaking the backward compatibility. 

*Testing done:*
Yes

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [X] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [X] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [X] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [X] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [X] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
