### PR TITLE
fix: Return ARM XGB/SKLearn tags if `image_scope` is `inference_graviton`

### DIFF
--- a/tests/unit/sagemaker/image_uris/test_graviton.py
+++ b/tests/unit/sagemaker/image_uris/test_graviton.py
@@ -89,7 +89,7 @@ def test_graviton_pytorch(graviton_pytorch_version):
     _test_graviton_framework_uris("pytorch", graviton_pytorch_version)
 
 
-def test_graviton_xgboost(graviton_xgboost_versions):
+def test_graviton_xgboost_instance_type_specified(graviton_xgboost_versions):
     for xgboost_version in graviton_xgboost_versions:
         for instance_type in GRAVITON_INSTANCE_TYPES:
             uri = image_uris.retrieve(
@@ -102,6 +102,33 @@ def test_graviton_xgboost(graviton_xgboost_versions):
             assert expected == uri
 
 
+def test_graviton_xgboost_image_scope_specified(graviton_xgboost_versions):
+    for xgboost_version in graviton_xgboost_versions:
+        for instance_type in GRAVITON_INSTANCE_TYPES:
+            uri = image_uris.retrieve(
+                "xgboost", "us-west-2", version=xgboost_version, image_scope="inference_graviton"
+            )
+            expected = (
+                "246618743249.dkr.ecr.us-west-2.amazonaws.com/sagemaker-xgboost:"
+                f"{xgboost_version}-arm64"
+            )
+            assert expected == uri
+
+
+def test_graviton_xgboost_image_scope_specified_x86_instance(graviton_xgboost_versions):
+    for xgboost_version in graviton_xgboost_versions:
+        for instance_type in GRAVITON_INSTANCE_TYPES:
+            with pytest.raises(ValueError) as error:
+                image_uris.retrieve(
+                    "xgboost",
+                    "us-west-2",
+                    version=xgboost_version,
+                    image_scope="inference_graviton",
+                    instance_type="ml.m5.xlarge",
+                )
+            assert "Unsupported instance type: m5." in str(error)
+
+
 def test_graviton_xgboost_unsupported_version(graviton_xgboost_unsupported_versions):
     for xgboost_version in graviton_xgboost_unsupported_versions:
         for instance_type in GRAVITON_INSTANCE_TYPES:
@@ -112,11 +139,24 @@ def test_graviton_xgboost_unsupported_version(graviton_xgboost_unsupported_versi
             assert f"Unsupported xgboost version: {xgboost_version}." in str(error)
 
 
-def test_graviton_sklearn(graviton_sklearn_versions):
+def test_graviton_sklearn_instance_type_specified(graviton_sklearn_versions):
     for sklearn_version in graviton_sklearn_versions:
         for instance_type in GRAVITON_INSTANCE_TYPES:
             uri = image_uris.retrieve(
                 "sklearn", "us-west-2", version=sklearn_version, instance_type=instance_type
+            )
+            expected = (
+                "246618743249.dkr.ecr.us-west-2.amazonaws.com/sagemaker-scikit-learn:"
+                f"{sklearn_version}-arm64-cpu-py3"
+            )
+            assert expected == uri
+
+
+def test_graviton_sklearn_image_scope_specified(graviton_sklearn_versions):
+    for sklearn_version in graviton_sklearn_versions:
+        for instance_type in GRAVITON_INSTANCE_TYPES:
+            uri = image_uris.retrieve(
+                "sklearn", "us-west-2", version=sklearn_version, image_scope="inference_graviton"
             )
             expected = (
                 "246618743249.dkr.ecr.us-west-2.amazonaws.com/sagemaker-scikit-learn:"
@@ -136,6 +176,20 @@ def test_graviton_sklearn_unsupported_version(graviton_sklearn_unsupported_versi
             # the default. See: image_uris._validate_version_and_set_if_needed
             expected = "246618743249.dkr.ecr.us-west-2.amazonaws.com/sagemaker-scikit-learn:1.0-1-arm64-cpu-py3"
             assert expected == uri
+
+
+def test_graviton_sklearn_image_scope_specified_x86_instance(graviton_sklearn_unsupported_versions):
+    for sklearn_version in graviton_sklearn_unsupported_versions:
+        for instance_type in GRAVITON_INSTANCE_TYPES:
+            with pytest.raises(ValueError) as error:
+                image_uris.retrieve(
+                    "sklearn",
+                    "us-west-2",
+                    version=sklearn_version,
+                    image_scope="inference_graviton",
+                    instance_type="ml.m5.xlarge",
+                )
+            assert "Unsupported instance type: m5." in str(error)
 
 
 def _expected_graviton_framework_uri(framework, version, region):


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*

Return ARM XGB/SKLearn tags if `image_scope` is `inference_graviton`.

Old behavior: 

```
In [2]: sagemaker.image_uris.retrieve("sklearn", "us-west-2", version="1.0-1", image_scope="inference_graviton")
Out[2]: '246618743249.dkr.ecr.us-west-2.amazonaws.com/sagemaker-scikit-learn:1.0-1'
```

New behavior:

```
In [2]: sagemaker.image_uris.retrieve("sklearn", "us-west-2", version="1.0-1", image_scope="inference_graviton")
Out[2]: '246618743249.dkr.ecr.us-west-2.amazonaws.com/sagemaker-scikit-learn:1.0-1-arm64-cpu-py3'
```

Also, a validation error is thrown if `image_scope` is set to `inference_graviton` with a non-arm instance.

Valid:

```
In [3]: sagemaker.image_uris.retrieve("sklearn", "us-west-2", version="1.0-1", image_scope="inference_graviton", instance_type="ml.m6g.xlarge")
Out[3]: '246618743249.dkr.ecr.us-west-2.amazonaws.com/sagemaker-scikit-learn:1.0-1-arm64-cpu-py3'
```

Invalid:

```
In [4]: sagemaker.image_uris.retrieve("sklearn", "us-west-2", version="1.0-1", image_scope="inference_graviton", instance_type="ml.m5.xlarge")
Out [4]: ValueError: Unsupported instance type: m5. You may need to upgrade your SDK version (pip install -U sagemaker) for newer instance types. Supported instance type(s): m6g, m6gd, c6g, c6gd, c6gn, c7g, r6g, r6gd.
```

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
