### PR TITLE
fix: Fix AsyncInferenceConfig documentation typo

### DIFF
--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -1171,7 +1171,7 @@ be ``s3://sagemaker-{REGION}-{ACCOUNTID}/async-endpoint-outputs/{UNIQUE-JOB-NAME
     from sagemaker.async_inference import AsyncInferenceConfig
 
     # Create an empty AsyncInferenceConfig object to use default values
-    async_config = new AsyncInferenceConfig()
+    async_config = AsyncInferenceConfig()
 
 Or you can specify configurations in ``AsyncInferenceConfig`` as you like. All of those configuration parameters
 are optional but if you don’t specify the ``output_path``, Amazon SageMaker will use the default ``S3OutputPath``
@@ -1180,7 +1180,7 @@ mentioned above (example shown below):
 .. code:: python
 
     # Specify S3OutputPath, MaxConcurrentInvocationsPerInstance and NotificationConfig in the async config object
-    async_config = new AsyncInferenceConfig(
+    async_config = AsyncInferenceConfig(
         output_path="s3://{s3_bucket}/{bucket_prefix}/output",
         max_concurrent_invocations_per_instance=10,
         notification_config = {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
There was a syntax error in the documentation for creating a new AsyncInferenceConfig object.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
