### PR TITLE
fix: Pop out ModelPackageName from pipeline definition

### DIFF
--- a/src/sagemaker/workflow/_utils.py
+++ b/src/sagemaker/workflow/_utils.py
@@ -13,6 +13,7 @@
 """Scrapper utilities to support repacking of models."""
 from __future__ import absolute_import
 
+import logging
 import os
 import shutil
 import tarfile
@@ -36,6 +37,8 @@ from sagemaker.workflow.retry import RetryPolicy
 
 if TYPE_CHECKING:
     from sagemaker.workflow.step_collections import StepCollection
+
+logger = logging.getLogger(__name__)
 
 FRAMEWORK_VERSION = "0.23-1"
 INSTANCE_TYPE = "ml.m5.large"
@@ -479,10 +482,19 @@ class _RegisterModelStep(ConfigurableRetryStep):
 
             request_dict = get_create_model_package_request(**model_package_args)
         # these are not available in the workflow service and will cause rejection
+        warn_msg_template = (
+            "Popping out '%s' from the pipeline definition "
+            "since it will be overridden in pipeline execution time."
+        )
         if "CertifyForMarketplace" in request_dict:
             request_dict.pop("CertifyForMarketplace")
+            logger.warning(warn_msg_template, "CertifyForMarketplace")
         if "Description" in request_dict:
             request_dict.pop("Description")
+            logger.warning(warn_msg_template, "Description")
+        if "ModelPackageName" in request_dict:
+            request_dict.pop("ModelPackageName")
+            logger.warning(warn_msg_template, "ModelPackageName")
 
         return request_dict
 

--- a/tests/integ/sagemaker/workflow/test_model_steps.py
+++ b/tests/integ/sagemaker/workflow/test_model_steps.py
@@ -112,6 +112,7 @@ def test_pytorch_training_model_registration_and_creation_without_custom_inferen
         inference_instances=["ml.m5.xlarge"],
         transform_instances=["ml.m5.xlarge"],
         description="test-description",
+        model_package_name="model-pkg-name-will-be-popped-out",
     )
     step_model_regis = ModelStep(
         name="pytorch-register-model",

--- a/tests/unit/sagemaker/workflow/conftest.py
+++ b/tests/unit/sagemaker/workflow/conftest.py
@@ -1,0 +1,75 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from __future__ import absolute_import
+
+from unittest.mock import Mock, PropertyMock
+
+import pytest
+
+from sagemaker import Session
+from sagemaker.workflow.pipeline_context import PipelineSession
+
+REGION = "us-west-2"
+BUCKET = "my-bucket"
+ROLE = "DummyRole"
+IMAGE_URI = "fakeimage"
+
+
+@pytest.fixture(scope="module")
+def client():
+    """Mock client.
+
+    Considerations when appropriate:
+
+        * utilize botocore.stub.Stubber
+        * separate runtime client from client
+    """
+    client_mock = Mock()
+    client_mock._client_config.user_agent = (
+        "Boto3/1.14.24 Python/3.8.5 Linux/5.4.0-42-generic Botocore/1.17.24 Resource"
+    )
+    return client_mock
+
+
+@pytest.fixture(scope="module")
+def boto_session(client):
+    role_mock = Mock()
+    type(role_mock).arn = PropertyMock(return_value=ROLE)
+
+    resource_mock = Mock()
+    resource_mock.Role.return_value = role_mock
+
+    session_mock = Mock(region_name=REGION)
+    session_mock.resource.return_value = resource_mock
+    session_mock.client.return_value = client
+
+    return session_mock
+
+
+@pytest.fixture(scope="module")
+def pipeline_session(boto_session, client):
+    return PipelineSession(
+        boto_session=boto_session,
+        sagemaker_client=client,
+        default_bucket=BUCKET,
+    )
+
+
+@pytest.fixture(scope="module")
+def sagemaker_session(boto_session, client):
+    return Session(
+        boto_session=boto_session,
+        sagemaker_client=client,
+        sagemaker_runtime_client=client,
+        default_bucket=BUCKET,
+    )

--- a/tests/unit/sagemaker/workflow/test_utils.py
+++ b/tests/unit/sagemaker/workflow/test_utils.py
@@ -18,12 +18,6 @@ import shutil
 import tempfile
 
 import pytest
-import sagemaker
-
-from mock import (
-    Mock,
-    PropertyMock,
-)
 
 from sagemaker.estimator import Estimator
 from sagemaker.workflow._utils import (
@@ -35,51 +29,7 @@ from sagemaker.workflow._utils import (
 from sagemaker.workflow.properties import Properties
 from tests.unit.test_utils import FakeS3, list_tar_files
 from tests.unit import DATA_DIR
-
-REGION = "us-west-2"
-BUCKET = "my-bucket"
-IMAGE_URI = "fakeimage"
-ROLE = "DummyRole"
-
-
-@pytest.fixture
-def boto_session():
-    role_mock = Mock()
-    type(role_mock).arn = PropertyMock(return_value=ROLE)
-
-    resource_mock = Mock()
-    resource_mock.Role.return_value = role_mock
-
-    session_mock = Mock(region_name=REGION)
-    session_mock.resource.return_value = resource_mock
-
-    return session_mock
-
-
-@pytest.fixture
-def client():
-    """Mock client.
-
-    Considerations when appropriate:
-
-        * utilize botocore.stub.Stubber
-        * separate runtime client from client
-    """
-    client_mock = Mock()
-    client_mock._client_config.user_agent = (
-        "Boto3/1.14.24 Python/3.8.5 Linux/5.4.0-42-generic Botocore/1.17.24 Resource"
-    )
-    return client_mock
-
-
-@pytest.fixture
-def sagemaker_session(boto_session, client):
-    return sagemaker.session.Session(
-        boto_session=boto_session,
-        sagemaker_client=client,
-        sagemaker_runtime_client=client,
-        default_bucket=BUCKET,
-    )
+from tests.unit.sagemaker.workflow.conftest import ROLE, IMAGE_URI, BUCKET
 
 
 @pytest.fixture
@@ -171,7 +121,7 @@ def test_repack_model_step(estimator):
     }
 
 
-def test_repack_model_step_with_invalid_input():
+def test_register_model_step_with_invalid_input():
     # without both step_args and any of the old required arguments
     with pytest.raises(ValueError) as error:
         _RegisterModelStep(


### PR DESCRIPTION
*Issue #, if available:* If a user provide `model_package_name` to a ModelStep, the pipeline definition can be successfully generated but it will break the CreatePipeline call with the following error:
```
botocore.exceptions.ClientError: An error occurred (ValidationException) when calling the CreatePipeline operation: Unable to parse pipeline definition. Unknown Argument member 'ModelPackageName'.
```
The reason is the pipeline backend excludes this field from the API model.

*Description of changes:*
- Pop out ModelPackageName from pipeline definition
- Add a warning to inform customers about the pop out behavior

*Testing done:* unit test and integ test

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
