### PR TITLE
fix: Fix failing jumpstart cache unit tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ required_packages = [
     "protobuf3-to-dict>=0.1.5,<1.0",
     "smdebug_rulesconfig==1.0.1",
     "importlib-metadata>=1.4.0,<5.0",
-    "packaging==22.0",
+    "packaging==20.9",
     "pandas",
     "pathos",
     "schema",

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ required_packages = [
     "protobuf3-to-dict>=0.1.5,<1.0",
     "smdebug_rulesconfig==1.0.1",
     "importlib-metadata>=1.4.0,<5.0",
-    "packaging>=20.0",
+    "packaging==22.0",
     "pandas",
     "pathos",
     "schema",

--- a/src/sagemaker/jumpstart/cache.py
+++ b/src/sagemaker/jumpstart/cache.py
@@ -20,7 +20,7 @@ import json
 import boto3
 import botocore
 from packaging.version import Version
-from packaging.specifiers import SpecifierSet
+from packaging.specifiers import SpecifierSet, InvalidSpecifier
 from sagemaker.jumpstart.constants import (
     ENV_VARIABLE_JUMPSTART_MANIFEST_LOCAL_ROOT_DIR_OVERRIDE,
     ENV_VARIABLE_JUMPSTART_SPECS_LOCAL_ROOT_DIR_OVERRIDE,
@@ -371,7 +371,10 @@ class JumpStartModelsCache:
                 return None
             return str(max(available_versions))
 
-        spec = SpecifierSet(f"=={semantic_version_str}")
+        try:
+            spec = SpecifierSet(f"=={semantic_version_str}")
+        except InvalidSpecifier:
+            raise KeyError(f"Bad semantic version: {semantic_version_str}")
         available_versions_filtered = list(spec.filter(available_versions))
         return (
             str(max(available_versions_filtered)) if available_versions_filtered != [] else None


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Packaging library changed the exception  if a version is invalid. A custom try-except statement has been added to fix the exceptions returned.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
