### PR TITLE
fix: Remove content type image/jpg from analysis configuration schema

### DIFF
--- a/src/sagemaker/clarify.py
+++ b/src/sagemaker/clarify.py
@@ -282,7 +282,6 @@ ANALYSIS_CONFIG_SCHEMA_V1_0 = Schema(
                     "text/csv",
                     "application/jsonlines",
                     "image/jpeg",
-                    "image/jpg",
                     "image/png",
                     "application/x-npy",
                 ),


### PR DESCRIPTION

*Issue #, if available:*

https://tiny.amazon.com/10tcxpyzj

*Description of changes:*

Currently the analysis configuration schema of SageMaker Clarify API allows the content_type configuration "image/jpeg" and "image/jpg", but the service side validation only accepts the former which is the registered MIME type for JPEG (see [rfc3745](https://www.rfc-editor.org/rfc/rfc3745) and [JPEG specification](https://www.w3.org/Graphics/JPEG/)). The commit removes the latter from the schema to avoid confusion, and enable early API validation.

*Testing done:*

**Manual Test**

Passed.

if the customer set content_type configuration to image/jpg, then the job will by CustomerError, the error message looks like below,

* Without the change, the job was launched and it rejected the type,

```
UnexpectedStatusException: Error for Processing job Clarify-Explainability-2022-11-28-19-22-30-436: Failed. Reason: ClientError: Unsupported content type image/jpg.Please provide one of the valid content_types:1. image/png,2. image/jpeg,3. application/x-npy
```

* With this change, the type is rejected early by the schema validation in the SDK code

```
                                except SchemaError as x:
                                    k = "Key '%s' error:" % nkey
                                    message = self._prepend_schema_name(k)
>                                   raise SchemaError([message] + x.autos, [e.format(data) if e else None] + x.errors)
E                                   schema.SchemaError: Key 'predictor' error:
E                                   Key 'content_type' error:
E                                   <lambda>('image/jpg') should evaluate to True

~/.virtualenvs/sagemaker-python-sdk/lib/python3.7/site-packages/schema.py:409: SchemaError
```

## Merge Checklist

#### General

- [X] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [X] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [X] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [X] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [X] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [X] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
