### PR TITLE
[DON'T MERGE YET] fix: Add sleep time to failing integ test

### DIFF
--- a/tests/integ/test_inference_pipeline.py
+++ b/tests/integ/test_inference_pipeline.py
@@ -191,7 +191,7 @@ def test_inference_pipeline_model_deploy_and_update_endpoint(
         )
         old_config_name = endpoint_desc["EndpointConfigName"]
 
-        sleep(1)
+        sleep(5)
 
         predictor.update_endpoint(initial_instance_count=1, instance_type=cpu_instance_type)
 

--- a/tests/integ/test_inference_pipeline.py
+++ b/tests/integ/test_inference_pipeline.py
@@ -14,6 +14,7 @@ from __future__ import absolute_import
 
 import json
 import os
+from time import sleep
 
 import pytest
 from tests.integ import DATA_DIR, TRANSFORM_DEFAULT_TIMEOUT_MINUTES
@@ -189,6 +190,8 @@ def test_inference_pipeline_model_deploy_and_update_endpoint(
             EndpointName=endpoint_name
         )
         old_config_name = endpoint_desc["EndpointConfigName"]
+
+        sleep(1)
 
         predictor.update_endpoint(initial_instance_count=1, instance_type=cpu_instance_type)
 

--- a/tests/integ/test_inference_pipeline.py
+++ b/tests/integ/test_inference_pipeline.py
@@ -191,7 +191,7 @@ def test_inference_pipeline_model_deploy_and_update_endpoint(
         )
         old_config_name = endpoint_desc["EndpointConfigName"]
 
-        sleep(5)
+        sleep(15)
 
         predictor.update_endpoint(initial_instance_count=1, instance_type=cpu_instance_type)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* `tests/integ/test_inference_pipeline.py::test_inference_pipeline_model_deploy_and_update_endpoint` has intermittent failures resulting from `old_config_name` being the same as `new_config_name`. Adding sleep time between when the config is updated in order to make sure that the timestamps in the config names are different.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
