### PR TITLE
fix: Do not specify S3 path for disabled profiler

### DIFF
--- a/src/sagemaker/debugger/profiler_config.py
+++ b/src/sagemaker/debugger/profiler_config.py
@@ -93,7 +93,7 @@ class ProfilerConfig(object):
         if (
             self.s3_output_path is not None
             and self.disable_profiler is not None
-            and self.disable_profiler is True
+            and self.disable_profiler is False
         ):
             profiler_config_request["S3OutputPath"] = self.s3_output_path
 

--- a/src/sagemaker/debugger/profiler_config.py
+++ b/src/sagemaker/debugger/profiler_config.py
@@ -90,7 +90,11 @@ class ProfilerConfig(object):
         """
         profiler_config_request = {}
 
-        if self.s3_output_path is not None:
+        if (
+            self.s3_output_path is not None
+            and self.disable_profiler is not None
+            and self.disable_profiler is True
+        ):
             profiler_config_request["S3OutputPath"] = self.s3_output_path
 
         profiler_config_request["DisableProfiler"] = self.disable_profiler


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
