### PR TITLE
change: Clean up Pipeline unit tests

### DIFF
--- a/tests/unit/sagemaker/workflow/test_automl_step.py
+++ b/tests/unit/sagemaker/workflow/test_automl_step.py
@@ -15,7 +15,6 @@ from __future__ import absolute_import
 import json
 
 import pytest
-from mock import Mock, PropertyMock
 from sagemaker.automl.automl import AutoML, AutoMLInput
 from sagemaker.exceptions import AutoMLStepInvalidModeError
 from sagemaker.workflow import ParameterString
@@ -23,49 +22,7 @@ from sagemaker.workflow import ParameterString
 from sagemaker.workflow.automl_step import AutoMLStep
 from sagemaker.workflow.model_step import ModelStep
 from sagemaker.workflow.pipeline import Pipeline
-from sagemaker.workflow.pipeline_context import PipelineSession
-
-REGION = "us-west-2"
-BUCKET = "my-bucket"
-ROLE = "DummyRole"
-
-
-@pytest.fixture
-def client():
-    """Mock client.
-    Considerations when appropriate:
-        * utilize botocore.stub.Stubber
-        * separate runtime client from client
-    """
-    client_mock = Mock()
-    client_mock._client_config.user_agent = (
-        "Boto3/1.14.24 Python/3.8.5 Linux/5.4.0-42-generic Botocore/1.17.24 Resource"
-    )
-    return client_mock
-
-
-@pytest.fixture
-def boto_session(client):
-    role_mock = Mock()
-    type(role_mock).arn = PropertyMock(return_value=ROLE)
-
-    resource_mock = Mock()
-    resource_mock.Role.return_value = role_mock
-
-    session_mock = Mock(region_name=REGION)
-    session_mock.resource.return_value = resource_mock
-    session_mock.client.return_value = client
-
-    return session_mock
-
-
-@pytest.fixture
-def pipeline_session(boto_session, client):
-    return PipelineSession(
-        boto_session=boto_session,
-        sagemaker_client=client,
-        default_bucket=BUCKET,
-    )
+from tests.unit.sagemaker.workflow.conftest import ROLE
 
 
 def test_single_automl_step(pipeline_session):

--- a/tests/unit/sagemaker/workflow/test_condition_step.py
+++ b/tests/unit/sagemaker/workflow/test_condition_step.py
@@ -13,8 +13,6 @@
 from __future__ import absolute_import
 import json
 
-import pytest
-from mock import Mock, MagicMock
 from sagemaker.workflow.conditions import (
     ConditionEquals,
     ConditionGreaterThan,
@@ -31,20 +29,6 @@ from sagemaker.workflow.condition_step import ConditionStep
 from sagemaker.workflow.pipeline import Pipeline, PipelineGraph
 from sagemaker.workflow.properties import Properties
 from tests.unit.sagemaker.workflow.helpers import CustomStep, ordered
-
-
-@pytest.fixture()
-def sagemaker_session():
-    boto_mock = Mock(name="boto_session", region_name="us-west-2")
-    session_mock = MagicMock(
-        name="sagemaker_session",
-        boto_session=boto_mock,
-        boto_region_name="us-west-2",
-        config=None,
-        local_mode=False,
-        account_id=Mock(),
-    )
-    return session_mock
 
 
 def test_condition_step():

--- a/tests/unit/sagemaker/workflow/test_emr_step.py
+++ b/tests/unit/sagemaker/workflow/test_emr_step.py
@@ -14,28 +14,11 @@ from __future__ import absolute_import
 
 import json
 
-import pytest
-
-from mock import Mock
-
 from sagemaker.workflow.emr_step import EMRStep, EMRStepConfig
 from sagemaker.workflow.steps import CacheConfig
 from sagemaker.workflow.pipeline import Pipeline, PipelineGraph
 from sagemaker.workflow.parameters import ParameterString
 from tests.unit.sagemaker.workflow.helpers import CustomStep, ordered
-
-
-@pytest.fixture()
-def sagemaker_session():
-    boto_mock = Mock(name="boto_session", region_name="us-west-2")
-    session_mock = Mock(
-        name="sagemaker_session",
-        boto_session=boto_mock,
-        boto_region_name="us-west-2",
-        config=None,
-        local_mode=False,
-    )
-    return session_mock
 
 
 def test_emr_step_with_one_step_config(sagemaker_session):

--- a/tests/unit/sagemaker/workflow/test_lambda_step.py
+++ b/tests/unit/sagemaker/workflow/test_lambda_step.py
@@ -27,20 +27,6 @@ from tests.unit.sagemaker.workflow.helpers import CustomStep, ordered
 
 
 @pytest.fixture()
-def sagemaker_session():
-    boto_mock = Mock(name="boto_session", region_name="us-west-2")
-    session_mock = MagicMock(
-        name="sagemaker_session",
-        boto_session=boto_mock,
-        boto_region_name="us-west-2",
-        config=None,
-        local_mode=False,
-        account_id=Mock(),
-    )
-    return session_mock
-
-
-@pytest.fixture()
 def sagemaker_session_cn():
     boto_mock = Mock(name="boto_session", region_name="cn-north-1")
     session_mock = MagicMock(

--- a/tests/unit/sagemaker/workflow/test_model_step.py
+++ b/tests/unit/sagemaker/workflow/test_model_step.py
@@ -54,10 +54,7 @@ from sagemaker.lambda_helper import Lambda
 from sagemaker.workflow.lambda_step import LambdaStep, LambdaOutput, LambdaOutputTypeEnum
 from tests.unit import DATA_DIR
 from tests.unit.sagemaker.workflow.helpers import CustomStep, ordered
-from tests.unit.sagemaker.workflow.conftest import BUCKET, ROLE
-
-_IMAGE_URI = "fakeimage"
-_INSTANCE_TYPE = "ml.m4.xlarge"
+from tests.unit.sagemaker.workflow.conftest import BUCKET, ROLE, IMAGE_URI, INSTANCE_TYPE
 
 _SAGEMAKER_PROGRAM = SCRIPT_PARAM_NAME.upper()
 _SAGEMAKER_SUBMIT_DIRECTORY = DIR_PARAM_NAME.upper()
@@ -79,7 +76,7 @@ def model_data_param():
 def model(pipeline_session, model_data_param):
     return Model(
         name="MyModel",
-        image_uri=_IMAGE_URI,
+        image_uri=IMAGE_URI,
         model_data=model_data_param,
         sagemaker_session=pipeline_session,
         entry_point=f"{DATA_DIR}/{_SCRIPT_NAME}",
@@ -159,7 +156,7 @@ def test_register_model_with_runtime_repack(pipeline_session, model_data_param, 
             assert arguments["ModelApprovalStatus"] == "PendingManualApproval"
             assert len(arguments["InferenceSpecification"]["Containers"]) == 1
             container = arguments["InferenceSpecification"]["Containers"][0]
-            assert container["Image"] == _IMAGE_URI
+            assert container["Image"] == IMAGE_URI
             assert container["ModelDataUrl"] == {
                 "Get": f"Steps.{expected_repack_step_name}.ModelArtifacts.S3ModelArtifacts"
             }
@@ -238,7 +235,7 @@ def test_create_model_with_runtime_repack(pipeline_session, model_data_param, mo
             assert step["Name"] == f"MyModelStep-{_CREATE_MODEL_NAME_BASE}"
             arguments = step["Arguments"]
             container = arguments["PrimaryContainer"]
-            assert container["Image"] == _IMAGE_URI
+            assert container["Image"] == IMAGE_URI
             assert container["ModelDataUrl"] == {
                 "Get": f"Steps.{expected_repack_step_name}.ModelArtifacts.S3ModelArtifacts"
             }
@@ -335,7 +332,7 @@ def test_create_pipeline_model_with_runtime_repack(pipeline_session, model_data_
             assert containers[0]["ModelDataUrl"] == {"Get": "Parameters.ModelData"}
             assert containers[1]["Environment"][_SAGEMAKER_PROGRAM] == _SCRIPT_NAME
             assert containers[1]["Environment"][_SAGEMAKER_SUBMIT_DIRECTORY] == _DIR_NAME
-            assert containers[1]["Image"] == _IMAGE_URI
+            assert containers[1]["Image"] == IMAGE_URI
             assert containers[1]["ModelDataUrl"] == {
                 "Get": f"Steps.{expected_repack_step_name}.ModelArtifacts.S3ModelArtifacts"
             }
@@ -371,7 +368,7 @@ def test_register_pipeline_model_with_runtime_repack(pipeline_session, model_dat
     )
     # The model need to runtime repack
     model = Model(
-        image_uri=_IMAGE_URI,
+        image_uri=IMAGE_URI,
         model_data=model_data_param,
         sagemaker_session=pipeline_session,
         entry_point=f"{DATA_DIR}/{_SCRIPT_NAME}",
@@ -431,7 +428,7 @@ def test_register_pipeline_model_with_runtime_repack(pipeline_session, model_dat
             assert containers[0]["ModelDataUrl"] == {"Get": "Parameters.ModelData"}
             assert containers[0]["Environment"][_SAGEMAKER_PROGRAM] == _SCRIPT_NAME
             assert "s3://" in containers[0]["Environment"][_SAGEMAKER_SUBMIT_DIRECTORY]
-            assert containers[1]["Image"] == _IMAGE_URI
+            assert containers[1]["Image"] == IMAGE_URI
             assert containers[1]["ModelDataUrl"] == {
                 "Get": f"Steps.{expected_repack_step_name}.ModelArtifacts.S3ModelArtifacts"
             }
@@ -459,7 +456,7 @@ def test_register_model_without_repack(pipeline_session):
     model_name = "MyModel"
     model = Model(
         name=model_name,
-        image_uri=_IMAGE_URI,
+        image_uri=IMAGE_URI,
         model_data=model_data,
         entry_point=f"{DATA_DIR}/{_SCRIPT_NAME}",
         sagemaker_session=pipeline_session,
@@ -489,7 +486,7 @@ def test_register_model_without_repack(pipeline_session):
     assert arguments["ModelApprovalStatus"] == "PendingManualApproval"
     containers = arguments["InferenceSpecification"]["Containers"]
     assert len(containers) == 1
-    assert containers[0]["Image"] == _IMAGE_URI
+    assert containers[0]["Image"] == IMAGE_URI
     assert containers[0]["ModelDataUrl"] == {"Get": "Parameters.ModelData"}
     assert containers[0]["Environment"][_SAGEMAKER_PROGRAM] == _SCRIPT_NAME
     assert (
@@ -506,7 +503,7 @@ def test_create_model_with_compile_time_repack(mock_repack, pipeline_session):
     model_name = "MyModel"
     model = Model(
         name=model_name,
-        image_uri=_IMAGE_URI,
+        image_uri=IMAGE_URI,
         model_data=f"s3://{BUCKET}/model.tar.gz",
         sagemaker_session=pipeline_session,
         entry_point=f"{DATA_DIR}/{_SCRIPT_NAME}",
@@ -527,7 +524,7 @@ def test_create_model_with_compile_time_repack(mock_repack, pipeline_session):
     assert len(step_dsl_list) == 2
     assert step_dsl_list[0]["Name"] == "MyModelStep-CreateModel"
     arguments = step_dsl_list[0]["Arguments"]
-    assert arguments["PrimaryContainer"]["Image"] == _IMAGE_URI
+    assert arguments["PrimaryContainer"]["Image"] == IMAGE_URI
     assert (
         arguments["PrimaryContainer"]["ModelDataUrl"] == f"s3://{BUCKET}/{model_name}/model.tar.gz"
     )
@@ -609,7 +606,7 @@ def test_conditional_model_create_and_regis(
             assert arguments["ModelApprovalStatus"] == "PendingManualApproval"
             assert len(arguments["InferenceSpecification"]["Containers"]) == 1
             container = arguments["InferenceSpecification"]["Containers"][0]
-            assert container["Image"] == _IMAGE_URI
+            assert container["Image"] == IMAGE_URI
             assert container["ModelDataUrl"] == {
                 "Get": f"Steps.{expected_repack_step_name}.ModelArtifacts.S3ModelArtifacts"
             }
@@ -619,7 +616,7 @@ def test_conditional_model_create_and_regis(
             assert step["Name"] == f"MyModelStepCreate-{_CREATE_MODEL_NAME_BASE}"
             arguments = step["Arguments"]
             container = arguments["PrimaryContainer"]
-            assert container["Image"] == _IMAGE_URI
+            assert container["Image"] == IMAGE_URI
             assert container["ModelDataUrl"] == {"Get": "Parameters.ModelData"}
             assert not container.get("Environment", {})
         else:
@@ -645,7 +642,7 @@ def test_conditional_model_create_and_regis(
             SKLearnModel(
                 name="MySKModel",
                 model_data="dummy_model_data",
-                image_uri=_IMAGE_URI,
+                image_uri=IMAGE_URI,
                 entry_point=f"{DATA_DIR}/{_SCRIPT_NAME}",
                 role=ROLE,
                 enable_network_isolation=True,
@@ -658,7 +655,7 @@ def test_conditional_model_create_and_regis(
                 name="MYXGBoostModel",
                 model_data="dummy_model_data",
                 framework_version="1.11.0",
-                image_uri=_IMAGE_URI,
+                image_uri=IMAGE_URI,
                 entry_point=f"{DATA_DIR}/{_SCRIPT_NAME}",
                 role=ROLE,
                 enable_network_isolation=False,
@@ -669,7 +666,7 @@ def test_conditional_model_create_and_regis(
             PyTorchModel(
                 name="MyPyTorchModel",
                 model_data="dummy_model_data",
-                image_uri=_IMAGE_URI,
+                image_uri=IMAGE_URI,
                 entry_point=f"{DATA_DIR}/{_SCRIPT_NAME}",
                 role=ROLE,
                 framework_version="1.5.0",
@@ -681,7 +678,7 @@ def test_conditional_model_create_and_regis(
             MXNetModel(
                 name="MyMXNetModel",
                 model_data="dummy_model_data",
-                image_uri=_IMAGE_URI,
+                image_uri=IMAGE_URI,
                 entry_point=f"{DATA_DIR}/{_SCRIPT_NAME}",
                 role=ROLE,
                 framework_version="1.2.0",
@@ -692,7 +689,7 @@ def test_conditional_model_create_and_regis(
             HuggingFaceModel(
                 name="MyHuggingFaceModel",
                 model_data="dummy_model_data",
-                image_uri=_IMAGE_URI,
+                image_uri=IMAGE_URI,
                 entry_point=f"{DATA_DIR}/{_SCRIPT_NAME}",
                 role=ROLE,
             ),
@@ -702,7 +699,7 @@ def test_conditional_model_create_and_regis(
             TensorFlowModel(
                 name="MyTensorFlowModel",
                 model_data="dummy_model_data",
-                image_uri=_IMAGE_URI,
+                image_uri=IMAGE_URI,
                 entry_point=f"{DATA_DIR}/{_SCRIPT_NAME}",
                 role=ROLE,
                 code_location=_MODEL_CODE_LOCATION_TRAILING_SLASH,
@@ -713,7 +710,7 @@ def test_conditional_model_create_and_regis(
             ChainerModel(
                 name="MyChainerModel",
                 model_data="dummy_model_data",
-                image_uri=_IMAGE_URI,
+                image_uri=IMAGE_URI,
                 entry_point=f"{DATA_DIR}/{_SCRIPT_NAME}",
                 role=ROLE,
             ),
@@ -824,7 +821,7 @@ def test_create_model_among_different_model_types(test_input, pipeline_session, 
             TensorFlowModel(
                 model_data="dummy_model_step",
                 role=ROLE,
-                image_uri=_IMAGE_URI,
+                image_uri=IMAGE_URI,
                 entry_point=os.path.join(_TENSORFLOW_PATH, "inference.py"),
             ),
             {
@@ -840,7 +837,7 @@ def test_create_model_among_different_model_types(test_input, pipeline_session, 
             TensorFlowModel(
                 model_data="dummy_model_step",
                 role=ROLE,
-                image_uri=_IMAGE_URI,
+                image_uri=IMAGE_URI,
             ),
             {
                 "expected_step_num": 1,
@@ -975,10 +972,10 @@ def test_model_step_with_lambda_property_reference(pipeline_session):
     [
         (
             Processor(
-                image_uri=_IMAGE_URI,
+                image_uri=IMAGE_URI,
                 role=ROLE,
                 instance_count=1,
-                instance_type=_INSTANCE_TYPE,
+                instance_type=INSTANCE_TYPE,
             ),
             dict(target_fun="run", func_args={}),
         ),
@@ -999,8 +996,8 @@ def test_model_step_with_lambda_property_reference(pipeline_session):
                 estimator=Estimator(
                     role=ROLE,
                     instance_count=1,
-                    instance_type=_INSTANCE_TYPE,
-                    image_uri=_IMAGE_URI,
+                    instance_type=INSTANCE_TYPE,
+                    image_uri=IMAGE_URI,
                 ),
                 objective_metric_name="test:acc",
                 hyperparameter_ranges={"batch-size": IntegerParameter(64, 128)},
@@ -1011,8 +1008,8 @@ def test_model_step_with_lambda_property_reference(pipeline_session):
             Estimator(
                 role=ROLE,
                 instance_count=1,
-                instance_type=_INSTANCE_TYPE,
-                image_uri=_IMAGE_URI,
+                instance_type=INSTANCE_TYPE,
+                image_uri=IMAGE_URI,
             ),
             dict(target_fun="fit", func_args={}),
         ),

--- a/tests/unit/sagemaker/workflow/test_step_collections.py
+++ b/tests/unit/sagemaker/workflow/test_step_collections.py
@@ -30,16 +30,8 @@ from sagemaker.workflow.model_step import (
 )
 from sagemaker.workflow.parameters import ParameterString
 from sagemaker.workflow.pipeline import Pipeline, PipelineGraph
-from sagemaker.workflow.pipeline_context import PipelineSession
 from sagemaker.workflow.utilities import list_to_request
 from tests.unit import DATA_DIR
-
-import sagemaker
-
-from mock import (
-    Mock,
-    PropertyMock,
-)
 
 from sagemaker import PipelineModel
 from sagemaker.estimator import Estimator
@@ -59,65 +51,12 @@ from sagemaker.workflow.step_collections import (
 )
 from sagemaker.workflow.retry import StepRetryPolicy, StepExceptionTypeEnum
 from tests.unit.sagemaker.workflow.helpers import ordered, CustomStep
+from tests.unit.sagemaker.workflow.conftest import IMAGE_URI, ROLE, BUCKET, REGION
 
-REGION = "us-west-2"
-BUCKET = "my-bucket"
-IMAGE_URI = "fakeimage"
-ROLE = "DummyRole"
 MODEL_NAME = "gisele"
 MODEL_REPACKING_IMAGE_URI = (
     "246618743249.dkr.ecr.us-west-2.amazonaws.com/sagemaker-scikit-learn:0.23-1-cpu-py3"
 )
-
-
-@pytest.fixture
-def client():
-    """Mock client.
-
-    Considerations when appropriate:
-
-        * utilize botocore.stub.Stubber
-        * separate runtime client from client
-    """
-    client_mock = Mock()
-    client_mock._client_config.user_agent = (
-        "Boto3/1.14.24 Python/3.8.5 Linux/5.4.0-42-generic Botocore/1.17.24 Resource"
-    )
-    return client_mock
-
-
-@pytest.fixture
-def boto_session(client):
-    role_mock = Mock()
-    type(role_mock).arn = PropertyMock(return_value=ROLE)
-
-    resource_mock = Mock()
-    resource_mock.Role.return_value = role_mock
-
-    session_mock = Mock(region_name=REGION)
-    session_mock.resource.return_value = resource_mock
-    session_mock.client.return_value = client
-
-    return session_mock
-
-
-@pytest.fixture
-def sagemaker_session(boto_session, client):
-    return sagemaker.session.Session(
-        boto_session=boto_session,
-        sagemaker_client=client,
-        sagemaker_runtime_client=client,
-        default_bucket=BUCKET,
-    )
-
-
-@pytest.fixture
-def pipeline_session(boto_session, client):
-    return PipelineSession(
-        boto_session=boto_session,
-        sagemaker_client=client,
-        default_bucket=BUCKET,
-    )
 
 
 @pytest.fixture

--- a/tests/unit/sagemaker/workflow/test_transform_step.py
+++ b/tests/unit/sagemaker/workflow/test_transform_step.py
@@ -13,7 +13,6 @@
 from __future__ import absolute_import
 
 import json
-from mock import Mock, PropertyMock
 
 import pytest
 import warnings
@@ -24,7 +23,6 @@ from sagemaker import Model, Processor
 from sagemaker.estimator import Estimator
 from sagemaker.parameter import IntegerParameter
 from sagemaker.tuner import HyperparameterTuner
-from sagemaker.workflow.pipeline_context import PipelineSession
 from tests.unit.sagemaker.workflow.helpers import CustomStep, get_step_args_helper
 
 from sagemaker.workflow.steps import TransformStep, TransformInput
@@ -34,57 +32,11 @@ from sagemaker.workflow.functions import Join
 from sagemaker.workflow import is_pipeline_variable
 
 from sagemaker.transformer import Transformer
+from tests.unit.sagemaker.workflow.conftest import IMAGE_URI, ROLE, INSTANCE_TYPE
 
-REGION = "us-west-2"
-ROLE = "DummyRole"
-IMAGE_URI = "fakeimage"
-MODEL_NAME = "gisele"
 DUMMY_S3_SCRIPT_PATH = "s3://dummy-s3/dummy_script.py"
 DUMMY_S3_SOURCE_DIR = "s3://dummy-s3-source-dir/"
-INSTANCE_TYPE = "ml.m4.xlarge"
-BUCKET = "my-bucket"
 custom_step = CustomStep(name="my-custom-step")
-
-
-@pytest.fixture
-def client():
-    """Mock client.
-
-    Considerations when appropriate:
-
-        * utilize botocore.stub.Stubber
-        * separate runtime client from client
-    """
-    client_mock = Mock()
-    client_mock._client_config.user_agent = (
-        "Boto3/1.14.24 Python/3.8.5 Linux/5.4.0-42-generic Botocore/1.17.24 Resource"
-    )
-    client_mock.describe_model.return_value = {"PrimaryContainer": {}, "Containers": {}}
-    return client_mock
-
-
-@pytest.fixture
-def boto_session(client):
-    role_mock = Mock()
-    type(role_mock).arn = PropertyMock(return_value=ROLE)
-
-    resource_mock = Mock()
-    resource_mock.Role.return_value = role_mock
-
-    session_mock = Mock(region_name=REGION)
-    session_mock.resource.return_value = resource_mock
-    session_mock.client.return_value = client
-
-    return session_mock
-
-
-@pytest.fixture
-def pipeline_session(boto_session, client):
-    return PipelineSession(
-        boto_session=boto_session,
-        sagemaker_client=client,
-        default_bucket=BUCKET,
-    )
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/sagemaker/workflow/test_tuning_step.py
+++ b/tests/unit/sagemaker/workflow/test_tuning_step.py
@@ -14,14 +14,12 @@ from __future__ import absolute_import
 
 import os
 import json
-from mock import Mock, PropertyMock
 import pytest
 import warnings
 
 from sagemaker import Model, Processor
 from sagemaker.estimator import Estimator
 from sagemaker.transformer import Transformer
-from sagemaker.workflow.pipeline_context import PipelineSession
 
 from sagemaker.workflow.steps import TuningStep
 from sagemaker.inputs import TrainingInput
@@ -34,50 +32,7 @@ from sagemaker.pytorch.estimator import PyTorch
 
 from tests.unit import DATA_DIR
 from tests.unit.sagemaker.workflow.helpers import get_step_args_helper
-
-REGION = "us-west-2"
-BUCKET = "my-bucket"
-ROLE = "DummyRole"
-IMAGE_URI = "fakeimage"
-INSTANCE_TYPE = "ml.m4.xlarge"
-
-
-@pytest.fixture
-def client():
-    """Mock client.
-    Considerations when appropriate:
-        * utilize botocore.stub.Stubber
-        * separate runtime client from client
-    """
-    client_mock = Mock()
-    client_mock._client_config.user_agent = (
-        "Boto3/1.14.24 Python/3.8.5 Linux/5.4.0-42-generic Botocore/1.17.24 Resource"
-    )
-    return client_mock
-
-
-@pytest.fixture
-def boto_session(client):
-    role_mock = Mock()
-    type(role_mock).arn = PropertyMock(return_value=ROLE)
-
-    resource_mock = Mock()
-    resource_mock.Role.return_value = role_mock
-
-    session_mock = Mock(region_name=REGION)
-    session_mock.resource.return_value = resource_mock
-    session_mock.client.return_value = client
-
-    return session_mock
-
-
-@pytest.fixture
-def pipeline_session(boto_session, client):
-    return PipelineSession(
-        boto_session=boto_session,
-        sagemaker_client=client,
-        default_bucket=BUCKET,
-    )
+from tests.unit.sagemaker.workflow.conftest import ROLE, INSTANCE_TYPE, IMAGE_URI
 
 
 @pytest.fixture


### PR DESCRIPTION
*Description of changes:* Clean up Pipeline unit tests by moving common constant vars and mock objects to `workflow/conftest.py`

*Testing done:* unit tests

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
