### PR TITLE
doc: Add a deprecation note for DetailedProfileConfig

### DIFF
--- a/src/sagemaker/debugger/framework_profile.py
+++ b/src/sagemaker/debugger/framework_profile.py
@@ -144,10 +144,9 @@ class FrameworkProfile:
                 :class:`~sagemaker.debugger.metrics_config.DetailedProfilingConfig` class.
                 Pass ``DetailedProfilingConfig()`` to use the default configuration.
 
-                .. warning:: 
-
-                    This detailed framework profiling feature discontinues support for TensorFlow v2.11 
-                    and later. To use the detailed profiling feature, use previous versions of 
+                .. warning::
+                    This detailed framework profiling feature discontinues support for TensorFlow v2.11
+                    and later. To use the detailed profiling feature, use previous versions of
                     TensorFlow between v2.3.1 and v2.10.0.
 
             dataloader_profiling_config (DataloaderProfilingConfig): The configuration for

--- a/src/sagemaker/debugger/framework_profile.py
+++ b/src/sagemaker/debugger/framework_profile.py
@@ -143,6 +143,13 @@ class FrameworkProfile:
                 profiling. Configure it using the
                 :class:`~sagemaker.debugger.metrics_config.DetailedProfilingConfig` class.
                 Pass ``DetailedProfilingConfig()`` to use the default configuration.
+
+                .. deprecated:: 
+
+                    This detailed framework profiling feature discontinues support for TensorFlow v2.11 
+                    and later. To use the detailed profiling feature, use previous versions of 
+                    TensorFlow between v2.3.1 and v2.10.0.
+
             dataloader_profiling_config (DataloaderProfilingConfig): The configuration for
                 dataloader metrics profiling. Configure it using the
                 :class:`~sagemaker.debugger.metrics_config.DataloaderProfilingConfig` class.

--- a/src/sagemaker/debugger/framework_profile.py
+++ b/src/sagemaker/debugger/framework_profile.py
@@ -144,7 +144,7 @@ class FrameworkProfile:
                 :class:`~sagemaker.debugger.metrics_config.DetailedProfilingConfig` class.
                 Pass ``DetailedProfilingConfig()`` to use the default configuration.
 
-                .. deprecated:: 
+                .. warning:: 
 
                     This detailed framework profiling feature discontinues support for TensorFlow v2.11 
                     and later. To use the detailed profiling feature, use previous versions of 

--- a/src/sagemaker/debugger/metrics_config.py
+++ b/src/sagemaker/debugger/metrics_config.py
@@ -223,7 +223,7 @@ class DetailedProfilingConfig(MetricsConfigBase):
             if one of the two pairs is used. If both pairs are specified, a
             conflict error occurs.
 
-        .. deprecated:: 
+        .. warning:: 
 
             This detailed framework profiling feature discontinues support for TensorFlow v2.11 
             and later. To use the detailed profiling feature, use previous versions of 

--- a/src/sagemaker/debugger/metrics_config.py
+++ b/src/sagemaker/debugger/metrics_config.py
@@ -223,10 +223,9 @@ class DetailedProfilingConfig(MetricsConfigBase):
             if one of the two pairs is used. If both pairs are specified, a
             conflict error occurs.
 
-        .. warning:: 
-
-            This detailed framework profiling feature discontinues support for TensorFlow v2.11 
-            and later. To use the detailed profiling feature, use previous versions of 
+        .. warning::
+            This detailed framework profiling feature discontinues support for TensorFlow v2.11
+            and later. To use the detailed profiling feature, use previous versions of
             TensorFlow between v2.3.1 and v2.10.0.
 
         """

--- a/src/sagemaker/debugger/metrics_config.py
+++ b/src/sagemaker/debugger/metrics_config.py
@@ -203,8 +203,7 @@ class DetailedProfilingConfig(MetricsConfigBase):
     ):
         """Specify target steps or a target duration to profile.
 
-        By default, it profiles step 5
-        of training.
+        By default, it profiles step 5 of the training job.
 
         If **profile_default_steps** is set to `True` and none of the other
         range parameters is specified,
@@ -223,6 +222,12 @@ class DetailedProfilingConfig(MetricsConfigBase):
             The two parameter pairs are mutually exclusive, and this class validates
             if one of the two pairs is used. If both pairs are specified, a
             conflict error occurs.
+
+        .. deprecated:: 
+
+            This detailed framework profiling feature discontinues support for TensorFlow v2.11 
+            and later. To use the detailed profiling feature, use previous versions of 
+            TensorFlow between v2.3.1 and v2.10.0.
 
         """
         assert isinstance(


### PR DESCRIPTION
*Description of changes:*

Add deprecation note for DetailedProfileConfig.

*Testing done:*

https://sagemaker--3583.org.readthedocs.build/en/3583/api/training/debugger.html#sagemaker.debugger.DetailedProfilingConfig

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
