### PR TITLE
change: Enable load_run without name args in Transform env

### DIFF
--- a/src/sagemaker/experiments/_utils.py
+++ b/src/sagemaker/experiments/_utils.py
@@ -127,11 +127,9 @@ def get_tc_and_exp_config_from_job_env(
             num_attempts=4,
         )
     else:  # environment.environment_type == _EnvironmentType.SageMakerTransformJob
-        raise RuntimeError(
-            "Failed to load the Run as loading experiment config "
-            "from transform job environment is not currently supported. "
-            "As a workaround, please explicitly pass in "
-            "the experiment_name and run_name in load_run."
+        job_response = retry_with_backoff(
+            callable_func=lambda: sagemaker_session.describe_transform_job(job_name),
+            num_attempts=4,
         )
 
     job_exp_config = job_response.get("ExperimentConfig", dict())

--- a/src/sagemaker/experiments/run.py
+++ b/src/sagemaker/experiments/run.py
@@ -120,19 +120,18 @@ class Run(object):
                 estimator.fit(job_name="my-job")  # Create a training job
 
         In order to reuse an existing run to log extra data, ``load_run`` is recommended.
+        For example, instead of the ``Run`` constructor, the ``load_run`` is recommended to use
+        in a job script to load the existing run created before the job launch.
+        Otherwise, a new run may be created each time you launch a job.
+
         The code snippet below displays how to load the run initialized above
         in a custom training job script, where no ``run_name`` or ``experiment_name``
         is presented as they are automatically retrieved from the experiment config
         in the job environment.
 
-        Note:
-            Instead of the ``Run`` constructor, the ``load_run`` is recommended to use
-            in a job script to load the existing run created before the job launch.
-            Otherwise, a new run may be created each time you launch a job.
-
         .. code:: python
 
-            with load_run() as run:
+            with load_run(sagemaker_session=sagemaker_session) as run:
                 run.log_metric(...)
                 ...
 

--- a/tests/data/experiment/inference.py
+++ b/tests/data/experiment/inference.py
@@ -46,6 +46,9 @@ def model_fn(model_dir):
         run.log_parameters({"p3": 3.0, "p4": 4.0})
         run.log_metric("test-job-load-log-metric", 0.1)
 
+    with load_run(sagemaker_session=sagemaker_session) as run:
+        run.log_parameters({"p5": 5.0, "p6": 6})
+
     model_file = "xgboost-model"
     booster = pkl.load(open(os.path.join(model_dir, model_file), "rb"))
     return booster

--- a/tests/integ/sagemaker/experiments/test_metrics.py
+++ b/tests/integ/sagemaker/experiments/test_metrics.py
@@ -30,8 +30,7 @@ def test_end_to_end(trial_component_obj, sagemaker_session):
             sagemaker_session=sagemaker_session,
         )
         metrics = updated_tc.metrics
-        # TODO: revert to len(metrics) == 2 once backend fix reaches prod
-        assert len(metrics) > 0
+        assert len(metrics) == 2
         assert list(filter(lambda x: x.metric_name == "test-x-step", metrics))
         assert list(filter(lambda x: x.metric_name == "test-x-timestamp", metrics))
 

--- a/tests/unit/sagemaker/experiments/test_run.py
+++ b/tests/unit/sagemaker/experiments/test_run.py
@@ -299,21 +299,45 @@ def test_run_load_in_sm_processing_job(mock_run_env, sagemaker_session):
     client.describe_processing_job.assert_called_once_with(ProcessingJobName=job_name)
 
 
+@patch(
+    "sagemaker.experiments.run._Experiment._load_or_create",
+    MagicMock(return_value=_Experiment(experiment_name=TEST_EXP_NAME)),
+)
+@patch(
+    "sagemaker.experiments.run._Trial._load_or_create",
+    MagicMock(side_effect=mock_trial_load_or_create_func),
+)
+@patch.object(_Trial, "add_trial_component", MagicMock(return_value=None))
+@patch(
+    "sagemaker.experiments.run._TrialComponent._load_or_create",
+    MagicMock(side_effect=mock_tc_load_or_create_func),
+)
+@patch.object(_TrialComponent, "save", MagicMock(return_value=None))
 @patch("sagemaker.experiments.run._RunEnvironment")
 def test_run_load_in_sm_transform_job(mock_run_env, sagemaker_session):
-    # TODO: update this test once figure out how to get source_arn from transform job
+    client = sagemaker_session.sagemaker_client
+    job_name = "my-transform-job"
     rv = unittest.mock.Mock()
+    rv.source_arn = f"arn:1234/{job_name}"
     rv.environment_type = _environment._EnvironmentType.SageMakerTransformJob
-    rv.source_arn = ""
     mock_run_env.load.return_value = rv
 
-    with pytest.raises(RuntimeError) as err:
-        with load_run(sagemaker_session=sagemaker_session):
-            pass
+    expected_tc_name = f"{TEST_EXP_NAME}{DELIMITER}{TEST_RUN_NAME}"
+    exp_config = {
+        EXPERIMENT_NAME: TEST_EXP_NAME,
+        TRIAL_NAME: Run._generate_trial_name(TEST_EXP_NAME),
+        RUN_NAME: expected_tc_name,
+    }
+    client.describe_transform_job.return_value = {
+        "TransformJobName": "transform-job-experiments",
+        # The Run object has been created else where
+        "ExperimentConfig": exp_config,
+    }
 
-    assert (
-        "loading experiment config from transform job environment is not currently supported"
-    ) in str(err)
+    with load_run(sagemaker_session=sagemaker_session):
+        pass
+
+    client.describe_transform_job.assert_called_once_with(TransformJobName=job_name)
 
 
 def test_log_parameter_outside_run_context(run_obj):


### PR DESCRIPTION
*Description of changes:* 
- As transform job team has helped to add a env var to supply the job source arn, it's a good time to enable load_run without name args in Transform env
- Clean up some TODO items in the unit/integ tests
- Clean up two unused clases

*Testing done:* unit tests and integ tests

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
