### PR TITLE
change: Enable Experiment integ test on beta clients

### DIFF
--- a/tests/data/experiment/inference.py
+++ b/tests/data/experiment/inference.py
@@ -10,6 +10,7 @@
 #  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 #  express or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
+import json
 import logging
 import os
 import pickle as pkl
@@ -24,11 +25,32 @@ code_dir = "/opt/ml/code"
 sdk_file = f"{code_dir}/{sdk_name}"
 os.system(f"pip install {sdk_file}")
 
+
+def _get_client_config_in_dict(cfg_in_str) -> dict:
+    return json.loads(cfg_in_str) if cfg_in_str else None
+
+
 from sagemaker.session import Session
 from sagemaker.experiments import load_run
 
 boto_session = boto3.Session(region_name=os.environ["AWS_REGION"])
-sagemaker_session = Session(boto_session=boto_session)
+
+sagemaker_client_config = _get_client_config_in_dict(os.environ.get("SM_CLIENT_CONFIG", None))
+sagemaker_metrics_config = _get_client_config_in_dict(os.environ.get("SM_METRICS_CONFIG", None))
+sagemaker_client = (
+    boto_session.client("sagemaker", **sagemaker_client_config) if sagemaker_client_config else None
+)
+metrics_client = (
+    boto_session.client("sagemaker-metrics", **sagemaker_metrics_config)
+    if sagemaker_metrics_config
+    else None
+)
+
+sagemaker_session = Session(
+    boto_session=boto_session,
+    sagemaker_client=sagemaker_client,
+    sagemaker_metrics_client=metrics_client,
+)
 
 
 def model_fn(model_dir):

--- a/tests/data/experiment/process_job_script_for_run_clz.py
+++ b/tests/data/experiment/process_job_script_for_run_clz.py
@@ -13,6 +13,7 @@
 """This script file runs on SageMaker processing job"""
 from __future__ import absolute_import
 
+import json
 import logging
 import os
 import boto3
@@ -25,8 +26,28 @@ from sagemaker import Session
 from sagemaker.experiments import load_run
 
 
+def _get_client_config_in_dict(cfg_in_str) -> dict:
+    return json.loads(cfg_in_str) if cfg_in_str else None
+
+
 boto_session = boto3.Session(region_name=os.environ["AWS_REGION"])
-sagemaker_session = Session(boto_session=boto_session)
+
+sagemaker_client_config = _get_client_config_in_dict(os.environ.get("SM_CLIENT_CONFIG", None))
+sagemaker_metrics_config = _get_client_config_in_dict(os.environ.get("SM_METRICS_CONFIG", None))
+sagemaker_client = (
+    boto_session.client("sagemaker", **sagemaker_client_config) if sagemaker_client_config else None
+)
+metrics_client = (
+    boto_session.client("sagemaker-metrics", **sagemaker_metrics_config)
+    if sagemaker_metrics_config
+    else None
+)
+
+sagemaker_session = Session(
+    boto_session=boto_session,
+    sagemaker_client=sagemaker_client,
+    sagemaker_metrics_client=metrics_client,
+)
 
 
 with load_run(sagemaker_session=sagemaker_session) as run:


### PR DESCRIPTION
*Description of changes:* Enable Experiment integ test on beta SageMaker and SageMaker Metrics clients so that we can include Experiment integ tests in beta stage in the service pipeline.

*Testing done:* Integ tests

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
