### PR TITLE
feature: Support role as PipelineParameter in Processor class

### DIFF
--- a/src/sagemaker/processing.py
+++ b/src/sagemaker/processing.py
@@ -59,7 +59,7 @@ class Processor(object):
 
     def __init__(
         self,
-        role: str,
+        role: Union[str, PipelineVariable],
         image_uri: Union[str, PipelineVariable],
         instance_count: Union[int, PipelineVariable],
         instance_type: Union[str, PipelineVariable],
@@ -79,7 +79,7 @@ class Processor(object):
         The ``Processor`` handles Amazon SageMaker Processing tasks.
 
         Args:
-            role (str): An AWS IAM role name or ARN. Amazon SageMaker Processing
+            role (str or PipelineVariable): An AWS IAM role name or ARN. Amazon SageMaker Processing
                 uses this role to access AWS resources, such as
                 data stored in Amazon S3.
             image_uri (str or PipelineVariable): The URI of the Docker image to use for the
@@ -438,7 +438,7 @@ class ScriptProcessor(Processor):
 
     def __init__(
         self,
-        role: str,
+        role: Union[str, PipelineVariable],
         image_uri: Union[str, PipelineVariable],
         command: List[str],
         instance_count: Union[int, PipelineVariable],
@@ -460,7 +460,7 @@ class ScriptProcessor(Processor):
         run as part of the Processing Job.
 
         Args:
-            role (str): An AWS IAM role name or ARN. Amazon SageMaker Processing
+            role (str or PipelineVariable): An AWS IAM role name or ARN. Amazon SageMaker Processing
                 uses this role to access AWS resources, such as
                 data stored in Amazon S3.
             image_uri (str or PipelineVariable): The URI of the Docker image to use for the
@@ -931,7 +931,11 @@ class ProcessingJob(_Job):
         else:
             process_request_args["network_config"] = None
 
-        process_request_args["role_arn"] = processor.sagemaker_session.expand_role(processor.role)
+        process_request_args["role_arn"] = (
+            processor.role
+            if is_pipeline_variable(processor.role)
+            else processor.sagemaker_session.expand_role(processor.role)
+        )
 
         process_request_args["tags"] = processor.tags
 

--- a/tests/unit/test_processing.py
+++ b/tests/unit/test_processing.py
@@ -34,6 +34,7 @@ from sagemaker.spark.processing import PySparkProcessor
 from sagemaker.sklearn.processing import SKLearnProcessor
 from sagemaker.pytorch.processing import PyTorchProcessor
 from sagemaker.tensorflow.processing import TensorFlowProcessor
+from sagemaker.workflow import ParameterString
 from sagemaker.xgboost.processing import XGBoostProcessor
 from sagemaker.mxnet.processing import MXNetProcessor
 from sagemaker.network import NetworkConfig
@@ -735,6 +736,62 @@ def test_processor_with_required_parameters(sagemaker_session):
     expected_args["inputs"] = []
 
     sagemaker_session.process.assert_called_with(**expected_args)
+
+
+def test_processor_with_role_as_pipeline_parameter(sagemaker_session):
+
+    role = ParameterString(name="Role", default_value=ROLE)
+
+    processor = Processor(
+        role=role,
+        image_uri=CUSTOM_IMAGE_URI,
+        instance_count=1,
+        instance_type="ml.m4.xlarge",
+        sagemaker_session=sagemaker_session,
+    )
+
+    processor.run()
+
+    expected_args = _get_expected_args(processor._current_job_name)
+    assert expected_args["role_arn"] == role.default_value
+
+
+@patch("os.path.exists", return_value=True)
+@patch("os.path.isfile", return_value=True)
+def test_script_processor_with_role_as_pipeline_parameter(
+    exists_mock, isfile_mock, sagemaker_session
+):
+    role = ParameterString(name="Role", default_value=ROLE)
+
+    script_processor = ScriptProcessor(
+        role=role,
+        image_uri=CUSTOM_IMAGE_URI,
+        instance_count=1,
+        instance_type="ml.m4.xlarge",
+        sagemaker_session=sagemaker_session,
+        command=["python3"],
+    )
+
+    run_args = script_processor.get_run_args(
+        code="/local/path/to/processing_code.py",
+        inputs=_get_data_inputs_all_parameters(),
+        outputs=_get_data_outputs_all_parameters(),
+        arguments=["--drop-columns", "'SelfEmployed'"],
+    )
+
+    script_processor.run(
+        code=run_args.code,
+        inputs=run_args.inputs,
+        outputs=run_args.outputs,
+        arguments=run_args.arguments,
+        wait=True,
+        logs=False,
+        job_name="my_job_name",
+        experiment_config={"ExperimentName": "AnExperiment"},
+    )
+
+    expected_args = _get_expected_args(script_processor._current_job_name)
+    assert expected_args["role_arn"] == role.default_value
 
 
 def test_processor_with_missing_network_config_parameters(sagemaker_session):


### PR DESCRIPTION
*Issue #, if available:*
No issue associated

*Description of changes:*
Currently, the SDK throws an error if the `role` parameter of the `Processor` class is passed as `PipelineParameter` [because it expects only strings](https://github.com/aws/sagemaker-python-sdk/blob/7faf9ce252a7694cac63be3a8ec8986776276708/src/sagemaker/processing.py#L62). With this modification the class `Processor` is now able to accept the role parameter as `PipelineParameter`, enabling then the possibility of feeding the role parameter when the pipeline is triggered.

*Testing done:*

## Merge Checklist

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
