### PR TITLE
increase creation time slack minutes

### DIFF
--- a/tests/integ/sagemaker/lineage/test_artifact.py
+++ b/tests/integ/sagemaker/lineage/test_artifact.py
@@ -22,6 +22,8 @@ import pytest
 from sagemaker.lineage import artifact
 from sagemaker.utils import retry_with_backoff
 
+CREATION_VERIFICATION_WINDOW_MINUTES = 2
+
 
 def test_create_delete(artifact_obj):
     # fixture does create and then delete, this test ensures it happens at least once
@@ -81,7 +83,7 @@ def test_list(artifact_objs, sagemaker_session):
 
 
 def test_list_by_type(artifact_objs, sagemaker_session):
-    slack = datetime.timedelta(minutes=1)
+    slack = datetime.timedelta(minutes=CREATION_VERIFICATION_WINDOW_MINUTES)
     now = datetime.datetime.now(datetime.timezone.utc)
     expected_name = list(
         filter(lambda x: x.artifact_type == "SDKIntegrationTestType2", artifact_objs)


### PR DESCRIPTION
*Issue #, if available:* flaky integration test, related to internal ticket

*Description of changes:* increase creation time verification window from 1 minute to 2 minutes

*Testing done:* ran locally

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
