### PR TITLE
fix(experiments/run.py): Stop duplication of RUN_TC_TAG on Consecutive Experiment Runs

### DIFF
--- a/src/sagemaker/experiments/run.py
+++ b/src/sagemaker/experiments/run.py
@@ -648,7 +648,8 @@ class Run(object):
         """
         if not tags:
             tags = []
-        tags.append(RUN_TC_TAG)
+        if RUN_TC_TAG not in tags:
+            tags.append(RUN_TC_TAG)
         return tags
 
     def __enter__(self):

--- a/tests/unit/sagemaker/experiments/test_run.py
+++ b/tests/unit/sagemaker/experiments/test_run.py
@@ -911,6 +911,11 @@ def test_append_run_tc_label_to_tags():
     ret = Run._append_run_tc_label_to_tags(tags)
     assert len(ret) == 2
     assert expected_tc_tag in ret
+    
+    tags = [expected_tc_tag]
+    ret = Run._append_run_tc_label_to_tags(tags)
+    assert len(ret) == 1
+    assert expected_tc_tag in ret
 
 
 def _verify_tc_status_before_enter_init(trial_component):

--- a/tests/unit/sagemaker/experiments/test_run.py
+++ b/tests/unit/sagemaker/experiments/test_run.py
@@ -911,7 +911,7 @@ def test_append_run_tc_label_to_tags():
     ret = Run._append_run_tc_label_to_tags(tags)
     assert len(ret) == 2
     assert expected_tc_tag in ret
-    
+
     tags = [expected_tc_tag]
     ret = Run._append_run_tc_label_to_tags(tags)
     assert len(ret) == 1


### PR DESCRIPTION


*Issue #, if available:*

*Description of changes:*

Whenever you execute an experiment run, the RUN_TC_TAG is appended to your run tags via the _append_run_tc_label_to_tags function. If you pass the same variable for tags over more than one experiment run, the RUN_TC_TAG gets appended more than once to your tag variable. This will cause a duplicate tag exception unless you manually remove the RUN_TC_TAG after each run. This change is to make sure that the RUN_TC_TAG doesn't get duplicated if it already exists on your tags.

RUN_TC_TAG
```
 {
                "key": "sagemaker:trial-component-source",
                "value": "run"
}
```

Exception
```
ClientError: An error occurred (ValidationException) when calling the CreateTrialComponent operation: Duplicate tag key
```

Scenario to re-create the exception
```
tags = [
  {
    "Key": "cat",
    "Value": "cat"
  }
]
experiment_name = 'experiment-name-1'

timestamp = time.strftime("%Y-%m-%d-%H-%M-%S", time.gmtime())
run_name1 = f'{experiment_name}-{timestamp}-1'
run_name2 = f'{experiment_name}-{timestamp}-2'

with Run(experiment_name=experiment_name, run_name=run_name1, sagemaker_session=Session(),tags=tags) as run:
    run.log_parameters({"test":"test"})

with Run(experiment_name=experiment_name, run_name=run_name2, sagemaker_session=Session(),tags=tags) as run:
    run.log_parameters({"test":"test"})

```

*Testing done:*

*  Unit test updated for this scenario
*  Manually PIP installed the project after making my change and re-tested that the scenario above didn't fail after making my changes.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [X] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [X] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [X] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [X] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [X] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [X] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [X] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
