### PR TITLE
feature: Support for environment variables in the HPO

### DIFF
--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -2150,6 +2150,7 @@ class Session(object):  # pylint: disable=too-many-public-methods
         checkpoint_s3_uri=None,
         checkpoint_local_path=None,
         random_seed=None,
+        environment=None,
     ):
         """Create an Amazon SageMaker hyperparameter tuning job.
 
@@ -2233,6 +2234,8 @@ class Session(object):  # pylint: disable=too-many-public-methods
             random_seed (int): An initial value used to initialize a pseudo-random number generator.
                 Setting a random seed will make the hyperparameter tuning search strategies to
                 produce more consistent configurations for the same tuning job. (default: ``None``).
+            environment (dict[str, str]) : Environment variables to be set for
+                use during training jobs (default: ``None``)
         """
 
         tune_request = {
@@ -2265,6 +2268,7 @@ class Session(object):  # pylint: disable=too-many-public-methods
                 use_spot_instances=use_spot_instances,
                 checkpoint_s3_uri=checkpoint_s3_uri,
                 checkpoint_local_path=checkpoint_local_path,
+                environment=environment,
             ),
         }
 
@@ -2508,6 +2512,7 @@ class Session(object):  # pylint: disable=too-many-public-methods
         checkpoint_s3_uri=None,
         checkpoint_local_path=None,
         max_retry_attempts=None,
+        environment=None,
     ):
         """Construct a dictionary of training job configuration from the arguments.
 
@@ -2562,6 +2567,8 @@ class Session(object):  # pylint: disable=too-many-public-methods
             parameter_ranges (dict): Dictionary of parameter ranges. These parameter ranges can
                 be one of three types: Continuous, Integer, or Categorical.
             max_retry_attempts (int): The number of times to retry the job.
+            environment (dict[str, str]) : Environment variables to be set for
+                use during training jobs (default: ``None``)
 
         Returns:
             A dictionary of training job configuration. For format details, please refer to
@@ -2624,6 +2631,9 @@ class Session(object):  # pylint: disable=too-many-public-methods
 
         if max_retry_attempts is not None:
             training_job_definition["RetryStrategy"] = {"MaximumRetryAttempts": max_retry_attempts}
+
+        if environment is not None:
+            training_job_definition["Environment"] = environment
         return training_job_definition
 
     def stop_tuning_job(self, name):

--- a/src/sagemaker/tuner.py
+++ b/src/sagemaker/tuner.py
@@ -1892,6 +1892,9 @@ class _TuningJob(_Job):
         if estimator.max_retry_attempts is not None:
             training_config["max_retry_attempts"] = estimator.max_retry_attempts
 
+        if estimator.environment is not None:
+            training_config["environment"] = estimator.environment
+
         return training_config
 
     def stop(self):

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -911,6 +911,7 @@ SAMPLE_TUNING_JOB_REQUEST = {
         "OutputDataConfig": SAMPLE_OUTPUT,
         "ResourceConfig": RESOURCE_CONFIG,
         "StoppingCondition": SAMPLE_STOPPING_CONDITION,
+        "Environment": ENV_INPUT,
     },
 }
 
@@ -937,6 +938,7 @@ SAMPLE_MULTI_ALGO_TUNING_JOB_REQUEST = {
             "OutputDataConfig": SAMPLE_OUTPUT,
             "ResourceConfig": RESOURCE_CONFIG,
             "StoppingCondition": SAMPLE_STOPPING_CONDITION,
+            "Environment": ENV_INPUT,
         },
         {
             "DefinitionName": "estimator_2",
@@ -953,6 +955,7 @@ SAMPLE_MULTI_ALGO_TUNING_JOB_REQUEST = {
             "OutputDataConfig": SAMPLE_OUTPUT,
             "ResourceConfig": RESOURCE_CONFIG,
             "StoppingCondition": SAMPLE_STOPPING_CONDITION,
+            "Environment": ENV_INPUT,
         },
     ],
 }
@@ -1009,6 +1012,7 @@ def test_tune_warm_start(sagemaker_session, warm_start_type, parents):
         warm_start_config=WarmStartConfig(
             warm_start_type=WarmStartTypes(warm_start_type), parents=parents
         ).to_input_req(),
+        environment=ENV_INPUT,
     )
 
 
@@ -1094,6 +1098,7 @@ def test_create_tuning_job(sagemaker_session):
             "output_config": SAMPLE_OUTPUT,
             "resource_config": RESOURCE_CONFIG,
             "stop_condition": SAMPLE_STOPPING_CONDITION,
+            "environment": ENV_INPUT,
         },
         tags=None,
         warm_start_config=None,
@@ -1135,6 +1140,7 @@ def test_create_tuning_job_multi_algo(sagemaker_session):
                 "objective_type": "Maximize",
                 "objective_metric_name": "val-score",
                 "parameter_ranges": SAMPLE_PARAM_RANGES,
+                "environment": ENV_INPUT,
             },
             {
                 "static_hyperparameters": STATIC_HPs_2,
@@ -1150,6 +1156,7 @@ def test_create_tuning_job_multi_algo(sagemaker_session):
                 "objective_type": "Maximize",
                 "objective_metric_name": "value-score",
                 "parameter_ranges": SAMPLE_PARAM_RANGES_2,
+                "environment": ENV_INPUT,
             },
         ],
         tags=None,
@@ -1190,6 +1197,7 @@ def test_tune(sagemaker_session):
         stop_condition=SAMPLE_STOPPING_CONDITION,
         tags=None,
         warm_start_config=None,
+        environment=ENV_INPUT,
     )
 
 
@@ -1231,6 +1239,7 @@ def test_tune_with_strategy_config(sagemaker_session):
         tags=None,
         warm_start_config=None,
         strategy_config=SAMPLE_HYPERBAND_STRATEGY_CONFIG,
+        environment=ENV_INPUT,
     )
 
 

--- a/tests/unit/tuner_test_utils.py
+++ b/tests/unit/tuner_test_utils.py
@@ -69,6 +69,8 @@ LIST_TAGS_RESULT = {"Tags": [{"Key": "key1", "Value": "value1"}]}
 ESTIMATOR_NAME = "estimator_name"
 ESTIMATOR_NAME_TWO = "estimator_name_two"
 
+ENV_INPUT = {"env_key1": "env_val1", "env_key2": "env_val2", "env_key3": "env_val3"}
+
 SAGEMAKER_SESSION = Mock()
 
 ESTIMATOR = Estimator(
@@ -78,6 +80,7 @@ ESTIMATOR = Estimator(
     INSTANCE_TYPE,
     output_path="s3://bucket/prefix",
     sagemaker_session=SAGEMAKER_SESSION,
+    environment=ENV_INPUT,
 )
 ESTIMATOR_TWO = PCA(
     ROLE,
@@ -85,6 +88,7 @@ ESTIMATOR_TWO = PCA(
     INSTANCE_TYPE,
     NUM_COMPONENTS,
     sagemaker_session=SAGEMAKER_SESSION,
+    environment=ENV_INPUT,
 )
 
 WARM_START_CONFIG = WarmStartConfig(
@@ -148,6 +152,7 @@ TUNING_JOB_DETAILS = {
         ],
         "StoppingCondition": {"MaxRuntimeInSeconds": 86400},
         "OutputDataConfig": {"S3OutputPath": BUCKET_NAME},
+        "Environment": ENV_INPUT,
     },
     "TrainingJobCounters": {
         "ClientError": 0,
@@ -212,6 +217,7 @@ MULTI_ALGO_TUNING_JOB_DETAILS = {
             ],
             "StoppingCondition": {"MaxRuntimeInSeconds": 86400},
             "OutputDataConfig": {"S3OutputPath": BUCKET_NAME},
+            "Environment": ENV_INPUT,
         },
         {
             "DefinitionName": ESTIMATOR_NAME_TWO,
@@ -252,6 +258,7 @@ MULTI_ALGO_TUNING_JOB_DETAILS = {
             ],
             "StoppingCondition": {"MaxRuntimeInSeconds": 86400},
             "OutputDataConfig": {"S3OutputPath": BUCKET_NAME},
+            "Environment": ENV_INPUT,
         },
     ],
     "TrainingJobCounters": {
@@ -291,6 +298,7 @@ TRAINING_JOB_DESCRIPTION = {
     "OutputDataConfig": {"KmsKeyId": "", "S3OutputPath": "s3://place/output/neo"},
     "TrainingJobOutput": {"S3TrainingJobOutput": "s3://here/output.tar.gz"},
     "ModelArtifacts": {"S3ModelArtifacts": MODEL_DATA},
+    "Environment": ENV_INPUT,
 }
 
 ENDPOINT_DESC = {"EndpointConfigName": "test-endpoint"}


### PR DESCRIPTION
*Description of changes:*
We know support the environment variables in the HPO. They already exist in the BaseEstimator class, so we'll just use them into our code.

*Testing done:*
Unit tests are extended.

## Merge Checklist

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
