### PR TITLE
Update feature_group.py ingest() description

### DIFF
--- a/src/sagemaker/feature_store/feature_group.py
+++ b/src/sagemaker/feature_store/feature_group.py
@@ -702,21 +702,26 @@ class FeatureGroup:
     ) -> IngestionManagerPandas:
         """Ingest the content of a pandas DataFrame to feature store.
 
-        ``max_worker`` number of thread will be created to work on different partitions of
-        the ``data_frame`` in parallel.
+        ``max_worker`` the number of threads created to work on different partitions of the 
+        ``data_frame`` in parallel.
 
-        ``max_processes`` number of processes will be created to work on different partitions
-        of the ``data_frame`` in parallel, each with ``max_worker`` threads.
+        ``max_processes`` the number of processes will be created to work on different 
+        partitions of the ``data_frame`` in parallel, each with ``max_worker`` threads.
 
-        The ingest function will attempt to ingest all records in the data frame. If ``wait``
-        is True, then an exception is thrown after all records have been processed. If ``wait``
-        is False, then a later call to the returned instance IngestionManagerPandas' ``wait()``
-        function will throw an exception.
+        The ingest function attempts to ingest all records in the data frame. SageMaker 
+        Feature Store throws an exception if it fails to ingest any records.
 
-        Zero based indices of rows that failed to be ingested can be found in the exception.
-        They can also be found from the IngestionManagerPandas' ``failed_rows`` function after
-        the exception is thrown.
-
+        If ``wait`` is ``True``, Feature Store runs the ``ingest`` function synchronously. 
+        You receive an ``IngestionError`` if there are any records that can't be ingested. 
+        If ``wait`` is ``False``, Feature Store runs the ``ingest`` function asynchronously.
+        
+        Instead of setting ``wait`` to ``True`` in the ``ingest`` function, you can invoke 
+        the ``wait`` function on the returned instance of ``IngestionManagerPandas`` to run 
+        the ``ingest`` function synchronously.
+        
+        To access the rows that failed to ingest, set ``wait`` to ``False``. The 
+        ``IngestionError.failed_rows`` object saves all of the rows that failed to ingest.
+        
         `profile_name` argument is an optional one. It will use the default credential if None is
         passed. This `profile_name` is used in the sagemaker_featurestore_runtime client only. See
         https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html for more

--- a/src/sagemaker/feature_store/feature_group.py
+++ b/src/sagemaker/feature_store/feature_group.py
@@ -702,26 +702,26 @@ class FeatureGroup:
     ) -> IngestionManagerPandas:
         """Ingest the content of a pandas DataFrame to feature store.
 
-        ``max_worker`` the number of threads created to work on different partitions of the 
+        ``max_worker`` the number of threads created to work on different partitions of the
         ``data_frame`` in parallel.
 
-        ``max_processes`` the number of processes will be created to work on different 
+        ``max_processes`` the number of processes will be created to work on different
         partitions of the ``data_frame`` in parallel, each with ``max_worker`` threads.
 
-        The ingest function attempts to ingest all records in the data frame. SageMaker 
+        The ingest function attempts to ingest all records in the data frame. SageMaker
         Feature Store throws an exception if it fails to ingest any records.
 
-        If ``wait`` is ``True``, Feature Store runs the ``ingest`` function synchronously. 
-        You receive an ``IngestionError`` if there are any records that can't be ingested. 
+        If ``wait`` is ``True``, Feature Store runs the ``ingest`` function synchronously.
+        You receive an ``IngestionError`` if there are any records that can't be ingested.
         If ``wait`` is ``False``, Feature Store runs the ``ingest`` function asynchronously.
-        
-        Instead of setting ``wait`` to ``True`` in the ``ingest`` function, you can invoke 
-        the ``wait`` function on the returned instance of ``IngestionManagerPandas`` to run 
+
+        Instead of setting ``wait`` to ``True`` in the ``ingest`` function, you can invoke
+        the ``wait`` function on the returned instance of ``IngestionManagerPandas`` to run
         the ``ingest`` function synchronously.
-        
-        To access the rows that failed to ingest, set ``wait`` to ``False``. The 
+
+        To access the rows that failed to ingest, set ``wait`` to ``False``. The
         ``IngestionError.failed_rows`` object saves all of the rows that failed to ingest.
-        
+
         `profile_name` argument is an optional one. It will use the default credential if None is
         passed. This `profile_name` is used in the sagemaker_featurestore_runtime client only. See
         https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html for more


### PR DESCRIPTION
Updating ingest function description (https://sagemaker.readthedocs.io/en/stable/api/prep_data/feature_store.html#sagemaker.feature_store.feature_group.FeatureGroup.ingest) according to discussion in a thread (https://amzn-aws.slack.com/archives/C02FT61K4BV/p1661876115110819).

*Issue #, if available:*
https://t.corp.amazon.com/P71244023

*Description of changes:*
Clarify failed_rows logic and other descriptions according to the discussion here: https://amzn-aws.slack.com/archives/C02FT61K4BV/p1661876115110819

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
