### PR TITLE
fix: Make test_processor_with_role_as_pipeline_parameter more concrete

### DIFF
--- a/src/sagemaker/processing.py
+++ b/src/sagemaker/processing.py
@@ -1361,7 +1361,7 @@ class FrameworkProcessor(ScriptProcessor):
         self,
         estimator_cls: type,
         framework_version: str,
-        role: str,
+        role: Union[str, PipelineVariable],
         instance_count: Union[int, PipelineVariable],
         instance_type: Union[str, PipelineVariable],
         py_version: str = "py3",
@@ -1389,8 +1389,9 @@ class FrameworkProcessor(ScriptProcessor):
                 estimator
             framework_version (str): The version of the framework. Value is ignored when
                 ``image_uri`` is provided.
-            role (str): An AWS IAM role name or ARN. Amazon SageMaker Processing uses
-                this role to access AWS resources, such as data stored in Amazon S3.
+            role (str or PipelineVariable): An AWS IAM role name or ARN. Amazon SageMaker
+                Processing uses this role to access AWS resources, such as data stored
+                in Amazon S3.
             instance_count (int or PipelineVariable): The number of instances to run a
                 processing job with.
             instance_type (str or PipelineVariable): The type of EC2 instance to use for

--- a/tests/integ/sagemaker/workflow/test_processing_steps.py
+++ b/tests/integ/sagemaker/workflow/test_processing_steps.py
@@ -385,8 +385,10 @@ def test_multi_step_framework_processing_pipeline_same_source_dir(
 
     SOURCE_DIR = "/pipeline/test_source_dir"
 
+    role_param = ParameterString(name="Role", default_value=role)
+
     framework_processor_tf = FrameworkProcessor(
-        role=role,
+        role=role_param,
         instance_type="ml.m5.xlarge",
         instance_count=1,
         estimator_cls=TensorFlow,
@@ -400,7 +402,7 @@ def test_multi_step_framework_processing_pipeline_same_source_dir(
         instance_type="ml.m5.xlarge",
         instance_count=1,
         base_job_name="my-job",
-        role=role,
+        role=role_param,
         estimator_cls=SKLearn,
         sagemaker_session=pipeline_session,
     )
@@ -431,7 +433,10 @@ def test_multi_step_framework_processing_pipeline_same_source_dir(
     )
 
     pipeline = Pipeline(
-        name=pipeline_name, steps=[step_1, step_2], sagemaker_session=pipeline_session
+        name=pipeline_name,
+        steps=[step_1, step_2],
+        sagemaker_session=pipeline_session,
+        parameters=[role_param],
     )
     try:
         pipeline.create(role)


### PR DESCRIPTION
*Description of changes:*
Thanks so much for francescoalongi@ to work on https://github.com/aws/sagemaker-python-sdk/pull/3605 to fill in a feature gap for us.
This PR3618 attempts to make the related tests more concrete, including:
- Update the two unit tests added by francescoalongi@ to make it more concrete, i.e. 
  - use the PipelineSession rather than the Sagemaker Session, as the new step interface (i.e. `step_args = processor.run(...)` ) only take effect when PipelineSession is presented.
  - Move these unit tests under workflow's processing step test files, as the test is extended to create a ProcessingStep and a Pipeline based on the processor.
  - Group these two similar tests with parametrize pytest. 
  - Verify in the eventual output - pipeline definition level.
- Update existing integ tests to make sure this change works E2E

*Testing done:* Integ and unit tests

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
