### PR TITLE
documentation: SageMaker distributed - model parallism library release note

### DIFF
--- a/doc/api/training/smd_model_parallel_release_notes/smd_model_parallel_change_log.rst
+++ b/doc/api/training/smd_model_parallel_release_notes/smd_model_parallel_change_log.rst
@@ -6,8 +6,46 @@ New features, bug fixes, and improvements are regularly made to the SageMaker
 distributed model parallel library.
 
 
-SageMaker Distributed Model Parallel 1.13.0 Release Notes
+SageMaker Distributed Model Parallel 1.14.0 Release Notes
 =========================================================
+
+*Date: Jan. 30. 2023*
+
+**Currency Updates**
+
+* Added support for PyTorch v1.13.1
+
+**Improvements**
+
+* Upgraded the flash-attention (https://github.com/HazyResearch/flash-attention) library to  v0.2.6.post1
+
+**Migration to AWS Deep Learning Containers**
+
+This version passed benchmark testing and is migrated to the following AWS Deep Learning Containers (DLC):
+
+- SageMaker training container for PyTorch v1.13.1
+
+  .. code::
+
+    763104351884.dkr.ecr.<region>.amazonaws.com/pytorch-training:1.13.1-gpu-py39-cu117-ubuntu20.04-sagemaker
+
+
+Binary file of this version of the library for `custom container
+<https://docs.aws.amazon.com/sagemaker/latest/dg/model-parallel-sm-sdk.html#model-parallel-bring-your-own-container>`_ users:
+
+- For PyTorch 1.12.0
+
+  .. code::
+
+    https://sagemaker-distributed-model-parallel.s3.us-west-2.amazonaws.com/pytorch-1.13.1/build-artifacts/2023-01-19-18-35/smdistributed_modelparallel-1.14.0-cp39-cp39-linux_x86_64.whl
+
+----
+
+Release History
+===============
+
+SageMaker Distributed Model Parallel 1.13.0 Release Notes
+---------------------------------------------------------
 
 *Date: Dec. 15. 2022*
 
@@ -52,10 +90,6 @@ Binary file of this version of the library for `custom container
 
     https://sagemaker-distributed-model-parallel.s3.us-west-2.amazonaws.com/pytorch-1.12.1/build-artifacts/2022-12-08-21-34/smdistributed_modelparallel-1.13.0-cp38-cp38-linux_x86_64.whl
 
-----
-
-Release History
-===============
 
 SageMaker Distributed Model Parallel 1.11.0 Release Notes
 ---------------------------------------------------------

--- a/doc/api/training/smd_model_parallel_release_notes/smd_model_parallel_change_log.rst
+++ b/doc/api/training/smd_model_parallel_release_notes/smd_model_parallel_change_log.rst
@@ -33,7 +33,7 @@ This version passed benchmark testing and is migrated to the following AWS Deep 
 Binary file of this version of the library for `custom container
 <https://docs.aws.amazon.com/sagemaker/latest/dg/model-parallel-sm-sdk.html#model-parallel-bring-your-own-container>`_ users:
 
-- For PyTorch 1.12.0
+- For PyTorch 1.13.1
 
   .. code::
 
@@ -126,7 +126,7 @@ Binary file of this version of the library for `custom container
 
   .. code::
 
-    https://sagemaker-distribu
+    https://sagemaker-distributed-model-parallel.s3.us-west-2.amazonaws.com/pytorch-1.12.0/build-artifacts/2022-08-12-16-58/smdistributed_modelparallel-1.11.0-cp38-cp38-linux_x86_64.whl
 
 SageMaker Distributed Model Parallel 1.10.1 Release Notes
 ---------------------------------------------------------

--- a/doc/api/training/smd_model_parallel_release_notes/smd_model_parallel_change_log.rst
+++ b/doc/api/training/smd_model_parallel_release_notes/smd_model_parallel_change_log.rst
@@ -84,7 +84,7 @@ This version passed benchmark testing and is migrated to the following AWS Deep 
 Binary file of this version of the library for `custom container
 <https://docs.aws.amazon.com/sagemaker/latest/dg/model-parallel-sm-sdk.html#model-parallel-bring-your-own-container>`_ users:
 
-- For PyTorch 1.12.0
+- For PyTorch 1.12.1
 
   .. code::
 

--- a/doc/api/training/smp_versions/latest.rst
+++ b/doc/api/training/smp_versions/latest.rst
@@ -10,7 +10,7 @@ depending on which version of the library you need to use.
 To use the library, reference the
 **Common API** documentation alongside the framework specific API documentation.
 
-Version 1.11.0, 1.13.0 (Latest)
+Version 1.11.0, 1.13.0, 1.14.0 (Latest)
 ===============================
 
 To use the library, reference the Common API documentation alongside the framework specific API documentation.

--- a/doc/api/training/smp_versions/latest.rst
+++ b/doc/api/training/smp_versions/latest.rst
@@ -11,7 +11,7 @@ To use the library, reference the
 **Common API** documentation alongside the framework specific API documentation.
 
 Version 1.11.0, 1.13.0, 1.14.0 (Latest)
-===============================
+=======================================
 
 To use the library, reference the Common API documentation alongside the framework specific API documentation.
 


### PR DESCRIPTION

*Description of changes:*

Update release note for SM model parallelism library

*Testing done:*

RTD PR build suceeded: https://sagemaker--3621.org.readthedocs.build/en/3621/api/training/smd_model_parallel_release_notes/smd_model_parallel_change_log.html#sagemaker-distributed-model-parallel-1-14-0-release-notes


## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
