### PR TITLE
documentation: add security note for the estimator hyperparameter arg 

### DIFF
--- a/src/sagemaker/estimator.py
+++ b/src/sagemaker/estimator.py
@@ -428,7 +428,7 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):  # pylint: disable=too-man
                     You must not include any security-sensitive information, such as
                     account access IDs, secrets, and tokens, in the dictionary for configuring
                     hyperparameters. SageMaker rejects the training job request and returns an
-                    exception error for detected credentials, if such user input is found.
+                    validation error for detected credentials, if such user input is found.
 
             container_log_level (int or PipelineVariable): The log level to use within the container
                 (default: logging.INFO). Valid values are defined in the Python
@@ -2474,7 +2474,7 @@ class Estimator(EstimatorBase):
                     You must not include any security-sensitive information, such as
                     account access IDs, secrets, and tokens, in the dictionary for configuring
                     hyperparameters. SageMaker rejects the training job request and returns an
-                    exception error for detected credentials, if such user input is found.
+                    validation error for detected credentials, if such user input is found.
 
             tags (list[dict[str, str] or list[dict[str, PipelineVariable]]): List of tags for
                 labeling a training job. For more, see
@@ -2958,8 +2958,8 @@ class Framework(EstimatorBase):
                     You must not include any security-sensitive information, such as
                     account access IDs, secrets, and tokens, in the dictionary for configuring
                     hyperparameters. SageMaker rejects the training job request and returns an
-                    exception error for detected credentials, if such user input is found.
-                    
+                    validation error for detected credentials, if such user input is found.
+
             container_log_level (int or PipelineVariable): Log level to use within the container
                 (default: logging.INFO). Valid values are defined in the Python
                 logging module.

--- a/src/sagemaker/estimator.py
+++ b/src/sagemaker/estimator.py
@@ -423,6 +423,13 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):  # pylint: disable=too-man
             hyperparameters (dict[str, str] or dict[str, PipelineVariable]):
                 A dictionary containing the hyperparameters to
                 initialize this estimator with. (Default: None).
+
+                .. caution::
+                    You must not include any security-sensitive information, such as
+                    account access IDs, secrets, and tokens, in the dictionary for configuring
+                    hyperparameters. SageMaker rejects the training job request and returns an
+                    exception error for detected credentials, if such user input is found.
+
             container_log_level (int or PipelineVariable): The log level to use within the container
                 (default: logging.INFO). Valid values are defined in the Python
                 logging module.
@@ -2462,6 +2469,13 @@ class Estimator(EstimatorBase):
                 using the default AWS configuration chain.
             hyperparameters (dict[str, str] or dict[str, PipelineVariable]):
                 Dictionary containing the hyperparameters to initialize this estimator with.
+
+                .. caution::
+                    You must not include any security-sensitive information, such as
+                    account access IDs, secrets, and tokens, in the dictionary for configuring
+                    hyperparameters. SageMaker rejects the training job request and returns an
+                    exception error for detected credentials, if such user input is found.
+
             tags (list[dict[str, str] or list[dict[str, PipelineVariable]]): List of tags for
                 labeling a training job. For more, see
                 https://docs.aws.amazon.com/sagemaker/latest/dg/API_Tag.html.
@@ -2939,6 +2953,13 @@ class Framework(EstimatorBase):
                 SageMaker. For convenience, this accepts other types for keys
                 and values, but ``str()`` will be called to convert them before
                 training.
+
+                .. caution::
+                    You must not include any security-sensitive information, such as
+                    account access IDs, secrets, and tokens, in the dictionary for configuring
+                    hyperparameters. SageMaker rejects the training job request and returns an
+                    exception error for detected credentials, if such user input is found.
+                    
             container_log_level (int or PipelineVariable): Log level to use within the container
                 (default: logging.INFO). Valid values are defined in the Python
                 logging module.


### PR DESCRIPTION
*Description of changes:*

Reopening this PR to refresh the outdated PR https://github.com/aws/sagemaker-python-sdk/pull/3350

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
