### PR TITLE
feature: feature store with_feature_group functionality changes

### DIFF
--- a/src/sagemaker/feature_store/dataset_builder.py
+++ b/src/sagemaker/feature_store/dataset_builder.py
@@ -124,7 +124,7 @@ def construct_feature_group_to_be_merged(
     target_feature_name_in_base: str = None,
     feature_name_in_target: str = None,
     join_comparator: JoinComparatorEnum = None,
-    join_type: JoinTypeEnum = None
+    join_type: JoinTypeEnum = None,
 ) -> FeatureGroupToBeMerged:
     """Construct a FeatureGroupToBeMerged object by provided parameters.
 
@@ -145,7 +145,9 @@ def construct_feature_group_to_be_merged(
         "DataCatalogConfig", None
     )
     if not data_catalog_config:
-        raise RuntimeError(f"No metastore is configured with FeatureGroup {target_feature_group.name}.")
+        raise RuntimeError(
+            f"No metastore is configured with FeatureGroup {target_feature_group.name}."
+        )
 
     record_identifier_feature_name = feature_group_metadata.get("RecordIdentifierFeatureName", None)
     feature_definitions = feature_group_metadata.get("FeatureDefinitions", [])
@@ -165,7 +167,7 @@ def construct_feature_group_to_be_merged(
     catalog = data_catalog_config.get("Catalog", None) if disable_glue else _DEFAULT_CATALOG
     features = [feature.get("FeatureName", None) for feature in feature_definitions]
 
-    if (feature_name_in_target is not None and feature_name_in_target not in features):
+    if feature_name_in_target is not None and feature_name_in_target not in features:
         raise ValueError(
             f"Feature {feature_name_in_target} not found in FeatureGroup {target_feature_group.name}"
         )
@@ -197,7 +199,7 @@ def construct_feature_group_to_be_merged(
         TableType.FEATURE_GROUP,
         feature_name_in_target,
         join_comparator,
-        join_type
+        join_type,
     )
 
 
@@ -276,7 +278,7 @@ class DatasetBuilder:
         included_feature_names: List[str] = None,
         feature_name_in_target: str = None,
         join_comparator: JoinComparatorEnum = None,
-        join_type: JoinTypeEnum = None
+        join_type: JoinTypeEnum = None,
     ):
         """Join FeatureGroup with base.
 
@@ -291,11 +293,12 @@ class DatasetBuilder:
         """
         self._feature_groups_to_be_merged.append(
             construct_feature_group_to_be_merged(
-                feature_group, included_feature_names,
+                feature_group,
+                included_feature_names,
                 target_feature_name_in_base,
                 feature_name_in_target,
                 join_comparator,
-                join_type
+                join_type,
             )
         )
         return self
@@ -960,16 +963,23 @@ class DatasetBuilder:
             The JOIN query string.
         """
 
-        join_type = (feature_group.join_type if feature_group.join_type is not None
-                     else JoinTypeEnum.INNER_JOIN)
+        join_type = (
+            feature_group.join_type
+            if feature_group.join_type is not None
+            else JoinTypeEnum.INNER_JOIN
+        )
 
-        join_comparator = (feature_group.join_comparator
-                           if feature_group.join_comparator is not None
-                           else JoinComparatorEnum.EQUALS)
+        join_comparator = (
+            feature_group.join_comparator
+            if feature_group.join_comparator is not None
+            else JoinComparatorEnum.EQUALS
+        )
 
-        feature_name_in_target = (feature_group.feature_name_in_target
-                                  if feature_group.feature_name_in_target is not None
-                                  else feature_group.record_identifier_feature_name)
+        feature_name_in_target = (
+            feature_group.feature_name_in_target
+            if feature_group.feature_name_in_target is not None
+            else feature_group.record_identifier_feature_name
+        )
 
         join_condition_string = (
             f"\n{join_type.value} fg_{suffix}\n"

--- a/src/sagemaker/feature_store/dataset_builder.py
+++ b/src/sagemaker/feature_store/dataset_builder.py
@@ -299,16 +299,16 @@ class DatasetBuilder:
                 will be used as a join key (default: None).
             included_feature_names (List[str]): A list of strings representing features to be
                 included in the output (default: None).
-        feature_name_in_target (str): A string representing the feature in the target feature group
-            that will be compared to the target feature in the base feature group. If None is
-            provided, the record identifier will be used in the join statement. (default: None).
-        join_comparator (JoinComparatorEnum): A JoinComparatorEnum representing the comparator used
-            when joining the target feature in the base feature group and the feature in the target
-            feature group (default: None).
-        join_type (JoinTypeEnum): A JoinTypeEnum representing the type of join between the base and
-            target feature groups. (default: None).
-        Returns:
-            This DatasetBuilder object.
+            feature_name_in_target (str): A string representing the feature in the target feature group
+                that will be compared to the target feature in the base feature group. If None is
+                provided, the record identifier will be used in the join statement. (default: None).
+            join_comparator (JoinComparatorEnum): A JoinComparatorEnum representing the comparator used
+                when joining the target feature in the base feature group and the feature in the target
+                feature group (default: None).
+            join_type (JoinTypeEnum): A JoinTypeEnum representing the type of join between the base and
+                target feature groups. (default: None).
+            Returns:
+                This DatasetBuilder object.
         """
         self._feature_groups_to_be_merged.append(
             construct_feature_group_to_be_merged(

--- a/src/sagemaker/feature_store/dataset_builder.py
+++ b/src/sagemaker/feature_store/dataset_builder.py
@@ -46,6 +46,7 @@ class TableType(Enum):
 @attr.s
 class JoinTypeEnum(Enum):
     """Enum of Join types.
+
     The Join comparator can be "INNER_JOIN", "LEFT_JOIN", "RIGHT_JOIN", "FULL_JOIN"
     """
 
@@ -58,6 +59,7 @@ class JoinTypeEnum(Enum):
 @attr.s
 class JoinComparatorEnum(Enum):
     """Enum of Join comparators.
+
     The Join comparator can be "EQUALS", "GREATER_THAN", "LESS_THAN",
     "GREATER_THAN_OR_EQUAL_TO", or "LESS_THAN_OR_EQUAL_TO"
     """
@@ -87,7 +89,7 @@ class FeatureGroupToBeMerged:
         catalog (str): A string representing the catalog.
         database (str): A string representing the database.
         table_name (str): A string representing the Athena table name of this FeatureGroup.
-        record_dentifier_feature_name (str): A string representing the record identifier feature.
+        record_identifier_feature_name (str): A string representing the record identifier feature.
         event_time_identifier_feature (FeatureDefinition): A FeatureDefinition representing the
             event time identifier feature.
         target_feature_name_in_base (str): A string representing the feature name in base which will
@@ -95,7 +97,8 @@ class FeatureGroupToBeMerged:
         table_type (TableType): A TableType representing the type of table if it is Feature Group or
             Panda Data Frame (default: None).
         feature_name_in_target (str): A string representing the feature in the target feature group
-            that will be compared to the target feature in the base feature group
+            that will be compared to the target feature in the base feature group. If None is
+            provided, the record identifier will be used in the join statement. (default: None).
         join_comparator (JoinComparatorEnum): A JoinComparatorEnum representing the comparator used
             when joining the target feature in the base feature group and the feature in the target
             feature group (default: None).
@@ -134,6 +137,14 @@ def construct_feature_group_to_be_merged(
             included in the output.
         target_feature_name_in_base (str): A string representing the feature name in base which
             will be used as target join key (default: None).
+        feature_name_in_target (str): A string representing the feature in the target feature group
+            that will be compared to the target feature in the base feature group. If None is
+            provided, the record identifier will be used in the join statement. (default: None).
+        join_comparator (JoinComparatorEnum): A JoinComparatorEnum representing the comparator used
+            when joining the target feature in the base feature group and the feature in the target
+            feature group (default: None).
+        join_type (JoinTypeEnum): A JoinTypeEnum representing the type of join between the base and
+            target feature groups. (default: None).
     Returns:
         A FeatureGroupToBeMerged object.
 
@@ -283,11 +294,19 @@ class DatasetBuilder:
         """Join FeatureGroup with base.
 
         Args:
-            feature_group (FeatureGroup): A FeatureGroup which will be joined to base.
+            feature_group (FeatureGroup): A target FeatureGroup which will be joined to base.
             target_feature_name_in_base (str): A string representing the feature name in base which
-                will be used as target join key (default: None).
+                will be used as a join key (default: None).
             included_feature_names (List[str]): A list of strings representing features to be
                 included in the output (default: None).
+        feature_name_in_target (str): A string representing the feature in the target feature group
+            that will be compared to the target feature in the base feature group. If None is
+            provided, the record identifier will be used in the join statement. (default: None).
+        join_comparator (JoinComparatorEnum): A JoinComparatorEnum representing the comparator used
+            when joining the target feature in the base feature group and the feature in the target
+            feature group (default: None).
+        join_type (JoinTypeEnum): A JoinTypeEnum representing the type of join between the base and
+            target feature groups. (default: None).
         Returns:
             This DatasetBuilder object.
         """

--- a/src/sagemaker/feature_store/dataset_builder.py
+++ b/src/sagemaker/feature_store/dataset_builder.py
@@ -96,14 +96,15 @@ class FeatureGroupToBeMerged:
             be used as target join key (default: None).
         table_type (TableType): A TableType representing the type of table if it is Feature Group or
             Panda Data Frame (default: None).
-        feature_name_in_target (str): A string representing the feature in the target feature group
-            that will be compared to the target feature in the base feature group. If None is
-            provided, the record identifier will be used in the join statement. (default: None).
-        join_comparator (JoinComparatorEnum): A JoinComparatorEnum representing the comparator used
-            when joining the target feature in the base feature group and the feature in the target
-            feature group (default: None).
-        join_type (JoinTypeEnum): A JoinTypeEnum representing the type of join between the base and
-            target feature groups. (default: None).
+        feature_name_in_target (str): A string representing the feature in the target feature
+            group that will be compared to the target feature in the base feature group.
+            If None is provided, the record identifier will be used in the
+            join statement. (default: None).
+        join_comparator (JoinComparatorEnum): A JoinComparatorEnum representing the comparator
+            used when joining the target feature in the base feature group and the feature
+            in the target feature group (default: None).
+        join_type (JoinTypeEnum): A JoinTypeEnum representing the type of join between
+            the base and target feature groups. (default: None).
     """
 
     features: List[str] = attr.ib()
@@ -137,14 +138,15 @@ def construct_feature_group_to_be_merged(
             included in the output.
         target_feature_name_in_base (str): A string representing the feature name in base which
             will be used as target join key (default: None).
-        feature_name_in_target (str): A string representing the feature in the target feature group
-            that will be compared to the target feature in the base feature group. If None is
-            provided, the record identifier will be used in the join statement. (default: None).
-        join_comparator (JoinComparatorEnum): A JoinComparatorEnum representing the comparator used
-            when joining the target feature in the base feature group and the feature in the target
-            feature group (default: None).
-        join_type (JoinTypeEnum): A JoinTypeEnum representing the type of join between the base and
-            target feature groups. (default: None).
+        feature_name_in_target (str): A string representing the feature in the target feature
+            group that will be compared to the target feature in the base feature group.
+            If None is provided, the record identifier will be used in the
+            join statement. (default: None).
+        join_comparator (JoinComparatorEnum): A JoinComparatorEnum representing the comparator
+            used when joining the target feature in the base feature group and the feature
+            in the target feature group (default: None).
+        join_type (JoinTypeEnum): A JoinTypeEnum representing the type of join between
+            the base and target feature groups. (default: None).
     Returns:
         A FeatureGroupToBeMerged object.
 
@@ -299,14 +301,15 @@ class DatasetBuilder:
                 will be used as a join key (default: None).
             included_feature_names (List[str]): A list of strings representing features to be
                 included in the output (default: None).
-            feature_name_in_target (str): A string representing the feature in the target feature group
-                that will be compared to the target feature in the base feature group. If None is
-                provided, the record identifier will be used in the join statement. (default: None).
-            join_comparator (JoinComparatorEnum): A JoinComparatorEnum representing the comparator used
-                when joining the target feature in the base feature group and the feature in the target
-                feature group (default: None).
-            join_type (JoinTypeEnum): A JoinTypeEnum representing the type of join between the base and
-                target feature groups. (default: None).
+            feature_name_in_target (str): A string representing the feature in the target feature
+                group that will be compared to the target feature in the base feature group.
+                If None is provided, the record identifier will be used in the
+                join statement. (default: None).
+            join_comparator (JoinComparatorEnum): A JoinComparatorEnum representing the comparator
+                used when joining the target feature in the base feature group and the feature
+                in the target feature group (default: None).
+            join_type (JoinTypeEnum): A JoinTypeEnum representing the type of join between
+                the base and target feature groups. (default: None).
             Returns:
                 This DatasetBuilder object.
         """

--- a/tests/integ/test_feature_store.py
+++ b/tests/integ/test_feature_store.py
@@ -34,6 +34,9 @@ from sagemaker.feature_store.inputs import (
     ResourceEnum,
     Identifier,
 )
+from sagemaker.feature_store.dataset_builder import (
+    JoinTypeEnum,
+)
 from sagemaker.session import get_execution_role, Session
 from tests.integ.timeout import timeout
 
@@ -782,6 +785,193 @@ def test_create_dataset_with_feature_group_base(
                 + "FROM fg_base\n"
                 + "JOIN fg_0\n"
                 + 'ON fg_base."base_id" = fg_0."fg_id"\n'
+                + ")\n"
+                + "WHERE row_recent <= 4"
+            )
+
+
+def test_create_dataset_with_feature_group_base_with_additional_params(
+    feature_store_session,
+    region_name,
+    role,
+    base_name,
+    feature_group_name,
+    offline_store_s3_uri,
+    base_dataframe,
+    feature_group_dataframe,
+):
+    base = FeatureGroup(name=base_name, sagemaker_session=feature_store_session)
+    feature_group = FeatureGroup(name=feature_group_name, sagemaker_session=feature_store_session)
+    with cleanup_feature_group(base), cleanup_feature_group(feature_group):
+        _create_feature_group_and_ingest_data(
+            base, base_dataframe, offline_store_s3_uri, "base_id", "base_time", role
+        )
+        _create_feature_group_and_ingest_data(
+            feature_group, feature_group_dataframe, offline_store_s3_uri, "fg_id", "fg_time", role
+        )
+        base_table_name = _get_athena_table_name_after_data_replication(
+            feature_store_session, base, offline_store_s3_uri
+        )
+        feature_group_table_name = _get_athena_table_name_after_data_replication(
+            feature_store_session, feature_group, offline_store_s3_uri
+        )
+
+        with timeout(minutes=10) and cleanup_offline_store(
+            base_table_name, feature_store_session
+        ) and cleanup_offline_store(feature_group_table_name, feature_store_session):
+            feature_store = FeatureStore(sagemaker_session=feature_store_session)
+            df, query_string = (
+                feature_store.create_dataset(base=base, output_path=offline_store_s3_uri)
+                .with_number_of_recent_records_by_record_identifier(4)
+                .with_feature_group(
+                    feature_group,
+                    target_feature_name_in_base="base_time",
+                    feature_name_in_target="fg_time",
+                    join_type=JoinTypeEnum.FULL_JOIN,
+                )
+                .to_dataframe()
+            )
+            sorted_df = df.sort_values(by=list(df.columns)).reset_index(drop=True)
+            merged_df = base_dataframe.merge(
+                feature_group_dataframe, left_on="base_time", right_on="fg_time", how="outer"
+            )
+
+            expect_df = merged_df.sort_values(by=list(merged_df.columns)).reset_index(drop=True)
+
+            expect_df.rename(
+                columns={
+                    "fg_id": "fg_id.1",
+                    "fg_time": "fg_time.1",
+                    "fg_feature_1": "fg_feature_1.1",
+                    "fg_feature_2": "fg_feature_2.1",
+                },
+                inplace=True,
+            )
+
+            assert sorted_df.equals(expect_df)
+            assert (
+                query_string
+                == "WITH fg_base AS (WITH table_base AS (\n"
+                + "SELECT *\n"
+                + "FROM (\n"
+                + "SELECT *, row_number() OVER (\n"
+                + 'PARTITION BY origin_base."base_id", origin_base."base_time"\n'
+                + 'ORDER BY origin_base."api_invocation_time" DESC, origin_base."write_time" DESC\n'
+                + ") AS dedup_row_base\n"
+                + f'FROM "sagemaker_featurestore"."{base_table_name}" origin_base\n'
+                + ")\n"
+                + "WHERE dedup_row_base = 1\n"
+                + "),\n"
+                + "deleted_base AS (\n"
+                + "SELECT *\n"
+                + "FROM (\n"
+                + "SELECT *, row_number() OVER (\n"
+                + 'PARTITION BY origin_base."base_id"\n'
+                + 'ORDER BY origin_base."base_time" DESC,'
+                ' origin_base."api_invocation_time" DESC,'
+                ' origin_base."write_time" DESC\n'
+                + ") AS deleted_row_base\n"
+                + f'FROM "sagemaker_featurestore"."{base_table_name}" origin_base\n'
+                + "WHERE is_deleted\n"
+                + ")\n"
+                + "WHERE deleted_row_base = 1\n"
+                + ")\n"
+                + 'SELECT table_base."base_id", table_base."base_time",'
+                ' table_base."base_feature_1", table_base."base_feature_2"\n'
+                + "FROM (\n"
+                + 'SELECT table_base."base_id", table_base."base_time",'
+                ' table_base."base_feature_1", table_base."base_feature_2",'
+                ' table_base."write_time"\n'
+                + "FROM table_base\n"
+                + "LEFT JOIN deleted_base\n"
+                + 'ON table_base."base_id" = deleted_base."base_id"\n'
+                + 'WHERE deleted_base."base_id" IS NULL\n'
+                + "UNION ALL\n"
+                + 'SELECT table_base."base_id", table_base."base_time",'
+                ' table_base."base_feature_1", table_base."base_feature_2",'
+                ' table_base."write_time"\n'
+                + "FROM deleted_base\n"
+                + "JOIN table_base\n"
+                + 'ON table_base."base_id" = deleted_base."base_id"\n'
+                + "AND (\n"
+                + 'table_base."base_time" > deleted_base."base_time"\n'
+                + 'OR (table_base."base_time" = deleted_base."base_time" AND'
+                ' table_base."api_invocation_time" >'
+                ' deleted_base."api_invocation_time")\n'
+                + 'OR (table_base."base_time" = deleted_base."base_time" AND'
+                ' table_base."api_invocation_time" ='
+                ' deleted_base."api_invocation_time" AND'
+                ' table_base."write_time" > deleted_base."write_time")\n'
+                + ")\n"
+                + ") AS table_base\n"
+                + "),\n"
+                + "fg_0 AS (WITH table_0 AS (\n"
+                + "SELECT *\n"
+                + "FROM (\n"
+                + "SELECT *, row_number() OVER (\n"
+                + 'PARTITION BY origin_0."fg_id", origin_0."fg_time"\n'
+                + 'ORDER BY origin_0."api_invocation_time" DESC, origin_0."write_time" DESC\n'
+                + ") AS dedup_row_0\n"
+                + f'FROM "sagemaker_featurestore"."{feature_group_table_name}" origin_0\n'
+                + ")\n"
+                + "WHERE dedup_row_0 = 1\n"
+                + "),\n"
+                + "deleted_0 AS (\n"
+                + "SELECT *\n"
+                + "FROM (\n"
+                + "SELECT *, row_number() OVER (\n"
+                + 'PARTITION BY origin_0."fg_id"\n'
+                + 'ORDER BY origin_0."fg_time" DESC, origin_0."api_invocation_time" DESC,'
+                ' origin_0."write_time" DESC\n'
+                + ") AS deleted_row_0\n"
+                + f'FROM "sagemaker_featurestore"."{feature_group_table_name}" origin_0\n'
+                + "WHERE is_deleted\n"
+                + ")\n"
+                + "WHERE deleted_row_0 = 1\n"
+                + ")\n"
+                + 'SELECT table_0."fg_id", table_0."fg_time", table_0."fg_feature_1",'
+                ' table_0."fg_feature_2"\n'
+                + "FROM (\n"
+                + 'SELECT table_0."fg_id", table_0."fg_time",'
+                ' table_0."fg_feature_1", table_0."fg_feature_2",'
+                ' table_0."write_time"\n'
+                + "FROM table_0\n"
+                + "LEFT JOIN deleted_0\n"
+                + 'ON table_0."fg_id" = deleted_0."fg_id"\n'
+                + 'WHERE deleted_0."fg_id" IS NULL\n'
+                + "UNION ALL\n"
+                + 'SELECT table_0."fg_id", table_0."fg_time",'
+                ' table_0."fg_feature_1", table_0."fg_feature_2",'
+                ' table_0."write_time"\n'
+                + "FROM deleted_0\n"
+                + "JOIN table_0\n"
+                + 'ON table_0."fg_id" = deleted_0."fg_id"\n'
+                + "AND (\n"
+                + 'table_0."fg_time" > deleted_0."fg_time"\n'
+                + 'OR (table_0."fg_time" = deleted_0."fg_time" AND'
+                ' table_0."api_invocation_time" >'
+                ' deleted_0."api_invocation_time")\n'
+                + 'OR (table_0."fg_time" = deleted_0."fg_time" AND'
+                ' table_0."api_invocation_time" ='
+                ' deleted_0."api_invocation_time" AND table_0."write_time" >'
+                ' deleted_0."write_time")\n'
+                + ")\n"
+                + ") AS table_0\n"
+                + ")\n"
+                + "SELECT base_id, base_time, base_feature_1, base_feature_2,"
+                ' "fg_id.1", "fg_time.1", "fg_feature_1.1",'
+                ' "fg_feature_2.1"\n' + "FROM (\n" + "SELECT fg_base.base_id, fg_base.base_time,"
+                " fg_base.base_feature_1, fg_base.base_feature_2,"
+                ' fg_0."fg_id" as "fg_id.1", fg_0."fg_time" as "fg_time.1",'
+                ' fg_0."fg_feature_1" as "fg_feature_1.1",'
+                ' fg_0."fg_feature_2" as "fg_feature_2.1", row_number()'
+                " OVER (\n"
+                + 'PARTITION BY fg_base."base_id"\n'
+                + 'ORDER BY fg_base."base_time" DESC, fg_0."fg_time" DESC\n'
+                + ") AS row_recent\n"
+                + "FROM fg_base\n"
+                + "FULL JOIN fg_0\n"
+                + 'ON fg_base."base_time" = fg_0."fg_time"\n'
                 + ")\n"
                 + "WHERE row_recent <= 4"
             )

--- a/tests/unit/sagemaker/feature_store/test_dataset_builder.py
+++ b/tests/unit/sagemaker/feature_store/test_dataset_builder.py
@@ -23,11 +23,13 @@ from sagemaker.feature_store.dataset_builder import (
     DatasetBuilder,
     FeatureGroupToBeMerged,
     TableType,
+    JoinComparatorEnum,
+    JoinTypeEnum
 )
 from sagemaker.feature_store.feature_group import (
     FeatureDefinition,
     FeatureGroup,
-    FeatureTypeEnum,
+    FeatureTypeEnum
 )
 
 
@@ -527,6 +529,149 @@ def test_construct_query_string(sagemaker_session_mock):
         + 'AND from_unixtime(fg_base."target-feature") >= from_unixtime(fg_0."feature-2")\n'
         + ")\n"
     )
+
+# Tests the optional feature_name_in_target, join_comparator and join_type parameters
+def test_with_feature_group_with_optional_params_query_string(sagemaker_session_mock):
+    base_feature_group = FeatureGroup(name="base_feature_group", sagemaker_session=sagemaker_session_mock)
+    target_feature_group = FeatureGroup(name="target_feature_group", sagemaker_session=sagemaker_session_mock)
+
+    dataset_builder = DatasetBuilder(
+        sagemaker_session=sagemaker_session_mock,
+        base=base_feature_group,
+        output_path="file/to/path",
+        record_identifier_feature_name="target-feature",
+    )
+
+    dataset_builder._event_time_identifier_feature_name = "target-feature"
+
+    sagemaker_session_mock.describe_feature_group.return_value = {
+        "OfflineStoreConfig": {"DataCatalogConfig": {"TableName": "table-name", "Database": "database"}},
+        "RecordIdentifierFeatureName": "feature-1",
+        "EventTimeFeatureName": "feature-2",
+        "FeatureDefinitions": [
+            {"FeatureName": "feature-1", "FeatureType": "String"},
+            {"FeatureName": "feature-2", "FeatureType": "String"},
+        ],
+    }
+
+    dataset_builder.with_feature_group(target_feature_group, 
+        "target-feature", 
+        ["feature-1", "feature-2"], 
+        "feature-2", 
+        JoinComparatorEnum.GREATER_THAN, 
+        JoinTypeEnum.FULL_JOIN)
+
+    query_string = dataset_builder._construct_query_string(BASE)
+
+    assert (
+        query_string
+        == "WITH fg_base AS (WITH table_base AS (\n"
+        + "SELECT *\n"
+        + "FROM (\n"
+        + "SELECT *, row_number() OVER (\n"
+        + 'PARTITION BY origin_base."target-feature", origin_base."other-feature"\n'
+        + 'ORDER BY origin_base."api_invocation_time" DESC, origin_base."write_time" DESC\n'
+        + ") AS dedup_row_base\n"
+        + 'FROM "database"."base-table" origin_base\n'
+        + ")\n"
+        + "WHERE dedup_row_base = 1\n"
+        + "),\n"
+        + "deleted_base AS (\n"
+        + "SELECT *\n"
+        + "FROM (\n"
+        + "SELECT *, row_number() OVER (\n"
+        + 'PARTITION BY origin_base."target-feature"\n'
+        + 'ORDER BY origin_base."other-feature" DESC, origin_base."api_invocation_time" '
+        + 'DESC, origin_base."write_time" DESC\n'
+        + ") AS deleted_row_base\n"
+        + 'FROM "database"."base-table" origin_base\n'
+        + "WHERE is_deleted\n"
+        + ")\n"
+        + "WHERE deleted_row_base = 1\n"
+        + ")\n"
+        + 'SELECT table_base."target-feature", table_base."other-feature"\n'
+        + "FROM (\n"
+        + 'SELECT table_base."target-feature", table_base."other-feature", '
+        + 'table_base."write_time"\n'
+        + "FROM table_base\n"
+        + "LEFT JOIN deleted_base\n"
+        + 'ON table_base."target-feature" = deleted_base."target-feature"\n'
+        + 'WHERE deleted_base."target-feature" IS NULL\n'
+        + "UNION ALL\n"
+        + 'SELECT table_base."target-feature", table_base."other-feature", '
+        + 'table_base."write_time"\n'
+        + "FROM deleted_base\n"
+        + "JOIN table_base\n"
+        + 'ON table_base."target-feature" = deleted_base."target-feature"\n'
+        + "AND (\n"
+        + 'table_base."other-feature" > deleted_base."other-feature"\n'
+        + 'OR (table_base."other-feature" = deleted_base."other-feature" AND '
+        + 'table_base."api_invocation_time" > deleted_base."api_invocation_time")\n'
+        + 'OR (table_base."other-feature" = deleted_base."other-feature" AND '
+        + 'table_base."api_invocation_time" = deleted_base."api_invocation_time" AND '
+        + 'table_base."write_time" > deleted_base."write_time")\n'
+        + ")\n"
+        + ") AS table_base\n"
+        + "),\n"
+        + "fg_0 AS (WITH table_0 AS (\n"
+        + "SELECT *\n"
+        + "FROM (\n"
+        + "SELECT *, row_number() OVER (\n"
+        + 'PARTITION BY origin_0."feature-1", origin_0."feature-2"\n'
+        + 'ORDER BY origin_0."api_invocation_time" DESC, origin_0."write_time" DESC\n'
+        + ") AS dedup_row_0\n"
+        + 'FROM "database"."table-name" origin_0\n'
+        + ")\n"
+        + "WHERE dedup_row_0 = 1\n"
+        + "),\n"
+        + "deleted_0 AS (\n"
+        + "SELECT *\n"
+        + "FROM (\n"
+        + "SELECT *, row_number() OVER (\n"
+        + 'PARTITION BY origin_0."feature-1"\n'
+        + 'ORDER BY origin_0."feature-2" DESC, origin_0."api_invocation_time" DESC, '
+        + 'origin_0."write_time" DESC\n'
+        + ") AS deleted_row_0\n"
+        + 'FROM "database"."table-name" origin_0\n'
+        + "WHERE is_deleted\n"
+        + ")\n"
+        + "WHERE deleted_row_0 = 1\n"
+        + ")\n"
+        + 'SELECT table_0."feature-1", table_0."feature-2"\n'
+        + "FROM (\n"
+        + 'SELECT table_0."feature-1", table_0."feature-2", table_0."write_time"\n'
+        + "FROM table_0\n"
+        + "LEFT JOIN deleted_0\n"
+        + 'ON table_0."feature-1" = deleted_0."feature-1"\n'
+        + 'WHERE deleted_0."feature-1" IS NULL\n'
+        + "UNION ALL\n"
+        + 'SELECT table_0."feature-1", table_0."feature-2", table_0."write_time"\n'
+        + "FROM deleted_0\n"
+        + "JOIN table_0\n"
+        + 'ON table_0."feature-1" = deleted_0."feature-1"\n'
+        + "AND (\n"
+        + 'table_0."feature-2" > deleted_0."feature-2"\n'
+        + 'OR (table_0."feature-2" = deleted_0."feature-2" AND '
+        + 'table_0."api_invocation_time" > deleted_0."api_invocation_time")\n'
+        + 'OR (table_0."feature-2" = deleted_0."feature-2" AND '
+        + 'table_0."api_invocation_time" = deleted_0."api_invocation_time" AND '
+        + 'table_0."write_time" > deleted_0."write_time")\n'
+        + ")\n"
+        + ") AS table_0\n"
+        + ")\n"
+        + 'SELECT target-feature, other-feature, "feature-1.1", "feature-2.1"\n'
+        + "FROM (\n"
+        + 'SELECT fg_base.target-feature, fg_base.other-feature, fg_0."feature-1" as '
+        + '"feature-1.1", fg_0."feature-2" as "feature-2.1", row_number() OVER (\n'
+        + 'PARTITION BY fg_base."target-feature"\n'
+        + 'ORDER BY fg_base."other-feature" DESC, fg_0."feature-2" DESC\n'
+        + ") AS row_recent\n"
+        + "FROM fg_base\n"
+        + "FULL JOIN fg_0\n"
+        + 'ON fg_base."target-feature" > fg_0."feature-2"\n'
+        + ")\n"
+    )
+
 
 
 def test_create_temp_table(sagemaker_session_mock):

--- a/tests/unit/sagemaker/feature_store/test_dataset_builder.py
+++ b/tests/unit/sagemaker/feature_store/test_dataset_builder.py
@@ -24,13 +24,9 @@ from sagemaker.feature_store.dataset_builder import (
     FeatureGroupToBeMerged,
     TableType,
     JoinComparatorEnum,
-    JoinTypeEnum
+    JoinTypeEnum,
 )
-from sagemaker.feature_store.feature_group import (
-    FeatureDefinition,
-    FeatureGroup,
-    FeatureTypeEnum
-)
+from sagemaker.feature_store.feature_group import FeatureDefinition, FeatureGroup, FeatureTypeEnum
 
 
 @pytest.fixture
@@ -530,10 +526,15 @@ def test_construct_query_string(sagemaker_session_mock):
         + ")\n"
     )
 
+
 # Tests the optional feature_name_in_target, join_comparator and join_type parameters
 def test_with_feature_group_with_optional_params_query_string(sagemaker_session_mock):
-    base_feature_group = FeatureGroup(name="base_feature_group", sagemaker_session=sagemaker_session_mock)
-    target_feature_group = FeatureGroup(name="target_feature_group", sagemaker_session=sagemaker_session_mock)
+    base_feature_group = FeatureGroup(
+        name="base_feature_group", sagemaker_session=sagemaker_session_mock
+    )
+    target_feature_group = FeatureGroup(
+        name="target_feature_group", sagemaker_session=sagemaker_session_mock
+    )
 
     dataset_builder = DatasetBuilder(
         sagemaker_session=sagemaker_session_mock,
@@ -545,7 +546,9 @@ def test_with_feature_group_with_optional_params_query_string(sagemaker_session_
     dataset_builder._event_time_identifier_feature_name = "target-feature"
 
     sagemaker_session_mock.describe_feature_group.return_value = {
-        "OfflineStoreConfig": {"DataCatalogConfig": {"TableName": "table-name", "Database": "database"}},
+        "OfflineStoreConfig": {
+            "DataCatalogConfig": {"TableName": "table-name", "Database": "database"}
+        },
         "RecordIdentifierFeatureName": "feature-1",
         "EventTimeFeatureName": "feature-2",
         "FeatureDefinitions": [
@@ -554,12 +557,14 @@ def test_with_feature_group_with_optional_params_query_string(sagemaker_session_
         ],
     }
 
-    dataset_builder.with_feature_group(target_feature_group, 
-        "target-feature", 
-        ["feature-1", "feature-2"], 
-        "feature-2", 
-        JoinComparatorEnum.GREATER_THAN, 
-        JoinTypeEnum.FULL_JOIN)
+    dataset_builder.with_feature_group(
+        target_feature_group,
+        "target-feature",
+        ["feature-1", "feature-2"],
+        "feature-2",
+        JoinComparatorEnum.GREATER_THAN,
+        JoinTypeEnum.FULL_JOIN,
+    )
 
     query_string = dataset_builder._construct_query_string(BASE)
 
@@ -671,7 +676,6 @@ def test_with_feature_group_with_optional_params_query_string(sagemaker_session_
         + 'ON fg_base."target-feature" > fg_0."feature-2"\n'
         + ")\n"
     )
-
 
 
 def test_create_temp_table(sagemaker_session_mock):

--- a/tests/unit/sagemaker/feature_store/test_dataset_builder.py
+++ b/tests/unit/sagemaker/feature_store/test_dataset_builder.py
@@ -163,9 +163,15 @@ def test_with_feature_group_with_additional_params(sagemaker_session_mock):
             {"FeatureName": "feature-2", "FeatureType": "String"},
         ],
     }
-    dataset_builder.with_feature_group(feature_group, "target-feature", [
-                                       "feature-1", "feature-2"], join_comparator=JoinComparatorEnum.LESS_THAN, join_type=JoinTypeEnum.LEFT_JOIN, feature_name_in_target='feature-2')
-                                       
+    dataset_builder.with_feature_group(
+        feature_group,
+        "target-feature",
+        ["feature-1", "feature-2"],
+        join_comparator=JoinComparatorEnum.LESS_THAN,
+        join_type=JoinTypeEnum.LEFT_JOIN,
+        feature_name_in_target="feature-2",
+    )
+
     assert len(dataset_builder._feature_groups_to_be_merged) == 1
     assert dataset_builder._feature_groups_to_be_merged[0].features == [
         "feature-1",
@@ -189,10 +195,7 @@ def test_with_feature_group_with_additional_params(sagemaker_session_mock):
         dataset_builder._feature_groups_to_be_merged[0].event_time_identifier_feature.feature_type
         == FeatureTypeEnum.STRING
     )
-    assert (
-        dataset_builder._feature_groups_to_be_merged[0].join_type
-        == JoinTypeEnum.LEFT_JOIN
-    )
+    assert dataset_builder._feature_groups_to_be_merged[0].join_type == JoinTypeEnum.LEFT_JOIN
     assert (
         dataset_builder._feature_groups_to_be_merged[0].join_comparator
         == JoinComparatorEnum.LESS_THAN


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds three new parameters to the `with_feature_group` Feature Store `dataset_builder` class.

These three new parameters are:
```
        feature_name_in_target (str): A string representing the feature in the target feature group
            that will be compared to the target feature in the base feature group. If None is
            provided, the record identifier will be used in the join statement. (default: None).
        join_comparator (JoinComparatorEnum): A JoinComparatorEnum representing the comparator used
            when joining the target feature in the base feature group and the feature in the target
            feature group (default: None).
        join_type (JoinTypeEnum): A JoinTypeEnum representing the type of join between the base and
            target feature groups. (default: None).
```

`feature_name_in_target`
- Allows users to provide the feature name in the target feature group that will be used as a join key alongside the currently existing `target_feature_name_in_base` feature in the SQL JOIN statement. Before, only the record identifier feature in the target feature group could be used when creating the query.

`join_comparator`
- Allows user to provide a Join comparator, which will be used to compare the two join keys. For example, we can now join a row together if feature_1 (target_feature_name_in_base) in feature group `A` is greater than `feature_1` (feature_name_in_target). Before, only `=` (Equals) was able to be used.

`join_type`
- Allows user to provide a Join type, which will specify the type of Join in the SQL statement. Before, users could only specify an (INNER) JOIN.
- Enum keys are based on the join types available in the Athena docs https://docs.aws.amazon.com/athena/latest/ug/select.html

### Usage
Say we have two feature groups, `feature_group_a`, and `feature_group_b`.

`feature_group_a` has three features, `rec-id-a`, `event-time-id-a` and `feature-a`.
`feature_group_b` has three features, `rec-id-b`, `event-time-id-b` and `feature-b`.

A user may want to join `feature-a` from `feature_group_a` (base) and `feature-b` from `feature_group_b` (target). Furthermore, the user wants to perform a `RIGHT_JOIN` instead of a regular JOIN (inner) and use the `LESS_THAN` comparator instead of equals

Our code could look like this:

```
dataset_builder = feature_store.create_dataset(
    base=feature_group_a,
    output_path=f"s3://{s3_bucket_name}",
)

result_df, query = dataset_builder.with_feature_group(
    feature_group=feature_group_b,
    target_feature_name_in_base="feature-a",
    feature_name_in_target="feature-b"
    join_comparator=JoinComparatorEnum.LESS_THAN,
    join_type=JoinTypeEnum.RIGHT_JOIN).to_dataframe()
```

or without named arguments

```
result_df, query = dataset_builder.with_feature_group(
    feature_group_b,
    "feature-a",
    None,
    "feature-b"
    JoinComparatorEnum.LESS_THAN,
    JoinTypeEnum.RIGHT_JOIN).to_dataframe()
```

*Testing done:*
- Unit & integration test to ensure properties of dataset_builder class are correctly updated when the new parameters are used in `with_feature_group`
- Unit & integration test for the SQL query generated when using the `with_feature_group` with the new parameters.
- Currently existing unit tests are unchanged.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
