### PR TITLE
feature: Add python 3.9 and spark 3.2 support for spark processor

### DIFF
--- a/src/sagemaker/image_uri_config/spark.json
+++ b/src/sagemaker/image_uri_config/spark.json
@@ -91,6 +91,36 @@
                     "ap-southeast-3": "732049463269"
                 },
                 "repository": "sagemaker-spark-processing"
+            },
+            "3.2": {
+                "py_versions": ["py39"],
+                "registries": {
+                    "me-south-1": "750251592176",
+                    "ap-south-1": "105495057255",
+                    "eu-north-1": "330188676905",
+                    "eu-west-3": "136845547031",
+                    "us-east-2": "314815235551",
+                    "eu-west-1": "571004829621",
+                    "eu-central-1": "906073651304",
+                    "sa-east-1": "737130764395",
+                    "ap-east-1": "732049463269",
+                    "us-east-1": "173754725891",
+                    "ap-northeast-2": "860869212795",
+                    "eu-west-2": "836651553127",
+                    "ap-northeast-1": "411782140378",
+                    "us-west-2": "153931337802",
+                    "us-west-1": "667973535471",
+                    "ap-southeast-1": "759080221371",
+                    "ap-southeast-2": "440695851116",
+                    "ca-central-1": "446299261295",
+                    "cn-north-1": "671472414489",
+                    "cn-northwest-1": "844356804704",
+                    "eu-south-1": "753923664805",
+                    "af-south-1": "309385258863",
+                    "us-gov-west-1": "271483468897",
+                    "ap-southeast-3": "732049463269"
+                },
+                "repository": "sagemaker-spark-processing"
             }
         }
     }


### PR DESCRIPTION
*Issue #, if available:*

Issue: We are not able to use newer version of Spark image because validation failure on the SageMaker Python SDK side. 

*Description of changes:*

I deep dive into the [code](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/image_uri_config/spark.json). This file should support our current Spark set up which doesn't right now. It should support python 3.9 and Spark 3.2 according to processing spark image.

*Testing done:*


## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [X ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [X] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [X ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [X ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ X] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ X] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ X] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ X] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ X] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
