### PR TITLE
fix: tag permission issue - remove describe before create

### DIFF
--- a/src/sagemaker/workflow/pipeline.py
+++ b/src/sagemaker/workflow/pipeline.py
@@ -246,10 +246,7 @@ sagemaker.html#SageMaker.Client.describe_pipeline>`_
         except ClientError as ce:
             error_code = ce.response["Error"]["Code"]
             error_message = ce.response["Error"]["Message"]
-            if not (
-                    error_code == "ValidationException"
-                    and "already exists" in error_message
-            ):
+            if not (error_code == "ValidationException" and "already exists" in error_message):
                 raise ce
             # already exists
             response = self.update(role_arn, description)

--- a/tests/integ/test_inference_pipeline.py
+++ b/tests/integ/test_inference_pipeline.py
@@ -28,7 +28,7 @@ from sagemaker.pipeline import PipelineModel
 from sagemaker.predictor import Predictor
 from sagemaker.serializers import JSONSerializer
 from sagemaker.sparkml.model import SparkMLModel
-from sagemaker.utils import sagemaker_timestamp
+from sagemaker.utils import unique_name_from_base
 
 SPARKML_DATA_PATH = os.path.join(DATA_DIR, "sparkml_model")
 XGBOOST_DATA_PATH = os.path.join(DATA_DIR, "xgboost_model")
@@ -60,7 +60,7 @@ def test_inference_pipeline_batch_transform(sagemaker_session, cpu_instance_type
         path=os.path.join(XGBOOST_DATA_PATH, "xgb_model.tar.gz"),
         key_prefix="integ-test-data/xgboost/model",
     )
-    batch_job_name = "test-inference-pipeline-batch-{}".format(sagemaker_timestamp())
+    batch_job_name = unique_name_from_base("test-inference-pipeline-batch")
     sparkml_model = SparkMLModel(
         model_data=sparkml_model_data,
         env={"SAGEMAKER_SPARKML_SCHEMA": SCHEMA},
@@ -99,7 +99,7 @@ def test_inference_pipeline_batch_transform(sagemaker_session, cpu_instance_type
 def test_inference_pipeline_model_deploy(sagemaker_session, cpu_instance_type):
     sparkml_data_path = os.path.join(DATA_DIR, "sparkml_model")
     xgboost_data_path = os.path.join(DATA_DIR, "xgboost_model")
-    endpoint_name = "test-inference-pipeline-deploy-{}".format(sagemaker_timestamp())
+    endpoint_name = unique_name_from_base("test-inference-pipeline-deploy")
     sparkml_model_data = sagemaker_session.upload_data(
         path=os.path.join(sparkml_data_path, "mleap_model.tar.gz"),
         key_prefix="integ-test-data/sparkml/model",
@@ -156,7 +156,7 @@ def test_inference_pipeline_model_deploy_and_update_endpoint(
 ):
     sparkml_data_path = os.path.join(DATA_DIR, "sparkml_model")
     xgboost_data_path = os.path.join(DATA_DIR, "xgboost_model")
-    endpoint_name = "test-inference-pipeline-deploy-{}".format(sagemaker_timestamp())
+    endpoint_name = unique_name_from_base("test-inference-pipeline-deploy")
     sparkml_model_data = sagemaker_session.upload_data(
         path=os.path.join(sparkml_data_path, "mleap_model.tar.gz"),
         key_prefix="integ-test-data/sparkml/model",

--- a/tests/integ/test_mxnet.py
+++ b/tests/integ/test_mxnet.py
@@ -24,7 +24,7 @@ from sagemaker.mxnet.estimator import MXNet
 from sagemaker.mxnet.model import MXNetModel
 from sagemaker.mxnet.processing import MXNetProcessor
 from sagemaker.serverless import ServerlessInferenceConfig
-from sagemaker.utils import sagemaker_timestamp
+from sagemaker.utils import unique_name_from_base
 from tests.integ import DATA_DIR, TRAINING_DEFAULT_TIMEOUT_MINUTES
 from tests.integ.kms_utils import get_or_create_kms_key
 from tests.integ.timeout import timeout, timeout_and_delete_endpoint_by_name
@@ -98,7 +98,7 @@ def test_framework_processing_job_with_deps(
 
 @pytest.mark.release
 def test_attach_deploy(mxnet_training_job, sagemaker_session, cpu_instance_type):
-    endpoint_name = "test-mxnet-attach-deploy-{}".format(sagemaker_timestamp())
+    endpoint_name = unique_name_from_base("test-mxnet-attach-deploy")
 
     with timeout_and_delete_endpoint_by_name(endpoint_name, sagemaker_session):
         estimator = MXNet.attach(mxnet_training_job, sagemaker_session=sagemaker_session)
@@ -165,7 +165,7 @@ def test_deploy_model(
     mxnet_inference_latest_py_version,
     cpu_instance_type,
 ):
-    endpoint_name = "test-mxnet-deploy-model-{}".format(sagemaker_timestamp())
+    endpoint_name = unique_name_from_base("test-mxnet-deploy-model")
 
     with timeout_and_delete_endpoint_by_name(endpoint_name, sagemaker_session):
         desc = sagemaker_session.sagemaker_client.describe_training_job(
@@ -200,7 +200,7 @@ def test_register_model_package(
     mxnet_inference_latest_py_version,
     cpu_instance_type,
 ):
-    endpoint_name = "test-mxnet-deploy-model-{}".format(sagemaker_timestamp())
+    endpoint_name = unique_name_from_base("test-mxnet-deploy-model")
 
     with timeout_and_delete_endpoint_by_name(endpoint_name, sagemaker_session):
         desc = sagemaker_session.sagemaker_client.describe_training_job(
@@ -216,7 +216,7 @@ def test_register_model_package(
             sagemaker_session=sagemaker_session,
             framework_version=mxnet_inference_latest_version,
         )
-        model_package_name = "register-model-package-{}".format(sagemaker_timestamp())
+        model_package_name = unique_name_from_base("register-model-package")
         model_pkg = model.register(
             content_types=["application/json"],
             response_types=["application/json"],
@@ -239,13 +239,13 @@ def test_register_model_package_versioned(
     mxnet_inference_latest_py_version,
     cpu_instance_type,
 ):
-    endpoint_name = "test-mxnet-deploy-model-{}".format(sagemaker_timestamp())
+    endpoint_name = unique_name_from_base("test-mxnet-deploy-model")
 
     with timeout_and_delete_endpoint_by_name(endpoint_name, sagemaker_session):
         desc = sagemaker_session.sagemaker_client.describe_training_job(
             TrainingJobName=mxnet_training_job
         )
-        model_package_group_name = "register-model-package-{}".format(sagemaker_timestamp())
+        model_package_group_name = unique_name_from_base("register-model-package")
         sagemaker_session.sagemaker_client.create_model_package_group(
             ModelPackageGroupName=model_package_group_name
         )
@@ -287,7 +287,7 @@ def test_deploy_model_with_tags_and_kms(
     mxnet_inference_latest_py_version,
     cpu_instance_type,
 ):
-    endpoint_name = "test-mxnet-deploy-model-{}".format(sagemaker_timestamp())
+    endpoint_name = unique_name_from_base("test-mxnet-deploy-model")
 
     with timeout_and_delete_endpoint_by_name(endpoint_name, sagemaker_session):
         desc = sagemaker_session.sagemaker_client.describe_training_job(
@@ -347,7 +347,7 @@ def test_deploy_model_and_update_endpoint(
     cpu_instance_type,
     alternative_cpu_instance_type,
 ):
-    endpoint_name = "test-mxnet-deploy-model-{}".format(sagemaker_timestamp())
+    endpoint_name = unique_name_from_base("test-mxnet-deploy-model")
 
     with timeout_and_delete_endpoint_by_name(endpoint_name, sagemaker_session):
         desc = sagemaker_session.sagemaker_client.describe_training_job(
@@ -395,7 +395,7 @@ def test_deploy_model_with_accelerator(
     mxnet_eia_latest_py_version,
     cpu_instance_type,
 ):
-    endpoint_name = "test-mxnet-deploy-model-ei-{}".format(sagemaker_timestamp())
+    endpoint_name = unique_name_from_base("test-mxnet-deploy-model-ei")
 
     with timeout_and_delete_endpoint_by_name(endpoint_name, sagemaker_session):
         desc = sagemaker_session.sagemaker_client.describe_training_job(
@@ -426,7 +426,7 @@ def test_deploy_model_with_serverless_inference_config(
     mxnet_inference_latest_version,
     mxnet_inference_latest_py_version,
 ):
-    endpoint_name = "test-mxnet-deploy-model-serverless-{}".format(sagemaker_timestamp())
+    endpoint_name = unique_name_from_base("test-mxnet-deploy-model-serverless")
 
     with timeout_and_delete_endpoint_by_name(endpoint_name, sagemaker_session):
         desc = sagemaker_session.sagemaker_client.describe_training_job(
@@ -465,7 +465,7 @@ def test_async_fit(
     mxnet_inference_latest_py_version,
     cpu_instance_type,
 ):
-    endpoint_name = "test-mxnet-attach-deploy-{}".format(sagemaker_timestamp())
+    endpoint_name = unique_name_from_base("test-mxnet-attach-deploy")
 
     with timeout(minutes=5):
         script_path = os.path.join(DATA_DIR, "mxnet_mnist", "mnist.py")

--- a/tests/integ/test_pytorch.py
+++ b/tests/integ/test_pytorch.py
@@ -20,7 +20,7 @@ from sagemaker.pytorch.estimator import PyTorch
 from sagemaker.pytorch.model import PyTorchModel
 from sagemaker.pytorch.processing import PyTorchProcessor
 from sagemaker.serverless import ServerlessInferenceConfig
-from sagemaker.utils import sagemaker_timestamp
+from sagemaker.utils import unique_name_from_base
 from tests.integ import (
     test_region,
     DATA_DIR,
@@ -130,7 +130,7 @@ def test_framework_processing_job_with_deps(
 def test_fit_deploy(
     pytorch_training_job_with_latest_infernce_version, sagemaker_session, cpu_instance_type
 ):
-    endpoint_name = "test-pytorch-sync-fit-attach-deploy{}".format(sagemaker_timestamp())
+    endpoint_name = unique_name_from_base("test-pytorch-sync-fit-attach-deploy")
     with timeout_and_delete_endpoint_by_name(endpoint_name, sagemaker_session):
         estimator = PyTorch.attach(
             pytorch_training_job_with_latest_infernce_version, sagemaker_session=sagemaker_session
@@ -180,7 +180,7 @@ def test_deploy_model(
     pytorch_inference_latest_version,
     pytorch_inference_latest_py_version,
 ):
-    endpoint_name = "test-pytorch-deploy-model-{}".format(sagemaker_timestamp())
+    endpoint_name = unique_name_from_base("test-pytorch-deploy-model")
 
     with timeout_and_delete_endpoint_by_name(endpoint_name, sagemaker_session):
         desc = sagemaker_session.sagemaker_client.describe_training_job(
@@ -210,7 +210,7 @@ def test_deploy_packed_model_with_entry_point_name(
     pytorch_inference_latest_version,
     pytorch_inference_latest_py_version,
 ):
-    endpoint_name = "test-pytorch-deploy-model-{}".format(sagemaker_timestamp())
+    endpoint_name = unique_name_from_base("test-pytorch-deploy-model")
 
     with timeout_and_delete_endpoint_by_name(endpoint_name, sagemaker_session):
         model_data = sagemaker_session.upload_data(path=PACKED_MODEL)
@@ -240,7 +240,7 @@ def test_deploy_model_with_accelerator(
     pytorch_eia_latest_version,
     pytorch_eia_latest_py_version,
 ):
-    endpoint_name = "test-pytorch-deploy-eia-{}".format(sagemaker_timestamp())
+    endpoint_name = unique_name_from_base("test-pytorch-deploy-eia")
     model_data = sagemaker_session.upload_data(path=EIA_MODEL)
     pytorch = PyTorchModel(
         model_data,
@@ -272,7 +272,7 @@ def test_deploy_model_with_serverless_inference_config(
     pytorch_inference_latest_version,
     pytorch_inference_latest_py_version,
 ):
-    endpoint_name = "test-pytorch-deploy-model-serverless-{}".format(sagemaker_timestamp())
+    endpoint_name = unique_name_from_base("test-pytorch-deploy-model-serverless")
 
     with timeout_and_delete_endpoint_by_name(endpoint_name, sagemaker_session):
         desc = sagemaker_session.sagemaker_client.describe_training_job(

--- a/tests/integ/test_sklearn.py
+++ b/tests/integ/test_sklearn.py
@@ -20,7 +20,7 @@ import numpy
 
 from sagemaker.serverless import ServerlessInferenceConfig
 from sagemaker.sklearn import SKLearn, SKLearnModel, SKLearnProcessor
-from sagemaker.utils import sagemaker_timestamp, unique_name_from_base
+from sagemaker.utils import unique_name_from_base
 from tests.integ import DATA_DIR, TRAINING_DEFAULT_TIMEOUT_MINUTES
 from tests.integ.timeout import timeout, timeout_and_delete_endpoint_by_name
 
@@ -119,7 +119,7 @@ def test_training_with_network_isolation(
     "This test should be fixed. Details in https://github.com/aws/sagemaker-python-sdk/pull/968"
 )
 def test_attach_deploy(sklearn_training_job, sagemaker_session, cpu_instance_type):
-    endpoint_name = "test-sklearn-attach-deploy-{}".format(sagemaker_timestamp())
+    endpoint_name = unique_name_from_base("test-sklearn-attach-deploy")
 
     with timeout_and_delete_endpoint_by_name(endpoint_name, sagemaker_session):
         estimator = SKLearn.attach(sklearn_training_job, sagemaker_session=sagemaker_session)
@@ -138,7 +138,7 @@ def test_deploy_model(
     sklearn_latest_version,
     sklearn_latest_py_version,
 ):
-    endpoint_name = "test-sklearn-deploy-model-{}".format(sagemaker_timestamp())
+    endpoint_name = unique_name_from_base("test-sklearn-deploy-model")
     with timeout_and_delete_endpoint_by_name(endpoint_name, sagemaker_session):
         desc = sagemaker_session.sagemaker_client.describe_training_job(
             TrainingJobName=sklearn_training_job
@@ -162,7 +162,7 @@ def test_deploy_model_with_serverless_inference_config(
     sklearn_latest_version,
     sklearn_latest_py_version,
 ):
-    endpoint_name = "test-sklearn-deploy-model-serverless-{}".format(sagemaker_timestamp())
+    endpoint_name = unique_name_from_base("test-sklearn-deploy-model-serverless")
     with timeout_and_delete_endpoint_by_name(endpoint_name, sagemaker_session):
         desc = sagemaker_session.sagemaker_client.describe_training_job(
             TrainingJobName=sklearn_training_job
@@ -192,7 +192,7 @@ def test_async_fit(
     sklearn_latest_version,
     sklearn_latest_py_version,
 ):
-    endpoint_name = "test-sklearn-attach-deploy-{}".format(sagemaker_timestamp())
+    endpoint_name = unique_name_from_base("test-sklearn-attach-deploy")
 
     with timeout(minutes=5):
         training_job_name = _run_mnist_training_job(

--- a/tests/unit/common.py
+++ b/tests/unit/common.py
@@ -1,0 +1,38 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from __future__ import absolute_import
+
+
+from botocore.exceptions import ClientError
+
+
+def _raise_unexpected_client_error(**kwargs):
+    response = {
+        "Error": {"Code": "ValidationException", "Message": "Name does not satisfy expression."}
+    }
+    raise ClientError(error_response=response, operation_name="foo")
+
+
+def _raise_does_not_exist_client_error(**kwargs):
+    response = {"Error": {"Code": "ValidationException", "Message": "Could not find entity."}}
+    raise ClientError(error_response=response, operation_name="foo")
+
+
+def _raise_does_already_exists_client_error(**kwargs):
+    response = {"Error": {"Code": "ValidationException", "Message": "Resource already exists."}}
+    raise ClientError(error_response=response, operation_name="foo")
+
+
+def _raise_access_denied_client_error(**kwargs):
+    response = {"Error": {"Code": "AccessDeniedException", "Message": "Could not access entity."}}
+    raise ClientError(error_response=response, operation_name="foo")

--- a/tests/unit/sagemaker/workflow/test_pipeline.py
+++ b/tests/unit/sagemaker/workflow/test_pipeline.py
@@ -36,7 +36,6 @@ from sagemaker.local.local_session import LocalSession
 from botocore.exceptions import ClientError
 
 
-
 @pytest.fixture
 def role_arn():
     return "arn:role"
@@ -207,8 +206,10 @@ def test_pipeline_upsert_resource_already_exists(sagemaker_session_mock, role_ar
     pipeline.upsert(role_arn=role_arn, tags=tags)
 
     sagemaker_session_mock.sagemaker_client.create_pipeline.assert_called_once_with(
-        PipelineName="MyPipeline", RoleArn=role_arn, PipelineDefinition=pipeline.definition(),
-        Tags=tags
+        PipelineName="MyPipeline",
+        RoleArn=role_arn,
+        PipelineDefinition=pipeline.definition(),
+        Tags=tags,
     )
 
     sagemaker_session_mock.sagemaker_client.update_pipeline.assert_called_once_with(
@@ -222,6 +223,7 @@ def test_pipeline_upsert_resource_already_exists(sagemaker_session_mock, role_ar
     assert sagemaker_session_mock.sagemaker_client.add_tags.called_with(
         ResourceArn="mock_pipeline_arn", Tags=tags
     )
+
 
 def test_pipeline_upsert_create_unexpected_failure(sagemaker_session_mock, role_arn):
 
@@ -258,15 +260,16 @@ def test_pipeline_upsert_create_unexpected_failure(sagemaker_session_mock, role_
     with pytest.raises(ClientError):
         pipeline.upsert(role_arn=role_arn, tags=tags)
 
-
-
     sagemaker_session_mock.sagemaker_client.create_pipeline.assert_called_once_with(
-        PipelineName="MyPipeline", RoleArn=role_arn, PipelineDefinition=pipeline.definition(),
-        Tags=tags
+        PipelineName="MyPipeline",
+        RoleArn=role_arn,
+        PipelineDefinition=pipeline.definition(),
+        Tags=tags,
     )
     sagemaker_session_mock.sagemaker_client.update_pipeline.assert_not_called()
     sagemaker_session_mock.sagemaker_client.list_tags.assert_not_called()
     sagemaker_session_mock.sagemaker_client.add_tags.assert_not_called()
+
 
 def test_pipeline_upsert_resourse_doesnt_exist(sagemaker_session_mock, role_arn):
 
@@ -295,11 +298,13 @@ def test_pipeline_upsert_resourse_doesnt_exist(sagemaker_session_mock, role_arn)
     try:
         pipeline.upsert(role_arn=role_arn, tags=tags)
     except ClientError:
-        assert False, f"Unexpected ClientError raised"
+        assert False, "Unexpected ClientError raised"
 
     sagemaker_session_mock.sagemaker_client.create_pipeline.assert_called_once_with(
-        PipelineName="MyPipeline", RoleArn=role_arn, PipelineDefinition=pipeline.definition(),
-        Tags=tags
+        PipelineName="MyPipeline",
+        RoleArn=role_arn,
+        PipelineDefinition=pipeline.definition(),
+        Tags=tags,
     )
 
     sagemaker_session_mock.sagemaker_client.update_pipeline.assert_not_called()

--- a/tests/unit/sagemaker/workflow/test_pipeline.py
+++ b/tests/unit/sagemaker/workflow/test_pipeline.py
@@ -33,6 +33,8 @@ from sagemaker.workflow.pipeline_experiment_config import (
 from sagemaker.workflow.step_collections import StepCollection
 from tests.unit.sagemaker.workflow.helpers import ordered, CustomStep
 from sagemaker.local.local_session import LocalSession
+from botocore.exceptions import ClientError
+
 
 
 @pytest.fixture
@@ -173,10 +175,17 @@ def test_large_pipeline_update(sagemaker_session_mock, role_arn):
     )
 
 
-def test_pipeline_upsert(sagemaker_session_mock, role_arn):
-    sagemaker_session_mock.sagemaker_client.describe_pipeline.return_value = {
-        "PipelineArn": "pipeline-arn"
-    }
+def test_pipeline_upsert_resource_already_exists(sagemaker_session_mock, role_arn):
+
+    # case 1: resource already exists
+    def _raise_does_already_exists_client_error(**kwargs):
+        response = {"Error": {"Code": "ValidationException", "Message": "Resource already exists."}}
+        raise ClientError(error_response=response, operation_name="create_pipeline")
+
+    sagemaker_session_mock.sagemaker_client.create_pipeline = Mock(
+        name="create_pipeline", side_effect=_raise_does_already_exists_client_error
+    )
+
     sagemaker_session_mock.sagemaker_client.update_pipeline.return_value = {
         "PipelineArn": "pipeline-arn"
     }
@@ -197,9 +206,12 @@ def test_pipeline_upsert(sagemaker_session_mock, role_arn):
     ]
     pipeline.upsert(role_arn=role_arn, tags=tags)
 
-    sagemaker_session_mock.sagemaker_client.create_pipeline.assert_not_called()
+    sagemaker_session_mock.sagemaker_client.create_pipeline.assert_called_once_with(
+        PipelineName="MyPipeline", RoleArn=role_arn, PipelineDefinition=pipeline.definition(),
+        Tags=tags
+    )
 
-    assert sagemaker_session_mock.sagemaker_client.update_pipeline.called_with(
+    sagemaker_session_mock.sagemaker_client.update_pipeline.assert_called_once_with(
         PipelineName="MyPipeline", PipelineDefinition=pipeline.definition(), RoleArn=role_arn
     )
     assert sagemaker_session_mock.sagemaker_client.list_tags.called_with(
@@ -210,6 +222,89 @@ def test_pipeline_upsert(sagemaker_session_mock, role_arn):
     assert sagemaker_session_mock.sagemaker_client.add_tags.called_with(
         ResourceArn="mock_pipeline_arn", Tags=tags
     )
+
+def test_pipeline_upsert_create_unexpected_failure(sagemaker_session_mock, role_arn):
+
+    # case 2: unexpected failure on create
+    def _raise_unexpected_client_error(**kwargs):
+        response = {
+            "Error": {"Code": "ValidationException", "Message": "Name does not satisfy expression."}
+        }
+        raise ClientError(error_response=response, operation_name="foo")
+
+    sagemaker_session_mock.sagemaker_client.create_pipeline = Mock(
+        name="create_pipeline", side_effect=_raise_unexpected_client_error
+    )
+
+    sagemaker_session_mock.sagemaker_client.update_pipeline.return_value = {
+        "PipelineArn": "pipeline-arn"
+    }
+    sagemaker_session_mock.sagemaker_client.list_tags.return_value = {
+        "Tags": [{"Key": "dummy", "Value": "dummy_tag"}]
+    }
+
+    tags = [
+        {"Key": "foo", "Value": "abc"},
+        {"Key": "bar", "Value": "xyz"},
+    ]
+
+    pipeline = Pipeline(
+        name="MyPipeline",
+        parameters=[],
+        steps=[],
+        sagemaker_session=sagemaker_session_mock,
+    )
+
+    with pytest.raises(ClientError):
+        pipeline.upsert(role_arn=role_arn, tags=tags)
+
+
+
+    sagemaker_session_mock.sagemaker_client.create_pipeline.assert_called_once_with(
+        PipelineName="MyPipeline", RoleArn=role_arn, PipelineDefinition=pipeline.definition(),
+        Tags=tags
+    )
+    sagemaker_session_mock.sagemaker_client.update_pipeline.assert_not_called()
+    sagemaker_session_mock.sagemaker_client.list_tags.assert_not_called()
+    sagemaker_session_mock.sagemaker_client.add_tags.assert_not_called()
+
+def test_pipeline_upsert_resourse_doesnt_exist(sagemaker_session_mock, role_arn):
+
+    # case 3: resource does not exist
+    sagemaker_session_mock.sagemaker_client.create_pipeline = Mock(name="create_pipeline")
+
+    sagemaker_session_mock.sagemaker_client.update_pipeline.return_value = {
+        "PipelineArn": "pipeline-arn"
+    }
+    sagemaker_session_mock.sagemaker_client.list_tags.return_value = {
+        "Tags": [{"Key": "dummy", "Value": "dummy_tag"}]
+    }
+
+    tags = [
+        {"Key": "foo", "Value": "abc"},
+        {"Key": "bar", "Value": "xyz"},
+    ]
+
+    pipeline = Pipeline(
+        name="MyPipeline",
+        parameters=[],
+        steps=[],
+        sagemaker_session=sagemaker_session_mock,
+    )
+
+    try:
+        pipeline.upsert(role_arn=role_arn, tags=tags)
+    except ClientError:
+        assert False, f"Unexpected ClientError raised"
+
+    sagemaker_session_mock.sagemaker_client.create_pipeline.assert_called_once_with(
+        PipelineName="MyPipeline", RoleArn=role_arn, PipelineDefinition=pipeline.definition(),
+        Tags=tags
+    )
+
+    sagemaker_session_mock.sagemaker_client.update_pipeline.assert_not_called()
+    sagemaker_session_mock.sagemaker_client.list_tags.assert_not_called()
+    sagemaker_session_mock.sagemaker_client.add_tags.assert_not_called()
 
 
 def test_pipeline_delete(sagemaker_session_mock):

--- a/tests/unit/test_endpoint_from_model_data.py
+++ b/tests/unit/test_endpoint_from_model_data.py
@@ -17,6 +17,11 @@ from botocore.exceptions import ClientError
 from mock import MagicMock, Mock
 from mock import patch
 
+from .common import (
+    _raise_unexpected_client_error,
+    _raise_does_already_exists_client_error,
+    _raise_does_not_exist_client_error,
+)
 import sagemaker
 
 ENDPOINT_NAME = "myendpoint"
@@ -126,7 +131,7 @@ def test_model_and_endpoint_config_exist(name_from_image_mock, sagemaker_session
             wait=False,
         )
     except ClientError:
-        assert False, f"Unexpected ClientError raised for resource already exists scenario"
+        assert False, "Unexpected ClientError raised for resource already exists scenario"
 
     sagemaker_session.create_model.assert_called_once_with(
         name=NAME_FROM_IMAGE,
@@ -208,20 +213,3 @@ def test_entity_doesnt_exist():
 def test_describe_failure():
     with pytest.raises(ClientError):
         sagemaker.session._deployment_entity_exists(_raise_unexpected_client_error)
-
-
-def _raise_unexpected_client_error(**kwargs):
-    response = {
-        "Error": {"Code": "ValidationException", "Message": "Name does not satisfy expression."}
-    }
-    raise ClientError(error_response=response, operation_name="foo")
-
-
-def _raise_does_not_exist_client_error(**kwargs):
-    response = {"Error": {"Code": "ValidationException", "Message": "Could not find entity."}}
-    raise ClientError(error_response=response, operation_name="foo")
-
-
-def _raise_does_already_exists_client_error(**kwargs):
-    response = {"Error": {"Code": "ValidationException", "Message": "Resource already exists."}}
-    raise ClientError(error_response=response, operation_name="foo")

--- a/tests/unit/test_endpoint_from_model_data.py
+++ b/tests/unit/test_endpoint_from_model_data.py
@@ -39,15 +39,6 @@ def sagemaker_session():
     ims = sagemaker.Session(
         sagemaker_client=MagicMock(name="sagemaker_client"), boto_session=boto_mock
     )
-    ims.sagemaker_client.describe_model = Mock(
-        name="describe_model", side_effect=_raise_does_not_exist_client_error
-    )
-    ims.sagemaker_client.describe_endpoint_config = Mock(
-        name="describe_endpoint_config", side_effect=_raise_does_not_exist_client_error
-    )
-    ims.sagemaker_client.describe_endpoint = Mock(
-        name="describe_endpoint", side_effect=_raise_does_not_exist_client_error
-    )
     ims.create_model = Mock(name="create_model")
     ims.create_endpoint_config = Mock(name="create_endpoint_config")
     ims.create_endpoint = Mock(name="create_endpoint")
@@ -63,16 +54,6 @@ def test_all_defaults_no_existing_entities(name_from_image_mock, sagemaker_sessi
         instance_type=INSTANCE_TYPE,
         role=DEPLOY_ROLE,
         wait=False,
-    )
-
-    sagemaker_session.sagemaker_client.describe_endpoint.assert_called_once_with(
-        EndpointName=NAME_FROM_IMAGE
-    )
-    sagemaker_session.sagemaker_client.describe_model.assert_called_once_with(
-        ModelName=NAME_FROM_IMAGE
-    )
-    sagemaker_session.sagemaker_client.describe_endpoint_config.assert_called_once_with(
-        EndpointConfigName=NAME_FROM_IMAGE
     )
     sagemaker_session.create_model.assert_called_once_with(
         name=NAME_FROM_IMAGE, role=DEPLOY_ROLE, container_defs=CONTAINER_DEF, vpc_config=None
@@ -108,16 +89,6 @@ def test_no_defaults_no_existing_entities(name_from_image_mock, sagemaker_sessio
         model_vpc_config=VPC_CONFIG,
         accelerator_type=ACCELERATOR_TYPE,
     )
-
-    sagemaker_session.sagemaker_client.describe_endpoint.assert_called_once_with(
-        EndpointName=ENDPOINT_NAME
-    )
-    sagemaker_session.sagemaker_client.describe_model.assert_called_once_with(
-        ModelName=ENDPOINT_NAME
-    )
-    sagemaker_session.sagemaker_client.describe_endpoint_config.assert_called_once_with(
-        EndpointConfigName=ENDPOINT_NAME
-    )
     sagemaker_session.create_model.assert_called_once_with(
         name=ENDPOINT_NAME,
         role=DEPLOY_ROLE,
@@ -140,27 +111,93 @@ def test_no_defaults_no_existing_entities(name_from_image_mock, sagemaker_sessio
 
 @patch("sagemaker.session.name_from_image", return_value=NAME_FROM_IMAGE)
 def test_model_and_endpoint_config_exist(name_from_image_mock, sagemaker_session):
-    sagemaker_session.sagemaker_client.describe_model = Mock(name="describe_model")
-    sagemaker_session.sagemaker_client.describe_endpoint_config = Mock(
-        name="describe_endpoint_config"
+    container_def_with_env = CONTAINER_DEF.copy()
+
+    sagemaker_session.create_endpoint_config = Mock(
+        name="create_endpoint_config", side_effect=_raise_does_already_exists_client_error
     )
 
-    sagemaker_session.endpoint_from_model_data(
-        model_s3_location=S3_MODEL_ARTIFACTS,
-        image_uri=DEPLOY_IMAGE,
+    try:
+        sagemaker_session.endpoint_from_model_data(
+            model_s3_location=S3_MODEL_ARTIFACTS,
+            image_uri=DEPLOY_IMAGE,
+            initial_instance_count=INITIAL_INSTANCE_COUNT,
+            instance_type=INSTANCE_TYPE,
+            wait=False,
+        )
+    except ClientError:
+        assert False, f"Unexpected ClientError raised for resource already exists scenario"
+
+    sagemaker_session.create_model.assert_called_once_with(
+        name=NAME_FROM_IMAGE,
+        role=None,
+        container_defs=container_def_with_env,
+        vpc_config=None,
+    )
+    sagemaker_session.create_endpoint_config.assert_called_once_with(
+        name=NAME_FROM_IMAGE,
+        model_name=NAME_FROM_IMAGE,
         initial_instance_count=INITIAL_INSTANCE_COUNT,
         instance_type=INSTANCE_TYPE,
-        wait=False,
+        accelerator_type=None,
+        data_capture_config_dict=None,
     )
-
-    sagemaker_session.create_model.assert_not_called()
-    sagemaker_session.create_endpoint_config.assert_not_called()
     sagemaker_session.create_endpoint.assert_called_once_with(
         endpoint_name=NAME_FROM_IMAGE, config_name=NAME_FROM_IMAGE, wait=False
     )
 
 
-def test_entity_exists():
+@patch("sagemaker.session.name_from_image", return_value=NAME_FROM_IMAGE)
+def test_model_and_endpoint_config_raises_unexpected_error(name_from_image_mock, sagemaker_session):
+    container_def_with_env = CONTAINER_DEF.copy()
+
+    sagemaker_session.create_endpoint_config = Mock(
+        name="create_endpoint_config", side_effect=_raise_unexpected_client_error
+    )
+
+    with pytest.raises(ClientError):
+        sagemaker_session.endpoint_from_model_data(
+            model_s3_location=S3_MODEL_ARTIFACTS,
+            image_uri=DEPLOY_IMAGE,
+            initial_instance_count=INITIAL_INSTANCE_COUNT,
+            instance_type=INSTANCE_TYPE,
+            wait=False,
+        )
+
+    sagemaker_session.create_model.assert_called_once_with(
+        name=NAME_FROM_IMAGE,
+        role=None,
+        container_defs=container_def_with_env,
+        vpc_config=None,
+    )
+    sagemaker_session.create_endpoint_config.assert_called_once_with(
+        name=NAME_FROM_IMAGE,
+        model_name=NAME_FROM_IMAGE,
+        initial_instance_count=INITIAL_INSTANCE_COUNT,
+        instance_type=INSTANCE_TYPE,
+        accelerator_type=None,
+        data_capture_config_dict=None,
+    )
+    sagemaker_session.create_endpoint.assert_not_called()
+
+
+def test_create_resource_entity_exists():
+    # _create_resource returns False
+    assert not sagemaker.session._create_resource(_raise_does_already_exists_client_error)
+
+
+def test_create_resource_unexpected_error():
+    # _create_resource returns ClientError
+    with pytest.raises(ClientError):
+        sagemaker.session._create_resource(_raise_unexpected_client_error)
+
+
+def test_create_resource_entity_doesnt_exist():
+    # _create_resource returns True
+    assert sagemaker.session._create_resource(lambda: None)
+
+
+def test_deployment_entity_exists():
     assert sagemaker.session._deployment_entity_exists(lambda: None)
 
 
@@ -169,16 +206,22 @@ def test_entity_doesnt_exist():
 
 
 def test_describe_failure():
-    def _raise_unexpected_client_error():
-        response = {
-            "Error": {"Code": "ValidationException", "Message": "Name does not satisfy expression."}
-        }
-        raise ClientError(error_response=response, operation_name="foo")
-
     with pytest.raises(ClientError):
         sagemaker.session._deployment_entity_exists(_raise_unexpected_client_error)
 
 
+def _raise_unexpected_client_error(**kwargs):
+    response = {
+        "Error": {"Code": "ValidationException", "Message": "Name does not satisfy expression."}
+    }
+    raise ClientError(error_response=response, operation_name="foo")
+
+
 def _raise_does_not_exist_client_error(**kwargs):
     response = {"Error": {"Code": "ValidationException", "Message": "Could not find entity."}}
+    raise ClientError(error_response=response, operation_name="foo")
+
+
+def _raise_does_already_exists_client_error(**kwargs):
+    response = {"Error": {"Code": "ValidationException", "Message": "Resource already exists."}}
     raise ClientError(error_response=response, operation_name="foo")

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -3432,8 +3432,8 @@ def test_wait_for_inference_recommendations_job_completed(sleep, sm_session_infe
         4
         == sm_session_inference_recommender.sagemaker_client.describe_inference_recommendations_job.call_count
     )
-    assert 2 == sleep.call_count
-    sleep.assert_has_calls([call(120), call(120)])
+    assert 3 == sleep.call_count
+    sleep.assert_has_calls([call(120), call(120), call(120)])
 
 
 def test_wait_for_inference_recommendations_job_failed(sagemaker_session):


### PR DESCRIPTION
…#3285)"

This reverts commit 5bc3ccf.*Issue #, if available:*

*Description of changes:*
The changes help fix the resource based tag related routines to unblock customers to use resource tags.
Issue 1: Tag permission issue due to describe before create
Fix: Describe before create routines are now switched to create and check for resource existence, to unblock tag based access.
Issue 2: Tag propagation delay
Fix: On resource create and wait for resource creation - we will now wait for tag propagation. 

*Testing done:*
Tested all units and integs as part of the PR checks.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
