### PR TITLE
Bugfix: Added support to update arguments in create_monitoring_schedule

### DIFF
--- a/src/sagemaker/model_monitor/model_monitoring.py
+++ b/src/sagemaker/model_monitor/model_monitoring.py
@@ -233,6 +233,7 @@ class ModelMonitor(object):
         monitor_schedule_name=None,
         schedule_cron_expression=None,
         batch_transform_input=None,
+        arguments=None,
     ):
         """Creates a monitoring schedule to monitor an Amazon SageMaker Endpoint.
 
@@ -262,6 +263,7 @@ class ModelMonitor(object):
             batch_transform_input (sagemaker.model_monitor.BatchTransformInput): Inputs to
                 run the monitoring schedule on the batch transform
                 (default: None)
+            arguments ([str]): A list of string arguments to be passed to a processing job.
 
         """
         if self.monitoring_schedule_name is not None:
@@ -325,6 +327,9 @@ class ModelMonitor(object):
         network_config_dict = None
         if self.network_config is not None:
             network_config_dict = self.network_config._to_request_dict()
+
+        if arguments is not None:
+            self.arguments = arguments
 
         self.sagemaker_session.create_monitoring_schedule(
             monitoring_schedule_name=self.monitoring_schedule_name,

--- a/tests/unit/sagemaker/monitor/test_model_monitoring.py
+++ b/tests/unit/sagemaker/monitor/test_model_monitoring.py
@@ -29,6 +29,7 @@ from sagemaker.model_monitor import (
     BatchTransformInput,
     ModelQualityMonitor,
     Statistics,
+    MonitoringOutput,
 )
 from sagemaker.model_monitor.monitoring_alert import (
     MonitoringAlertSummary,
@@ -132,6 +133,7 @@ PREPROCESSOR_URI = "s3://my_bucket/preprocessor.py"
 POSTPROCESSOR_URI = "s3://my_bucket/postprocessor.py"
 DATA_CAPTURED_S3_URI = "s3://my-bucket/batch-fraud-detection/on-schedule-monitoring/in/"
 DATASET_FORMAT = MonitoringDatasetFormat.csv(header=False)
+ARGUMENTS = ["test-argument"]
 JOB_OUTPUT_CONFIG = {
     "MonitoringOutputs": [
         {
@@ -372,6 +374,20 @@ NEW_MODEL_QUALITY_JOB_INPUT = {
     },
     "GroundTruthS3Input": {"S3Uri": NEW_GROUND_TRUTH_S3_URI},
 }
+MODEL_QUALITY_MONITOR_JOB_INPUT = {
+    "EndpointInput": {
+        "EndpointName": ENDPOINT_NAME,
+        "LocalPath": ENDPOINT_INPUT_LOCAL_PATH,
+        "S3InputMode": S3_INPUT_MODE,
+        "S3DataDistributionType": S3_DATA_DISTRIBUTION_TYPE,
+        "StartTimeOffset": START_TIME_OFFSET,
+        "EndTimeOffset": END_TIME_OFFSET,
+        "FeaturesAttribute": FEATURES_ATTRIBUTE,
+        "InferenceAttribute": INFERENCE_ATTRIBUTE,
+        "ProbabilityAttribute": PROBABILITY_ATTRIBUTE,
+        "ProbabilityThresholdAttribute": PROBABILITY_THRESHOLD_ATTRIBUTE,
+    },
+}
 NEW_MODEL_QUALITY_JOB_DEFINITION = {
     "ModelQualityAppSpecification": NEW_MODEL_QUALITY_APP_SPECIFICATION,
     "ModelQualityJobInput": NEW_MODEL_QUALITY_JOB_INPUT,
@@ -480,6 +496,25 @@ def data_quality_monitor(sagemaker_session):
         env=ENVIRONMENT,
         tags=TAGS,
         network_config=NETWORK_CONFIG,
+    )
+
+
+@pytest.fixture()
+def model_monitor_arguments(sagemaker_session):
+    return ModelMonitor(
+        role=ROLE,
+        instance_count=INSTANCE_COUNT,
+        instance_type=INSTANCE_TYPE,
+        volume_size_in_gb=VOLUME_SIZE_IN_GB,
+        volume_kms_key=VOLUME_KMS_KEY,
+        output_kms_key=OUTPUT_KMS_KEY,
+        max_runtime_in_seconds=MAX_RUNTIME_IN_SECONDS,
+        base_job_name=BASE_JOB_NAME,
+        sagemaker_session=sagemaker_session,
+        env=ENVIRONMENT,
+        tags=TAGS,
+        network_config=NETWORK_CONFIG,
+        image_uri=DefaultModelMonitor._get_default_image_uri(REGION),
     )
 
 
@@ -1691,3 +1726,54 @@ def test_batch_transform_and_endpoint_input_simultaneous_failure(
         )
     except Exception as e:
         assert "Need to have either batch_transform_input or endpoint_input" in str(e)
+
+
+def test_model_monitor_with_arguments(
+    model_monitor_arguments,
+    sagemaker_session,
+    constraints=None,
+    statistics=None,
+    endpoint_input=EndpointInput(
+        endpoint_name=ENDPOINT_NAME,
+        destination=ENDPOINT_INPUT_LOCAL_PATH,
+        start_time_offset=START_TIME_OFFSET,
+        end_time_offset=END_TIME_OFFSET,
+        features_attribute=FEATURES_ATTRIBUTE,
+        inference_attribute=INFERENCE_ATTRIBUTE,
+        probability_attribute=PROBABILITY_ATTRIBUTE,
+        probability_threshold_attribute=PROBABILITY_THRESHOLD_ATTRIBUTE,
+    ),
+):
+    # for batch transform input
+    model_monitor_arguments.create_monitoring_schedule(
+        constraints=constraints,
+        statistics=statistics,
+        monitor_schedule_name=SCHEDULE_NAME,
+        schedule_cron_expression=CRON_HOURLY,
+        endpoint_input=endpoint_input,
+        arguments=ARGUMENTS,
+        output=MonitoringOutput(source="/opt/ml/processing/output", destination=OUTPUT_S3_URI),
+    )
+
+    sagemaker_session.create_monitoring_schedule.assert_called_with(
+        monitoring_schedule_name="schedule",
+        schedule_expression="cron(0 * ? * * *)",
+        statistics_s3_uri=None,
+        constraints_s3_uri=None,
+        monitoring_inputs=[MODEL_QUALITY_MONITOR_JOB_INPUT],
+        monitoring_output_config=JOB_OUTPUT_CONFIG,
+        instance_count=INSTANCE_COUNT,
+        instance_type=INSTANCE_TYPE,
+        volume_size_in_gb=VOLUME_SIZE_IN_GB,
+        volume_kms_key=VOLUME_KMS_KEY,
+        image_uri=DEFAULT_IMAGE_URI,
+        entrypoint=None,
+        arguments=ARGUMENTS,
+        record_preprocessor_source_uri=None,
+        post_analytics_processor_source_uri=None,
+        max_runtime_in_seconds=3,
+        environment=ENVIRONMENT,
+        network_config=NETWORK_CONFIG._to_request_dict(),
+        role_arn=ROLE,
+        tags=TAGS,
+    )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
