### PR TITLE
Create a default SageMaker Session inside FeatureGroup class

### DIFF
--- a/src/sagemaker/feature_store/feature_group.py
+++ b/src/sagemaker/feature_store/feature_group.py
@@ -473,11 +473,12 @@ class FeatureGroup:
     Attributes:
         name (str): name of the FeatureGroup instance.
         sagemaker_session (Session): session instance to perform boto calls.
+            If None, a new Session will be created.
         feature_definitions (Sequence[FeatureDefinition]): list of FeatureDefinitions.
     """
 
     name: str = attr.ib(factory=str)
-    sagemaker_session: Session = attr.ib(default=Session)
+    sagemaker_session: Session = attr.ib(factory=Session)
     feature_definitions: Sequence[FeatureDefinition] = attr.ib(factory=list)
 
     _INTEGER_TYPES = [


### PR DESCRIPTION

### Issue
https://github.com/aws/sagemaker-python-sdk/issues/3090


### Description
Sagemaker Session in `FeatureGroup` class is not initialized properly if the input is `None`. It is being set to `Session` _class_ instead of an instance of it (i.e `session = Session` instead of `sesssion = Session()`).  

Problems created by this incorrect assignment is explained in linked issue. 


### Testing
Installed the SDK in virutalenv, created a `FeatureGroup` without passing a Session and invoked `describe()`. 
```
from sagemaker.feature_store.feature_group import FeatureGroup

f = FeatureGroup(
    name = 'test-fg'
)

print(f.describe())

```
**Output**
```
botocore.errorfactory.ResourceNotFound: An error occurred (ResourceNotFound) when calling the DescribeFeatureGroup operation: Resource Not Found: Amazon SageMaker can't find a FeatureGroup with name test-fg
```
Above error implies the session was instantiated correctly and the service call went through. 

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
