### PR TITLE
fix: update lambda function when function arn is provided

### DIFF
--- a/tests/unit/sagemaker/workflow/test_lambda_step.py
+++ b/tests/unit/sagemaker/workflow/test_lambda_step.py
@@ -203,10 +203,12 @@ def test_lambda_step_no_inputs_outputs(sagemaker_session):
     }
 
 
-def test_lambda_step_with_function_arn(sagemaker_session):
+def test_lambda_step_with_function_arn_no_lambda_update(sagemaker_session):
     lambda_func = MagicMock(
         function_arn="arn:aws:lambda:us-west-2:123456789012:function:sagemaker_test_lambda",
         session=sagemaker_session,
+        zipped_code_dir=None,
+        script=None,
     )
     lambda_step = LambdaStep(
         name="MyLambdaStep",
@@ -218,6 +220,24 @@ def test_lambda_step_with_function_arn(sagemaker_session):
     function_arn = lambda_step._get_function_arn()
     assert function_arn == "arn:aws:lambda:us-west-2:123456789012:function:sagemaker_test_lambda"
     lambda_func.upsert.assert_not_called()
+
+
+def test_lambda_step_with_function_arn_lambda_updated(sagemaker_session):
+    lambda_func = MagicMock(
+        function_arn="arn:aws:lambda:us-west-2:123456789012:function:sagemaker_test_lambda",
+        zipped_code_dir=None,
+        script="code",
+        session=sagemaker_session,
+    )
+    lambda_step = LambdaStep(
+        name="MyLambdaStep",
+        depends_on=["TestStep"],
+        lambda_func=lambda_func,
+        inputs={},
+        outputs=[],
+    )
+    lambda_step._get_function_arn()
+    lambda_func.update.assert_called_once()
 
 
 def test_lambda_step_without_function_arn(sagemaker_session):


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/sagemaker-python-sdk/issues/3568
https://t.corp.amazon.com/D68130934/communication

*Description of changes:*
This PR fixes two things:
1. fixes lambda.update in lambda_helper use default S3 bucket if one is not provided
2. Update the lambda function code when function_arn parameter is provided to Lambda instance in LambdaStep

*Testing done:*
Added unit tests

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
