### PR TITLE
fix: Support cloning private repo using ssh key

### DIFF
--- a/src/sagemaker/git_utils.py
+++ b/src/sagemaker/git_utils.py
@@ -278,11 +278,15 @@ def _run_clone_command(repo_url, dest_dir):
         my_env["GIT_TERMINAL_PROMPT"] = "0"
         subprocess.check_call(["git", "clone", repo_url, dest_dir], env=my_env)
     elif repo_url.startswith("git@") or repo_url.startswith("ssh://"):
-        with tempfile.NamedTemporaryFile() as sshnoprompt:
-            with open(sshnoprompt.name, "w") as write_pipe:
-                write_pipe.write("ssh -oBatchMode=yes $@")
-            os.chmod(sshnoprompt.name, 0o511)
-            my_env["GIT_SSH"] = sshnoprompt.name
+        try:
+            with tempfile.NamedTemporaryFile() as sshnoprompt:
+                with open(sshnoprompt.name, "w") as write_pipe:
+                    write_pipe.write("ssh -oBatchMode=yes $@")
+                os.chmod(sshnoprompt.name, 0o511)
+                my_env["GIT_SSH"] = sshnoprompt.name
+                subprocess.check_call(["git", "clone", repo_url, dest_dir], env=my_env)
+        except subprocess.CalledProcessError:
+            del my_env["GIT_SSH"]
             subprocess.check_call(["git", "clone", repo_url, dest_dir], env=my_env)
 
 

--- a/src/sagemaker/git_utils.py
+++ b/src/sagemaker/git_utils.py
@@ -174,7 +174,7 @@ def _clone_command_for_github_like(git_config, dest_dir):
         CalledProcessError: If failed to clone git repo.
     """
     is_https = git_config["repo"].startswith("https://")
-    is_ssh = git_config["repo"].startswith("git@")
+    is_ssh = git_config["repo"].startswith("git@") or git_config["repo"].startswith("ssh://")
     if not is_https and not is_ssh:
         raise ValueError("Invalid Git url provided.")
     if is_ssh:
@@ -277,7 +277,7 @@ def _run_clone_command(repo_url, dest_dir):
     if repo_url.startswith("https://"):
         my_env["GIT_TERMINAL_PROMPT"] = "0"
         subprocess.check_call(["git", "clone", repo_url, dest_dir], env=my_env)
-    elif repo_url.startswith("git@"):
+    elif repo_url.startswith("git@") or repo_url.startswith("ssh://"):
         with tempfile.NamedTemporaryFile() as sshnoprompt:
             with open(sshnoprompt.name, "w") as write_pipe:
                 write_pipe.write("ssh -oBatchMode=yes $@")


### PR DESCRIPTION
*Issue #, if available:* [#2242](https://github.com/aws/sagemaker-python-sdk/issues/2442)

*Description of changes:* Currently users cannot use configured ssh/config to clone private repos, since we override with GIT_SSH; this allows cloning of private repo.
With this change, we try the original method, and if it doesn't work we remove GIT_SSH and try to run same command. If ssh config is present without GIT_SSH it will succeed, as demonstrated by the workarounds implemented in the issue (see [here](https://github.com/aws/sagemaker-python-sdk/issues/2442#issuecomment-893592131) and [here](https://github.com/aws/sagemaker-python-sdk/pull/3645/files))

*Testing done:* Tested git_clone_repo with private repo using ssh before change and got `CalledProcessError`; after change clone succeeds.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
