### PR TITLE
docs: update feature store dataset builder docs

### DIFF
--- a/doc/amazon_sagemaker_featurestore.rst
+++ b/doc/amazon_sagemaker_featurestore.rst
@@ -467,11 +467,12 @@ be chained.
    dataset_builder
       .with_number_of_records_from_query_results(number_of_records=100)
       .include_duplicated_records()
-      .to_dataframe()
+      .with_number_of_recent_records_by_record_identifier(number_of_recent_records=1)
 
 There are additional configurations that can be made for various use cases,
 such as time travel and point-in-time join. These are outlined in the
-Feature Store DatasetBuilder API Reference.
+Feature Store `DatasetBuilder API Reference
+<https://sagemaker.readthedocs.io/en/stable/api/prep_data/feature_store.html#dataset-builder>`__.
 
 .. rubric:: Delete a feature group
    :name: bCe9CA61b78

--- a/doc/amazon_sagemaker_featurestore.rst
+++ b/doc/amazon_sagemaker_featurestore.rst
@@ -436,15 +436,12 @@ dataset builder.
 
 .. code:: python
 
-   dataset_builder.include_duplicated_records().to_dataframe()
+   dataset_builder.include_duplicated_records()
+   dataset_builder.include_deleted_records()
 
 The DatasetBuilder provides `with_number_of_records_from_query_results` and
 `with_number_of_recent_records_by_record_identifier` methods to limit the
 number of records returned for the offline snapshot.
-
-.. code:: python
-
-   dataset_builder.with_number_of_recent_records_by_record_identifier(number_of_recent_records=1).to_dataframe()
 
 `with_number_of_records_from_query_results` will limit the number of records
 in the output. For example, when N = 100, only 100 records are going to be
@@ -452,12 +449,16 @@ returned in either the csv or dataframe.
 
 .. code:: python
 
-   dataset_builder.with_number_of_records_from_query_results(number_of_records=100).to_dataframe()
+   dataset_builder.with_number_of_records_from_query_results(number_of_records=N)
 
 On the other hand, `with_number_of_recent_records_by_record_identifier` is
 used to deal with records which have the same identifier. They are going
 to be sorted according to `event_time` and return at most N recent records
 in the output.
+
+.. code:: python
+
+   dataset_builder.with_number_of_recent_records_by_record_identifier(number_of_recent_records=N)
 
 Since these functions return the dataset builder, these functions can
 be chained.
@@ -465,9 +466,10 @@ be chained.
 .. code:: python
    
    dataset_builder
-      .with_number_of_records_from_query_results(number_of_records=100)
+      .with_number_of_records_from_query_results(number_of_records=N)
       .include_duplicated_records()
-      .with_number_of_recent_records_by_record_identifier(number_of_recent_records=1)
+      .with_number_of_recent_records_by_record_identifier(number_of_recent_records=N)
+      .to_dataframe()
 
 There are additional configurations that can be made for various use cases,
 such as time travel and point-in-time join. These are outlined in the

--- a/doc/amazon_sagemaker_featurestore.rst
+++ b/doc/amazon_sagemaker_featurestore.rst
@@ -464,7 +464,7 @@ Since these functions return the dataset builder, these functions can
 be chained.
 
 .. code:: python
-   
+
    dataset_builder
       .with_number_of_records_from_query_results(number_of_records=N)
       .include_duplicated_records()

--- a/src/sagemaker/feature_store/dataset_builder.py
+++ b/src/sagemaker/feature_store/dataset_builder.py
@@ -171,24 +171,33 @@ class DatasetBuilder:
         _event_time_identifier_feature_name (str): A string representing the event time identifier
             feature if base is a DataFrame (default: None).
         _included_feature_names (List[str]): A list of strings representing features to be
-            included in the output (default: None).
-        _kms_key_id (str): An KMS key id. If set, will be used to encrypt the result file
+            included in the output. If not set, all features will be included in the output.
             (default: None).
-        _point_in_time_accurate_join (bool): A boolean representing whether using point in time join
-            or not (default: False).
-        _include_duplicated_records (bool): A boolean representing whether including duplicated
-            records or not (default: False).
-        _include_deleted_records (bool): A boolean representing whether including deleted records or
-            not (default: False).
-        _number_of_recent_records (int): An int that how many records will be returned for each
-            record identifier (default: 1).
-        _number_of_records (int): An int that how many records will be returned (default: None).
-        _write_time_ending_timestamp (datetime.datetime): A datetime that all records' write time in
-            dataset will be before it (default: None).
-        _event_time_starting_timestamp (datetime.datetime): A datetime that all records' event time
-            in dataset will be after it (default: None).
-        _event_time_ending_timestamp (datetime.datetime): A datetime that all records' event time in
-            dataset will be before it (default: None).
+        _kms_key_id (str): A KMS key id. If set, will be used to encrypt the result file
+            (default: None).
+        _point_in_time_accurate_join (bool): A boolean representing if point-in-time join
+            is applied to the resulting dataframe when calling "to_dataframe".
+            When set to True, users can retrieve data using “row-level time travel”
+            according to the event times provided to the DatasetBuilder. This requires that the 
+            entity dataframe with event times is submitted as the base in the constructor
+            (default: False).
+        _include_duplicated_records (bool): A boolean representing whether the resulting dataframe
+            when calling "to_dataframe" should include duplicated records (default: False).
+        _include_deleted_records (bool): A boolean representing whether the resulting 
+            dataframe when calling "to_dataframe" should include deleted records (default: False).
+        _number_of_recent_records (int): An integer representing how many records will be
+            returned for each record identifier (default: 1).
+        _number_of_records (int): An integer representing the number of records that should be
+            returned in the resulting dataframe when calling "to_dataframe" (default: None).
+        _write_time_ending_timestamp (datetime.datetime): A datetime that represents the latest 
+            write time for a record to be included in the resulting dataset. Records with a
+            newer write time will be omitted from the resulting dataset. (default: None).
+        _event_time_starting_timestamp (datetime.datetime): A datetime that represents the earliest 
+            event time for a record to be included in the resulting dataset. Records
+            with an older event time will be omitted from the resulting dataset. (default: None).
+        _event_time_ending_timestamp (datetime.datetime): A datetime that represents the latest 
+            event time for a record to be included in the resulting dataset. Records
+            with a newer event time will be omitted from the resulting dataset. (default: None).
         _feature_groups_to_be_merged (List[FeatureGroupToBeMerged]): A list of
             FeatureGroupToBeMerged which will be joined to base (default: []).
         _event_time_identifier_feature_type (FeatureTypeEnum): A FeatureTypeEnum representing the
@@ -247,7 +256,7 @@ class DatasetBuilder:
         return self
 
     def point_in_time_accurate_join(self):
-        """Set join type as point in time accurate join.
+        """Enable point-in-time accurate join.
 
         Returns:
             This DatasetBuilder object.

--- a/src/sagemaker/feature_store/dataset_builder.py
+++ b/src/sagemaker/feature_store/dataset_builder.py
@@ -178,24 +178,24 @@ class DatasetBuilder:
         _point_in_time_accurate_join (bool): A boolean representing if point-in-time join
             is applied to the resulting dataframe when calling "to_dataframe".
             When set to True, users can retrieve data using “row-level time travel”
-            according to the event times provided to the DatasetBuilder. This requires that the 
+            according to the event times provided to the DatasetBuilder. This requires that the
             entity dataframe with event times is submitted as the base in the constructor
             (default: False).
         _include_duplicated_records (bool): A boolean representing whether the resulting dataframe
             when calling "to_dataframe" should include duplicated records (default: False).
-        _include_deleted_records (bool): A boolean representing whether the resulting 
+        _include_deleted_records (bool): A boolean representing whether the resulting
             dataframe when calling "to_dataframe" should include deleted records (default: False).
         _number_of_recent_records (int): An integer representing how many records will be
             returned for each record identifier (default: 1).
         _number_of_records (int): An integer representing the number of records that should be
             returned in the resulting dataframe when calling "to_dataframe" (default: None).
-        _write_time_ending_timestamp (datetime.datetime): A datetime that represents the latest 
+        _write_time_ending_timestamp (datetime.datetime): A datetime that represents the latest
             write time for a record to be included in the resulting dataset. Records with a
             newer write time will be omitted from the resulting dataset. (default: None).
-        _event_time_starting_timestamp (datetime.datetime): A datetime that represents the earliest 
+        _event_time_starting_timestamp (datetime.datetime): A datetime that represents the earliest
             event time for a record to be included in the resulting dataset. Records
             with an older event time will be omitted from the resulting dataset. (default: None).
-        _event_time_ending_timestamp (datetime.datetime): A datetime that represents the latest 
+        _event_time_ending_timestamp (datetime.datetime): A datetime that represents the latest
             event time for a record to be included in the resulting dataset. Records
             with a newer event time will be omitted from the resulting dataset. (default: None).
         _feature_groups_to_be_merged (List[FeatureGroupToBeMerged]): A list of


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Improves API reference for the DatasetBuilder class
- Adds brief user guide for using Offline Store SDK / Databuilder class in Feature Store docs

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
