### PR TITLE
fix: Typo in graviton algos

### DIFF
--- a/tests/unit/sagemaker/image_uris/test_graviton.py
+++ b/tests/unit/sagemaker/image_uris/test_graviton.py
@@ -27,7 +27,7 @@ GRAVITON_ALLOWED_TARGET_INSTANCE_FAMILY = [
     "r6g",
     "r6gd",
 ]
-GRAVITON_ALGOS = ("tensorflow", "pytotch")
+GRAVITON_ALGOS = ("tensorflow", "pytorch")
 GRAVITON_INSTANCE_TYPES = [
     "ml.m6g.4xlarge",
     "ml.m6gd.2xlarge",


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/sagemaker-python-sdk/issues/3680

*Description of changes:* Fixing typo: 'pytotch' -> 'pytorch

*Testing done:* Ran tests in test_graviton.py.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
