### PR TITLE
feature: Decouple model.right_size() from model registry

### DIFF
--- a/src/sagemaker/inference_recommender/inference_recommender_mixin.py
+++ b/src/sagemaker/inference_recommender/inference_recommender_mixin.py
@@ -149,7 +149,9 @@ class InferenceRecommenderMixin:
         self._init_sagemaker_session_if_does_not_exist()
 
         self.temp_model_name = None
-        if isinstance(self, sagemaker.model.Model) and not isinstance(self, sagemaker.model.ModelPackage):
+        if isinstance(self, sagemaker.model.Model) and not isinstance(
+            self, sagemaker.model.ModelPackage
+        ):
 
             unique_tail = uuid.uuid4()
             self.temp_model_name = "SMPYTHONSDK-" + str(unique_tail)
@@ -160,10 +162,13 @@ class InferenceRecommenderMixin:
                 container_defs=None,
                 primary_container=self.prepare_container_def(),
                 vpc_config=self.vpc_config,
-                enable_network_isolation=self.enable_network_isolation()
+                enable_network_isolation=self.enable_network_isolation(),
             )
-            print(f"Creating temporary model with name: {self.temp_model_name}"
-                   " for Inference Recommender.", flush=True)
+            print(
+                f"Creating temporary model with name: {self.temp_model_name}"
+                " for Inference Recommender.",
+                flush=True,
+            )
             self.sagemaker_session.create_model(**create_model_args)
             print("Temporary model created. Start to run Inference Recommender...", flush=True)
 
@@ -195,8 +200,11 @@ class InferenceRecommenderMixin:
         )
 
         if self.temp_model_name is not None:
-            print(f"Deleting temporary model with name: {self.temp_model_name} "
-                   "for Inference Recommender.", flush=True)
+            print(
+                f"Deleting temporary model with name: {self.temp_model_name} "
+                "for Inference Recommender.",
+                flush=True,
+            )
             self.sagemaker_session.delete_model(self.temp_model_name)
             self.temp_model_name = None
             print("Delete complete.")

--- a/src/sagemaker/inference_recommender/inference_recommender_mixin.py
+++ b/src/sagemaker/inference_recommender/inference_recommender_mixin.py
@@ -162,11 +162,10 @@ class InferenceRecommenderMixin:
                 vpc_config=self.vpc_config,
                 enable_network_isolation=self.enable_network_isolation()
             )
-            print(f"Creating temporary model with name: {self.temp_model_name}" \
-                " for Inference Recommender.", flush=True)
+            print(f"Creating temporary model with name: {self.temp_model_name}"
+                   " for Inference Recommender.", flush=True)
             self.sagemaker_session.create_model(**create_model_args)
             print("Temporary model created. Start to run Inference Recommender...", flush=True)
-
 
         ret_name = self.sagemaker_session.create_inference_recommendations_job(
             role=self.role,
@@ -196,8 +195,8 @@ class InferenceRecommenderMixin:
         )
 
         if self.temp_model_name is not None:
-            print(f"Deleting temporary model with name: {self.temp_model_name} " \
-                "for Inference Recommender.", flush=True)
+            print(f"Deleting temporary model with name: {self.temp_model_name} "
+                   "for Inference Recommender.", flush=True)
             self.sagemaker_session.delete_model(self.temp_model_name)
             self.temp_model_name = None
             print("Delete complete.")

--- a/src/sagemaker/inference_recommender/inference_recommender_mixin.py
+++ b/src/sagemaker/inference_recommender/inference_recommender_mixin.py
@@ -148,22 +148,22 @@ class InferenceRecommenderMixin:
 
         self._init_sagemaker_session_if_does_not_exist()
 
-        temp_model_name = None
+        self.temp_model_name = None
         if isinstance(self, sagemaker.model.Model) and not isinstance(self, sagemaker.model.ModelPackage):
 
             unique_tail = uuid.uuid4()
-            temp_model_name = "SMPYTHONSDK-" + str(unique_tail)
+            self.temp_model_name = "SMPYTHONSDK-" + str(unique_tail)
 
             create_model_args = dict(
-                name=temp_model_name,
+                name=self.temp_model_name,
                 role=self.role,
                 container_defs=None,
                 primary_container=self.prepare_container_def(),
                 vpc_config=self.vpc_config,
                 enable_network_isolation=self.enable_network_isolation()
             )
-            print(f"Creating temporary model with name: {temp_model_name}" \
-                "for Inference Recommender.", flush=True)
+            print(f"Creating temporary model with name: {self.temp_model_name}" \
+                " for Inference Recommender.", flush=True)
             self.sagemaker_session.create_model(**create_model_args)
             print("Temporary model created. Start to run Inference Recommender...", flush=True)
 
@@ -173,7 +173,7 @@ class InferenceRecommenderMixin:
             job_name=job_name,
             job_type=job_type,
             job_duration_in_seconds=job_duration_in_seconds,
-            model_name=temp_model_name,
+            model_name=self.temp_model_name,
             model_package_version_arn=getattr(self, "model_package_arn", None),
             framework=framework,
             framework_version=framework_version,
@@ -195,10 +195,11 @@ class InferenceRecommenderMixin:
             "InferenceRecommendations"
         )
 
-        if temp_model_name is not None:
-            print(f"Deleting temporary model with name: {temp_model_name}" \
+        if self.temp_model_name is not None:
+            print(f"Deleting temporary model with name: {self.temp_model_name} " \
                 "for Inference Recommender.", flush=True)
-            self.sagemaker_session.delete_model(temp_model_name)
+            self.sagemaker_session.delete_model(self.temp_model_name)
+            self.temp_model_name = None
             print("Delete complete.")
         return self
 

--- a/src/sagemaker/inference_recommender/inference_recommender_mixin.py
+++ b/src/sagemaker/inference_recommender/inference_recommender_mixin.py
@@ -15,7 +15,6 @@ from __future__ import absolute_import
 
 import logging
 import re
-import uuid
 
 from typing import List, Dict, Optional
 import sagemaker
@@ -157,14 +156,20 @@ class InferenceRecommenderMixin:
         if isinstance(self, sagemaker.model.Model) and not isinstance(
             self, sagemaker.model.ModelPackage
         ):
+            primary_container_def = self.prepare_container_def()
             if not self.name:
-                unique_tail = uuid.uuid4()
-                self.name = "SageMaker-Model-RightSized-" + str(unique_tail)
+                self._ensure_base_name_if_needed(
+                    image_uri=primary_container_def["Image"],
+                    script_uri=self.source_dir,
+                    model_uri=self.model_data,
+                )
+                self._set_model_name_if_needed()
+
             create_model_args = dict(
                 name=self.name,
                 role=self.role,
                 container_defs=None,
-                primary_container=self.prepare_container_def(),
+                primary_container=primary_container_def,
                 vpc_config=self.vpc_config,
                 enable_network_isolation=self.enable_network_isolation(),
             )

--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -4974,14 +4974,10 @@ class Session(object):  # pylint: disable=too-many-public-methods
         """
 
         if model_name is None and model_package_version_arn is None:
-            raise ValueError(
-                "Please provide either model_name or model_package_version_arn, not both."
-            )
+            raise ValueError("Please provide either model_name or model_package_version_arn.")
 
         if model_name is not None and model_package_version_arn is not None:
-            raise ValueError(
-                "Please provide either model_name or model_package_version_arn, not both."
-            )
+            raise ValueError("Please provide either model_name or model_package_version_arn.")
 
         if not job_name:
             unique_tail = uuid.uuid4()

--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -4896,9 +4896,9 @@ class Session(object):  # pylint: disable=too-many-public-methods
         }
 
         request.get("InputConfig").update(
-            { "ModelPackageVersionArn": model_package_version_arn}
+            {"ModelPackageVersionArn": model_package_version_arn}
             if model_package_version_arn
-            else { "ModelName": model_name }
+            else {"ModelName": model_name}
         )
 
         if job_description:
@@ -4974,12 +4974,12 @@ class Session(object):  # pylint: disable=too-many-public-methods
         """
 
         if model_name is None and model_package_version_arn is None:
-            raise ValueError("Missing model_name and model_package_version_arn,"\
-                " please provide one of them.")
+            raise ValueError("Missing model_name and model_package_version_arn,"
+                             " please provide one of them.")
 
         if model_name is not None and model_package_version_arn is not None:
-            raise ValueError("Please provide either model_name or model_package_version_arn" \
-            " should be provided, not both.")
+            raise ValueError("Please provide either model_name or model_package_version_arn"
+                             " should be provided, not both.")
 
         if not job_name:
             unique_tail = uuid.uuid4()

--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -4820,6 +4820,7 @@ class Session(object):  # pylint: disable=too-many-public-methods
         framework: str,
         sample_payload_url: str,
         supported_content_types: List[str],
+        model_name: str = None,
         model_package_version_arn: str = None,
         job_duration_in_seconds: int = None,
         job_type: str = "Default",
@@ -4843,6 +4844,7 @@ class Session(object):  # pylint: disable=too-many-public-methods
             framework (str): The machine learning framework of the Image URI.
             sample_payload_url (str): The S3 path where the sample payload is stored.
             supported_content_types (List[str]): The supported MIME types for the input data.
+            model_name (str): Name of the Amazon SageMaker ``Model`` to be used.
             model_package_version_arn (str): The Amazon Resource Name (ARN) of a
                 versioned model package.
             job_duration_in_seconds (int): The maximum job duration that a job
@@ -4884,15 +4886,26 @@ class Session(object):  # pylint: disable=too-many-public-methods
         if supported_instance_types:
             containerConfig["SupportedInstanceTypes"] = supported_instance_types
 
-        request = {
-            "JobName": job_name,
-            "JobType": job_type,
-            "RoleArn": role,
-            "InputConfig": {
-                "ContainerConfig": containerConfig,
-                "ModelPackageVersionArn": model_package_version_arn,
-            },
-        }
+        if model_package_version_arn:
+            request = {
+                "JobName": job_name,
+                "JobType": job_type,
+                "RoleArn": role,
+                "InputConfig": {
+                    "ContainerConfig": containerConfig,
+                    "ModelPackageVersionArn": model_package_version_arn,
+                },
+            }
+        else:
+            request = {
+                "JobName": job_name,
+                "JobType": job_type,
+                "RoleArn": role,
+                "InputConfig": {
+                    "ContainerConfig": containerConfig,
+                    "ModelName": model_name,
+                },
+            }
 
         if job_description:
             request["JobDescription"] = job_description
@@ -4918,6 +4931,7 @@ class Session(object):  # pylint: disable=too-many-public-methods
         supported_content_types: List[str],
         job_name: str = None,
         job_type: str = "Default",
+        model_name: str = None,
         model_package_version_arn: str = None,
         job_duration_in_seconds: int = None,
         nearest_model_name: str = None,
@@ -4938,6 +4952,7 @@ class Session(object):  # pylint: disable=too-many-public-methods
                 You must grant sufficient permissions to this role.
             sample_payload_url (str): The S3 path where the sample payload is stored.
             supported_content_types (List[str]): The supported MIME types for the input data.
+            model_name (str): Name of the Amazon SageMaker ``Model`` to be used.
             model_package_version_arn (str): The Amazon Resource Name (ARN) of a
                 versioned model package.
             job_name (str): The name of the job being run.
@@ -4964,6 +4979,9 @@ class Session(object):  # pylint: disable=too-many-public-methods
             str: The name of the job created. In the form of `SMPYTHONSDK-<timestamp>`
         """
 
+        if model_name is None and model_package_version_arn is None:
+            raise ValueError("Either model_name or model_package_version_arn should be provided.")
+
         if not job_name:
             unique_tail = uuid.uuid4()
             job_name = "SMPYTHONSDK-" + str(unique_tail)
@@ -4972,6 +4990,7 @@ class Session(object):  # pylint: disable=too-many-public-methods
         create_inference_recommendations_job_request = (
             self._create_inference_recommendations_job_request(
                 role=role,
+                model_name=model_name,
                 model_package_version_arn=model_package_version_arn,
                 job_name=job_name,
                 job_type=job_type,

--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -4975,13 +4975,12 @@ class Session(object):  # pylint: disable=too-many-public-methods
 
         if model_name is None and model_package_version_arn is None:
             raise ValueError(
-                "Missing model_name and model_package_version_arn," " please provide one of them."
+                "Please provide either model_name or model_package_version_arn, not both."
             )
 
         if model_name is not None and model_package_version_arn is not None:
             raise ValueError(
-                "Please provide either model_name or model_package_version_arn"
-                " should be provided, not both."
+                "Please provide either model_name or model_package_version_arn, not both."
             )
 
         if not job_name:

--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -4974,12 +4974,15 @@ class Session(object):  # pylint: disable=too-many-public-methods
         """
 
         if model_name is None and model_package_version_arn is None:
-            raise ValueError("Missing model_name and model_package_version_arn,"
-                             " please provide one of them.")
+            raise ValueError(
+                "Missing model_name and model_package_version_arn," " please provide one of them."
+            )
 
         if model_name is not None and model_package_version_arn is not None:
-            raise ValueError("Please provide either model_name or model_package_version_arn"
-                             " should be provided, not both.")
+            raise ValueError(
+                "Please provide either model_name or model_package_version_arn"
+                " should be provided, not both."
+            )
 
         if not job_name:
             unique_tail = uuid.uuid4()

--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -4886,26 +4886,20 @@ class Session(object):  # pylint: disable=too-many-public-methods
         if supported_instance_types:
             containerConfig["SupportedInstanceTypes"] = supported_instance_types
 
-        if model_package_version_arn:
-            request = {
-                "JobName": job_name,
-                "JobType": job_type,
-                "RoleArn": role,
-                "InputConfig": {
-                    "ContainerConfig": containerConfig,
-                    "ModelPackageVersionArn": model_package_version_arn,
-                },
-            }
-        else:
-            request = {
-                "JobName": job_name,
-                "JobType": job_type,
-                "RoleArn": role,
-                "InputConfig": {
-                    "ContainerConfig": containerConfig,
-                    "ModelName": model_name,
-                },
-            }
+        request = {
+            "JobName": job_name,
+            "JobType": job_type,
+            "RoleArn": role,
+            "InputConfig": {
+                "ContainerConfig": containerConfig,
+            },
+        }
+
+        request.get("InputConfig").update(
+            { "ModelPackageVersionArn": model_package_version_arn}
+            if model_package_version_arn
+            else { "ModelName": model_name }
+        )
 
         if job_description:
             request["JobDescription"] = job_description
@@ -4980,7 +4974,12 @@ class Session(object):  # pylint: disable=too-many-public-methods
         """
 
         if model_name is None and model_package_version_arn is None:
-            raise ValueError("Either model_name or model_package_version_arn should be provided.")
+            raise ValueError("Missing model_name and model_package_version_arn,"\
+                " please provide one of them.")
+
+        if model_name is not None and model_package_version_arn is not None:
+            raise ValueError("Please provide either model_name or model_package_version_arn" \
+            " should be provided, not both.")
 
         if not job_name:
             unique_tail = uuid.uuid4()

--- a/tests/integ/test_inference_recommender.py
+++ b/tests/integ/test_inference_recommender.py
@@ -156,7 +156,7 @@ def advanced_right_sized_model(sagemaker_session, cpu_instance_type):
 
 @pytest.fixture(scope="module")
 def default_right_sized_unregistered_model(sagemaker_session, cpu_instance_type):
-     with timeout(minutes=45):
+    with timeout(minutes=45):
         try:
             ir_job_name = unique_name_from_base("test-ir-right-size-job-name")
             model_data = sagemaker_session.upload_data(path=IR_SKLEARN_MODEL)
@@ -225,24 +225,25 @@ def advanced_right_sized_unregistered_model(sagemaker_session, cpu_instance_type
             ]
 
             return sklearn_model.right_size(
-                    sample_payload_url=payload_data,
-                    supported_content_types=IR_SKLEARN_CONTENT_TYPE,
-                    framework=IR_SKLEARN_FRAMEWORK,
-                    job_duration_in_seconds=3600,
-                    hyperparameter_ranges=hyperparameter_ranges,
-                    phases=phases,
-                    model_latency_thresholds=model_latency_thresholds,
-                    max_invocations=100,
-                    max_tests=5,
-                    max_parallel_tests=5,
-                    log_level="Quiet",
-                )
-            
+                sample_payload_url=payload_data,
+                supported_content_types=IR_SKLEARN_CONTENT_TYPE,
+                framework=IR_SKLEARN_FRAMEWORK,
+                job_duration_in_seconds=3600,
+                hyperparameter_ranges=hyperparameter_ranges,
+                phases=phases,
+                model_latency_thresholds=model_latency_thresholds,
+                max_invocations=100,
+                max_tests=5,
+                max_parallel_tests=5,
+                log_level="Quiet",
+            )
+
         except Exception:
             sagemaker_session.delete_model(
                 ModelName=sklearn_model.temp_model_name
             )
-            
+
+
 @pytest.mark.slow_test
 def test_default_right_size_and_deploy_registered_model_sklearn(
     default_right_sized_model, sagemaker_session
@@ -263,6 +264,7 @@ def test_default_right_size_and_deploy_registered_model_sklearn(
         finally:
             predictor.delete_model()
             predictor.delete_endpoint()
+
 
 @pytest.mark.slow_test
 def test_default_right_size_and_deploy_unregistered_model_sklearn(
@@ -285,6 +287,7 @@ def test_default_right_size_and_deploy_unregistered_model_sklearn(
             predictor.delete_model()
             predictor.delete_endpoint()
 
+
 @pytest.mark.slow_test
 def test_advanced_right_size_and_deploy_unregistered_model_sklearn(
     advanced_right_sized_unregistered_model, sagemaker_session
@@ -304,8 +307,7 @@ def test_advanced_right_size_and_deploy_unregistered_model_sklearn(
             assert 26 == len(inference)
         finally:
             predictor.delete_model()
-            predictor.delete_endpoint() 
-
+            predictor.delete_endpoint()
 
 
 @pytest.mark.slow_test

--- a/tests/integ/test_inference_recommender.py
+++ b/tests/integ/test_inference_recommender.py
@@ -154,6 +154,95 @@ def advanced_right_sized_model(sagemaker_session, cpu_instance_type):
             )
 
 
+@pytest.fixture(scope="module")
+def default_right_sized_unregistered_model(sagemaker_session, cpu_instance_type):
+     with timeout(minutes=45):
+        try:
+            ir_job_name = unique_name_from_base("test-ir-right-size-job-name")
+            model_data = sagemaker_session.upload_data(path=IR_SKLEARN_MODEL)
+            payload_data = sagemaker_session.upload_data(path=IR_SKLEARN_PAYLOAD)
+
+            iam_client = sagemaker_session.boto_session.client("iam")
+            role_arn = iam_client.get_role(RoleName="SageMakerRole")["Role"]["Arn"]
+
+            sklearn_model = SKLearnModel(
+                model_data=model_data,
+                role=role_arn,
+                entry_point=IR_SKLEARN_ENTRY_POINT,
+                framework_version=IR_SKLEARN_FRAMEWORK_VERSION,
+            )
+
+            return (
+                sklearn_model.right_size(
+                    job_name=ir_job_name,
+                    sample_payload_url=payload_data,
+                    supported_content_types=IR_SKLEARN_CONTENT_TYPE,
+                    supported_instance_types=[cpu_instance_type],
+                    framework=IR_SKLEARN_FRAMEWORK,
+                    log_level="Quiet",
+                ),
+                ir_job_name,
+            )
+        except Exception:
+            sagemaker_session.delete_model(
+                ModelName=sklearn_model.temp_model_name
+            )
+
+
+@pytest.fixture(scope="module")
+def advanced_right_sized_unregistered_model(sagemaker_session, cpu_instance_type):
+    with timeout(minutes=45):
+        try:
+            model_data = sagemaker_session.upload_data(path=IR_SKLEARN_MODEL)
+            payload_data = sagemaker_session.upload_data(path=IR_SKLEARN_PAYLOAD)
+
+            iam_client = sagemaker_session.boto_session.client("iam")
+            role_arn = iam_client.get_role(RoleName="SageMakerRole")["Role"]["Arn"]
+
+            sklearn_model = SKLearnModel(
+                model_data=model_data,
+                role=role_arn,
+                entry_point=IR_SKLEARN_ENTRY_POINT,
+                framework_version=IR_SKLEARN_FRAMEWORK_VERSION,
+            )
+
+            hyperparameter_ranges = [
+                {
+                    "instance_types": CategoricalParameter([cpu_instance_type]),
+                    "TEST_PARAM": CategoricalParameter(
+                        ["TEST_PARAM_VALUE_1", "TEST_PARAM_VALUE_2"]
+                    ),
+                }
+            ]
+
+            phases = [
+                Phase(duration_in_seconds=300, initial_number_of_users=2, spawn_rate=2),
+                Phase(duration_in_seconds=300, initial_number_of_users=14, spawn_rate=2),
+            ]
+
+            model_latency_thresholds = [
+                ModelLatencyThreshold(percentile="P95", value_in_milliseconds=100)
+            ]
+
+            return sklearn_model.right_size(
+                    sample_payload_url=payload_data,
+                    supported_content_types=IR_SKLEARN_CONTENT_TYPE,
+                    framework=IR_SKLEARN_FRAMEWORK,
+                    job_duration_in_seconds=3600,
+                    hyperparameter_ranges=hyperparameter_ranges,
+                    phases=phases,
+                    model_latency_thresholds=model_latency_thresholds,
+                    max_invocations=100,
+                    max_tests=5,
+                    max_parallel_tests=5,
+                    log_level="Quiet",
+                )
+            
+        except Exception:
+            sagemaker_session.delete_model(
+                ModelName=sklearn_model.temp_model_name
+            )
+            
 @pytest.mark.slow_test
 def test_default_right_size_and_deploy_registered_model_sklearn(
     default_right_sized_model, sagemaker_session
@@ -174,6 +263,49 @@ def test_default_right_size_and_deploy_registered_model_sklearn(
         finally:
             predictor.delete_model()
             predictor.delete_endpoint()
+
+@pytest.mark.slow_test
+def test_default_right_size_and_deploy_unregistered_model_sklearn(
+    default_right_sized_unregistered_model, sagemaker_session
+):
+    endpoint_name = unique_name_from_base("test-ir-right-size-default-unregistered-sklearn")
+
+    right_size_model, ir_job_name = default_right_sized_unregistered_model
+    with timeout(minutes=45):
+        try:
+            right_size_model.predictor_cls = SKLearnPredictor
+            predictor = right_size_model.deploy(endpoint_name=endpoint_name)
+
+            payload = pd.read_csv(IR_SKLEARN_DATA, header=None)
+
+            inference = predictor.predict(payload)
+            assert inference is not None
+            assert 26 == len(inference)
+        finally:
+            predictor.delete_model()
+            predictor.delete_endpoint()
+
+@pytest.mark.slow_test
+def test_advanced_right_size_and_deploy_unregistered_model_sklearn(
+    advanced_right_sized_unregistered_model, sagemaker_session
+):
+    endpoint_name = unique_name_from_base("test-ir-right-size-advanced-sklearn")
+
+    right_size_model = advanced_right_sized_unregistered_model
+    with timeout(minutes=45):
+        try:
+            right_size_model.predictor_cls = SKLearnPredictor
+            predictor = right_size_model.deploy(endpoint_name=endpoint_name)
+
+            payload = pd.read_csv(IR_SKLEARN_DATA, header=None)
+
+            inference = predictor.predict(payload)
+            assert inference is not None
+            assert 26 == len(inference)
+        finally:
+            predictor.delete_model()
+            predictor.delete_endpoint() 
+
 
 
 @pytest.mark.slow_test

--- a/tests/integ/test_inference_recommender.py
+++ b/tests/integ/test_inference_recommender.py
@@ -184,9 +184,7 @@ def default_right_sized_unregistered_model(sagemaker_session, cpu_instance_type)
                 ir_job_name,
             )
         except Exception:
-            sagemaker_session.delete_model(
-                ModelName=sklearn_model.temp_model_name
-            )
+            sagemaker_session.delete_model(ModelName=sklearn_model.temp_model_name)
 
 
 @pytest.fixture(scope="module")
@@ -239,9 +237,7 @@ def advanced_right_sized_unregistered_model(sagemaker_session, cpu_instance_type
             )
 
         except Exception:
-            sagemaker_session.delete_model(
-                ModelName=sklearn_model.temp_model_name
-            )
+            sagemaker_session.delete_model(ModelName=sklearn_model.temp_model_name)
 
 
 @pytest.mark.slow_test

--- a/tests/unit/sagemaker/inference_recommender/test_inference_recommender_mixin.py
+++ b/tests/unit/sagemaker/inference_recommender/test_inference_recommender_mixin.py
@@ -26,7 +26,6 @@ IR_SAMPLE_FRAMEWORK = "SAGEMAKER-SCIKIT-LEARN"
 IR_SUPPORTED_CONTENT_TYPES = ["text/csv"]
 IR_JOB_NAME = "SMPYTHONSDK-1234567891"
 IR_SAMPLE_INSTANCE_TYPE = "ml.c5.xlarge"
-IR_MODEL_NAME = "SageMaker-Model-RightSized-sample-unique-uuid"
 
 IR_SAMPLE_LIST_OF_INSTANCES_HYPERPARAMETER_RANGES = [
     {
@@ -187,7 +186,7 @@ def test_right_size_default_with_model_name_successful(sagemaker_session, model)
     )
 
     assert sagemaker_session.create_model.called_with(
-        name=IR_MODEL_NAME,
+        name=ANY,
         role=IR_ROLE_ARN,
         container_defs=None,
         primary_container={},
@@ -201,7 +200,7 @@ def test_right_size_default_with_model_name_successful(sagemaker_session, model)
         job_name=IR_JOB_NAME,
         job_type="Default",
         job_duration_in_seconds=None,
-        model_name=IR_MODEL_NAME,
+        model_name=ANY,
         model_package_version_arn=None,
         framework=IR_SAMPLE_FRAMEWORK,
         framework_version=None,
@@ -252,7 +251,7 @@ def test_right_size_advanced_list_instances_model_name_successful(sagemaker_sess
         job_name=IR_JOB_NAME,
         job_type="Advanced",
         job_duration_in_seconds=7200,
-        model_name=IR_MODEL_NAME,
+        model_name=ANY,
         model_package_version_arn=None,
         framework=IR_SAMPLE_FRAMEWORK,
         framework_version=None,
@@ -303,7 +302,7 @@ def test_right_size_advanced_single_instances_model_name_successful(sagemaker_se
         job_name=IR_JOB_NAME,
         job_type="Advanced",
         job_duration_in_seconds=7200,
-        model_name=IR_MODEL_NAME,
+        model_name=ANY,
         model_package_version_arn=None,
         framework=IR_SAMPLE_FRAMEWORK,
         framework_version=None,

--- a/tests/unit/sagemaker/inference_recommender/test_inference_recommender_mixin.py
+++ b/tests/unit/sagemaker/inference_recommender/test_inference_recommender_mixin.py
@@ -26,6 +26,7 @@ IR_SAMPLE_FRAMEWORK = "SAGEMAKER-SCIKIT-LEARN"
 IR_SUPPORTED_CONTENT_TYPES = ["text/csv"]
 IR_JOB_NAME = "SMPYTHONSDK-1234567891"
 IR_SAMPLE_INSTANCE_TYPE = "ml.c5.xlarge"
+IR_MODEL_NAME = "SMPYTHONSDK-sample-unique-uuid"
 
 IR_SAMPLE_LIST_OF_INSTANCES_HYPERPARAMETER_RANGES = [
     {
@@ -174,7 +175,7 @@ def default_right_sized_model(model_package):
         framework=IR_SAMPLE_FRAMEWORK,
     )
 
-
+@patch("uuid.uuid4", MagicMock(return_value="sample-unique-uuid"))
 def test_right_size_default_with_model_name_successful(sagemaker_session, model):
     inference_recommender_model = model.right_size(
         sample_payload_url=IR_SAMPLE_PAYLOAD_URL,
@@ -184,13 +185,23 @@ def test_right_size_default_with_model_name_successful(sagemaker_session, model)
         framework=IR_SAMPLE_FRAMEWORK,
     )
 
+    # assert that the create model api has been called with default parameters
+    assert sagemaker_session.create_model.called_with(
+        name=IR_MODEL_NAME,
+        role=IR_ROLE_ARN,
+        container_defs=None,
+        primary_container={},
+        vpc_config=None,
+        enable_network_isolation=False
+    )
+
     # assert that the create api has been called with default parameters with model name
     assert sagemaker_session.create_inference_recommendations_job.called_with(
         role=IR_ROLE_ARN,
         job_name=IR_JOB_NAME,
         job_type="Default",
         job_duration_in_seconds=None,
-        model_name=ANY,
+        model_name=IR_MODEL_NAME,
         model_package_version_arn=None,
         framework=IR_SAMPLE_FRAMEWORK,
         framework_version=None,
@@ -218,6 +229,7 @@ def test_right_size_default_with_model_name_successful(sagemaker_session, model)
     # confirm that the returned object of right_size is itself
     assert inference_recommender_model == model
 
+@patch("uuid.uuid4", MagicMock(return_value="sample-unique-uuid"))
 def test_right_size_advanced_list_instances_model_name_successful(sagemaker_session, model):
     inference_recommender_model = model.right_size(
         sample_payload_url=IR_SAMPLE_PAYLOAD_URL,
@@ -239,7 +251,7 @@ def test_right_size_advanced_list_instances_model_name_successful(sagemaker_sess
         job_name=IR_JOB_NAME,
         job_type="Advanced",
         job_duration_in_seconds=7200,
-        model_name=ANY,
+        model_name=IR_MODEL_NAME,
         model_package_version_arn=None,
         framework=IR_SAMPLE_FRAMEWORK,
         framework_version=None,
@@ -267,6 +279,7 @@ def test_right_size_advanced_list_instances_model_name_successful(sagemaker_sess
     # confirm that the returned object of right_size is itself
     assert inference_recommender_model == model
     
+@patch("uuid.uuid4", MagicMock(return_value="sample-unique-uuid"))
 def test_right_size_advanced_single_instances_model_name_successful(sagemaker_session, model):
     model.right_size(
         sample_payload_url=IR_SAMPLE_PAYLOAD_URL,
@@ -288,7 +301,7 @@ def test_right_size_advanced_single_instances_model_name_successful(sagemaker_se
         job_name=IR_JOB_NAME,
         job_type="Advanced",
         job_duration_in_seconds=7200,
-        model_name=ANY,
+        model_name=IR_MODEL_NAME,
         model_package_version_arn=None,
         framework=IR_SAMPLE_FRAMEWORK,
         framework_version=None,

--- a/tests/unit/sagemaker/inference_recommender/test_inference_recommender_mixin.py
+++ b/tests/unit/sagemaker/inference_recommender/test_inference_recommender_mixin.py
@@ -193,7 +193,7 @@ def test_right_size_default_with_model_name_successful(sagemaker_session, model)
         container_defs=None,
         primary_container={},
         vpc_config=None,
-        enable_network_isolation=False
+        enable_network_isolation=False,
     )
 
     # assert that the create api has been called with default parameters with model name

--- a/tests/unit/sagemaker/inference_recommender/test_inference_recommender_mixin.py
+++ b/tests/unit/sagemaker/inference_recommender/test_inference_recommender_mixin.py
@@ -26,7 +26,7 @@ IR_SAMPLE_FRAMEWORK = "SAGEMAKER-SCIKIT-LEARN"
 IR_SUPPORTED_CONTENT_TYPES = ["text/csv"]
 IR_JOB_NAME = "SMPYTHONSDK-1234567891"
 IR_SAMPLE_INSTANCE_TYPE = "ml.c5.xlarge"
-IR_MODEL_NAME = "SMPYTHONSDK-sample-unique-uuid"
+IR_MODEL_NAME = "SageMaker-Model-RightSized-sample-unique-uuid"
 
 IR_SAMPLE_LIST_OF_INSTANCES_HYPERPARAMETER_RANGES = [
     {
@@ -186,7 +186,6 @@ def test_right_size_default_with_model_name_successful(sagemaker_session, model)
         framework=IR_SAMPLE_FRAMEWORK,
     )
 
-    # assert that the create model api has been called with default parameters
     assert sagemaker_session.create_model.called_with(
         name=IR_MODEL_NAME,
         role=IR_ROLE_ARN,

--- a/tests/unit/sagemaker/inference_recommender/test_inference_recommender_mixin.py
+++ b/tests/unit/sagemaker/inference_recommender/test_inference_recommender_mixin.py
@@ -175,6 +175,134 @@ def default_right_sized_model(model_package):
     )
 
 
+def test_right_size_default_with_model_name_successful(sagemaker_session, model):
+    inference_recommender_model = model.right_size(
+        sample_payload_url=IR_SAMPLE_PAYLOAD_URL,
+        supported_content_types=IR_SUPPORTED_CONTENT_TYPES,
+        supported_instance_types=[IR_SAMPLE_INSTANCE_TYPE],
+        job_name=IR_JOB_NAME,
+        framework=IR_SAMPLE_FRAMEWORK,
+    )
+
+    # assert that the create api has been called with default parameters with model name
+    assert sagemaker_session.create_inference_recommendations_job.called_with(
+        role=IR_ROLE_ARN,
+        job_name=IR_JOB_NAME,
+        job_type="Default",
+        job_duration_in_seconds=None,
+        model_name=ANY,
+        model_package_version_arn=None,
+        framework=IR_SAMPLE_FRAMEWORK,
+        framework_version=None,
+        sample_payload_url=IR_SAMPLE_PAYLOAD_URL,
+        supported_content_types=IR_SUPPORTED_CONTENT_TYPES,
+        supported_instance_types=[IR_SAMPLE_INSTANCE_TYPE],
+        endpoint_configurations=None,
+        traffic_pattern=None,
+        stopping_conditions=None,
+        resource_limit=None,
+    )
+
+    assert sagemaker_session.wait_for_inference_recommendations_job.called_with(IR_JOB_NAME)
+
+    # confirm that the IR instance attributes have been set
+    assert (
+        inference_recommender_model.inference_recommender_job_results
+        == IR_SAMPLE_INFERENCE_RESPONSE
+    )
+    assert (
+        inference_recommender_model.inference_recommendations
+        == IR_SAMPLE_INFERENCE_RESPONSE["InferenceRecommendations"]
+    )
+
+    # confirm that the returned object of right_size is itself
+    assert inference_recommender_model == model
+
+def test_right_size_advanced_list_instances_model_name_successful(sagemaker_session, model):
+    inference_recommender_model = model.right_size(
+        sample_payload_url=IR_SAMPLE_PAYLOAD_URL,
+        supported_content_types=IR_SUPPORTED_CONTENT_TYPES,
+        framework="SAGEMAKER-SCIKIT-LEARN",
+        job_duration_in_seconds=7200,
+        hyperparameter_ranges=IR_SAMPLE_LIST_OF_INSTANCES_HYPERPARAMETER_RANGES,
+        phases=IR_SAMPLE_PHASES,
+        traffic_type="PHASES",
+        max_invocations=100,
+        model_latency_thresholds=IR_SAMPLE_MODEL_LATENCY_THRESHOLDS,
+        max_tests=5,
+        max_parallel_tests=5,
+    )
+
+    # assert that the create api has been called with advanced parameters
+    assert sagemaker_session.create_inference_recommendations_job.called_with(
+        role=IR_ROLE_ARN,
+        job_name=IR_JOB_NAME,
+        job_type="Advanced",
+        job_duration_in_seconds=7200,
+        model_name=ANY,
+        model_package_version_arn=None,
+        framework=IR_SAMPLE_FRAMEWORK,
+        framework_version=None,
+        sample_payload_url=IR_SAMPLE_PAYLOAD_URL,
+        supported_content_types=IR_SUPPORTED_CONTENT_TYPES,
+        supported_instance_types=[IR_SAMPLE_INSTANCE_TYPE],
+        endpoint_configurations=IR_SAMPLE_ENDPOINT_CONFIG,
+        traffic_pattern=IR_SAMPLE_TRAFFIC_PATTERN,
+        stopping_conditions=IR_SAMPLE_STOPPING_CONDITIONS,
+        resource_limit=IR_SAMPLE_RESOURCE_LIMIT,
+    )
+
+    assert sagemaker_session.wait_for_inference_recommendations_job.called_with(IR_JOB_NAME)
+
+    # confirm that the IR instance attributes have been set
+    assert (
+        inference_recommender_model.inference_recommender_job_results
+        == IR_SAMPLE_INFERENCE_RESPONSE
+    )
+    assert (
+        inference_recommender_model.inference_recommendations
+        == IR_SAMPLE_INFERENCE_RESPONSE["InferenceRecommendations"]
+    )
+
+    # confirm that the returned object of right_size is itself
+    assert inference_recommender_model == model
+    
+def test_right_size_advanced_single_instances_model_name_successful(sagemaker_session, model):
+    model.right_size(
+        sample_payload_url=IR_SAMPLE_PAYLOAD_URL,
+        supported_content_types=IR_SUPPORTED_CONTENT_TYPES,
+        framework="SAGEMAKER-SCIKIT-LEARN",
+        job_duration_in_seconds=7200,
+        hyperparameter_ranges=IR_SAMPLE_SINGLE_INSTANCES_HYPERPARAMETER_RANGES,
+        phases=IR_SAMPLE_PHASES,
+        traffic_type="PHASES",
+        max_invocations=100,
+        model_latency_thresholds=IR_SAMPLE_MODEL_LATENCY_THRESHOLDS,
+        max_tests=5,
+        max_parallel_tests=5,
+    )
+
+    # assert that the create api has been called with advanced parameters
+    assert sagemaker_session.create_inference_recommendations_job.called_with(
+        role=IR_ROLE_ARN,
+        job_name=IR_JOB_NAME,
+        job_type="Advanced",
+        job_duration_in_seconds=7200,
+        model_name=ANY,
+        model_package_version_arn=None,
+        framework=IR_SAMPLE_FRAMEWORK,
+        framework_version=None,
+        sample_payload_url=IR_SAMPLE_PAYLOAD_URL,
+        supported_content_types=IR_SUPPORTED_CONTENT_TYPES,
+        supported_instance_types=[IR_SAMPLE_INSTANCE_TYPE],
+        endpoint_configurations=IR_SAMPLE_ENDPOINT_CONFIG,
+        traffic_pattern=IR_SAMPLE_TRAFFIC_PATTERN,
+        stopping_conditions=IR_SAMPLE_STOPPING_CONDITIONS,
+        resource_limit=IR_SAMPLE_RESOURCE_LIMIT,
+    )
+
+
+
 def test_right_size_default_with_model_package_successful(sagemaker_session, model_package):
     inference_recommender_model_pkg = model_package.right_size(
         sample_payload_url=IR_SAMPLE_PAYLOAD_URL,
@@ -190,6 +318,7 @@ def test_right_size_default_with_model_package_successful(sagemaker_session, mod
         job_name=IR_JOB_NAME,
         job_type="Default",
         job_duration_in_seconds=None,
+        model_name=None,
         model_package_version_arn=model_package.model_package_arn,
         framework=IR_SAMPLE_FRAMEWORK,
         framework_version=None,
@@ -202,7 +331,7 @@ def test_right_size_default_with_model_package_successful(sagemaker_session, mod
         resource_limit=None,
     )
 
-    assert sagemaker_session.wait_for_inference_recomendations_job.called_with(IR_JOB_NAME)
+    assert sagemaker_session.wait_for_inference_recommendations_job.called_with(IR_JOB_NAME)
 
     # confirm that the IR instance attributes have been set
     assert (
@@ -216,7 +345,7 @@ def test_right_size_default_with_model_package_successful(sagemaker_session, mod
 
     # confirm that the returned object of right_size is itself
     assert inference_recommender_model_pkg == model_package
-
+    
 
 def test_right_size_advanced_list_instances_model_package_successful(
     sagemaker_session, model_package
@@ -253,7 +382,7 @@ def test_right_size_advanced_list_instances_model_package_successful(
         resource_limit=IR_SAMPLE_RESOURCE_LIMIT,
     )
 
-    assert sagemaker_session.wait_for_inference_recomendations_job.called_with(IR_JOB_NAME)
+    assert sagemaker_session.wait_for_inference_recommendations_job.called_with(IR_JOB_NAME)
 
     # confirm that the IR instance attributes have been set
     assert (
@@ -356,21 +485,6 @@ def test_right_size_invalid_hyperparameter_ranges(sagemaker_session, model_packa
             model_latency_thresholds=IR_SAMPLE_MODEL_LATENCY_THRESHOLDS,
             max_tests=5,
             max_parallel_tests=5,
-        )
-
-
-# TODO -> removed once model registry is decoupled
-def test_right_size_missing_model_package_arn(sagemaker_session, model):
-    with pytest.raises(
-        ValueError,
-        match="right_size\\(\\) is currently only supported with a registered model",
-    ):
-        model.right_size(
-            sample_payload_url=IR_SAMPLE_PAYLOAD_URL,
-            supported_content_types=IR_SUPPORTED_CONTENT_TYPES,
-            supported_instance_types=[IR_SAMPLE_INSTANCE_TYPE],
-            job_name=IR_JOB_NAME,
-            framework=IR_SAMPLE_FRAMEWORK,
         )
 
 

--- a/tests/unit/sagemaker/inference_recommender/test_inference_recommender_mixin.py
+++ b/tests/unit/sagemaker/inference_recommender/test_inference_recommender_mixin.py
@@ -175,6 +175,7 @@ def default_right_sized_model(model_package):
         framework=IR_SAMPLE_FRAMEWORK,
     )
 
+
 @patch("uuid.uuid4", MagicMock(return_value="sample-unique-uuid"))
 def test_right_size_default_with_model_name_successful(sagemaker_session, model):
     inference_recommender_model = model.right_size(
@@ -229,6 +230,7 @@ def test_right_size_default_with_model_name_successful(sagemaker_session, model)
     # confirm that the returned object of right_size is itself
     assert inference_recommender_model == model
 
+
 @patch("uuid.uuid4", MagicMock(return_value="sample-unique-uuid"))
 def test_right_size_advanced_list_instances_model_name_successful(sagemaker_session, model):
     inference_recommender_model = model.right_size(
@@ -278,7 +280,8 @@ def test_right_size_advanced_list_instances_model_name_successful(sagemaker_sess
 
     # confirm that the returned object of right_size is itself
     assert inference_recommender_model == model
-    
+
+
 @patch("uuid.uuid4", MagicMock(return_value="sample-unique-uuid"))
 def test_right_size_advanced_single_instances_model_name_successful(sagemaker_session, model):
     model.right_size(
@@ -313,7 +316,6 @@ def test_right_size_advanced_single_instances_model_name_successful(sagemaker_se
         stopping_conditions=IR_SAMPLE_STOPPING_CONDITIONS,
         resource_limit=IR_SAMPLE_RESOURCE_LIMIT,
     )
-
 
 
 def test_right_size_default_with_model_package_successful(sagemaker_session, model_package):
@@ -358,7 +360,7 @@ def test_right_size_default_with_model_package_successful(sagemaker_session, mod
 
     # confirm that the returned object of right_size is itself
     assert inference_recommender_model_pkg == model_package
-    
+
 
 def test_right_size_advanced_list_instances_model_package_successful(
     sagemaker_session, model_package

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -3396,7 +3396,7 @@ def test_create_inference_recommendations_job_advanced_model_name_happy(sagemake
 def test_create_inference_recommendations_job_missing_model_name_and_pkg(sagemaker_session):
     with pytest.raises(
         ValueError,
-        match="Please provide either model_name or model_package_version_arn, not both.",
+        match="Please provide either model_name or model_package_version_arn.",
     ):
         sagemaker_session.create_inference_recommendations_job(
             role=IR_ROLE_ARN,
@@ -3415,7 +3415,7 @@ def test_create_inference_recommendations_job_missing_model_name_and_pkg(sagemak
 def test_create_inference_recommendations_job_provided_model_name_and_pkg(sagemaker_session):
     with pytest.raises(
         ValueError,
-        match="Please provide either model_name or model_package_version_arn, not both.",
+        match="Please provide either model_name or model_package_version_arn.",
     ):
         sagemaker_session.create_inference_recommendations_job(
             role=IR_ROLE_ARN,

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -3194,6 +3194,7 @@ IR_SUPPORTED_CONTENT_TYPES = ["text/csv"]
 IR_MODEL_PACKAGE_VERSION_ARN = (
     "arn:aws:sagemaker:us-west-2:123456789123:model-package/unit-test-package-version/1"
 )
+IR_MODEL_NAME = "MODEL_NAME"
 IR_NEAREST_MODEL_NAME = "xgboost"
 IR_SUPPORTED_INSTANCE_TYPES = ["ml.c5.xlarge", "ml.c5.2xlarge"]
 IR_FRAMEWORK = "XGBOOST"
@@ -3243,9 +3244,46 @@ def create_inference_recommendations_job_default_happy_response():
         "JobDescription": "#python-sdk-create",
     }
 
+def create_inference_recommendations_job_default_model_name_happy_response():
+    return {
+        "JobName": IR_USER_JOB_NAME,
+        "JobType": "Default",
+        "RoleArn": IR_ROLE_ARN,
+        "InputConfig": {
+            "ContainerConfig": {
+                "Domain": "MACHINE_LEARNING",
+                "Task": "OTHER",
+                "Framework": IR_FRAMEWORK,
+                "PayloadConfig": {
+                    "SamplePayloadUrl": IR_SAMPLE_PAYLOAD_URL,
+                    "SupportedContentTypes": IR_SUPPORTED_CONTENT_TYPES,
+                },
+                "FrameworkVersion": IR_FRAMEWORK_VERSION,
+                "NearestModelName": IR_NEAREST_MODEL_NAME,
+                "SupportedInstanceTypes": IR_SUPPORTED_INSTANCE_TYPES,
+            },
+            "ModelName": IR_MODEL_NAME,
+        },
+        "JobDescription": "#python-sdk-create",
+    }
+
 
 def create_inference_recommendations_job_advanced_happy_response():
     base_advanced_job_response = create_inference_recommendations_job_default_happy_response()
+
+    base_advanced_job_response["JobName"] = IR_JOB_NAME
+    base_advanced_job_response["JobType"] = IR_ADVANCED_JOB
+    base_advanced_job_response["StoppingConditions"] = IR_STOPPING_CONDITIONS
+    base_advanced_job_response["InputConfig"]["JobDurationInSeconds"] = IR_JOB_DURATION_IN_SECONDS
+    base_advanced_job_response["InputConfig"]["EndpointConfigurations"] = IR_ENDPOINT_CONFIGURATIONS
+    base_advanced_job_response["InputConfig"]["TrafficPattern"] = IR_TRAFFIC_PATTERN
+    base_advanced_job_response["InputConfig"]["ResourceLimit"] = IR_RESOURCE_LIMIT
+
+    return base_advanced_job_response
+
+
+def create_inference_recommendations_job_advanced_model_name_happy_response():
+    base_advanced_job_response = create_inference_recommendations_job_default_model_name_happy_response()
 
     base_advanced_job_response["JobName"] = IR_JOB_NAME
     base_advanced_job_response["JobType"] = IR_ADVANCED_JOB
@@ -3302,6 +3340,89 @@ def test_create_inference_recommendations_job_advanced_happy(sagemaker_session):
     )
 
     assert IR_JOB_NAME == job_name
+
+
+def test_create_inference_recommendations_job_default_model_name_happy(sagemaker_session):
+    job_name = sagemaker_session.create_inference_recommendations_job(
+        role=IR_ROLE_ARN,
+        sample_payload_url=IR_SAMPLE_PAYLOAD_URL,
+        supported_content_types=IR_SUPPORTED_CONTENT_TYPES,
+        model_name = IR_MODEL_NAME,
+        model_package_version_arn=None,
+        framework=IR_FRAMEWORK,
+        framework_version=IR_FRAMEWORK_VERSION,
+        nearest_model_name=IR_NEAREST_MODEL_NAME,
+        supported_instance_types=IR_SUPPORTED_INSTANCE_TYPES,
+        job_name=IR_USER_JOB_NAME,
+    )
+
+    sagemaker_session.sagemaker_client.create_inference_recommendations_job.assert_called_with(
+        **create_inference_recommendations_job_default_model_name_happy_response()
+    )
+
+    assert IR_USER_JOB_NAME == job_name
+
+@patch("uuid.uuid4", MagicMock(return_value="sample-unique-uuid"))
+def test_create_inference_recommendations_job_advanced_model_name_happy(sagemaker_session):
+    job_name = sagemaker_session.create_inference_recommendations_job(
+        role=IR_ROLE_ARN,
+        sample_payload_url=IR_SAMPLE_PAYLOAD_URL,
+        supported_content_types=IR_SUPPORTED_CONTENT_TYPES,
+        model_name=IR_MODEL_NAME,
+        model_package_version_arn=None,
+        framework=IR_FRAMEWORK,
+        framework_version=IR_FRAMEWORK_VERSION,
+        nearest_model_name=IR_NEAREST_MODEL_NAME,
+        supported_instance_types=IR_SUPPORTED_INSTANCE_TYPES,
+        endpoint_configurations=IR_ENDPOINT_CONFIGURATIONS,
+        traffic_pattern=IR_TRAFFIC_PATTERN,
+        stopping_conditions=IR_STOPPING_CONDITIONS,
+        resource_limit=IR_RESOURCE_LIMIT,
+        job_type=IR_ADVANCED_JOB,
+        job_duration_in_seconds=IR_JOB_DURATION_IN_SECONDS,
+    )
+
+    sagemaker_session.sagemaker_client.create_inference_recommendations_job.assert_called_with(
+        **create_inference_recommendations_job_advanced_model_name_happy_response()
+    )
+
+    assert IR_JOB_NAME == job_name
+
+def test_create_inference_recommendations_job_missing_model_name_and_pkg(sagemaker_session):
+    with pytest.raises(
+        ValueError,
+        match="Missing model_name and model_package_version_arn, please provide one of them."
+    ):
+        sagemaker_session.create_inference_recommendations_job(
+        role=IR_ROLE_ARN,
+        sample_payload_url=IR_SAMPLE_PAYLOAD_URL,
+        supported_content_types=IR_SUPPORTED_CONTENT_TYPES,
+        model_name = None,
+        model_package_version_arn=None,
+        framework=IR_FRAMEWORK,
+        framework_version=IR_FRAMEWORK_VERSION,
+        nearest_model_name=IR_NEAREST_MODEL_NAME,
+        supported_instance_types=IR_SUPPORTED_INSTANCE_TYPES,
+        job_name=IR_USER_JOB_NAME,
+        )
+
+def test_create_inference_recommendations_job_provided_model_name_and_pkg(sagemaker_session):
+    with pytest.raises(
+        ValueError,
+        match="Please provide either model_name or model_package_version_arn should be provided, not both."
+    ):
+        sagemaker_session.create_inference_recommendations_job(
+        role=IR_ROLE_ARN,
+        sample_payload_url=IR_SAMPLE_PAYLOAD_URL,
+        supported_content_types=IR_SUPPORTED_CONTENT_TYPES,
+        model_name=IR_MODEL_NAME,
+        model_package_version_arn=IR_MODEL_PACKAGE_VERSION_ARN,
+        framework=IR_FRAMEWORK,
+        framework_version=IR_FRAMEWORK_VERSION,
+        nearest_model_name=IR_NEAREST_MODEL_NAME,
+        supported_instance_types=IR_SUPPORTED_INSTANCE_TYPES,
+        job_name=IR_USER_JOB_NAME,
+        )
 
 
 def test_create_inference_recommendations_job_propogate_validation_exception(sagemaker_session):

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -3284,7 +3284,9 @@ def create_inference_recommendations_job_advanced_happy_response():
 
 
 def create_inference_recommendations_job_advanced_model_name_happy_response():
-    base_advanced_job_response = create_inference_recommendations_job_default_model_name_happy_response()
+    base_advanced_job_response = (
+        create_inference_recommendations_job_default_model_name_happy_response()
+    )
 
     base_advanced_job_response["JobName"] = IR_JOB_NAME
     base_advanced_job_response["JobType"] = IR_ADVANCED_JOB
@@ -3394,7 +3396,7 @@ def test_create_inference_recommendations_job_advanced_model_name_happy(sagemake
 def test_create_inference_recommendations_job_missing_model_name_and_pkg(sagemaker_session):
     with pytest.raises(
         ValueError,
-        match="Missing model_name and model_package_version_arn, please provide one of them."
+        match="Missing model_name and model_package_version_arn, please provide one of them.",
     ):
         sagemaker_session.create_inference_recommendations_job(
             role=IR_ROLE_ARN,
@@ -3413,7 +3415,7 @@ def test_create_inference_recommendations_job_missing_model_name_and_pkg(sagemak
 def test_create_inference_recommendations_job_provided_model_name_and_pkg(sagemaker_session):
     with pytest.raises(
         ValueError,
-        match="Please provide either model_name or model_package_version_arn should be provided, not both."
+        match="Please provide either model_name or model_package_version_arn should be provided, not both.",
     ):
         sagemaker_session.create_inference_recommendations_job(
             role=IR_ROLE_ARN,

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -3396,7 +3396,7 @@ def test_create_inference_recommendations_job_advanced_model_name_happy(sagemake
 def test_create_inference_recommendations_job_missing_model_name_and_pkg(sagemaker_session):
     with pytest.raises(
         ValueError,
-        match="Missing model_name and model_package_version_arn, please provide one of them.",
+        match="Please provide either model_name or model_package_version_arn, not both.",
     ):
         sagemaker_session.create_inference_recommendations_job(
             role=IR_ROLE_ARN,
@@ -3415,7 +3415,7 @@ def test_create_inference_recommendations_job_missing_model_name_and_pkg(sagemak
 def test_create_inference_recommendations_job_provided_model_name_and_pkg(sagemaker_session):
     with pytest.raises(
         ValueError,
-        match="Please provide either model_name or model_package_version_arn should be provided, not both.",
+        match="Please provide either model_name or model_package_version_arn, not both.",
     ):
         sagemaker_session.create_inference_recommendations_job(
             role=IR_ROLE_ARN,

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -3244,6 +3244,7 @@ def create_inference_recommendations_job_default_happy_response():
         "JobDescription": "#python-sdk-create",
     }
 
+
 def create_inference_recommendations_job_default_model_name_happy_response():
     return {
         "JobName": IR_USER_JOB_NAME,
@@ -3347,7 +3348,7 @@ def test_create_inference_recommendations_job_default_model_name_happy(sagemaker
         role=IR_ROLE_ARN,
         sample_payload_url=IR_SAMPLE_PAYLOAD_URL,
         supported_content_types=IR_SUPPORTED_CONTENT_TYPES,
-        model_name = IR_MODEL_NAME,
+        model_name=IR_MODEL_NAME,
         model_package_version_arn=None,
         framework=IR_FRAMEWORK,
         framework_version=IR_FRAMEWORK_VERSION,
@@ -3361,6 +3362,7 @@ def test_create_inference_recommendations_job_default_model_name_happy(sagemaker
     )
 
     assert IR_USER_JOB_NAME == job_name
+
 
 @patch("uuid.uuid4", MagicMock(return_value="sample-unique-uuid"))
 def test_create_inference_recommendations_job_advanced_model_name_happy(sagemaker_session):
@@ -3388,23 +3390,25 @@ def test_create_inference_recommendations_job_advanced_model_name_happy(sagemake
 
     assert IR_JOB_NAME == job_name
 
+
 def test_create_inference_recommendations_job_missing_model_name_and_pkg(sagemaker_session):
     with pytest.raises(
         ValueError,
         match="Missing model_name and model_package_version_arn, please provide one of them."
     ):
         sagemaker_session.create_inference_recommendations_job(
-        role=IR_ROLE_ARN,
-        sample_payload_url=IR_SAMPLE_PAYLOAD_URL,
-        supported_content_types=IR_SUPPORTED_CONTENT_TYPES,
-        model_name = None,
-        model_package_version_arn=None,
-        framework=IR_FRAMEWORK,
-        framework_version=IR_FRAMEWORK_VERSION,
-        nearest_model_name=IR_NEAREST_MODEL_NAME,
-        supported_instance_types=IR_SUPPORTED_INSTANCE_TYPES,
-        job_name=IR_USER_JOB_NAME,
+            role=IR_ROLE_ARN,
+            sample_payload_url=IR_SAMPLE_PAYLOAD_URL,
+            supported_content_types=IR_SUPPORTED_CONTENT_TYPES,
+            model_name=None,
+            model_package_version_arn=None,
+            framework=IR_FRAMEWORK,
+            framework_version=IR_FRAMEWORK_VERSION,
+            nearest_model_name=IR_NEAREST_MODEL_NAME,
+            supported_instance_types=IR_SUPPORTED_INSTANCE_TYPES,
+            job_name=IR_USER_JOB_NAME,
         )
+
 
 def test_create_inference_recommendations_job_provided_model_name_and_pkg(sagemaker_session):
     with pytest.raises(
@@ -3412,16 +3416,16 @@ def test_create_inference_recommendations_job_provided_model_name_and_pkg(sagema
         match="Please provide either model_name or model_package_version_arn should be provided, not both."
     ):
         sagemaker_session.create_inference_recommendations_job(
-        role=IR_ROLE_ARN,
-        sample_payload_url=IR_SAMPLE_PAYLOAD_URL,
-        supported_content_types=IR_SUPPORTED_CONTENT_TYPES,
-        model_name=IR_MODEL_NAME,
-        model_package_version_arn=IR_MODEL_PACKAGE_VERSION_ARN,
-        framework=IR_FRAMEWORK,
-        framework_version=IR_FRAMEWORK_VERSION,
-        nearest_model_name=IR_NEAREST_MODEL_NAME,
-        supported_instance_types=IR_SUPPORTED_INSTANCE_TYPES,
-        job_name=IR_USER_JOB_NAME,
+            role=IR_ROLE_ARN,
+            sample_payload_url=IR_SAMPLE_PAYLOAD_URL,
+            supported_content_types=IR_SUPPORTED_CONTENT_TYPES,
+            model_name=IR_MODEL_NAME,
+            model_package_version_arn=IR_MODEL_PACKAGE_VERSION_ARN,
+            framework=IR_FRAMEWORK,
+            framework_version=IR_FRAMEWORK_VERSION,
+            nearest_model_name=IR_NEAREST_MODEL_NAME,
+            supported_instance_types=IR_SUPPORTED_INSTANCE_TYPES,
+            job_name=IR_USER_JOB_NAME,
         )
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Decouple moel.right_size() from model registry

*Testing done:*
Add unit test.
pip install . and run end 2 end tests with model not registerd.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
