### PR TITLE
Revert back to stable apache-airflow-providers-amazon from 7.2.1 to 4.0.0.

### DIFF
--- a/requirements/extras/test_requirements.txt
+++ b/requirements/extras/test_requirements.txt
@@ -13,7 +13,7 @@ black==22.3.0
 stopit==1.1.2
 # Update tox.ini to have correct version of airflow constraints file
 apache-airflow==2.4.1
-apache-airflow-providers-amazon==7.2.1
+apache-airflow-providers-amazon==4.0.0
 attrs==22.1.0
 fabric==2.6.0
 requests==2.27.1


### PR DESCRIPTION
Reverts aws/sagemaker-python-sdk#3682
Causes multiple tests to fail - unable to find 'airflow.providers.amazon.aws.operators.sagemaker_transform'