### PR TITLE
[change] Add DJL FasterTransformer image uris

### DIFF
--- a/src/sagemaker/image_uri_config/djl-fastertransformer.json
+++ b/src/sagemaker/image_uri_config/djl-fastertransformer.json
@@ -1,0 +1,35 @@
+{
+    "scope": ["inference"],
+    "versions": {
+        "0.21.0": {
+            "registries": {
+                "af-south-1": "626614931356",
+                "ap-east-1": "871362719292",
+                "ap-northeast-1": "763104351884",
+                "ap-northeast-2": "763104351884",
+                "ap-northeast-3": "364406365360",
+                "ap-south-1": "763104351884",
+                "ap-southeast-1": "763104351884",
+                "ap-southeast-2": "763104351884",
+                "ap-southeast-3": "907027046896",
+                "ca-central-1": "763104351884",
+                "cn-north-1": "727897471807",
+                "cn-northwest-1": "727897471807",
+                "eu-central-1": "763104351884",
+                "eu-north-1": "763104351884",
+                "eu-west-1": "763104351884",
+                "eu-west-2": "763104351884",
+                "eu-west-3": "763104351884",
+                "eu-south-1": "692866216735",
+                "me-south-1": "217643126080",
+                "sa-east-1": "763104351884",
+                "us-east-1": "763104351884",
+                "us-east-2": "763104351884",
+                "us-west-1": "763104351884",
+                "us-west-2": "763104351884"
+            },
+            "repository": "djl-inference",
+            "tag_prefix": "0.21.0-fastertransformer5.3.0-cu117"
+        }
+    }
+}

--- a/tests/unit/sagemaker/image_uris/test_djl.py
+++ b/tests/unit/sagemaker/image_uris/test_djl.py
@@ -41,19 +41,31 @@ ACCOUNTS = {
     "us-west-1": "763104351884",
     "us-west-2": "763104351884",
 }
-VERSIONS = ["0.21.0", "0.20.0", "0.19.0"]
-DJL_FRAMEWORKS = ["djl-deepspeed"]
+DJL_DEEPSPEED_VERSIONS = ["0.21.0", "0.20.0", "0.19.0"]
+DJL_FASTERTRANSFORMER_VERSIONS = ["0.21.0"]
 DJL_VERSIONS_TO_FRAMEWORK = {
     "0.19.0": {"djl-deepspeed": "deepspeed0.7.3-cu113"},
     "0.20.0": {"djl-deepspeed": "deepspeed0.7.5-cu116"},
-    "0.21.0": {"djl-deepspeed": "deepspeed0.8.0-cu117"},
+    "0.21.0": {
+        "djl-deepspeed": "deepspeed0.8.0-cu117",
+        "djl-fastertransformer": "fastertransformer5.3.0-cu117",
+    },
 }
 
 
 @pytest.mark.parametrize("region", ACCOUNTS.keys())
-@pytest.mark.parametrize("version", VERSIONS)
-@pytest.mark.parametrize("djl_framework", DJL_FRAMEWORKS)
-def test_djl_uris(region, version, djl_framework):
+@pytest.mark.parametrize("version", DJL_DEEPSPEED_VERSIONS)
+def test_djl_deepspeed(region, version):
+    _test_djl_uris(region, version, "djl-deepspeed")
+
+
+@pytest.mark.parametrize("region", ACCOUNTS.keys())
+@pytest.mark.parametrize("version", DJL_FASTERTRANSFORMER_VERSIONS)
+def test_djl_fastertransformer(region, version):
+    _test_djl_uris(region, version, "djl-fastertransformer")
+
+
+def _test_djl_uris(region, version, djl_framework):
     uri = image_uris.retrieve(framework=djl_framework, region=region, version=version)
     expected = expected_uris.djl_framework_uri(
         "djl-inference",


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
This change makes the new DJL FasterTransformer DLCs available through the PySDK image_uris module.

*Testing done:*
Added new unit tests for the change.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
