### PR TITLE
deprecation: Remove support for Python 3.7

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -12,5 +12,5 @@ start_time=`date +%s`
 tox -e sphinx,doc8 --parallel all
 ./ci-scripts/displaytime.sh 'sphinx,doc8' $start_time
 start_time=`date +%s`
-tox -e py37,py38,py39 --parallel all -- tests/unit
-./ci-scripts/displaytime.sh 'py37,py38,py39 unit' $start_time
+tox -e py38,py39 --parallel all -- tests/unit
+./ci-scripts/displaytime.sh 'py38,py39,py310 unit' $start_time

--- a/README.rst
+++ b/README.rst
@@ -87,7 +87,6 @@ Supported Python Versions
 
 SageMaker Python SDK is tested on:
 
-- Python 3.7
 - Python 3.8
 - Python 3.9
 - Python 3.10

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ setup(
     url="https://github.com/aws/sagemaker-python-sdk/",
     license="Apache License 2.0",
     keywords="ML Amazon AWS AI Tensorflow MXNet",
-    python_requires=">= 3.6",
+    python_requires=">= 3.8",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ setup(
     url="https://github.com/aws/sagemaker-python-sdk/",
     license="Apache License 2.0",
     keywords="ML Amazon AWS AI Tensorflow MXNet",
-    python_requires=">= 3.8",
+    python_requires=">= 3.7",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",

--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,6 @@ setup(
         "Natural Language :: English",
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = black-format,flake8,pylint,docstyle,sphinx,doc8,twine,py37,py38,py39,py310
+envlist = black-format,flake8,pylint,docstyle,sphinx,doc8,twine,py38,py39,py310
 
 skip_missing_interpreters = False
 
@@ -79,7 +79,7 @@ commands =
     {env:IGNORE_COVERAGE:} coverage report -i --fail-under=86
 deps = .[test]
 depends =
-    {py37,py38,py39,py310}: clean
+    {py38,py39,py310}: clean
 
 [testenv:flake8]
 skipdist = true


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Sagemaker Python SDK would is now removing support for Python 3.7
*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
