### PR TITLE
fix: Fix cross account register model

### DIFF
--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -3222,7 +3222,9 @@ class Session(object):  # pylint: disable=too-many-public-methods
         )
 
         def submit(request):
-            if model_package_group_name is not None and not model_package_group_name.startswith("arn:"):
+            if model_package_group_name is not None and not model_package_group_name.startswith(
+                "arn:"
+            ):
                 _create_resource(
                     lambda: self.sagemaker_client.create_model_package_group(
                         ModelPackageGroupName=request["ModelPackageGroupName"]

--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -3222,7 +3222,7 @@ class Session(object):  # pylint: disable=too-many-public-methods
         )
 
         def submit(request):
-            if model_package_group_name is not None:
+            if model_package_group_name is not None and not model_package_group_name.startswith("arn:"):
                 _create_resource(
                     lambda: self.sagemaker_client.create_model_package_group(
                         ModelPackageGroupName=request["ModelPackageGroupName"]

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -2650,6 +2650,35 @@ def test_create_model_package_from_containers(sagemaker_session):
     sagemaker_session.sagemaker_client.create_model_package.assert_called_once()
 
 
+def test_create_model_package_from_containers_cross_account_mpg_name(sagemaker_session):
+    mpg_name = "arn:aws:sagemaker:us-east-1:215995503607:model-package-group/stage-dev"
+    content_types = ["text/csv"]
+    response_types = ["text/csv"]
+    sagemaker_session.create_model_package_from_containers(
+        model_package_group_name=mpg_name,
+        content_types=content_types,
+        response_types=response_types,
+    )
+    sagemaker_session.sagemaker_client.create_model_package.assert_called_once()
+
+
+def test_create_mpg_from_containers_cross_account_mpg_name(sagemaker_session):
+    mpg_name = "arn:aws:sagemaker:us-east-1:215995503607:model-package-group/stage-dev"
+    content_types = ["text/csv"]
+    response_types = ["text/csv"]
+    with pytest.raises(AssertionError) as error:
+        sagemaker_session.create_model_package_from_containers(
+            model_package_group_name=mpg_name,
+            content_types=content_types,
+            response_types=response_types,
+        )
+        sagemaker_session.sagemaker_client.create_model_package_group.assert_called_once()
+        assert (
+            "Expected 'create_model_package_group' to have been called once. "
+            "Called 0 times." == str(error)
+        )
+
+
 def test_create_model_package_from_containers_name_conflict(sagemaker_session):
     model_package_name = "sagemaker-model-package"
     model_package_group_name = "sagemaker-model-package-group"


### PR DESCRIPTION
*Issue #, if available:* N/A, internal sim ticket

*Description of changes:* Register model step for cross account must make create_model_package call rather than create_model_package_group call, due to which when customer is passing arn in model_package_group_name, they are facing a ValidationException. This change was not accomodated when migration to ModelStep.

*Testing done:* Yes
tox -e pylint, flake8, black-format, twine, docstyle, sphinx, doc8 
tox -e py39 tests/unit/test_session.py::test_create_model_package_from_containers_cross_account_mpg_name export 
All passed locally

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
