### PR TITLE
fix: Disable module-not-measured warnings to avoid clutter in build logs

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,3 +2,4 @@
 concurrency = threading
 omit = sagemaker/tests/*
 timid = True
+disable_warnings = module-not-measured


### PR DESCRIPTION
*Issue #, if available:*
There is a lot of clutter in codebuild logs with module-not-measured warnings such as below
```
/codebuild/output/src977214894/src/github.com/aws/sagemaker-python-sdk/.tox/py37/lib/python3.7/site-packages/coverage/inorout.py:533: CoverageWarning: Module sagemaker was previously imported, but not measured (module-not-measured)
  self.warn(msg, slug="module-not-measured")
```
As per this [doc](https://coverage.readthedocs.io/en/coverage-5.2.1/cmd.html?highlight=warnings#warnings:~:text=Module%20XXX%20was%20never%20imported%20(module%2Dnot%2Dimported)) we are asking coverage.py to measure module XXX, but it was never imported by our program.
Disabling this to avoid this.


*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
