### PR TITLE
fix: Upgrade apache-airflow-providers-amazon version

### DIFF
--- a/requirements/extras/test_requirements.txt
+++ b/requirements/extras/test_requirements.txt
@@ -13,7 +13,7 @@ black==22.3.0
 stopit==1.1.2
 # Update tox.ini to have correct version of airflow constraints file
 apache-airflow==2.5.1
-apache-airflow-providers-amazon==4.0.0
+apache-airflow-providers-amazon==7.2.1
 attrs==22.1.0
 fabric==2.6.0
 requests==2.27.1

--- a/tests/integ/test_airflow_config.py
+++ b/tests/integ/test_airflow_config.py
@@ -56,10 +56,7 @@ for _ in retries(
         import sagemaker.workflow.airflow as sm_airflow
         import airflow.utils as utils
         from airflow import DAG
-        from airflow.providers.amazon.aws.operators.sagemaker import SageMakerTrainingOperator
-        from airflow.providers.amazon.aws.operators.sagemaker_transform import (
-            SageMakerTransformOperator,
-        )
+        from airflow.providers.amazon.aws.operators.sagemaker import SageMakerTrainingOperator, SageMakerTransformOperator
 
         break
     except ParsingError:

--- a/tests/integ/test_airflow_config.py
+++ b/tests/integ/test_airflow_config.py
@@ -56,7 +56,10 @@ for _ in retries(
         import sagemaker.workflow.airflow as sm_airflow
         import airflow.utils as utils
         from airflow import DAG
-        from airflow.providers.amazon.aws.operators.sagemaker import SageMakerTrainingOperator, SageMakerTransformOperator
+        from airflow.providers.amazon.aws.operators.sagemaker import (
+            SageMakerTrainingOperator,
+            SageMakerTransformOperator,
+        )
 
         break
     except ParsingError:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
