### PR TITLE
Fixes the completion_criteria_config dict in the to_input_req method

### DIFF
--- a/src/sagemaker/tuner.py
+++ b/src/sagemaker/tuner.py
@@ -559,6 +559,7 @@ class TuningJobCompletionCriteriaConfig(object):
         """
         completion_criteria_config = {}
         if self.max_number_of_training_jobs_not_improving is not None:
+            completion_criteria_config[BEST_OBJECTIVE_NOT_IMPROVING] = {}
             completion_criteria_config[BEST_OBJECTIVE_NOT_IMPROVING][
                 MAX_NUMBER_OF_TRAINING_JOBS_NOT_IMPROVING
             ] = self.max_number_of_training_jobs_not_improving
@@ -569,6 +570,7 @@ class TuningJobCompletionCriteriaConfig(object):
             ] = self.target_objective_metric_value
 
         if self.complete_on_convergence is not None:
+            completion_criteria_config[CONVERGENCE_DETECTED] = {}
             completion_criteria_config[CONVERGENCE_DETECTED][COMPLETE_ON_CONVERGENCE_DETECTED] = (
                 "Enabled" if self.complete_on_convergence else "Disabled"
             )


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/sagemaker-python-sdk/issues/3743

*Description of changes:* adds missing dictionary keys in the `to_input_req` method of the `TuningJobCompletionCriteriaConfig` class

*Testing done:* interactively in jupyter notebook and by launching an HPO job successfully

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
