### PR TITLE
change: Added ml.p4d and ml.p4de as supported instances for DeepSpeed

### DIFF
--- a/src/sagemaker/djl_inference/defaults.py
+++ b/src/sagemaker/djl_inference/defaults.py
@@ -48,5 +48,7 @@ ALLOWED_INSTANCE_FAMILIES = {
     "ml.g5",
     "ml.p3",
     "ml.p4",
+    "ml.p4d",
+    "ml.p4de",
     "local_gpu",
 }

--- a/src/sagemaker/djl_inference/defaults.py
+++ b/src/sagemaker/djl_inference/defaults.py
@@ -47,6 +47,7 @@ ALLOWED_INSTANCE_FAMILIES = {
     "ml.g4dn",
     "ml.g5",
     "ml.p3",
+    "ml.p3dn",
     "ml.p4",
     "ml.p4d",
     "ml.p4de",


### PR DESCRIPTION
*Issue #, if available:* [3748](https://github.com/aws/sagemaker-python-sdk/issues/3748)

*Description of changes:* Add `ml.p4d.*` and `ml.p4de.*` as supported instance types for DeepSpeedModel

*Testing done:* Ran unit tests. Tested model deploy using Sagemaker Python SDK.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [X] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [X] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [X] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [X] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
