### PR TITLE
Add end of support messaging for DLCs

### DIFF
--- a/src/sagemaker/image_uri_config/pytorch.json
+++ b/src/sagemaker/image_uri_config/pytorch.json
@@ -34,8 +34,7 @@
                     "us-east-2": "763104351884",
                     "us-west-2": "763104351884"
                 },
-                "repository": "pytorch-inference-eia",
-                "end_of_support": "2022-06-21T00:00:00.0Z"
+                "repository": "pytorch-inference-eia"
             },
             "1.5.1": {
                 "py_versions": [
@@ -79,6 +78,14 @@
             "1.11": "1.11.0",
             "1.12": "1.12.1",
             "1.13": "1.13.1"
+        },
+        "version_support": {
+            "1.12.1": {
+                "end_of_support": "2023-07-01T00:00:00.0Z"
+            },
+            "1.13.1": {
+                "end_of_support": "2023-10-28T00:00:00.0Z"
+            }
         },
         "versions": {
             "0.4.0": {
@@ -147,8 +154,7 @@
                     "us-west-1": "520713654638",
                     "us-west-2": "520713654638"
                 },
-                "repository": "sagemaker-pytorch",
-                "end_of_support": "2022-06-21T00:00:00.0Z"
+                "repository": "sagemaker-pytorch"
             },
             "1.1.0": {
                 "py_versions": [
@@ -182,8 +188,7 @@
                     "us-west-1": "520713654638",
                     "us-west-2": "520713654638"
                 },
-                "repository": "sagemaker-pytorch",
-                "end_of_support": "2022-06-21T00:00:00.0Z"
+                "repository": "sagemaker-pytorch"
             },
             "1.2.0": {
                 "py_versions": [
@@ -225,8 +230,7 @@
                     "us-west-1": "763104351884",
                     "us-west-2": "763104351884"
                 },
-                "repository": "pytorch-inference",
-                "end_of_support": "2022-06-21T00:00:00.0Z"
+                "repository": "pytorch-inference"
             },
             "1.3.1": {
                 "py_versions": [
@@ -268,8 +272,7 @@
                     "us-west-1": "763104351884",
                     "us-west-2": "763104351884"
                 },
-                "repository": "pytorch-inference",
-                "end_of_support": "2022-06-21T00:00:00.0Z"
+                "repository": "pytorch-inference"
             },
             "1.4.0": {
                 "py_versions": [
@@ -310,8 +313,7 @@
                     "us-west-1": "763104351884",
                     "us-west-2": "763104351884"
                 },
-                "repository": "pytorch-inference",
-                "end_of_support": "2022-06-21T00:00:00.0Z"
+                "repository": "pytorch-inference"
             },
             "1.5.0": {
                 "py_versions": [
@@ -352,8 +354,7 @@
                     "us-west-1": "763104351884",
                     "us-west-2": "763104351884"
                 },
-                "repository": "pytorch-inference",
-                "end_of_support": "2022-06-21T00:00:00.0Z"
+                "repository": "pytorch-inference" 
             },
             "1.6.0": {
                 "py_versions": [
@@ -395,8 +396,7 @@
                     "us-west-1": "763104351884",
                     "us-west-2": "763104351884"
                 },
-                "repository": "pytorch-inference",
-                "end_of_support": "2022-06-21T00:00:00.0Z"
+                "repository": "pytorch-inference"        
             },
             "1.7.1": {
                 "py_versions": [
@@ -438,8 +438,7 @@
                     "us-west-1": "763104351884",
                     "us-west-2": "763104351884"
                 },
-                "repository": "pytorch-inference",
-                "end_of_support": "2022-06-21T00:00:00.0Z"
+                "repository": "pytorch-inference"
             },
             "1.8.0": {
                 "py_versions": [
@@ -481,8 +480,7 @@
                     "us-west-1": "763104351884",
                     "us-west-2": "763104351884"
                 },
-                "repository": "pytorch-inference",
-                "end_of_support": "2022-06-21T00:00:00.0Z"
+                "repository": "pytorch-inference"
             },
             "1.8.1": {
                 "py_versions": [
@@ -524,8 +522,7 @@
                     "us-west-1": "763104351884",
                     "us-west-2": "763104351884"
                 },
-                "repository": "pytorch-inference",
-                "end_of_support": "2022-06-21T00:00:00.0Z"
+                "repository": "pytorch-inference"
             },
             "1.9.0": {
                 "py_versions": [
@@ -566,8 +563,7 @@
                     "us-west-1": "763104351884",
                     "us-west-2": "763104351884"
                 },
-                "repository": "pytorch-inference",
-                "end_of_support": "2022-06-21T00:00:00.0Z"
+                "repository": "pytorch-inference"
             },
             "1.9.1": {
                 "py_versions": [
@@ -608,8 +604,7 @@
                     "us-west-1": "763104351884",
                     "us-west-2": "763104351884"
                 },
-                "repository": "pytorch-inference",
-                "end_of_support": "2022-06-21T00:00:00.0Z"
+                "repository": "pytorch-inference"
             },
             "1.10.0": {
                 "py_versions": [
@@ -650,8 +645,7 @@
                     "us-west-1": "763104351884",
                     "us-west-2": "763104351884"
                 },
-                "repository": "pytorch-inference",
-                "end_of_support": "2022-10-26T00:00:00.0Z"
+                "repository": "pytorch-inference"
             },
             "1.10.2": {
                 "py_versions": [
@@ -692,8 +686,7 @@
                     "us-west-1": "763104351884",
                     "us-west-2": "763104351884"
                 },
-                "repository": "pytorch-inference",
-                "end_of_support": "2022-10-26T00:00:00.0Z"
+                "repository": "pytorch-inference"
             },
             "1.11.0": {
                 "py_versions": [
@@ -734,8 +727,7 @@
                     "us-west-1": "763104351884",
                     "us-west-2": "763104351884"
                 },
-                "repository": "pytorch-inference",
-                "end_of_support": "2023-03-10T00:00:00.0Z"
+                "repository": "pytorch-inference"
             },
             "1.12.0": {
                 "py_versions": [
@@ -776,8 +768,7 @@
                     "us-west-1": "763104351884",
                     "us-west-2": "763104351884"
                 },
-                "repository": "pytorch-inference",
-                "end_of_support": "2022-09-16T00:00:00.0Z"
+                "repository": "pytorch-inference"
             },
             "1.12.1": {
                 "py_versions": [
@@ -817,8 +808,7 @@
                     "us-west-1": "763104351884",
                     "us-west-2": "763104351884"
                 },
-                "repository": "pytorch-inference",
-                "end_of_support": "2023-07-01T00:00:00.0Z"
+                "repository": "pytorch-inference"
             },
             "1.13.1": {
                 "py_versions": [
@@ -855,8 +845,7 @@
                     "us-west-1": "763104351884",
                     "us-west-2": "763104351884"
                 },
-                "repository": "pytorch-inference",
-                "end_of_support": "2023-10-28T00:00:00.0Z"
+                "repository": "pytorch-inference"
             }
         }
     },
@@ -932,6 +921,14 @@
             "1.11": "1.11.0",
             "1.12": "1.12.1",
             "1.13": "1.13.1"
+        },
+        "version_support": {
+            "1.12.1": {
+                "end_of_support": "2023-07-01T00:00:00.0Z"
+            },
+            "1.13.1": {
+                "end_of_support": "2023-10-28T00:00:00.0Z"
+            }
         },
         "versions": {
             "0.4.0": {

--- a/src/sagemaker/image_uri_config/pytorch.json
+++ b/src/sagemaker/image_uri_config/pytorch.json
@@ -34,7 +34,8 @@
                     "us-east-2": "763104351884",
                     "us-west-2": "763104351884"
                 },
-                "repository": "pytorch-inference-eia"
+                "repository": "pytorch-inference-eia",
+                "end_of_support": "2022-06-21T00:00:00.0Z"
             },
             "1.5.1": {
                 "py_versions": [
@@ -146,7 +147,8 @@
                     "us-west-1": "520713654638",
                     "us-west-2": "520713654638"
                 },
-                "repository": "sagemaker-pytorch"
+                "repository": "sagemaker-pytorch",
+                "end_of_support": "2022-06-21T00:00:00.0Z"
             },
             "1.1.0": {
                 "py_versions": [
@@ -180,7 +182,8 @@
                     "us-west-1": "520713654638",
                     "us-west-2": "520713654638"
                 },
-                "repository": "sagemaker-pytorch"
+                "repository": "sagemaker-pytorch",
+                "end_of_support": "2022-06-21T00:00:00.0Z"
             },
             "1.2.0": {
                 "py_versions": [
@@ -222,7 +225,8 @@
                     "us-west-1": "763104351884",
                     "us-west-2": "763104351884"
                 },
-                "repository": "pytorch-inference"
+                "repository": "pytorch-inference",
+                "end_of_support": "2022-06-21T00:00:00.0Z"
             },
             "1.3.1": {
                 "py_versions": [
@@ -264,7 +268,8 @@
                     "us-west-1": "763104351884",
                     "us-west-2": "763104351884"
                 },
-                "repository": "pytorch-inference"
+                "repository": "pytorch-inference",
+                "end_of_support": "2022-06-21T00:00:00.0Z"
             },
             "1.4.0": {
                 "py_versions": [
@@ -305,7 +310,8 @@
                     "us-west-1": "763104351884",
                     "us-west-2": "763104351884"
                 },
-                "repository": "pytorch-inference"
+                "repository": "pytorch-inference",
+                "end_of_support": "2022-06-21T00:00:00.0Z"
             },
             "1.5.0": {
                 "py_versions": [
@@ -346,7 +352,8 @@
                     "us-west-1": "763104351884",
                     "us-west-2": "763104351884"
                 },
-                "repository": "pytorch-inference"
+                "repository": "pytorch-inference",
+                "end_of_support": "2022-06-21T00:00:00.0Z"
             },
             "1.6.0": {
                 "py_versions": [
@@ -388,7 +395,8 @@
                     "us-west-1": "763104351884",
                     "us-west-2": "763104351884"
                 },
-                "repository": "pytorch-inference"
+                "repository": "pytorch-inference",
+                "end_of_support": "2022-06-21T00:00:00.0Z"
             },
             "1.7.1": {
                 "py_versions": [
@@ -430,7 +438,8 @@
                     "us-west-1": "763104351884",
                     "us-west-2": "763104351884"
                 },
-                "repository": "pytorch-inference"
+                "repository": "pytorch-inference",
+                "end_of_support": "2022-06-21T00:00:00.0Z"
             },
             "1.8.0": {
                 "py_versions": [
@@ -472,7 +481,8 @@
                     "us-west-1": "763104351884",
                     "us-west-2": "763104351884"
                 },
-                "repository": "pytorch-inference"
+                "repository": "pytorch-inference",
+                "end_of_support": "2022-06-21T00:00:00.0Z"
             },
             "1.8.1": {
                 "py_versions": [
@@ -514,7 +524,8 @@
                     "us-west-1": "763104351884",
                     "us-west-2": "763104351884"
                 },
-                "repository": "pytorch-inference"
+                "repository": "pytorch-inference",
+                "end_of_support": "2022-06-21T00:00:00.0Z"
             },
             "1.9.0": {
                 "py_versions": [
@@ -555,7 +566,8 @@
                     "us-west-1": "763104351884",
                     "us-west-2": "763104351884"
                 },
-                "repository": "pytorch-inference"
+                "repository": "pytorch-inference",
+                "end_of_support": "2022-06-21T00:00:00.0Z"
             },
             "1.9.1": {
                 "py_versions": [
@@ -596,7 +608,8 @@
                     "us-west-1": "763104351884",
                     "us-west-2": "763104351884"
                 },
-                "repository": "pytorch-inference"
+                "repository": "pytorch-inference",
+                "end_of_support": "2022-06-21T00:00:00.0Z"
             },
             "1.10.0": {
                 "py_versions": [
@@ -637,7 +650,8 @@
                     "us-west-1": "763104351884",
                     "us-west-2": "763104351884"
                 },
-                "repository": "pytorch-inference"
+                "repository": "pytorch-inference",
+                "end_of_support": "2022-10-26T00:00:00.0Z"
             },
             "1.10.2": {
                 "py_versions": [
@@ -678,7 +692,8 @@
                     "us-west-1": "763104351884",
                     "us-west-2": "763104351884"
                 },
-                "repository": "pytorch-inference"
+                "repository": "pytorch-inference",
+                "end_of_support": "2022-10-26T00:00:00.0Z"
             },
             "1.11.0": {
                 "py_versions": [
@@ -719,7 +734,8 @@
                     "us-west-1": "763104351884",
                     "us-west-2": "763104351884"
                 },
-                "repository": "pytorch-inference"
+                "repository": "pytorch-inference",
+                "end_of_support": "2023-03-10T00:00:00.0Z"
             },
             "1.12.0": {
                 "py_versions": [
@@ -760,7 +776,8 @@
                     "us-west-1": "763104351884",
                     "us-west-2": "763104351884"
                 },
-                "repository": "pytorch-inference"
+                "repository": "pytorch-inference",
+                "end_of_support": "2022-09-16T00:00:00.0Z"
             },
             "1.12.1": {
                 "py_versions": [
@@ -800,7 +817,8 @@
                     "us-west-1": "763104351884",
                     "us-west-2": "763104351884"
                 },
-                "repository": "pytorch-inference"
+                "repository": "pytorch-inference",
+                "end_of_support": "2023-07-01T00:00:00.0Z"
             },
             "1.13.1": {
                 "py_versions": [
@@ -837,7 +855,8 @@
                     "us-west-1": "763104351884",
                     "us-west-2": "763104351884"
                 },
-                "repository": "pytorch-inference"
+                "repository": "pytorch-inference",
+                "end_of_support": "2023-10-28T00:00:00.0Z"
             }
         }
     },

--- a/src/sagemaker/image_uris.py
+++ b/src/sagemaker/image_uris.py
@@ -471,14 +471,14 @@ def _get_end_of_support_warn_message(end_of_support, framework, version):
     time_delt_days = (end_of_support_dt - current_dt).days
     if current_dt >= end_of_support_dt:
         return (
-            f"Unsupported DLC {framework} version: {version}." 
-            f"Please choose a supported version from our support policy - {dlc_support_policy}"
+            f"The {framework} {version} DLC has reached end of support. " 
+            f"Please choose a supported version from our support policy - {dlc_support_policy}."
             )
     if time_delt_days <= 60:
         return (
             f"The {framework} {version} DLC is approaching end of support, "
-            f"and patching will stop on {end_of_support}. "
-            f"Please choose a supported version from our support policy - {dlc_support_policy}"
+            f"and patching will stop on {end_of_support_dt.strftime('%Y-%m-%d %Z')}. "
+            f"Please choose a supported version from our support policy - {dlc_support_policy}."
             )
     return ""
 
@@ -487,6 +487,8 @@ def _validate_version_and_set_if_needed(version, config, framework):
     """Checks if the framework/algorithm version is one of the supported versions."""
     available_versions = list(config["versions"].keys())
     aliased_versions = list(config.get("version_aliases", {}).keys())
+
+
 
     if len(available_versions) == 1 and version not in aliased_versions:
         log_message = "Defaulting to the only supported framework/algorithm version: {}.".format(
@@ -502,10 +504,14 @@ def _validate_version_and_set_if_needed(version, config, framework):
     _validate_arg(version, available_versions + aliased_versions, "{} version".format(framework))
 
     # For DLCs, warn if image is out of support
-    end_of_support = config.get("end_of_support")
+    long_version = version
+    if version in aliased_versions:
+        long_version = config["version_aliases"][version]
+    end_of_support = config["versions"][long_version].get("end_of_support")
     end_of_support_warning = _get_end_of_support_warn_message(end_of_support, framework, version)
     if end_of_support_warning:
         logger.warning(end_of_support_warning)
+
     return version
 
 

--- a/tests/unit/sagemaker/image_uris/test_dlc_frameworks.py
+++ b/tests/unit/sagemaker/image_uris/test_dlc_frameworks.py
@@ -14,7 +14,6 @@ from __future__ import absolute_import
 
 import io
 import contextlib
-import datetime
 
 from packaging.version import Version
 
@@ -93,13 +92,7 @@ def _test_image_uris(
         assert expected == uri
 
 
-def _test_end_of_support_messaging(
-    framework,
-    fw_version,
-    py_version,
-    scope,
-    accelerator_type=None
-):
+def _test_end_of_support_messaging(framework, fw_version, py_version, scope, accelerator_type=None):
     base_args = {
         "framework": framework,
         "version": fw_version,
@@ -107,7 +100,9 @@ def _test_end_of_support_messaging(
         "image_scope": scope,
     }
 
-    config = image_uris._config_for_framework_and_scope(framework=framework, image_scope=scope, accelerator_type=accelerator_type)
+    config = image_uris._config_for_framework_and_scope(
+        framework=framework, image_scope=scope, accelerator_type=accelerator_type
+    )
     version_support = config.get("version_support")
     aliases = config.get("version_aliases")
 
@@ -116,7 +111,9 @@ def _test_end_of_support_messaging(
             # Version in version_support MUST be in an aliased value
             assert v in aliases.values()
 
-    expected_warning_message = image_uris._get_end_of_support_warn_message(fw_version, config, framework)
+    expected_warning_message = image_uris._get_end_of_support_warn_message(
+        fw_version, config, framework
+    )
 
     TYPES_AND_PROCESSORS = INSTANCE_TYPES_AND_PROCESSORS
     if framework == "pytorch" and Version(fw_version) >= Version("1.13"):
@@ -169,7 +166,7 @@ def test_tensorflow_training(tensorflow_training_version, tensorflow_training_py
         "tf_training_version": tensorflow_training_version,
         "py_version": tensorflow_training_py_version,
     }
-    
+
     framework = "tensorflow"
     scope = "training"
 
@@ -531,19 +528,15 @@ def _sagemaker_or_dlc_account(repo, region):
 
 def test_end_of_support():
     config = {
-        "version_aliases": {
-            "1.6": "1.6.0"
-        },
-        "version_support": {
-            "1.6.0": {
-                "end_of_support": "2021-06-21T00:00:00.0Z"
-            }
-        }
+        "version_aliases": {"1.6": "1.6.0"},
+        "version_support": {"1.6.0": {"end_of_support": "2021-06-21T00:00:00.0Z"}},
     }
     dlc_support_policy = "https://aws.amazon.com/releasenotes/dlc-support-policy/"
-    warn_message = image_uris._get_end_of_support_warn_message(config=config, framework="pytorch", version="1.6.0")
+    warn_message = image_uris._get_end_of_support_warn_message(
+        config=config, framework="pytorch", version="1.6.0"
+    )
 
     assert warn_message == (
-        f"The pytorch 1.6.0 DLC has reached end of support. " 
+        f"The pytorch 1.6.0 DLC has reached end of support. "
         f"Please choose a supported version from our support policy - {dlc_support_policy}."
-        )
+    )

--- a/tests/unit/sagemaker/image_uris/test_dlc_frameworks.py
+++ b/tests/unit/sagemaker/image_uris/test_dlc_frameworks.py
@@ -520,3 +520,14 @@ def _sagemaker_or_dlc_account(repo, region):
         )
     else:
         return DLC_ACCOUNT if region == REGION else DLC_ALTERNATE_REGION_ACCOUNTS[region]
+
+
+def test_end_of_support():
+    end_of_support = "2021-06-21T00:00:00.0Z"
+    dlc_support_policy = "https://aws.amazon.com/releasenotes/dlc-support-policy/"
+    warn_message = image_uris._get_end_of_support_warn_message(end_of_support=end_of_support, framework="pytorch", version="1.6.0")
+
+    assert warn_message == (
+        f"Unsupported DLC pytorch version: 1.6.0" 
+        f"Please choose a supported version from our support policy - {dlc_support_policy}"
+        )

--- a/tests/unit/sagemaker/image_uris/test_dlc_frameworks.py
+++ b/tests/unit/sagemaker/image_uris/test_dlc_frameworks.py
@@ -528,6 +528,6 @@ def test_end_of_support():
     warn_message = image_uris._get_end_of_support_warn_message(end_of_support=end_of_support, framework="pytorch", version="1.6.0")
 
     assert warn_message == (
-        f"Unsupported DLC pytorch version: 1.6.0" 
-        f"Please choose a supported version from our support policy - {dlc_support_policy}"
+        f"The pytorch 1.6.0 DLC has reached end of support. " 
+        f"Please choose a supported version from our support policy - {dlc_support_policy}."
         )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
For images that are out of support via public support policy (https://aws.amazon.com/releasenotes/dlc-support-policy/), add warning message if the image is out of support.

TODO:
1. apply end of support to all other images (currently only applied to PT inference)
~~2. add explicit test cases for known out of support images~~

Sample warning message:
```
In [1]: import sagemaker

In [2]: sagemaker.image_uris.retrieve('pytorch', 'us-west-2', version='1.10', image_scope="inference", instance_type='ml.p3.8xlarge')
The pytorch 1.10 DLC has reached end of support. Please choose a supported version from our support policy - https://aws.amazon.com/releasenotes/dlc-support-policy/.
Out[2]: '763104351884.dkr.ecr.us-west-2.amazonaws.com/pytorch-inference:1.10-gpu-py38'

# Note: manually changed 1.10.0 to date within 60 days to test
In [3]: sagemaker.image_uris.retrieve('pytorch', 'us-west-2', version='1.10.0', image_scope="inference", instance_type='ml.p3.8xlarge')
The pytorch 1.10.0 DLC is approaching end of support, and patching will stop on 2023-03-31 UTC. Please choose a supported version from our support policy - https://aws.amazon.com/releasenotes/dlc-support-policy/.
Out[3]: '763104351884.dkr.ecr.us-west-2.amazonaws.com/pytorch-inference:1.10.0-gpu-py38'

In [4]: sagemaker.image_uris.retrieve('pytorch', 'us-west-2', version='1.12', image_scope="inference", instance_type='ml.p3.8xlarge')
Out[4]: '763104351884.dkr.ecr.us-west-2.amazonaws.com/pytorch-inference:1.12-gpu-py38'
```

*Testing done:*
Add unit tests to test warning messages are as expected

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
