### PR TITLE
fix: load_sagemaker_config should lazy initialize a default S3 resource

### DIFF
--- a/src/sagemaker/local/local_session.py
+++ b/src/sagemaker/local/local_session.py
@@ -674,22 +674,19 @@ class LocalSession(Session):
         self.sagemaker_client = LocalSagemakerClient(self)
         self.sagemaker_runtime_client = LocalSagemakerRuntimeClient(self.config)
         self.local_mode = True
-        sagemaker_config = kwargs.get("sagemaker_config", None)
-        if sagemaker_config:
-            validate_sagemaker_config(sagemaker_config)
 
         if self.s3_endpoint_url is not None:
             self.s3_resource = boto_session.resource("s3", endpoint_url=self.s3_endpoint_url)
             self.s3_client = boto_session.client("s3", endpoint_url=self.s3_endpoint_url)
-            self.sagemaker_config = (
-                sagemaker_config
-                if sagemaker_config
-                else load_sagemaker_config(s3_resource=self.s3_resource)
-            )
+
+        sagemaker_config = kwargs.get("sagemaker_config", None)
+        if sagemaker_config:
+            validate_sagemaker_config(sagemaker_config)
+            self.sagemaker_config = sagemaker_config
         else:
-            self.sagemaker_config = (
-                sagemaker_config if sagemaker_config else load_sagemaker_config()
-            )
+            # self.s3_resource might be None. If it is None, load_sagemaker_config will
+            # create a default S3 resource, but only if it needs to fetch from S3
+            self.sagemaker_config = load_sagemaker_config(s3_resource=self.s3_resource)
 
         sagemaker_config_file = os.path.join(os.path.expanduser("~"), ".sagemaker", "config.yaml")
         if os.path.exists(sagemaker_config_file):

--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -266,15 +266,14 @@ class Session(object):  # pylint: disable=too-many-public-methods
         prepend_user_agent(self.sagemaker_metrics_client)
 
         self.local_mode = False
+
         if sagemaker_config:
             validate_sagemaker_config(sagemaker_config)
             self.sagemaker_config = sagemaker_config
         else:
-            if self.s3_resource is None:
-                s3 = self.boto_session.resource("s3", region_name=self.boto_region_name)
-            else:
-                s3 = self.s3_resource
-            self.sagemaker_config = load_sagemaker_config(s3_resource=s3)
+            # self.s3_resource might be None. If it is None, load_sagemaker_config will
+            # create a default S3 resource, but only if it needs to fetch from S3
+            self.sagemaker_config = load_sagemaker_config(s3_resource=self.s3_resource)
 
     @property
     def boto_region_name(self):

--- a/tests/integ/test_sagemaker_config.py
+++ b/tests/integ/test_sagemaker_config.py
@@ -172,10 +172,19 @@ def test_config_download_from_s3_and_merge(
         sagemaker_session=sagemaker_session,
     )
 
+    # Set env variable so load_sagemaker_config can construct an S3 resource in the right region
+    previous_env_value = os.getenv("AWS_DEFAULT_REGION")
+    os.environ["AWS_DEFAULT_REGION"] = sagemaker_session.boto_session.region_name
+
     # The thing being tested.
     sagemaker_config = load_sagemaker_config(
         additional_config_paths=[s3_uri_config_1, config_file_2_local_path]
     )
+
+    # Reset the env variable to what it was before (if it was set before)
+    os.unsetenv("AWS_DEFAULT_REGION")
+    if previous_env_value is not None:
+        os.environ["AWS_DEFAULT_REGION"] = previous_env_value
 
     assert sagemaker_config == expected_merged_config
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
