### PR TITLE
[fix]: Pass sagemaker session to downstream s3 calls

### DIFF
--- a/src/sagemaker/djl_inference/model.py
+++ b/src/sagemaker/djl_inference/model.py
@@ -135,15 +135,17 @@ def _read_existing_serving_properties(directory: str):
     return properties
 
 
-def _get_model_config_properties_from_s3(model_s3_uri: str):
+def _get_model_config_properties_from_s3(model_s3_uri: str, sagemaker_session: Session):
     """Placeholder docstring"""
 
-    s3_files = s3.S3Downloader.list(model_s3_uri)
+    s3_files = s3.S3Downloader.list(model_s3_uri, sagemaker_session=sagemaker_session)
     model_config = None
     for config in defaults.VALID_MODEL_CONFIG_FILES:
         config_file = os.path.join(model_s3_uri, config)
         if config_file in s3_files:
-            model_config = json.loads(s3.S3Downloader.read_file(config_file))
+            model_config = json.loads(
+                s3.S3Downloader.read_file(config_file, sagemaker_session=sagemaker_session)
+            )
             break
     if not model_config:
         raise ValueError(
@@ -198,7 +200,8 @@ class DJLModel(FrameworkModel):
                 "containing folder"
             )
         if model_id.startswith("s3://"):
-            model_config = _get_model_config_properties_from_s3(model_id)
+            sagemaker_session = kwargs.get("sagemaker_session")
+            model_config = _get_model_config_properties_from_s3(model_id, sagemaker_session)
         else:
             model_config = _get_model_config_properties_from_hf(model_id)
         if model_config.get("_class_name") == "StableDiffusionPipeline":

--- a/tests/unit/test_djl_inference.py
+++ b/tests/unit/test_djl_inference.py
@@ -174,6 +174,9 @@ def test_create_model_automatic_engine_selection(mock_s3_list, mock_read_file, s
             sagemaker_session=sagemaker_session,
             number_of_partitions=2,
         )
+        mock_s3_list.assert_any_call(
+            VALID_UNCOMPRESSED_MODEL_DATA, sagemaker_session=sagemaker_session
+        )
         if model_type == defaults.STABLE_DIFFUSION_MODEL_TYPE:
             assert ds_model.engine == DJLServingEngineEntryPointDefaults.STABLE_DIFFUSION
         else:


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/sagemaker-python-sdk/issues/3769

*Description of changes:*
If user provides sagemaker session, we should honor that and pass it to downstream calls.

*Testing done:*
Updated unit test to validate this use case.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
