### PR TITLE
feature: support different types of deletion mode

### DIFF
--- a/src/sagemaker/feature_store/feature_group.py
+++ b/src/sagemaker/feature_store/feature_group.py
@@ -60,6 +60,7 @@ from sagemaker.feature_store.inputs import (
     FeatureValue,
     FeatureParameter,
     TableFormatEnum,
+    DeletionModeEnum,
 )
 from sagemaker.utils import resolve_value_from_config
 
@@ -785,6 +786,7 @@ class FeatureGroup:
         self,
         record_identifier_value_as_string: str,
         event_time: str,
+        deletion_mode: DeletionModeEnum = DeletionModeEnum.SOFT_DELETE,
     ):
         """Delete a single record from a FeatureGroup.
 
@@ -793,11 +795,15 @@ class FeatureGroup:
                 a String representing the value of the record identifier.
             event_time (String):
                 a timestamp format String indicating when the deletion event occurred.
+            deletion_mode (DeletionModeEnum):
+                deletion mode for deleting record. (default: DetectionModeEnum.SOFT_DELETE)
         """
+
         return self.sagemaker_session.delete_record(
             feature_group_name=self.name,
             record_identifier_value_as_string=record_identifier_value_as_string,
             event_time=event_time,
+            deletion_mode=deletion_mode.value,
         )
 
     def ingest(

--- a/src/sagemaker/feature_store/inputs.py
+++ b/src/sagemaker/feature_store/inputs.py
@@ -369,3 +369,13 @@ class Identifier(Config):
             RecordIdentifiersValueAsString=self.record_identifiers_value_as_string,
             FeatureNames=None if not self.feature_names else self.feature_names,
         )
+
+
+class DeletionModeEnum(Enum):
+    """Enum of deletion modes.
+
+    The deletion mode for deleting records can be SoftDelete or HardDelete.
+    """
+
+    SOFT_DELETE = "SoftDelete"
+    HARD_DELETE = "HardDelete"

--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -5196,6 +5196,7 @@ class Session(object):  # pylint: disable=too-many-public-methods
         feature_group_name: str,
         record_identifier_value_as_string: str,
         event_time: str,
+        deletion_mode: str = None,
     ):
         """Deletes a single record from the FeatureGroup.
 
@@ -5203,11 +5204,13 @@ class Session(object):  # pylint: disable=too-many-public-methods
             feature_group_name (str): name of the FeatureGroup.
             record_identifier_value_as_string (str): name of the record identifier.
             event_time (str): a timestamp indicating when the deletion event occurred.
+            deletion_mode: (str): deletion mode for deleting record.
         """
         return self.sagemaker_featurestore_runtime_client.delete_record(
             FeatureGroupName=feature_group_name,
             RecordIdentifierValueAsString=record_identifier_value_as_string,
             EventTime=event_time,
+            DeletionMode=deletion_mode,
         )
 
     def get_record(

--- a/tests/unit/sagemaker/feature_store/test_feature_group.py
+++ b/tests/unit/sagemaker/feature_store/test_feature_group.py
@@ -31,7 +31,7 @@ from sagemaker.feature_store.feature_group import (
     AthenaQuery,
     IngestionError,
 )
-from sagemaker.feature_store.inputs import FeatureParameter
+from sagemaker.feature_store.inputs import FeatureParameter, DeletionModeEnum
 
 from tests.unit import SAGEMAKER_CONFIG_FEATURE_GROUP
 
@@ -296,6 +296,41 @@ def test_delete_record(sagemaker_session_mock):
         feature_group_name="MyFeatureGroup",
         record_identifier_value_as_string=record_identifier_value_as_string,
         event_time=event_time,
+        deletion_mode=DeletionModeEnum.SOFT_DELETE.value,
+    )
+
+
+def test_soft_delete_record(sagemaker_session_mock):
+    feature_group = FeatureGroup(name="MyFeatureGroup", sagemaker_session=sagemaker_session_mock)
+    record_identifier_value_as_string = "1.0"
+    event_time = "2022-09-14"
+    feature_group.delete_record(
+        record_identifier_value_as_string=record_identifier_value_as_string,
+        event_time=event_time,
+        deletion_mode=DeletionModeEnum.SOFT_DELETE,
+    )
+    sagemaker_session_mock.delete_record.assert_called_with(
+        feature_group_name="MyFeatureGroup",
+        record_identifier_value_as_string=record_identifier_value_as_string,
+        event_time=event_time,
+        deletion_mode=DeletionModeEnum.SOFT_DELETE.value,
+    )
+
+
+def test_hard_delete_record(sagemaker_session_mock):
+    feature_group = FeatureGroup(name="MyFeatureGroup", sagemaker_session=sagemaker_session_mock)
+    record_identifier_value_as_string = "1.0"
+    event_time = "2022-09-14"
+    feature_group.delete_record(
+        record_identifier_value_as_string=record_identifier_value_as_string,
+        event_time=event_time,
+        deletion_mode=DeletionModeEnum.HARD_DELETE,
+    )
+    sagemaker_session_mock.delete_record.assert_called_with(
+        feature_group_name="MyFeatureGroup",
+        record_identifier_value_as_string=record_identifier_value_as_string,
+        event_time=event_time,
+        deletion_mode=DeletionModeEnum.HARD_DELETE.value,
     )
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes: Add support for specifying different record deletion modes

*Testing done: Unit and integration testing

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
