### PR TITLE
Support npz archives in NumpyDeserializer

### DIFF
--- a/tests/unit/sagemaker/test_deserializers.py
+++ b/tests/unit/sagemaker/test_deserializers.py
@@ -164,6 +164,23 @@ def test_numpy_deserializer_from_npy_object_array_with_allow_pickle_false():
         numpy_deserializer.deserialize(stream, "application/x-npy")
 
 
+def test_numpy_deserializer_from_npz(numpy_deserializer):
+    arrays = {
+        "alpha": np.ones((2, 3)),
+        "beta": np.zeros((3, 2)),
+    }
+    stream = io.BytesIO()
+    np.savez_compressed(stream, **arrays)
+    stream.seek(0)
+
+    result = numpy_deserializer.deserialize(stream, "application/x-npz")
+
+    assert isinstance(result, np.lib.npyio.NpzFile)
+    assert set(arrays.keys()) == set(result.keys())
+    for key, arr in arrays.items():
+        assert np.array_equal(arr, result[key])
+
+
 @pytest.fixture
 def json_deserializer():
     return JSONDeserializer()


### PR DESCRIPTION
**Issue #, if available:** #3696

**Description of changes:**

Enable the built-in `NumpyDeserializer` to read `application/x-npz` archives (which may be produced model-side by e.g. [numpy.savez](https://numpy.org/doc/stable/reference/generated/numpy.savez.html) or [numpy.savez_compressed](https://numpy.org/doc/stable/reference/generated/numpy.savez_compressed.html)) containing multiple named arrays. Added a unit test to exercise the new functionality.

As mentioned in the attached issue, this feature is already implemented in the same `numpy.load` method the serializer currently calls, but the typical `application/x-npz` Content Type is rejected by the header check.

**Testing done:**

- Run linting/formatting/etc locally
- Added unit test to demonstrate the deserialization

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
