### PR TITLE
Add Data Wrangler 2.x container URIs

### DIFF
--- a/src/sagemaker/image_uri_config/data-wrangler.json
+++ b/src/sagemaker/image_uri_config/data-wrangler.json
@@ -27,6 +27,33 @@
           "cn-northwest-1": "249157047649"
         },
         "repository": "sagemaker-data-wrangler-container"
+      },
+      "2.x": {
+        "registries": {
+          "af-south-1": "143210264188",
+          "ap-east-1": "707077482487",
+          "ap-northeast-1": "649008135260",
+          "ap-northeast-2": "131546521161",
+          "ap-south-1": "089933028263",
+          "ap-southeast-1": "119527597002",
+          "ap-southeast-2": "422173101802",
+          "ca-central-1": "557239378090",
+          "eu-central-1": "024640144536",
+          "eu-north-1": "054986407534",
+          "eu-south-1": "488287956546",
+          "eu-west-1": "245179582081",
+          "eu-west-2": "894491911112",
+          "eu-west-3": "807237891255",
+          "me-south-1": "376037874950",
+          "sa-east-1": "424196993095",
+          "us-east-1": "663277389841",
+          "us-east-2": "415577184552",
+          "us-west-1": "926135532090",
+          "us-west-2": "174368400705",
+          "cn-north-1": "245909111842",
+          "cn-northwest-1": "249157047649"
+        },
+        "repository": "sagemaker-data-wrangler-container"
       }
     }
   }

--- a/src/sagemaker/image_uris.py
+++ b/src/sagemaker/image_uris.py
@@ -462,6 +462,13 @@ def _validate_version_and_set_if_needed(version, config, framework):
 
         return available_versions[0]
 
+    if version is None and framework == "data-wrangler":
+        logger.warning(
+            "Defaulting unspecified Data Wrangler version to '1.x' for backward compatibility. "
+            "Consider specifying version='2.x' or newer."
+        )
+        version = "1.x"
+
     _validate_arg(version, available_versions + aliased_versions, "{} version".format(framework))
     return version
 

--- a/tests/unit/sagemaker/image_uris/test_data_wrangler.py
+++ b/tests/unit/sagemaker/image_uris/test_data_wrangler.py
@@ -12,6 +12,8 @@
 # language governing permissions and limitations under the License.
 from __future__ import absolute_import
 
+import pytest
+
 from sagemaker import image_uris
 from tests.unit.sagemaker.image_uris import expected_uris
 
@@ -39,9 +41,12 @@ DATA_WRANGLER_ACCOUNTS = {
     "cn-north-1": "245909111842",
     "cn-northwest-1": "249157047649",
 }
+VERSIONS = ["1.x", "2.x"]
 
 
-def test_data_wrangler_ecr_uri():
+def test_data_wrangler_ecr_uri_default_version():
+    # Added so we could introduce version '2.x' without breaking any workflows that previously
+    # relied on implicit '1.x' (the only listed version)
     for region in DATA_WRANGLER_ACCOUNTS.keys():
         actual_uri = image_uris.retrieve("data-wrangler", region=region)
         expected_uri = expected_uris.algo_uri(
@@ -49,5 +54,18 @@ def test_data_wrangler_ecr_uri():
             DATA_WRANGLER_ACCOUNTS[region],
             region,
             version="1.x",
+        )
+        assert expected_uri == actual_uri
+
+
+@pytest.mark.parametrize("version", VERSIONS)
+def test_data_wrangler_ecr_uri(version):
+    for region in DATA_WRANGLER_ACCOUNTS.keys():
+        actual_uri = image_uris.retrieve("data-wrangler", region=region, version=version)
+        expected_uri = expected_uris.algo_uri(
+            "sagemaker-data-wrangler-container",
+            DATA_WRANGLER_ACCOUNTS[region],
+            region,
+            version=version,
         )
         assert expected_uri == actual_uri


### PR DESCRIPTION
Extend image_uris.retrieve() to support newer '2.x' Data Wrangler processing containers in addition to the existing '1.x'. Add handling logic for backward compatibility with any any user code that did not specify a framework version and assumed resolution to '1.x'.

**Issue #, if available:** #3798

**Description of changes:**

- Extend `image_uris.retrieve()` to support newer `2.x` Data Wrangler processing containers (which now seem to be generated when exporting from Data Wrangler UI to a notebook in Studio), in addition to the existing `1.x` series.
- Add handling logic to maintain backward compatibility for any user code that did not specify a framework version for data-wrangler and assumed implicit resolution to `1.x` (Is this necessary/right? Or should we force users to explicitly select a version like with other frameworks, or default to the newer version rather than the older one?)

**Testing done:**

Reflected the changes in unit tests, but as far as I can tell there are no existing integration tests for starting Data Wrangler jobs? Maybe that work would be better tackled as part of a more end-to-end usability project like #2771?

We also seem not to be able to pull this image, so I've copied the 1.x regional account IDs as-is but don't really have a scalable way to check they're all still valid for 2.x. So far I've manually confirmed (by generating flow export notebooks) the account IDs seem to match for at least: `ap-northeast-1`, `ap-southeast-1`, `us-east-1`, `us-east-2`

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [X] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [X] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [X] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] ~I have passed the region in to all S3 and STS clients that I've initialized as part of this change.~ (N/A)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [X] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [X] I have added unit ~and/or integration~ tests as appropriate to ensure backward compatibility of the changes
- [X] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
