### PR TITLE
feature: Enable default role for Spark processors

### DIFF
--- a/src/sagemaker/spark/processing.py
+++ b/src/sagemaker/spark/processing.py
@@ -122,11 +122,11 @@ class _SparkProcessorBase(ScriptProcessor):
             framework_version (str): The version of SageMaker PySpark.
             py_version (str): The version of python.
             container_version (str): The version of spark container.
-            role (str): An AWS IAM role name or ARN. The Amazon SageMaker training jobs
-                and APIs that create Amazon SageMaker endpoints use this role
-                to access training data and model artifacts. After the endpoint
-                is created, the inference code might use the IAM role, if it
-                needs to access an AWS resource.
+            role (str): An AWS IAM role name or ARN. Amazon SageMaker Processing
+                uses this role to access AWS resources, such as
+                data stored in Amazon S3 (default: None).
+                If not specified, the value from the defaults configuration file
+                will be used.
             instance_type (str): Type of EC2 instance to use for
                 processing, for example, 'ml.c4.xlarge'.
             instance_count (int): The number of instances to run
@@ -761,11 +761,11 @@ class PySparkProcessor(_SparkProcessorBase):
             framework_version (str): The version of SageMaker PySpark.
             py_version (str): The version of python.
             container_version (str): The version of spark container.
-            role (str): An AWS IAM role name or ARN. The Amazon SageMaker training jobs
-                and APIs that create Amazon SageMaker endpoints use this role
-                to access training data and model artifacts. After the endpoint
-                is created, the inference code might use the IAM role, if it
-                needs to access an AWS resource.
+            role (str): An AWS IAM role name or ARN. Amazon SageMaker Processing
+                uses this role to access AWS resources, such as
+                data stored in Amazon S3 (default: None).
+                If not specified, the value from the defaults configuration file
+                will be used.
             instance_type (str or PipelineVariable): Type of EC2 instance to use for
                 processing, for example, 'ml.c4.xlarge'.
             instance_count (int or PipelineVariable): The number of instances to run
@@ -1038,11 +1038,11 @@ class SparkJarProcessor(_SparkProcessorBase):
             framework_version (str): The version of SageMaker PySpark.
             py_version (str): The version of python.
             container_version (str): The version of spark container.
-            role (str): An AWS IAM role name or ARN. The Amazon SageMaker training jobs
-                and APIs that create Amazon SageMaker endpoints use this role
-                to access training data and model artifacts. After the endpoint
-                is created, the inference code might use the IAM role, if it
-                needs to access an AWS resource.
+            role (str): An AWS IAM role name or ARN. Amazon SageMaker Processing
+                uses this role to access AWS resources, such as
+                data stored in Amazon S3 (default: None).
+                If not specified, the value from the defaults configuration file
+                will be used.
             instance_type (str or PipelineVariable): Type of EC2 instance to use for
                 processing, for example, 'ml.c4.xlarge'.
             instance_count (int or PipelineVariable): The number of instances to run

--- a/src/sagemaker/spark/processing.py
+++ b/src/sagemaker/spark/processing.py
@@ -733,9 +733,9 @@ class PySparkProcessor(_SparkProcessorBase):
 
     def __init__(
         self,
-        role: str,
-        instance_type: Union[str, PipelineVariable],
-        instance_count: Union[int, PipelineVariable],
+        role: str = None,
+        instance_type: Union[str, PipelineVariable] = None,
+        instance_count: Union[int, PipelineVariable] = None,
         framework_version: Optional[str] = None,
         py_version: Optional[str] = None,
         container_version: Optional[str] = None,
@@ -1010,9 +1010,9 @@ class SparkJarProcessor(_SparkProcessorBase):
 
     def __init__(
         self,
-        role: str,
-        instance_type: Union[str, PipelineVariable],
-        instance_count: Union[int, PipelineVariable],
+        role: str = None,
+        instance_type: Union[str, PipelineVariable] = None,
+        instance_count: Union[int, PipelineVariable] = None,
         framework_version: Optional[str] = None,
         py_version: Optional[str] = None,
         container_version: Optional[str] = None,


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
This patch enables setting [default values](https://aws.amazon.com/about-aws/whats-new/2023/03/amazon-sagemaker-python-sdk-default-values-parameters/) (`role` parameter) for Spark processors.

*Testing done:*
Yes

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
