### PR TITLE
documentation: fix minor misses from the remote function doc release

### DIFF
--- a/doc/remote_function/sagemaker.remote_function.rst
+++ b/doc/remote_function/sagemaker.remote_function.rst
@@ -9,7 +9,7 @@ Remote function classes and methods specification
 
 
 RemoteExecutor
--------------
+--------------
 
 .. autoclass:: sagemaker.remote_function.RemoteExecutor
     :members:

--- a/doc/remote_function/sagemaker.remote_function.rst
+++ b/doc/remote_function/sagemaker.remote_function.rst
@@ -8,7 +8,7 @@ Remote function classes and methods specification
 .. automethod:: sagemaker.remote_function.client.remote
 
 
-RemoteExcutor
+RemoteExecutor
 -------------
 
 .. autoclass:: sagemaker.remote_function.RemoteExecutor

--- a/src/sagemaker/remote_function/client.py
+++ b/src/sagemaker/remote_function/client.py
@@ -87,7 +87,7 @@ def remote(
     This decorator wraps the annotated code and runs it as a new SageMaker job synchronously
     with the provided runtime settings.
 
-    In case a parameter value is not set, the decorator first looks up the value from the SageMaker
+    If a parameter value is not set, the decorator first looks up the value from the SageMaker
     configuration file. If no value is specified in the configuration file or no configuration file
     is found, the decorator selects the default as specified below. For more information, see
     `Configuring and using defaults with the SageMaker Python SDK <https://sagemaker.readthedocs.io/
@@ -475,7 +475,7 @@ class RemoteExecutor(object):
     ):
         """Constructor for RemoteExecutor
 
-        In case a parameter value is not set, the constructor first looks up the value from the
+        If a parameter value is not set, the constructor first looks up the value from the
         SageMaker configuration file. If no value is specified in the configuration file or
         no configuration file is found, the constructor selects the default as specified below.
         For more information, see `Configuring and using defaults with the SageMaker Python SDK
@@ -1045,28 +1045,28 @@ class Future(object):
             return True
 
     def running(self) -> bool:
-        """Check if the underlying sagemaker job is running.
+        """Check if the underlying SageMaker job is running.
 
         Returns:
-            ``True`` if the underlying sagemaker job is still running. ``False``, otherwise.
+            ``True`` if the underlying SageMaker job is still running. ``False``, otherwise.
         """
         with self._condition:
             return self._state == _RUNNING
 
     def cancelled(self) -> bool:
-        """Check if the underlying sagemaker job was cancelled.
+        """Check if the underlying SageMaker job was cancelled.
 
         Returns:
-            ``True`` if the underlying sagemaker job was cancelled. ``False``, otherwise.
+            ``True`` if the underlying SageMaker job was cancelled. ``False``, otherwise.
         """
         with self._condition:
             return self._state == _CANCELLED
 
     def done(self) -> bool:
-        """Check if the underlying sagemaker job is finished.
+        """Check if the underlying SageMaker job is finished.
 
         Returns:
-            ``True`` if the underlying sagemaker job finished running. ``False``, otherwise.
+            ``True`` if the underlying SageMaker job finished running. ``False``, otherwise.
         """
         with self._condition:
             if self._state == _RUNNING and self._job.describe()["TrainingJobStatus"] in [

--- a/src/sagemaker/remote_function/client.py
+++ b/src/sagemaker/remote_function/client.py
@@ -1052,7 +1052,7 @@ class Future(object):
         with self._condition:
             return self._state == _RUNNING
 
-    def cancelled(self):
+    def cancelled(self) -> bool:
         """
         Returns:
             ``True`` if the underlying sagemaker job was cancelled. ``False``, otherwise.
@@ -1060,7 +1060,7 @@ class Future(object):
         with self._condition:
             return self._state == _CANCELLED
 
-    def done(self):
+    def done(self) -> bool:
         """
         Returns:
             ``True`` if the underlying sagemaker job finished running.
@@ -1079,7 +1079,7 @@ class Future(object):
             return False
 
 
-def get_future(job_name, sagemaker_session=None):
+def get_future(job_name, sagemaker_session=None) -> Future:
     """Get a future object with information about a job with the given job_name.
 
     Args:

--- a/src/sagemaker/remote_function/client.py
+++ b/src/sagemaker/remote_function/client.py
@@ -87,7 +87,7 @@ def remote(
     This decorator wraps the annotated code and runs it as a new SageMaker job synchronously
     with the provided runtime settings.
 
-    Unless mentioned otherwise, the decorator first looks up the value from the SageMaker
+    In case a parameter value is not set, the decorator first looks up the value from the SageMaker
     configuration file. If no value is specified in the configuration file or no configuration file
     is found, the decorator selects the default as specified below. For more information, see
     `Configuring and using defaults with the SageMaker Python SDK <https://sagemaker.readthedocs.io/
@@ -131,7 +131,7 @@ def remote(
               annotated with the remote decorator is invoked using the Python runtime available
               in the system path.
 
-          * The parameter dependencies is set to auto_capture. SageMaker will automatically
+          * The parameter dependencies is set to ``auto_capture``. SageMaker will automatically
             generate an env_snapshot.yml corresponding to the current active conda environment’s
             snapshot. You do not need to provide a dependencies file. The following conditions
             apply:
@@ -204,7 +204,7 @@ def remote(
           downloaded in the previous runs.
 
         max_retry_attempts (int): The max number of times the job is retried on
-          ```InternalServerFailure``` Error from SageMaker service. Defaults to 1.
+          ``InternalServerFailure`` Error from SageMaker service. Defaults to 1.
 
         max_runtime_in_seconds (int): The upper limit in seconds to be used for training. After
           this specified amount of time, SageMaker terminates the job regardless of its current
@@ -475,10 +475,10 @@ class RemoteExecutor(object):
     ):
         """Constructor for RemoteExecutor
 
-        Unless mentioned otherwise, the constructor first looks up the value from the SageMaker
-        configuration file. If no value is specified in the configuration file or no configuration
-        file is found, the constructor selects the default as specified below. For more
-        information, see `Configuring and using defaults with the SageMaker Python SDK
+        In case a parameter value is not set, the constructor first looks up the value from the
+        SageMaker configuration file. If no value is specified in the configuration file or
+        no configuration file is found, the constructor selects the default as specified below.
+        For more information, see `Configuring and using defaults with the SageMaker Python SDK
         <https://sagemaker.readthedocs.io/en/stable/overview.html
         #configuring-and-using-defaults-with-the-sagemaker-python-sdk>`_.
 
@@ -520,7 +520,7 @@ class RemoteExecutor(object):
                 annotated with the remote decorator is invoked using the Python runtime available
                 in the system path.
 
-            * The parameter dependencies is set to auto_capture. SageMaker will automatically
+            * The parameter dependencies is set to ``auto_capture``. SageMaker will automatically
                 generate an env_snapshot.yml corresponding to the current active conda environment’s
                 snapshot. You do not need to provide a dependencies file. The following conditions
                 apply:
@@ -595,7 +595,7 @@ class RemoteExecutor(object):
             max_parallel_jobs (int): Maximum number of jobs that run in parallel. Defaults to 1.
 
             max_retry_attempts (int): The max number of times the job is retried on
-              ```InternalServerFailure``` Error from SageMaker service. Defaults to 1.
+              ``InternalServerFailure`` Error from SageMaker service. Defaults to 1.
 
             max_runtime_in_seconds (int): The upper limit in seconds to be used for training. After
               this specified amount of time, SageMaker terminates the job regardless of its current
@@ -1012,7 +1012,8 @@ class Future(object):
             timeout (int): Timeout in seconds to wait until the job is completed before it is
               stopped. Defaults to ``None``.
 
-        Returns: None
+        Returns:
+            None
         """
 
         with self._condition:
@@ -1022,14 +1023,15 @@ class Future(object):
             if self._state == _RUNNING:
                 self._job.wait(timeout=timeout)
 
-    def cancel(self):
+    def cancel(self) -> bool:
         """Cancel the function execution.
 
         This method prevents the SageMaker job being created or stops the underlying SageMaker job
         early if it is already in progress.
 
-        Returns: ``True`` if the underlying SageMaker job created as a result of the remote function
-          run is cancelled.
+        Returns:
+            ``True`` if the underlying SageMaker job created as a result of the remote function
+            run is cancelled.
         """
         with self._condition:
             if self._state == _FINISHED:
@@ -1042,18 +1044,27 @@ class Future(object):
             self._state = _CANCELLED
             return True
 
-    def running(self):
-        """Returns ``True`` if the underlying sagemaker job is still running."""
+    def running(self) -> bool:
+        """
+        Returns:
+            ``True`` if the underlying sagemaker job is still running.
+        """
         with self._condition:
             return self._state == _RUNNING
 
     def cancelled(self):
-        """Returns ``True`` if the underlying sagemaker job was cancelled. ``False``, otherwise."""
+        """
+        Returns:
+            ``True`` if the underlying sagemaker job was cancelled. ``False``, otherwise.
+        """
         with self._condition:
             return self._state == _CANCELLED
 
     def done(self):
-        """Returns ``True`` if the underlying sagemaker job finished running."""
+        """
+        Returns:
+            ``True`` if the underlying sagemaker job finished running.
+        """
         with self._condition:
             if self._state == _RUNNING and self._job.describe()["TrainingJobStatus"] in [
                 "Completed",

--- a/src/sagemaker/remote_function/client.py
+++ b/src/sagemaker/remote_function/client.py
@@ -1045,15 +1045,17 @@ class Future(object):
             return True
 
     def running(self) -> bool:
-        """
+        """Check if the underlying sagemaker job is running.
+
         Returns:
-            ``True`` if the underlying sagemaker job is still running.
+            ``True`` if the underlying sagemaker job is still running. ``False``, otherwise.
         """
         with self._condition:
             return self._state == _RUNNING
 
     def cancelled(self) -> bool:
-        """
+        """Check if the underlying sagemaker job was cancelled.
+
         Returns:
             ``True`` if the underlying sagemaker job was cancelled. ``False``, otherwise.
         """
@@ -1061,9 +1063,10 @@ class Future(object):
             return self._state == _CANCELLED
 
     def done(self) -> bool:
-        """
+        """Check if the underlying sagemaker job is finished.
+
         Returns:
-            ``True`` if the underlying sagemaker job finished running.
+            ``True`` if the underlying sagemaker job finished running. ``False``, otherwise.
         """
         with self._condition:
             if self._state == _RUNNING and self._job.describe()["TrainingJobStatus"] in [


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Address some small misses from remote function doc release.

*Testing done:*
* ran `tox -e twine,sphinx --parallel` locally - no failures.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
