### PR TITLE
fix: make RemoteExecutor context manager non-blocking on pending futures

### DIFF
--- a/src/sagemaker/remote_function/client.py
+++ b/src/sagemaker/remote_function/client.py
@@ -731,7 +731,7 @@ class RemoteExecutor(object):
         futures = map(self.submit, itertools.repeat(func), *iterables)
         return [future.result() for future in futures]
 
-    def shutdown(self):
+    def shutdown(self, wait=True):
         """Prevent more function executions to be submitted to this executor."""
         with self._state_condition:
             self._shutdown = True
@@ -742,7 +742,7 @@ class RemoteExecutor(object):
             self._state_condition.notify_all()
 
         if self._workers is not None:
-            self._workers.shutdown(wait=True)
+            self._workers.shutdown(wait)
 
     def __enter__(self):
         """Create an executor instance and return it"""
@@ -750,7 +750,7 @@ class RemoteExecutor(object):
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         """Make sure the executor instance is shutdown."""
-        self.shutdown()
+        self.shutdown(wait=False)
         return False
 
     @staticmethod

--- a/tests/unit/sagemaker/remote_function/test_client.py
+++ b/tests/unit/sagemaker/remote_function/test_client.py
@@ -509,6 +509,11 @@ def test_executor_submit_happy_case(mock_start, mock_job_settings, parallelism):
         future_3 = e.submit(job_function, 9, 10, c=11, d=12)
         future_4 = e.submit(job_function, 13, 14, c=15, d=16)
 
+    future_1.wait()
+    future_2.wait()
+    future_3.wait()
+    future_4.wait()
+
     mock_start.assert_has_calls(
         [
             call(ANY, job_function, (1, 2), {"c": 3, "d": 4}, None),
@@ -517,10 +522,6 @@ def test_executor_submit_happy_case(mock_start, mock_job_settings, parallelism):
             call(ANY, job_function, (13, 14), {"c": 15, "d": 16}, None),
         ]
     )
-    mock_job_1.describe.assert_called()
-    mock_job_2.describe.assert_called()
-    mock_job_3.describe.assert_called()
-    mock_job_4.describe.assert_called()
 
     assert future_1.done()
     assert future_2.done()
@@ -545,14 +546,15 @@ def test_executor_submit_with_run(mock_start, mock_job_settings, run_obj):
             future_1 = e.submit(job_function, 1, 2, c=3, d=4)
             future_2 = e.submit(job_function, 5, 6, c=7, d=8)
 
+    future_1.wait()
+    future_2.wait()
+
     mock_start.assert_has_calls(
         [
             call(ANY, job_function, (1, 2), {"c": 3, "d": 4}, run_info),
             call(ANY, job_function, (5, 6), {"c": 7, "d": 8}, run_info),
         ]
     )
-    mock_job_1.describe.assert_called()
-    mock_job_2.describe.assert_called()
 
     assert future_1.done()
     assert future_2.done()
@@ -562,14 +564,15 @@ def test_executor_submit_with_run(mock_start, mock_job_settings, run_obj):
             future_3 = e.submit(job_function, 9, 10, c=11, d=12)
             future_4 = e.submit(job_function, 13, 14, c=15, d=16)
 
+    future_3.wait()
+    future_4.wait()
+
     mock_start.assert_has_calls(
         [
             call(ANY, job_function, (9, 10), {"c": 11, "d": 12}, run_info),
             call(ANY, job_function, (13, 14), {"c": 15, "d": 16}, run_info),
         ]
     )
-    mock_job_3.describe.assert_called()
-    mock_job_4.describe.assert_called()
 
     assert future_3.done()
     assert future_4.done()
@@ -621,7 +624,7 @@ def test_executor_fails_to_start_job(mock_start, *args):
 
     with pytest.raises(TypeError):
         future_1.result()
-    print(future_2._state)
+    future_2.wait()
     assert future_2.done()
 
 
@@ -678,6 +681,8 @@ def test_executor_describe_job_throttled_temporarily(mock_start, *args):
         # submit second job
         future_2 = e.submit(job_function, 5, 6, c=7, d=8)
 
+    future_1.wait()
+    future_2.wait()
     assert future_1.done()
     assert future_2.done()
 
@@ -697,9 +702,9 @@ def test_executor_describe_job_failed_permanently(mock_start, *args):
         future_2 = e.submit(job_function, 5, 6, c=7, d=8)
 
     with pytest.raises(RuntimeError):
-        future_1.done()
+        future_1.result()
     with pytest.raises(RuntimeError):
-        future_2.done()
+        future_2.result()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Right now, the `RemoteExecutor` context manager blocks on all pending futures completing. This is not the intended behavior. This change makes it non-blocking by changing the value of `wait` parameter provided to `ThreadPoolExecutor.shutdown()`  https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.Executor.shutdown

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
