### PR TITLE
[feat] Add FasterTransformer DJL support

### DIFF
--- a/doc/frameworks/djl/sagemaker.djl_inference.rst
+++ b/doc/frameworks/djl/sagemaker.djl_inference.rst
@@ -26,6 +26,14 @@ HuggingFaceAccelerateModel
     :undoc-members:
     :show-inheritance:
 
+FasterTransformerModel
+---------------------------
+
+.. autoclass:: sagemaker.djl_inference.model.FasterTransformerModel
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 DJLPredictor
 ---------------------------
 

--- a/doc/frameworks/djl/using_djl.rst
+++ b/doc/frameworks/djl/using_djl.rst
@@ -23,7 +23,7 @@ With the SageMaker Python SDK, you can use DJL Serving to host models that have 
 These can either be models you have trained/fine-tuned yourself, or models available publicly from the HuggingFace Hub.
 DJL Serving in the SageMaker Python SDK supports hosting models for the popular HuggingFace NLP tasks, as well as Stable Diffusion.
 
-You can either deploy your model using DeepSpeed or HuggingFace Accelerate, or let DJL Serving determine the best backend based on your model architecture and configuration.
+You can either deploy your model using DeepSpeed, FasterTransformer, or HuggingFace Accelerate, or let DJL Serving determine the best backend based on your model architecture and configuration.
 
 .. code:: python
 
@@ -63,11 +63,23 @@ If you want to use a specific backend, then you can create an instance of the co
         number_of_partitions=2, # number of gpus to partition the model across
     )
 
+    # Create a model using the FasterTransformer backend
+
+    fastertransformer_model = FasterTransformerModel(
+        "s3://my_bucket/my_saved_model_artifacts/", # This can also be a HuggingFace Hub model id
+        "my_sagemaker_role",
+        data_type="fp16",
+        task="text-generation",
+        tensor_parallel_degree=2, # number of gpus to partition the model across
+    )
+
     # Deploy the model to an Amazon SageMaker Endpoint and get a Predictor
     deepspeed_predictor = deepspeed_model.deploy("ml.g5.12xlarge",
                                                  initial_instance_count=1)
     hf_accelerate_predictor = hf_accelerate_model.deploy("ml.g5.12xlarge",
                                                          initial_instance_count=1)
+    fastertransformer_predictor = fastertransformer_model.deploy("ml.g5.12xlarge",
+                                                                 initial_instance_count=1)
 
 Regardless of which way you choose to create your model, a ``Predictor`` object is returned. You can use this ``Predictor``
 to do inference on the endpoint hosting your DJLModel.

--- a/src/sagemaker/djl_inference/__init__.py
+++ b/src/sagemaker/djl_inference/__init__.py
@@ -17,3 +17,4 @@ from sagemaker.djl_inference.model import DJLPredictor  # noqa: F401
 from sagemaker.djl_inference.model import DJLModel  # noqa: F401
 from sagemaker.djl_inference.model import DeepSpeedModel  # noqa: F401
 from sagemaker.djl_inference.model import HuggingFaceAccelerateModel  # noqa: F401
+from sagemaker.djl_inference.model import FasterTransformerModel  # noqa: F401

--- a/src/sagemaker/djl_inference/defaults.py
+++ b/src/sagemaker/djl_inference/defaults.py
@@ -30,17 +30,19 @@ DEEPSPEED_RECOMMENDED_ARCHITECTURES = {
     STABLE_DIFFUSION_MODEL_TYPE,
 }
 
-DEEPSPEED_SUPPORTED_ARCHITECTURES = {
+FASTER_TRANSFORMER_RECOMMENDED_ARCHITECTURES = {
+    "t5",
+}
+
+FASTER_TRANSFORMER_SUPPORTED_ARCHITECTURES = {
+    "bert",
+    "gpt2",
     "bloom",
     "opt",
-    "gpt_neox",
     "gptj",
+    "gpt_neox",
     "gpt_neo",
-    "gpt2",
-    "xlm-roberta",
-    "roberta",
-    "bert",
-    STABLE_DIFFUSION_MODEL_TYPE,
+    "t5",
 }
 
 ALLOWED_INSTANCE_FAMILIES = {

--- a/tests/unit/test_djl_inference.py
+++ b/tests/unit/test_djl_inference.py
@@ -147,7 +147,7 @@ def test_create_model_automatic_engine_selection(mock_s3_list, mock_read_file, s
         sagemaker_session=sagemaker_session,
         number_of_partitions=4,
     )
-    assert hf_model.engine == DJLServingEngineEntryPointDefaults.HUGGINGFACE_ACCELERATE
+    assert hf_model.engine == DJLServingEngineEntryPointDefaults.FASTER_TRANSFORMER
 
     hf_model_config = {
         "model_type": "gpt2",
@@ -199,20 +199,6 @@ def test_create_deepspeed_model(mock_s3_list, mock_read_file, sagemaker_session)
         tensor_parallel_degree=4,
     )
     assert ds_model.engine == DJLServingEngineEntryPointDefaults.DEEPSPEED
-
-    ds_model_config = {
-        "model_type": "t5",
-        "n_head": 12,
-    }
-    mock_read_file.return_value = json.dumps(ds_model_config)
-    with pytest.raises(ValueError) as invalid_model_type:
-        _ = DeepSpeedModel(
-            VALID_UNCOMPRESSED_MODEL_DATA,
-            ROLE,
-            sagemaker_session=sagemaker_session,
-            tensor_parallel_degree=1,
-        )
-    assert str(invalid_model_type.value).startswith("t5 is not supported by DeepSpeed")
 
     ds_model_config = {
         "model_type": "opt",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds support for DJLFasterTransformer container in djl_inference module.

*Testing done:*
endpoint tested on ml.g5.48xlarge

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
