### PR TITLE
fix: Skip edge test

### DIFF
--- a/tests/integ/test_edge.py
+++ b/tests/integ/test_edge.py
@@ -58,7 +58,9 @@ def mxnet_training_job(
         return mx.latest_training_job.name
 
 
-@pytest.mark.skip(reason="Edge has been deprecated. Skipping until feature team deprecates functionality.")
+@pytest.mark.skip(
+    reason="Edge has been deprecated. Skipping until feature team deprecates functionality."
+)
 def test_edge_packaging_job(mxnet_training_job, sagemaker_session):
     estimator = MXNet.attach(mxnet_training_job, sagemaker_session=sagemaker_session)
     model = estimator.compile_model(

--- a/tests/integ/test_edge.py
+++ b/tests/integ/test_edge.py
@@ -20,8 +20,6 @@ from sagemaker.mxnet.estimator import MXNet
 from tests.integ import (
     DATA_DIR,
     TRAINING_DEFAULT_TIMEOUT_MINUTES,
-    EDGE_PACKAGING_SUPPORTED_REGIONS,
-    test_region,
 )
 from tests.integ.timeout import timeout
 

--- a/tests/integ/test_edge.py
+++ b/tests/integ/test_edge.py
@@ -58,10 +58,7 @@ def mxnet_training_job(
         return mx.latest_training_job.name
 
 
-@pytest.mark.skipif(
-    test_region() not in EDGE_PACKAGING_SUPPORTED_REGIONS,
-    reason="Edge packaging isn't supported in that specific region.",
-)
+@pytest.mark.skip(reason="Edge has been deprecated. Skipping until feature team deprecates functionality.")
 def test_edge_packaging_job(mxnet_training_job, sagemaker_session):
     estimator = MXNet.attach(mxnet_training_job, sagemaker_session=sagemaker_session)
     model = estimator.compile_model(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Test failed with error `E           botocore.exceptions.ClientError: An error occurred (ValidationException) when calling the CreateEdgePackagingJob operation: We are retiring Amazon Sagemaker Edge on April 26th, 2024. Use this (step-by-step guide)<https://docs.aws.amazon.com/sagemaker/latest/dg/edge-eol.html> to learn about how to continue deploying your models to edge devices`. Disabling test until feature team can fix/deprecate feature

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
