### PR TITLE
[change] change data_type argument to dtype to keep consistent with D…

### DIFF
--- a/doc/frameworks/djl/using_djl.rst
+++ b/doc/frameworks/djl/using_djl.rst
@@ -31,7 +31,7 @@ You can either deploy your model using DeepSpeed or HuggingFace Accelerate, or l
     djl_model = DJLModel(
         "s3://my_bucket/my_saved_model_artifacts/", # This can also be a HuggingFace Hub model id
         "my_sagemaker_role",
-        data_type="fp16",
+        dtype="fp16",
         task="text-generation",
         number_of_partitions=2 # number of gpus to partition the model across
     )
@@ -48,7 +48,7 @@ If you want to use a specific backend, then you can create an instance of the co
     deepspeed_model = DeepSpeedModel(
         "s3://my_bucket/my_saved_model_artifacts/", # This can also be a HuggingFace Hub model id
         "my_sagemaker_role",
-        data_type="bf16",
+        dtype="bf16",
         task="text-generation",
         tensor_parallel_degree=2, # number of gpus to partition the model across using tensor parallelism
     )
@@ -58,7 +58,7 @@ If you want to use a specific backend, then you can create an instance of the co
     hf_accelerate_model = HuggingFaceAccelerateModel(
         "s3://my_bucket/my_saved_model_artifacts/", # This can also be a HuggingFace Hub model id
         "my_sagemaker_role",
-        data_type="fp16",
+        dtype="fp16",
         task="text-generation",
         number_of_partitions=2, # number of gpus to partition the model across
     )
@@ -109,7 +109,7 @@ For example, you can deploy the EleutherAI gpt-j-6B model like this:
     model = DJLModel(
         "EleutherAI/gpt-j-6B",
         "my_sagemaker_role",
-        data_type="fp16",
+        dtype="fp16",
         number_of_partitions=2
     )
 
@@ -142,7 +142,7 @@ You would then pass "s3://my_bucket/gpt-j-6B" as ``model_id`` to the ``DJLModel`
     model = DJLModel(
         "s3://my_bucket/gpt-j-6B",
         "my_sagemaker_role",
-        data_type="fp16",
+        dtype="fp16",
         number_of_partitions=2
     )
 

--- a/tests/unit/test_djl_inference.py
+++ b/tests/unit/test_djl_inference.py
@@ -351,12 +351,12 @@ def test_generate_huggingface_serving_properties_invalid_configurations(
         VALID_UNCOMPRESSED_MODEL_DATA,
         ROLE,
         sagemaker_session=sagemaker_session,
-        data_type="fp16",
+        dtype="fp16",
         load_in_8bit=True,
     )
     with pytest.raises(ValueError) as invalid_config:
         _ = model.generate_serving_properties()
-    assert str(invalid_config.value).startswith("Set data_type='int8' to use load_in_8bit")
+    assert str(invalid_config.value).startswith("Set dtype='int8' to use load_in_8bit")
 
     model = HuggingFaceAccelerateModel(
         VALID_UNCOMPRESSED_MODEL_DATA,
@@ -391,7 +391,7 @@ def test_generate_serving_properties_with_valid_configurations(
         min_workers=1,
         max_workers=3,
         job_queue_size=4,
-        data_type="fp16",
+        dtype="fp16",
         parallel_loading=True,
         model_loading_timeout=120,
         prediction_timeout=4,
@@ -429,7 +429,7 @@ def test_generate_serving_properties_with_valid_configurations(
         sagemaker_session=sagemaker_session,
         tensor_parallel_degree=1,
         task="text-generation",
-        data_type="bf16",
+        dtype="bf16",
         max_tokens=2048,
         low_cpu_mem_usage=True,
         enable_cuda_graph=True,
@@ -459,7 +459,7 @@ def test_generate_serving_properties_with_valid_configurations(
         number_of_partitions=1,
         device_id=4,
         device_map="balanced",
-        data_type="fp32",
+        dtype="fp32",
         low_cpu_mem_usage=False,
     )
     serving_properties = model.generate_serving_properties()
@@ -513,7 +513,7 @@ def test_deploy_model_no_local_code(
         ROLE,
         sagemaker_session=sagemaker_session,
         number_of_partitions=4,
-        data_type="fp16",
+        dtype="fp16",
         container_log_level=logging.DEBUG,
         env=ENV,
     )


### PR DESCRIPTION
…JL Serving

*Issue #, if available:*
N/A
*Description of changes:*
This changes `data_type` usages to `dtype` within DJLModel. This is done as `dtype` is the preferred usage.

This change is backwards compatible, and raises a warning when users use `data_type` indicating to migrate to `dtype`. 

*Testing done:*
Tested on notebook with launching an endpoint using both `data_type` (confirmed warning), and `dtype`.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
