### PR TITLE
feature: support for Sample Weights for SageMaker Autopilot (Flintstone)

### DIFF
--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -2100,7 +2100,8 @@ class Session(object):  # pylint: disable=too-many-public-methods
 
         Args:
             input_config (list[dict]): A list of Channel objects. Each channel contains "DataSource"
-                and "TargetAttributeName", "CompressionType" is an optional field.
+                and "TargetAttributeName", "CompressionType" and "SampleWeightAttributeName" are
+                optional fields.
             output_config (dict): The S3 URI where you want to store the training results and
                 optional KMS key ID.
             auto_ml_job_config (dict): A dict of AutoMLJob config, containing "StoppingCondition",
@@ -2167,7 +2168,8 @@ class Session(object):  # pylint: disable=too-many-public-methods
 
         Args:
             input_config (list[dict]): A list of Channel objects. Each channel contains "DataSource"
-                and "TargetAttributeName", "CompressionType" is an optional field.
+                and "TargetAttributeName", "CompressionType" and "SampleWeightAttributeName" are
+                optional fields.
             output_config (dict): The S3 URI where you want to store the training results and
                 optional KMS key ID.
             auto_ml_job_config (dict): A dict of AutoMLJob config, containing "StoppingCondition",

--- a/tests/unit/sagemaker/automl/test_auto_ml.py
+++ b/tests/unit/sagemaker/automl/test_auto_ml.py
@@ -34,6 +34,7 @@ INSTANCE_TYPE = "ml.c5.2xlarge"
 RESOURCE_POOLS = [{"InstanceType": INSTANCE_TYPE, "PoolSize": INSTANCE_COUNT}]
 ROLE = "DummyRole"
 TARGET_ATTRIBUTE_NAME = "target"
+SAMPLE_WEIGHT_ATTRIBUTE_NAME = "sampleWeight"
 REGION = "us-west-2"
 DEFAULT_S3_INPUT_DATA = "s3://{}/data".format(BUCKET_NAME)
 DEFAULT_S3_VALIDATION_DATA = "s3://{}/validation_data".format(BUCKET_NAME)
@@ -103,6 +104,7 @@ AUTO_ML_DESC_3 = {
                 }
             },
             "TargetAttributeName": "y",
+            "SampleWeightAttributeName": "sampleWeight",
         },
         {
             "ChannelType": "validation",
@@ -115,6 +117,7 @@ AUTO_ML_DESC_3 = {
                 }
             },
             "TargetAttributeName": "y",
+            "SampleWeightAttributeName": "sampleWeight",
         },
     ],
     "OutputDataConfig": {"KmsKeyId": "string", "S3OutputPath": "s3://output_prefix"},
@@ -360,12 +363,14 @@ def test_auto_ml_validation_channel_name(sagemaker_session):
     input_training = AutoMLInput(
         inputs=DEFAULT_S3_INPUT_DATA,
         target_attribute_name="target",
+        sample_weight_attribute_name="sampleWeight",
         compression="Gzip",
         channel_type="training",
     )
     input_validation = AutoMLInput(
         inputs=DEFAULT_S3_VALIDATION_DATA,
         target_attribute_name="target",
+        sample_weight_attribute_name="sampleWeight",
         compression="Gzip",
         channel_type="validation",
     )
@@ -384,6 +389,7 @@ def test_auto_ml_validation_channel_name(sagemaker_session):
                 }
             },
             "TargetAttributeName": TARGET_ATTRIBUTE_NAME,
+            "SampleWeightAttributeName": SAMPLE_WEIGHT_ATTRIBUTE_NAME,
         },
         {
             "ChannelType": "validation",
@@ -395,6 +401,7 @@ def test_auto_ml_validation_channel_name(sagemaker_session):
                 }
             },
             "TargetAttributeName": TARGET_ATTRIBUTE_NAME,
+            "SampleWeightAttributeName": SAMPLE_WEIGHT_ATTRIBUTE_NAME,
         },
     ]
 
@@ -617,7 +624,10 @@ def test_auto_ml_local_input(sagemaker_session):
 
 def test_auto_ml_input(sagemaker_session):
     inputs = AutoMLInput(
-        inputs=DEFAULT_S3_INPUT_DATA, target_attribute_name="target", compression="Gzip"
+        inputs=DEFAULT_S3_INPUT_DATA,
+        target_attribute_name="target",
+        sample_weight_attribute_name="sampleWeight",
+        compression="Gzip",
     )
     auto_ml = AutoML(
         role=ROLE,
@@ -636,6 +646,7 @@ def test_auto_ml_input(sagemaker_session):
                 }
             },
             "TargetAttributeName": TARGET_ATTRIBUTE_NAME,
+            "SampleWeightAttributeName": SAMPLE_WEIGHT_ATTRIBUTE_NAME,
         }
     ]
 

--- a/tests/unit/sagemaker/automl/test_auto_ml.py
+++ b/tests/unit/sagemaker/automl/test_auto_ml.py
@@ -363,9 +363,9 @@ def test_auto_ml_validation_channel_name(sagemaker_session):
     input_training = AutoMLInput(
         inputs=DEFAULT_S3_INPUT_DATA,
         target_attribute_name="target",
-        sample_weight_attribute_name="sampleWeight",
         compression="Gzip",
         channel_type="training",
+        sample_weight_attribute_name="sampleWeight",
     )
     input_validation = AutoMLInput(
         inputs=DEFAULT_S3_VALIDATION_DATA,
@@ -626,8 +626,8 @@ def test_auto_ml_input(sagemaker_session):
     inputs = AutoMLInput(
         inputs=DEFAULT_S3_INPUT_DATA,
         target_attribute_name="target",
-        sample_weight_attribute_name="sampleWeight",
         compression="Gzip",
+        sample_weight_attribute_name="sampleWeight",
     )
     auto_ml = AutoML(
         role=ROLE,

--- a/tests/unit/sagemaker/workflow/test_automl_step.py
+++ b/tests/unit/sagemaker/workflow/test_automl_step.py
@@ -54,12 +54,14 @@ def test_single_automl_step(pipeline_session):
     input_training = AutoMLInput(
         inputs="s3://bucket/data",
         target_attribute_name="target",
+        sample_weight_attribute_name="sampleWeight",
         compression="Gzip",
         channel_type="training",
     )
     input_validation = AutoMLInput(
         inputs="s3://bucket/validation_data",
         target_attribute_name="target",
+        sample_weight_attribute_name="sampleWeight",
         compression="Gzip",
         channel_type="validation",
     )
@@ -114,6 +116,7 @@ def test_single_automl_step(pipeline_session):
                         }
                     },
                     "TargetAttributeName": "target",
+                    "SampleWeightAttributeName": "sampleWeight",
                 },
                 {
                     "ChannelType": "validation",
@@ -125,6 +128,7 @@ def test_single_automl_step(pipeline_session):
                         }
                     },
                     "TargetAttributeName": "target",
+                    "SampleWeightAttributeName": "sampleWeight",
                 },
             ],
             "OutputDataConfig": {

--- a/tests/unit/sagemaker/workflow/test_automl_step.py
+++ b/tests/unit/sagemaker/workflow/test_automl_step.py
@@ -54,16 +54,16 @@ def test_single_automl_step(pipeline_session):
     input_training = AutoMLInput(
         inputs="s3://bucket/data",
         target_attribute_name="target",
-        sample_weight_attribute_name="sampleWeight",
         compression="Gzip",
         channel_type="training",
+        sample_weight_attribute_name="sampleWeight",
     )
     input_validation = AutoMLInput(
         inputs="s3://bucket/validation_data",
         target_attribute_name="target",
-        sample_weight_attribute_name="sampleWeight",
         compression="Gzip",
         channel_type="validation",
+        sample_weight_attribute_name="sampleWeight",
     )
     inputs = [input_training, input_validation]
 

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -3175,6 +3175,7 @@ DEFAULT_EXPECTED_AUTO_ML_JOB_ARGS = {
         {
             "DataSource": {"S3DataSource": {"S3DataType": "S3Prefix", "S3Uri": S3_INPUT_URI}},
             "TargetAttributeName": "y",
+            "SampleWeightAttributeName": "sampleWeight",
         }
     ],
     "OutputDataConfig": {"S3OutputPath": S3_OUTPUT},
@@ -3202,6 +3203,7 @@ COMPLETE_EXPECTED_AUTO_ML_JOB_ARGS = {
                 }
             },
             "TargetAttributeName": "y",
+            "SampleWeightAttributeName": "sampleWeight",
         },
         {
             "ChannelType": "validation",
@@ -3213,6 +3215,7 @@ COMPLETE_EXPECTED_AUTO_ML_JOB_ARGS = {
                 }
             },
             "TargetAttributeName": "y",
+            "SampleWeightAttributeName": "sampleWeight",
         },
     ],
     "OutputDataConfig": {"S3OutputPath": S3_OUTPUT},
@@ -3254,6 +3257,7 @@ def test_auto_ml_pack_to_request(sagemaker_session):
         {
             "DataSource": {"S3DataSource": {"S3DataType": "S3Prefix", "S3Uri": S3_INPUT_URI}},
             "TargetAttributeName": "y",
+            "SampleWeightAttributeName": "sampleWeight",
         }
     ]
 
@@ -3288,6 +3292,7 @@ def test_create_auto_ml_with_sagemaker_config_injection(sagemaker_session):
         {
             "DataSource": {"S3DataSource": {"S3DataType": "S3Prefix", "S3Uri": S3_INPUT_URI}},
             "TargetAttributeName": "y",
+            "SampleWeightAttributeName": "sampleWeight",
         }
     ]
 
@@ -3350,6 +3355,7 @@ def test_auto_ml_pack_to_request_with_optional_args(sagemaker_session):
                 }
             },
             "TargetAttributeName": "y",
+            "SampleWeightAttributeName": "sampleWeight",
         },
         {
             "ChannelType": "validation",
@@ -3361,6 +3367,7 @@ def test_auto_ml_pack_to_request_with_optional_args(sagemaker_session):
                 }
             },
             "TargetAttributeName": "y",
+            "SampleWeightAttributeName": "sampleWeight",
         },
     ]
 


### PR DESCRIPTION
*Issue #, if available:*
N.A

*Description of changes:*
This change allows Autopilot customers to now provide a sample weight column when creating an Autopilot job with ENSEMBLING mode only. If specified, this column name indicates which column of the dataset should be treated as sample weights for use by the objective metric during the training, evaluation, and the selection of the best model.

*Testing done:*
* Ran all unit tests and ensured they pass.
* Modified unit tests to account for the new optional field
* Conducted a manual test by creating, via the locally updated Python SDK, an autopilot job with sample weight and verified in the Autopilot backend that the job was successfully created and that the sample weights were used. 

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [n/a] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
