### PR TITLE
[change] Update DJL deepspeed and fastertransformer dlc image uris

### DIFF
--- a/src/sagemaker/djl_inference/model.py
+++ b/src/sagemaker/djl_inference/model.py
@@ -599,7 +599,7 @@ class DJLModel(FrameworkModel):
             str: The appropriate image URI based on the given parameters.
         """
         if not self.djl_version:
-            self.djl_version = "0.21.0"
+            self.djl_version = "0.22.1"
 
         return image_uris.retrieve(
             self._framework(),

--- a/src/sagemaker/image_uri_config/djl-deepspeed.json
+++ b/src/sagemaker/image_uri_config/djl-deepspeed.json
@@ -1,6 +1,36 @@
 {
     "scope": ["inference"],
     "versions": {
+        "0.22.1": {
+            "registries": {
+                "af-south-1": "626614931356",
+                "ap-east-1": "871362719292",
+                "ap-northeast-1": "763104351884",
+                "ap-northeast-2": "763104351884",
+                "ap-northeast-3": "364406365360",
+                "ap-south-1": "763104351884",
+                "ap-southeast-1": "763104351884",
+                "ap-southeast-2": "763104351884",
+                "ap-southeast-3": "907027046896",
+                "ca-central-1": "763104351884",
+                "cn-north-1": "727897471807",
+                "cn-northwest-1": "727897471807",
+                "eu-central-1": "763104351884",
+                "eu-north-1": "763104351884",
+                "eu-west-1": "763104351884",
+                "eu-west-2": "763104351884",
+                "eu-west-3": "763104351884",
+                "eu-south-1": "692866216735",
+                "me-south-1": "217643126080",
+                "sa-east-1": "763104351884",
+                "us-east-1": "763104351884",
+                "us-east-2": "763104351884",
+                "us-west-1": "763104351884",
+                "us-west-2": "763104351884"
+            },
+            "repository": "djl-inference",
+            "tag_prefix": "0.22.1-deepspeed0.8.3-cu118"
+        },
         "0.21.0": {
             "registries": {
                 "af-south-1": "626614931356",

--- a/src/sagemaker/image_uri_config/djl-fastertransformer.json
+++ b/src/sagemaker/image_uri_config/djl-fastertransformer.json
@@ -1,6 +1,36 @@
 {
     "scope": ["inference"],
     "versions": {
+        "0.22.1": {
+            "registries": {
+                "af-south-1": "626614931356",
+                "ap-east-1": "871362719292",
+                "ap-northeast-1": "763104351884",
+                "ap-northeast-2": "763104351884",
+                "ap-northeast-3": "364406365360",
+                "ap-south-1": "763104351884",
+                "ap-southeast-1": "763104351884",
+                "ap-southeast-2": "763104351884",
+                "ap-southeast-3": "907027046896",
+                "ca-central-1": "763104351884",
+                "cn-north-1": "727897471807",
+                "cn-northwest-1": "727897471807",
+                "eu-central-1": "763104351884",
+                "eu-north-1": "763104351884",
+                "eu-west-1": "763104351884",
+                "eu-west-2": "763104351884",
+                "eu-west-3": "763104351884",
+                "eu-south-1": "692866216735",
+                "me-south-1": "217643126080",
+                "sa-east-1": "763104351884",
+                "us-east-1": "763104351884",
+                "us-east-2": "763104351884",
+                "us-west-1": "763104351884",
+                "us-west-2": "763104351884"
+            },
+            "repository": "djl-inference",
+            "tag_prefix": "0.22.1-fastertransformer5.3.0-cu118"
+        },
         "0.21.0": {
             "registries": {
                 "af-south-1": "626614931356",

--- a/tests/unit/sagemaker/image_uris/test_djl.py
+++ b/tests/unit/sagemaker/image_uris/test_djl.py
@@ -41,8 +41,8 @@ ACCOUNTS = {
     "us-west-1": "763104351884",
     "us-west-2": "763104351884",
 }
-DJL_DEEPSPEED_VERSIONS = ["0.21.0", "0.20.0", "0.19.0"]
-DJL_FASTERTRANSFORMER_VERSIONS = ["0.21.0"]
+DJL_DEEPSPEED_VERSIONS = ["0.22.1", "0.21.0", "0.20.0", "0.19.0"]
+DJL_FASTERTRANSFORMER_VERSIONS = ["0.22.1", "0.21.0"]
 DJL_NEURONX_VERSIONS = ["0.22.1"]
 DJL_VERSIONS_TO_FRAMEWORK = {
     "0.19.0": {"djl-deepspeed": "deepspeed0.7.3-cu113"},
@@ -52,6 +52,8 @@ DJL_VERSIONS_TO_FRAMEWORK = {
         "djl-fastertransformer": "fastertransformer5.3.0-cu117",
     },
     "0.22.1": {
+        "djl-deepspeed": "deepspeed0.8.3-cu118",
+        "djl-fastertransformer": "fastertransformer5.3.0-cu118",
         "djl-neuronx": "neuronx-sdk2.9.0",
     },
 }


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Updates image uris to latest released versions. 
Updates default model image to latest version.

*Testing done:*
Validated with HF accelerate and DeepSpeed by spinning up endpoints with the SDK changes here.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
