### PR TITLE
fix: remote_function python version mismatch issue

### DIFF
--- a/src/sagemaker/remote_function/runtime_environment/runtime_environment_manager.py
+++ b/src/sagemaker/remote_function/runtime_environment/runtime_environment_manager.py
@@ -254,7 +254,7 @@ class RuntimeEnvironmentManager:
     def _current_python_version(self):
         """Returns the current python version where program is running"""
 
-        return f"{sys.version_info.major}.{sys.version_info.minor}"
+        return f"{sys.version_info.major}.{sys.version_info.minor}".strip()
 
     def _validate_python_version(self, client_python_version: str, conda_env: str = None):
         """Validate the python version
@@ -266,10 +266,10 @@ class RuntimeEnvironmentManager:
             job_python_version = self._python_version_in_conda_env(conda_env)
         else:
             job_python_version = self._current_python_version()
-        if client_python_version != job_python_version:
+        if client_python_version.strip() != job_python_version.strip():
             raise RuntimeEnvironmentError(
-                f"Python version found in the container is {job_python_version} which "
-                f"does not match python version {client_python_version} on the local client . "
+                f"Python version found in the container is '{job_python_version}' which "
+                f"does not match python version '{client_python_version}' on the local client. "
                 f"Please make sure that the python version used in the training container "
                 f"is same as the local python version."
             )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
