### PR TITLE
fix: Make type annotation of UploadedCode consistent

### DIFF
--- a/src/sagemaker/estimator.py
+++ b/src/sagemaker/estimator.py
@@ -556,7 +556,7 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):  # pylint: disable=too-man
         self.code_location = code_location
         self.entry_point = entry_point
         self.dependencies = dependencies or []
-        self.uploaded_code = None
+        self.uploaded_code: Optional[UploadedCode] = None
         self.tags = add_jumpstart_tags(
             tags=tags, training_model_uri=self.model_uri, training_script_uri=self.source_dir
         )
@@ -839,7 +839,7 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):  # pylint: disable=too-man
 
         self._hyperparameters.update(EstimatorBase._json_encode_hyperparameters(hyperparams))
 
-    def _stage_user_code_in_s3(self) -> str:
+    def _stage_user_code_in_s3(self) -> UploadedCode:
         """Uploads the user training script to S3 and returns the S3 URI.
 
         Returns: S3 URI
@@ -3135,7 +3135,7 @@ class Framework(EstimatorBase):
         self.git_config = git_config
         self.source_dir = source_dir
         self.dependencies = dependencies or []
-        self.uploaded_code = None
+        self.uploaded_code: Optional[UploadedCode] = None
 
         self.container_log_level = container_log_level
         self.code_location = code_location

--- a/src/sagemaker/fw_utils.py
+++ b/src/sagemaker/fw_utils.py
@@ -37,8 +37,8 @@ logger = logging.getLogger(__name__)
 
 _TAR_SOURCE_FILENAME = "source.tar.gz"
 
-UploadedCode = namedtuple("UserCode", ["s3_prefix", "script_name"])
-"""sagemaker.fw_utils.UserCode: An object containing the S3 prefix and script name.
+UploadedCode = namedtuple("UploadedCode", ["s3_prefix", "script_name"])
+"""sagemaker.fw_utils.UploadedCode: An object containing the S3 prefix and script name.
 This is for the source code used for the entry point with an ``Estimator``. It can be
 instantiated with positional or keyword arguments.
 """
@@ -398,7 +398,7 @@ def tar_and_upload_dir(
     kms_key=None,
     s3_resource=None,
     settings: Optional[SessionSettings] = None,
-):
+) -> UploadedCode:
     """Package source files and upload a compress tar file to S3.
 
     The S3 location will be ``s3://<bucket>/s3_key_prefix/sourcedir.tar.gz``.
@@ -429,7 +429,7 @@ def tar_and_upload_dir(
             of the SageMaker ``Session``, can be used to override the default encryption
             behavior (default: None).
     Returns:
-        sagemaker.fw_utils.UserCode: An object with the S3 bucket and key (S3 prefix) and
+        sagemaker.fw_utils.UploadedCode: An object with the S3 bucket and key (S3 prefix) and
             script name.
     """
     if directory and (is_pipeline_variable(directory) or directory.lower().startswith("s3://")):


### PR DESCRIPTION
*Description of changes:*

Corrected the documentation and type annotations for some methods and variables which handle `UploadedCode` instances. In some places they were referred to as `str` and in some places as the nonexistent `UserCode` type. Now they are all `UploadedCode` (or `Optional[UploadedCode]`).

*Testing done:*

* ran it through mypy, got one fewer error than before
* ran `tox tests/unit`

## Merge Checklist

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
