### PR TITLE
feature: add integ tests for remote_function auto_capture functionality

### DIFF
--- a/tests/integ/sagemaker/remote_function/test_auto_capture.py
+++ b/tests/integ/sagemaker/remote_function/test_auto_capture.py
@@ -1,0 +1,39 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from __future__ import absolute_import
+
+import pandas as pd
+
+from sagemaker.remote_function import remote
+
+
+@remote(
+    role="SageMakerRole",
+    instance_type="ml.m5.xlarge",
+    dependencies="auto_capture",
+)
+def multiply(dataframe: pd.DataFrame, factor: float):
+    return dataframe * factor
+
+
+df = pd.DataFrame(
+    {
+        "A": [14, 4, 5, 4, 1],
+        "B": [5, 2, 54, 3, 2],
+        "C": [20, 20, 7, 3, 8],
+        "D": [14, 3, 6, 2, 6],
+    }
+)
+
+if __name__ == "__main__":
+    multiply(df, 10.0)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add a test for remote function auto_capture functionality. This test is a bit non trivial where we first create a docker container and run the test in that docker container. The test execution needs a conda environment to be available on the client side which is not present in the container used by code build. Hence we need to run the test in its own container.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
