### PR TITLE
fix: Pass KMS value to create processing job

### DIFF
--- a/src/sagemaker/processing.py
+++ b/src/sagemaker/processing.py
@@ -1566,6 +1566,7 @@ class FrameworkProcessor(ScriptProcessor):
             sagemaker_session=self.sagemaker_session,
             debugger_hook_config=False,
             disable_profiler=True,
+            output_kms_key=self.output_kms_key,
         )
 
     def get_run_args(
@@ -1804,7 +1805,10 @@ class FrameworkProcessor(ScriptProcessor):
             raise RuntimeError("S3 source_dir file must be named `sourcedir.tar.gz.`")
 
         script = estimator.uploaded_code.script_name
-        s3_runproc_sh = self._create_and_upload_runproc(script, kms_key, entrypoint_s3_uri)
+        evaluated_kms_key = kms_key if kms_key else self.output_kms_key
+        s3_runproc_sh = self._create_and_upload_runproc(
+            script, evaluated_kms_key, entrypoint_s3_uri
+        )
 
         return s3_runproc_sh, inputs, job_name
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/sagemaker-python-sdk/issues/3699

*Description of changes:*
fixing: https://github.com/aws/sagemaker-python-sdk/pull/3366

When using an S3 bucket with a policy that restricts PUT objects unless a kms key is specified, the creation of a processing job fails due to the fact that the SDK doesn't pass the value to all sections of the code. This change will fix that.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
