### PR TITLE
feature: Add Neuronx Image uri - Transformers 4.28 - PyTorch 1.13

### DIFF
--- a/src/sagemaker/huggingface/model.py
+++ b/src/sagemaker/huggingface/model.py
@@ -448,7 +448,11 @@ class HuggingFaceModel(FrameworkModel):
         )
 
     def prepare_container_def(
-        self, instance_type=None, accelerator_type=None, serverless_inference_config=None
+        self,
+        instance_type=None,
+        accelerator_type=None,
+        serverless_inference_config=None,
+        inference_tool=None,
     ):
         """A container definition with framework configuration set in model environment variables.
 
@@ -461,6 +465,8 @@ class HuggingFaceModel(FrameworkModel):
             serverless_inference_config (sagemaker.serverless.ServerlessInferenceConfig):
                 Specifies configuration related to serverless endpoint. Instance type is
                 not provided in serverless inference. So this is used to find image URIs.
+            inference_tool (str): the tool that will be used to aid in the inference.
+                Valid values: "neuron, neuronx, None" (default: None).
 
         Returns:
             dict[str, str]: A container definition object usable with the
@@ -479,6 +485,7 @@ class HuggingFaceModel(FrameworkModel):
                 instance_type,
                 accelerator_type=accelerator_type,
                 serverless_inference_config=serverless_inference_config,
+                inference_tool=inference_tool,
             )
 
         deploy_key_prefix = model_code_key_prefix(self.key_prefix, self.name, deploy_image)
@@ -500,6 +507,7 @@ class HuggingFaceModel(FrameworkModel):
         instance_type=None,
         accelerator_type=None,
         serverless_inference_config=None,
+        inference_tool=None,
     ):
         """Create a URI for the serving image.
 
@@ -513,6 +521,8 @@ class HuggingFaceModel(FrameworkModel):
             serverless_inference_config (sagemaker.serverless.ServerlessInferenceConfig):
                 Specifies configuration related to serverless endpoint. Instance type is
                 not provided in serverless inference. So this is used used to determine device type.
+            inference_tool (str): the tool that will be used to aid in the inference.
+                Valid values: "neuron, neuronx, None" (default: None).
 
         Returns:
             str: The appropriate image URI based on the given parameters.
@@ -534,4 +544,5 @@ class HuggingFaceModel(FrameworkModel):
             image_scope="inference",
             base_framework_version=base_framework_version,
             serverless_inference_config=serverless_inference_config,
+            inference_tool=inference_tool,
         )

--- a/src/sagemaker/image_uri_config/huggingface-neuronx.json
+++ b/src/sagemaker/image_uri_config/huggingface-neuronx.json
@@ -1,0 +1,98 @@
+{
+    "training": {
+        "processors": ["trn"],
+        "version_aliases": {"4.28": "4.28.1"},
+        "versions": {
+            "4.28.1": {
+                "version_aliases": {"pytorch1.13": "pytorch1.13.0"},
+                "pytorch1.13.0": {
+                    "py_versions": ["py38"],
+                    "repository": "huggingface-pytorch-training-neuronx",
+                    "registries": {
+                        "af-south-1": "626614931356",
+                        "ap-east-1": "871362719292",
+                        "ap-northeast-1": "763104351884",
+                        "ap-northeast-2": "763104351884",
+                        "ap-northeast-3": "364406365360",
+                        "ap-south-1": "763104351884",
+                        "ap-south-2": "772153158452",
+                        "ap-southeast-1": "763104351884",
+                        "ap-southeast-2": "763104351884",
+                        "ap-southeast-4": "457447274322",
+                        "ca-central-1": "763104351884",
+                        "cn-north-1": "727897471807",
+                        "cn-northwest-1": "727897471807",
+                        "eu-central-1": "763104351884",
+                        "eu-central-2": "380420809688",
+                        "eu-north-1": "763104351884",
+                        "eu-west-1": "763104351884",
+                        "eu-west-2": "763104351884",
+                        "eu-west-3": "763104351884",
+                        "eu-south-1": "692866216735",
+                        "eu-south-2": "503227376785",
+                        "me-south-1": "217643126080",
+                        "sa-east-1": "763104351884",
+                        "us-east-1": "763104351884",
+                        "us-east-2": "763104351884",
+                        "us-gov-east-1": "446045086412",
+                        "us-gov-west-1": "442386744353",
+                        "us-iso-east-1": "886529160074",
+                        "us-isob-east-1": "094389454867",
+                        "us-west-1": "763104351884",
+                        "us-west-2": "763104351884"
+                    },
+                    "container_version": {"trn": "ubuntu20.04"},
+                    "sdk_versions": ["sdk2.9.1"]
+                }
+            }
+        }
+    },
+    "inference": {
+        "processors": ["inf"],
+        "version_aliases": {"4.28": "4.28.1"},
+        "versions": {
+            "4.28.1": {
+                "version_aliases": {"pytorch1.13": "pytorch1.13.0"},
+                "pytorch1.13.0": {
+                    "py_versions": ["py38"],
+                    "repository": "huggingface-pytorch-inference-neuronx",
+                    "registries": {
+                        "af-south-1": "626614931356",
+                        "ap-east-1": "871362719292",
+                        "ap-northeast-1": "763104351884",
+                        "ap-northeast-2": "763104351884",
+                        "ap-northeast-3": "364406365360",
+                        "ap-south-1": "763104351884",
+                        "ap-south-2": "772153158452",
+                        "ap-southeast-1": "763104351884",
+                        "ap-southeast-2": "763104351884",
+                        "ap-southeast-4": "457447274322",
+                        "ca-central-1": "763104351884",
+                        "cn-north-1": "727897471807",
+                        "cn-northwest-1": "727897471807",
+                        "eu-central-1": "763104351884",
+                        "eu-central-2": "380420809688",
+                        "eu-north-1": "763104351884",
+                        "eu-west-1": "763104351884",
+                        "eu-west-2": "763104351884",
+                        "eu-west-3": "763104351884",
+                        "eu-south-1": "692866216735",
+                        "eu-south-2": "503227376785",
+                        "me-south-1": "217643126080",
+                        "sa-east-1": "763104351884",
+                        "us-east-1": "763104351884",
+                        "us-east-2": "763104351884",
+                        "us-gov-east-1": "446045086412",
+                        "us-gov-west-1": "442386744353",
+                        "us-iso-east-1": "886529160074",
+                        "us-isob-east-1": "094389454867",
+                        "us-west-1": "763104351884",
+                        "us-west-2": "763104351884"
+                    },
+                    "container_version": {"inf": "ubuntu20.04"},
+                    "sdk_versions": ["sdk2.9.1"]
+                }
+            }
+        }
+    }
+}

--- a/src/sagemaker/image_uris.py
+++ b/src/sagemaker/image_uris.py
@@ -158,7 +158,7 @@ def retrieve(
         _framework = framework
         if framework == HUGGING_FACE_FRAMEWORK or framework in TRAINIUM_ALLOWED_FRAMEWORKS:
             inference_tool = _get_inference_tool(inference_tool, instance_type)
-            if inference_tool == "neuron" or inference_tool == "neuronx":
+            if inference_tool in ["neuron", "neuronx"]:
                 _framework = f"{framework}-{inference_tool}"
         final_image_scope = _get_final_image_scope(framework, instance_type, image_scope)
         _validate_for_suppported_frameworks_and_instance_type(framework, instance_type)

--- a/src/sagemaker/image_uris.py
+++ b/src/sagemaker/image_uris.py
@@ -104,7 +104,7 @@ def retrieve(
         sdk_version (str): the version of python-sdk that will be used in the image retrieval.
             (default: None).
         inference_tool (str): the tool that will be used to aid in the inference.
-            Valid values: "neuron, None"
+            Valid values: "neuron, neuronx, None"
             (default: None).
         serverless_inference_config (sagemaker.serverless.ServerlessInferenceConfig):
             Specifies configuration related to serverless endpoint. Instance type is
@@ -158,7 +158,7 @@ def retrieve(
         _framework = framework
         if framework == HUGGING_FACE_FRAMEWORK or framework in TRAINIUM_ALLOWED_FRAMEWORKS:
             inference_tool = _get_inference_tool(inference_tool, instance_type)
-            if inference_tool == "neuron":
+            if inference_tool == "neuron" or inference_tool == "neuronx":
                 _framework = f"{framework}-{inference_tool}"
         final_image_scope = _get_final_image_scope(framework, instance_type, image_scope)
         _validate_for_suppported_frameworks_and_instance_type(framework, instance_type)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -408,13 +408,43 @@ def huggingface_neuron_latest_inference_pytorch_version():
 
 
 @pytest.fixture(scope="module")
+def huggingface_neuronx_latest_inference_pytorch_version():
+    return "1.13"
+
+
+@pytest.fixture(scope="module")
+def huggingface_neuronx_latest_training_pytorch_version():
+    return "1.13"
+
+
+@pytest.fixture(scope="module")
 def huggingface_neuron_latest_inference_transformer_version():
     return "4.12"
 
 
 @pytest.fixture(scope="module")
+def huggingface_neuronx_latest_inference_transformer_version():
+    return "4.28"
+
+
+@pytest.fixture(scope="module")
+def huggingface_neuronx_latest_training_transformer_version():
+    return "4.28"
+
+
+@pytest.fixture(scope="module")
 def huggingface_neuron_latest_inference_py_version():
     return "py37"
+
+
+@pytest.fixture(scope="module")
+def huggingface_neuronx_latest_inference_py_version():
+    return "py38"
+
+
+@pytest.fixture(scope="module")
+def huggingface_neuronx_latest_training_py_version():
+    return "py38"
 
 
 @pytest.fixture(scope="module")

--- a/tests/unit/sagemaker/huggingface/huggingface_utils.py
+++ b/tests/unit/sagemaker/huggingface/huggingface_utils.py
@@ -35,6 +35,7 @@ def get_full_gpu_image_uri(
         container_version="cu110-ubuntu18.04",
     )
 
+
 def get_full_neuronx_image_uri(
     version,
     base_framework_version,

--- a/tests/unit/sagemaker/huggingface/huggingface_utils.py
+++ b/tests/unit/sagemaker/huggingface/huggingface_utils.py
@@ -16,6 +16,7 @@ from sagemaker import image_uris
 
 REGION = "us-east-1"
 GPU_INSTANCE_TYPE = "ml.p2.xlarge"
+NEURONX_INSTANCE_TYPE = "ml.trn1.2xlarge"
 
 
 def get_full_gpu_image_uri(
@@ -23,6 +24,22 @@ def get_full_gpu_image_uri(
     base_framework_version,
     region=REGION,
     instance_type=GPU_INSTANCE_TYPE,
+):
+    return image_uris.retrieve(
+        "huggingface",
+        region,
+        version=version,
+        instance_type=instance_type,
+        image_scope="training",
+        base_framework_version=base_framework_version,
+        container_version="cu110-ubuntu18.04",
+    )
+
+def get_full_neuronx_image_uri(
+    version,
+    base_framework_version,
+    region=REGION,
+    instance_type=NEURONX_INSTANCE_TYPE,
 ):
     return image_uris.retrieve(
         "huggingface",

--- a/tests/unit/sagemaker/huggingface/huggingface_utils.py
+++ b/tests/unit/sagemaker/huggingface/huggingface_utils.py
@@ -50,4 +50,5 @@ def get_full_neuronx_image_uri(
         image_scope="training",
         base_framework_version=base_framework_version,
         container_version="cu110-ubuntu18.04",
+        inference_tool="neuronx",
     )

--- a/tests/unit/sagemaker/huggingface/test_estimator.py
+++ b/tests/unit/sagemaker/huggingface/test_estimator.py
@@ -269,7 +269,7 @@ def test_huggingface_neuron(
         pytorch_version=huggingface_neuron_latest_inference_pytorch_version,
         py_version=huggingface_neuron_latest_inference_py_version,
     )
-    container = huggingface_model.prepare_container_def("ml.inf1.xlarge")
+    container = huggingface_model.prepare_container_def("ml.inf1.xlarge", inference_tool="neuron")
     assert container["Image"]
 
 
@@ -289,7 +289,7 @@ def test_huggingface_neuronx(
         pytorch_version=huggingface_neuronx_latest_inference_pytorch_version,
         py_version=huggingface_neuronx_latest_inference_py_version,
     )
-    container = huggingface_model.prepare_container_def("ml.inf2.xlarge")
+    container = huggingface_model.prepare_container_def("ml.inf2.xlarge", inference_tool="neuronx")
     assert container["Image"]
 
 

--- a/tests/unit/sagemaker/huggingface/test_estimator.py
+++ b/tests/unit/sagemaker/huggingface/test_estimator.py
@@ -269,7 +269,27 @@ def test_huggingface_neuron(
         pytorch_version=huggingface_neuron_latest_inference_pytorch_version,
         py_version=huggingface_neuron_latest_inference_py_version,
     )
-    container = huggingface_model.prepare_container_def("ml.inf.xlarge")
+    container = huggingface_model.prepare_container_def("ml.inf1.xlarge")
+    assert container["Image"]
+
+
+def test_huggingface_neuronx(
+    sagemaker_session,
+    huggingface_neuronx_latest_inference_pytorch_version,
+    huggingface_neuronx_latest_inference_transformer_version,
+    huggingface_neuronx_latest_inference_py_version,
+):
+
+    inputs = "s3://mybucket/train"
+    huggingface_model = HuggingFaceModel(
+        model_data=inputs,
+        transformers_version=huggingface_neuronx_latest_inference_transformer_version,
+        role=ROLE,
+        sagemaker_session=sagemaker_session,
+        pytorch_version=huggingface_neuronx_latest_inference_pytorch_version,
+        py_version=huggingface_neuronx_latest_inference_py_version,
+    )
+    container = huggingface_model.prepare_container_def("ml.inf2.xlarge")
     assert container["Image"]
 
 


### PR DESCRIPTION
*Issue #3845:*

*Description of changes:*

Add Image URI for:
* [Transformers 4.28 - PyTorch 1.13.0 - Neuronx Training DLC](https://github.com/aws/deep-learning-containers/releases/tag/v1.0-hf-4.28.1-pt-1.13.0-tr-neuronx-sdk2.9.1-py38)
* [Transformers 4.28 - PyTorch 1.13.0 - Neuronx Inference DLC](https://github.com/aws/deep-learning-containers/releases/tag/v1.0-hf-4.28.1-pt-1.13.0-inf-neuronx-sdk2.9.1-py38)

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
