### PR TITLE
[fix] Update dtype logic for huggingface backend for new containers

### DIFF
--- a/src/sagemaker/djl_inference/model.py
+++ b/src/sagemaker/djl_inference/model.py
@@ -854,11 +854,13 @@ class HuggingFaceAccelerateModel(DJLModel):
         if self.low_cpu_mem_usage:
             serving_properties["option.low_cpu_mem_usage"] = self.low_cpu_mem_usage
         # This is a workaround due to a bug in our built in handler for huggingface
-        # TODO: This needs to be fixed when new dlc is published
+        # TODO: Remove this logic whenever 0.20.0 image is out of service
         if (
             serving_properties["option.entryPoint"] == "djl_python.huggingface"
             and self.dtype
             and self.dtype != "auto"
+            and self.djl_version
+            and int(self.djl_version.split(".")[1]) < 21
         ):
             serving_properties["option.dtype"] = "auto"
             serving_properties.pop("option.load_in_8bit", None)

--- a/tests/unit/test_djl_inference.py
+++ b/tests/unit/test_djl_inference.py
@@ -454,7 +454,7 @@ def test_generate_serving_properties_with_valid_configurations(
         "option.entryPoint": "djl_python.huggingface",
         "option.s3url": VALID_UNCOMPRESSED_MODEL_DATA,
         "option.tensor_parallel_degree": 1,
-        "option.dtype": "auto",
+        "option.dtype": "fp32",
         "option.device_id": 4,
         "option.device_map": "balanced",
     }


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
There is a bug in the 0.20.0 versions of DJL containers for huggingface that is fixed in subsequent versions (0.21.0, 0.22.1). This change in the SDK only implements the workaround for containers and scenarios known to have the issue, and removes the workaround in other cases.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
