### PR TITLE
fix: integs - pytorch transformer deps and add test retry

### DIFF
--- a/tests/data/huggingface_byoc/requirements.txt
+++ b/tests/data/huggingface_byoc/requirements.txt
@@ -1,2 +1,2 @@
-transformers
-datasets
+transformers<=4.28.1
+datasets<=2.12.0

--- a/tests/integ/test_clarify_model_monitor.py
+++ b/tests/integ/test_clarify_model_monitor.py
@@ -291,6 +291,7 @@ def test_bias_monitor(sagemaker_session, scheduled_bias_monitor, endpoint_name, 
     tests.integ.test_region() in tests.integ.NO_MODEL_MONITORING_REGIONS,
     reason="ModelMonitoring is not yet supported in this region.",
 )
+@pytest.mark.flaky(reruns=5, reruns_delay=2)
 def test_run_bias_monitor(
     scheduled_bias_monitor, sagemaker_session, endpoint_name, ground_truth_input, upload_actual_data
 ):
@@ -400,6 +401,7 @@ def test_explainability_monitor(sagemaker_session, scheduled_explainability_moni
     tests.integ.test_region() in tests.integ.NO_MODEL_MONITORING_REGIONS,
     reason="ModelMonitoring is not yet supported in this region.",
 )
+@pytest.mark.flaky(reruns=5, reruns_delay=2)
 def test_run_explainability_monitor(
     scheduled_explainability_monitor,
     sagemaker_session,

--- a/tests/integ/test_inference_pipeline.py
+++ b/tests/integ/test_inference_pipeline.py
@@ -151,6 +151,7 @@ def test_inference_pipeline_model_deploy(sagemaker_session, cpu_instance_type):
 
 
 @pytest.mark.slow_test
+@pytest.mark.flaky(reruns=5, reruns_delay=2)
 def test_inference_pipeline_model_deploy_and_update_endpoint(
     sagemaker_session, cpu_instance_type, alternative_cpu_instance_type
 ):

--- a/tests/integ/test_model_quality_monitor.py
+++ b/tests/integ/test_model_quality_monitor.py
@@ -235,6 +235,7 @@ def test_model_quality_monitor(
     tests.integ.test_region() in tests.integ.NO_MODEL_MONITORING_REGIONS,
     reason="ModelMonitoring is not yet supported in this region.",
 )
+@pytest.mark.flaky(reruns=5, reruns_delay=2)
 def test_run_model_quality_monitor(
     scheduled_model_quality_monitor,
     sagemaker_session,
@@ -260,6 +261,7 @@ def test_run_model_quality_monitor(
     tests.integ.test_region() in tests.integ.NO_MODEL_MONITORING_REGIONS,
     reason="ModelMonitoring is not yet supported in this region.",
 )
+@pytest.mark.flaky(reruns=5, reruns_delay=2)
 def test_run_model_quality_monitor_baseline(
     sagemaker_session,
     endpoint_name,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Pinned the deps of pytorch training integ test to unblock repo contribution.
2. Added retries to some known flaky slow tests.

*Testing done:*
Tested in personal account.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
