### PR TITLE
feature: Add support for SageMaker Serverless inference Provisioned Concurrency feature

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ def read_requirements(filename):
 # Declare minimal set for installation
 required_packages = [
     "attrs>=20.3.0,<23",
-    "boto3>=1.26.28,<2.0",
+    "boto3>=1.26.131,<2.0",
     "cloudpickle==2.2.1",
     "google-pasta",
     "numpy>=1.9.0,<2.0",

--- a/src/sagemaker/serverless/serverless_inference_config.py
+++ b/src/sagemaker/serverless/serverless_inference_config.py
@@ -12,10 +12,11 @@
 # language governing permissions and limitations under the License.
 """This module contains code related to the ServerlessInferenceConfig class.
 
-Codes are used for configuring async inference endpoint. Use it when deploying
+Codes are used for configuring serverless inference endpoint. Use it when deploying
 the model to the endpoints.
 """
 from __future__ import print_function, absolute_import
+from typing import Optional
 
 
 class ServerlessInferenceConfig(object):
@@ -29,6 +30,7 @@ class ServerlessInferenceConfig(object):
         self,
         memory_size_in_mb: int = 2048,
         max_concurrency: int = 5,
+        provisioned_concurrency: Optional[int] = None,
     ):
         """Initialize a ServerlessInferenceConfig object for serverless inference configuration.
 
@@ -40,9 +42,13 @@ class ServerlessInferenceConfig(object):
             max_concurrency (int): Optional. The maximum number of concurrent invocations
                 your serverless endpoint can process. If no value is provided, Amazon
                 SageMaker will choose the default value for you. (Default: 5)
+            provisioned_concurrency (int): Optional. The provisioned concurrency of your
+                serverless endpoint. If no value is provided, Amazon SageMaker will not
+                apply provisioned concucrrency to your Serverless endpoint. (Default: None)
         """
         self.memory_size_in_mb = memory_size_in_mb
         self.max_concurrency = max_concurrency
+        self.provisioned_concurrency = provisioned_concurrency
 
     def _to_request_dict(self):
         """Generates a request dictionary using the parameters provided to the class."""
@@ -50,5 +56,8 @@ class ServerlessInferenceConfig(object):
             "MemorySizeInMB": self.memory_size_in_mb,
             "MaxConcurrency": self.max_concurrency,
         }
+
+        if self.provisioned_concurrency is not None:
+            request_dict["ProvisionedConcurrency"] = self.provisioned_concurrency
 
         return request_dict

--- a/tests/unit/sagemaker/serverless/test_serverless_inference_config.py
+++ b/tests/unit/sagemaker/serverless/test_serverless_inference_config.py
@@ -16,10 +16,17 @@ from sagemaker.serverless import ServerlessInferenceConfig
 
 DEFAULT_MEMORY_SIZE_IN_MB = 2048
 DEFAULT_MAX_CONCURRENCY = 5
+DEFAULT_PROVISIONED_CONCURRENCY = 5
 
 DEFAULT_REQUEST_DICT = {
     "MemorySizeInMB": DEFAULT_MEMORY_SIZE_IN_MB,
     "MaxConcurrency": DEFAULT_MAX_CONCURRENCY,
+}
+
+PROVISIONED_CONCURRENCY_REQUEST_DICT = {
+    "MemorySizeInMB": DEFAULT_MEMORY_SIZE_IN_MB,
+    "MaxConcurrency": DEFAULT_MAX_CONCURRENCY,
+    "ProvisionedConcurrency": DEFAULT_PROVISIONED_CONCURRENCY,
 }
 
 
@@ -29,8 +36,34 @@ def test_init():
     assert serverless_inference_config.memory_size_in_mb == DEFAULT_MEMORY_SIZE_IN_MB
     assert serverless_inference_config.max_concurrency == DEFAULT_MAX_CONCURRENCY
 
+    serverless_provisioned_concurrency_inference_config = ServerlessInferenceConfig(
+        provisioned_concurrency=DEFAULT_PROVISIONED_CONCURRENCY
+    )
+
+    assert (
+        serverless_provisioned_concurrency_inference_config.memory_size_in_mb
+        == DEFAULT_MEMORY_SIZE_IN_MB
+    )
+    assert (
+        serverless_provisioned_concurrency_inference_config.max_concurrency
+        == DEFAULT_MAX_CONCURRENCY
+    )
+    assert (
+        serverless_provisioned_concurrency_inference_config.provisioned_concurrency
+        == DEFAULT_PROVISIONED_CONCURRENCY
+    )
+
 
 def test_to_request_dict():
     serverless_inference_config_dict = ServerlessInferenceConfig()._to_request_dict()
 
     assert serverless_inference_config_dict == DEFAULT_REQUEST_DICT
+
+    serverless_provisioned_concurrency_inference_config_dict = ServerlessInferenceConfig(
+        provisioned_concurrency=DEFAULT_PROVISIONED_CONCURRENCY
+    )._to_request_dict()
+
+    assert (
+        serverless_provisioned_concurrency_inference_config_dict
+        == PROVISIONED_CONCURRENCY_REQUEST_DICT
+    )


### PR DESCRIPTION
feature: Add support for SageMaker Serverless inference Provisioned Concurrency feature)

*Issue #, if available:* N/A

*Description of changes:* Amazon SageMaker Serverless Inference support Provisioned Concurrency recently. Adding this support to SageMaker Python SDK as well.

*Testing done:*
- Adding Unit test for this new field in ServerlessInferenceConfig
- Adding integ test for Provisioned Concurrency Serverless inference

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
