### PR TITLE
fix: update apache airflow and update test requirements

### DIFF
--- a/requirements/extras/test_requirements.txt
+++ b/requirements/extras/test_requirements.txt
@@ -12,9 +12,9 @@ awslogs==0.14.0
 black==22.3.0
 stopit==1.1.2
 # Update tox.ini to have correct version of airflow constraints file
-apache-airflow==2.5.1
+apache-airflow==2.6.0
 apache-airflow-providers-amazon==7.2.1
-attrs==22.1.0
+attrs>=23.1.0,<24
 fabric==2.6.0
 requests==2.27.1
 sagemaker-experiments==0.1.35
@@ -23,3 +23,7 @@ pyvis==0.2.1
 pandas>=1.3.5,<1.5
 scikit-learn==1.0.2
 cloudpickle==2.2.1
+scipy==1.7.3
+urllib3==1.26.8
+docker>=5.0.2,<7.0.0
+PyYAML==6.0

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ def read_requirements(filename):
 
 # Declare minimal set for installation
 required_packages = [
-    "attrs>=20.3.0,<23",
+    "attrs>=23.1.0,<24",
     "boto3>=1.26.131,<2.0",
     "cloudpickle==2.2.1",
     "google-pasta",
@@ -60,7 +60,7 @@ required_packages = [
     "pandas",
     "pathos",
     "schema",
-    "PyYAML==5.4.1",
+    "PyYAML==6.0",
     "jsonschema",
     "platformdirs",
     "tblib==1.7.0",
@@ -75,7 +75,7 @@ extras = {
 # Meta dependency groups
 extras["all"] = [item for group in extras.values() for item in group]
 # Tests specific dependencies (do not need to be included in 'all')
-extras["test"] = (extras["all"] + read_requirements("requirements/extras/test_requirements.txt"),)
+extras["test"] = (read_requirements("requirements/extras/test_requirements.txt"),)
 
 setup(
     name="sagemaker",

--- a/tox.ini
+++ b/tox.ini
@@ -73,7 +73,7 @@ passenv =
 # Can be used to specify which tests to run, e.g.: tox -- -s
 commands =
     python -c "import os; os.system('install-custom-pkgs --install-boto-wheels')"
-    pip install 'apache-airflow==2.5.1' --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.5.1/constraints-3.7.txt"
+    pip install 'apache-airflow==2.6.0' --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.6.0/constraints-3.7.txt"
 
     pytest --cov=sagemaker --cov-append {posargs}
     {env:IGNORE_COVERAGE:} coverage report -i --fail-under=86


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Updating airflow to 2.6.0
* Moving relevant local and scipy requirements in test requirements. Skipping docker compose due to conflicts with airflow and also pypi seems to be an unsupported distribution partner for latest docker compose releases. We install docker compose in our infra image directly.

```
The conflict is caused by:
    sagemaker[test] 2.154.1.dev0 depends on jsonschema
    apache-airflow 2.6.0 depends on jsonschema>=4.0.0
    docker-compose 1.29.2 depends on jsonschema<4 and >=2.5.1
```

*Testing done:*
* Tested package resolution locally.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
