### PR TITLE
feat: Allow using an UploadedCode object for script processor's code parameter

### DIFF
--- a/src/sagemaker/processing.py
+++ b/src/sagemaker/processing.py
@@ -712,11 +712,6 @@ class ScriptProcessor(Processor):
             # code has already been uploaded (presumably via a ProcessingInput)
             inputs_with_code = inputs or []
             user_script_name = code.script_name
-            if is_pipeline_variable(user_script_name):
-                raise ValueError(
-                    "code argument destination must be a local file path "
-                    + "rather than a pipeline variable"
-                )
         else:
             user_code_s3_uri = self._handle_user_code_url(code, kms_key)
             user_script_name = self._get_user_code_name(code)
@@ -1614,7 +1609,7 @@ class FrameworkProcessor(ScriptProcessor):
             code (str): This can be an S3 URI or a local path to a file with the framework
                 script to run. See the ``code`` argument in
                 `sagemaker.processing.FrameworkProcessor.run()`.
-            source_dir (str): Path (absolute, relative, or an S3 URI) to a directory wit
+            source_dir (str): Path (absolute, relative, or an S3 URI) to a directory with
                 any other processing source code dependencies aside from the entrypoint
                 file (default: None). See the ``source_dir`` argument in
                 `sagemaker.processing.FrameworkProcessor.run()`

--- a/src/sagemaker/workflow/steps.py
+++ b/src/sagemaker/workflow/steps.py
@@ -24,6 +24,7 @@ import attr
 
 from sagemaker import Session
 from sagemaker.estimator import EstimatorBase, _TrainingJob
+from sagemaker.fw_utils import UploadedCode
 from sagemaker.inputs import CreateModelInput, TrainingInput, TransformInput, FileSystemInput
 from sagemaker.model import Model
 from sagemaker.pipeline import PipelineModel
@@ -765,7 +766,7 @@ class ProcessingStep(ConfigurableRetryStep):
         inputs: List[ProcessingInput] = None,
         outputs: List[ProcessingOutput] = None,
         job_arguments: List[str] = None,
-        code: str = None,
+        code: Union[str, UploadedCode] = None,
         property_files: List[PropertyFile] = None,
         cache_config: CacheConfig = None,
         depends_on: Optional[List[Union[str, Step, "StepCollection"]]] = None,
@@ -789,7 +790,7 @@ class ProcessingStep(ConfigurableRetryStep):
                 instances. Defaults to `None`.
             job_arguments (List[str]): A list of strings to be passed into the processing job.
                 Defaults to `None`.
-            code (str): This can be an S3 URI or a local path to a file with the framework
+            code (str or ProcessingInput): This can be an S3 URI or a local path to a file with the framework
                 script to run. Defaults to `None`.
             property_files (List[PropertyFile]): A list of property files that workflow looks
                 for and resolves from the configured processing output list.
@@ -835,7 +836,7 @@ class ProcessingStep(ConfigurableRetryStep):
             # arguments attribute. Refactor `Processor.run`, if possible.
             self.processor.arguments = job_arguments
 
-            if code:
+            if code and not isinstance(code, UploadedCode):
                 if is_pipeline_variable(code):
                     raise ValueError(
                         "code argument has to be a valid S3 URI or local file path "

--- a/src/sagemaker/workflow/utilities.py
+++ b/src/sagemaker/workflow/utilities.py
@@ -23,6 +23,7 @@ from urllib.parse import unquote, urlparse
 from contextlib import contextmanager
 from _hashlib import HASH as Hash
 
+from sagemaker.fw_utils import UploadedCode
 from sagemaker.workflow.parameters import Parameter
 from sagemaker.workflow.pipeline_context import _StepArguments, _PipelineConfig
 from sagemaker.workflow.entities import (
@@ -168,19 +169,18 @@ def get_processing_code_hash(code: str, source_dir: str, dependencies: List[str]
     Returns:
         str: A hash string representing the unique code artifact(s) for the step
     """
-
     # FrameworkProcessor
     if source_dir:
         source_dir_url = urlparse(source_dir)
         if source_dir_url.scheme == "" or source_dir_url.scheme == "file":
             # Include code in the hash when possible
-            if code:
+            if code and not isinstance(code, UploadedCode):
                 code_url = urlparse(code)
                 if code_url.scheme == "" or code_url.scheme == "file":
                     return hash_files_or_dirs([code, source_dir] + dependencies)
             return hash_files_or_dirs([source_dir] + dependencies)
     # Other Processors - Spark, Script, Base, etc.
-    if code:
+    if code and not isinstance(code, UploadedCode):
         code_url = urlparse(code)
         if code_url.scheme == "" or code_url.scheme == "file":
             return hash_files_or_dirs([code] + dependencies)

--- a/tests/unit/sagemaker/workflow/test_processing_step.py
+++ b/tests/unit/sagemaker/workflow/test_processing_step.py
@@ -22,6 +22,7 @@ import warnings
 from copy import deepcopy
 
 from sagemaker.estimator import Estimator
+from sagemaker.fw_utils import UploadedCode
 from sagemaker.parameter import IntegerParameter
 from sagemaker.transformer import Transformer
 from sagemaker.tuner import HyperparameterTuner
@@ -70,6 +71,10 @@ from tests.unit.sagemaker.workflow.conftest import ROLE, BUCKET, IMAGE_URI, INST
 
 DUMMY_S3_SCRIPT_PATH = "s3://dummy-s3/dummy_script.py"
 LOCAL_SCRIPT_PATH = os.path.join(DATA_DIR, "workflow/abalone/preprocessing.py")
+UPLOADED_SCRIPT_INPUT = UploadedCode(
+    s3_prefix=DUMMY_S3_SCRIPT_PATH,
+    script_name="/opt/ml/processing/code/script_from_s3.py",
+)
 SPARK_APP_JAR_PATH = os.path.join(
     DATA_DIR, "spark/code/java/hello-java-spark/HelloJavaSparkApp.jar"
 )
@@ -379,7 +384,9 @@ def test_processing_step_with_processor_and_step_args(
 
 
 @patch("sagemaker.workflow.utilities._pipeline_config", MOCKED_PIPELINE_CONFIG)
-@pytest.mark.parametrize("code_artifact", [DUMMY_S3_SCRIPT_PATH, LOCAL_SCRIPT_PATH])
+@pytest.mark.parametrize(
+    "code_artifact", [DUMMY_S3_SCRIPT_PATH, LOCAL_SCRIPT_PATH, UPLOADED_SCRIPT_INPUT]
+)
 def test_processing_step_with_script_processor(
     pipeline_session, processing_input, network_config, code_artifact
 ):


### PR DESCRIPTION
*Issue #:* #3846

*Description of changes:*

Allows passing a `UploadedCode` as a code parameter to ScriptProcessor and ProcessingStep (instead of passing a path or URI which is internally converted to a ProcessingInput).

*Testing done:*

* existing unit tests pass
* new unit test added to cover this case
* my usage of this feature works-for-me

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [X] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [X] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
