### PR TITLE
Relax local-mode PyPI requirements on urllib3

### DIFF
--- a/requirements/extras/local_requirements.txt
+++ b/requirements/extras/local_requirements.txt
@@ -1,4 +1,4 @@
-urllib3==1.26.8
+urllib3>=1.26.8,<1.26.15
 docker-compose==1.29.2
 docker>=5.0.2,<7.0.0
 PyYAML==5.4.1

--- a/requirements/extras/test_requirements.txt
+++ b/requirements/extras/test_requirements.txt
@@ -24,6 +24,6 @@ pandas>=1.3.5,<1.5
 scikit-learn==1.0.2
 cloudpickle==2.2.1
 scipy==1.7.3
-urllib3==1.26.8
+urllib3>=1.26.8,<1.26.15
 docker>=5.0.2,<7.0.0
 PyYAML==6.0


### PR DESCRIPTION
*Issue #, if available:* 
#3857

*Description of changes:*
Relax local-mode PyPI requirements on `urllib3` to a range `urllib3>=1.26.8,<1.26.15`
*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
