### PR TITLE
feature: handle use case where endpoint is created outside of python …

### DIFF
--- a/src/sagemaker/predictor_async.py
+++ b/src/sagemaker/predictor_async.py
@@ -99,7 +99,7 @@ class AsyncPredictor:
         self._input_path = input_path
         response = self._submit_async_request(input_path, initial_args, inference_id)
         output_location = response["OutputLocation"]
-        failure_location = response["FailureLocation"]
+        failure_location = response.get("FailureLocation")
         result = self._wait_for_output(
             output_path=output_location, failure_path=failure_location, waiter_config=waiter_config
         )
@@ -145,7 +145,7 @@ class AsyncPredictor:
         self._input_path = input_path
         response = self._submit_async_request(input_path, initial_args, inference_id)
         output_location = response["OutputLocation"]
-        failure_location = response["FailureLocation"]
+        failure_location = response.get("FailureLocation")
         response_async = AsyncInferenceResponse(
             predictor_async=self,
             output_path=output_location,
@@ -216,6 +216,35 @@ class AsyncPredictor:
         return response
 
     def _wait_for_output(self, output_path, failure_path, waiter_config):
+        """Retrieve output based on the presense of failure_path."""
+        if failure_path is not None:
+            return self._check_output_and_failure_paths(
+                output_path, failure_path, waiter_config
+            )
+
+        return self._check_output_path(output_path, waiter_config)
+
+    def _check_output_path(self, output_path, waiter_config):
+        """Check the Amazon S3 output path for the output.
+
+        Periodically check Amazon S3 output path for async inference result.
+        Timeout automatically after max attempts reached
+        """
+        bucket, key = parse_s3_url(output_path)
+        s3_waiter = self.s3_client.get_waiter("object_exists")
+        try:
+            s3_waiter.wait(Bucket=bucket, Key=key, WaiterConfig=waiter_config._to_request_dict())
+        except WaiterError:
+            raise PollingTimeoutError(
+                message="Inference could still be running",
+                output_path=output_path,
+                seconds=waiter_config.delay * waiter_config.max_attempts,
+            )
+        s3_object = self.s3_client.get_object(Bucket=bucket, Key=key)
+        result = self.predictor._handle_response(response=s3_object)
+        return result
+
+    def _check_output_and_failure_paths(self, output_path, failure_path, waiter_config):
         """Check the Amazon S3 output path for the output.
 
         This method waits for either the output file or the failure file to be found on the

--- a/src/sagemaker/predictor_async.py
+++ b/src/sagemaker/predictor_async.py
@@ -218,9 +218,7 @@ class AsyncPredictor:
     def _wait_for_output(self, output_path, failure_path, waiter_config):
         """Retrieve output based on the presense of failure_path."""
         if failure_path is not None:
-            return self._check_output_and_failure_paths(
-                output_path, failure_path, waiter_config
-            )
+            return self._check_output_and_failure_paths(output_path, failure_path, waiter_config)
 
         return self._check_output_path(output_path, waiter_config)
 

--- a/tests/unit/test_predictor_async.py
+++ b/tests/unit/test_predictor_async.py
@@ -76,6 +76,37 @@ def empty_sagemaker_session():
     return ims
 
 
+def empty_sagemaker_session_with_null_failure_path():
+    ims = Mock(name="sagemaker_session")
+    ims.default_bucket = Mock(name="default_bucket", return_value=BUCKET_NAME)
+    ims.sagemaker_runtime_client = Mock(name="sagemaker_runtime")
+    ims.sagemaker_client.describe_endpoint = Mock(return_value=ENDPOINT_DESC)
+    ims.sagemaker_client.describe_endpoint_config = Mock(return_value=ENDPOINT_CONFIG_DESC)
+
+    ims.sagemaker_runtime_client.invoke_endpoint_async = Mock(
+        name="invoke_endpoint_async",
+        return_value={
+            "OutputLocation": ASYNC_OUTPUT_LOCATION,
+        },
+    )
+
+    polling_timeout_error = PollingTimeoutError(
+        message="Inference could still be running",
+        output_path=ASYNC_OUTPUT_LOCATION,
+        seconds=DEFAULT_WAITER_CONFIG.delay * DEFAULT_WAITER_CONFIG.max_attempts,
+    )
+
+    ims.s3_client = Mock(name="s3_client")
+    ims.s3_client.get_object = Mock(
+        name="get_object",
+        side_effect=[polling_timeout_error],
+    )
+
+    ims.s3_client.put_object = Mock(name="put_object")
+
+    return ims
+
+
 def empty_predictor():
     predictor = Mock(name="predictor")
     predictor.update_endpoint = Mock(name="update_endpoint")
@@ -161,6 +192,31 @@ def test_async_predict_call_with_data_and_input_path():
     assert result.failure_path == ASYNC_FAILURE_LOCATION
 
 
+def test_async_predict_call_with_data_and_input_and_null_failure_path():
+    sagemaker_session = empty_sagemaker_session_with_null_failure_path()
+    predictor_async = AsyncPredictor(Predictor(ENDPOINT, sagemaker_session))
+    predictor_async.name = ASYNC_PREDICTOR
+    data = DUMMY_DATA
+
+    result = predictor_async.predict_async(data=data, input_path=ASYNC_INPUT_LOCATION)
+    assert sagemaker_session.s3_client.put_object.called
+
+    assert sagemaker_session.sagemaker_runtime_client.invoke_endpoint_async.called
+    assert sagemaker_session.sagemaker_client.describe_endpoint.not_called
+    assert sagemaker_session.sagemaker_client.describe_endpoint_config.not_called
+
+    expected_request_args = {
+        "Accept": DEFAULT_ACCEPT,
+        "InputLocation": ASYNC_INPUT_LOCATION,
+        "EndpointName": ENDPOINT,
+    }
+
+    call_args, kwargs = sagemaker_session.sagemaker_runtime_client.invoke_endpoint_async.call_args
+    assert kwargs == expected_request_args
+    assert result.output_path == ASYNC_OUTPUT_LOCATION
+    assert result.failure_path is None
+
+
 def test_async_predict_call_verify_exceptions():
     sagemaker_session = empty_sagemaker_session()
     predictor_async = AsyncPredictor(Predictor(ENDPOINT, sagemaker_session))
@@ -185,7 +241,27 @@ def test_async_predict_call_verify_exceptions():
     assert sagemaker_session.sagemaker_client.describe_endpoint_config.not_called
 
 
-def test_async_predict_call_pass_through_success():
+def test_async_predict_call_verify_exceptions_with_null_failure_path():
+    sagemaker_session = empty_sagemaker_session_with_null_failure_path()
+    predictor_async = AsyncPredictor(Predictor(ENDPOINT, sagemaker_session))
+
+    input_location = "s3://some-input-path"
+
+    with pytest.raises(
+        PollingTimeoutError,
+        match=f"No result at {ASYNC_OUTPUT_LOCATION} after polling for "
+        f"{DEFAULT_WAITER_CONFIG.delay*DEFAULT_WAITER_CONFIG.max_attempts}"
+        f" seconds. Inference could still be running",
+    ):
+        predictor_async.predict(input_path=input_location, waiter_config=DEFAULT_WAITER_CONFIG)
+
+    assert sagemaker_session.sagemaker_runtime_client.invoke_endpoint_async.called
+    assert sagemaker_session.s3_client.get_object.called
+    assert sagemaker_session.sagemaker_client.describe_endpoint.not_called
+    assert sagemaker_session.sagemaker_client.describe_endpoint_config.not_called
+
+
+def test_async_predict_call_pass_through_output_failure_paths():
     sagemaker_session = empty_sagemaker_session()
 
     response_body = Mock("body")
@@ -206,6 +282,42 @@ def test_async_predict_call_pass_through_success():
         return_value={
             "OutputLocation": ASYNC_OUTPUT_LOCATION,
             "FailureLocation": ASYNC_FAILURE_LOCATION,
+        },
+    )
+
+    input_location = "s3://some-input-path"
+
+    result = predictor_async.predict(
+        input_path=input_location,
+    )
+
+    assert result == RETURN_VALUE
+    assert sagemaker_session.sagemaker_runtime_client.invoke_endpoint_async.called
+    assert sagemaker_session.s3_client.get_waiter.called_with("object_exists")
+    assert sagemaker_session.sagemaker_client.describe_endpoint.not_called
+    assert sagemaker_session.sagemaker_client.describe_endpoint_config.not_called
+
+
+def test_async_predict_call_pass_through_with_null_failure_path():
+    sagemaker_session = empty_sagemaker_session_with_null_failure_path()
+
+    response_body = Mock("body")
+    response_body.read = Mock("read", return_value=RETURN_VALUE)
+    response_body.close = Mock("close", return_value=None)
+
+    sagemaker_session.s3_client = Mock(name="s3_client")
+    sagemaker_session.s3_client.get_object = Mock(
+        name="get_object",
+        return_value={"Body": response_body},
+    )
+    sagemaker_session.s3_client.put_object = Mock(name="put_object")
+
+    predictor_async = AsyncPredictor(Predictor(ENDPOINT, sagemaker_session))
+
+    sagemaker_session.sagemaker_runtime_client.invoke_endpoint_async = Mock(
+        name="invoke_endpoint_async",
+        return_value={
+            "OutputLocation": ASYNC_OUTPUT_LOCATION,
         },
     )
 


### PR DESCRIPTION
feature: handle use case where endpoint is created outside of python sdk with failure path as None

*Issue #, if available:*

*Description of changes:* Updating the predictor (async predictor) to handle the endpoints that are created outside of python sdk (say console) with failure path as None

*Testing done:* Manual & Unit Tests

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [X ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ X] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ X] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [X ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ X] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ X] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ X] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
