### PR TITLE
doc: Update doc for model_server_workers param in PyTorchModel

### DIFF
--- a/src/sagemaker/pytorch/model.py
+++ b/src/sagemaker/pytorch/model.py
@@ -123,9 +123,9 @@ class PyTorchModel(FrameworkModel):
                 to call to create a predictor with an endpoint name and
                 SageMaker ``Session``. If specified, ``deploy()`` returns the
                 result of invoking this function on the created endpoint name.
-            model_server_workers (int or PipelineVariable): Optional. The number of worker processes
-                used by the inference server. If None, server will use one
-                worker per vCPU.
+            model_server_workers (int or PipelineVariable): Optional. The number of worker
+                processes used by the TorchServe model server. If None, available GPUs
+                in system or number of logical processors available to the JVM.
             **kwargs: Keyword arguments passed to the superclass
                 :class:`~sagemaker.model.FrameworkModel` and, subsequently, its
                 superclass :class:`~sagemaker.model.Model`.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Documentation on default value for `model_server_workers` on GPU for PyTorch is confusing.
Hence we are fixing this doc with correct explanation.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
