### PR TITLE
change: SDK Defaults - switch from config printing to logging

### DIFF
--- a/src/sagemaker/config/config_utils.py
+++ b/src/sagemaker/config/config_utils.py
@@ -1,0 +1,199 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+"""This file contains util functions for the sagemaker Defaults Config.
+
+These utils may be used inside or outside the config module.
+"""
+from __future__ import absolute_import
+
+import logging
+import sys
+
+
+def get_sagemaker_config_logger():
+    """Return a logger with the name 'sagemaker.config'
+
+    If the logger to be returned has no level or handlers set, this will get level and handler
+    attributes. (So if the SDK user has setup loggers in a certain way, that setup will not be
+    changed by this function.) It is safe to make repeat calls to this function.
+    """
+    sagemaker_config_logger = logging.getLogger("sagemaker.config")
+    sagemaker_logger = logging.getLogger("sagemaker")
+
+    if sagemaker_config_logger.level == logging.NOTSET:
+        sagemaker_config_logger.setLevel(logging.INFO)
+
+    # check sagemaker_logger here as well, so that if handlers were set for the parent logger
+    # already, we dont change behavior for the child logger
+    if len(sagemaker_config_logger.handlers) == 0 and len(sagemaker_logger.handlers) == 0:
+        # use sys.stdout so logs dont show up with a red background in a notebook
+        handler = logging.StreamHandler(sys.stdout)
+
+        formatter = logging.Formatter("%(name)s %(levelname)-4s - %(message)s")
+        handler.setFormatter(formatter)
+        sagemaker_config_logger.addHandler(handler)
+
+        # if a handler is being added, we dont want the root handler to also process the same events
+        sagemaker_config_logger.propagate = False
+
+    return sagemaker_config_logger
+
+
+def _log_sagemaker_config_single_substitution(source_value, config_value, config_key_path: str):
+    """Informs the SDK user whether a config value was present and automatically substituted
+
+    Args:
+        source_value: The value that will be used if it exists. Usually, this is user-provided
+            input to a Class or to a session.py method, or None if no input was provided.
+        config_value: The value fetched from sagemaker_config. If it exists, this is the value that
+            will be used if direct_input is None.
+        config_key_path: A string denoting the path of keys that point to the config value in the
+            sagemaker_config.
+
+    Returns:
+        None. Logs information to the "sagemaker.config" logger.
+    """
+    logger = get_sagemaker_config_logger()
+
+    if config_value is not None:
+
+        if source_value is None:
+            # Sagemaker Config value is going to be used. By default the user should know about
+            # this scenario because the behavior they expect could change because of a new config
+            # value being injected in.
+            # However, it may not be safe to log ARNs to stdout by default. We can include more
+            # diagnostic info if the user enabled DEBUG logs though.
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug(
+                    "Applied value\n  config key = %s\n  config value that will be used = %s",
+                    config_key_path,
+                    config_value,
+                )
+            else:
+                logger.info(
+                    "Applied value from config key = %s",
+                    config_key_path,
+                )
+
+        # The cases below here are logged as just debug statements because this info can be useful
+        # when debugging the config, but should not affect current behavior with/without the config.
+
+        elif source_value is not None and config_value == source_value:
+            # Sagemaker Config had a value defined that is NOT going to be used here.
+            # Either (1) the config value was already fetched and applied earlier, or
+            # (2) the user happened to pass in the same value.
+            logger.debug(
+                (
+                    "Skipped value\n"
+                    "  config key = %s\n"
+                    "  config value = %s\n"
+                    "  source value that will be used = %s"
+                ),
+                config_key_path,
+                config_value,
+                source_value,
+            )
+        elif source_value is not None and config_value != source_value:
+            # Sagemaker Config had a value defined that is NOT going to be used
+            # and the config value has not already been applied earlier (we know because the values
+            # are different).
+            logger.debug(
+                (
+                    "Skipped value\n"
+                    "  config key = %s\n"
+                    "  config value = %s\n"
+                    "  source value that will be used = %s",
+                ),
+                config_key_path,
+                config_value,
+                source_value,
+            )
+    else:
+        # nothing was specified in the config and nothing is being automatically applied
+        logger.debug("Skipped value because no value defined\n  config key = %s", config_key_path)
+
+
+def _log_sagemaker_config_merge(
+    source_value=None,
+    config_value=None,
+    merged_source_and_config_value=None,
+    config_key_path: str = None,
+):
+    """Informs the SDK user whether a config value was present and automatically substituted
+
+    Args:
+        source_value: The dict or object that would be used if no default values existed. Usually,
+            this is user-provided input to a Class or to a session.py method, or None if no input
+            was provided.
+        config_value: The dict or object fetched from sagemaker_config. If it exists, this is the
+            value that will be used if source_value is None.
+        merged_source_and_config_value: The value that results from the merging of source_value and
+            original_config_value. This will be the value used.
+        config_key_path: A string denoting the path of keys that point to the config value in the
+            sagemaker_config.
+
+    Returns:
+        None. Logs information to the "sagemaker.config" logger.
+    """
+    logger = get_sagemaker_config_logger()
+
+    if config_value:
+
+        if source_value != merged_source_and_config_value:
+            # Sagemaker Config value(s) were used and affected the final object/dictionary. By
+            # default the user should know about this scenario because the behavior they expect
+            # could change because of new config values being injected in.
+            # However, it may not be safe to log ARNs to stdout by default. We can include more
+            # diagnostic info if the user enabled DEBUG logs though.
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug(
+                    (
+                        "Applied value(s)\n"
+                        "  config key = %s\n"
+                        "  config value = %s\n"
+                        "  source value = %s\n"
+                        "  combined value that will be used = %s"
+                    ),
+                    config_key_path,
+                    config_value,
+                    source_value,
+                    merged_source_and_config_value,
+                )
+            else:
+                logger.info(
+                    "Applied value(s) from config key = %s",
+                    config_key_path,
+                )
+
+        # The cases below here are logged as just debug statements because this info can be useful
+        # when debugging the config, but should not affect current behavior with/without the config.
+
+        else:
+            # Sagemaker Config had a value defined that is NOT going to be used here.
+            # Either (1) the config value was already fetched and applied earlier, or
+            # (2) the user happened to pass in the same values.
+            logger.debug(
+                (
+                    "Skipped value(s)\n"
+                    "  config key = %s\n"
+                    "  config value = %s\n"
+                    "  source value that will be used = %s"
+                ),
+                config_key_path,
+                config_value,
+                merged_source_and_config_value,
+            )
+
+    else:
+        # nothing was specified in the config and nothing is being automatically applied
+        logger.debug("Skipped value because no value defined\n  config key = %s", config_key_path)

--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -95,6 +95,7 @@ from sagemaker.config import (
     SESSION_DEFAULT_S3_BUCKET_PATH,
     SESSION_DEFAULT_S3_OBJECT_KEY_PREFIX_PATH,
 )
+from sagemaker.config.config_utils import _log_sagemaker_config_merge
 from sagemaker.deprecations import deprecated_class
 from sagemaker.inputs import ShuffleConfig, TrainingInput, BatchDataCaptureConfig
 from sagemaker.user_agent import prepend_user_agent
@@ -606,47 +607,6 @@ class Session(object):  # pylint: disable=too-many-public-methods
                 else:
                     raise
 
-    def _print_message_on_sagemaker_config_usage(
-        self, direct_input, config_value, config_path: str
-    ):
-        """Informs the SDK user whether a config value was present and automatically substituted
-
-        Args:
-            direct_input: the value that would be used if no sagemaker_config or default values
-                          existed. Usually this will be user-provided input to a Class or to a
-                          session.py method, or None if no input was provided.
-            config_value: the value fetched from sagemaker_config. This is usually the value that
-                          will be used if direct_input is None.
-            config_path: a string denoting the path of keys that point to the config value in the
-                         sagemaker_config
-
-        Returns:
-            No output (just prints information)
-        """
-
-        if config_value is not None:
-
-            if direct_input is not None and config_value != direct_input:
-                # Sagemaker Config had a value defined that is NOT going to be used
-                # and the config value has not already been applied earlier
-                print(
-                    "[Sagemaker Config - skipped value]\n",
-                    "config key = {}\n".format(config_path),
-                    "config value = {}\n".format(config_value),
-                    "specified value that will be used = {}\n".format(direct_input),
-                )
-
-            elif direct_input is None:
-                # Sagemaker Config value is going to be used
-                print(
-                    "[Sagemaker Config - applied value]\n",
-                    "config key = {}\n".format(config_path),
-                    "config value that will be used = {}\n".format(config_value),
-                )
-
-        # There is no print statement needed if nothing was specified in the config and nothing is
-        # being automatically applied
-
     def _append_sagemaker_config_tags(self, tags: list, config_path_to_tags: str):
         """Appends tags specified in the sagemaker_config to the given list of tags.
 
@@ -677,12 +637,11 @@ class Session(object):  # pylint: disable=too-many-public-methods
                 # user-provided tags.
                 all_tags.append(config_tag)
 
-        print(
-            "[Sagemaker Config - applied value]\n",
-            "config key = {}\n".format(config_path_to_tags),
-            "config value = {}\n".format(config_tags),
-            "source value = {}\n".format(tags),
-            "combined value that will be used = {}\n".format(all_tags),
+        _log_sagemaker_config_merge(
+            source_value=tags,
+            config_value=config_tags,
+            merged_source_and_config_value=all_tags,
+            config_key_path=config_path_to_tags,
         )
 
         return all_tags

--- a/src/sagemaker/utils.py
+++ b/src/sagemaker/utils.py
@@ -38,6 +38,10 @@ from six.moves.urllib import parse
 
 from sagemaker import deprecations
 from sagemaker.config import validate_sagemaker_config
+from sagemaker.config.config_utils import (
+    _log_sagemaker_config_single_substitution,
+    _log_sagemaker_config_merge,
+)
 from sagemaker.session_settings import SessionSettings
 from sagemaker.workflow import is_pipeline_variable, is_pipeline_parameter_string
 
@@ -1069,7 +1073,7 @@ def resolve_value_from_config(
     config_value = (
         get_sagemaker_config_value(sagemaker_session, config_path) if config_path else None
     )
-    _print_message_on_sagemaker_config_usage(direct_input, config_value, config_path)
+    _log_sagemaker_config_single_substitution(direct_input, config_value, config_path)
 
     if direct_input is not None:
         return direct_input
@@ -1098,46 +1102,6 @@ def get_sagemaker_config_value(sagemaker_session, key):
     config_value = get_config_value(key, sagemaker_session.sagemaker_config)
     # Copy the value so any modifications to the output will not modify the source config
     return copy.deepcopy(config_value)
-
-
-def _print_message_on_sagemaker_config_usage(direct_input, config_value, config_path: str):
-    """Informs the SDK user whether a config value was present and automatically substituted
-
-    Args:
-        direct_input: The value that is used if no default values exist. Usually,
-        this is user-provided input to a Class or to a session.py method, or None if no input
-        was provided.
-        config_value: The value fetched from sagemaker_config. This is usually the value that
-        will be used if direct_input is None.
-        config_path: A string denoting the path of keys that point to the config value in the
-        sagemaker_config.
-
-    Returns:
-        None. Prints information.
-    """
-
-    if config_value is not None:
-
-        if direct_input is not None and config_value != direct_input:
-            # Sagemaker Config had a value defined that is NOT going to be used
-            # and the config value has not already been applied earlier
-            print(
-                "[Sagemaker Config - skipped value]\n",
-                "config key = {}\n".format(config_path),
-                "config value = {}\n".format(config_value),
-                "specified value that will be used = {}\n".format(direct_input),
-            )
-
-        elif direct_input is None:
-            # Sagemaker Config value is going to be used
-            print(
-                "[Sagemaker Config - applied value]\n",
-                "config key = {}\n".format(config_path),
-                "config value that will be used = {}\n".format(config_value),
-            )
-
-    # There is no print statement needed if nothing was specified in the config and nothing is
-    # being automatically applied
 
 
 def resolve_class_attribute_from_config(
@@ -1206,7 +1170,7 @@ def resolve_class_attribute_from_config(
         elif default_value is not None:
             setattr(instance, attribute, default_value)
 
-    _print_message_on_sagemaker_config_usage(current_value, config_value, config_path)
+    _log_sagemaker_config_single_substitution(current_value, config_value, config_path)
 
     return instance
 
@@ -1259,7 +1223,7 @@ def resolve_nested_dict_value_from_config(
         elif default_value is not None:
             dictionary = set_nested_value(dictionary, nested_keys, default_value)
 
-    _print_message_on_sagemaker_config_usage(current_nested_value, config_value, config_path)
+    _log_sagemaker_config_single_substitution(current_nested_value, config_value, config_path)
 
     return dictionary
 
@@ -1324,14 +1288,12 @@ def update_list_of_dicts_with_values_from_config(
             continue
         input_list[i] = dict_from_config
 
-    if unmodified_inputs_from_config:
-        print(
-            "[Sagemaker Config - applied value]\n",
-            "config key = {}\n".format(config_key_path),
-            "config value = {}\n".format(unmodified_inputs_from_config),
-            "source value = {}\n".format(inputs_copy),
-            "combined value that will be used = {}\n".format(input_list),
-        )
+    _log_sagemaker_config_merge(
+        source_value=inputs_copy,
+        config_value=unmodified_inputs_from_config,
+        merged_source_and_config_value=input_list,
+        config_key_path=config_key_path,
+    )
 
 
 def _validate_required_paths_in_a_dict(source_dict, required_key_paths: List[str] = None) -> bool:
@@ -1392,19 +1354,11 @@ def update_nested_dictionary_with_values_from_config(
         # Don't need to print because no config value was used or defined
         return source_dict
 
-    if source_dict == inferred_config_dict:
-        # We didn't use any values from the config, but we should print if any of the config
-        # values were defined
-        _print_message_on_sagemaker_config_usage(
-            source_dict, original_config_dict_value, config_key_path
-        )
-    else:
-        # Something from the config was merged in
-        print(
-            "[Sagemaker Config - applied value]\n",
-            "config key = {}\n".format(config_key_path),
-            "config value = {}\n".format(original_config_dict_value),
-            "source value = {}\n".format(source_dict),
-            "combined value that will be used = {}\n".format(inferred_config_dict),
-        )
+    _log_sagemaker_config_merge(
+        source_value=source_dict,
+        config_value=original_config_dict_value,
+        merged_source_and_config_value=inferred_config_dict,
+        config_key_path=config_key_path,
+    )
+
     return inferred_config_dict


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
