### PR TITLE
fix: Update neo multiversion support to include edge devices

### DIFF
--- a/src/sagemaker/model.py
+++ b/src/sagemaker/model.py
@@ -69,6 +69,17 @@ NEO_ALLOWED_FRAMEWORKS = set(
 
 NEO_IOC_TARGET_DEVICES = ["ml_c4", "ml_c5", "ml_m4", "ml_m5", "ml_p2", "ml_p3", "ml_g4dn"]
 
+NEO_MULTIVERSION_UNSUPPORTED = [
+    "imx8mplus",
+    "jacinto_tda4vm",
+    "coreml",
+    "sitara_am57x",
+    "amba_cv2",
+    "amba_cv22",
+    "amba_cv25",
+    "lambda",
+]
+
 
 class ModelBase(abc.ABC):
     """An object that encapsulates a trained model.
@@ -836,11 +847,14 @@ api/latest/reference/services/sagemaker.html#SageMaker.Client.add_tags>`_
                 multi_version_frameworks_support_mapping = {
                     "inferentia": ["pytorch", "tensorflow", "mxnet"],
                     "neo_ioc_targets": ["pytorch", "tensorflow"],
+                    "neo_edge_targets": ["pytorch", "tensorflow"],
                 }
                 if target_instance_type in NEO_IOC_TARGET_DEVICES:
                     return framework in multi_version_frameworks_support_mapping["neo_ioc_targets"]
                 if target_instance_type == "ml_inf1":
                     return framework in multi_version_frameworks_support_mapping["inferentia"]
+                if target_instance_type not in NEO_MULTIVERSION_UNSUPPORTED:
+                    return framework in multi_version_frameworks_support_mapping["neo_edge_targets"]
             return False
 
         if multi_version_compilation_supported(target_instance_type, framework, framework_version):

--- a/tests/unit/sagemaker/model/test_neo.py
+++ b/tests/unit/sagemaker/model/test_neo.py
@@ -382,3 +382,39 @@ def test_compile_validates_framework_version(sagemaker_session):
     )
 
     assert model.image_uri is None
+
+    sagemaker_session.wait_for_compilation_job = Mock(
+        return_value={
+            "CompilationJobStatus": "Completed",
+            "ModelArtifacts": {"S3ModelArtifacts": "s3://output-path/model.tar.gz"},
+            "InferenceImage": None,
+        }
+    )
+
+    config = model._compilation_job_config(
+        "rasp3b",
+        {"data": [1, 3, 1024, 1024]},
+        "s3://output",
+        "role",
+        900,
+        "compile-model",
+        "pytorch",
+        None,
+        framework_version="1.6.1",
+    )
+
+    assert config["input_model_config"]["FrameworkVersion"] == "1.6"
+
+    config = model._compilation_job_config(
+        "amba_cv2",
+        {"data": [1, 3, 1024, 1024]},
+        "s3://output",
+        "role",
+        900,
+        "compile-model",
+        "pytorch",
+        None,
+        framework_version="1.6.1",
+    )
+
+    assert config["input_model_config"].get("FrameworkVersion", None) is None


### PR DESCRIPTION
*Description of changes:*
Fixing a bug that was stopping version information from being passed to Neo service even when Neo supports versions for that edge target.

*Testing done:*
Added unit tests to validate that devices that should now pass version info do, and that devices that shouldn't still don't

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
