### PR TITLE
fix: SDK Defaults Config - Handle config injection for None Sessions

### DIFF
--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -456,9 +456,8 @@ def resolve_model_intelligent_default_field(
     over intelligent defaults. For all other fields, intelligent defaults takes precedence
     over the JumpStart default fields.
     """
-    # Workaround for config injection if sagemaker_session is None, since in
-    # that case sagemaker_session will not be initialized until
-    # `_init_sagemaker_session_if_does_not_exist` is called later
+    # In case, sagemaker_session is None, get sagemaker_config from load_sagemaker_config()
+    # to resolve value from config for the respective field_name parameter
     _sagemaker_config = load_sagemaker_config() if (sagemaker_session is None) else None
 
     # We allow customers to define a role which takes precedence

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -38,6 +38,7 @@ from sagemaker.jumpstart.types import (
     JumpStartVersionedModelId,
 )
 from sagemaker.session import Session
+from sagemaker.config import load_sagemaker_config
 from sagemaker.utils import resolve_value_from_config
 from sagemaker.workflow import is_pipeline_variable
 
@@ -455,6 +456,10 @@ def resolve_model_intelligent_default_field(
     over intelligent defaults. For all other fields, intelligent defaults takes precedence
     over the JumpStart default fields.
     """
+    # Workaround for config injection if sagemaker_session is None, since in
+    # that case sagemaker_session will not be initialized until
+    # `_init_sagemaker_session_if_does_not_exist` is called later
+    _sagemaker_config = load_sagemaker_config() if (sagemaker_session is None) else None
 
     # We allow customers to define a role which takes precedence
     # over intelligent defaults
@@ -464,6 +469,7 @@ def resolve_model_intelligent_default_field(
             config_path=MODEL_EXECUTION_ROLE_ARN_PATH,
             default_value=default_value or sagemaker_session.get_caller_identity_arn(),
             sagemaker_session=sagemaker_session,
+            sagemaker_config=_sagemaker_config,
         )
 
     # JumpStart Models have certain default field values. We want
@@ -474,6 +480,7 @@ def resolve_model_intelligent_default_field(
             config_path=MODEL_ENABLE_NETWORK_ISOLATION_PATH,
             sagemaker_session=sagemaker_session,
             default_value=default_value,
+            sagemaker_config=_sagemaker_config,
         )
         return resolved_val if resolved_val is not None else field_val
 
@@ -494,6 +501,11 @@ def resolve_estimator_intelligent_default_field(
     over the JumpStart default fields.
     """
 
+    # Workaround for config injection if sagemaker_session is None, since in
+    # that case sagemaker_session will not be initialized until
+    # `_init_sagemaker_session_if_does_not_exist` is called later
+    _sagemaker_config = load_sagemaker_config() if (sagemaker_session is None) else None
+
     # We allow customers to define a role which takes precedence
     # over intelligent defaults
     if field_name == "role":
@@ -502,6 +514,7 @@ def resolve_estimator_intelligent_default_field(
             config_path=TRAINING_JOB_ROLE_ARN_PATH,
             default_value=default_value or sagemaker_session.get_caller_identity_arn(),
             sagemaker_session=sagemaker_session,
+            sagemaker_config=_sagemaker_config,
         )
 
     # JumpStart Estimators have certain default field values. We want
@@ -513,6 +526,7 @@ def resolve_estimator_intelligent_default_field(
             config_path=TRAINING_JOB_ENABLE_NETWORK_ISOLATION_PATH,
             sagemaker_session=sagemaker_session,
             default_value=default_value,
+            sagemaker_config=_sagemaker_config,
         )
         return resolved_val if resolved_val is not None else field_val
 
@@ -523,6 +537,7 @@ def resolve_estimator_intelligent_default_field(
             config_path=TRAINING_JOB_INTER_CONTAINER_ENCRYPTION_PATH,
             sagemaker_session=sagemaker_session,
             default_value=default_value,
+            sagemaker_config=_sagemaker_config,
         )
         return resolved_val if resolved_val is not None else field_val
 

--- a/src/sagemaker/model.py
+++ b/src/sagemaker/model.py
@@ -41,6 +41,7 @@ from sagemaker.config import (
     MODEL_EXECUTION_ROLE_ARN_PATH,
     MODEL_PRIMARY_CONTAINER_ENVIRONMENT_PATH,
     ENDPOINT_CONFIG_ASYNC_KMS_KEY_ID_PATH,
+    load_sagemaker_config,
 )
 from sagemaker.session import Session
 from sagemaker.model_metrics import ModelMetrics
@@ -313,13 +314,25 @@ class Model(ModelBase, InferenceRecommenderMixin):
         self.name = name
         self._base_name = None
         self.sagemaker_session = sagemaker_session
+
+        # Workaround for config injection if sagemaker_session is None, since in
+        # that case sagemaker_session will not be initialized until
+        # `_init_sagemaker_session_if_does_not_exist` is called later
+        self._sagemaker_config = (
+            load_sagemaker_config() if (self.sagemaker_session is None) else None
+        )
+
         self.role = resolve_value_from_config(
             role,
             MODEL_EXECUTION_ROLE_ARN_PATH,
             sagemaker_session=self.sagemaker_session,
+            sagemaker_config=self._sagemaker_config,
         )
         self.vpc_config = resolve_value_from_config(
-            vpc_config, MODEL_VPC_CONFIG_PATH, sagemaker_session=self.sagemaker_session
+            vpc_config,
+            MODEL_VPC_CONFIG_PATH,
+            sagemaker_session=self.sagemaker_session,
+            sagemaker_config=self._sagemaker_config,
         )
         self.endpoint_name = None
         self._is_compiled_model = False
@@ -330,16 +343,17 @@ class Model(ModelBase, InferenceRecommenderMixin):
         self._enable_network_isolation = resolve_value_from_config(
             enable_network_isolation,
             MODEL_ENABLE_NETWORK_ISOLATION_PATH,
+            default_value=False,
             sagemaker_session=self.sagemaker_session,
+            sagemaker_config=self._sagemaker_config,
         )
         self.env = resolve_value_from_config(
             env,
             MODEL_PRIMARY_CONTAINER_ENVIRONMENT_PATH,
             default_value={},
             sagemaker_session=self.sagemaker_session,
+            sagemaker_config=self._sagemaker_config,
         )
-        if self._enable_network_isolation is None:
-            self._enable_network_isolation = False
         self.model_kms_key = model_kms_key
         self.image_config = image_config
         self.entry_point = entry_point
@@ -542,9 +556,9 @@ api/latest/reference/services/sagemaker.html#SageMaker.Client.add_tags>`_
             return
 
         if instance_type in ("local", "local_gpu"):
-            self.sagemaker_session = local.LocalSession()
+            self.sagemaker_session = local.LocalSession(sagemaker_config=self._sagemaker_config)
         else:
-            self.sagemaker_session = session.Session()
+            self.sagemaker_session = session.Session(sagemaker_config=self._sagemaker_config)
 
     def prepare_container_def(
         self,

--- a/src/sagemaker/pipeline.py
+++ b/src/sagemaker/pipeline.py
@@ -94,9 +94,8 @@ class PipelineModel(object):
         self.endpoint_name = None
         self.sagemaker_session = sagemaker_session
 
-        # Workaround for config injection if sagemaker_session is None, since in
-        # that case sagemaker_session will not be initialized until
-        # `_init_sagemaker_session_if_does_not_exist` is called later
+        # In case, sagemaker_session is None, get sagemaker_config from load_sagemaker_config()
+        # to resolve value from config for the respective parameter
         self._sagemaker_config = (
             load_sagemaker_config() if (self.sagemaker_session is None) else None
         )

--- a/src/sagemaker/utils.py
+++ b/src/sagemaker/utils.py
@@ -1106,10 +1106,9 @@ def get_sagemaker_config_value(sagemaker_session, key, sagemaker_config: dict = 
         sagemaker_config (dict): The sdk defaults config that is normally accessed through a
             Session object by doing `session.sagemaker_config`. (default: None) This parameter will
             be checked for the config value if (and only if) sagemaker_session is None. This
-            parameter exists for the rare cases where no Session provided no Session but a default
-            Session cannot be initialized before config injection is needed. In that case,
-            the config dictionary may be loaded and passed here before a default Session object
-            is created.
+            parameter exists for the rare cases where no Session provided but a default Session
+            cannot be initialized before config injection is needed. In that case, the config
+            dictionary may be loaded and passed here before a default Session object is created.
 
     Returns:
         object: The corresponding default value in the configuration file.

--- a/src/sagemaker/utils.py
+++ b/src/sagemaker/utils.py
@@ -1046,6 +1046,7 @@ def resolve_value_from_config(
     config_path: str = None,
     default_value=None,
     sagemaker_session=None,
+    sagemaker_config: dict = None,
 ):
     """Decides which value for the caller to use.
 
@@ -1059,19 +1060,30 @@ def resolve_value_from_config(
 
     Args:
         direct_input: The value that the caller of this method starts with. Usually this is an
-        input to the caller's class or method.
+            input to the caller's class or method.
         config_path (str): A string denoting the path used to lookup the value in the
-        sagemaker config.
+            sagemaker config.
         default_value: The value used if not present elsewhere.
         sagemaker_session (sagemaker.session.Session): A SageMaker Session object, used for
-        SageMaker interactions (default: None).
+            SageMaker interactions (default: None).
+        sagemaker_config (dict): The sdk defaults config that is normally accessed through a
+            Session object by doing `session.sagemaker_config`. (default: None) This parameter will
+            be checked for the config value if (and only if) sagemaker_session is None. This
+            parameter exists for the rare cases where the user provided no Session but a default
+            Session cannot be initialized before config injection is needed. In that case,
+            the config dictionary may be loaded and passed here before a default Session object
+            is created.
 
     Returns:
         The value that should be used by the caller
     """
 
     config_value = (
-        get_sagemaker_config_value(sagemaker_session, config_path) if config_path else None
+        get_sagemaker_config_value(
+            sagemaker_session, config_path, sagemaker_config=sagemaker_config
+        )
+        if config_path
+        else None
     )
     _log_sagemaker_config_single_substitution(direct_input, config_value, config_path)
 
@@ -1084,23 +1096,34 @@ def resolve_value_from_config(
     return default_value
 
 
-def get_sagemaker_config_value(sagemaker_session, key):
+def get_sagemaker_config_value(sagemaker_session, key, sagemaker_config: dict = None):
     """Returns the value that corresponds to the provided key from the configuration file.
 
     Args:
         key: Key Path of the config file entry.
         sagemaker_session (sagemaker.session.Session): A SageMaker Session object, used for
-        SageMaker interactions.
+            SageMaker interactions.
+        sagemaker_config (dict): The sdk defaults config that is normally accessed through a
+            Session object by doing `session.sagemaker_config`. (default: None) This parameter will
+            be checked for the config value if (and only if) sagemaker_session is None. This
+            parameter exists for the rare cases where no Session provided no Session but a default
+            Session cannot be initialized before config injection is needed. In that case,
+            the config dictionary may be loaded and passed here before a default Session object
+            is created.
 
     Returns:
         object: The corresponding default value in the configuration file.
     """
-    if not sagemaker_session:
+    if sagemaker_session:
+        config_to_check = sagemaker_session.sagemaker_config
+    else:
+        config_to_check = sagemaker_config
+
+    if not config_to_check:
         return None
 
-    if sagemaker_session.sagemaker_config:
-        validate_sagemaker_config(sagemaker_session.sagemaker_config)
-    config_value = get_config_value(key, sagemaker_session.sagemaker_config)
+    validate_sagemaker_config(config_to_check)
+    config_value = get_config_value(key, config_to_check)
     # Copy the value so any modifications to the output will not modify the source config
     return copy.deepcopy(config_value)
 

--- a/tests/unit/sagemaker/jumpstart/estimator/test_intelligent_defaults.py
+++ b/tests/unit/sagemaker/jumpstart/estimator/test_intelligent_defaults.py
@@ -57,7 +57,7 @@ metadata_inference_enable_network_isolation = random.choice([True, False])
 metadata_inference_role = "th1234567iant role"
 
 
-def config_value_impl(sagemaker_session: Session, config_path: str):
+def config_value_impl(sagemaker_session: Session, config_path: str, sagemaker_config: dict):
     if config_path == TRAINING_JOB_ENABLE_NETWORK_ISOLATION_PATH:
         return config_enable_network_isolation
 

--- a/tests/unit/sagemaker/jumpstart/model/test_intelligent_defaults.py
+++ b/tests/unit/sagemaker/jumpstart/model/test_intelligent_defaults.py
@@ -42,7 +42,7 @@ config_enable_network_isolation = random.choice([True, False])
 metadata_enable_network_isolation = random.choice([True, False])
 
 
-def config_value_impl(sagemaker_session: Session, config_path: str):
+def config_value_impl(sagemaker_session: Session, config_path: str, sagemaker_config: dict):
     if config_path == MODEL_EXECUTION_ROLE_ARN_PATH:
         return config_role
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -35,6 +35,7 @@ from sagemaker.session_settings import SessionSettings
 from sagemaker.utils import (
     retry_with_backoff,
     check_and_get_run_experiment_config,
+    get_sagemaker_config_value,
     resolve_value_from_config,
     resolve_class_attribute_from_config,
     resolve_nested_dict_value_from_config,
@@ -1190,6 +1191,10 @@ def test_resolve_value_from_config():
     sagemaker_session.sagemaker_config.update(
         {"SageMaker": {"EndpointConfig": {"KmsKeyId": "CONFIG_VALUE"}}}
     )
+    sagemaker_config = {
+        "SchemaVersion": "1.0",
+        "SageMaker": {"EndpointConfig": {"KmsKeyId": "CONFIG_VALUE"}},
+    }
 
     # direct_input should be respected
     assert (
@@ -1223,6 +1228,13 @@ def test_resolve_value_from_config():
 
     assert resolve_value_from_config(None, None, None, sagemaker_session) is None
 
+    # Config value from sagemaker_config should be returned
+    # if no direct_input and sagemaker_session is None
+    assert (
+        resolve_value_from_config(None, config_key_path, None, None, sagemaker_config)
+        == "CONFIG_VALUE"
+    )
+
     # Different falsy direct_inputs
     assert resolve_value_from_config("", config_key_path, None, sagemaker_session) == ""
 
@@ -1237,6 +1249,58 @@ def test_resolve_value_from_config():
     assert resolve_value_from_config(None, config_key_path, None, sagemaker_session) == ""
 
     mock_info_logger.reset_mock()
+
+
+def test_get_sagemaker_config_value():
+    mock_config_logger = Mock()
+
+    mock_info_logger = Mock()
+    mock_config_logger.info = mock_info_logger
+    # using a shorter name for inside the test
+    sagemaker_session = MagicMock()
+    sagemaker_session.sagemaker_config = {"SchemaVersion": "1.0"}
+    config_key_path = "SageMaker.EndpointConfig.KmsKeyId"
+    sagemaker_session.sagemaker_config.update(
+        {"SageMaker": {"EndpointConfig": {"KmsKeyId": "CONFIG_VALUE"}}}
+    )
+    sagemaker_config = {
+        "SchemaVersion": "1.0",
+        "SageMaker": {"EndpointConfig": {"KmsKeyId": "CONFIG_VALUE"}},
+    }
+
+    # Tests that the function returns the correct value when the key exists in the sagemaker_session configuration.
+    assert (
+        get_sagemaker_config_value(
+            sagemaker_session=sagemaker_session, key=config_key_path, sagemaker_config=None
+        )
+        == "CONFIG_VALUE"
+    )
+
+    # Tests that the function correctly uses the sagemaker_config to get value for the requested
+    # config_key_path when sagemaker_session is None.
+    assert (
+        get_sagemaker_config_value(
+            sagemaker_session=None, key=config_key_path, sagemaker_config=sagemaker_config
+        )
+        == "CONFIG_VALUE"
+    )
+
+    # Tests that the function returns None when the key does not exist in the configuration.
+    invalid_key = "inavlid_key"
+    assert (
+        get_sagemaker_config_value(
+            sagemaker_session=sagemaker_session, key=invalid_key, sagemaker_config=sagemaker_config
+        )
+        is None
+    )
+
+    # Tests that the function returns None when sagemaker_session and sagemaker_config are None.
+    assert (
+        get_sagemaker_config_value(
+            sagemaker_session=None, key=config_key_path, sagemaker_config=None
+        )
+        is None
+    )
 
 
 @patch("jsonschema.validate")


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

*Testing done:*

TBA: unit tests

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
