### PR TITLE
feature: Add autotune for HyperparameterTuner

### DIFF
--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -2619,9 +2619,10 @@ class Session(object):  # pylint: disable=too-many-public-methods
                 * volume_kms_key_id: The AWS Key Management Service (AWS KMS) key
                 that Amazon SageMaker uses to encrypt data on the storage
                 volume attached to the ML compute instance(s) that run the training job.
-            autotune (bool): Whether to turn on autotune (default: False).
+            autotune (bool): Whether the parameter ranges or other unset settings of a tuning job
+                should be chosen automatically (default: False).
             auto_parameters (dict[str, str]): Dictionary of auto parameters. The keys are names
-                of auto parameters and valeus are example values of auto parameters
+                of auto parameters and values are example values of auto parameters
                 (default: ``None``).
         """
 
@@ -2705,7 +2706,8 @@ class Session(object):  # pylint: disable=too-many-public-methods
                 other required configurations.
             tags (list[dict]): List of tags for labeling the tuning job. For more, see
                 https://docs.aws.amazon.com/sagemaker/latest/dg/API_Tag.html.
-            autotune (bool): whether to turn on autotune.
+            autotune (bool): Whether the parameter ranges or other unset settings of a tuning job
+                should be chosen automatically.
         """
 
         if training_config is None and training_config_list is None:
@@ -2756,7 +2758,8 @@ class Session(object):  # pylint: disable=too-many-public-methods
                 other required configurations.
             tags (list[dict]): List of tags for labeling the tuning job. For more, see
                 https://docs.aws.amazon.com/sagemaker/latest/dg/API_Tag.html.
-            autotune (bool): whether to turn on autotune.
+            autotune (bool): Whether the parameter ranges or other unset settings of a tuning job
+                should be chosen automatically.
         Returns:
             dict: A dictionary for CreateHyperParameterTuningJob request
         """
@@ -2868,10 +2871,13 @@ class Session(object):  # pylint: disable=too-many-public-methods
 
         if parameter_ranges is not None:
             tuning_config["ParameterRanges"] = parameter_ranges
-            if auto_parameters is not None:
-                tuning_config["ParameterRanges"]["AutoParameters"] = [
-                    {"Name": name, "ValueHint": value} for name, value in auto_parameters.items()
-                ]
+
+        if auto_parameters is not None:
+            if parameter_ranges is None:
+                tuning_config["ParameterRanges"] = {}
+            tuning_config["ParameterRanges"]["AutoParameters"] = [
+                {"Name": name, "ValueHint": value} for name, value in auto_parameters.items()
+            ]
 
         if strategy_config is not None:
             tuning_config["StrategyConfig"] = strategy_config
@@ -3054,10 +3060,13 @@ class Session(object):  # pylint: disable=too-many-public-methods
 
         if parameter_ranges is not None:
             training_job_definition["HyperParameterRanges"] = parameter_ranges
-            if auto_parameters is not None:
-                training_job_definition["HyperParameterRanges"]["AutoParameters"] = [
-                    {"Name": name, "ValueHint": value} for name, value in auto_parameters.items()
-                ]
+
+        if auto_parameters is not None:
+            if parameter_ranges is None:
+                training_job_definition["HyperParameterRanges"] = {}
+            training_job_definition["HyperParameterRanges"]["AutoParameters"] = [
+                {"Name": name, "ValueHint": value} for name, value in auto_parameters.items()
+            ]
 
         if max_retry_attempts is not None:
             training_job_definition["RetryStrategy"] = {"MaximumRetryAttempts": max_retry_attempts}

--- a/src/sagemaker/tuner.py
+++ b/src/sagemaker/tuner.py
@@ -685,13 +685,13 @@ class HyperparameterTuner(object):
         """
         if hyperparameter_ranges is None or len(hyperparameter_ranges) == 0:
             if not autotune:
-                raise ValueError("Need to specify hyperparameter ranges")
+                raise ValueError("Need to specify hyperparameter ranges or set autotune=True.")
 
         if not autotune and hyperparameters_to_keep_static is not None:
             raise ValueError(
-                "hyperparameters_to_keep_static is set, however Autotune mode is not enabled. "
-                "Either do not set value for hyperparameters_to_keep_static, or enable Autotune "
-                "mode by setting autotune=True."
+                "hyperparameters_to_keep_static parameter is set, however Autotune mode is not "
+                "enabled. Either do not set value for hyperparameters_to_keep_static parameter, "
+                "or enable Autotune mode by setting autotune=True."
             )
 
         if hyperparameters_to_keep_static is not None:
@@ -888,13 +888,13 @@ class HyperparameterTuner(object):
             }
 
             self.static_hyperparameters_dict = {}
-            for estimator_name, (static_hyperparameters, _) in static_auto_parameters_dict.items():
+            self.auto_parameters_dict = {}
+            for estimator_name, (
+                static_hyperparameters,
+                auto_parameters,
+            ) in static_auto_parameters_dict.items():
                 self.static_hyperparameters_dict[estimator_name] = static_hyperparameters
-
-            self.auto_parameters_dict = {
-                estimator_name: auto_parameters
-                for estimator_name, (_, auto_parameters) in static_auto_parameters_dict.items()
-            }
+                self.auto_parameters_dict[estimator_name] = auto_parameters
 
     @classmethod
     def _prepare_static_hyperparameters(
@@ -925,12 +925,14 @@ class HyperparameterTuner(object):
         """Prepare auto parameters for one estimator before tuning."""
         if not self.autotune:
             return static_hyperparameters, None
+
         if hyperparameters_to_keep_static is None:
             hyperparameters_to_keep_static = {}
 
         if not set(hyperparameters_to_keep_static).issubset(set(static_hyperparameters.keys())):
             raise ValueError(
-                "Names in hyperparameters_to_keep_static must be members of estimator's hyperparameters."
+                "Names in hyperparameters_to_keep_static must be members of estimator's "
+                "hyperparameters."
             )
 
         new_static_hyperparameters = {
@@ -1935,11 +1937,12 @@ class HyperparameterTuner(object):
                 produce more consistent configurations for the same tuning job.
             autotune (bool): Whether the parameter ranges or other unset settings of a tuning job
                 should be chosen automatically (default: False).
-            hyperparameters_to_keep_static_dict (dict(str, list[str]]): Dictionary of parameter names to prevent being
-                autotuned when autotune is enabled. The keys are the same set or a subset of
-                estimator names as in estimator_dict, and there must be one entry for each estimator
-                in estimator_dict. Each value is a list of parameter names to prevent being
-                autotuned (default: None).
+            hyperparameters_to_keep_static_dict (dict(str, list[str]]): Dictionary of
+                hyperparameter names that will be kept static. The keys are the same set or a subset
+                of estimator names as in estimator_dict, and there must be one entry for each
+                estimator in estimator_dict. Each value is a list of hyperparameter names that will
+                be kept static and will not be assigned a tunable range with Autotune functionality
+                (default: None).
 
         Returns:
             sagemaker.tuner.HyperparameterTuner: a new ``HyperparameterTuner`` object that can

--- a/src/sagemaker/tuner.py
+++ b/src/sagemaker/tuner.py
@@ -611,6 +611,8 @@ class HyperparameterTuner(object):
         early_stopping_type: Union[str, PipelineVariable] = "Off",
         estimator_name: Optional[str] = None,
         random_seed: Optional[int] = None,
+        autotune: bool = False,
+        keep_static: Optional[List[str]] = None,
     ):
         """Creates a ``HyperparameterTuner`` instance.
 
@@ -675,9 +677,16 @@ class HyperparameterTuner(object):
             random_seed (int): An initial value used to initialize a pseudo-random number generator.
                 Setting a random seed will make the hyperparameter tuning search strategies to
                 produce more consistent configurations for the same tuning job.
+            autotune (bool): Whether to turn on autotune (default: False).
+            keep_static: list[str]: List of parameter names to prevent being autotuned when autotune
+                is enabled (default: None).
         """
         if hyperparameter_ranges is None or len(hyperparameter_ranges) == 0:
-            raise ValueError("Need to specify hyperparameter ranges")
+            if not autotune:
+                raise ValueError("Need to specify hyperparameter ranges")
+
+        if not autotune and keep_static is not None:
+            raise ValueError("Autotune is not enabled but keep_static is set.")
 
         if estimator_name is not None:
             self.estimator = None
@@ -691,6 +700,10 @@ class HyperparameterTuner(object):
                 {estimator_name: metric_definitions} if metric_definitions is not None else {}
             )
             self.static_hyperparameters = None
+            self.auto_parameters = None
+            self.auto_parameters_dict = None
+            self.keep_static = None
+            self.keep_static_dict = {estimator_name: keep_static}
         else:
             self.estimator = estimator
             self.objective_metric_name = objective_metric_name
@@ -701,6 +714,10 @@ class HyperparameterTuner(object):
             self._hyperparameter_ranges_dict = None
             self.metric_definitions_dict = None
             self.static_hyperparameters_dict = None
+            self.auto_parameters = None
+            self.auto_parameters_dict = None
+            self.keep_static = keep_static
+            self.keep_static_dict = None
 
         self._validate_parameter_ranges(estimator, hyperparameter_ranges)
 
@@ -726,6 +743,7 @@ class HyperparameterTuner(object):
         self.random_seed = random_seed
         self.instance_configs_dict = None
         self.instance_configs = None
+        self.autotune = autotune
 
     def override_resource_config(
         self, instance_configs: Union[List[InstanceConfig], Dict[str, List[InstanceConfig]]]
@@ -754,6 +772,7 @@ class HyperparameterTuner(object):
         """Prepare the tuner instance for tuning (fit)."""
         self._prepare_job_name_for_tuning(job_name=job_name)
         self._prepare_static_hyperparameters_for_tuning(include_cls_metadata=include_cls_metadata)
+        self._prepare_auto_parameters_for_tuning()
         self._prepare_tags_for_tuning()
 
     def _get_model_uri(
@@ -836,6 +855,37 @@ class HyperparameterTuner(object):
                 for (estimator_name, estimator) in self.estimator_dict.items()
             }
 
+    def _prepare_auto_parameters_for_tuning(self):
+        """Prepare auto parameters for all estimators before tuning."""
+        self.auto_parameters = None
+        if self.estimator is not None:
+            self.static_hyperparameters, self.auto_parameters = self._prepare_auto_parameters(
+                self.static_hyperparameters, self.keep_static
+            )
+
+        self.auto_parameters_dict = None
+        if self.estimator_dict is not None:
+            static_auto_parameters_dict = {
+                estimator_name: self._prepare_auto_parameters(
+                    self.static_hyperparameters_dict[estimator_name],
+                    self.keep_static_dict.get(estimator_name, None)
+                    if self.keep_static_dict is not None
+                    else None,
+                )
+                for estimator_name in sorted(self.estimator_dict.keys())
+            }
+            self.static_hyperparameters_dict = {
+                estimator_name: static_hyperparameters
+                for estimator_name, (
+                    static_hyperparameters,
+                    _,
+                ) in static_auto_parameters_dict.items()
+            }
+            self.auto_parameters_dict = {
+                estimator_name: auto_parameters
+                for estimator_name, (_, auto_parameters) in static_auto_parameters_dict.items()
+            }
+
     @classmethod
     def _prepare_static_hyperparameters(
         cls, estimator, hyperparameter_ranges, include_cls_metadata
@@ -859,6 +909,23 @@ class HyperparameterTuner(object):
             )
 
         return static_hyperparameters
+
+    def _prepare_auto_parameters(self, static_hyperparameters, keep_static):
+        """Prepare auto parameters for one estimator before tuning."""
+        if not self.autotune:
+            return static_hyperparameters, None
+        if keep_static is None:
+            keep_static = {}
+
+        if not set(keep_static).issubset(set(static_hyperparameters.keys())):
+            raise ValueError("Names in keep_static must be members of estimator's hyperparameters.")
+
+        new_static_hyperparameters = {
+            k: v for k, v in static_hyperparameters.items() if k in keep_static
+        }
+        auto_parameters = {k: v for k, v in static_hyperparameters.items() if k not in keep_static}
+
+        return new_static_hyperparameters, auto_parameters
 
     @runnable_by_pipeline
     def fit(
@@ -1781,6 +1848,8 @@ class HyperparameterTuner(object):
         warm_start_config=None,
         early_stopping_type="Off",
         random_seed=None,
+        autotune=False,
+        keep_static_dict=None,
     ):
         """Factory method to create a ``HyperparameterTuner`` instance.
 
@@ -1847,6 +1916,12 @@ class HyperparameterTuner(object):
             random_seed (int): An initial value used to initialize a pseudo-random number generator.
                 Setting a random seed will make the hyperparameter tuning search strategies to
                 produce more consistent configurations for the same tuning job.
+            autotune (bool): Whether to turn on autotune (default: False).
+            keep_static_dict (dict(str, list[str]]): Dictionary of parameter names to prevent being
+                autotuned when autotune is enabled. The keys are the same set or a subset of
+                estimator names as in estimator_dict, and there must be one entry for each estimator
+                in estimator_dict. Each value is a list of parameter names to prevent being
+                autotuned (default: None).
 
         Returns:
             sagemaker.tuner.HyperparameterTuner: a new ``HyperparameterTuner`` object that can
@@ -1859,6 +1934,7 @@ class HyperparameterTuner(object):
             objective_metric_name_dict,
             hyperparameter_ranges_dict,
             metric_definitions_dict,
+            keep_static_dict,
         )
 
         estimator_names = sorted(estimator_dict.keys())
@@ -1867,6 +1943,12 @@ class HyperparameterTuner(object):
         metric_definitions = (
             metric_definitions_dict.get(first_estimator_name, None)
             if metric_definitions_dict is not None
+            else None
+        )
+
+        keep_static = (
+            keep_static_dict.get(first_estimator_name, None)
+            if keep_static_dict is not None
             else None
         )
 
@@ -1888,6 +1970,8 @@ class HyperparameterTuner(object):
             warm_start_config=warm_start_config,
             early_stopping_type=early_stopping_type,
             random_seed=random_seed,
+            autotune=autotune,
+            keep_static=keep_static,
         )
 
         for estimator_name in estimator_names[1:]:
@@ -1896,12 +1980,16 @@ class HyperparameterTuner(object):
                 if metric_definitions_dict is not None
                 else None
             )
+            keep_static = (
+                keep_static_dict.get(estimator_name, None) if keep_static_dict is not None else None
+            )
             tuner._add_estimator(
                 estimator_name=estimator_name,
                 estimator=estimator_dict[estimator_name],
                 objective_metric_name=objective_metric_name_dict[estimator_name],
                 hyperparameter_ranges=hyperparameter_ranges_dict[estimator_name],
                 metric_definitions=metric_definitions,
+                keep_static=keep_static,
             )
         return tuner
 
@@ -1912,6 +2000,7 @@ class HyperparameterTuner(object):
         objective_metric_name_dict,
         hyperparameter_ranges_dict,
         metric_definitions_dict=None,
+        keep_static_dict=None,
     ):
         """Validate inputs for ``HyperparameterTuner.create()``"""
         cls._validate_estimator_dict(estimator_dict)
@@ -1933,6 +2022,11 @@ class HyperparameterTuner(object):
         cls._validate_dict_argument(
             name="metric_definitions_dict",
             value=metric_definitions_dict,
+            allowed_keys=estimator_names,
+        )
+        cls._validate_dict_argument(
+            name="keep_static_dict",
+            value=keep_static_dict,
             allowed_keys=estimator_names,
         )
 
@@ -1975,6 +2069,7 @@ class HyperparameterTuner(object):
         objective_metric_name,
         hyperparameter_ranges,
         metric_definitions=None,
+        keep_static=None,
     ):
         """Add an estimator with corresponding attributes, if applicable.
 
@@ -1984,6 +2079,8 @@ class HyperparameterTuner(object):
         self.estimator_dict[estimator_name] = estimator
         self.objective_metric_name_dict[estimator_name] = objective_metric_name
         self._hyperparameter_ranges_dict[estimator_name] = hyperparameter_ranges
+        if keep_static is not None:
+            self.keep_static_dict[estimator_name] = keep_static
         if metric_definitions is not None:
             self.metric_definitions_dict[estimator_name] = metric_definitions
 
@@ -2056,6 +2153,9 @@ class _TuningJob(_Job):
         if parameter_ranges is not None:
             tuning_config["parameter_ranges"] = parameter_ranges
 
+        if tuner.auto_parameters is not None:
+            tuning_config["auto_parameters"] = tuner.auto_parameters
+
         if tuner.completion_criteria_config is not None:
             tuning_config[
                 "completion_criteria_config"
@@ -2066,6 +2166,7 @@ class _TuningJob(_Job):
             "tuning_config": tuning_config,
             "tags": tuner.tags,
             "warm_start_config": warm_start_config_req,
+            "autotune": tuner.autotune,
         }
 
         if tuner.estimator is not None:
@@ -2090,6 +2191,9 @@ class _TuningJob(_Job):
                     tuner.hyperparameter_ranges_dict()[estimator_name],
                     tuner.instance_configs_dict.get(estimator_name, None)
                     if tuner.instance_configs_dict is not None
+                    else None,
+                    tuner.auto_parameters_dict.get(estimator_name, None)
+                    if tuner.auto_parameters_dict is not None
                     else None,
                 )
                 for estimator_name in sorted(tuner.estimator_dict.keys())
@@ -2135,6 +2239,7 @@ class _TuningJob(_Job):
         objective_metric_name=None,
         parameter_ranges=None,
         instance_configs=None,
+        auto_parameters=None,
     ):
         """Prepare training config for one estimator."""
         training_config = _Job._load_config(inputs, estimator)
@@ -2186,6 +2291,9 @@ class _TuningJob(_Job):
 
         if parameter_ranges is not None:
             training_config["parameter_ranges"] = parameter_ranges
+
+        if auto_parameters is not None:
+            training_config["auto_parameters"] = auto_parameters
 
         if estimator.max_retry_attempts is not None:
             training_config["max_retry_attempts"] = estimator.max_retry_attempts

--- a/tests/data/mxnet_mnist/mnist.py
+++ b/tests/data/mxnet_mnist/mnist.py
@@ -121,7 +121,7 @@ if __name__ == "__main__":
 
     parser.add_argument("--batch-size", type=int, default=100)
     parser.add_argument("--epochs", type=int, default=10)
-    parser.add_argument("--learning-rate", type=float, default=0.1)
+    parser.add_argument("--learning-rate", "--learning_rate", type=float, default=0.1)
 
     parser.add_argument("--model-dir", type=str, default=os.environ["SM_MODEL_DIR"])
     parser.add_argument("--train", type=str, default=os.environ["SM_CHANNEL_TRAIN"])

--- a/tests/integ/test_tuner.py
+++ b/tests/integ/test_tuner.py
@@ -99,6 +99,8 @@ def _tune_and_deploy(
     warm_start_config=None,
     early_stopping_type="Off",
     instance_configs=None,
+    autotune=False,
+    keep_static=None,
 ):
     tuner = _tune(
         kmeans_estimator,
@@ -108,6 +110,8 @@ def _tune_and_deploy(
         job_name=job_name,
         early_stopping_type=early_stopping_type,
         instance_configs=instance_configs,
+        autotune=autotune,
+        keep_static=keep_static,
     )
     _deploy(kmeans_train_set, sagemaker_session, tuner, early_stopping_type, cpu_instance_type)
 
@@ -138,6 +142,8 @@ def _tune(
     max_parallel_jobs=2,
     early_stopping_type="Off",
     instance_configs=None,
+    autotune=False,
+    keep_static=None,
 ):
     with timeout(minutes=TUNING_DEFAULT_TIMEOUT_MINUTES):
 
@@ -151,6 +157,8 @@ def _tune(
                 max_parallel_jobs=max_parallel_jobs,
                 warm_start_config=warm_start_config,
                 early_stopping_type=early_stopping_type,
+                autotune=autotune,
+                keep_static=keep_static,
             )
         tuner.override_resource_config(instance_configs=instance_configs)
         records = kmeans_estimator.record_set(kmeans_train_set[0][:100])
@@ -174,6 +182,26 @@ def test_tuning_kmeans(
         cpu_instance_type,
         hyperparameter_ranges=hyperparameter_ranges,
         job_name=job_name,
+    )
+
+
+def test_tuning_kmeans_autotune(
+    sagemaker_session, kmeans_train_set, kmeans_estimator, hyperparameter_ranges, cpu_instance_type
+):
+    job_name = unique_name_from_base("test-tune-kmeans-autotune", 32)
+    _tune_and_deploy(
+        kmeans_estimator,
+        kmeans_train_set,
+        sagemaker_session,
+        cpu_instance_type,
+        hyperparameter_ranges=hyperparameter_ranges,
+        job_name=job_name,
+        autotune=True,
+        keep_static=[
+            "local_lloyd_init_method",
+            "local_lloyd_num_trials",
+            "local_lloyd_tol",
+        ],
     )
 
 
@@ -590,6 +618,63 @@ def test_tuning_mxnet(
         )
 
         tuning_job_name = unique_name_from_base("tune-mxnet", max_length=32)
+        print("Started hyperparameter tuning job with name:" + tuning_job_name)
+        tuner.fit({"train": train_input, "test": test_input}, job_name=tuning_job_name)
+
+    best_training_job = tuner.best_training_job()
+    with timeout_and_delete_endpoint_by_name(best_training_job, sagemaker_session):
+        predictor = tuner.deploy(1, cpu_instance_type)
+        data = np.zeros(shape=(1, 1, 28, 28))
+        predictor.predict(data)
+
+
+@pytest.mark.slow_test
+@pytest.mark.release
+def test_tuning_mxnet_autotune(
+    sagemaker_session,
+    mxnet_training_latest_version,
+    mxnet_training_latest_py_version,
+    cpu_instance_type,
+):
+    with timeout(minutes=TUNING_DEFAULT_TIMEOUT_MINUTES):
+        script_path = os.path.join(DATA_DIR, "mxnet_mnist", "mnist.py")
+        data_path = os.path.join(DATA_DIR, "mxnet_mnist")
+
+        estimator = MXNet(
+            entry_point=script_path,
+            role="SageMakerRole",
+            py_version=mxnet_training_latest_py_version,
+            instance_count=1,
+            instance_type=cpu_instance_type,
+            framework_version=mxnet_training_latest_version,
+            sagemaker_session=sagemaker_session,
+        )
+        estimator.set_hyperparameters(learning_rate=0.1)
+
+        hyperparameter_ranges = {}
+        objective_metric_name = "Validation-accuracy"
+        metric_definitions = [
+            {"Name": "Validation-accuracy", "Regex": "Validation-accuracy=([0-9\\.]+)"}
+        ]
+        tuner = HyperparameterTuner(
+            estimator,
+            objective_metric_name,
+            hyperparameter_ranges,
+            metric_definitions,
+            max_jobs=4,
+            max_parallel_jobs=2,
+            autotune=True,
+            keep_static=None,
+        )
+
+        train_input = estimator.sagemaker_session.upload_data(
+            path=os.path.join(data_path, "train"), key_prefix="integ-test-data/mxnet_mnist/train"
+        )
+        test_input = estimator.sagemaker_session.upload_data(
+            path=os.path.join(data_path, "test"), key_prefix="integ-test-data/mxnet_mnist/test"
+        )
+
+        tuning_job_name = unique_name_from_base("tune-mxnet-autotune", max_length=32)
         print("Started hyperparameter tuning job with name:" + tuning_job_name)
         tuner.fit({"train": train_input, "test": test_input}, job_name=tuning_job_name)
 

--- a/tests/integ/test_tuner.py
+++ b/tests/integ/test_tuner.py
@@ -100,7 +100,7 @@ def _tune_and_deploy(
     early_stopping_type="Off",
     instance_configs=None,
     autotune=False,
-    keep_static=None,
+    hyperparameters_to_keep_static=None,
 ):
     tuner = _tune(
         kmeans_estimator,
@@ -111,7 +111,7 @@ def _tune_and_deploy(
         early_stopping_type=early_stopping_type,
         instance_configs=instance_configs,
         autotune=autotune,
-        keep_static=keep_static,
+        hyperparameters_to_keep_static=hyperparameters_to_keep_static,
     )
     _deploy(kmeans_train_set, sagemaker_session, tuner, early_stopping_type, cpu_instance_type)
 
@@ -143,7 +143,7 @@ def _tune(
     early_stopping_type="Off",
     instance_configs=None,
     autotune=False,
-    keep_static=None,
+    hyperparameters_to_keep_static=None,
 ):
     with timeout(minutes=TUNING_DEFAULT_TIMEOUT_MINUTES):
 
@@ -158,7 +158,7 @@ def _tune(
                 warm_start_config=warm_start_config,
                 early_stopping_type=early_stopping_type,
                 autotune=autotune,
-                keep_static=keep_static,
+                hyperparameters_to_keep_static=hyperparameters_to_keep_static,
             )
         tuner.override_resource_config(instance_configs=instance_configs)
         records = kmeans_estimator.record_set(kmeans_train_set[0][:100])
@@ -197,7 +197,7 @@ def test_tuning_kmeans_autotune(
         hyperparameter_ranges=hyperparameter_ranges,
         job_name=job_name,
         autotune=True,
-        keep_static=[
+        hyperparameters_to_keep_static=[
             "local_lloyd_init_method",
             "local_lloyd_num_trials",
             "local_lloyd_tol",
@@ -664,7 +664,7 @@ def test_tuning_mxnet_autotune(
             max_jobs=4,
             max_parallel_jobs=2,
             autotune=True,
-            keep_static=None,
+            hyperparameters_to_keep_static=None,
         )
 
         train_input = estimator.sagemaker_session.upload_data(

--- a/tests/integ/test_tuner_multi_algo.py
+++ b/tests/integ/test_tuner_multi_algo.py
@@ -127,9 +127,46 @@ def test_multi_estimator_tuning(
     _deploy_and_predict(sagemaker_session, tuner_attached, data_set, cpu_instance_type)
 
 
-def _fit_tuner(sagemaker_session, tuner):
+def test_multi_estimator_tuning_autotune(
+    sagemaker_session, estimator_fm, estimator_knn, data_set, cpu_instance_type
+):
+    tuner = HyperparameterTuner.create(
+        base_tuning_job_name=BASE_TUNING_JOB_NAME,
+        estimator_dict={ESTIMATOR_FM: estimator_fm, ESTIMATOR_KNN: estimator_knn},
+        objective_metric_name_dict={
+            ESTIMATOR_FM: OBJECTIVE_METRIC_NAME_FM,
+            ESTIMATOR_KNN: OBJECTIVE_METRIC_NAME_KNN,
+        },
+        hyperparameter_ranges_dict={
+            ESTIMATOR_FM: HYPER_PARAMETER_RANGES_FM,
+            ESTIMATOR_KNN: HYPER_PARAMETER_RANGES_KNN,
+        },
+        strategy=STRATEGY,
+        objective_type=OBJECTIVE_TYPE,
+        max_jobs=MAX_JOBS,
+        max_parallel_jobs=MAX_PARALLEL_JOBS,
+        tags=TAGS,
+        autotune=True,
+        keep_static_dict={
+            ESTIMATOR_FM: ["num_factors", "predictor_type"],
+            ESTIMATOR_KNN: ["predictor_type", "mini_batch_size"],
+        },
+    )
+    tuning_job_base_name = "test-multi-autotune"
+    _fit_tuner(sagemaker_session, tuner, tuning_job_base_name=tuning_job_base_name)
+
+    _retrieve_analytics(sagemaker_session, tuner.latest_tuning_job.name)
+
+    tuner_attached = _attach_tuner(sagemaker_session, tuner.latest_tuning_job.name)
+
+    _deploy_and_predict(sagemaker_session, tuner_attached, data_set, cpu_instance_type)
+
+
+def _fit_tuner(sagemaker_session, tuner, tuning_job_base_name=None):
     training_inputs = _create_training_inputs(sagemaker_session)
-    job_name = utils.unique_name_from_base("test-multi-algo-tuning", max_length=32)
+    if tuning_job_base_name is None:
+        tuning_job_base_name = "test-multi-algo-tuning"
+    job_name = utils.unique_name_from_base(tuning_job_base_name, max_length=32)
 
     with timeout(minutes=TUNING_DEFAULT_TIMEOUT_MINUTES):
         tuner.fit(

--- a/tests/integ/test_tuner_multi_algo.py
+++ b/tests/integ/test_tuner_multi_algo.py
@@ -147,7 +147,7 @@ def test_multi_estimator_tuning_autotune(
         max_parallel_jobs=MAX_PARALLEL_JOBS,
         tags=TAGS,
         autotune=True,
-        keep_static_dict={
+        hyperparameters_to_keep_static_dict={
             ESTIMATOR_FM: ["num_factors", "predictor_type"],
             ESTIMATOR_KNN: ["predictor_type", "mini_batch_size"],
         },

--- a/tests/unit/test_tuner.py
+++ b/tests/unit/test_tuner.py
@@ -245,10 +245,9 @@ def test_validate_invalid_keep_static_autotune_not_enabled(sagemaker_session):
         tuner.fit(records, mini_batch_size=9999)
 
     assert (
-        "hyperparameters_to_keep_static is set, however Autotune mode is not enabled. "
-        "Either do not set value for hyperparameters_to_keep_static, or enable Autotune "
-        "mode by setting autotune=True."
-        in str(e)
+        "hyperparameters_to_keep_static parameter is set, however Autotune mode is not enabled. "
+        "Either do not set value for hyperparameters_to_keep_static parameter, or enable Autotune "
+        "mode by setting autotune=True." in str(e)
     )
 
 

--- a/tests/unit/test_tuner.py
+++ b/tests/unit/test_tuner.py
@@ -219,6 +219,56 @@ def test_validate_parameter_ranges_string_value_validation_error(sagemaker_sessi
     assert 'Value must be one of "regular" and "randomized"' in str(e)
 
 
+def test_validate_invalid_keep_static_autotune_not_enabled(sagemaker_session):
+    pca = PCA(
+        ROLE,
+        INSTANCE_COUNT,
+        INSTANCE_TYPE,
+        NUM_COMPONENTS,
+        base_job_name="pca",
+        sagemaker_session=sagemaker_session,
+    )
+
+    autotune = False
+    invalid_keep_static = ["feature_dim"]
+
+    with pytest.raises(ValueError) as e:
+        HyperparameterTuner(
+            estimator=pca,
+            objective_metric_name=OBJECTIVE_METRIC_NAME,
+            hyperparameter_ranges=HYPERPARAMETER_RANGES_TWO,
+            metric_definitions=METRIC_DEFINITIONS,
+            autotune=autotune,
+            keep_static=invalid_keep_static,
+        )
+        records = RecordSet(s3_data=INPUTS, num_records=1, feature_dim=1)
+        tuner.fit(records, mini_batch_size=9999)
+
+    assert "Autotune is not enabled but keep_static is set." in str(e)
+
+
+def test_validate_invalid_keep_static_autotune_enabled(sagemaker_session, tuner):
+    pca = PCA(
+        ROLE,
+        INSTANCE_COUNT,
+        INSTANCE_TYPE,
+        NUM_COMPONENTS,
+        base_job_name="pca",
+        sagemaker_session=sagemaker_session,
+    )
+
+    with pytest.raises(ValueError) as e:
+        tuner.estimator = pca
+        tuner._hyperparameter_ranges = HYPERPARAMETER_RANGES_TWO
+        tuner.autotune = True
+        tuner.keep_static = ["unknown_static_parameter"]
+
+        records = RecordSet(s3_data=INPUTS, num_records=1, feature_dim=1)
+        tuner.fit(records, mini_batch_size=9999)
+
+    assert "Names in keep_static must be members of estimator's hyperparameters." in str(e)
+
+
 def test_fit_pca(sagemaker_session, tuner):
     pca = PCA(
         ROLE,
@@ -264,6 +314,36 @@ def test_fit_pca(sagemaker_session, tuner):
     assert "objective_type" not in tune_kwargs["training_config"]
     assert "objective_metric_name" not in tune_kwargs["training_config"]
     assert "parameter_ranges" not in tune_kwargs["training_config"]
+
+
+def test_fit_pca_with_autotune(sagemaker_session, tuner):
+    pca = PCA(
+        ROLE,
+        INSTANCE_COUNT,
+        INSTANCE_TYPE,
+        NUM_COMPONENTS,
+        base_job_name="pca",
+        sagemaker_session=sagemaker_session,
+    )
+
+    tuner.estimator = pca
+    tuner.autotune = True
+    tuner.keep_static = ["feature_dim"]
+
+    records = RecordSet(s3_data=INPUTS, num_records=1, feature_dim=1)
+    tuner.fit(records, mini_batch_size=9999)
+
+    _, _, tune_kwargs = sagemaker_session.create_tuning_job.mock_calls[0]
+
+    assert tune_kwargs["autotune"] is True
+    assert tuner.keep_static_dict is None
+    assert tuner.auto_parameters_dict is None
+    assert len(tune_kwargs["tuning_config"]["auto_parameters"]) == 2
+    assert "mini_batch_size" in tune_kwargs["tuning_config"]["auto_parameters"]
+    assert "num_components" in tune_kwargs["tuning_config"]["auto_parameters"]
+
+    assert len(tune_kwargs["training_config"]["static_hyperparameters"]) == 1
+    assert "feature_dim" in tune_kwargs["training_config"]["static_hyperparameters"]
 
 
 def test_fit_pca_with_early_stopping(sagemaker_session, tuner):
@@ -575,6 +655,55 @@ def test_fit_multi_estimators(sagemaker_session):
     assert training_config_two["image_uri"] == estimator_two.training_image_uri()
     assert training_config_two["metric_definitions"] is None
     assert training_config_two["static_hyperparameters"]["mini_batch_size"] == "4000"
+    _assert_parameter_ranges(
+        HYPERPARAMETER_RANGES_TWO,
+        training_config_two["parameter_ranges"],
+        isinstance(estimator_two, Framework),
+    )
+
+
+def test_fit_multi_estimators_autotune(sagemaker_session):
+    (tuner, estimator_one, estimator_two) = _create_multi_estimator_tuner(sagemaker_session)
+    tuner.autotune = True
+    tuner.keep_static_dict = {
+        ESTIMATOR_NAME_TWO: ["feature_dim"],
+    }
+
+    records = {ESTIMATOR_NAME_TWO: RecordSet(s3_data=INPUTS, num_records=1, feature_dim=1)}
+
+    estimator_kwargs = {ESTIMATOR_NAME_TWO: {"mini_batch_size": 4000}}
+
+    tuner.fit(inputs=records, include_cls_metadata={}, estimator_kwargs=estimator_kwargs)
+
+    _, _, tune_kwargs = sagemaker_session.create_tuning_job.mock_calls[0]
+
+    assert tune_kwargs["autotune"] is True
+    assert tuner.keep_static is None
+    assert tuner.auto_parameters is None
+
+    assert "tuning_objective" not in tune_kwargs["tuning_config"]
+    assert "parameter_ranges" not in tune_kwargs["tuning_config"]
+
+    assert "training_config" not in tune_kwargs
+    assert "training_config_list" in tune_kwargs
+
+    assert len(tune_kwargs["training_config_list"]) == 2
+
+    training_config_one = tune_kwargs["training_config_list"][0]
+    training_config_two = tune_kwargs["training_config_list"][1]
+
+    assert len(training_config_one["static_hyperparameters"]) == 0
+    assert "mini_batch_size" in tuner.auto_parameters_dict["estimator_name_two"]
+    assert "sagemaker_estimator_module" in training_config_one["auto_parameters"]
+    _assert_parameter_ranges(
+        HYPERPARAMETER_RANGES,
+        training_config_one["parameter_ranges"],
+        isinstance(estimator_one, Framework),
+    )
+
+    assert len(training_config_two["static_hyperparameters"]) == 1
+    assert "feature_dim" in training_config_two["static_hyperparameters"]
+    assert "mini_batch_size" in training_config_two["auto_parameters"]
     _assert_parameter_ranges(
         HYPERPARAMETER_RANGES_TWO,
         training_config_two["parameter_ranges"],


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- HyperparameterTuner constructor: add extra fields for autotune functionality, _map_tuning_config and _map_training_config are adapted for autotune
- Session: add autotune field to create_tuning_job


*Testing done:*
- unit test
- end2end integration test


## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
