### PR TITLE
fix: skip pipelines abalone notebook test

### DIFF
--- a/tests/scripts/run-notebook-test.sh
+++ b/tests/scripts/run-notebook-test.sh
@@ -133,6 +133,5 @@ echo "set SAGEMAKER_ROLE_ARN=$SAGEMAKER_ROLE_ARN"
 ./amazon-sagemaker-examples/sagemaker-python-sdk/tensorflow_moving_from_framework_mode_to_script_mode/tensorflow_moving_from_framework_mode_to_script_mode.ipynb \
 ./amazon-sagemaker-examples/sagemaker-python-sdk/tensorflow_script_mode_pipe_mode/tensorflow_script_mode_pipe_mode.ipynb \
 ./amazon-sagemaker-examples/sagemaker-python-sdk/tensorflow_serving_using_elastic_inference_with_your_own_model/tensorflow_serving_pretrained_model_elastic_inference.ipynb \
-./amazon-sagemaker-examples/sagemaker-pipelines/tabular/abalone_build_train_deploy/sagemaker-pipelines-preprocess-train-evaluate-batch-transform.ipynb
 
 (DeleteLifeCycleConfig "$LIFECYCLE_CONFIG_NAME")


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This notebook is currently failing at: https://github.com/aws/amazon-sagemaker-examples/blob/main/sagemaker-pipelines/tabular/abalone_build_train_deploy/sagemaker-pipelines-preprocess-train-evaluate-batch-transform.ipynb?short_path=bd99ba4#L1306

Traceback:
```
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
File ~/anaconda3/envs/python3/lib/python3.10/site-packages/sagemaker/utils.py:1384, in volume_size_supported(instance_type)
   1381 try:
   1382 
   1383     # local mode does not support volume size
-> 1384     if instance_type.startswith("local"):
   1385         return False

AttributeError: 'ParameterString' object has no attribute 'startswith'

During handling of the above exception, another exception occurred:

TypeError                                 Traceback (most recent call last)
Cell In[28], line 4
      1 import json
----> 4 definition = json.loads(pipeline.definition())
      5 definition

File ~/anaconda3/envs/python3/lib/python3.10/site-packages/sagemaker/workflow/pipeline.py:354, in Pipeline.definition(self)
    352 def definition(self) -> str:
    353     """Converts a request structure to string representation for workflow service calls."""
--> 354     request_dict = self.to_request()
    355     self._interpolate_step_collection_name_in_depends_on(request_dict["Steps"])
    356     request_dict["PipelineExperimentConfig"] = interpolate(
    357         request_dict["PipelineExperimentConfig"], {}, {}
    358     )

File ~/anaconda3/envs/python3/lib/python3.10/site-packages/sagemaker/workflow/pipeline.py:107, in Pipeline.to_request(self)
     98 def to_request(self) -> RequestType:
     99     """Gets the request structure for workflow service calls."""
    100     return {
    101         "Version": self._version,
    102         "Metadata": self._metadata,
    103         "Parameters": list_to_request(self.parameters),
    104         "PipelineExperimentConfig": self.pipeline_experiment_config.to_request()
    105         if self.pipeline_experiment_config is not None
    106         else None,
--> 107         "Steps": build_steps(self.steps, self.name),
    108     }

File ~/anaconda3/envs/python3/lib/python3.10/site-packages/sagemaker/workflow/utilities.py:100, in build_steps(steps, pipeline_name)
     96     else:
     97         with _pipeline_config_manager(
     98             pipeline_name, step.name, get_code_hash(step), get_config_hash(step)
     99         ):
--> 100             request_dicts.append(step.to_request())
    101 return request_dicts

File ~/anaconda3/envs/python3/lib/python3.10/site-packages/sagemaker/workflow/steps.py:508, in TrainingStep.to_request(self)
    506 def to_request(self) -> RequestType:
    507     """Updates the request dictionary with cache configuration."""
--> 508     request_dict = super().to_request()
    509     if self.cache_config:
    510         request_dict.update(self.cache_config.config)

File ~/anaconda3/envs/python3/lib/python3.10/site-packages/sagemaker/workflow/steps.py:352, in ConfigurableRetryStep.to_request(self)
    350 def to_request(self) -> RequestType:
    351     """Gets the request structure for `ConfigurableRetryStep`."""
--> 352     step_dict = super().to_request()
    353     if self.retry_policies:
    354         step_dict["RetryPolicies"] = self._resolve_retry_policy(self.retry_policies)

File ~/anaconda3/envs/python3/lib/python3.10/site-packages/sagemaker/workflow/steps.py:121, in Step.to_request(self)
    116 def to_request(self) -> RequestType:
    117     """Gets the request structure for workflow service calls."""
    118     request_dict = {
    119         "Name": self.name,
    120         "Type": self.step_type.value,
--> 121         "Arguments": self.arguments,
    122     }
    123     if self.depends_on:
    124         request_dict["DependsOn"] = self._resolve_depends_on(self.depends_on)

File ~/anaconda3/envs/python3/lib/python3.10/site-packages/sagemaker/workflow/steps.py:481, in TrainingStep.arguments(self)
    476 from sagemaker.workflow.utilities import execute_job_functions
    478 if self.step_args:
    479     # execute fit function with saved parameters,
    480     # and store args in PipelineSession's _context
--> 481     execute_job_functions(self.step_args)
    483     # populate request dict with args
    484     estimator = self.step_args.func_args[0]

File ~/anaconda3/envs/python3/lib/python3.10/site-packages/sagemaker/workflow/utilities.py:408, in execute_job_functions(step_args)
    393 def execute_job_functions(step_args: _StepArguments):
    394     """Execute the job class functions during pipeline definition construction
    395 
    396     Executes the job functions such as run(), fit(), or transform() that have been
   (...)
    405             a pipeline step, contains the necessary function information
    406     """
--> 408     chained_args = step_args.func(*step_args.func_args, **step_args.func_kwargs)
    409     if isinstance(chained_args, _StepArguments):
    410         execute_job_functions(chained_args)

File ~/anaconda3/envs/python3/lib/python3.10/site-packages/sagemaker/estimator.py:1243, in EstimatorBase.fit(self, inputs, wait, logs, job_name, experiment_config)
   1240 self._prepare_for_training(job_name=job_name)
   1242 experiment_config = check_and_get_run_experiment_config(experiment_config)
-> 1243 self.latest_training_job = _TrainingJob.start_new(self, inputs, experiment_config)
   1244 self.jobs.append(self.latest_training_job)
   1245 if wait:

File ~/anaconda3/envs/python3/lib/python3.10/site-packages/sagemaker/estimator.py:2179, in _TrainingJob.start_new(cls, estimator, inputs, experiment_config)
   2154 """Create a new Amazon SageMaker training job from the estimator.
   2155 
   2156 Args:
   (...)
   2175     all information about the started training job.
   2176 """
   2177 train_args = cls._get_train_args(estimator, inputs, experiment_config)
-> 2179 estimator.sagemaker_session.train(**train_args)
   2181 return cls(estimator.sagemaker_session, estimator._current_job_name)

File ~/anaconda3/envs/python3/lib/python3.10/site-packages/sagemaker/session.py:822, in Session.train(self, input_mode, input_config, role, job_name, output_config, resource_config, vpc_config, hyperparameters, stop_condition, tags, metric_definitions, enable_network_isolation, image_uri, training_image_config, algorithm_arn, encrypt_inter_container_traffic, use_spot_instances, checkpoint_s3_uri, checkpoint_local_path, experiment_config, debugger_rule_configs, debugger_hook_config, tensorboard_output_config, enable_sagemaker_metrics, profiler_rule_configs, profiler_config, environment, retry_strategy)
    815 customer_supplied_kms_key = "VolumeKmsKeyId" in resource_config
    816 inferred_resource_config = update_nested_dictionary_with_values_from_config(
    817     resource_config, TRAINING_JOB_RESOURCE_CONFIG_PATH, sagemaker_session=self
    818 )
    819 if (
    820     not customer_supplied_kms_key
    821     and "InstanceType" in inferred_resource_config
--> 822     and not instance_supports_kms(inferred_resource_config["InstanceType"])
    823     and "VolumeKmsKeyId" in inferred_resource_config
    824 ):
    825     del inferred_resource_config["VolumeKmsKeyId"]
    826 train_request = self._get_train_request(
    827     input_mode=input_mode,
    828     input_config=input_config,
   (...)
    854     retry_strategy=retry_strategy,
    855 )

File ~/anaconda3/envs/python3/lib/python3.10/site-packages/sagemaker/utils.py:1409, in instance_supports_kms(instance_type)
   1403 def instance_supports_kms(instance_type: str) -> bool:
   1404     """Returns True if SageMaker allows KMS keys to be attached to the instance.
   1405 
   1406     Raises:
   1407         ValueError: If the instance type is improperly formatted.
   1408     """
-> 1409     return volume_size_supported(instance_type)

File ~/anaconda3/envs/python3/lib/python3.10/site-packages/sagemaker/utils.py:1400, in volume_size_supported(instance_type)
   1398     return "d" not in family and not family.startswith("g5")
   1399 except Exception as e:
-> 1400     raise ValueError(f"Failed to parse instance type '{instance_type}': {str(e)}")

File ~/anaconda3/envs/python3/lib/python3.10/site-packages/sagemaker/workflow/entities.py:86, in PipelineVariable.__str__(self)
     84 def __str__(self):
     85     """Override built-in String function for PipelineVariable"""
---> 86     raise TypeError(
     87         "Pipeline variables do not support __str__ operation. "
     88         "Please use `.to_string()` to convert it to string type in execution time"
     89         "or use `.expr` to translate it to Json for display purpose in Python SDK."
     90     )

TypeError: Pipeline variables do not support __str__ operation. Please use `.to_string()` to convert it to string type in execution timeor use `.expr` to translate it to Json for display purpose in Python SDK.
```

Will be skipping the notebook test for now!

Need to RCA/fix the notebook/sdk code and re-enable this notebook test.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
