### PR TITLE
feat: Add transformers 4.29 - PyTorch 2.0.0 training and inference

### DIFF
--- a/src/sagemaker/image_uri_config/huggingface.json
+++ b/src/sagemaker/image_uri_config/huggingface.json
@@ -10,7 +10,8 @@
             "4.12": "4.12.3",
             "4.17": "4.17.0",
             "4.26": "4.26.0",
-            "4.28": "4.28.1"
+            "4.28": "4.28.1",
+            "4.29": "4.29.0"
         },
         "versions": {
             "4.4.2": {
@@ -876,6 +877,47 @@
                     "repository": "huggingface-pytorch-training",
                     "container_version": {"gpu": "cu118-ubuntu20.04"}
                 }
+            },
+            "4.29.0": {
+                "version_aliases": {
+                    "pytorch2.0": "pytorch2.0.0"
+                },
+                "pytorch2.0.0": {
+                    "py_versions": ["py310"],
+                    "registries": {
+                        "af-south-1": "626614931356",
+                        "ap-east-1": "871362719292",
+                        "ap-northeast-1": "763104351884",
+                        "ap-northeast-2": "763104351884",
+                        "ap-northeast-3": "364406365360",
+                        "ap-south-1": "763104351884",
+                        "ap-southeast-1": "763104351884",
+                        "ap-southeast-2": "763104351884",
+                        "ap-southeast-3": "907027046896",
+                        "ca-central-1": "763104351884",
+                        "cn-north-1": "727897471807",
+                        "cn-northwest-1": "727897471807",
+                        "eu-central-1": "763104351884",
+                        "eu-north-1": "763104351884",
+                        "eu-west-1": "763104351884",
+                        "eu-west-2": "763104351884",
+                        "eu-west-3": "763104351884",
+                        "eu-south-1": "692866216735",
+                        "me-south-1": "217643126080",
+                        "me-central-1": "914824155844",
+                        "sa-east-1": "763104351884",
+                        "us-east-1": "763104351884",
+                        "us-east-2": "763104351884",
+                        "us-gov-east-1": "446045086412",
+                        "us-gov-west-1": "442386744353",
+                        "us-iso-east-1": "886529160074",
+                        "us-isob-east-1": "094389454867",
+                        "us-west-1": "763104351884",
+                        "us-west-2": "763104351884"
+                    },
+                    "repository": "huggingface-pytorch-training",
+                    "container_version": {"gpu": "cu118-ubuntu20.04"}
+                }
             }
         }
     },
@@ -889,7 +931,8 @@
             "4.12": "4.12.3",
             "4.17": "4.17.0",
             "4.26": "4.26.0",
-            "4.28": "4.28.1"
+            "4.28": "4.28.1",
+            "4.29": "4.29.0"
         },
         "versions": {
             "4.6.1": {
@@ -1554,6 +1597,51 @@
                     "registries": {
                         "af-south-1": "626614931356",
                         "il-central-1": "780543022126",
+                        "ap-east-1": "871362719292",
+                        "ap-northeast-1": "763104351884",
+                        "ap-northeast-2": "763104351884",
+                        "ap-northeast-3": "364406365360",
+                        "ap-south-1": "763104351884",
+                        "ap-south-2": "772153158452",
+                        "ap-southeast-1": "763104351884",
+                        "ap-southeast-2": "763104351884",
+                        "ap-southeast-3": "907027046896",
+                        "ap-southeast-4": "457447274322",
+                        "ca-central-1": "763104351884",
+                        "cn-north-1": "727897471807",
+                        "cn-northwest-1": "727897471807",
+                        "eu-central-1": "763104351884",
+                        "eu-central-2": "380420809688",
+                        "eu-north-1": "763104351884",
+                        "eu-west-1": "763104351884",
+                        "eu-west-2": "763104351884",
+                        "eu-west-3": "763104351884",
+                        "eu-south-1": "692866216735",
+                        "eu-south-2": "503227376785",
+                        "me-south-1": "217643126080",
+                        "me-central-1": "914824155844",
+                        "sa-east-1": "763104351884",
+                        "us-east-1": "763104351884",
+                        "us-east-2": "763104351884",
+                        "us-gov-east-1": "446045086412",
+                        "us-gov-west-1": "442386744353",
+                        "us-iso-east-1": "886529160074",
+                        "us-isob-east-1": "094389454867",
+                        "us-west-1": "763104351884",
+                        "us-west-2": "763104351884"
+                    },
+                    "repository": "huggingface-pytorch-inference",
+                    "container_version": {"gpu": "cu118-ubuntu20.04", "cpu": "ubuntu20.04" }
+                }
+            },
+            "4.29.0": {
+                "version_aliases": {
+                    "pytorch2.0": "pytorch2.0.0"
+                },
+                "pytorch2.0.0": {
+                    "py_versions": ["py310"],
+                    "registries": {
+                        "af-south-1": "626614931356",
                         "ap-east-1": "871362719292",
                         "ap-northeast-1": "763104351884",
                         "ap-northeast-2": "763104351884",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -279,7 +279,7 @@ def huggingface_pytorch_training_version(huggingface_training_version):
 def huggingface_pytorch_training_py_version(huggingface_pytorch_training_version):
     if Version(huggingface_pytorch_training_version) >= Version("2.0"):
         return "py310"
-    if Version(huggingface_pytorch_training_version) >= Version("1.13"):
+    elif Version(huggingface_pytorch_training_version) >= Version("1.13"):
         return "py39"
     elif Version(huggingface_pytorch_training_version) >= Version("1.9"):
         return "py38"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -279,7 +279,7 @@ def huggingface_pytorch_training_version(huggingface_training_version):
 def huggingface_pytorch_training_py_version(huggingface_pytorch_training_version):
     if Version(huggingface_pytorch_training_version) >= Version("2.0"):
         return "py310"
-    elif Version(huggingface_pytorch_training_version) >= Version("1.13"):
+    if Version(huggingface_pytorch_training_version) >= Version("1.13"):
         return "py39"
     elif Version(huggingface_pytorch_training_version) >= Version("1.9"):
         return "py38"


### PR DESCRIPTION
*Issue #, if available:* #3896

*Description of changes:*
Update Image URI for:

Transformers 4.29 - PyTorch 2.0 Inference DLC
Transformers 4.29 - PyTorch 2.0 Training DLC

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
