### PR TITLE
change: enable neo framework version support on ml_inf2 and ml_trn1

### DIFF
--- a/src/sagemaker/model.py
+++ b/src/sagemaker/model.py
@@ -844,15 +844,20 @@ api/latest/reference/services/sagemaker.html#SageMaker.Client.add_tags>`_
         ):
             if target_instance_type and framework and framework_version:
                 framework = framework.lower()
+
                 multi_version_frameworks_support_mapping = {
-                    "inferentia": ["pytorch", "tensorflow", "mxnet"],
+                    "ml_inf1": ["pytorch", "tensorflow", "mxnet"],
+                    "ml_inf2": ["pytorch", "tensorflow"],
+                    "ml_trn1": ["pytorch", "tensorflow"],
                     "neo_ioc_targets": ["pytorch", "tensorflow"],
                     "neo_edge_targets": ["pytorch", "tensorflow"],
                 }
                 if target_instance_type in NEO_IOC_TARGET_DEVICES:
                     return framework in multi_version_frameworks_support_mapping["neo_ioc_targets"]
-                if target_instance_type == "ml_inf1":
-                    return framework in multi_version_frameworks_support_mapping["inferentia"]
+                if target_instance_type in ["ml_inf1", "ml_inf2", "ml_trn1"]:
+                    return (
+                        framework in multi_version_frameworks_support_mapping[target_instance_type]
+                    )
                 if target_instance_type not in NEO_MULTIVERSION_UNSUPPORTED:
                     return framework in multi_version_frameworks_support_mapping["neo_edge_targets"]
             return False

--- a/tests/unit/sagemaker/model/test_neo.py
+++ b/tests/unit/sagemaker/model/test_neo.py
@@ -362,59 +362,35 @@ def test_compile_with_tensorflow_neo_in_ml_inf(session):
     )
 
 
-def test_compile_validates_framework_version(sagemaker_session):
-    sagemaker_session.wait_for_compilation_job = Mock(
-        return_value={
-            "CompilationJobStatus": "Completed",
-            "ModelArtifacts": {"S3ModelArtifacts": "s3://output-path/model.tar.gz"},
-            "InferenceImage": None,
-        }
-    )
+@pytest.mark.parametrize(
+    "target,framework,fx_version,expected_fx_version",
+    [
+        ("ml_c4", "pytorch", "1.6", "1.6"),
+        ("rasp3b", "pytorch", "1.6.1", "1.6"),
+        ("amba_cv2", "pytorch", "1.6.1", None),
+        ("ml_c4", "tensorflow", "1.15.1", "1.15"),
+        ("ml_c4", "tensorflow", "2.15.1", "2.15"),
+        ("ml_inf1", "tensorflow", "2.15.1", "2.15"),
+        ("ml_inf2", "pytorch", "2.0", "2.0"),
+        ("ml_inf2", "pytorch", "2.0.1", "2.0"),
+        ("ml_trn1", "pytorch", "2.0.1", "2.0"),
+        ("ml_trn1", "tensorflow", "2.0.1", "2.0"),
+    ],
+)
+def test_compile_validates_framework_version(
+    sagemaker_session, target, framework, fx_version, expected_fx_version
+):
     model = _create_model(sagemaker_session)
-    model.compile(
-        target_instance_family="ml_c4",
-        input_shape={"data": [1, 3, 1024, 1024]},
-        output_path="s3://output",
-        role="role",
-        framework="pytorch",
-        framework_version="1.6.1",
-        job_name="compile-model",
-    )
-
-    assert model.image_uri is None
-
-    sagemaker_session.wait_for_compilation_job = Mock(
-        return_value={
-            "CompilationJobStatus": "Completed",
-            "ModelArtifacts": {"S3ModelArtifacts": "s3://output-path/model.tar.gz"},
-            "InferenceImage": None,
-        }
-    )
-
     config = model._compilation_job_config(
-        "rasp3b",
+        target,
         {"data": [1, 3, 1024, 1024]},
         "s3://output",
         "role",
         900,
         "compile-model",
-        "pytorch",
+        framework,
         None,
-        framework_version="1.6.1",
+        framework_version=fx_version,
     )
 
-    assert config["input_model_config"]["FrameworkVersion"] == "1.6"
-
-    config = model._compilation_job_config(
-        "amba_cv2",
-        {"data": [1, 3, 1024, 1024]},
-        "s3://output",
-        "role",
-        900,
-        "compile-model",
-        "pytorch",
-        None,
-        framework_version="1.6.1",
-    )
-
-    assert config["input_model_config"].get("FrameworkVersion", None) is None
+    assert config["input_model_config"].get("FrameworkVersion", None) == expected_fx_version


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add ml_inf2 and ml_trn1 framework version support in compilation job config

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
