### PR TITLE
fix: breaking deviations in _create_sagemaker_model call

### DIFF
--- a/src/sagemaker/model.py
+++ b/src/sagemaker/model.py
@@ -17,6 +17,7 @@ import abc
 import json
 import logging
 import os
+import re
 import copy
 from typing import List, Dict, Optional, Union
 
@@ -1648,6 +1649,10 @@ class FrameworkModel(Model):
         )
 
 
+# works for MODEL_PACKAGE_ARN with or without version info.
+MODEL_PACKAGE_ARN_PATTERN = r"arn:aws:sagemaker:(.*?):(.*?):model-package/(.*?)(?:/(\d+))?$"
+
+
 class ModelPackage(Model):
     """A SageMaker ``Model`` that can be deployed to an ``Endpoint``."""
 
@@ -1755,14 +1760,19 @@ class ModelPackage(Model):
             model_package_name = self._created_model_package_name
         else:
             # When a ModelPackageArn is provided we just create the Model
-            model_package_name = self.model_package_arn
+            match = re.match(MODEL_PACKAGE_ARN_PATTERN, self.model_package_arn)
+            if match:
+                model_package_name = match.group(3)
+            else:
+                # model_package_arn can be just the name if your account owns the Model Package
+                model_package_name = self.model_package_arn
 
         container_def = {"ModelPackageName": model_package_name}
 
         if self.env != {}:
             container_def["Environment"] = self.env
 
-        self._ensure_base_name_if_needed(model_package_name.split("/")[-1])
+        self._ensure_base_name_if_needed(model_package_name)
         self._set_model_name_if_needed()
 
         self.sagemaker_session.create_model(
@@ -1771,6 +1781,7 @@ class ModelPackage(Model):
             container_def,
             vpc_config=self.vpc_config,
             enable_network_isolation=self.enable_network_isolation(),
+            tags=kwargs.get("tags"),
         )
 
     def _ensure_base_name_if_needed(self, base_name):

--- a/tests/unit/sagemaker/model/test_model_package.py
+++ b/tests/unit/sagemaker/model/test_model_package.py
@@ -115,6 +115,42 @@ def test_create_sagemaker_model_uses_model_name(name_from_base, sagemaker_sessio
         {"ModelPackageName": model_package_name},
         vpc_config=None,
         enable_network_isolation=False,
+        tags=None,
+    )
+
+
+@pytest.mark.parametrize(
+    "model_package_arn",
+    [
+        "arn:aws:sagemaker:us-east-2:123:model-package/my-model-package-arn",
+        "arn:aws:sagemaker:us-east-2:123:model-package/my-model-package-arn/12",
+    ],
+)
+@patch("sagemaker.utils.name_from_base")
+def test_create_sagemaker_model_uses_model_package_arn(
+    name_from_base, sagemaker_session, model_package_arn
+):
+    model_name = "my-model"
+
+    model_package = ModelPackage(
+        role="role",
+        name=model_name,
+        model_package_arn=model_package_arn,
+        sagemaker_session=sagemaker_session,
+    )
+
+    model_package._create_sagemaker_model()
+
+    assert model_name == model_package.name
+    name_from_base.assert_not_called()
+
+    sagemaker_session.create_model.assert_called_with(
+        model_name,
+        "role",
+        {"ModelPackageName": "my-model-package-arn"},
+        vpc_config=None,
+        enable_network_isolation=False,
+        tags=None,
     )
 
 
@@ -141,6 +177,35 @@ def test_create_sagemaker_model_include_environment_variable(sagemaker_session):
         {"ModelPackageName": model_package_name, "Environment": environment},
         vpc_config=None,
         enable_network_isolation=False,
+        tags=None,
+    )
+
+
+def test_create_sagemaker_model_include_tags(sagemaker_session):
+    model_name = "my-model"
+    model_package_name = "my-model-package"
+    env_key = "env_key"
+    env_value = "env_value"
+    environment = {env_key: env_value}
+    tags = {"Key": "foo", "Value": "bar"}
+
+    model_package = ModelPackage(
+        role="role",
+        name=model_name,
+        model_package_arn=model_package_name,
+        env=environment,
+        sagemaker_session=sagemaker_session,
+    )
+
+    model_package._create_sagemaker_model(tags=tags)
+
+    sagemaker_session.create_model.assert_called_with(
+        model_name,
+        "role",
+        {"ModelPackageName": model_package_name, "Environment": environment},
+        vpc_config=None,
+        enable_network_isolation=False,
+        tags=tags,
     )
 
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/sagemaker-python-sdk/issues/3891

*Description of changes:*
For issues mentioned in above bug report, 

1. When we use the ModelPackage object to create a model with tags (something that was added to parent Model object), the tags are not passed to the session create_model call. In fact, all kwargs are ignored during this call.
2. When [we create the model name](https://github.com/aws/sagemaker-python-sdk/blob/6a252f9ab16febdddb0c7b691677e6c0db41f826/src/sagemaker/model.py#LL1746C8-L1746C76), we do a split to create the model name. This pulls the last part of the string in the model package name. Typically this is an integer for version number. As such, the created model names are like 1-2023-05-31-15-26-49-641. We should be using the second from the last to get the model_package_name instead of (or in addition to) the version number. This is also different behavior from the parent which uses the container name for the model name.

this change fixes them using, 
1. Pass tags if present to underlying create_model call.
2. Added a regex based model packge retrieval mechanism if model package arn is provided.

*Testing done:*
Added unit tests.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
