### PR TITLE
feat: Add support for Deployment Recommendation ID in model.deploy(). No tagging support

### DIFF
--- a/src/sagemaker/inference_recommender/inference_recommender_mixin.py
+++ b/src/sagemaker/inference_recommender/inference_recommender_mixin.py
@@ -398,9 +398,7 @@ class InferenceRecommenderMixin:
         # Update params beased on model recommendation
         if model_recommendation:
             if initial_instance_count is None:
-                raise ValueError(
-                    "Please specify initial_instance_count with model recommendation id"
-                )
+                raise ValueError("Must specify model recommendation id and instance count.")
             self.env.update(model_recommendation["Environment"])
             instance_type = model_recommendation["InstanceType"]
             return (instance_type, initial_instance_count)
@@ -408,9 +406,9 @@ class InferenceRecommenderMixin:
         # Update params based on default inference recommendation
         if bool(instance_type) != bool(initial_instance_count):
             raise ValueError(
-                "Please either do not specify instance_type and initial_instance_count"
-                "since they are in recommendation, or specify both of them if you want"
-                "to override the recommendation."
+                "instance_type and initial_instance_count are mutually exclusive with"
+                "recommendation id since they are in recommendation."
+                "Please specify both of them if you want to override the recommendation."
             )
         input_config = right_size_job_res["InputConfig"]
         model_config = right_size_recommendation["ModelConfiguration"]

--- a/src/sagemaker/inference_recommender/inference_recommender_mixin.py
+++ b/src/sagemaker/inference_recommender/inference_recommender_mixin.py
@@ -30,10 +30,6 @@ INFERENCE_RECOMMENDER_FRAMEWORK_MAPPING = {
 
 LOGGER = logging.getLogger("sagemaker")
 
-DEPLOYMENT_RECOMMENDATION_TAG = "PythonSDK-DeploymentRecommendation"
-
-RIGHT_SIZE_TAG = "PythonSDK-RightSize"
-
 
 class Phase:
     """Used to store phases of a traffic pattern to perform endpoint load testing.
@@ -222,7 +218,6 @@ class InferenceRecommenderMixin:
         explainer_config = kwargs["explainer_config"]
         inference_recommendation_id = kwargs["inference_recommendation_id"]
         inference_recommender_job_results = kwargs["inference_recommender_job_results"]
-        tags = kwargs["tags"]
         if inference_recommendation_id is not None:
             inference_recommendation = self._update_params_for_recommendation_id(
                 instance_type=instance_type,
@@ -243,10 +238,11 @@ class InferenceRecommenderMixin:
                 explainer_config,
             )
 
-        if inference_recommendation:
-            tags = self._add_client_type_tag(tags, inference_recommendation[2])
-            return (inference_recommendation[0], inference_recommendation[1], tags)
-        return (instance_type, initial_instance_count, tags)
+        return (
+            inference_recommendation
+            if inference_recommendation
+            else (instance_type, initial_instance_count)
+        )
 
     def _update_params_for_right_size(
         self,
@@ -310,7 +306,7 @@ class InferenceRecommenderMixin:
         initial_instance_count = self.inference_recommendations[0]["EndpointConfiguration"][
             "InitialInstanceCount"
         ]
-        return (instance_type, initial_instance_count, RIGHT_SIZE_TAG)
+        return (instance_type, initial_instance_count)
 
     def _update_params_for_recommendation_id(
         self,
@@ -410,7 +406,7 @@ class InferenceRecommenderMixin:
                 raise ValueError("Must specify model recommendation id and instance count.")
             self.env.update(model_recommendation["Environment"])
             instance_type = model_recommendation["InstanceType"]
-            return (instance_type, initial_instance_count, DEPLOYMENT_RECOMMENDATION_TAG)
+            return (instance_type, initial_instance_count)
 
         # Update params based on default inference recommendation
         if bool(instance_type) != bool(initial_instance_count):
@@ -474,7 +470,7 @@ class InferenceRecommenderMixin:
             "InitialInstanceCount"
         ]
 
-        return (instance_type, initial_instance_count, RIGHT_SIZE_TAG)
+        return (instance_type, initial_instance_count)
 
     def _convert_to_endpoint_configurations_json(
         self, hyperparameter_ranges: List[Dict[str, CategoricalParameter]]
@@ -614,9 +610,3 @@ class InferenceRecommenderMixin:
             ),
             None,
         )
-
-    def _add_client_type_tag(self, tags, client_type):
-        """Tagging for Inference Recommender and Deployment Recommendations"""
-        client_type_tag = {"Key": "ClientType", "Value": client_type}
-        tags = tags.append(client_type_tag) if tags else [client_type_tag]
-        return tags

--- a/src/sagemaker/inference_recommender/inference_recommender_mixin.py
+++ b/src/sagemaker/inference_recommender/inference_recommender_mixin.py
@@ -310,7 +310,7 @@ class InferenceRecommenderMixin:
         initial_instance_count = self.inference_recommendations[0]["EndpointConfiguration"][
             "InitialInstanceCount"
         ]
-        return (instance_type, initial_instance_count, "PythonSDK-RightSize")
+        return (instance_type, initial_instance_count, RIGHT_SIZE_TAG)
 
     def _update_params_for_recommendation_id(
         self,

--- a/src/sagemaker/inference_recommender/inference_recommender_mixin.py
+++ b/src/sagemaker/inference_recommender/inference_recommender_mixin.py
@@ -34,6 +34,7 @@ DEPLOYMENT_RECOMMENDATION_TAG = "PythonSDK-DeploymentRecommendation"
 
 RIGHT_SIZE_TAG = "PythonSDK-RightSize"
 
+
 class Phase:
     """Used to store phases of a traffic pattern to perform endpoint load testing.
 
@@ -615,9 +616,6 @@ class InferenceRecommenderMixin:
         )
 
     def _add_client_type_tag(self, tags, client_type):
-        client_type_tag = {
-            "Key": "ClientType",
-            "Value": client_type
-        }
+        client_type_tag = {"Key": "ClientType", "Value": client_type}
         tags = tags.append(client_type_tag) if tags else [client_type_tag]
         return tags

--- a/src/sagemaker/inference_recommender/inference_recommender_mixin.py
+++ b/src/sagemaker/inference_recommender/inference_recommender_mixin.py
@@ -616,6 +616,7 @@ class InferenceRecommenderMixin:
         )
 
     def _add_client_type_tag(self, tags, client_type):
+        """Tagging for Inference Recommender and Deployment Recommendations"""
         client_type_tag = {"Key": "ClientType", "Value": client_type}
         tags = tags.append(client_type_tag) if tags else [client_type_tag]
         return tags

--- a/src/sagemaker/model.py
+++ b/src/sagemaker/model.py
@@ -1784,7 +1784,7 @@ class ModelPackage(Model):
 
         # If tags are in args, it must be the 3rd param
         # If not, then check kwargs and set to either tags or None
-        tags = args[2] if len(args) >= 3 else kwargs.get('tags')
+        tags = args[2] if len(args) >= 3 else kwargs.get("tags")
 
         self.sagemaker_session.create_model(
             self.name,

--- a/src/sagemaker/model.py
+++ b/src/sagemaker/model.py
@@ -1253,7 +1253,7 @@ api/latest/reference/services/sagemaker.html#SageMaker.Client.add_tags>`_
             inference_recommendation_id is not None
             or self.inference_recommender_job_results is not None
         ):
-            instance_type, initial_instance_count, tags = self._update_params(
+            instance_type, initial_instance_count = self._update_params(
                 instance_type=instance_type,
                 initial_instance_count=initial_instance_count,
                 accelerator_type=accelerator_type,
@@ -1262,7 +1262,6 @@ api/latest/reference/services/sagemaker.html#SageMaker.Client.add_tags>`_
                 explainer_config=explainer_config,
                 inference_recommendation_id=inference_recommendation_id,
                 inference_recommender_job_results=self.inference_recommender_job_results,
-                tags=tags,
             )
 
         is_async = async_inference_config is not None
@@ -1757,10 +1756,10 @@ class ModelPackage(Model):
 
         Args:
             args: Positional arguments coming from the caller. This class does not require
-                any but will look for tags in the 3rd parameter.
+                any so they are ignored.
 
             kwargs: Keyword arguments coming from the caller. This class does not require
-                any but will search for tags if not in args.
+                any so they are ignored.
         """
         if self.algorithm_arn:
             # When ModelPackage is created using an algorithm_arn we need to first
@@ -1782,17 +1781,12 @@ class ModelPackage(Model):
         self._ensure_base_name_if_needed(model_package_name.split("/")[-1])
         self._set_model_name_if_needed()
 
-        # If tags are in args, it must be the 3rd param
-        # If not, then check kwargs and set to either tags or None
-        tags = args[2] if len(args) >= 3 else kwargs.get("tags")
-
         self.sagemaker_session.create_model(
             self.name,
             self.role,
             container_def,
             vpc_config=self.vpc_config,
             enable_network_isolation=self.enable_network_isolation(),
-            tags=tags,
         )
 
     def _ensure_base_name_if_needed(self, base_name):

--- a/src/sagemaker/model.py
+++ b/src/sagemaker/model.py
@@ -1757,10 +1757,10 @@ class ModelPackage(Model):
 
         Args:
             args: Positional arguments coming from the caller. This class does not require
-                any but will specifically look for Tags (3rd arg positionally) if specified
+                any but will look for tags in the 3rd parameter.
 
             kwargs: Keyword arguments coming from the caller. This class does not require
-                any so they are ignored.
+                any but will search for tags if not in args.
         """
         if self.algorithm_arn:
             # When ModelPackage is created using an algorithm_arn we need to first
@@ -1782,13 +1782,17 @@ class ModelPackage(Model):
         self._ensure_base_name_if_needed(model_package_name.split("/")[-1])
         self._set_model_name_if_needed()
 
+        # If tags are in args, it must be the 3rd param
+        # If not, then check kwargs and set to either tags or None
+        tags = args[2] if len(args) >= 3 else kwargs.get('tags')
+
         self.sagemaker_session.create_model(
             self.name,
             self.role,
             container_def,
             vpc_config=self.vpc_config,
             enable_network_isolation=self.enable_network_isolation(),
-            tags=args[2],
+            tags=tags,
         )
 
     def _ensure_base_name_if_needed(self, base_name):

--- a/src/sagemaker/model.py
+++ b/src/sagemaker/model.py
@@ -1209,6 +1209,8 @@ api/latest/reference/services/sagemaker.html#SageMaker.Client.add_tags>`_
             inference_recommendation_id (str): The recommendation id which specifies the
                 recommendation you picked from inference recommendation job results and
                 would like to deploy the model and endpoint with recommended parameters.
+                This can also be a recommendation id returned from ``DescribeModel`` contained in
+                a list of ``RealtimeInferenceRecommendations`` within ``DeploymentRecommendation``
             explainer_config (sagemaker.explainer.ExplainerConfig): Specifies online explainability
                 configuration for use with Amazon SageMaker Clarify. Default: None.
         Raises:

--- a/src/sagemaker/model.py
+++ b/src/sagemaker/model.py
@@ -1251,7 +1251,7 @@ api/latest/reference/services/sagemaker.html#SageMaker.Client.add_tags>`_
             inference_recommendation_id is not None
             or self.inference_recommender_job_results is not None
         ):
-            instance_type, initial_instance_count = self._update_params(
+            instance_type, initial_instance_count, tags = self._update_params(
                 instance_type=instance_type,
                 initial_instance_count=initial_instance_count,
                 accelerator_type=accelerator_type,
@@ -1260,6 +1260,7 @@ api/latest/reference/services/sagemaker.html#SageMaker.Client.add_tags>`_
                 explainer_config=explainer_config,
                 inference_recommendation_id=inference_recommendation_id,
                 inference_recommender_job_results=self.inference_recommender_job_results,
+                tags=tags,
             )
 
         is_async = async_inference_config is not None
@@ -1754,7 +1755,7 @@ class ModelPackage(Model):
 
         Args:
             args: Positional arguments coming from the caller. This class does not require
-                any so they are ignored.
+                any but will specifically look for Tags (3rd arg positionally) if specified
 
             kwargs: Keyword arguments coming from the caller. This class does not require
                 any so they are ignored.
@@ -1785,6 +1786,7 @@ class ModelPackage(Model):
             container_def,
             vpc_config=self.vpc_config,
             enable_network_isolation=self.enable_network_isolation(),
+            tags=args[2],
         )
 
     def _ensure_base_name_if_needed(self, base_name):

--- a/tests/integ/test_inference_recommender.py
+++ b/tests/integ/test_inference_recommender.py
@@ -487,7 +487,7 @@ def test_deploy_deployment_recommendation_id_with_model(created_base_model, sage
                 created_base_model, sagemaker_session
             )
 
-            assert deployment_recommendation != None
+            assert deployment_recommendation is not None
 
             real_time_recommendations = deployment_recommendation.get(
                 "RealTimeInferenceRecommendations"

--- a/tests/integ/test_inference_recommender.py
+++ b/tests/integ/test_inference_recommender.py
@@ -325,7 +325,7 @@ def created_base_model(sagemaker_session, cpu_instance_type):
     model.create(instance_type=cpu_instance_type)
 
     return model
-            
+
 
 @pytest.mark.slow_test
 def test_default_right_size_and_deploy_registered_model_sklearn(
@@ -483,17 +483,23 @@ def test_deploy_inference_recommendation_id_with_registered_model_sklearn(
 def test_deploy_deployment_recommendation_id_with_model(created_base_model, sagemaker_session):
     with timeout(minutes=20):
         try:
-            deployment_recommendation = poll_for_deployment_recommendation(created_base_model, sagemaker_session)
+            deployment_recommendation = poll_for_deployment_recommendation(
+                created_base_model, sagemaker_session
+            )
 
             assert deployment_recommendation != None
 
-            real_time_recommendations = deployment_recommendation.get("RealTimeInferenceRecommendations")
-            recommendation_id = real_time_recommendations[0].get('RecommendationId')
-            
+            real_time_recommendations = deployment_recommendation.get(
+                "RealTimeInferenceRecommendations"
+            )
+            recommendation_id = real_time_recommendations[0].get("RecommendationId")
+
             endpoint_name = unique_name_from_base("test-rec-id-deployment-default-sklearn")
             created_base_model.predictor_cls = SKLearnPredictor
             predictor = created_base_model.deploy(
-                inference_recommendation_id=recommendation_id, initial_instance_count=1, endpoint_name=endpoint_name
+                inference_recommendation_id=recommendation_id,
+                initial_instance_count=1,
+                endpoint_name=endpoint_name,
             )
 
             payload = pd.read_csv(IR_SKLEARN_DATA, header=None)
@@ -503,7 +509,7 @@ def test_deploy_deployment_recommendation_id_with_model(created_base_model, sage
             assert 26 == len(inference)
         finally:
             predictor.delete_model()
-            predictor.delete_endpoint()            
+            predictor.delete_endpoint()
 
 
 def poll_for_deployment_recommendation(created_base_model, sagemaker_session):
@@ -511,7 +517,9 @@ def poll_for_deployment_recommendation(created_base_model, sagemaker_session):
         try:
             completed = False
             while not completed:
-                describe_model_response = sagemaker_session.sagemaker_client.describe_model(ModelName=created_base_model.name)
+                describe_model_response = sagemaker_session.sagemaker_client.describe_model(
+                    ModelName=created_base_model.name
+                )
                 deployment_recommendation = describe_model_response.get("DeploymentRecommendation")
 
                 completed = (

--- a/tests/unit/sagemaker/inference_recommender/constants.py
+++ b/tests/unit/sagemaker/inference_recommender/constants.py
@@ -37,10 +37,10 @@ IR_SUPPORTED_INSTANCE_TYPES = ["ml.c5.xlarge", "ml.c5.2xlarge"]
 
 INVALID_RECOMMENDATION_ID = "ir-job6ab0ff22"
 NOT_EXISTED_RECOMMENDATION_ID = IR_JOB_NAME + "/ad3ec9ee"
-NOT_EXISTED_INSTANT_RECOMMENDATION_ID = IR_MODEL_NAME + "/ad3ec9ee"
+NOT_EXISTED_MODEL_RECOMMENDATION_ID = IR_MODEL_NAME + "/ad3ec9ee"
 RECOMMENDATION_ID = IR_JOB_NAME + "/5bcee92e"
-INSTANT_RECOMMENDATION_ID = IR_MODEL_NAME + "/v0KObO5d"
-INSTANT_RECOMMENDATION_ENV = {"TS_DEFAULT_WORKERS_PER_MODEL": "4"}
+MODEL_RECOMMENDATION_ID = IR_MODEL_NAME + "/v0KObO5d"
+MODEL_RECOMMENDATION_ENV = {"TS_DEFAULT_WORKERS_PER_MODEL": "4"}
 
 IR_CONTAINER_CONFIG = {
     "Domain": "MACHINE_LEARNING",
@@ -102,9 +102,9 @@ DESCRIBE_MODEL_RESPONSE = {
         "RecommendationStatus": "COMPLETED",
         "RealTimeInferenceRecommendations": [
             {
-                "RecommendationId": INSTANT_RECOMMENDATION_ID,
+                "RecommendationId": MODEL_RECOMMENDATION_ID,
                 "InstanceType": "ml.g4dn.2xlarge",
-                "Environment": INSTANT_RECOMMENDATION_ENV,
+                "Environment": MODEL_RECOMMENDATION_ENV,
             },
             {
                 "RecommendationId": "test-model-name/d248qVYU",

--- a/tests/unit/sagemaker/inference_recommender/constants.py
+++ b/tests/unit/sagemaker/inference_recommender/constants.py
@@ -152,3 +152,44 @@ DESCRIBE_COMPILATION_JOB_RESPONSE = {
     "ModelArtifacts": {"S3ModelArtifacts": IR_COMPILATION_MODEL_DATA},
     "InferenceImage": IR_COMPILATION_IMAGE,
 }
+
+IR_CONTAINER_DEF = {
+    "Image": IR_IMAGE,
+    "Environment": IR_ENV,
+    "ModelDataUrl": IR_MODEL_DATA,
+}
+
+DEPLOYMENT_RECOMMENDATION_CONTAINER_DEF = {
+    "Image": IR_IMAGE,
+    "Environment": MODEL_RECOMMENDATION_ENV,
+    "ModelDataUrl": IR_MODEL_DATA,
+}
+
+IR_COMPILATION_CONTAINER_DEF = {
+    "Image": IR_COMPILATION_IMAGE,
+    "Environment": {},
+    "ModelDataUrl": IR_COMPILATION_MODEL_DATA,
+}
+
+IR_MODEL_PACKAGE_CONTAINER_DEF = {
+    "ModelPackageName": IR_MODEL_PACKAGE_VERSION_ARN,
+    "Environment": IR_ENV,
+}
+
+IR_COMPILATION_MODEL_PACKAGE_CONTAINER_DEF = {
+    "ModelPackageName": IR_MODEL_PACKAGE_VERSION_ARN,
+}
+
+IR_TAGS = [
+    {
+        "Key": "ClientType",
+        "Value": "PythonSDK-RightSize",
+    }
+]
+
+DEPLOYMENT_RECOMMENDATION_TAGS = [
+    {
+        "Key": "ClientType",
+        "Value": "PythonSDK-DeploymentRecommendation",
+    }
+]

--- a/tests/unit/sagemaker/inference_recommender/constants.py
+++ b/tests/unit/sagemaker/inference_recommender/constants.py
@@ -37,7 +37,10 @@ IR_SUPPORTED_INSTANCE_TYPES = ["ml.c5.xlarge", "ml.c5.2xlarge"]
 
 INVALID_RECOMMENDATION_ID = "ir-job6ab0ff22"
 NOT_EXISTED_RECOMMENDATION_ID = IR_JOB_NAME + "/ad3ec9ee"
+NOT_EXISTED_INSTANT_RECOMMENDATION_ID = IR_MODEL_NAME + "/ad3ec9ee"
 RECOMMENDATION_ID = IR_JOB_NAME + "/5bcee92e"
+INSTANT_RECOMMENDATION_ID = IR_MODEL_NAME + "/v0KObO5d"
+INSTANT_RECOMMENDATION_ENV = {"TS_DEFAULT_WORKERS_PER_MODEL": "4"}
 
 IR_CONTAINER_CONFIG = {
     "Domain": "MACHINE_LEARNING",
@@ -94,6 +97,21 @@ DESCRIBE_MODEL_RESPONSE = {
         "Environment": {"SAGEMAKER_REGION": "us-west-2"},
         "Image": IR_IMAGE,
         "ModelDataUrl": IR_MODEL_DATA,
+    },
+    "DeploymentRecommendation": {
+        "RecommendationStatus": "COMPLETED",
+        "RealTimeInferenceRecommendations": [
+            {
+                "RecommendationId": INSTANT_RECOMMENDATION_ID,
+                "InstanceType": "ml.g4dn.2xlarge",
+                "Environment": INSTANT_RECOMMENDATION_ENV,
+            },
+            {
+                "RecommendationId": "test-model-name/d248qVYU",
+                "InstanceType": "ml.c6i.large",
+                "Environment": {},
+            },
+        ],
     },
 }
 

--- a/tests/unit/sagemaker/inference_recommender/constants.py
+++ b/tests/unit/sagemaker/inference_recommender/constants.py
@@ -179,17 +179,3 @@ IR_MODEL_PACKAGE_CONTAINER_DEF = {
 IR_COMPILATION_MODEL_PACKAGE_CONTAINER_DEF = {
     "ModelPackageName": IR_MODEL_PACKAGE_VERSION_ARN,
 }
-
-IR_TAGS = [
-    {
-        "Key": "ClientType",
-        "Value": "PythonSDK-RightSize",
-    }
-]
-
-DEPLOYMENT_RECOMMENDATION_TAGS = [
-    {
-        "Key": "ClientType",
-        "Value": "PythonSDK-DeploymentRecommendation",
-    }
-]

--- a/tests/unit/sagemaker/inference_recommender/test_inference_recommender_mixin.py
+++ b/tests/unit/sagemaker/inference_recommender/test_inference_recommender_mixin.py
@@ -177,6 +177,17 @@ IR_SERVERLESS_PRODUCTION_VARIANTS = [
     }
 ]
 
+IR_MODEL_PACKAGE_CONTAINER_DEF = {
+    "ModelPackageName": MODEL_PACKAGE_ARN,
+}
+
+IR_TAGS = [
+    {
+        "Key": "ClientType",
+        "Value": "PythonSDK-RightSize",
+    }
+]
+
 
 @pytest.fixture()
 def sagemaker_session():
@@ -371,6 +382,8 @@ def test_right_size_default_with_model_package_successful(sagemaker_session, mod
         framework=IR_SAMPLE_FRAMEWORK,
     )
 
+    sagemaker_session.create_model.assert_not_called()
+
     # assert that the create api has been called with default parameters
     sagemaker_session.create_inference_recommendations_job.assert_called_with(
         role=IR_ROLE_ARN,
@@ -425,6 +438,8 @@ def test_right_size_advanced_list_instances_model_package_successful(
         max_tests=5,
         max_parallel_tests=5,
     )
+
+    sagemaker_session.create_model.assert_not_called()
 
     # assert that the create api has been called with advanced parameters
     sagemaker_session.create_inference_recommendations_job.assert_called_with(
@@ -481,6 +496,8 @@ def test_right_size_advanced_single_instances_model_package_successful(
         max_parallel_tests=5,
     )
 
+    sagemaker_session.create_model.assert_not_called()
+
     # assert that the create api has been called with advanced parameters
     sagemaker_session.create_inference_recommendations_job.assert_called_with(
         role=IR_ROLE_ARN,
@@ -516,6 +533,8 @@ def test_right_size_advanced_model_package_partial_params_successful(
         max_invocations=100,
         model_latency_thresholds=IR_SAMPLE_MODEL_LATENCY_THRESHOLDS,
     )
+
+    sagemaker_session.create_model.assert_not_called()
 
     # assert that the create api has been called with advanced parameters
     sagemaker_session.create_inference_recommendations_job.assert_called_with(
@@ -567,6 +586,15 @@ def test_deploy_right_size_with_model_package_succeeds(
     default_right_sized_model.name = MODEL_NAME
     default_right_sized_model.deploy(endpoint_name=IR_DEPLOY_ENDPOINT_NAME)
 
+    sagemaker_session.create_model.assert_called_with(
+        MODEL_NAME,
+        IR_ROLE_ARN,
+        IR_MODEL_PACKAGE_CONTAINER_DEF,
+        vpc_config=None,
+        enable_network_isolation=False,
+        tags=IR_TAGS,
+    )
+
     sagemaker_session.endpoint_from_production_variants.assert_called_with(
         async_inference_config_dict=None,
         data_capture_config_dict=None,
@@ -574,7 +602,7 @@ def test_deploy_right_size_with_model_package_succeeds(
         kms_key=None,
         name="ir-endpoint-test",
         production_variants=IR_PRODUCTION_VARIANTS,
-        tags=None,
+        tags=IR_TAGS,
         wait=True,
     )
 
@@ -587,6 +615,15 @@ def test_deploy_right_size_with_both_overrides_succeeds(
         instance_type="ml.c5.2xlarge",
         initial_instance_count=5,
         endpoint_name=IR_DEPLOY_ENDPOINT_NAME,
+    )
+
+    sagemaker_session.create_model.assert_called_with(
+        MODEL_NAME,
+        IR_ROLE_ARN,
+        IR_MODEL_PACKAGE_CONTAINER_DEF,
+        vpc_config=None,
+        enable_network_isolation=False,
+        tags=None,
     )
 
     sagemaker_session.endpoint_from_production_variants.assert_called_with(
@@ -637,6 +674,15 @@ def test_deploy_right_size_serverless_override(sagemaker_session, default_right_
     serverless_inference_config = ServerlessInferenceConfig()
     default_right_sized_model.deploy(serverless_inference_config=serverless_inference_config)
 
+    sagemaker_session.create_model.assert_called_with(
+        MODEL_NAME,
+        IR_ROLE_ARN,
+        IR_MODEL_PACKAGE_CONTAINER_DEF,
+        vpc_config=None,
+        enable_network_isolation=False,
+        tags=None,
+    )
+
     sagemaker_session.endpoint_from_production_variants.assert_called_with(
         name=MODEL_NAME,
         production_variants=IR_SERVERLESS_PRODUCTION_VARIANTS,
@@ -659,6 +705,15 @@ def test_deploy_right_size_async_override(sagemaker_session, default_right_sized
         instance_type="ml.c5.2xlarge",
         initial_instance_count=1,
         async_inference_config=async_inference_config,
+    )
+
+    sagemaker_session.create_model.assert_called_with(
+        MODEL_NAME,
+        IR_ROLE_ARN,
+        IR_MODEL_PACKAGE_CONTAINER_DEF,
+        vpc_config=None,
+        enable_network_isolation=False,
+        tags=None,
     )
 
     sagemaker_session.endpoint_from_production_variants.assert_called_with(
@@ -693,6 +748,15 @@ def test_deploy_right_size_explainer_config_override(sagemaker_session, default_
         instance_type="ml.c5.2xlarge",
         initial_instance_count=1,
         explainer_config=explainer_config,
+    )
+
+    sagemaker_session.create_model.assert_called_with(
+        MODEL_NAME,
+        IR_ROLE_ARN,
+        IR_MODEL_PACKAGE_CONTAINER_DEF,
+        vpc_config=None,
+        enable_network_isolation=False,
+        tags=None,
     )
 
     sagemaker_session.endpoint_from_production_variants.assert_called_with(

--- a/tests/unit/sagemaker/inference_recommender/test_inference_recommender_mixin.py
+++ b/tests/unit/sagemaker/inference_recommender/test_inference_recommender_mixin.py
@@ -181,13 +181,6 @@ IR_MODEL_PACKAGE_CONTAINER_DEF = {
     "ModelPackageName": MODEL_PACKAGE_ARN,
 }
 
-IR_TAGS = [
-    {
-        "Key": "ClientType",
-        "Value": "PythonSDK-RightSize",
-    }
-]
-
 
 @pytest.fixture()
 def sagemaker_session():
@@ -592,7 +585,6 @@ def test_deploy_right_size_with_model_package_succeeds(
         IR_MODEL_PACKAGE_CONTAINER_DEF,
         vpc_config=None,
         enable_network_isolation=False,
-        tags=IR_TAGS,
     )
 
     sagemaker_session.endpoint_from_production_variants.assert_called_with(
@@ -602,7 +594,7 @@ def test_deploy_right_size_with_model_package_succeeds(
         kms_key=None,
         name="ir-endpoint-test",
         production_variants=IR_PRODUCTION_VARIANTS,
-        tags=IR_TAGS,
+        tags=None,
         wait=True,
     )
 
@@ -623,7 +615,6 @@ def test_deploy_right_size_with_both_overrides_succeeds(
         IR_MODEL_PACKAGE_CONTAINER_DEF,
         vpc_config=None,
         enable_network_isolation=False,
-        tags=None,
     )
 
     sagemaker_session.endpoint_from_production_variants.assert_called_with(
@@ -680,7 +671,6 @@ def test_deploy_right_size_serverless_override(sagemaker_session, default_right_
         IR_MODEL_PACKAGE_CONTAINER_DEF,
         vpc_config=None,
         enable_network_isolation=False,
-        tags=None,
     )
 
     sagemaker_session.endpoint_from_production_variants.assert_called_with(
@@ -713,7 +703,6 @@ def test_deploy_right_size_async_override(sagemaker_session, default_right_sized
         IR_MODEL_PACKAGE_CONTAINER_DEF,
         vpc_config=None,
         enable_network_isolation=False,
-        tags=None,
     )
 
     sagemaker_session.endpoint_from_production_variants.assert_called_with(
@@ -756,7 +745,6 @@ def test_deploy_right_size_explainer_config_override(sagemaker_session, default_
         IR_MODEL_PACKAGE_CONTAINER_DEF,
         vpc_config=None,
         enable_network_isolation=False,
-        tags=None,
     )
 
     sagemaker_session.endpoint_from_production_variants.assert_called_with(

--- a/tests/unit/sagemaker/model/test_deploy.py
+++ b/tests/unit/sagemaker/model/test_deploy.py
@@ -26,8 +26,8 @@ from tests.unit.sagemaker.inference_recommender.constants import (
     DESCRIBE_COMPILATION_JOB_RESPONSE,
     DESCRIBE_MODEL_PACKAGE_RESPONSE,
     DESCRIBE_MODEL_RESPONSE,
-    INSTANT_RECOMMENDATION_ENV,
-    INSTANT_RECOMMENDATION_ID,
+    MODEL_RECOMMENDATION_ENV,
+    MODEL_RECOMMENDATION_ID,
     INVALID_RECOMMENDATION_ID,
     IR_COMPILATION_JOB_NAME,
     IR_ENV,
@@ -37,7 +37,7 @@ from tests.unit.sagemaker.inference_recommender.constants import (
     IR_MODEL_PACKAGE_VERSION_ARN,
     IR_COMPILATION_IMAGE,
     IR_COMPILATION_MODEL_DATA,
-    NOT_EXISTED_INSTANT_RECOMMENDATION_ID,
+    NOT_EXISTED_MODEL_RECOMMENDATION_ID,
     RECOMMENDATION_ID,
     NOT_EXISTED_RECOMMENDATION_ID,
 )
@@ -700,7 +700,7 @@ def test_deploy_with_recommendation_id_with_model_name_and_compilation(sagemaker
     assert model.image_uri == IR_COMPILATION_IMAGE
 
 
-def test_deploy_with_not_existed_recommendation_id(sagemaker_session):
+def test_deploy_with_invalid_inference_recommendation_id(sagemaker_session):
     sagemaker_session.sagemaker_client.describe_inference_recommendations_job.return_value = (
         create_inference_recommendations_job_default_with_model_name_and_compilation()
     )
@@ -713,14 +713,14 @@ def test_deploy_with_not_existed_recommendation_id(sagemaker_session):
 
     with pytest.raises(
         ValueError,
-        match="Inference Recommendation id does not exist",
+        match="Inference Recommendation id is not valid",
     ):
         model.deploy(
             inference_recommendation_id=NOT_EXISTED_RECOMMENDATION_ID,
         )
 
 
-def test_deploy_with_invalid_instant_recommendation_id(sagemaker_session):
+def test_deploy_with_invalid_model_recommendation_id(sagemaker_session):
     sagemaker_session.sagemaker_client.describe_inference_recommendations_job.return_value = None
     sagemaker_session.sagemaker_client.describe_model.side_effect = mock_describe_model
 
@@ -728,26 +728,26 @@ def test_deploy_with_invalid_instant_recommendation_id(sagemaker_session):
 
     with pytest.raises(
         ValueError,
-        match="Inference Recommendation id does not exist",
+        match="Inference Recommendation id is not valid",
     ):
         model.deploy(
-            inference_recommendation_id=NOT_EXISTED_INSTANT_RECOMMENDATION_ID,
+            inference_recommendation_id=NOT_EXISTED_MODEL_RECOMMENDATION_ID,
         )
 
 
-def test_deploy_with_valid_instant_recommendation_id(sagemaker_session):
+def test_deploy_with_valid_model_recommendation_id(sagemaker_session):
     sagemaker_session.sagemaker_client.describe_inference_recommendations_job.return_value = None
     sagemaker_session.sagemaker_client.describe_model.side_effect = mock_describe_model
 
     model = Model(MODEL_IMAGE, MODEL_DATA, sagemaker_session=sagemaker_session, role=ROLE)
     model.deploy(
-        inference_recommendation_id=INSTANT_RECOMMENDATION_ID,
+        inference_recommendation_id=MODEL_RECOMMENDATION_ID,
         initial_instance_count=INSTANCE_COUNT,
     )
 
     assert model.model_data == MODEL_DATA
     assert model.image_uri == MODEL_IMAGE
-    assert model.env == INSTANT_RECOMMENDATION_ENV
+    assert model.env == MODEL_RECOMMENDATION_ENV
 
 
 @patch("sagemaker.model.Model._create_sagemaker_model", Mock())

--- a/tests/unit/sagemaker/model/test_deploy.py
+++ b/tests/unit/sagemaker/model/test_deploy.py
@@ -45,8 +45,6 @@ from tests.unit.sagemaker.inference_recommender.constants import (
     IR_COMPILATION_CONTAINER_DEF,
     IR_MODEL_PACKAGE_CONTAINER_DEF,
     IR_COMPILATION_MODEL_PACKAGE_CONTAINER_DEF,
-    IR_TAGS,
-    DEPLOYMENT_RECOMMENDATION_TAGS,
 )
 from tests.unit.sagemaker.inference_recommender.constructs import (
     create_inference_recommendations_job_default_with_model_name,
@@ -649,7 +647,6 @@ def test_deploy_with_recommendation_id_with_model_pkg_arn(name_from_base, sagema
         IR_MODEL_PACKAGE_CONTAINER_DEF,
         vpc_config=None,
         enable_network_isolation=False,
-        tags=IR_TAGS,
     )
 
     assert model_package.model_package_arn == IR_MODEL_PACKAGE_VERSION_ARN
@@ -682,7 +679,7 @@ def test_deploy_with_recommendation_id_with_model_name(name_from_base, sagemaker
         container_defs=IR_CONTAINER_DEF,
         vpc_config=None,
         enable_network_isolation=False,
-        tags=IR_TAGS,
+        tags=None,
     )
 
     assert model.model_data == IR_MODEL_DATA
@@ -718,7 +715,6 @@ def test_deploy_with_recommendation_id_with_model_pkg_arn_and_compilation(
         IR_COMPILATION_MODEL_PACKAGE_CONTAINER_DEF,
         vpc_config=None,
         enable_network_isolation=False,
-        tags=IR_TAGS,
     )
 
     assert model_package.model_data == IR_COMPILATION_MODEL_DATA
@@ -753,7 +749,7 @@ def test_deploy_with_recommendation_id_with_model_name_and_compilation(
         container_defs=IR_COMPILATION_CONTAINER_DEF,
         vpc_config=None,
         enable_network_isolation=False,
-        tags=IR_TAGS,
+        tags=None,
     )
 
     assert model.model_data == IR_COMPILATION_MODEL_DATA
@@ -812,7 +808,7 @@ def test_deploy_with_valid_model_recommendation_id(name_from_base, sagemaker_ses
         container_defs=DEPLOYMENT_RECOMMENDATION_CONTAINER_DEF,
         vpc_config=None,
         enable_network_isolation=False,
-        tags=DEPLOYMENT_RECOMMENDATION_TAGS,
+        tags=None,
     )
 
     assert model.model_data == IR_MODEL_DATA

--- a/tests/unit/sagemaker/model/test_deploy.py
+++ b/tests/unit/sagemaker/model/test_deploy.py
@@ -605,7 +605,7 @@ def test_deploy_ir_with_incompatible_parameters(sagemaker_session):
 def test_deploy_with_wrong_recommendation_id(sagemaker_session):
     model = Model(MODEL_IMAGE, MODEL_DATA, sagemaker_session=sagemaker_session, role=ROLE)
 
-    with pytest.raises(ValueError, match="Inference Recommendation id is not valid"):
+    with pytest.raises(ValueError, match="inference_recommendation_id is not valid"):
         model.deploy(
             inference_recommendation_id=INVALID_RECOMMENDATION_ID,
         )
@@ -713,7 +713,7 @@ def test_deploy_with_invalid_inference_recommendation_id(sagemaker_session):
 
     with pytest.raises(
         ValueError,
-        match="Inference Recommendation id is not valid",
+        match="inference_recommendation_id is not valid",
     ):
         model.deploy(
             inference_recommendation_id=NOT_EXISTED_RECOMMENDATION_ID,
@@ -728,7 +728,7 @@ def test_deploy_with_invalid_model_recommendation_id(sagemaker_session):
 
     with pytest.raises(
         ValueError,
-        match="Inference Recommendation id is not valid",
+        match="inference_recommendation_id is not valid",
     ):
         model.deploy(
             inference_recommendation_id=NOT_EXISTED_MODEL_RECOMMENDATION_ID,

--- a/tests/unit/sagemaker/model/test_deploy.py
+++ b/tests/unit/sagemaker/model/test_deploy.py
@@ -633,7 +633,9 @@ def test_deploy_with_recommendation_id_with_model_pkg_arn(name_from_base, sagema
     )
     sagemaker_session.sagemaker_client.describe_model.return_value = None
 
-    model_package = ModelPackage(role=ROLE, model_data=IR_MODEL_DATA, model_package_arn=IR_MODEL_PACKAGE_VERSION_ARN)
+    model_package = ModelPackage(
+        role=ROLE, model_data=IR_MODEL_DATA, model_package_arn=IR_MODEL_PACKAGE_VERSION_ARN
+    )
 
     model_package.sagemaker_session = sagemaker_session
 
@@ -659,7 +661,6 @@ def test_deploy_with_recommendation_id_with_model_pkg_arn(name_from_base, sagema
 def mock_describe_model(ModelName):
     if ModelName == IR_MODEL_NAME:
         return DESCRIBE_MODEL_RESPONSE
-
 
 
 @patch("sagemaker.utils.name_from_base", return_value=MODEL_IMAGE)
@@ -690,7 +691,9 @@ def test_deploy_with_recommendation_id_with_model_name(name_from_base, sagemaker
 
 
 @patch("sagemaker.utils.name_from_base", return_value=IR_COMPILATION_IMAGE)
-def test_deploy_with_recommendation_id_with_model_pkg_arn_and_compilation(name_from_base, sagemaker_session):
+def test_deploy_with_recommendation_id_with_model_pkg_arn_and_compilation(
+    name_from_base, sagemaker_session
+):
     sagemaker_session.sagemaker_client.describe_inference_recommendations_job.return_value = (
         create_inference_recommendations_job_default_with_model_package_arn_and_compilation()
     )
@@ -699,7 +702,9 @@ def test_deploy_with_recommendation_id_with_model_pkg_arn_and_compilation(name_f
     )
     sagemaker_session.sagemaker_client.describe_model.return_value = None
 
-    model_package = ModelPackage(role=ROLE, model_data=MODEL_DATA, model_package_arn=IR_MODEL_PACKAGE_VERSION_ARN)
+    model_package = ModelPackage(
+        role=ROLE, model_data=MODEL_DATA, model_package_arn=IR_MODEL_PACKAGE_VERSION_ARN
+    )
 
     model_package.sagemaker_session = sagemaker_session
 
@@ -721,7 +726,9 @@ def test_deploy_with_recommendation_id_with_model_pkg_arn_and_compilation(name_f
 
 
 @patch("sagemaker.utils.name_from_base", return_value=MODEL_IMAGE)
-def test_deploy_with_recommendation_id_with_model_name_and_compilation(name_from_base, sagemaker_session):
+def test_deploy_with_recommendation_id_with_model_name_and_compilation(
+    name_from_base, sagemaker_session
+):
     def mock_describe_compilation_job(CompilationJobName):
         if CompilationJobName == IR_COMPILATION_JOB_NAME:
             return DESCRIBE_COMPILATION_JOB_RESPONSE

--- a/tests/unit/sagemaker/model/test_deploy.py
+++ b/tests/unit/sagemaker/model/test_deploy.py
@@ -18,7 +18,7 @@ import pytest
 from mock import Mock, patch
 
 import sagemaker
-from sagemaker.model import Model
+from sagemaker.model import Model, ModelPackage
 from sagemaker.async_inference import AsyncInferenceConfig
 from sagemaker.serverless import ServerlessInferenceConfig
 from sagemaker.explainer import ExplainerConfig
@@ -40,6 +40,13 @@ from tests.unit.sagemaker.inference_recommender.constants import (
     NOT_EXISTED_MODEL_RECOMMENDATION_ID,
     RECOMMENDATION_ID,
     NOT_EXISTED_RECOMMENDATION_ID,
+    IR_CONTAINER_DEF,
+    DEPLOYMENT_RECOMMENDATION_CONTAINER_DEF,
+    IR_COMPILATION_CONTAINER_DEF,
+    IR_MODEL_PACKAGE_CONTAINER_DEF,
+    IR_COMPILATION_MODEL_PACKAGE_CONTAINER_DEF,
+    IR_TAGS,
+    DEPLOYMENT_RECOMMENDATION_TAGS,
 )
 from tests.unit.sagemaker.inference_recommender.constructs import (
     create_inference_recommendations_job_default_with_model_name,
@@ -616,7 +623,8 @@ def mock_describe_model_package(ModelPackageName):
         return DESCRIBE_MODEL_PACKAGE_RESPONSE
 
 
-def test_deploy_with_recommendation_id_with_model_pkg_arn(sagemaker_session):
+@patch("sagemaker.utils.name_from_base", return_value=IR_IMAGE)
+def test_deploy_with_recommendation_id_with_model_pkg_arn(name_from_base, sagemaker_session):
     sagemaker_session.sagemaker_client.describe_inference_recommendations_job.return_value = (
         create_inference_recommendations_job_default_with_model_package_arn()
     )
@@ -625,15 +633,27 @@ def test_deploy_with_recommendation_id_with_model_pkg_arn(sagemaker_session):
     )
     sagemaker_session.sagemaker_client.describe_model.return_value = None
 
-    model = Model(MODEL_IMAGE, MODEL_DATA, sagemaker_session=sagemaker_session, role=ROLE)
+    model_package = ModelPackage(role=ROLE, model_data=IR_MODEL_DATA, model_package_arn=IR_MODEL_PACKAGE_VERSION_ARN)
 
-    model.deploy(
+    model_package.sagemaker_session = sagemaker_session
+
+    model_package.deploy(
         inference_recommendation_id=RECOMMENDATION_ID,
     )
 
-    assert model.model_data == IR_MODEL_DATA
-    assert model.image_uri == IR_IMAGE
-    assert model.env == IR_ENV
+    sagemaker_session.create_model.assert_called_with(
+        IR_IMAGE,
+        ROLE,
+        IR_MODEL_PACKAGE_CONTAINER_DEF,
+        vpc_config=None,
+        enable_network_isolation=False,
+        tags=IR_TAGS,
+    )
+
+    assert model_package.model_package_arn == IR_MODEL_PACKAGE_VERSION_ARN
+    assert model_package.model_data == IR_MODEL_DATA
+    assert model_package.image_uri == IR_IMAGE
+    assert model_package.env == IR_ENV
 
 
 def mock_describe_model(ModelName):
@@ -641,7 +661,9 @@ def mock_describe_model(ModelName):
         return DESCRIBE_MODEL_RESPONSE
 
 
-def test_deploy_with_recommendation_id_with_model_name(sagemaker_session):
+
+@patch("sagemaker.utils.name_from_base", return_value=MODEL_IMAGE)
+def test_deploy_with_recommendation_id_with_model_name(name_from_base, sagemaker_session):
     sagemaker_session.sagemaker_client.describe_inference_recommendations_job.return_value = (
         create_inference_recommendations_job_default_with_model_name()
     )
@@ -653,12 +675,22 @@ def test_deploy_with_recommendation_id_with_model_name(sagemaker_session):
         inference_recommendation_id=RECOMMENDATION_ID,
     )
 
+    sagemaker_session.create_model.assert_called_with(
+        name=MODEL_IMAGE,
+        role=ROLE,
+        container_defs=IR_CONTAINER_DEF,
+        vpc_config=None,
+        enable_network_isolation=False,
+        tags=IR_TAGS,
+    )
+
     assert model.model_data == IR_MODEL_DATA
     assert model.image_uri == IR_IMAGE
     assert model.env == IR_ENV
 
 
-def test_deploy_with_recommendation_id_with_model_pkg_arn_and_compilation(sagemaker_session):
+@patch("sagemaker.utils.name_from_base", return_value=IR_COMPILATION_IMAGE)
+def test_deploy_with_recommendation_id_with_model_pkg_arn_and_compilation(name_from_base, sagemaker_session):
     sagemaker_session.sagemaker_client.describe_inference_recommendations_job.return_value = (
         create_inference_recommendations_job_default_with_model_package_arn_and_compilation()
     )
@@ -667,17 +699,29 @@ def test_deploy_with_recommendation_id_with_model_pkg_arn_and_compilation(sagema
     )
     sagemaker_session.sagemaker_client.describe_model.return_value = None
 
-    model = Model(MODEL_IMAGE, MODEL_DATA, sagemaker_session=sagemaker_session, role=ROLE)
+    model_package = ModelPackage(role=ROLE, model_data=MODEL_DATA, model_package_arn=IR_MODEL_PACKAGE_VERSION_ARN)
 
-    model.deploy(
+    model_package.sagemaker_session = sagemaker_session
+
+    model_package.deploy(
         inference_recommendation_id=RECOMMENDATION_ID,
     )
 
-    assert model.model_data == IR_COMPILATION_MODEL_DATA
-    assert model.image_uri == IR_COMPILATION_IMAGE
+    sagemaker_session.create_model.assert_called_with(
+        IR_COMPILATION_IMAGE,
+        ROLE,
+        IR_COMPILATION_MODEL_PACKAGE_CONTAINER_DEF,
+        vpc_config=None,
+        enable_network_isolation=False,
+        tags=IR_TAGS,
+    )
+
+    assert model_package.model_data == IR_COMPILATION_MODEL_DATA
+    assert model_package.image_uri == IR_COMPILATION_IMAGE
 
 
-def test_deploy_with_recommendation_id_with_model_name_and_compilation(sagemaker_session):
+@patch("sagemaker.utils.name_from_base", return_value=MODEL_IMAGE)
+def test_deploy_with_recommendation_id_with_model_name_and_compilation(name_from_base, sagemaker_session):
     def mock_describe_compilation_job(CompilationJobName):
         if CompilationJobName == IR_COMPILATION_JOB_NAME:
             return DESCRIBE_COMPILATION_JOB_RESPONSE
@@ -694,6 +738,15 @@ def test_deploy_with_recommendation_id_with_model_name_and_compilation(sagemaker
 
     model.deploy(
         inference_recommendation_id=RECOMMENDATION_ID,
+    )
+
+    sagemaker_session.create_model.assert_called_with(
+        name=MODEL_IMAGE,
+        role=ROLE,
+        container_defs=IR_COMPILATION_CONTAINER_DEF,
+        vpc_config=None,
+        enable_network_isolation=False,
+        tags=IR_TAGS,
     )
 
     assert model.model_data == IR_COMPILATION_MODEL_DATA
@@ -735,18 +788,28 @@ def test_deploy_with_invalid_model_recommendation_id(sagemaker_session):
         )
 
 
-def test_deploy_with_valid_model_recommendation_id(sagemaker_session):
+@patch("sagemaker.utils.name_from_base", return_value=IR_IMAGE)
+def test_deploy_with_valid_model_recommendation_id(name_from_base, sagemaker_session):
     sagemaker_session.sagemaker_client.describe_inference_recommendations_job.return_value = None
     sagemaker_session.sagemaker_client.describe_model.side_effect = mock_describe_model
 
-    model = Model(MODEL_IMAGE, MODEL_DATA, sagemaker_session=sagemaker_session, role=ROLE)
+    model = Model(IR_IMAGE, IR_MODEL_DATA, sagemaker_session=sagemaker_session, role=ROLE)
     model.deploy(
         inference_recommendation_id=MODEL_RECOMMENDATION_ID,
         initial_instance_count=INSTANCE_COUNT,
     )
 
-    assert model.model_data == MODEL_DATA
-    assert model.image_uri == MODEL_IMAGE
+    sagemaker_session.create_model.assert_called_with(
+        name=IR_IMAGE,
+        role=ROLE,
+        container_defs=DEPLOYMENT_RECOMMENDATION_CONTAINER_DEF,
+        vpc_config=None,
+        enable_network_isolation=False,
+        tags=DEPLOYMENT_RECOMMENDATION_TAGS,
+    )
+
+    assert model.model_data == IR_MODEL_DATA
+    assert model.image_uri == IR_IMAGE
     assert model.env == MODEL_RECOMMENDATION_ENV
 
 

--- a/tests/unit/sagemaker/model/test_deploy.py
+++ b/tests/unit/sagemaker/model/test_deploy.py
@@ -555,9 +555,9 @@ def test_deploy_ir_with_incompatible_parameters(sagemaker_session):
 
     with pytest.raises(
         ValueError,
-        match="Please either do not specify instance_type and initial_instance_count"
-        "since they are in recommendation, or specify both of them if you want"
-        "to override the recommendation.",
+        match="instance_type and initial_instance_count are mutually exclusive with"
+        "recommendation id since they are in recommendation."
+        "Please specify both of them if you want to override the recommendation.",
     ):
         model.deploy(
             instance_type=INSTANCE_TYPE,
@@ -566,9 +566,9 @@ def test_deploy_ir_with_incompatible_parameters(sagemaker_session):
 
     with pytest.raises(
         ValueError,
-        match="Please either do not specify instance_type and initial_instance_count"
-        "since they are in recommendation, or specify both of them if you want"
-        "to override the recommendation.",
+        match="instance_type and initial_instance_count are mutually exclusive with"
+        "recommendation id since they are in recommendation."
+        "Please specify both of them if you want to override the recommendation.",
     ):
         model.deploy(
             initial_instance_count=INSTANCE_COUNT,

--- a/tests/unit/sagemaker/model/test_model_package.py
+++ b/tests/unit/sagemaker/model/test_model_package.py
@@ -115,6 +115,7 @@ def test_create_sagemaker_model_uses_model_name(name_from_base, sagemaker_sessio
         {"ModelPackageName": model_package_name},
         vpc_config=None,
         enable_network_isolation=False,
+        tags=None,
     )
 
 
@@ -141,6 +142,7 @@ def test_create_sagemaker_model_include_environment_variable(sagemaker_session):
         {"ModelPackageName": model_package_name, "Environment": environment},
         vpc_config=None,
         enable_network_isolation=False,
+        tags=None,
     )
 
 

--- a/tests/unit/sagemaker/model/test_model_package.py
+++ b/tests/unit/sagemaker/model/test_model_package.py
@@ -115,7 +115,6 @@ def test_create_sagemaker_model_uses_model_name(name_from_base, sagemaker_sessio
         {"ModelPackageName": model_package_name},
         vpc_config=None,
         enable_network_isolation=False,
-        tags=None,
     )
 
 
@@ -142,7 +141,6 @@ def test_create_sagemaker_model_include_environment_variable(sagemaker_session):
         {"ModelPackageName": model_package_name, "Environment": environment},
         vpc_config=None,
         enable_network_isolation=False,
-        tags=None,
     )
 
 


### PR DESCRIPTION
*Issue #, if available:*
The Inference Experience Team has launched a new feature called Deployment Recommendation that can be retrieved from the DescribeModel API. Provide PythonSDK support for deployment via Deployment Recommendation ID

See: https://github.com/aws/sagemaker-python-sdk/pull/3695

*Description of changes:*
- within inference_recommender_mixin -> provided support for Deployment Recommendation ID
- add requisite unit tests
- add requisite integ tests

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
