### PR TITLE
feature: Add segment config for Clarify

### DIFF
--- a/src/sagemaker/clarify.py
+++ b/src/sagemaker/clarify.py
@@ -350,9 +350,10 @@ class SegmentationConfig:
                 columns, each segment should contain one or more of the categorical values for
                 the categorical column, which may be strings or integers.
                 Eg,: For a continuous column, ``segments`` could be
-                [["[1, 4]", "(5, 6]"], ["(7, 9)"]] - this generates 3 segments including the default
-                 segment. For a categorical columns with values ("A", "B", "C", "D"), ``segments``
-                 could be [["A", "B"]]. This generate 2 segments, including the default segment.
+                [["[1, 4]", "(5, 6]"], ["(7, 9)"]] - this generates 3 segments including the
+                default segment. For a categorical columns with values ("A", "B", "C", "D"),
+                ``segments``,could be [["A", "B"]]. This generate 2 segments, including the default
+                segment.
             config_name (str) - Optional name for the segment config to identify the config.
             display_aliases (List[str]) - Optional list of display names for the ``segments`` for
                 the analysis output and report. This list should be the same length as the number of
@@ -374,13 +375,13 @@ class SegmentationConfig:
             raise ValueError("`segments` must be a list of lists of values or intervals.")
         self.segments = segments
         self.config_name = config_name
-        if (
-            display_aliases is not None
-            and not (len(display_aliases) == len(segments)
-                     or len(display_aliases) == len(segments) + 1)
+        if display_aliases is not None and not (
+            len(display_aliases) == len(segments) or len(display_aliases) == len(segments) + 1
         ):
-            raise ValueError("Number of `display_aliases` must equal the number of segments"
-                             " specified or with one additional default segment display alias.")
+            raise ValueError(
+                "Number of `display_aliases` must equal the number of segments"
+                " specified or with one additional default segment display alias."
+            )
         self.display_aliases = display_aliases
 
     def to_dict(self) -> Dict[str, Any]:  # pragma: no cover

--- a/src/sagemaker/clarify.py
+++ b/src/sagemaker/clarify.py
@@ -325,9 +325,7 @@ class DatasetType(Enum):
 
 
 class SegmentationConfig:
-    """Config object that defines segment(s) of the dataset on which bias and explainability metrics
-    must be computed. SegmentationConfig can only be defined on numerical or categorical columns.
-    """
+    """Config object that defines segment(s) of the dataset on which metrics are computed."""
 
     def __init__(
         self,
@@ -336,7 +334,7 @@ class SegmentationConfig:
         config_name: Optional[str] = None,
         display_aliases: Optional[List[str]] = None,
     ):
-        """Initializes a segmentation configuration for a dataset column
+        """Initializes a segmentation configuration for a dataset column.
 
         Args:
             name_or_index (str or int): The name or index of the column in the dataset on which

--- a/src/sagemaker/clarify.py
+++ b/src/sagemaker/clarify.py
@@ -336,29 +336,32 @@ class SegmentationConfig:
         config_name: Optional[str] = None,
         display_aliases: Optional[List[str]] = None,
     ):
-        """Initializes SegmentationConfig object
+        """Initializes a segmentation configuration for a dataset column
+
         Args:
             name_or_index (str or int): The name or index of the column in the dataset on which
                 the segment(s) is defined.
             segments (List[List[str or int]]): Each List of values represents one segment. If N
                 Lists are provided, we generate N+1 segments - the additional segment, denoted as
                 the '__default__' segment, is for the rest of the values that are not covered by
-                these lists.
-                For continuous columns, a segment must be given as strings in interval notation
-                (eg.: ["[1, 4]"] or ["(2, 5]"]). A segment can also be composed of multiple intervals
-                (eg.: ["[1, 4]", "(5, 6]"] is one segment). For categorical columns, each segment
-                should contain one or more of the categorical values for the categorical column,
-                which may be strings or integers.
-                Eg,: For a continuous column, `segments` could be
-                [["[1, 4]", "(5, 6]"], ["(7, 9)"]] - this generates 3 segments including the
-                default segment. For a categorical columns with values ("A", "B", "C", "D"),
-                `segments` could be [["A", "B"]]. This generate 2 segments, including the default
-                segment.
+                these lists. For continuous columns, a segment must be given as strings in interval
+                notation (eg.: ["[1, 4]"] or ["(2, 5]"]). A segment can also be composed of
+                multiple intervals (eg.: ["[1, 4]", "(5, 6]"] is one segment). For categorical
+                columns, each segment should contain one or more of the categorical values for
+                the categorical column, which may be strings or integers.
+                Eg,: For a continuous column, ``segments`` could be
+                [["[1, 4]", "(5, 6]"], ["(7, 9)"]] - this generates 3 segments including the default
+                 segment. For a categorical columns with values ("A", "B", "C", "D"), ``segments``
+                 could be [["A", "B"]]. This generate 2 segments, including the default segment.
             config_name (str) - Optional name for the segment config to identify the config.
-            display_aliases (List[str]) - Optional list of display names for the segments for the
-                analysis output and report. This list should be the same length as the number of
-                lists provided in `segments` or with one additional display alias for the default
+            display_aliases (List[str]) - Optional list of display names for the ``segments`` for
+                the analysis output and report. This list should be the same length as the number of
+                lists provided in ``segments`` or with one additional display alias for the default
                 segment.
+
+        Raises:
+            ValueError: when the ``name_or_index`` is None, ``segments`` is invalid, or a wrong
+                number of ``display_aliases`` are specified.
         """
         if name_or_index is None:
             raise ValueError("`name_or_index` cannot be None")
@@ -477,7 +480,8 @@ class DataConfig:
                 Only a single predicted label per sample is supported at this time.
             excluded_columns (list[int] or list[str]): A list of names or indices of the columns
                 which are to be excluded from making model inference API calls.
-            segmentation_config (list[SegmentationConfig]): A list of SegmentationConfig objects.
+            segmentation_config (list[SegmentationConfig]): A list of ``SegmentationConfig``
+                objects.
 
         Raises:
             ValueError: when the ``dataset_type`` is invalid, predicted label dataset parameters

--- a/src/sagemaker/clarify.py
+++ b/src/sagemaker/clarify.py
@@ -330,7 +330,7 @@ class SegmentationConfig:
     def __init__(
         self,
         name_or_index: Union[str, int],
-        segments: [[str, int]],
+        segments: List[List[Union[str, int]]],
         config_name: Optional[str] = None,
         display_aliases: Optional[List[str]] = None,
     ):

--- a/src/sagemaker/clarify.py
+++ b/src/sagemaker/clarify.py
@@ -339,7 +339,7 @@ class SegmentationConfig:
         """Initializes SegmentationConfig object
         Args:
             name_or_index (str or int): The name or index of the column in the dataset on which
-                this segment is defined.
+                the segment(s) is defined.
             segments (List[List[str or int]]): Each List of values represents one segment. If N
                 Lists are provided, we generate N+1 segments - the additional segment, denoted as
                 the '__default__' segment, is for the rest of the values that are not covered by
@@ -410,7 +410,7 @@ class DataConfig:
         predicted_label_headers: Optional[List[str]] = None,
         predicted_label: Optional[Union[str, int]] = None,
         excluded_columns: Optional[Union[List[int], List[str]]] = None,
-        segmentation_config: List[SegmentationConfig] = None,
+        segmentation_config: Optional[List[SegmentationConfig]] = None,
     ):
         """Initializes a configuration of both input and output datasets.
 
@@ -477,7 +477,7 @@ class DataConfig:
                 Only a single predicted label per sample is supported at this time.
             excluded_columns (list[int] or list[str]): A list of names or indices of the columns
                 which are to be excluded from making model inference API calls.
-            segmentation_config (list[SegmentationConfig]): A list of SegmentationConfig objects
+            segmentation_config (list[SegmentationConfig]): A list of SegmentationConfig objects.
 
         Raises:
             ValueError: when the ``dataset_type`` is invalid, predicted label dataset parameters

--- a/src/sagemaker/clarify.py
+++ b/src/sagemaker/clarify.py
@@ -63,6 +63,14 @@ ANALYSIS_CONFIG_SCHEMA_V1_0 = Schema(
         SchemaOptional("features"): str,
         SchemaOptional("label_values_or_threshold"): [Or(int, float, str)],
         SchemaOptional("probability_threshold"): float,
+        SchemaOptional("segment_config"): [
+            {
+                SchemaOptional("config_name"): str,
+                "name_or_index": Or(str, int),
+                "segments": [[Or(str, int)]],
+                SchemaOptional("display_aliases"): [str],
+            }
+        ],
         SchemaOptional("facet"): [
             {
                 "name_or_index": Or(str, int),
@@ -316,6 +324,72 @@ class DatasetType(Enum):
     IMAGE = "application/x-image"
 
 
+class SegmentationConfig:
+    """Config object that defines segment(s) of the dataset on which bias and explainability metrics
+    must be computed. SegmentationConfig can only be defined on numerical or categorical columns.
+    """
+
+    def __init__(
+        self,
+        name_or_index: Union[str, int],
+        segments: [[str, int]],
+        config_name: Optional[str] = None,
+        display_aliases: Optional[List[str]] = None,
+    ):
+        """Initializes SegmentationConfig object
+        Args:
+            name_or_index (str or int): The name or index of the column in the dataset on which
+                this segment is defined.
+            segments (List[List[str or int]]): Each List of values represents one segment. If N
+                Lists are provided, we generate N+1 segments - the additional segment, denoted as
+                the '__default__' segment, is for the rest of the values that are not covered by
+                these lists.
+                For continuous columns, a segment must be given as strings in interval notation
+                (eg.: ["[1, 4]"] or ["(2, 5]"]). A segment can also be composed of multiple intervals
+                (eg.: ["[1, 4]", "(5, 6]"] is one segment). For categorical columns, each segment
+                should contain one or more of the categorical values for the categorical column,
+                which may be strings or integers.
+                Eg,: For a continuous column, `segments` could be
+                [["[1, 4]", "(5, 6]"], ["(7, 9)"]] - this generates 3 segments including the
+                default segment. For a categorical columns with values ("A", "B", "C", "D"),
+                `segments` could be [["A", "B"]]. This generate 2 segments, including the default
+                segment.
+            config_name (str) - Optional name for the segment config to identify the config.
+            display_aliases (List[str]) - Optional list of display names for the segments for the
+                analysis output and report. This list should be the same length as the number of
+                lists provided in `segments` or with one additional display alias for the default
+                segment.
+        """
+        if name_or_index is None:
+            raise ValueError("`name_or_index` cannot be None")
+        self.name_or_index = name_or_index
+        if (
+            not segments
+            or not isinstance(segments, list)
+            or not all([isinstance(segment, list) for segment in segments])
+        ):
+            raise ValueError("`segments` must be a list of lists of values or intervals.")
+        self.segments = segments
+        self.config_name = config_name
+        if (
+            display_aliases is not None
+            and not (len(display_aliases) == len(segments)
+                     or len(display_aliases) == len(segments) + 1)
+        ):
+            raise ValueError("Number of `display_aliases` must equal the number of segments"
+                             " specified or with one additional default segment display alias.")
+        self.display_aliases = display_aliases
+
+    def to_dict(self) -> Dict[str, Any]:  # pragma: no cover
+        """Returns SegmentationConfig as a dict."""
+        segment_config_dict = {"name_or_index": self.name_or_index, "segments": self.segments}
+        if self.config_name:
+            segment_config_dict["config_name"] = self.config_name
+        if self.display_aliases:
+            segment_config_dict["display_aliases"] = self.display_aliases
+        return segment_config_dict
+
+
 class DataConfig:
     """Config object related to configurations of the input and output dataset."""
 
@@ -336,6 +410,7 @@ class DataConfig:
         predicted_label_headers: Optional[List[str]] = None,
         predicted_label: Optional[Union[str, int]] = None,
         excluded_columns: Optional[Union[List[int], List[str]]] = None,
+        segmentation_config: List[SegmentationConfig] = None,
     ):
         """Initializes a configuration of both input and output datasets.
 
@@ -402,6 +477,7 @@ class DataConfig:
                 Only a single predicted label per sample is supported at this time.
             excluded_columns (list[int] or list[str]): A list of names or indices of the columns
                 which are to be excluded from making model inference API calls.
+            segmentation_config (list[SegmentationConfig]): A list of SegmentationConfig objects
 
         Raises:
             ValueError: when the ``dataset_type`` is invalid, predicted label dataset parameters
@@ -469,6 +545,7 @@ class DataConfig:
         self.predicted_label_headers = predicted_label_headers
         self.predicted_label = predicted_label
         self.excluded_columns = excluded_columns
+        self.segmentation_configs = segmentation_config
         self.analysis_config = {
             "dataset_type": dataset_type,
         }
@@ -486,6 +563,12 @@ class DataConfig:
         _set(predicted_label_headers, "predicted_label_headers", self.analysis_config)
         _set(predicted_label, "predicted_label", self.analysis_config)
         _set(excluded_columns, "excluded_columns", self.analysis_config)
+        if segmentation_config:
+            _set(
+                [item.to_dict() for item in segmentation_config],
+                "segment_config",
+                self.analysis_config,
+            )
 
     def get_config(self):
         """Returns part of an analysis config dictionary."""

--- a/tests/unit/test_clarify.py
+++ b/tests/unit/test_clarify.py
@@ -279,7 +279,7 @@ def test_invalid_segmentation_config(
     name_or_index, segments, config_name, display_aliases, error_msg
 ):
     with pytest.raises(ValueError, match=error_msg):
-        segmentation_config = SegmentationConfig(
+        SegmentationConfig(
             name_or_index=name_or_index,
             segments=segments,
             config_name=config_name,

--- a/tests/unit/test_clarify.py
+++ b/tests/unit/test_clarify.py
@@ -60,12 +60,14 @@ def test_data_config(dataset_type, features, excluded_columns, predicted_label):
     s3_output_path = "s3://path/to/output"
     label_name = "Label"
     headers = ["Label", "F1", "F2", "F3", "F4", "Predicted Label"]
-    segment_config = [SegmentationConfig(
-        name_or_index='F1',
-        segments=[[0]],
-        config_name="c1",
-        display_aliases=['a1'],
-    )]
+    segment_config = [
+        SegmentationConfig(
+            name_or_index="F1",
+            segments=[[0]],
+            config_name="c1",
+            display_aliases=["a1"],
+        )
+    ]
 
     data_config = DataConfig(
         s3_data_input_path=s3_data_input_path,
@@ -83,7 +85,14 @@ def test_data_config(dataset_type, features, excluded_columns, predicted_label):
         "dataset_type": dataset_type,
         "headers": headers,
         "label": "Label",
-        'segment_config': [{'config_name': 'c1', 'display_aliases': ['a1'], 'name_or_index': 'F1', 'segments': [[0]]}],
+        "segment_config": [
+            {
+                "config_name": "c1",
+                "display_aliases": ["a1"],
+                "name_or_index": "F1",
+                "segments": [[0]],
+            }
+        ],
     }
     if features:
         expected_config["features"] = features
@@ -249,18 +258,26 @@ def test_segmentation_config(name_or_index, segments, config_name, display_alias
     ("name_or_index", "segments", "config_name", "display_aliases", "error_msg"),
     [
         (None, [[0]], "config1", None, "`name_or_index` cannot be None"),
-        ("feature1", "0", "config1", ["seg1"], "`segments` must be a list of lists of values or intervals."),
+        (
+            "feature1",
+            "0",
+            "config1",
+            ["seg1"],
+            "`segments` must be a list of lists of values or intervals.",
+        ),
         (
             "feature1",
             [[0]],
             "config1",
             ["seg1", "seg2", "seg3"],
             "Number of `display_aliases` must equal the number of segments specified or with one "
-            "additional default segment display alias."
+            "additional default segment display alias.",
         ),
     ],
 )
-def test_invalid_segmentation_config(name_or_index, segments, config_name, display_aliases, error_msg):
+def test_invalid_segmentation_config(
+    name_or_index, segments, config_name, display_aliases, error_msg
+):
     with pytest.raises(ValueError, match=error_msg):
         segmentation_config = SegmentationConfig(
             name_or_index=name_or_index,

--- a/tests/unit/test_clarify.py
+++ b/tests/unit/test_clarify.py
@@ -32,6 +32,7 @@ from sagemaker.clarify import (
     _AnalysisConfigGenerator,
     DatasetType,
     ProcessingOutputHandler,
+    SegmentationConfig,
 )
 
 JOB_NAME_PREFIX = "my-prefix"
@@ -59,6 +60,13 @@ def test_data_config(dataset_type, features, excluded_columns, predicted_label):
     s3_output_path = "s3://path/to/output"
     label_name = "Label"
     headers = ["Label", "F1", "F2", "F3", "F4", "Predicted Label"]
+    segment_config = [SegmentationConfig(
+        name_or_index='F1',
+        segments=[[0]],
+        config_name="c1",
+        display_aliases=['a1'],
+    )]
+
     data_config = DataConfig(
         s3_data_input_path=s3_data_input_path,
         s3_output_path=s3_output_path,
@@ -68,12 +76,14 @@ def test_data_config(dataset_type, features, excluded_columns, predicted_label):
         dataset_type=dataset_type,
         excluded_columns=excluded_columns,
         predicted_label=predicted_label,
+        segmentation_config=segment_config,
     )
 
     expected_config = {
         "dataset_type": dataset_type,
         "headers": headers,
         "label": "Label",
+        'segment_config': [{'config_name': 'c1', 'display_aliases': ['a1'], 'name_or_index': 'F1', 'segments': [[0]]}],
     }
     if features:
         expected_config["features"] = features
@@ -206,6 +216,57 @@ def test_invalid_data_config():
             dataset_type="application/jsonlines",
             predicted_label_dataset_uri="pred_dataset/URI",
             predicted_label_headers="prediction",
+        )
+
+
+@pytest.mark.parametrize(
+    ("name_or_index", "segments", "config_name", "display_aliases"),
+    [
+        ("feature1", [[0]], None, None),
+        ("feature1", [[0], ["[1, 3)", "(5, 10]"]], None, None),
+        ("feature1", [[0], ["[1, 3)", "(5, 10]"]], "config1", None),
+        ("feature1", [["A", "B"]], "config1", ["seg1"]),
+        ("feature1", [["A", "B"]], "config1", ["seg1", "default_seg"]),
+    ],
+)
+def test_segmentation_config(name_or_index, segments, config_name, display_aliases):
+    segmentation_config = SegmentationConfig(
+        name_or_index=name_or_index,
+        segments=segments,
+        config_name=config_name,
+        display_aliases=display_aliases,
+    )
+
+    assert segmentation_config.name_or_index == name_or_index
+    assert segmentation_config.segments == segments
+    if segmentation_config.config_name:
+        assert segmentation_config.config_name == config_name
+    if segmentation_config.display_aliases:
+        assert segmentation_config.display_aliases == display_aliases
+
+
+@pytest.mark.parametrize(
+    ("name_or_index", "segments", "config_name", "display_aliases", "error_msg"),
+    [
+        (None, [[0]], "config1", None, "`name_or_index` cannot be None"),
+        ("feature1", "0", "config1", ["seg1"], "`segments` must be a list of lists of values or intervals."),
+        (
+            "feature1",
+            [[0]],
+            "config1",
+            ["seg1", "seg2", "seg3"],
+            "Number of `display_aliases` must equal the number of segments specified or with one "
+            "additional default segment display alias."
+        ),
+    ],
+)
+def test_invalid_segmentation_config(name_or_index, segments, config_name, display_aliases, error_msg):
+    with pytest.raises(ValueError, match=error_msg):
+        segmentation_config = SegmentationConfig(
+            name_or_index=name_or_index,
+            segments=segments,
+            config_name=config_name,
+            display_aliases=display_aliases,
         )
 
 


### PR DESCRIPTION

*Issue #, if available:* https://issues.amazon.com/issues/RAI-2685

*Description of changes:* Add `SegmentationConfig` class and `segmentation_config` parameter to `DataConfig` to support customer defined row wise dataset segments.

*Testing done:* Added unit tests and ran unit and integration tests locally.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
