### PR TITLE
fix: add tagging assert to inference recommender integ tests

### DIFF
--- a/tests/unit/sagemaker/inference_recommender/test_inference_recommender_mixin.py
+++ b/tests/unit/sagemaker/inference_recommender/test_inference_recommender_mixin.py
@@ -585,6 +585,7 @@ def test_deploy_right_size_with_model_package_succeeds(
         IR_MODEL_PACKAGE_CONTAINER_DEF,
         vpc_config=None,
         enable_network_isolation=False,
+        tags=None,
     )
 
     sagemaker_session.endpoint_from_production_variants.assert_called_with(
@@ -615,6 +616,7 @@ def test_deploy_right_size_with_both_overrides_succeeds(
         IR_MODEL_PACKAGE_CONTAINER_DEF,
         vpc_config=None,
         enable_network_isolation=False,
+        tags=None,
     )
 
     sagemaker_session.endpoint_from_production_variants.assert_called_with(
@@ -671,6 +673,7 @@ def test_deploy_right_size_serverless_override(sagemaker_session, default_right_
         IR_MODEL_PACKAGE_CONTAINER_DEF,
         vpc_config=None,
         enable_network_isolation=False,
+        tags=None,
     )
 
     sagemaker_session.endpoint_from_production_variants.assert_called_with(
@@ -703,6 +706,7 @@ def test_deploy_right_size_async_override(sagemaker_session, default_right_sized
         IR_MODEL_PACKAGE_CONTAINER_DEF,
         vpc_config=None,
         enable_network_isolation=False,
+        tags=None,
     )
 
     sagemaker_session.endpoint_from_production_variants.assert_called_with(
@@ -745,6 +749,7 @@ def test_deploy_right_size_explainer_config_override(sagemaker_session, default_
         IR_MODEL_PACKAGE_CONTAINER_DEF,
         vpc_config=None,
         enable_network_isolation=False,
+        tags=None,
     )
 
     sagemaker_session.endpoint_from_production_variants.assert_called_with(

--- a/tests/unit/sagemaker/model/test_deploy.py
+++ b/tests/unit/sagemaker/model/test_deploy.py
@@ -647,6 +647,7 @@ def test_deploy_with_recommendation_id_with_model_pkg_arn(name_from_base, sagema
         IR_MODEL_PACKAGE_CONTAINER_DEF,
         vpc_config=None,
         enable_network_isolation=False,
+        tags=None,
     )
 
     assert model_package.model_package_arn == IR_MODEL_PACKAGE_VERSION_ARN
@@ -715,6 +716,7 @@ def test_deploy_with_recommendation_id_with_model_pkg_arn_and_compilation(
         IR_COMPILATION_MODEL_PACKAGE_CONTAINER_DEF,
         vpc_config=None,
         enable_network_isolation=False,
+        tags=None,
     )
 
     assert model_package.model_data == IR_COMPILATION_MODEL_DATA


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
add `tags=None` into failing asserts


*Testing done:*
ran test ir and test deploy. All passing

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
