### PR TITLE
fix: maketplace integs

### DIFF
--- a/src/sagemaker/model.py
+++ b/src/sagemaker/model.py
@@ -1774,6 +1774,7 @@ class ModelPackage(Model):
                 self.sagemaker_session.wait_for_model_package(model_package_name)
                 self._created_model_package_name = model_package_name
             model_package_name = self._created_model_package_name
+            container_def = {"ModelPackageName": model_package_name}
         else:
             # When a ModelPackageArn is provided we just create the Model
             match = re.match(MODEL_PACKAGE_ARN_PATTERN, self.model_package_arn)
@@ -1782,8 +1783,7 @@ class ModelPackage(Model):
             else:
                 # model_package_arn can be just the name if your account owns the Model Package
                 model_package_name = self.model_package_arn
-
-        container_def = {"ModelPackageName": self.model_package_arn}
+            container_def = {"ModelPackageName": self.model_package_arn}
 
         if self.env != {}:
             container_def["Environment"] = self.env


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

2 integ-tests are failing due to ParamValidation Error:
Can you take a look once
FAILED tests/integ/test_marketplace.py::test_marketplace_attach - botocore.ex...
FAILED tests/integ/test_marketplace.py::test_marketplace_transform_job - boto...

```
=================================== FAILURES ===================================
___________________________ test_marketplace_attach ____________________________
[gw220] linux -- Python 3.7.13 /codebuild/output/src470532371/src/github.com/aws/sagemaker-python-sdk/.tox/py37/bin/python

sagemaker_session = <sagemaker.session.Session object at 0x7f9e43fa5a90>
cpu_instance_type = 'ml.m4.xlarge'

    @pytest.mark.skipif(
        tests.integ.test_region() in tests.integ.NO_MARKET_PLACE_REGIONS,
        reason="Marketplace is not available in {}".format(tests.integ.test_region()),
    )
    def test_marketplace_attach(sagemaker_session, cpu_instance_type):
        with timeout(minutes=15):
            data_path = os.path.join(DATA_DIR, "marketplace", "training")
            region = sagemaker_session.boto_region_name
            account = REGION_ACCOUNT_MAP[region]
            algorithm_arn = ALGORITHM_ARN.format(
                partition=_aws_partition(region), region=region, account=account
            )
    
            mktplace = AlgorithmEstimator(
                algorithm_arn=algorithm_arn,
                role="SageMakerRole",
                instance_count=1,
                instance_type=cpu_instance_type,
                sagemaker_session=sagemaker_session,
                base_job_name=unique_name_from_base("test-marketplace"),
            )
    
            train_input = mktplace.sagemaker_session.upload_data(
                path=data_path, key_prefix="integ-test-data/marketplace/train"
            )
    
            mktplace.fit({"training": train_input}, wait=False)
            training_job_name = mktplace.latest_training_job.name
    
            print("Waiting to re-attach to the training job: %s" % training_job_name)
            time.sleep(20)
            endpoint_name = "test-marketplace-estimator{}".format(sagemaker_timestamp())
    
        with timeout_and_delete_endpoint_by_name(endpoint_name, sagemaker_session, minutes=20):
            print("Re-attaching now to: %s" % training_job_name)
            estimator = AlgorithmEstimator.attach(
                training_job_name=training_job_name, sagemaker_session=sagemaker_session
            )
            predictor = estimator.deploy(
>               1, cpu_instance_type, endpoint_name=endpoint_name, serializer=CSVSerializer()
            )

tests/integ/test_marketplace.py:150: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
.tox/py37/lib/python3.7/site-packages/sagemaker/estimator.py:1632: in deploy
    inference_recommendation_id=inference_recommendation_id,
.tox/py37/lib/python3.7/site-packages/sagemaker/model.py:1301: in deploy
    instance_type, accelerator_type, tags, serverless_inference_config
.tox/py37/lib/python3.7/site-packages/sagemaker/model.py:1800: in _create_sagemaker_model
    tags=kwargs.get("tags"),
.tox/py37/lib/python3.7/site-packages/sagemaker/session.py:3548: in create_model
    self._intercept_create_request(create_model_request, submit, self.create_model.__name__)
.tox/py37/lib/python3.7/site-packages/sagemaker/session.py:5427: in _intercept_create_request
    return create(request)
.tox/py37/lib/python3.7/site-packages/sagemaker/session.py:3536: in submit
    self.sagemaker_client.create_model(**request)
.tox/py37/lib/python3.7/site-packages/botocore/client.py:530: in _api_call
    return self._make_api_call(operation_name, kwargs)
.tox/py37/lib/python3.7/site-packages/botocore/client.py:928: in _make_api_call
    headers=additional_headers,
.tox/py37/lib/python3.7/site-packages/botocore/client.py:992: in _convert_to_request_dict
    api_params, operation_model
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <botocore.validate.ParamValidationDecorator object at 0x7f9e449c1c50>
parameters = {'Containers': [{'ModelPackageName': None}], 'EnableNetworkIsolation': True, 'ExecutionRoleArn': 'arn:aws:iam::142577830533:role/SageMakerRole', 'ModelName': 'test-marketplace-1686350945-f70d-2023-06-09-22-51-43-805'}
operation_model = OperationModel(name=CreateModel)

    def serialize_to_request(self, parameters, operation_model):
        input_shape = operation_model.input_shape
        if input_shape is not None:
            report = self._param_validator.validate(
                parameters, operation_model.input_shape
            )
            if report.has_errors():
>               raise ParamValidationError(report=report.generate_report())
E               botocore.exceptions.ParamValidationError: Parameter validation failed:
E               Invalid type for parameter Containers[0].ModelPackageName, value: None, type: <class 'NoneType'>, valid types: <class 'str'>

.tox/py37/lib/python3.7/site-packages/botocore/validate.py:381: ParamValidationError
----------------------------- Captured stdout call -----------------------------
```

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
