### PR TITLE
fix: Fix HPO Grid Search comparison and name

### DIFF
--- a/src/sagemaker/tuner.py
+++ b/src/sagemaker/tuner.py
@@ -71,7 +71,7 @@ WARM_START_TYPE = "WarmStartType"
 HYPERBAND_STRATEGY_CONFIG = "HyperbandStrategyConfig"
 HYPERBAND_MIN_RESOURCE = "MinResource"
 HYPERBAND_MAX_RESOURCE = "MaxResource"
-GRID_SEARCH = "GridSearch"
+GRID_SEARCH = "Grid"
 MAX_NUMBER_OF_TRAINING_JOBS_NOT_IMPROVING = "MaxNumberOfTrainingJobsNotImproving"
 BEST_OBJECTIVE_NOT_IMPROVING = "BestObjectiveNotImproving"
 CONVERGENCE_DETECTED = "ConvergenceDetected"
@@ -645,7 +645,7 @@ class HyperparameterTuner(object):
                 evaluating training jobs. This value can be either 'Minimize' or
                 'Maximize' (default: 'Maximize').
             max_jobs (int or PipelineVariable): Maximum total number of training jobs to start for
-                the hyperparameter tuning job. The default value is unspecified fot the GridSearch
+                the hyperparameter tuning job. The default value is unspecified fot the 'Grid'
                 strategy and the default value is 1 for all others strategies (default: None).
             max_parallel_jobs (int or PipelineVariable): Maximum number of parallel training jobs to
                 start (default: 1).
@@ -1917,7 +1917,7 @@ class HyperparameterTuner(object):
             objective_type (str): The type of the objective metric for evaluating training jobs.
                 This value can be either 'Minimize' or 'Maximize' (default: 'Maximize').
             max_jobs (int): Maximum total number of training jobs to start for the hyperparameter
-                tuning job. The default value is unspecified fot the GridSearch strategy
+                tuning job. The default value is unspecified fot the 'Grid' strategy
                 and the value is 1 for all others strategies (default: None).
             max_parallel_jobs (int): Maximum number of parallel training jobs to start
                 (default: 1).

--- a/src/sagemaker/tuner.py
+++ b/src/sagemaker/tuner.py
@@ -741,7 +741,7 @@ class HyperparameterTuner(object):
         # For all other strategies for the backward compatibility we keep
         # the default value as 1 (previous default value).
         self.max_jobs = max_jobs
-        if max_jobs is None and strategy is not GRID_SEARCH:
+        if max_jobs is None and strategy != GRID_SEARCH:
             self.max_jobs = 1
         self.max_parallel_jobs = max_parallel_jobs
         self.max_runtime_in_seconds = max_runtime_in_seconds

--- a/tests/unit/test_tuner.py
+++ b/tests/unit/test_tuner.py
@@ -2171,7 +2171,7 @@ def test_create_tuner_with_grid_search_strategy():
         objective_metric_name_dict={ESTIMATOR_NAME: OBJECTIVE_METRIC_NAME},
         hyperparameter_ranges_dict={ESTIMATOR_NAME: HYPERPARAMETER_RANGES},
         metric_definitions_dict={ESTIMATOR_NAME: METRIC_DEFINITIONS},
-        strategy="GridSearch",
+        strategy="Grid",
         objective_type="Minimize",
         max_parallel_jobs=1,
         tags=TAGS,


### PR DESCRIPTION
*Issue #, if available:*
\-

*Description of changes:*
1. Replaced an identity-based `strategy` argument comparison with the `GRID_SEARCH` variable in the `__init__` of the `HyperparameterTuner` class with the `==` comparison.
2. Renamed incorrect `GridSearch` hyperparameter tuning strategy to `Grid` ([Amazon Sagemaker API Reference](https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_HyperParameterTuningJobConfig.html#sagemaker-Type-HyperParameterTuningJobConfig-Strategy)).

*Testing done:*
Existing unit tests already cover the issues.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
