### PR TITLE
fix: Remove deprecated option.s3url in favor of option.model_id

### DIFF
--- a/src/sagemaker/djl_inference/model.py
+++ b/src/sagemaker/djl_inference/model.py
@@ -739,10 +739,7 @@ class DJLModel(FrameworkModel):
             serving_properties = {}
         serving_properties["engine"] = self.engine.value[0]  # pylint: disable=E1101
         serving_properties["option.entryPoint"] = self.engine.value[1]  # pylint: disable=E1101
-        if self.model_id.startswith("s3://"):
-            serving_properties["option.s3url"] = self.model_id
-        else:
-            serving_properties["option.model_id"] = self.model_id
+        serving_properties["option.model_id"] = self.model_id
         if self.number_of_partitions:
             serving_properties["option.tensor_parallel_degree"] = self.number_of_partitions
         if self.entry_point:

--- a/tests/unit/test_djl_inference.py
+++ b/tests/unit/test_djl_inference.py
@@ -46,7 +46,7 @@ ENV = {"ENV_VAR": "env_value"}
 ROLE = "dummy_role"
 REGION = "us-west-2"
 BUCKET = "mybucket"
-IMAGE_URI = "763104351884.dkr.ecr.us-west-2.amazon.com/djl-inference:0.20.0-deepspeed0.7.5-cu116"
+IMAGE_URI = "763104351884.dkr.ecr.us-west-2.amazon.com/djl-inference:0.22.1-deepspeed0.9.2-cu118"
 GPU_INSTANCE = "ml.g5.12xlarge"
 
 
@@ -111,7 +111,6 @@ def test_create_model_valid_hf_hub_model_id(
 
     serving_properties = model.generate_serving_properties()
     assert serving_properties["option.model_id"] == HF_MODEL_ID
-    assert "option.s3url" not in serving_properties
 
 
 @patch("json.load")
@@ -396,7 +395,7 @@ def test_generate_serving_properties_with_valid_configurations(
     expected_dict = {
         "engine": "Python",
         "option.entryPoint": ENTRY_POINT,
-        "option.s3url": VALID_UNCOMPRESSED_MODEL_DATA,
+        "option.model_id": VALID_UNCOMPRESSED_MODEL_DATA,
         "option.tensor_parallel_degree": 4,
         "option.task": "text-classification",
         "option.dtype": "fp16",
@@ -431,7 +430,7 @@ def test_generate_serving_properties_with_valid_configurations(
     expected_dict = {
         "engine": "DeepSpeed",
         "option.entryPoint": "djl_python.deepspeed",
-        "option.s3url": VALID_UNCOMPRESSED_MODEL_DATA,
+        "option.model_id": VALID_UNCOMPRESSED_MODEL_DATA,
         "option.tensor_parallel_degree": 1,
         "option.task": "text-generation",
         "option.dtype": "bf16",
@@ -459,7 +458,7 @@ def test_generate_serving_properties_with_valid_configurations(
     expected_dict = {
         "engine": "Python",
         "option.entryPoint": "djl_python.huggingface",
-        "option.s3url": VALID_UNCOMPRESSED_MODEL_DATA,
+        "option.model_id": VALID_UNCOMPRESSED_MODEL_DATA,
         "option.tensor_parallel_degree": 1,
         "option.dtype": "fp32",
         "option.device_id": 4,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This change fixes a bug where the s3url option for djl model was still being set. This option is deprecated in favor of model_id, and has been causing issues with the partition method which assumes that only model_id is set.

*Testing done:*
DJL SageMaker Endpoint Test run for gpt-j-6b exposed this issue, and this change has fixed it https://github.com/deepjavalibrary/djl-serving/actions/runs/5283377099/jobs/9559547157.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
