### PR TITLE
feat: Add optional monitoring_config_override parameter in suggest_baseline API

### DIFF
--- a/doc/api/inference/model_monitor.rst
+++ b/doc/api/inference/model_monitor.rst
@@ -41,3 +41,8 @@ Model Monitor
     :members:
     :undoc-members:
     :show-inheritance:
+
+.. automodule:: sagemaker.model_monitor.data_quality_monitoring_config
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/src/sagemaker/model_monitor/__init__.py
+++ b/src/sagemaker/model_monitor/__init__.py
@@ -46,3 +46,10 @@ from sagemaker.model_monitor.dataset_format import DatasetFormat  # noqa: F401
 from sagemaker.model_monitor.dataset_format import MonitoringDatasetFormat  # noqa: F401
 
 from sagemaker.network import NetworkConfig  # noqa: F401
+
+from sagemaker.model_monitor.data_quality_monitoring_config import (  # noqa: F401
+    DataQualityMonitoringConfig,
+)
+from sagemaker.model_monitor.data_quality_monitoring_config import (  # noqa: F401
+    DataQualityDistributionConstraints,
+)

--- a/src/sagemaker/model_monitor/data_quality_monitoring_config.py
+++ b/src/sagemaker/model_monitor/data_quality_monitoring_config.py
@@ -1,0 +1,66 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+"""This module contains code related to the MonitoringConfig of constraints file.
+
+Code is used to represent the Monitoring Config object and its parameters suggested
+in constraints file by Model Monitor Container in data quality analysis.
+"""
+from __future__ import print_function, absolute_import
+
+CHI_SQUARED_METHOD = "ChiSquared"
+L_INFINITY_METHOD = "LInfinity"
+
+
+class DataQualityDistributionConstraints:
+    """Represents the distribution_constraints object of monitoring_config in constraints file."""
+
+    def __init__(self, categorical_drift_method: str = None):
+        self.categorical_drift_method = categorical_drift_method
+
+    @staticmethod
+    def valid_distribution_constraints(distribution_constraints):
+        """Checks whether distribution_constraints are valid or not."""
+
+        if not distribution_constraints:
+            return True
+
+        return DataQualityDistributionConstraints.valid_categorical_drift_method(
+            distribution_constraints.categorical_drift_method
+        )
+
+    @staticmethod
+    def valid_categorical_drift_method(categorical_drift_method):
+        """Checks whether categorical_drift_method is valid or not."""
+
+        if not categorical_drift_method:
+            return True
+
+        return categorical_drift_method in [CHI_SQUARED_METHOD, L_INFINITY_METHOD]
+
+
+class DataQualityMonitoringConfig:
+    """Represents monitoring_config object in constraints file."""
+
+    def __init__(self, distribution_constraints: DataQualityDistributionConstraints = None):
+        self.distribution_constraints = distribution_constraints
+
+    @staticmethod
+    def valid_monitoring_config(monitoring_config):
+        """Checks whether monitoring_config is valid or not."""
+
+        if not monitoring_config:
+            return True
+
+        return DataQualityDistributionConstraints.valid_distribution_constraints(
+            monitoring_config.distribution_constraints
+        )

--- a/src/sagemaker/model_monitor/model_monitoring.py
+++ b/src/sagemaker/model_monitor/model_monitoring.py
@@ -52,6 +52,7 @@ from sagemaker.model_monitor.monitoring_alert import (
     MonitoringAlertActions,
     ModelDashboardIndicatorAction,
 )
+from sagemaker.model_monitor.data_quality_monitoring_config import DataQualityMonitoringConfig
 from sagemaker.model_monitor.dataset_format import MonitoringDatasetFormat
 from sagemaker.network import NetworkConfig
 from sagemaker.processing import Processor, ProcessingInput, ProcessingJob, ProcessingOutput
@@ -98,6 +99,7 @@ _GROUND_TRUTH_ATTRIBUTE_ENV_NAME = "ground_truth_attribute"
 _INFERENCE_ATTRIBUTE_ENV_NAME = "inference_attribute"
 _PROBABILITY_ATTRIBUTE_ENV_NAME = "probability_attribute"
 _PROBABILITY_THRESHOLD_ATTRIBUTE_ENV_NAME = "probability_threshold_attribute"
+_CATEGORICAL_DRIFT_METHOD_ENV_NAME = "categorical_drift_method"
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -1136,6 +1138,7 @@ class ModelMonitor(object):
         probability_attribute=None,
         ground_truth_attribute=None,
         probability_threshold_attribute=None,
+        categorical_drift_method=None,
     ):
         """Generate a list of environment variables from first-class parameters.
 
@@ -1157,6 +1160,9 @@ class ModelMonitor(object):
                 Only used for ModelQualityMonitor.
             probability_threshold_attribute (float): threshold to convert probabilities to binaries
                 Only used for ModelQualityMonitor.
+            categorical_drift_method (str): categorical_drift_method to override the
+                categorical_drift_method of global monitoring_config in constraints
+                suggested by Model Monitor container. Only used for DataQualityMonitor.
 
         Returns:
             dict: Dictionary of environment keys and values.
@@ -1205,6 +1211,9 @@ class ModelMonitor(object):
 
         if probability_threshold_attribute is not None:
             env[_PROBABILITY_THRESHOLD_ATTRIBUTE_ENV_NAME] = probability_threshold_attribute
+
+        if categorical_drift_method is not None:
+            env[_CATEGORICAL_DRIFT_METHOD_ENV_NAME] = categorical_drift_method
 
         return env
 
@@ -1647,6 +1656,7 @@ class DefaultModelMonitor(ModelMonitor):
         wait=True,
         logs=True,
         job_name=None,
+        monitoring_config_override=None,
     ):
         """Suggest baselines for use with Amazon SageMaker Model Monitoring Schedules.
 
@@ -1666,12 +1676,18 @@ class DefaultModelMonitor(ModelMonitor):
                 Only meaningful when wait is True (default: True).
             job_name (str): Processing job name. If not specified, the processor generates
                 a default job name, based on the image name and current timestamp.
-
+            monitoring_config_override (DataQualityMonitoringConfig): monitoring_config object to
+                override the global monitoring_config parameter of constraints suggested by
+                Model Monitor Container. If not specified, the values suggested by container is
+                set.
         Returns:
             sagemaker.processing.ProcessingJob: The ProcessingJob object representing the
                 baselining job.
 
         """
+        if not DataQualityMonitoringConfig.valid_monitoring_config(monitoring_config_override):
+            raise RuntimeError("Invalid value for monitoring_config_override.")
+
         self.latest_baselining_job_name = self._generate_baselining_job_name(job_name=job_name)
 
         normalized_baseline_dataset_input = self._upload_and_convert_to_processing_input(
@@ -1731,6 +1747,11 @@ class DefaultModelMonitor(ModelMonitor):
 
         normalized_baseline_output = self._normalize_baseline_output(output_s3_uri=output_s3_uri)
 
+        categorical_drift_method = None
+        if monitoring_config_override and monitoring_config_override.distribution_constraints:
+            distribution_constraints = monitoring_config_override.distribution_constraints
+            categorical_drift_method = distribution_constraints.categorical_drift_method
+
         normalized_env = self._generate_env_map(
             env=self.env,
             dataset_format=dataset_format,
@@ -1739,6 +1760,7 @@ class DefaultModelMonitor(ModelMonitor):
             dataset_source_container_path=baseline_dataset_container_path,
             record_preprocessor_script_container_path=record_preprocessor_script_container_path,
             post_processor_script_container_path=post_processor_script_container_path,
+            categorical_drift_method=categorical_drift_method,
         )
 
         baselining_processor = Processor(

--- a/tests/unit/sagemaker/monitor/test_data_quality_monitoring_config.py
+++ b/tests/unit/sagemaker/monitor/test_data_quality_monitoring_config.py
@@ -1,0 +1,67 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from __future__ import absolute_import
+
+from sagemaker.model_monitor import (
+    DataQualityMonitoringConfig,
+    DataQualityDistributionConstraints,
+)
+
+INVALID_CATEGORICAL_DRIFT_METHOD = "Invalid"
+CHISQUARED_CATEGORICAL_DRIFT_METHOD = "ChiSquared"
+LINFINITY_CATEGORICAL_DRIFT_METHOD = "LInfinity"
+
+
+def test_valid_distribution_constraints_with_valid_input():
+    valid_distribution_constraints = DataQualityDistributionConstraints()
+    assert DataQualityDistributionConstraints.valid_distribution_constraints(
+        valid_distribution_constraints
+    )
+
+
+def test_valid_distribution_constraints_with_invalid_input():
+    invalid_distribution_constraints = DataQualityDistributionConstraints(
+        categorical_drift_method=INVALID_CATEGORICAL_DRIFT_METHOD
+    )
+    assert not DataQualityDistributionConstraints.valid_distribution_constraints(
+        invalid_distribution_constraints
+    )
+
+
+def test_valid_categorical_drift_method_with_valid_input():
+    assert DataQualityDistributionConstraints.valid_categorical_drift_method(
+        CHISQUARED_CATEGORICAL_DRIFT_METHOD
+    )
+    assert DataQualityDistributionConstraints.valid_categorical_drift_method(
+        LINFINITY_CATEGORICAL_DRIFT_METHOD
+    )
+
+
+def test_valid_categorical_drift_method_with_invalid_input():
+    assert not DataQualityDistributionConstraints.valid_categorical_drift_method(
+        INVALID_CATEGORICAL_DRIFT_METHOD
+    )
+
+
+def test_valid_monitoring_config_with_valid_input():
+    valid_monitoring_config = DataQualityMonitoringConfig()
+    assert DataQualityMonitoringConfig.valid_monitoring_config(valid_monitoring_config)
+
+
+def test_valid_monitoring_config_with_invalid_input():
+    invalid_monitoring_config = DataQualityMonitoringConfig(
+        distribution_constraints=DataQualityDistributionConstraints(
+            categorical_drift_method=INVALID_CATEGORICAL_DRIFT_METHOD
+        ),
+    )
+    assert not DataQualityMonitoringConfig.valid_monitoring_config(invalid_monitoring_config)

--- a/tests/unit/sagemaker/monitor/test_model_monitoring.py
+++ b/tests/unit/sagemaker/monitor/test_model_monitoring.py
@@ -18,7 +18,7 @@ from typing import Union
 
 import sagemaker
 import pytest
-from mock import Mock, MagicMock
+from mock import Mock, patch, MagicMock
 
 from sagemaker.model_monitor import (
     ModelMonitor,
@@ -30,6 +30,8 @@ from sagemaker.model_monitor import (
     ModelQualityMonitor,
     Statistics,
     MonitoringOutput,
+    DataQualityMonitoringConfig,
+    DataQualityDistributionConstraints,
 )
 from sagemaker.model_monitor.monitoring_alert import (
     MonitoringAlertSummary,
@@ -66,6 +68,9 @@ NETWORK_CONFIG = NetworkConfig(enable_network_isolation=False, encrypt_inter_con
 ENABLE_CLOUDWATCH_METRICS = True
 PROBLEM_TYPE = "Regression"
 GROUND_TRUTH_ATTRIBUTE = "TestAttribute"
+_CATEGORICAL_DRIFT_METHOD_ENV_NAME = "categorical_drift_method"
+CHISQUARED_METHOD = "ChiSquared"
+LINFINITY_METHOD = "LInfinity"
 
 CRON_DAILY = CronExpressionGenerator.daily()
 BASELINING_JOB_NAME = "baselining-job"
@@ -570,6 +575,159 @@ def test_default_model_monitor_suggest_baseline(sagemaker_session):
     assert my_default_monitor.latest_baselining_job_name != BASE_JOB_NAME
 
     assert my_default_monitor.env[ENV_KEY_1] == ENV_VALUE_1
+
+
+@patch("sagemaker.model_monitor.model_monitoring.Processor")
+def test_default_model_monitor_suggest_baseline_with_chisquared_categorical_drift_method(
+    processor_init, sagemaker_session
+):
+    my_default_monitor = DefaultModelMonitor(
+        role=ROLE,
+        instance_count=INSTANCE_COUNT,
+        instance_type=INSTANCE_TYPE,
+        volume_size_in_gb=VOLUME_SIZE_IN_GB,
+        volume_kms_key=VOLUME_KMS_KEY,
+        output_kms_key=OUTPUT_KMS_KEY,
+        max_runtime_in_seconds=MAX_RUNTIME_IN_SECONDS,
+        base_job_name=BASE_JOB_NAME,
+        sagemaker_session=sagemaker_session,
+        env=ENVIRONMENT,
+        tags=TAGS,
+        network_config=NETWORK_CONFIG,
+    )
+    distribution_constraints_with_chisquared_categorical_drift_method = (
+        DataQualityDistributionConstraints(categorical_drift_method=CHISQUARED_METHOD)
+    )
+    monitoring_config_with_chisquared_categorical_drift_method = DataQualityMonitoringConfig(
+        distribution_constraints=distribution_constraints_with_chisquared_categorical_drift_method
+    )
+    processor_init.return_value = Mock()
+    my_default_monitor.suggest_baseline(
+        baseline_dataset=BASELINE_DATASET_PATH,
+        dataset_format=DatasetFormat.csv(header=False),
+        record_preprocessor_script=PREPROCESSOR_PATH,
+        post_analytics_processor_script=POSTPROCESSOR_PATH,
+        output_s3_uri=OUTPUT_S3_URI,
+        wait=False,
+        logs=False,
+        monitoring_config_override=monitoring_config_with_chisquared_categorical_drift_method,
+    )
+
+    assert my_default_monitor.role == ROLE
+    assert my_default_monitor.instance_count == INSTANCE_COUNT
+    assert my_default_monitor.instance_type == INSTANCE_TYPE
+    assert my_default_monitor.volume_size_in_gb == VOLUME_SIZE_IN_GB
+    assert my_default_monitor.volume_kms_key == VOLUME_KMS_KEY
+    assert my_default_monitor.output_kms_key == OUTPUT_KMS_KEY
+    assert my_default_monitor.max_runtime_in_seconds == MAX_RUNTIME_IN_SECONDS
+    assert my_default_monitor.base_job_name == BASE_JOB_NAME
+    assert my_default_monitor.sagemaker_session == sagemaker_session
+    assert my_default_monitor.tags == TAGS
+    assert my_default_monitor.network_config == NETWORK_CONFIG
+    assert my_default_monitor.image_uri == DEFAULT_IMAGE_URI
+    assert BASE_JOB_NAME in my_default_monitor.latest_baselining_job_name
+    assert my_default_monitor.latest_baselining_job_name != BASE_JOB_NAME
+    assert my_default_monitor.env[ENV_KEY_1] == ENV_VALUE_1
+
+    assert (
+        processor_init.call_args.kwargs["env"][_CATEGORICAL_DRIFT_METHOD_ENV_NAME]
+        == CHISQUARED_METHOD
+    )
+
+
+@patch("sagemaker.model_monitor.model_monitoring.Processor")
+def test_default_model_monitor_suggest_baseline_with_linfinity_categorical_drift_method(
+    processor_init, sagemaker_session
+):
+    my_default_monitor = DefaultModelMonitor(
+        role=ROLE,
+        instance_count=INSTANCE_COUNT,
+        instance_type=INSTANCE_TYPE,
+        volume_size_in_gb=VOLUME_SIZE_IN_GB,
+        volume_kms_key=VOLUME_KMS_KEY,
+        output_kms_key=OUTPUT_KMS_KEY,
+        max_runtime_in_seconds=MAX_RUNTIME_IN_SECONDS,
+        base_job_name=BASE_JOB_NAME,
+        sagemaker_session=sagemaker_session,
+        env=ENVIRONMENT,
+        tags=TAGS,
+        network_config=NETWORK_CONFIG,
+    )
+    distribution_constraints_with_linfinity_categorical_drift_method = (
+        DataQualityDistributionConstraints(categorical_drift_method=LINFINITY_METHOD)
+    )
+    monitoring_config_with_linfinity_categorical_drift_method = DataQualityMonitoringConfig(
+        distribution_constraints=distribution_constraints_with_linfinity_categorical_drift_method
+    )
+    processor_init.return_value = Mock()
+    my_default_monitor.suggest_baseline(
+        baseline_dataset=BASELINE_DATASET_PATH,
+        dataset_format=DatasetFormat.csv(header=False),
+        record_preprocessor_script=PREPROCESSOR_PATH,
+        post_analytics_processor_script=POSTPROCESSOR_PATH,
+        output_s3_uri=OUTPUT_S3_URI,
+        wait=False,
+        logs=False,
+        monitoring_config_override=monitoring_config_with_linfinity_categorical_drift_method,
+    )
+
+    assert my_default_monitor.role == ROLE
+    assert my_default_monitor.instance_count == INSTANCE_COUNT
+    assert my_default_monitor.instance_type == INSTANCE_TYPE
+    assert my_default_monitor.volume_size_in_gb == VOLUME_SIZE_IN_GB
+    assert my_default_monitor.volume_kms_key == VOLUME_KMS_KEY
+    assert my_default_monitor.output_kms_key == OUTPUT_KMS_KEY
+    assert my_default_monitor.max_runtime_in_seconds == MAX_RUNTIME_IN_SECONDS
+    assert my_default_monitor.base_job_name == BASE_JOB_NAME
+    assert my_default_monitor.sagemaker_session == sagemaker_session
+    assert my_default_monitor.tags == TAGS
+    assert my_default_monitor.network_config == NETWORK_CONFIG
+    assert my_default_monitor.image_uri == DEFAULT_IMAGE_URI
+    assert BASE_JOB_NAME in my_default_monitor.latest_baselining_job_name
+    assert my_default_monitor.latest_baselining_job_name != BASE_JOB_NAME
+    assert my_default_monitor.env[ENV_KEY_1] == ENV_VALUE_1
+
+    assert (
+        processor_init.call_args.kwargs["env"][_CATEGORICAL_DRIFT_METHOD_ENV_NAME]
+        == LINFINITY_METHOD
+    )
+
+
+def test_default_model_monitor_suggest_baseline_with_invalid_categorical_drift_method(
+    sagemaker_session,
+):
+    my_default_monitor = DefaultModelMonitor(
+        role=ROLE,
+        instance_count=INSTANCE_COUNT,
+        instance_type=INSTANCE_TYPE,
+        volume_size_in_gb=VOLUME_SIZE_IN_GB,
+        volume_kms_key=VOLUME_KMS_KEY,
+        output_kms_key=OUTPUT_KMS_KEY,
+        max_runtime_in_seconds=MAX_RUNTIME_IN_SECONDS,
+        base_job_name=BASE_JOB_NAME,
+        sagemaker_session=sagemaker_session,
+        env=ENVIRONMENT,
+        tags=TAGS,
+        network_config=NETWORK_CONFIG,
+    )
+    distribution_constraints_with_invalid_categorical_drift_method = (
+        DataQualityDistributionConstraints(categorical_drift_method="Invalid")
+    )
+    monitoring_config_with_invalid_categorical_drift_method = DataQualityMonitoringConfig(
+        distribution_constraints=distribution_constraints_with_invalid_categorical_drift_method
+    )
+    with pytest.raises(RuntimeError) as error:
+        my_default_monitor.suggest_baseline(
+            baseline_dataset=BASELINE_DATASET_PATH,
+            dataset_format=DatasetFormat.csv(header=False),
+            record_preprocessor_script=PREPROCESSOR_PATH,
+            post_analytics_processor_script=POSTPROCESSOR_PATH,
+            output_s3_uri=OUTPUT_S3_URI,
+            wait=False,
+            logs=False,
+            monitoring_config_override=monitoring_config_with_invalid_categorical_drift_method,
+        )
+    assert "Invalid value for monitoring_config_override." in str(error)
 
 
 def test_data_quality_monitor_suggest_baseline(sagemaker_session, data_quality_monitor):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Added an optional parameter `monitoring_config_override` in `suggest_baseline` API for `overriding` global monitoring_config suggested in constraints by Model Monitor container. Currently, categorical_drift_method can only be overriden using the same.

*Testing done:*
* Tested `suggest_baseline API` manually and added corresponding integration tests for the same.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
