### PR TITLE
fix: Fix unclear error messages for SageMaker Pipelines

### DIFF
--- a/src/sagemaker/workflow/entities.py
+++ b/src/sagemaker/workflow/entities.py
@@ -85,8 +85,11 @@ class PipelineVariable(Expression):
         """Override built-in String function for PipelineVariable"""
         raise TypeError(
             "Pipeline variables do not support __str__ operation. "
-            "Please use `.to_string()` to convert it to string type in execution time"
-            "or use `.expr` to translate it to Json for display purpose in Python SDK."
+            "If you are trying to use a pipeline variable in an Estimator, Processor or Model "
+            "object, please make sure the object is built with a PipelineSession object."
+            "If you are trying to convert a pipeline variable of any type into a pipeline variable "
+            "of string type, please use `.to_string()` method."
+            "Use `.expr` method to display the expression structure of the pipeline variable."
         )
 
     def __int__(self):

--- a/src/sagemaker/workflow/model_step.py
+++ b/src/sagemaker/workflow/model_step.py
@@ -124,8 +124,9 @@ class ModelStep(StepCollection):
                 Session.create_model.__name__,
                 Session.create_model_package_from_containers.__name__,
             },
-            error_message="The step_args of ModelStep must be obtained from model.create() "
-            "or model.register(). For more, see: https://sagemaker.readthedocs.io/en/stable/"
+            error_message="The step_args of ModelStep must be obtained from the create method "
+            "or register method of a Model object and the Model object must be built with "
+            "PipelineSession. For more, see: https://sagemaker.readthedocs.io/en/stable/"
             "amazon_sagemaker_model_building_pipeline.html#model-step",
         )
         if not (step_args.create_model_request is None) ^ (


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* fix some unclear error messages for SageMaker pipelines

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [N/A] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [N/A] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [N/A] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [N/A] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [N/A] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [N/A] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
