### PR TITLE
Chore/reset cache if js model not found

### DIFF
--- a/src/sagemaker/jumpstart/model.py
+++ b/src/sagemaker/jumpstart/model.py
@@ -20,6 +20,7 @@ from sagemaker.async_inference.async_inference_config import AsyncInferenceConfi
 from sagemaker.base_deserializers import BaseDeserializer
 from sagemaker.base_serializers import BaseSerializer
 from sagemaker.explainer.explainer_config import ExplainerConfig
+from sagemaker.jumpstart.accessors import JumpStartModelsAccessor
 from sagemaker.jumpstart.enums import JumpStartScriptScope
 from sagemaker.jumpstart.exceptions import INVALID_MODEL_ID_ERROR_MSG
 from sagemaker.jumpstart.factory.model import (
@@ -252,13 +253,18 @@ class JumpStartModel(Model):
             ValueError: If the model ID is not recognized by JumpStart.
         """
 
-        if not is_valid_model_id(
-            model_id=model_id,
-            model_version=model_version,
-            region=region,
-            script=JumpStartScriptScope.INFERENCE,
-        ):
-            raise ValueError(INVALID_MODEL_ID_ERROR_MSG.format(model_id=model_id))
+        def _is_valid_model_id_hook():
+            return is_valid_model_id(
+                model_id=model_id,
+                model_version=model_version,
+                region=region,
+                script=JumpStartScriptScope.INFERENCE,
+            )
+
+        if not _is_valid_model_id_hook():
+            JumpStartModelsAccessor.reset_cache()
+            if not _is_valid_model_id_hook():
+                raise ValueError(INVALID_MODEL_ID_ERROR_MSG.format(model_id=model_id))
 
         model_init_kwargs = get_init_kwargs(
             model_id=model_id,

--- a/tests/unit/sagemaker/jumpstart/estimator/test_estimator.py
+++ b/tests/unit/sagemaker/jumpstart/estimator/test_estimator.py
@@ -947,9 +947,9 @@ class EstimatorTest(unittest.TestCase):
     @mock.patch("sagemaker.jumpstart.factory.estimator._retrieve_estimator_init_kwargs")
     @mock.patch("sagemaker.jumpstart.factory.estimator.Session")
     @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
-    @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.reset_cache")
+    @mock.patch("sagemaker.jumpstart.estimator.JumpStartModelsAccessor.reset_cache")
     @mock.patch("sagemaker.jumpstart.factory.estimator.JUMPSTART_DEFAULT_REGION_NAME", region)
-    def test_model_id_not_found_refeshes_cache(
+    def test_model_id_not_found_refeshes_cache_training(
         self,
         mock_reset_cache: mock.Mock,
         mock_get_model_specs: mock.Mock,

--- a/tests/unit/sagemaker/jumpstart/estimator/test_estimator.py
+++ b/tests/unit/sagemaker/jumpstart/estimator/test_estimator.py
@@ -22,6 +22,7 @@ import pytest
 from sagemaker.debugger.profiler_config import ProfilerConfig
 from sagemaker.estimator import Estimator
 from sagemaker.instance_group import InstanceGroup
+from sagemaker.jumpstart.enums import JumpStartScriptScope
 
 from sagemaker.jumpstart.estimator import JumpStartEstimator
 
@@ -938,6 +939,85 @@ class EstimatorTest(unittest.TestCase):
             enable_network_isolation=False,
             model_name="blahblahblah-3456",
             endpoint_name="blahblahblah-3456",
+        )
+
+    @mock.patch("sagemaker.jumpstart.estimator.is_valid_model_id")
+    @mock.patch("sagemaker.jumpstart.estimator.Estimator.deploy")
+    @mock.patch("sagemaker.jumpstart.estimator.Estimator.__init__")
+    @mock.patch("sagemaker.jumpstart.factory.estimator._retrieve_estimator_init_kwargs")
+    @mock.patch("sagemaker.jumpstart.factory.estimator.Session")
+    @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
+    @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.reset_cache")
+    @mock.patch("sagemaker.jumpstart.factory.estimator.JUMPSTART_DEFAULT_REGION_NAME", region)
+    def test_model_id_not_found_refeshes_cache(
+        self,
+        mock_reset_cache: mock.Mock,
+        mock_get_model_specs: mock.Mock,
+        mock_session: mock.Mock,
+        mock_retrieve_kwargs: mock.Mock,
+        mock_estimator_init: mock.Mock,
+        mock_estimator_deploy: mock.Mock,
+        mock_is_valid_model_id: mock.Mock,
+    ):
+        mock_estimator_deploy.return_value = default_predictor
+
+        mock_is_valid_model_id.side_effect = [False, False]
+
+        model_id, _ = "js-trainable-model", "*"
+
+        mock_retrieve_kwargs.return_value = {}
+
+        mock_get_model_specs.side_effect = get_special_model_spec
+
+        mock_session.return_value = sagemaker_session
+
+        with pytest.raises(ValueError):
+            JumpStartEstimator(
+                model_id=model_id,
+            )
+
+        mock_reset_cache.assert_called_once_with()
+        mock_is_valid_model_id.assert_has_calls(
+            calls=[
+                mock.call(
+                    model_id="js-trainable-model",
+                    model_version=None,
+                    region=None,
+                    script=JumpStartScriptScope.TRAINING,
+                ),
+                mock.call(
+                    model_id="js-trainable-model",
+                    model_version=None,
+                    region=None,
+                    script=JumpStartScriptScope.TRAINING,
+                ),
+            ]
+        )
+
+        mock_is_valid_model_id.reset_mock()
+        mock_reset_cache.reset_mock()
+
+        mock_is_valid_model_id.side_effect = [False, True]
+        JumpStartEstimator(
+            model_id=model_id,
+        )
+
+        mock_reset_cache.assert_called_once_with()
+        mock_is_valid_model_id.assert_has_calls(
+            calls=[
+                mock.call(
+                    model_id="js-trainable-model",
+                    model_version=None,
+                    region=None,
+                    script=JumpStartScriptScope.TRAINING,
+                ),
+                mock.call(
+                    model_id="js-trainable-model",
+                    model_version=None,
+                    region=None,
+                    script=JumpStartScriptScope.TRAINING,
+                ),
+            ]
         )
 
 

--- a/tests/unit/sagemaker/jumpstart/model/test_model.py
+++ b/tests/unit/sagemaker/jumpstart/model/test_model.py
@@ -458,9 +458,9 @@ class ModelTest(unittest.TestCase):
     @mock.patch("sagemaker.jumpstart.factory.model._retrieve_model_init_kwargs")
     @mock.patch("sagemaker.jumpstart.factory.model.Session")
     @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
-    @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.reset_cache")
+    @mock.patch("sagemaker.jumpstart.model.JumpStartModelsAccessor.reset_cache")
     @mock.patch("sagemaker.jumpstart.factory.estimator.JUMPSTART_DEFAULT_REGION_NAME", region)
-    def test_model_id_not_found_refeshes_cache(
+    def test_model_id_not_found_refeshes_cach_inference(
         self,
         mock_reset_cache: mock.Mock,
         mock_get_model_specs: mock.Mock,

--- a/tests/unit/sagemaker/jumpstart/model/test_model.py
+++ b/tests/unit/sagemaker/jumpstart/model/test_model.py
@@ -16,6 +16,7 @@ from typing import Optional, Set
 from unittest import mock
 import unittest
 import pytest
+from sagemaker.jumpstart.enums import JumpStartScriptScope
 
 from sagemaker.jumpstart.model import JumpStartModel
 from sagemaker.model import Model
@@ -451,6 +452,82 @@ class ModelTest(unittest.TestCase):
         mock_get_default_predictor.assert_not_called()
         self.assertEqual(type(predictor), Predictor)
         self.assertEqual(predictor, default_predictor)
+
+    @mock.patch("sagemaker.jumpstart.model.is_valid_model_id")
+    @mock.patch("sagemaker.jumpstart.model.Model.__init__")
+    @mock.patch("sagemaker.jumpstart.factory.model._retrieve_model_init_kwargs")
+    @mock.patch("sagemaker.jumpstart.factory.model.Session")
+    @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
+    @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.reset_cache")
+    @mock.patch("sagemaker.jumpstart.factory.estimator.JUMPSTART_DEFAULT_REGION_NAME", region)
+    def test_model_id_not_found_refeshes_cache(
+        self,
+        mock_reset_cache: mock.Mock,
+        mock_get_model_specs: mock.Mock,
+        mock_session: mock.Mock,
+        mock_retrieve_kwargs: mock.Mock,
+        mock_model_init: mock.Mock,
+        mock_is_valid_model_id: mock.Mock,
+    ):
+
+        mock_is_valid_model_id.side_effect = [False, False]
+
+        model_id, _ = "js-trainable-model", "*"
+
+        mock_retrieve_kwargs.return_value = {}
+
+        mock_get_model_specs.side_effect = get_special_model_spec
+
+        mock_session.return_value = sagemaker_session
+
+        with pytest.raises(ValueError):
+            JumpStartModel(
+                model_id=model_id,
+            )
+
+        mock_reset_cache.assert_called_once_with()
+        mock_is_valid_model_id.assert_has_calls(
+            calls=[
+                mock.call(
+                    model_id="js-trainable-model",
+                    model_version=None,
+                    region=None,
+                    script=JumpStartScriptScope.INFERENCE,
+                ),
+                mock.call(
+                    model_id="js-trainable-model",
+                    model_version=None,
+                    region=None,
+                    script=JumpStartScriptScope.INFERENCE,
+                ),
+            ]
+        )
+
+        mock_is_valid_model_id.reset_mock()
+        mock_reset_cache.reset_mock()
+
+        mock_is_valid_model_id.side_effect = [False, True]
+        JumpStartModel(
+            model_id=model_id,
+        )
+
+        mock_reset_cache.assert_called_once_with()
+        mock_is_valid_model_id.assert_has_calls(
+            calls=[
+                mock.call(
+                    model_id="js-trainable-model",
+                    model_version=None,
+                    region=None,
+                    script=JumpStartScriptScope.INFERENCE,
+                ),
+                mock.call(
+                    model_id="js-trainable-model",
+                    model_version=None,
+                    region=None,
+                    script=JumpStartScriptScope.INFERENCE,
+                ),
+            ]
+        )
 
 
 def test_jumpstart_model_requires_model_id():


### PR DESCRIPTION
*Description of changes:*
If the model id inputted into `JumpStartModel` or `JumpStartEstimator` cannot be found in the cache, the cache is reset and metadata refetched. This allows customers to use new models in metadata that they would otherwise not have access to unless they kill their python script.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
