### PR TITLE
feat: add PipelineDefinitionConfig to pipelines to toggle custom job …

### DIFF
--- a/doc/workflows/pipelines/sagemaker.workflow.pipelines.rst
+++ b/doc/workflows/pipelines/sagemaker.workflow.pipelines.rst
@@ -103,6 +103,11 @@ Parallelism Configuration
 .. autoclass:: sagemaker.workflow.parallelism_config.ParallelismConfiguration
     :members:
 
+Pipeline Definition Config
+--------------------------
+
+.. autoclass:: sagemaker.workflow.pipeline_definition_config.PipelineDefinitionConfig
+
 Pipeline Experiment Config
 --------------------------
 

--- a/src/sagemaker/model_monitor/clarify_model_monitoring.py
+++ b/src/sagemaker/model_monitor/clarify_model_monitoring.py
@@ -175,6 +175,7 @@ class ClarifyModelMonitor(mm.ModelMonitor):
             network_config=self.network_config,
         )
         baselining_processor.image_uri = self.image_uri
+        baselining_processor.base_job_name = self.base_job_name
         return baselining_processor
 
     def _upload_analysis_config(self, analysis_config, output_s3_uri, job_definition_name):

--- a/src/sagemaker/workflow/_utils.py
+++ b/src/sagemaker/workflow/_utils.py
@@ -34,6 +34,7 @@ from sagemaker.workflow.steps import (
 )
 from sagemaker.utils import _save_model, download_file_from_url
 from sagemaker.workflow.retry import RetryPolicy
+from sagemaker.workflow.utilities import strip_timestamp_from_job_name
 
 if TYPE_CHECKING:
     from sagemaker.workflow.step_collections import StepCollection
@@ -498,6 +499,10 @@ class _RegisterModelStep(ConfigurableRetryStep):
             if not _pipeline_config or not _pipeline_config.use_custom_job_prefix:
                 request_dict.pop("ModelPackageName", None)
                 logger.warning(warn_msg_template, "ModelPackageName")
+            else:
+                request_dict = strip_timestamp_from_job_name(
+                    request_dict, job_key="ModelPackageName"
+                )
 
         return request_dict
 

--- a/src/sagemaker/workflow/_utils.py
+++ b/src/sagemaker/workflow/_utils.py
@@ -34,7 +34,7 @@ from sagemaker.workflow.steps import (
 )
 from sagemaker.utils import _save_model, download_file_from_url
 from sagemaker.workflow.retry import RetryPolicy
-from sagemaker.workflow.utilities import strip_timestamp_from_job_name
+from sagemaker.workflow.utilities import trim_request_dict
 
 if TYPE_CHECKING:
     from sagemaker.workflow.step_collections import StepCollection
@@ -495,14 +495,9 @@ class _RegisterModelStep(ConfigurableRetryStep):
         if "Description" in request_dict:
             request_dict.pop("Description")
             logger.warning(warn_msg_template, "Description")
-        if "ModelPackageName" in request_dict:
-            if not _pipeline_config or not _pipeline_config.use_custom_job_prefix:
-                request_dict.pop("ModelPackageName", None)
-                logger.warning(warn_msg_template, "ModelPackageName")
-            else:
-                request_dict = strip_timestamp_from_job_name(
-                    request_dict, job_key="ModelPackageName"
-                )
+
+        # Continue to pop job name if not explicitly opted-in via config
+        request_dict = trim_request_dict(request_dict, "ModelPackageName", _pipeline_config)
 
         return request_dict
 

--- a/src/sagemaker/workflow/_utils.py
+++ b/src/sagemaker/workflow/_utils.py
@@ -412,6 +412,8 @@ class _RegisterModelStep(ConfigurableRetryStep):
     @property
     def arguments(self) -> RequestType:
         """The arguments dict that are used to call `create_model_package`."""
+        from sagemaker.workflow.utilities import _pipeline_config
+
         model_name = self.name
 
         if self.step_args:
@@ -493,8 +495,9 @@ class _RegisterModelStep(ConfigurableRetryStep):
             request_dict.pop("Description")
             logger.warning(warn_msg_template, "Description")
         if "ModelPackageName" in request_dict:
-            request_dict.pop("ModelPackageName")
-            logger.warning(warn_msg_template, "ModelPackageName")
+            if not _pipeline_config or not _pipeline_config.use_custom_job_prefix:
+                request_dict.pop("ModelPackageName", None)
+                logger.warning(warn_msg_template, "ModelPackageName")
 
         return request_dict
 

--- a/src/sagemaker/workflow/automl_step.py
+++ b/src/sagemaker/workflow/automl_step.py
@@ -93,6 +93,7 @@ class AutoMLStep(ConfigurableRetryStep):
             attribute cannot be included.
         """
         from sagemaker.workflow.utilities import execute_job_functions
+        from sagemaker.workflow.utilities import _pipeline_config
 
         # execute fit function in AutoML with saved parameters,
         # and store args in PipelineSession's _context
@@ -114,7 +115,9 @@ class AutoMLStep(ConfigurableRetryStep):
             request_dict.pop("ModelDeployConfig", None)
         if "GenerateCandidateDefinitionsOnly" in request_dict:
             request_dict.pop("GenerateCandidateDefinitionsOnly", None)
-        request_dict.pop("AutoMLJobName", None)
+        if not _pipeline_config or not _pipeline_config.use_custom_job_prefix:
+            request_dict.pop("AutoMLJobName", None)
+
         return request_dict
 
     @property

--- a/src/sagemaker/workflow/automl_step.py
+++ b/src/sagemaker/workflow/automl_step.py
@@ -23,7 +23,7 @@ from sagemaker.workflow.pipeline_context import _JobStepArguments
 from sagemaker.workflow.properties import Properties
 from sagemaker.workflow.retry import RetryPolicy
 from sagemaker.workflow.steps import ConfigurableRetryStep, CacheConfig, Step, StepTypeEnum
-from sagemaker.workflow.utilities import validate_step_args_input, strip_timestamp_from_job_name
+from sagemaker.workflow.utilities import validate_step_args_input, trim_request_dict
 from sagemaker.workflow.step_collections import StepCollection
 
 
@@ -115,11 +115,9 @@ class AutoMLStep(ConfigurableRetryStep):
             request_dict.pop("ModelDeployConfig", None)
         if "GenerateCandidateDefinitionsOnly" in request_dict:
             request_dict.pop("GenerateCandidateDefinitionsOnly", None)
-        if not _pipeline_config or not _pipeline_config.use_custom_job_prefix:
-            request_dict.pop("AutoMLJobName", None)
-        else:
-            # AutoML Trims to AutoMLJo-2023-06-23-22-57-39-083
-            request_dict = strip_timestamp_from_job_name(request_dict, job_key="AutoMLJobName")
+        # Continue to pop job name if not explicitly opted-in via config
+        # AutoML Trims to AutoMLJo-2023-06-23-22-57-39-083
+        request_dict = trim_request_dict(request_dict, "AutoMLJobName", _pipeline_config)
 
         return request_dict
 

--- a/src/sagemaker/workflow/automl_step.py
+++ b/src/sagemaker/workflow/automl_step.py
@@ -23,7 +23,7 @@ from sagemaker.workflow.pipeline_context import _JobStepArguments
 from sagemaker.workflow.properties import Properties
 from sagemaker.workflow.retry import RetryPolicy
 from sagemaker.workflow.steps import ConfigurableRetryStep, CacheConfig, Step, StepTypeEnum
-from sagemaker.workflow.utilities import validate_step_args_input
+from sagemaker.workflow.utilities import validate_step_args_input, strip_timestamp_from_job_name
 from sagemaker.workflow.step_collections import StepCollection
 
 
@@ -89,7 +89,7 @@ class AutoMLStep(ConfigurableRetryStep):
         NOTE: The `CreateAutoMLJob` request is not quite the
             args list that workflow needs.
 
-        The `AutoMLJobName`, `ModelDeployConfig` and `GenerateCandidateDefinitionsOnly`
+        `ModelDeployConfig` and `GenerateCandidateDefinitionsOnly`
             attribute cannot be included.
         """
         from sagemaker.workflow.utilities import execute_job_functions
@@ -117,6 +117,9 @@ class AutoMLStep(ConfigurableRetryStep):
             request_dict.pop("GenerateCandidateDefinitionsOnly", None)
         if not _pipeline_config or not _pipeline_config.use_custom_job_prefix:
             request_dict.pop("AutoMLJobName", None)
+        else:
+            # AutoML Trims to AutoMLJo-2023-06-23-22-57-39-083
+            request_dict = strip_timestamp_from_job_name(request_dict, job_key="AutoMLJobName")
 
         return request_dict
 

--- a/src/sagemaker/workflow/clarify_check_step.py
+++ b/src/sagemaker/workflow/clarify_check_step.py
@@ -44,7 +44,7 @@ from sagemaker.workflow.properties import Properties
 from sagemaker.workflow.step_collections import StepCollection
 from sagemaker.workflow.steps import Step, StepTypeEnum, CacheConfig
 from sagemaker.workflow.check_job_config import CheckJobConfig
-from sagemaker.workflow.utilities import strip_timestamp_from_job_name
+from sagemaker.workflow.utilities import trim_request_dict
 
 _DATA_BIAS_TYPE = "DATA_BIAS"
 _MODEL_BIAS_TYPE = "MODEL_BIAS"
@@ -269,13 +269,8 @@ class ClarifyCheckStep(Step):
         request_dict = self._baselining_processor.sagemaker_session._get_process_request(
             **process_args
         )
-        # Continue to pop custom prefix if not explicitly opted-in
-        if not _pipeline_config or not _pipeline_config.use_custom_job_prefix:
-            if "ProcessingJobName" in request_dict:
-                request_dict.pop("ProcessingJobName")
-        else:
-            print(request_dict["ProcessingJobName"])
-            request_dict = strip_timestamp_from_job_name(request_dict, job_key="ProcessingJobName")
+        # Continue to pop job name if not explicitly opted-in via config
+        request_dict = trim_request_dict(request_dict, "ProcessingJobName", _pipeline_config)
 
         return request_dict
 

--- a/src/sagemaker/workflow/clarify_check_step.py
+++ b/src/sagemaker/workflow/clarify_check_step.py
@@ -253,6 +253,8 @@ class ClarifyCheckStep(Step):
     @property
     def arguments(self) -> RequestType:
         """The arguments dict that is used to define the ClarifyCheck step."""
+        from sagemaker.workflow.utilities import _pipeline_config
+
         normalized_inputs, normalized_outputs = self._baselining_processor._normalize_args(
             inputs=[self._processing_params["config_input"], self._processing_params["data_input"]],
             outputs=[self._processing_params["result_output"]],
@@ -266,8 +268,9 @@ class ClarifyCheckStep(Step):
         request_dict = self._baselining_processor.sagemaker_session._get_process_request(
             **process_args
         )
-        if "ProcessingJobName" in request_dict:
-            request_dict.pop("ProcessingJobName")
+        if not _pipeline_config or not _pipeline_config.use_custom_job_prefix:
+            if "ProcessingJobName" in request_dict:
+                request_dict.pop("ProcessingJobName")
 
         return request_dict
 

--- a/src/sagemaker/workflow/clarify_check_step.py
+++ b/src/sagemaker/workflow/clarify_check_step.py
@@ -44,6 +44,7 @@ from sagemaker.workflow.properties import Properties
 from sagemaker.workflow.step_collections import StepCollection
 from sagemaker.workflow.steps import Step, StepTypeEnum, CacheConfig
 from sagemaker.workflow.check_job_config import CheckJobConfig
+from sagemaker.workflow.utilities import strip_timestamp_from_job_name
 
 _DATA_BIAS_TYPE = "DATA_BIAS"
 _MODEL_BIAS_TYPE = "MODEL_BIAS"
@@ -268,9 +269,13 @@ class ClarifyCheckStep(Step):
         request_dict = self._baselining_processor.sagemaker_session._get_process_request(
             **process_args
         )
+        # Continue to pop custom prefix if not explicitly opted-in
         if not _pipeline_config or not _pipeline_config.use_custom_job_prefix:
             if "ProcessingJobName" in request_dict:
                 request_dict.pop("ProcessingJobName")
+        else:
+            print(request_dict["ProcessingJobName"])
+            request_dict = strip_timestamp_from_job_name(request_dict, job_key="ProcessingJobName")
 
         return request_dict
 

--- a/src/sagemaker/workflow/pipeline.py
+++ b/src/sagemaker/workflow/pipeline.py
@@ -64,9 +64,9 @@ class Pipeline(Entity):
         name: str = "",
         parameters: Optional[Sequence[Parameter]] = None,
         pipeline_experiment_config: Optional[PipelineExperimentConfig] = _DEFAULT_EXPERIMENT_CFG,
-        pipeline_definition_config: Optional[PipelineDefinitionConfig] = _DEFAULT_DEFINITION_CFG,
         steps: Optional[Sequence[Union[Step, StepCollection]]] = None,
         sagemaker_session: Optional[Session] = None,
+        pipeline_definition_config: Optional[PipelineDefinitionConfig] = _DEFAULT_DEFINITION_CFG,
     ):
         """Initialize a Pipeline
 
@@ -79,9 +79,6 @@ class Pipeline(Entity):
                 the same name already exists. By default, pipeline name is used as
                 experiment name and execution id is used as the trial name.
                 If set to None, no experiment or trial will be created automatically.
-            pipeline_definition_config (Optional[PipelineDefinitionConfig]): If set,
-                the workflow customizes the pipeline definition using the configurations
-                specified. By default, custom job-prefixing is turned off.
             steps (Sequence[Union[Step, StepCollection]]): The list of the non-conditional steps
                 associated with the pipeline. Any steps that are within the
                 `if_steps` or `else_steps` of a `ConditionStep` cannot be listed in the steps of a
@@ -91,13 +88,16 @@ class Pipeline(Entity):
             sagemaker_session (sagemaker.session.Session): Session object that manages interactions
                 with Amazon SageMaker APIs and any other AWS services needed. If not specified, the
                 pipeline creates one using the default AWS configuration chain.
+            pipeline_definition_config (Optional[PipelineDefinitionConfig]): If set,
+                the workflow customizes the pipeline definition using the configurations
+                specified. By default, custom job-prefixing is turned off.
         """
         self.name = name
         self.parameters = parameters if parameters else []
         self.pipeline_experiment_config = pipeline_experiment_config
-        self.pipeline_definition_config = pipeline_definition_config
         self.steps = steps if steps else []
         self.sagemaker_session = sagemaker_session if sagemaker_session else Session()
+        self.pipeline_definition_config = pipeline_definition_config
 
         self._version = "2020-12-01"
         self._metadata = dict()

--- a/src/sagemaker/workflow/pipeline.py
+++ b/src/sagemaker/workflow/pipeline.py
@@ -37,6 +37,7 @@ from sagemaker.workflow.entities import (
 )
 from sagemaker.workflow.execution_variables import ExecutionVariables
 from sagemaker.workflow.parameters import Parameter
+from sagemaker.workflow.pipeline_definition_config import PipelineDefinitionConfig
 from sagemaker.workflow.pipeline_experiment_config import PipelineExperimentConfig
 from sagemaker.workflow.parallelism_config import ParallelismConfiguration
 from sagemaker.workflow.properties import Properties
@@ -52,6 +53,8 @@ _DEFAULT_EXPERIMENT_CFG = PipelineExperimentConfig(
     ExecutionVariables.PIPELINE_NAME, ExecutionVariables.PIPELINE_EXECUTION_ID
 )
 
+_DEFAULT_DEFINITION_CFG = PipelineDefinitionConfig(use_custom_job_prefix=False)
+
 
 class Pipeline(Entity):
     """Pipeline for workflow."""
@@ -61,6 +64,7 @@ class Pipeline(Entity):
         name: str = "",
         parameters: Optional[Sequence[Parameter]] = None,
         pipeline_experiment_config: Optional[PipelineExperimentConfig] = _DEFAULT_EXPERIMENT_CFG,
+        pipeline_definition_config: Optional[PipelineDefinitionConfig] = _DEFAULT_DEFINITION_CFG,
         steps: Optional[Sequence[Union[Step, StepCollection]]] = None,
         sagemaker_session: Optional[Session] = None,
     ):
@@ -88,6 +92,7 @@ class Pipeline(Entity):
         self.name = name
         self.parameters = parameters if parameters else []
         self.pipeline_experiment_config = pipeline_experiment_config
+        self.pipeline_definition_config = pipeline_definition_config
         self.steps = steps if steps else []
         self.sagemaker_session = sagemaker_session if sagemaker_session else Session()
 
@@ -105,7 +110,9 @@ class Pipeline(Entity):
             "PipelineExperimentConfig": self.pipeline_experiment_config.to_request()
             if self.pipeline_experiment_config is not None
             else None,
-            "Steps": build_steps(self.steps, self.name),
+            "Steps": build_steps(
+                self.steps, self.name, self.pipeline_definition_config.use_custom_job_prefix
+            ),
         }
 
     def create(

--- a/src/sagemaker/workflow/pipeline.py
+++ b/src/sagemaker/workflow/pipeline.py
@@ -79,6 +79,9 @@ class Pipeline(Entity):
                 the same name already exists. By default, pipeline name is used as
                 experiment name and execution id is used as the trial name.
                 If set to None, no experiment or trial will be created automatically.
+            pipeline_definition_config (Optional[PipelineDefinitionConfig]): If set,
+                the workflow customizes the pipeline definition using the configurations
+                specified. By default, custom job-prefixing is turned off.
             steps (Sequence[Union[Step, StepCollection]]): The list of the non-conditional steps
                 associated with the pipeline. Any steps that are within the
                 `if_steps` or `else_steps` of a `ConditionStep` cannot be listed in the steps of a

--- a/src/sagemaker/workflow/pipeline.py
+++ b/src/sagemaker/workflow/pipeline.py
@@ -111,7 +111,9 @@ class Pipeline(Entity):
             if self.pipeline_experiment_config is not None
             else None,
             "Steps": build_steps(
-                self.steps, self.name, self.pipeline_definition_config.use_custom_job_prefix
+                self.steps,
+                self.name,
+                self.pipeline_definition_config,
             ),
         }
 

--- a/src/sagemaker/workflow/pipeline_context.py
+++ b/src/sagemaker/workflow/pipeline_context.py
@@ -20,6 +20,7 @@ from typing import Dict, Optional, Callable
 
 from sagemaker.session import Session, SessionSettings
 from sagemaker.local import LocalSession
+from sagemaker.workflow.pipeline_definition_config import PipelineDefinitionConfig
 
 
 class _StepArguments:
@@ -87,14 +88,23 @@ class _PipelineConfig:
         step_name (str): step name
         code_hash (str): a hash of the code artifact for the particular step
         config_hash (str): a hash of the config artifact for the particular step (Processing)
+        pipeline_definition_config (PipelineDefinitionConfig): a configuration used to toggle
+            feature flags persistent in a pipeline definition
     """
 
-    def __init__(self, pipeline_name, step_name, code_hash, config_hash, use_custom_job_prefix):
+    def __init__(
+        self,
+        pipeline_name: str,
+        step_name: str,
+        code_hash: str,
+        config_hash: str,
+        pipeline_definition_config: PipelineDefinitionConfig,
+    ):
         self.pipeline_name = pipeline_name
         self.step_name = step_name
         self.code_hash = code_hash
         self.config_hash = config_hash
-        self.use_custom_job_prefix = use_custom_job_prefix
+        self.pipeline_definition_config = pipeline_definition_config
 
 
 class PipelineSession(Session):

--- a/src/sagemaker/workflow/pipeline_context.py
+++ b/src/sagemaker/workflow/pipeline_context.py
@@ -89,11 +89,12 @@ class _PipelineConfig:
         config_hash (str): a hash of the config artifact for the particular step (Processing)
     """
 
-    def __init__(self, pipeline_name, step_name, code_hash, config_hash):
+    def __init__(self, pipeline_name, step_name, code_hash, config_hash, use_custom_job_prefix):
         self.pipeline_name = pipeline_name
         self.step_name = step_name
         self.code_hash = code_hash
         self.config_hash = config_hash
+        self.use_custom_job_prefix = use_custom_job_prefix
 
 
 class PipelineSession(Session):

--- a/src/sagemaker/workflow/pipeline_definition_config.py
+++ b/src/sagemaker/workflow/pipeline_definition_config.py
@@ -22,9 +22,9 @@ class PipelineDefinitionConfig:
 
         Examples:
         Use a PipelineDefinitionConfig to specify pipeline specific configurations.
-        We will use this as a feature flag grab bag for creating pipeline definitions.
+        Think of this as a feature flag grab bag for creating pipeline definitions.
 
-            PipelineDefinitionConfig(use_custom_job_prefix=true)
+            PipelineDefinitionConfig(use_custom_job_prefix=True)
 
         Args:
             use_custom_job_prefix (bool): feature flag to toggle on/off custom name prefixing

--- a/src/sagemaker/workflow/pipeline_definition_config.py
+++ b/src/sagemaker/workflow/pipeline_definition_config.py
@@ -18,11 +18,10 @@ class PipelineDefinitionConfig:
     """Pipeline Definition Configuration for SageMaker pipeline."""
 
     def __init__(self, use_custom_job_prefix: bool):
-        """Create a PipelineDefinitionConfig
+        """Create a PipelineDefinitionConfiga
 
         Examples:
         Use a PipelineDefinitionConfig to specify pipeline specific configurations.
-        Think of this as a feature flag grab bag for creating pipeline definitions.
 
             PipelineDefinitionConfig(use_custom_job_prefix=True)
 

--- a/src/sagemaker/workflow/pipeline_definition_config.py
+++ b/src/sagemaker/workflow/pipeline_definition_config.py
@@ -18,15 +18,14 @@ class PipelineDefinitionConfig:
     """Pipeline Definition Configuration for SageMaker pipeline."""
 
     def __init__(self, use_custom_job_prefix: bool):
-        """Create a PipelineDefinitionConfiga
+        """Create a `PipelineDefinitionConfig`.
 
-        Examples:
-        Use a PipelineDefinitionConfig to specify pipeline specific configurations.
+        Examples: Use a `PipelineDefinitionConfig` to turn on custom job prefixing::
 
             PipelineDefinitionConfig(use_custom_job_prefix=True)
 
         Args:
-            use_custom_job_prefix (bool): feature flag to toggle on/off custom name prefixing
-                during pipeline orchestration
+            use_custom_job_prefix (bool): A feature flag to toggle on/off custom name prefixing
+                during pipeline orchestration.
         """
         self.use_custom_job_prefix = use_custom_job_prefix

--- a/src/sagemaker/workflow/pipeline_definition_config.py
+++ b/src/sagemaker/workflow/pipeline_definition_config.py
@@ -1,0 +1,35 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+"""Pipeline experiment config for SageMaker pipeline."""
+from __future__ import absolute_import
+
+
+class PipelineDefinitionConfig:
+    """Pipeline Definition Configuration for SageMaker pipeline."""
+
+    def __init__(self, use_custom_job_prefix: bool):
+        """Create a PipelineDefinitionConfig
+
+        Examples:
+            Use a PipelineDefinitionConfig to specify pipeline specific configurations.
+            We will use this as a feature flag grab bag for creating pipeline definitions.
+
+        Examples:
+        Use feature flag to toggle on using custom job prefixes in a pipeline execution:
+
+            PipelineExperimentConfig(true)
+
+        Args:
+            use_custom_job_prefix (bool): feature flag to toggle on/off custom prefixing in pipeline orchestration
+        """
+        self.use_custom_job_prefix = use_custom_job_prefix

--- a/src/sagemaker/workflow/pipeline_definition_config.py
+++ b/src/sagemaker/workflow/pipeline_definition_config.py
@@ -21,15 +21,13 @@ class PipelineDefinitionConfig:
         """Create a PipelineDefinitionConfig
 
         Examples:
-            Use a PipelineDefinitionConfig to specify pipeline specific configurations.
-            We will use this as a feature flag grab bag for creating pipeline definitions.
+        Use a PipelineDefinitionConfig to specify pipeline specific configurations.
+        We will use this as a feature flag grab bag for creating pipeline definitions.
 
-        Examples:
-        Use feature flag to toggle on using custom job prefixes in a pipeline execution:
-
-            PipelineExperimentConfig(true)
+            PipelineDefinitionConfig(use_custom_job_prefix=true)
 
         Args:
-            use_custom_job_prefix (bool): feature flag to toggle on/off custom prefixing in pipeline orchestration
+            use_custom_job_prefix (bool): feature flag to toggle on/off custom name prefixing
+                during pipeline orchestration
         """
         self.use_custom_job_prefix = use_custom_job_prefix

--- a/src/sagemaker/workflow/quality_check_step.py
+++ b/src/sagemaker/workflow/quality_check_step.py
@@ -31,6 +31,7 @@ from sagemaker.workflow.properties import (
 from sagemaker.workflow.step_collections import StepCollection
 from sagemaker.workflow.steps import Step, StepTypeEnum, CacheConfig
 from sagemaker.workflow.check_job_config import CheckJobConfig
+from sagemaker.workflow.utilities import strip_timestamp_from_job_name
 
 _CONTAINER_BASE_PATH = "/opt/ml/processing"
 _CONTAINER_INPUT_PATH = "input"
@@ -243,6 +244,8 @@ class QualityCheckStep(Step):
         if not _pipeline_config or not _pipeline_config.use_custom_job_prefix:
             if "ProcessingJobName" in request_dict:
                 request_dict.pop("ProcessingJobName")
+        else:
+            request_dict = strip_timestamp_from_job_name(request_dict, job_key="ProcessingJobName")
 
         return request_dict
 

--- a/src/sagemaker/workflow/quality_check_step.py
+++ b/src/sagemaker/workflow/quality_check_step.py
@@ -225,6 +225,8 @@ class QualityCheckStep(Step):
     @property
     def arguments(self) -> RequestType:
         """The arguments dict that is used to define the QualityCheck step."""
+        from sagemaker.workflow.utilities import _pipeline_config
+
         normalized_inputs, normalized_outputs = self._baselining_processor._normalize_args(
             inputs=self._baseline_job_inputs,
             outputs=[self._baseline_output],
@@ -238,8 +240,9 @@ class QualityCheckStep(Step):
         request_dict = self._baselining_processor.sagemaker_session._get_process_request(
             **process_args
         )
-        if "ProcessingJobName" in request_dict:
-            request_dict.pop("ProcessingJobName")
+        if not _pipeline_config or not _pipeline_config.use_custom_job_prefix:
+            if "ProcessingJobName" in request_dict:
+                request_dict.pop("ProcessingJobName")
 
         return request_dict
 

--- a/src/sagemaker/workflow/quality_check_step.py
+++ b/src/sagemaker/workflow/quality_check_step.py
@@ -31,7 +31,7 @@ from sagemaker.workflow.properties import (
 from sagemaker.workflow.step_collections import StepCollection
 from sagemaker.workflow.steps import Step, StepTypeEnum, CacheConfig
 from sagemaker.workflow.check_job_config import CheckJobConfig
-from sagemaker.workflow.utilities import strip_timestamp_from_job_name
+from sagemaker.workflow.utilities import trim_request_dict
 
 _CONTAINER_BASE_PATH = "/opt/ml/processing"
 _CONTAINER_INPUT_PATH = "input"
@@ -241,11 +241,8 @@ class QualityCheckStep(Step):
         request_dict = self._baselining_processor.sagemaker_session._get_process_request(
             **process_args
         )
-        if not _pipeline_config or not _pipeline_config.use_custom_job_prefix:
-            if "ProcessingJobName" in request_dict:
-                request_dict.pop("ProcessingJobName")
-        else:
-            request_dict = strip_timestamp_from_job_name(request_dict, job_key="ProcessingJobName")
+        # Continue to pop job name if not explicitly opted-in via config
+        request_dict = trim_request_dict(request_dict, "ProcessingJobName", _pipeline_config)
 
         return request_dict
 

--- a/src/sagemaker/workflow/steps.py
+++ b/src/sagemaker/workflow/steps.py
@@ -50,7 +50,7 @@ from sagemaker.workflow.properties import (
 from sagemaker.workflow.entities import PipelineVariable
 from sagemaker.workflow.functions import Join, JsonGet
 from sagemaker.workflow.retry import RetryPolicy
-from sagemaker.workflow.utilities import strip_timestamp_from_job_name
+from sagemaker.workflow.utilities import trim_request_dict
 
 if TYPE_CHECKING:
     from sagemaker.workflow.step_collections import StepCollection
@@ -495,11 +495,8 @@ class TrainingStep(ConfigurableRetryStep):
         if "HyperParameters" in request_dict:
             request_dict["HyperParameters"].pop("sagemaker_job_name", None)
 
-        # Continue to pop custom prefix if not explicitly opted-in
-        if not _pipeline_config or not _pipeline_config.use_custom_job_prefix:
-            request_dict.pop("TrainingJobName", None)
-        else:
-            request_dict = strip_timestamp_from_job_name(request_dict, job_key="TrainingJobName")
+        # Continue to pop job name if not explicitly opted-in via config
+        request_dict = trim_request_dict(request_dict, "TrainingJobName", _pipeline_config)
 
         Step._trim_experiment_config(request_dict)
 
@@ -628,11 +625,8 @@ class CreateModelStep(ConfigurableRetryStep):
                     enable_network_isolation=self.model.enable_network_isolation(),
                 )
 
-        # Continue to pop custom prefix if not explicitly opted-in
-        if not _pipeline_config or not _pipeline_config.use_custom_job_prefix:
-            request_dict.pop("ModelName", None)
-        else:
-            request_dict = strip_timestamp_from_job_name(request_dict, job_key="ModelName")
+        # Continue to pop job name if not explicitly opted-in via config
+        request_dict = trim_request_dict(request_dict, "ModelName", _pipeline_config)
 
         return request_dict
 
@@ -746,11 +740,8 @@ class TransformStep(ConfigurableRetryStep):
                 **transform_args
             )
 
-        # Continue to pop custom prefix if not explicitly opted-in
-        if not _pipeline_config or not _pipeline_config.use_custom_job_prefix:
-            request_dict.pop("TransformJobName", None)
-        else:
-            request_dict = strip_timestamp_from_job_name(request_dict, job_key="TransformJobName")
+        # Continue to pop job name if not explicitly opted-in via config
+        request_dict = trim_request_dict(request_dict, "TransformJobName", _pipeline_config)
 
         Step._trim_experiment_config(request_dict)
 
@@ -909,11 +900,8 @@ class ProcessingStep(ConfigurableRetryStep):
             )
             request_dict = self.processor.sagemaker_session._get_process_request(**process_args)
 
-        # Continue to pop custom prefix if not explicitly opted-in
-        if not _pipeline_config or not _pipeline_config.use_custom_job_prefix:
-            request_dict.pop("ProcessingJobName", None)
-        else:
-            request_dict = strip_timestamp_from_job_name(request_dict, job_key="ProcessingJobName")
+        # Continue to pop job name if not explicitly opted-in via config
+        request_dict = trim_request_dict(request_dict, "ProcessingJobName", _pipeline_config)
 
         Step._trim_experiment_config(request_dict)
 
@@ -1072,13 +1060,10 @@ class TuningStep(ConfigurableRetryStep):
             tuner_args = _TuningJob._get_tuner_args(self.tuner, self.inputs)
             request_dict = self.tuner.sagemaker_session._get_tuning_request(**tuner_args)
 
-        # Continue to pop custom prefix if not explicitly opted-in
-        if not _pipeline_config or not _pipeline_config.use_custom_job_prefix:
-            request_dict.pop("HyperParameterTuningJobName", None)
-        else:
-            request_dict = strip_timestamp_from_job_name(
-                request_dict, job_key="HyperParameterTuningJobName"
-            )
+        # Continue to pop job name if not explicitly opted-in via config
+        request_dict = trim_request_dict(
+            request_dict, "HyperParameterTuningJobName", _pipeline_config
+        )
 
         return request_dict
 

--- a/src/sagemaker/workflow/steps.py
+++ b/src/sagemaker/workflow/steps.py
@@ -18,7 +18,6 @@ import warnings
 
 from enum import Enum
 from typing import Dict, List, Set, Union, Optional, Any, TYPE_CHECKING
-import re
 from urllib.parse import urlparse
 
 import attr
@@ -51,6 +50,7 @@ from sagemaker.workflow.properties import (
 from sagemaker.workflow.entities import PipelineVariable
 from sagemaker.workflow.functions import Join, JsonGet
 from sagemaker.workflow.retry import RetryPolicy
+from sagemaker.workflow.utilities import strip_timestamp_from_job_name
 
 if TYPE_CHECKING:
     from sagemaker.workflow.step_collections import StepCollection
@@ -499,12 +499,7 @@ class TrainingStep(ConfigurableRetryStep):
         if not _pipeline_config or not _pipeline_config.use_custom_job_prefix:
             request_dict.pop("TrainingJobName", None)
         else:
-            # Strip timestamp -- workflow will use only the base-job name for name generation
-            if "TrainingJobName" in request_dict.keys():
-                job_name = request_dict["TrainingJobName"]
-                match = re.search("-([0-9]+(-[0-9]+)+)", job_name)
-                if match:
-                    request_dict["TrainingJobName"] = job_name[: match.start()]
+            request_dict = strip_timestamp_from_job_name(request_dict, job_key="TrainingJobName")
 
         Step._trim_experiment_config(request_dict)
 
@@ -637,12 +632,7 @@ class CreateModelStep(ConfigurableRetryStep):
         if not _pipeline_config or not _pipeline_config.use_custom_job_prefix:
             request_dict.pop("ModelName", None)
         else:
-            # Strip timestamp -- workflow will use only the base-job name for name generation
-            if "ModelName" in request_dict.keys():
-                job_name = request_dict["ModelName"]
-                match = re.search("-([0-9]+(-[0-9]+)+)", job_name)
-                if match:
-                    request_dict["ModelName"] = job_name[: match.start()]
+            request_dict = strip_timestamp_from_job_name(request_dict, job_key="ModelName")
 
         return request_dict
 
@@ -756,16 +746,12 @@ class TransformStep(ConfigurableRetryStep):
                 **transform_args
             )
 
-        print(request_dict)
         # Continue to pop custom prefix if not explicitly opted-in
         if not _pipeline_config or not _pipeline_config.use_custom_job_prefix:
             request_dict.pop("TransformJobName", None)
         else:
-            if "TransformJobName" in request_dict.keys():
-                job_name = request_dict["TransformJobName"]
-                match = re.search("-([0-9]+(-[0-9]+)+)", job_name)
-                if match:
-                    request_dict["TransformJobName"] = job_name[: match.start()]
+            request_dict = strip_timestamp_from_job_name(request_dict, job_key="TransformJobName")
+
         Step._trim_experiment_config(request_dict)
 
         return request_dict
@@ -927,12 +913,7 @@ class ProcessingStep(ConfigurableRetryStep):
         if not _pipeline_config or not _pipeline_config.use_custom_job_prefix:
             request_dict.pop("ProcessingJobName", None)
         else:
-            # Strip timestamp -- workflow will use only the base-job name for name generation
-            if "ProcessingJobName" in request_dict.keys():
-                job_name = request_dict["ProcessingJobName"]
-                match = re.search("-([0-9]+(-[0-9]+)+)", job_name)
-                if match:
-                    request_dict["ProcessingJobName"] = job_name[: match.start()]
+            request_dict = strip_timestamp_from_job_name(request_dict, job_key="ProcessingJobName")
 
         Step._trim_experiment_config(request_dict)
 
@@ -1095,12 +1076,9 @@ class TuningStep(ConfigurableRetryStep):
         if not _pipeline_config or not _pipeline_config.use_custom_job_prefix:
             request_dict.pop("HyperParameterTuningJobName", None)
         else:
-            # Strip timestamp -- workflow will use only the base-job name for name generation
-            if "HyperParameterTuningJobName" in request_dict.keys():
-                job_name = request_dict["HyperParameterTuningJobName"]
-                match = re.search("-([0-9]+(-[0-9]+)+)", job_name)
-                if match:
-                    request_dict["HyperParameterTuningJobName"] = job_name[: match.start()]
+            request_dict = strip_timestamp_from_job_name(
+                request_dict, job_key="HyperParameterTuningJobName"
+            )
 
         return request_dict
 

--- a/tests/unit/sagemaker/workflow/helpers.py
+++ b/tests/unit/sagemaker/workflow/helpers.py
@@ -13,8 +13,6 @@
 """Helper methods for testing."""
 from __future__ import absolute_import
 
-import re
-
 from sagemaker.utils import base_from_name
 from sagemaker.workflow.properties import Properties
 from sagemaker.workflow.steps import ConfigurableRetryStep, StepTypeEnum

--- a/tests/unit/sagemaker/workflow/helpers.py
+++ b/tests/unit/sagemaker/workflow/helpers.py
@@ -14,6 +14,8 @@
 from __future__ import absolute_import
 
 import re
+
+from sagemaker.utils import base_from_name
 from sagemaker.workflow.properties import Properties
 from sagemaker.workflow.steps import ConfigurableRetryStep, StepTypeEnum
 from sagemaker.workflow.step_collections import StepCollection
@@ -75,10 +77,7 @@ def get_step_args_helper(step_args, step_type, use_custom_job_prefix=False):
 
 
 def strip_timestamp(job_name):
-    match = re.search(
-        "-([0-9]+(-[0-9]+)+)", job_name
-    )  # pop timestamp so we can simply retrieve the base_job_name
-    return job_name[: match.start()] if match else job_name
+    return base_from_name(job_name)
 
 
 class CustomStep(ConfigurableRetryStep):

--- a/tests/unit/sagemaker/workflow/helpers.py
+++ b/tests/unit/sagemaker/workflow/helpers.py
@@ -13,6 +13,7 @@
 """Helper methods for testing."""
 from __future__ import absolute_import
 
+import re
 from sagemaker.workflow.properties import Properties
 from sagemaker.workflow.steps import ConfigurableRetryStep, StepTypeEnum
 from sagemaker.workflow.step_collections import StepCollection
@@ -38,25 +39,46 @@ def ordered(obj):
         return obj
 
 
-def get_step_args_helper(step_args, step_type):
+def get_step_args_helper(step_args, step_type, use_custom_job_prefix=False):
     execute_job_functions(step_args)
     request_args = step_args.func_args[0].sagemaker_session.context.args
 
     if step_type == "Processing":
-        request_args.pop("ProcessingJobName", None)
+        if not use_custom_job_prefix:
+            request_args.pop("ProcessingJobName", None)
+        else:
+            request_args["ProcessingJobName"] = strip_timestamp(request_args["ProcessingJobName"])
         request_args.pop("ExperimentConfig", None)
     elif step_type == "Training":
         if "HyperParameters" in request_args:
             request_args["HyperParameters"].pop("sagemaker_job_name", None)
-        request_args.pop("TrainingJobName", None)
+        if not use_custom_job_prefix:
+            request_args.pop("TrainingJobName", None)
+        else:
+            request_args["TrainingJobName"] = strip_timestamp(request_args["TrainingJobName"])
         request_args.pop("ExperimentConfig", None)
     elif step_type == "Transform":
-        request_args.pop("TransformJobName", None)
+        if not use_custom_job_prefix:
+            request_args.pop("TransformJobName", None)
+        else:
+            request_args["TransformJobName"] = strip_timestamp(request_args["TransformJobName"])
         request_args.pop("ExperimentConfig", None)
     elif step_type == "HyperParameterTuning":
-        request_args.pop("HyperParameterTuningJobName", None)
+        if not use_custom_job_prefix:
+            request_args.pop("HyperParameterTuningJobName", None)
+        else:
+            request_args["HyperParameterTuningJobName"] = strip_timestamp(
+                request_args["HyperParameterTuningJobName"]
+            )
 
     return request_args
+
+
+def strip_timestamp(job_name):
+    match = re.search(
+        "-([0-9]+(-[0-9]+)+)", job_name
+    )  # pop timestamp so we can simply retrieve the base_job_name
+    return job_name[: match.start()] if match else job_name
 
 
 class CustomStep(ConfigurableRetryStep):

--- a/tests/unit/sagemaker/workflow/test_pipeline_definition_config.py
+++ b/tests/unit/sagemaker/workflow/test_pipeline_definition_config.py
@@ -1,0 +1,27 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+# language governing permissions and limitations under the License.
+from __future__ import absolute_import
+
+from sagemaker.workflow.pipeline import Pipeline
+from sagemaker.workflow.pipeline_definition_config import PipelineDefinitionConfig
+
+
+def test_pipeline_definition_config():
+    config = PipelineDefinitionConfig(use_custom_job_prefix=True)
+    assert config.use_custom_job_prefix is True
+
+
+def test_pipeline_definition_config_not_set():
+    pipeline = Pipeline()
+    assert pipeline.pipeline_definition_config.use_custom_job_prefix is False

--- a/tests/unit/sagemaker/workflow/test_processing_step.py
+++ b/tests/unit/sagemaker/workflow/test_processing_step.py
@@ -1126,7 +1126,7 @@ def test_processor_with_role_as_pipeline_parameter(
 
 
 @patch("sagemaker.workflow.utilities._pipeline_config", MOCKED_PIPELINE_CONFIG_WITH_CUSTOM_PREFIX)
-def test_processing_step_with_custom_job_prefixes(
+def test_processing_step_with_processor_using_custom_job_prefixes(
     pipeline_session, processing_input, network_config
 ):
 

--- a/tests/unit/sagemaker/workflow/test_training_step.py
+++ b/tests/unit/sagemaker/workflow/test_training_step.py
@@ -75,10 +75,16 @@ MOCKED_PIPELINE_CONFIG = _PipelineConfig(
     "MyTrainingStep",
     hash_files_or_dirs([LOCAL_SOURCE_DIR] + LOCAL_DEPS),
     "config-hash-abcdefg",
-    False,
+    None,
 )
+
+_DEFINITION_CONFIG = PipelineDefinitionConfig(use_custom_job_prefix=True)
 MOCKED_PIPELINE_CONFIG_WITH_CUSTOM_PREFIX = _PipelineConfig(
-    "MyPipelineWithCustomPrefix", "MyTrainingStep", None, None, True
+    "MyPipelineWithCustomPrefix",
+    "MyProcessingStep",
+    None,
+    None,
+    _DEFINITION_CONFIG,
 )
 
 ESTIMATOR_LISTS = [

--- a/tests/unit/sagemaker/workflow/test_training_step.py
+++ b/tests/unit/sagemaker/workflow/test_training_step.py
@@ -30,6 +30,7 @@ from sagemaker.workflow.parameters import ParameterString, ParameterBoolean
 
 from sagemaker.workflow.steps import TrainingStep
 from sagemaker.workflow.pipeline import Pipeline, PipelineGraph
+from sagemaker.workflow.pipeline_definition_config import PipelineDefinitionConfig
 from sagemaker.workflow.utilities import hash_files_or_dirs
 from sagemaker.workflow.functions import Join
 
@@ -74,6 +75,10 @@ MOCKED_PIPELINE_CONFIG = _PipelineConfig(
     "MyTrainingStep",
     hash_files_or_dirs([LOCAL_SOURCE_DIR] + LOCAL_DEPS),
     "config-hash-abcdefg",
+    False,
+)
+MOCKED_PIPELINE_CONFIG_WITH_CUSTOM_PREFIX = _PipelineConfig(
+    "MyPipelineWithCustomPrefix", "MyTrainingStep", None, None, True
 )
 
 ESTIMATOR_LISTS = [
@@ -801,3 +806,62 @@ def test_insert_wrong_step_args_into_training_step(inputs, pipeline_session):
         )
 
     assert "The step_args of TrainingStep must be obtained from estimator.fit()" in str(error.value)
+
+
+@patch("sagemaker.workflow.utilities._pipeline_config", MOCKED_PIPELINE_CONFIG_WITH_CUSTOM_PREFIX)
+def test_training_step_with_estimator_using_custom_prefixes(
+    pipeline_session, training_input, hyperparameters
+):
+    entry_point = ParameterString(name="EntryPoint")
+    source_dir = ParameterString(name="SourceDir")
+
+    custom_job_prefix = "TrainingJobPrefix"
+    estimator = Estimator(
+        role=ROLE,
+        instance_count=1,
+        instance_type=INSTANCE_TYPE,
+        sagemaker_session=pipeline_session,
+        image_uri=IMAGE_URI,
+        hyperparameters=hyperparameters,
+        entry_point=entry_point,
+        source_dir=source_dir,
+        base_job_name=custom_job_prefix,  # Include a custom prefix for the job
+    )
+
+    with warnings.catch_warnings(record=True) as w:
+        step_args = estimator.fit(inputs=training_input)
+        assert len(w) == 1
+        assert issubclass(w[-1].category, UserWarning)
+        assert "Running within a PipelineSession" in str(w[-1].message)
+
+    with warnings.catch_warnings(record=True) as w:
+        step = TrainingStep(
+            name="MyTrainingStep",
+            step_args=step_args,
+            description="TrainingStep description",
+            display_name="MyTrainingStep",
+        )
+        assert len(w) == 0
+
+    # Toggle the custom prefixing feature ON for this pipeline
+    definition_config = PipelineDefinitionConfig(use_custom_job_prefix=True)
+
+    pipeline = Pipeline(
+        name="MyPipeline",
+        steps=[step],
+        sagemaker_session=pipeline_session,
+        pipeline_definition_config=definition_config,
+    )
+    step_args = get_step_args_helper(step_args, "Training", True)
+    step_args["HyperParameters"]["sagemaker_program"] = {"Get": "Parameters.EntryPoint"}
+    step_args["HyperParameters"]["sagemaker_submit_directory"] = {"Get": "Parameters.SourceDir"}
+    step_def = json.loads(pipeline.definition())["Steps"][0]
+
+    assert step_def["Arguments"]["TrainingJobName"] == "TrainingJobPrefix"
+    assert step_def == {
+        "Name": "MyTrainingStep",
+        "Description": "TrainingStep description",
+        "DisplayName": "MyTrainingStep",
+        "Type": "Training",
+        "Arguments": step_args,
+    }

--- a/tests/unit/sagemaker/workflow/test_utilities.py
+++ b/tests/unit/sagemaker/workflow/test_utilities.py
@@ -14,11 +14,10 @@
 from __future__ import absolute_import
 
 import tempfile
-from sagemaker.workflow.utilities import (
-    hash_file,
-    hash_files_or_dirs,
-    strip_timestamp_from_job_name,
-)
+
+from sagemaker.workflow.pipeline_context import _PipelineConfig
+from sagemaker.workflow.pipeline_definition_config import PipelineDefinitionConfig
+from sagemaker.workflow.utilities import hash_file, hash_files_or_dirs, trim_request_dict
 from pathlib import Path
 
 
@@ -103,26 +102,33 @@ def test_hash_files_or_dirs_unsorted_input_list():
             assert hash1 == hash2
 
 
-def test_strip_timestamp_from_job_name():
+def test_trim_request_dict():
+    config = PipelineDefinitionConfig(use_custom_job_prefix=True)
+    _pipeline_config = _PipelineConfig(
+        pipeline_name="test",
+        step_name="test-step",
+        code_hash="123467890",
+        config_hash="123467890",
+        pipeline_definition_config=config,
+    )
     custom_job_prefix = "MyTrainingJobNamePrefix"
     sample_training_job_name = f"{custom_job_prefix}-2023-06-22-23-39-36-766"
     request_dict = {"TrainingJobName": sample_training_job_name}
     assert (
         custom_job_prefix
-        == strip_timestamp_from_job_name(request_dict=request_dict, job_key="TrainingJobName")[
-            "TrainingJobName"
-        ]
+        == trim_request_dict(
+            request_dict=request_dict, job_key="TrainingJobName", config=_pipeline_config
+        )["TrainingJobName"]
     )
     request_dict = {"TrainingJobName": custom_job_prefix}
     assert (
         custom_job_prefix
-        == strip_timestamp_from_job_name(request_dict=request_dict, job_key="TrainingJobName")[
-            "TrainingJobName"
-        ]
+        == trim_request_dict(
+            request_dict=request_dict, job_key="TrainingJobName", config=_pipeline_config
+        )["TrainingJobName"]
     )
-    request_dict = {
-        "NotSupportedJobName": custom_job_prefix
-    }  # do nothing in the case our jobKey is invalid
-    assert request_dict == strip_timestamp_from_job_name(
-        request_dict=request_dict, job_key="NotSupportedJobName"
+    request_dict = {"NotSupportedJobName": custom_job_prefix}
+    # noop in the case our job_key is invalid
+    assert request_dict == trim_request_dict(
+        request_dict=request_dict, job_key="NotSupportedJobName", config=_pipeline_config
     )

--- a/tests/unit/sagemaker/workflow/test_utilities.py
+++ b/tests/unit/sagemaker/workflow/test_utilities.py
@@ -14,7 +14,11 @@
 from __future__ import absolute_import
 
 import tempfile
-from sagemaker.workflow.utilities import hash_file, hash_files_or_dirs
+from sagemaker.workflow.utilities import (
+    hash_file,
+    hash_files_or_dirs,
+    strip_timestamp_from_job_name,
+)
 from pathlib import Path
 
 
@@ -97,3 +101,28 @@ def test_hash_files_or_dirs_unsorted_input_list():
             hash1 = hash_files_or_dirs([tmp1.name, tmp2.name])
             hash2 = hash_files_or_dirs([tmp2.name, tmp1.name])
             assert hash1 == hash2
+
+
+def test_strip_timestamp_from_job_name():
+    custom_job_prefix = "MyTrainingJobNamePrefix"
+    sample_training_job_name = f"{custom_job_prefix}-2023-06-22-23-39-36-766"
+    request_dict = {"TrainingJobName": sample_training_job_name}
+    assert (
+        custom_job_prefix
+        == strip_timestamp_from_job_name(request_dict=request_dict, job_key="TrainingJobName")[
+            "TrainingJobName"
+        ]
+    )
+    request_dict = {"TrainingJobName": custom_job_prefix}
+    assert (
+        custom_job_prefix
+        == strip_timestamp_from_job_name(request_dict=request_dict, job_key="TrainingJobName")[
+            "TrainingJobName"
+        ]
+    )
+    request_dict = {
+        "NotSupportedJobName": custom_job_prefix
+    }  # do nothing in the case our jobKey is invalid
+    assert request_dict == strip_timestamp_from_job_name(
+        request_dict=request_dict, job_key="NotSupportedJobName"
+    )

--- a/tests/unit/test_estimator.py
+++ b/tests/unit/test_estimator.py
@@ -58,6 +58,7 @@ from sagemaker.transformer import Transformer
 from sagemaker.workflow.execution_variables import ExecutionVariable
 from sagemaker.workflow.parameters import ParameterString, ParameterBoolean
 from sagemaker.workflow.pipeline_context import PipelineSession, _PipelineConfig
+from sagemaker.workflow.pipeline_definition_config import PipelineDefinitionConfig
 from sagemaker.xgboost.estimator import XGBoost
 from tests.unit import (
     SAGEMAKER_CONFIG_TRAINING_JOB,
@@ -154,8 +155,13 @@ DISTRIBUTION_SM_DDP_ENABLED = {
     "smdistributed": {"dataparallel": {"enabled": True, "custom_mpi_options": "options"}}
 }
 MOCKED_S3_URI = "s3://mocked_s3_uri_from_source_dir"
+_DEFINITION_CONFIG = PipelineDefinitionConfig(use_custom_job_prefix=False)
 MOCKED_PIPELINE_CONFIG = _PipelineConfig(
-    "test-pipeline", "test-training-step", "code-hash-0123456789", "config-hash-0123456789", False
+    "test-pipeline",
+    "test-training-step",
+    "code-hash-0123456789",
+    "config-hash-0123456789",
+    _DEFINITION_CONFIG,
 )
 
 

--- a/tests/unit/test_estimator.py
+++ b/tests/unit/test_estimator.py
@@ -155,7 +155,7 @@ DISTRIBUTION_SM_DDP_ENABLED = {
 }
 MOCKED_S3_URI = "s3://mocked_s3_uri_from_source_dir"
 MOCKED_PIPELINE_CONFIG = _PipelineConfig(
-    "test-pipeline", "test-training-step", "code-hash-0123456789", "config-hash-0123456789"
+    "test-pipeline", "test-training-step", "code-hash-0123456789", "config-hash-0123456789", False
 )
 
 

--- a/tests/unit/test_processing.py
+++ b/tests/unit/test_processing.py
@@ -37,6 +37,7 @@ from sagemaker.spark.processing import PySparkProcessor
 from sagemaker.sklearn.processing import SKLearnProcessor
 from sagemaker.pytorch.processing import PyTorchProcessor
 from sagemaker.tensorflow.processing import TensorFlowProcessor
+from sagemaker.workflow.pipeline_definition_config import PipelineDefinitionConfig
 from sagemaker.xgboost.processing import XGBoostProcessor
 from sagemaker.mxnet.processing import MXNetProcessor
 from sagemaker.network import NetworkConfig
@@ -53,8 +54,13 @@ ROLE = "arn:aws:iam::012345678901:role/SageMakerRole"
 ECR_HOSTNAME = "ecr.us-west-2.amazonaws.com"
 CUSTOM_IMAGE_URI = "012345678901.dkr.ecr.us-west-2.amazonaws.com/my-custom-image-uri"
 MOCKED_S3_URI = "s3://mocked_s3_uri_from_upload_data"
+_DEFINITION_CONFIG = PipelineDefinitionConfig(use_custom_job_prefix=False)
 MOCKED_PIPELINE_CONFIG = _PipelineConfig(
-    "test-pipeline", "test-processing-step", "code-hash-abcdefg", "config-hash-abcdefg", False
+    "test-pipeline",
+    "test-processing-step",
+    "code-hash-abcdefg",
+    "config-hash-abcdefg",
+    _DEFINITION_CONFIG,
 )
 
 

--- a/tests/unit/test_processing.py
+++ b/tests/unit/test_processing.py
@@ -54,7 +54,7 @@ ECR_HOSTNAME = "ecr.us-west-2.amazonaws.com"
 CUSTOM_IMAGE_URI = "012345678901.dkr.ecr.us-west-2.amazonaws.com/my-custom-image-uri"
 MOCKED_S3_URI = "s3://mocked_s3_uri_from_upload_data"
 MOCKED_PIPELINE_CONFIG = _PipelineConfig(
-    "test-pipeline", "test-processing-step", "code-hash-abcdefg", "config-hash-abcdefg"
+    "test-pipeline", "test-processing-step", "code-hash-abcdefg", "config-hash-abcdefg", False
 )
 
 

--- a/tests/unit/test_transformer.py
+++ b/tests/unit/test_transformer.py
@@ -19,6 +19,7 @@ from sagemaker.session_settings import SessionSettings
 from sagemaker.transformer import _TransformJob, Transformer
 from sagemaker.workflow.pipeline_context import PipelineSession, _PipelineConfig
 from sagemaker.inputs import BatchDataCaptureConfig
+from sagemaker.workflow.pipeline_definition_config import PipelineDefinitionConfig
 
 from tests.integ import test_local_mode
 from tests.unit import SAGEMAKER_CONFIG_TRANSFORM_JOB
@@ -52,8 +53,13 @@ MODEL_DESC_PRIMARY_CONTAINER = {"PrimaryContainer": {"Image": IMAGE_URI}}
 
 MODEL_DESC_CONTAINERS_ONLY = {"Containers": [{"Image": IMAGE_URI}]}
 
+_DEFINITION_CONFIG = PipelineDefinitionConfig(use_custom_job_prefix=False)
 MOCKED_PIPELINE_CONFIG = _PipelineConfig(
-    "test-pipeline", "test-training-step", "code-hash-0123456789", "config-hash-0123456789", False
+    "test-pipeline",
+    "test-training-step",
+    "code-hash-0123456789",
+    "config-hash-0123456789",
+    _DEFINITION_CONFIG,
 )
 
 

--- a/tests/unit/test_transformer.py
+++ b/tests/unit/test_transformer.py
@@ -53,7 +53,7 @@ MODEL_DESC_PRIMARY_CONTAINER = {"PrimaryContainer": {"Image": IMAGE_URI}}
 MODEL_DESC_CONTAINERS_ONLY = {"Containers": [{"Image": IMAGE_URI}]}
 
 MOCKED_PIPELINE_CONFIG = _PipelineConfig(
-    "test-pipeline", "test-training-step", "code-hash-0123456789", "config-hash-0123456789"
+    "test-pipeline", "test-training-step", "code-hash-0123456789", "config-hash-0123456789", False
 )
 
 


### PR DESCRIPTION
…prefixing in job-names generated via pipeline executions

*Issue #, if available:*

Currently, we drop the respective job_names from each of the instance types when set via `base_job_name` in an Estimator/Processor/etc. There has been a feature request to persist these names from the SDK such that they can be used during pipeline orchestration to generate the job-name using that field as a prefix.
 
We will  call this a `custom job prefix`, such that now when a pipeline is created and started, the respective pipeline definition will have that job's name as apart of the step_arguments. Persisting that field in the `.definition()` allows pipeline orchestration to consume that new field and use it to build against a new template.

```
<baseJobName>-<executionId>-<entityToken>-<failureCount>
```

*Description of changes:*
- add new PipelineDefinitionConfig class w/ new `use_custom_job_prefixes` feature flag toggle 
- persist default config in `Pipeline()` constructor
- trim timestamp off job names persisted from job classes of the form `-2023-06-22-23-39-36-766` to ensure we get the raw data (only the base_job_name) to be used during name generation in our backend.
  - `arn::trainingjob/mytrainingjobprefix-2023-06-22-23-39-36-766`

*Sample step_def* 
```
{
    'Name': 'MyTransformStep',
    'Type': 'Transform',
    'Arguments': {
        'TransformJobName': 'TestTransformJobPrefix',    <<<<<<<<<< Now persistent in opt-in cases (use_custom_job_prefix=True)
        'ModelName': {
            'Get': 'Parameters.ModelName'
        }
.
.
.
    }
}
```

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
