### PR TITLE
feat: SDK Defaults - DebugHookConfig defaults in TrainingJob API

### DIFF
--- a/src/sagemaker/config/__init__.py
+++ b/src/sagemaker/config/__init__.py
@@ -17,6 +17,7 @@ from sagemaker.config.config import load_sagemaker_config, validate_sagemaker_co
 from sagemaker.config.config_schema import (  # noqa: F401
     KEY,
     TRAINING_JOB,
+    ESTIMATOR_DEBUG_HOOK_CONFIG_PATH,
     TRAINING_JOB_INTER_CONTAINER_ENCRYPTION_PATH,
     TRAINING_JOB_ROLE_ARN_PATH,
     TRAINING_JOB_ENABLE_NETWORK_ISOLATION_PATH,
@@ -158,4 +159,6 @@ from sagemaker.config.config_schema import (  # noqa: F401
     CONTAINERS,
     PRIMARY_CONTAINER,
     INFERENCE_SPECIFICATION,
+    ESTIMATOR,
+    DEBUG_HOOK_CONFIG,
 )

--- a/src/sagemaker/config/config_schema.py
+++ b/src/sagemaker/config/config_schema.py
@@ -100,6 +100,8 @@ PRIMARY_CONTAINER = "PrimaryContainer"
 INFERENCE_SPECIFICATION = "InferenceSpecification"
 PROFILER_CONFIG = "ProfilerConfig"
 DISABLE_PROFILER = "DisableProfiler"
+ESTIMATOR = "Estimator"
+DEBUG_HOOK_CONFIG = "DebugHookConfig"
 
 
 def _simple_path(*args: str):
@@ -337,6 +339,9 @@ SESSION_DEFAULT_S3_BUCKET_PATH = _simple_path(
 )
 SESSION_DEFAULT_S3_OBJECT_KEY_PREFIX_PATH = _simple_path(
     SAGEMAKER, PYTHON_SDK, MODULES, SESSION, DEFAULT_S3_OBJECT_KEY_PREFIX
+)
+ESTIMATOR_DEBUG_HOOK_CONFIG_PATH = _simple_path(
+    SAGEMAKER, PYTHON_SDK, MODULES, ESTIMATOR, DEBUG_HOOK_CONFIG
 )
 
 
@@ -642,6 +647,24 @@ SAGEMAKER_PYTHON_SDK_CONFIG_SCHEMA = {
                                             # (even though S3 allows multiple "/" in a row)
                                             "minLength": 1,
                                             "maxLength": 1024,
+                                        },
+                                    },
+                                },
+                                ESTIMATOR: {
+                                    TYPE: OBJECT,
+                                    ADDITIONAL_PROPERTIES: False,
+                                    PROPERTIES: {
+                                        DEBUG_HOOK_CONFIG: {
+                                            TYPE: "boolean",
+                                            "description": (
+                                                "Sets a boolean for `debugger_hook_config` of"
+                                                "Estimator which will be then used for training job"
+                                                "API call. As of today, config_schema does not"
+                                                "support the dict as a valid value to be provided."
+                                                "In case, we decide to support it in the future,"
+                                                "we can add a new schema for it under"
+                                                "`SageMaker.TrainingJob` config path."
+                                            ),
                                         },
                                     },
                                 },
@@ -990,6 +1013,11 @@ SAGEMAKER_PYTHON_SDK_CONFIG_SCHEMA = {
                 },
                 # Training Job
                 # https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_CreateTrainingJob.html
+                # Please note that we currently support 'DebugHookConfig' as a boolean value
+                # which can be provided under [SageMaker.PythonSDK.Modules.Estimator] config path.
+                # As of today, config_schema does not support the dict as a valid value to be
+                # provided. In case, we decide to support it in the future, we can add a new schema
+                # for it under [SageMaker.TrainingJob] config path.
                 TRAINING_JOB: {
                     TYPE: OBJECT,
                     ADDITIONAL_PROPERTIES: False,

--- a/src/sagemaker/config/config_schema.py
+++ b/src/sagemaker/config/config_schema.py
@@ -659,11 +659,14 @@ SAGEMAKER_PYTHON_SDK_CONFIG_SCHEMA = {
                                             "description": (
                                                 "Sets a boolean for `debugger_hook_config` of"
                                                 "Estimator which will be then used for training job"
-                                                "API call. As of today, config_schema does not"
-                                                "support the dict as a valid value to be provided."
-                                                "In case, we decide to support it in the future,"
-                                                "we can add a new schema for it under"
-                                                "`SageMaker.TrainingJob` config path."
+                                                "API call. Today, the config_schema doesn't support"
+                                                "a dictionary as a valid value to be provided."
+                                                "In the future to add support for DebugHookConfig"
+                                                "as a dictionary, schema should be added under"
+                                                "the config path `SageMaker.TrainingJob` instead of"
+                                                "here, since the TrainingJob API supports"
+                                                "DebugHookConfig as a dictionary, we can add"
+                                                "a schema for it at API level."
                                             ),
                                         },
                                     },

--- a/src/sagemaker/estimator.py
+++ b/src/sagemaker/estimator.py
@@ -30,6 +30,7 @@ import sagemaker
 from sagemaker import git_utils, image_uris, vpc_utils, s3
 from sagemaker.analytics import TrainingJobAnalytics
 from sagemaker.config import (
+    ESTIMATOR_DEBUG_HOOK_CONFIG_PATH,
     TRAINING_JOB_VOLUME_KMS_KEY_ID_PATH,
     TRAINING_JOB_SECURITY_GROUP_IDS_PATH,
     TRAINING_JOB_SUBNETS_PATH,
@@ -675,7 +676,18 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):  # pylint: disable=too-man
         self.checkpoint_local_path = checkpoint_local_path
 
         self.rules = rules
-        self.debugger_hook_config = debugger_hook_config
+
+        self.debugger_hook_config = resolve_value_from_config(
+            direct_input=debugger_hook_config,
+            config_path=ESTIMATOR_DEBUG_HOOK_CONFIG_PATH,
+            sagemaker_session=sagemaker_session,
+        )
+        # If customer passes True from either direct_input or sagemaker_config, we will
+        # create a default hook config as an empty dict which will later be populated
+        # with default s3_output_path from _prepare_debugger_for_training function
+        if self.debugger_hook_config is True:
+            self.debugger_hook_config = {}
+
         self.tensorboard_output_config = tensorboard_output_config
 
         self.debugger_rule_configs = None

--- a/src/sagemaker/estimator.py
+++ b/src/sagemaker/estimator.py
@@ -677,6 +677,14 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):  # pylint: disable=too-man
 
         self.rules = rules
 
+        # Today, we ONLY support debugger_hook_config to be provided as a boolean value
+        # from sagemaker_config. We resolve value for this parameter as per the order
+        # 1. value from direct_input which can be a boolean or a dictionary
+        # 2. value from sagemaker_config which can be a boolean
+        # In future, if we support debugger_hook_config to be provided as a dictionary
+        # from sagemaker_config [SageMaker.TrainingJob] then we will need to update the
+        # logic below to resolve the values as per the type of value received from
+        # direct_input and sagemaker_config
         self.debugger_hook_config = resolve_value_from_config(
             direct_input=debugger_hook_config,
             config_path=ESTIMATOR_DEBUG_HOOK_CONFIG_PATH,

--- a/tests/data/config/config.yaml
+++ b/tests/data/config/config.yaml
@@ -5,6 +5,8 @@ SageMaker:
       Session:
         DefaultS3Bucket: 'sagemaker-python-sdk-test-bucket'
         DefaultS3ObjectKeyPrefix: 'test-prefix'
+      Estimator:
+        DebugHookConfig: false
       RemoteFunction:
         Dependencies: "./requirements.txt"
         EnvironmentVariables:

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -85,6 +85,8 @@ from sagemaker.config import (
     CONTAINERS,
     PRIMARY_CONTAINER,
     INFERENCE_SPECIFICATION,
+    ESTIMATOR,
+    DEBUG_HOOK_CONFIG,
 )
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), "..", "data")
@@ -323,6 +325,13 @@ SAGEMAKER_CONFIG_PROCESSING_JOB = {
 SAGEMAKER_CONFIG_TRAINING_JOB = {
     SCHEMA_VERSION: "1.0",
     SAGEMAKER: {
+        PYTHON_SDK: {
+            MODULES: {
+                ESTIMATOR: {
+                    DEBUG_HOOK_CONFIG: False,
+                },
+            },
+        },
         TRAINING_JOB: {
             ENABLE_INTER_CONTAINER_TRAFFIC_ENCRYPTION: True,
             ENABLE_NETWORK_ISOLATION: True,

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -346,6 +346,32 @@ SAGEMAKER_CONFIG_TRAINING_JOB = {
     },
 }
 
+SAGEMAKER_CONFIG_TRAINING_JOB_WITH_DEBUG_HOOK_CONFIG_AS_FALSE = {
+    SCHEMA_VERSION: "1.0",
+    SAGEMAKER: {
+        PYTHON_SDK: {
+            MODULES: {
+                ESTIMATOR: {
+                    DEBUG_HOOK_CONFIG: False,
+                },
+            },
+        },
+    },
+}
+
+SAGEMAKER_CONFIG_TRAINING_JOB_WITH_DEBUG_HOOK_CONFIG_AS_TRUE = {
+    SCHEMA_VERSION: "1.0",
+    SAGEMAKER: {
+        PYTHON_SDK: {
+            MODULES: {
+                ESTIMATOR: {
+                    DEBUG_HOOK_CONFIG: True,
+                },
+            },
+        },
+    },
+}
+
 SAGEMAKER_CONFIG_TRANSFORM_JOB = {
     SCHEMA_VERSION: "1.0",
     SAGEMAKER: {

--- a/tests/unit/sagemaker/config/conftest.py
+++ b/tests/unit/sagemaker/config/conftest.py
@@ -46,6 +46,13 @@ def valid_session_config():
 
 
 @pytest.fixture()
+def valid_estimator_config():
+    return {
+        "DebugHookConfig": False,
+    }
+
+
+@pytest.fixture()
 def valid_environment_config():
     return {
         "var1": "value1",
@@ -251,10 +258,12 @@ def valid_config_with_all_the_scopes(
     valid_training_job_config,
     valid_edge_packaging_config,
     valid_remote_function_config,
+    valid_estimator_config,
 ):
     return {
         "PythonSDK": {
             "Modules": {
+                "Estimator": valid_estimator_config,
                 "RemoteFunction": valid_remote_function_config,
                 "Session": valid_session_config,
             }

--- a/tests/unit/sagemaker/config/test_config_schema.py
+++ b/tests/unit/sagemaker/config/test_config_schema.py
@@ -102,6 +102,13 @@ def test_valid_remote_function_schema(base_config_with_schema, valid_remote_func
     )
 
 
+def test_valid_estimator_schema(base_config_with_schema, valid_estimator_config):
+    _validate_config(
+        base_config_with_schema,
+        {"PythonSDK": {"Modules": {"Estimator": valid_estimator_config}}},
+    )
+
+
 def test_tags_with_invalid_schema(base_config_with_schema, valid_edge_packaging_config):
     edge_packaging_config = valid_edge_packaging_config.copy()
     edge_packaging_config["Tags"] = [{"Key": "somekey"}]

--- a/tests/unit/sagemaker/config/test_config_schema.py
+++ b/tests/unit/sagemaker/config/test_config_schema.py
@@ -109,6 +109,18 @@ def test_valid_estimator_schema(base_config_with_schema, valid_estimator_config)
     )
 
 
+def test_invalid_estimator_schema(base_config_with_schema, valid_estimator_config):
+    invalid_estimator_config = {
+        "DebugHookConfig": {
+            "S3OutputPath": "s3://somepath",
+        }
+    }
+    config = base_config_with_schema
+    config["SageMaker"] = {"PythonSDK": {"Modules": {"Estimator": invalid_estimator_config}}}
+    with pytest.raises(exceptions.ValidationError):
+        validate(config, SAGEMAKER_PYTHON_SDK_CONFIG_SCHEMA)
+
+
 def test_tags_with_invalid_schema(base_config_with_schema, valid_edge_packaging_config):
     edge_packaging_config = valid_edge_packaging_config.copy()
     edge_packaging_config["Tags"] = [{"Key": "somekey"}]

--- a/tests/unit/test_estimator.py
+++ b/tests/unit/test_estimator.py
@@ -159,6 +159,9 @@ MOCKED_S3_URI = "s3://mocked_s3_uri_from_source_dir"
 MOCKED_PIPELINE_CONFIG = _PipelineConfig(
     "test-pipeline", "test-training-step", "code-hash-0123456789", "config-hash-0123456789"
 )
+HOOK_CONFIG = DebuggerHookConfig(
+    hook_parameters={"save_interval": "1"},
+)
 
 
 class DummyFramework(Framework):
@@ -410,6 +413,9 @@ def test_framework_initialization_with_sagemaker_config_injection(sagemaker_sess
     expected_disable_profiler_attribute = SAGEMAKER_CONFIG_TRAINING_JOB["SageMaker"]["TrainingJob"][
         "ProfilerConfig"
     ]["DisableProfiler"]
+    expected_debugger_hook_config = SAGEMAKER_CONFIG_TRAINING_JOB["SageMaker"]["PythonSDK"][
+        "Modules"
+    ]["Estimator"]["DebugHookConfig"]
     assert framework.role == expected_role_arn
     assert framework.enable_network_isolation() == expected_enable_network_isolation
     assert (
@@ -422,10 +428,14 @@ def test_framework_initialization_with_sagemaker_config_injection(sagemaker_sess
     assert framework.subnets == expected_subnets
     assert framework.environment == expected_environment
     assert framework.disable_profiler == expected_disable_profiler_attribute
+    assert framework.debugger_hook_config == expected_debugger_hook_config
 
 
 def test_estimator_initialization_with_sagemaker_config_injection(sagemaker_session):
-
+    """
+    Tests that the estimator initialization works when all the supported defaults config params "
+    are provided from the sagemaker_config
+    """
     sagemaker_session.sagemaker_config = SAGEMAKER_CONFIG_TRAINING_JOB
 
     estimator = Estimator(
@@ -460,6 +470,9 @@ def test_estimator_initialization_with_sagemaker_config_injection(sagemaker_sess
     expected_disable_profiler_attribute = SAGEMAKER_CONFIG_TRAINING_JOB["SageMaker"]["TrainingJob"][
         "ProfilerConfig"
     ]["DisableProfiler"]
+    expected_debugger_hook_config = SAGEMAKER_CONFIG_TRAINING_JOB["SageMaker"]["PythonSDK"][
+        "Modules"
+    ]["Estimator"]["DebugHookConfig"]
     assert estimator.role == expected_role_arn
     assert estimator.enable_network_isolation() == expected_enable_network_isolation
     assert (
@@ -472,6 +485,50 @@ def test_estimator_initialization_with_sagemaker_config_injection(sagemaker_sess
     assert estimator.subnets == expected_subnets
     assert estimator.environment == expected_environment
     assert estimator.disable_profiler == expected_disable_profiler_attribute
+    assert estimator.debugger_hook_config == expected_debugger_hook_config
+
+
+def test_estimator_with_debugger_hook_config_provided_as_bool_from_direct_input(
+    sagemaker_session,
+):
+    """
+    Tests that the estimator initialization works correctly with sagemaker_config injection
+    when debugger_hook_config is provided as True from direct input
+    """
+    sagemaker_session.sagemaker_config = SAGEMAKER_CONFIG_TRAINING_JOB
+
+    estimator = Estimator(
+        image_uri="some-image",
+        instance_groups=[
+            InstanceGroup("group1", "ml.c4.xlarge", 1),
+            InstanceGroup("group2", "ml.p3.16xlarge", 2),
+        ],
+        sagemaker_session=sagemaker_session,
+        base_job_name="base_job_name",
+        debugger_hook_config=True,
+    )
+    assert estimator.debugger_hook_config == {}
+
+
+def test_estimator_with_debugger_hook_config_provided_as_dict_from_direct_input(
+    sagemaker_session,
+):
+    """
+    Tests that the estimator initialization works correctly with sagemaker_config injection
+    when debugger_hook_config is provided as dict from direct input
+    """
+    sagemaker_session.sagemaker_config = SAGEMAKER_CONFIG_TRAINING_JOB
+    estimator = Estimator(
+        image_uri="some-image",
+        instance_groups=[
+            InstanceGroup("group1", "ml.c4.xlarge", 1),
+            InstanceGroup("group2", "ml.p3.16xlarge", 2),
+        ],
+        sagemaker_session=sagemaker_session,
+        base_job_name="base_job_name",
+        debugger_hook_config=HOOK_CONFIG,
+    )
+    assert estimator.debugger_hook_config == HOOK_CONFIG
 
 
 def test_estimator_initialization_with_sagemaker_config_injection_no_kms_supported(
@@ -509,6 +566,9 @@ def test_estimator_initialization_with_sagemaker_config_injection_no_kms_support
     expected_disable_profiler_attribute = SAGEMAKER_CONFIG_TRAINING_JOB["SageMaker"]["TrainingJob"][
         "ProfilerConfig"
     ]["DisableProfiler"]
+    expected_debugger_hook_config = SAGEMAKER_CONFIG_TRAINING_JOB["SageMaker"]["PythonSDK"][
+        "Modules"
+    ]["Estimator"]["DebugHookConfig"]
     assert estimator.role == expected_role_arn
     assert estimator.enable_network_isolation() == expected_enable_network_isolation
     assert (
@@ -520,6 +580,7 @@ def test_estimator_initialization_with_sagemaker_config_injection_no_kms_support
     assert estimator.security_group_ids == expected_security_groups
     assert estimator.subnets == expected_subnets
     assert estimator.disable_profiler == expected_disable_profiler_attribute
+    assert estimator.debugger_hook_config == expected_debugger_hook_config
 
 
 def test_estimator_initialization_with_sagemaker_config_injection_partial_kms_support(
@@ -560,6 +621,9 @@ def test_estimator_initialization_with_sagemaker_config_injection_partial_kms_su
     expected_disable_profiler_attribute = SAGEMAKER_CONFIG_TRAINING_JOB["SageMaker"]["TrainingJob"][
         "ProfilerConfig"
     ]["DisableProfiler"]
+    expected_debugger_hook_config = SAGEMAKER_CONFIG_TRAINING_JOB["SageMaker"]["PythonSDK"][
+        "Modules"
+    ]["Estimator"]["DebugHookConfig"]
     assert estimator.role == expected_role_arn
     assert estimator.enable_network_isolation() == expected_enable_network_isolation
     assert (
@@ -571,6 +635,7 @@ def test_estimator_initialization_with_sagemaker_config_injection_partial_kms_su
     assert estimator.security_group_ids == expected_security_groups
     assert estimator.subnets == expected_subnets
     assert estimator.disable_profiler == expected_disable_profiler_attribute
+    assert estimator.debugger_hook_config == expected_debugger_hook_config
 
 
 def test_framework_with_heterogeneous_cluster(sagemaker_session):
@@ -2152,6 +2217,74 @@ def test_fit_verify_job_name(strftime, sagemaker_session):
     assert train_kwargs["job_name"] == JOB_NAME
     assert train_kwargs["encrypt_inter_container_traffic"] is True
     assert fw.latest_training_job.name == JOB_NAME
+
+
+def test_prepare_for_training_with_sagemaker_config_injection_for_partial_debug_hook_config_provided_from_direct_input(
+    sagemaker_session,
+):
+    """
+    Tests that the default_bucket from sagemaker_config is injected into the debugger_hook_config.s3_output_path
+    when only partial debugger_hook_config is provided from direct input
+    """
+    sagemaker_session.sagemaker_config = SAGEMAKER_CONFIG_TRAINING_JOB
+    fw = DummyFramework(
+        entry_point=SCRIPT_PATH,
+        role=ROLE,
+        sagemaker_session=sagemaker_session,
+        instance_count=INSTANCE_COUNT,
+        instance_type=INSTANCE_TYPE,
+        debugger_hook_config=HOOK_CONFIG,
+    )
+    fw._prepare_for_training()
+    assert fw.debugger_hook_config.hook_parameters == HOOK_CONFIG.hook_parameters
+    assert fw.debugger_hook_config.s3_output_path == f"s3://{sagemaker_session.default_bucket()}/"
+
+
+def test_prepare_for_training_with_sagemaker_config_injection_for_full_debug_hook_config_provided_from_direct_input(
+    sagemaker_session,
+):
+    """
+    Tests that the default_bucket from sagemaker_config is NOT injected into the debugger_hook_config.s3_output_path
+    when full debugger_hook_config is provided from direct input
+    """
+    sagemaker_session.sagemaker_config = SAGEMAKER_CONFIG_TRAINING_JOB
+    debugger_hook_config_input = DebuggerHookConfig(
+        hook_parameters={
+            "save_interval": "100",
+        },
+        s3_output_path="s3://mytestbucket/testpath/",
+    )
+    fw = DummyFramework(
+        entry_point=SCRIPT_PATH,
+        role=ROLE,
+        sagemaker_session=sagemaker_session,
+        instance_count=INSTANCE_COUNT,
+        instance_type=INSTANCE_TYPE,
+        debugger_hook_config=debugger_hook_config_input,
+    )
+    fw._prepare_for_training()
+    assert fw.debugger_hook_config.hook_parameters == debugger_hook_config_input.hook_parameters
+    assert fw.debugger_hook_config.s3_output_path == debugger_hook_config_input.s3_output_path
+
+
+def test_prepare_for_training_with_sagemaker_config_injection_for_debug_hook_config_provided_from_direct_input_as_true(
+    sagemaker_session,
+):
+    """
+    Tests that the default_bucket from sagemaker_config is injected into the debugger_hook_config.s3_output_path
+    when debugger_hook_config is provided from direct input as True
+    """
+    sagemaker_session.sagemaker_config = SAGEMAKER_CONFIG_TRAINING_JOB
+    fw = DummyFramework(
+        entry_point=SCRIPT_PATH,
+        role=ROLE,
+        sagemaker_session=sagemaker_session,
+        instance_count=INSTANCE_COUNT,
+        instance_type=INSTANCE_TYPE,
+        debugger_hook_config=True,
+    )
+    fw._prepare_for_training()
+    assert fw.debugger_hook_config.s3_output_path == f"s3://{sagemaker_session.default_bucket()}/"
 
 
 def test_prepare_for_training_unique_job_name_generation(sagemaker_session):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add support for DebugHookConfig defaults in TrainingJob API as part of SDK defaults feature.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
