### PR TITLE
fix: Add volume to partition djl_inference

### DIFF
--- a/tests/unit/test_djl_inference.py
+++ b/tests/unit/test_djl_inference.py
@@ -598,7 +598,7 @@ def test_partition(
             IMAGE_URI, model_data_url="s3prefix", env=expected_env
         )
 
-        assert model.model_id == f"{s3_output_uri}s3prefix/aot-partitioned-checkpoints"
+        assert model.model_id == f"{s3_output_uri}aot-partitioned-checkpoints"
 
 
 @patch("sagemaker.djl_inference.model.fw_utils.model_code_key_prefix")
@@ -741,15 +741,15 @@ def test__upload_model_to_s3__without_upload_as_tar__default_bucket_and_prefix_c
             "s3://code-test-bucket/code-test-prefix/code-test-prefix-2",
             "s3://code-test-bucket/code-test-prefix/code-test-prefix-2/image_uri",
             "s3://code-test-bucket/code-test-prefix/code-test-prefix-2/image_uri",
-            "s3://test-bucket/test-prefix/test-prefix-2/code-test-prefix/code-test-prefix-2/image_uri",
-            "s3://test-bucket/test-prefix/test-prefix-2/code-test-prefix/code-test-prefix-2/image_uri",
+            "s3://test-bucket/test-prefix/test-prefix-2",
+            "s3://test-bucket/test-prefix/test-prefix-2",
         ),
         (
             None,
             f"s3://{DEFAULT_S3_BUCKET_NAME}/{DEFAULT_S3_OBJECT_KEY_PREFIX_NAME}/image_uri",
             f"s3://{DEFAULT_S3_BUCKET_NAME}/image_uri",
-            "s3://test-bucket/test-prefix/test-prefix-2/image_uri",
-            "s3://test-bucket/test-prefix/test-prefix-2/image_uri",
+            "s3://test-bucket/test-prefix/test-prefix-2",
+            "s3://test-bucket/test-prefix/test-prefix-2",
         ),
     ],
 )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
