### PR TITLE
fix: Update CreateEdgePackagingJob resourceKey with type string

### DIFF
--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -2543,7 +2543,7 @@ class Session(object):  # pylint: disable=too-many-public-methods
         if tags is not None:
             edge_packaging_job_request["Tags"] = tags
         if resource_key is not None:
-            edge_packaging_job_request["ResourceKey"] = (resource_key,)
+            edge_packaging_job_request["ResourceKey"] = resource_key
 
         LOGGER.info("Creating edge-packaging-job with name: %s", job_name)
         self.sagemaker_client.create_edge_packaging_job(**edge_packaging_job_request)

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -2851,9 +2851,9 @@ def test_create_edge_packaging_with_sagemaker_config_injection(sagemaker_session
         "OutputConfig"
     ]["KmsKeyId"]
     expected_tags = SAGEMAKER_CONFIG_EDGE_PACKAGING_JOB["SageMaker"]["EdgePackagingJob"]["Tags"]
-    expected_resource_key = (
-        SAGEMAKER_CONFIG_EDGE_PACKAGING_JOB["SageMaker"]["EdgePackagingJob"]["ResourceKey"],
-    )
+    expected_resource_key = SAGEMAKER_CONFIG_EDGE_PACKAGING_JOB["SageMaker"]["EdgePackagingJob"][
+        "ResourceKey"
+    ]
     sagemaker_session.sagemaker_client.create_edge_packaging_job.assert_called_with(
         RoleArn=expected_role_arn,  # provided from config
         OutputConfig={


### PR DESCRIPTION
resource key is of type string as per:
https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sagemaker/client/create_edge_packaging_job.html

docs mention it is of type string but it is being converted to tuple causing a ParamValidationError when calling
session.package_model_for_edge

However in this commit it is being used as a tuple: https://github.com/aws/sagemaker-python-sdk/blame/master/src/sagemaker/session.py#L2546


Updating to use string, modified Unit test to cover the use case

*Issue #, if available:*

resource key is of type string as per:
https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sagemaker/client/create_edge_packaging_job.html

but it is being passed as tuple and throws Parameter Validation Error. Not sure if this ever worked
<Image redacted>

```
#With config injection
sm_session.package_model_for_edge(
    output_model_config={
        "S3OutputLocation": S3OutputLocation
    },
    model_name=model_name,
    job_name='TestJob',
    compilation_job_name='TestComplicationJob',
    model_version='1.0'
)

#Without Config injection( hidden for security reasons)
sm_session.package_model_for_edge(
    output_model_config={
        "S3OutputLocation": S3OutputLocation
    },
    model_name=model_name,
    job_name='TestJob',
    compilation_job_name='TestComplicationJob',
    model_version='1.0',
    resource_key='xxxxxxxxxx-xxx-xxxx-xxxx-xxxxxxxx'
)
```

*Description of changes:*

Changing resource key to String as per docs 

*Testing done:*

UTs and Manually 

(Note: boto3 does throw a ClientError: An error occurred (ValidationException) when calling the CreateEdgePackagingJob operation: We are retiring Amazon Sagemaker Edge on April 26th, 2024. Use this (step-by-step guide)<https://docs.aws.amazon.com/sagemaker/latest/dg/edge-eol.html> to learn about how to continue deploying your models to edge devices. but it is out of scope for SDK defaults, SDK defaults should pass the attribute down accurately)

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
