### PR TITLE
change: Add local_nvidia.<count> instance type

### DIFF
--- a/tests/unit/sagemaker/local/test_local_image.py
+++ b/tests/unit/sagemaker/local/test_local_image.py
@@ -599,6 +599,21 @@ def test_container_has_gpu_support(tmpdir, sagemaker_session):
     }
 
 
+@pytest.mark.parametrize("count",[ "all", 1, 4 ])
+def test_container_has_nvidia_support(tmpdir, sagemaker_session, count):
+    instance_count = 1
+    image = "my-image"
+    sagemaker_container = _SageMakerContainer(
+        f"local_nvidia.{count}", instance_count, image, sagemaker_session=sagemaker_session
+    )
+
+    docker_host = sagemaker_container._create_docker_host("host-1", {}, set(), "train", [])
+    assert "deploy" in docker_host
+    assert docker_host["deploy"] == {
+        "resources": {"reservations": {"devices": [{"driver": "nvidia", "count": count, "capabilities": ["gpu"]}]}}
+    }
+
+
 def test_container_does_not_enable_nvidia_docker_for_cpu_containers(sagemaker_session):
     instance_count = 1
     image = "my-image"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR adds the `local_nvidia.<count|all>` instance type to allow the user to choose how many GPUs to use in local mode as well select the `nvidia` driver in the generated `docker-compose.yaml` file.

*Testing done:*

Add unit-test the ensure the generated docker_compose contains the two additional fields.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
