### PR TITLE
documentation: fix wait_for_endpoint docstring

### DIFF
--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -4398,7 +4398,7 @@ class Session(object):  # pylint: disable=too-many-public-methods
 
         Args:
             endpoint (str): Name of the ``Endpoint`` to wait for.
-            poll (int): Polling interval in seconds (default: 5).
+            poll (int): Polling interval in seconds (default: 30).
 
         Raises:
             exceptions.CapacityError: If the endpoint creation job fails with CapacityError.


### PR DESCRIPTION
*Issue #, if available:* None.

*Description of changes:* In #1204, the `wait_for_endpoint` `poll` default was changed from 5 to 30, but the docstring wasn't updated. Update the docstring to  match.

*Testing done:* None.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
