### PR TITLE
feat: Support logging for Hyperparameter Tuning Jobs in Sagemaker Experiments

### DIFF
--- a/src/sagemaker/experiments/_utils.py
+++ b/src/sagemaker/experiments/_utils.py
@@ -140,7 +140,6 @@ def get_tc_and_exp_config_from_job_env(
     if job_exp_config.get(RUN_NAME, None):
         return job_exp_config
     hpo_experiment_config = get_experiment_name_from_hpo_env(job_name, sagemaker_session)
-    logging.info(hpo_experiment_config)
     if hpo_experiment_config is not None:
         return hpo_experiment_config
     raise RuntimeError(
@@ -226,7 +225,8 @@ def get_experiment_name_from_hpo_env(
     training_job_name: str, sagemaker_session: Session
 ) -> dict:
     """Check if an experiment is running in a Training Job that is part
-       of a Hyperparameter Tuning Job
+       of a Hyperparameter Tuning Job and return an experiment configuration
+       if it is.
 
     Args:
         training_job_name (str): The name of the training job.

--- a/tests/unit/sagemaker/experiments/helpers.py
+++ b/tests/unit/sagemaker/experiments/helpers.py
@@ -24,6 +24,9 @@ TEST_RUN_DISPLAY_NAME = "my-run-display-name"
 TEST_TAGS = [{"Key": "some-key", "Value": "some-value"}]
 TEST_ARTIFACT_BUCKET = "my-artifact-bucket"
 TEST_ARTIFACT_PREFIX = "my-artifact-prefix"
+TEST_HPO_TRIAL_NAME = f"{TEST_EXP_NAME}-abcd"
+TEST_HPO_TC_NAME = f"{TEST_HPO_TRIAL_NAME}-aws-training-job"
+TEST_HPO_EXPERIMENT_NAME = f"{TEST_EXP_NAME}-aws-tuning-job"
 
 
 def mock_tc_load_or_create_func(

--- a/tests/unit/sagemaker/experiments/test_run.py
+++ b/tests/unit/sagemaker/experiments/test_run.py
@@ -1094,7 +1094,9 @@ def test_append_run_tc_label_to_tags():
     assert len(ret) == 1
     assert expected_tc_tag in ret
 
-@patch("sagemaker.experiments.run._TrialComponent.load", MagicMock(return_value=_TrialComponent(trial_component_name=TEST_HPO_TC_NAME)))
+
+@patch("sagemaker.experiments.run._TrialComponent.load",
+       MagicMock(return_value=_TrialComponent(trial_component_name=TEST_HPO_TC_NAME)))
 @patch(
     "sagemaker.experiments.run.Experiment.load",
     MagicMock(return_value=Experiment(experiment_name=TEST_HPO_EXPERIMENT_NAME)),
@@ -1118,12 +1120,23 @@ def test_run_load_no_run_name_and_in_hpo_job(mock_run_env, sagemaker_session):
     }
     client.describe_trial.return_value = {
         "TrialName": TEST_HPO_TRIAL_NAME,
-        "ExperimentName" : TEST_HPO_EXPERIMENT_NAME
+        "ExperimentName": TEST_HPO_EXPERIMENT_NAME
     }
     client.describe_trial_component.return_value = {
         "TrialComponentName": TEST_HPO_TC_NAME
     }
-
+    client.search.return_value = {
+        "Results": [
+            {
+                "TrialComponent": {
+                    "Parents": [
+                        {"ExperimentName": TEST_HPO_EXPERIMENT_NAME, "TrialName": TEST_HPO_TRIAL_NAME}
+                    ],
+                    "TrialComponentName": TEST_HPO_TC_NAME,
+                }
+            }
+        ]
+    }
 
     with load_run(sagemaker_session=sagemaker_session) as run_obj:
         assert run_obj._in_load


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Adds support for logging in Hyper parameter tuning jobs. HPO(Hyper parameter Optimization) consists of a series of training jobs. This commit allows users to log metrics/other artifacts in auto created training jobs.

*Testing done:*
- Manual testing (Verified that all log_* works)
- Unit testing

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
