### PR TITLE
documentation: add smp class for supporting flash attn

### DIFF
--- a/doc/api/training/smp_versions/latest/smd_model_parallel_pytorch.rst
+++ b/doc/api/training/smp_versions/latest/smd_model_parallel_pytorch.rst
@@ -494,6 +494,110 @@ smdistributed.modelparallel.torch.DistributedOptimizer
       ``state_dict`` contains elements corresponding to only the current
       partition, or to the entire model.
 
+smdistributed.modelparallel.torch.nn.FlashAttentionLayer
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. function:: class smdistributed.modelparallel.torch.nn.FlashAttentionLayer(
+   attention_dropout_prob=0.1,
+   attention_head_size=None,
+   scale_attention_scores=True,
+   scale_attn_by_layer_idx=False,
+   layer_idx=None,
+   scale=None,
+   triton_flash_attention=False,
+   use_alibi=False
+)
+
+   This FlashAttentionLayer class supports 
+   `FlashAttention <https://github.com/HazyResearch/flash-attention>`_. 
+   It takes the ``qkv`` matrix as argument, computes attention scores and probabilities, 
+   and then does the matrix multiplication with value layer. 
+
+   Note that custom attention masks such as Attention with 
+   Linear Biases (ALiBi) are only supported when 
+   ``triton_flash_attention`` and ``use_alibi`` are set to ``True``. 
+   
+   Note also that Triton flash attention does not support dropout 
+   on the attention probabilities. It uses standard lower triangular 
+   causal mask when causal mode is enabled. It also runs only 
+   on P4d and P4de instances, with fp16 or bf16.
+
+   This class computes the scale factor to apply when computing attention. 
+   By default, scale is ``None``, and it's automatically calculated. 
+   When ``scale_attention_scores`` is ``True`` (which is default), 
+   ``attention_head_size`` must be passed. When ``scale_attn_by_layer_idx`` is True, 
+   then ``layer_idx`` must be passed. If both factors are used, they will 
+   be multiplied ``(1/(sqrt(attention_head_size) * (layer_idx+1)))``. 
+   This scale calculation can be bypassed by passing a custom scaling 
+   factor if needed with ``scale`` parameter.
+
+   **Parameters**
+
+   * ``attention_dropout_prob`` (float): (default: 0.1) specifies dropout probability 
+     to apply to attention.
+   * ``attention_head_size`` (int): Required when scale_attention_scores is True. 
+     When ``scale_attention_scores`` is passed, this contributes 
+     ``1/sqrt(attention_head_size)`` to the scale factor.
+   * ``scale_attention_scores`` (boolean): (default: True) determines whether 
+     to multiply 1/sqrt(attention_head_size) to the scale factor.
+   * ``layer_idx`` (int): Required when ``scale_attn_by_layer_idx`` is True. 
+     The layer id to use for scaling attention by layer id. 
+     It contributes 1/(layer_idx + 1) to the scaling factor.
+   * ``scale_attn_by_layer_idx`` (boolean): (default: False) determines whether 
+     to multiply 1/(layer_idx + 1) to the scale factor.
+   * ``scale`` (float) (default: None): If passed, this scale factor will be 
+     applied bypassing the above arguments.
+   * ``triton_flash_attention`` (bool): (default: False) If passed, Triton 
+     implementation of flash attention will be used. This is necessary to supports 
+     Attention with Linear Biases (ALiBi) (see next arg). Note that this version of the kernel doesn’t support dropout.
+   * ``use_alibi`` (bool): (default: False) If passed, it enables Attention with 
+     Linear Biases (ALiBi) using the mask provided. 
+
+   .. method:: forward(self, qkv, attn_mask=None, causal=False)
+
+      Returns a single ``torch.Tensor`` ``(batch_size x num_heads x seq_len x head_size)``, 
+      which represents the output of attention computation.
+
+      **Parameters**
+      
+      * ``qkv``: ``torch.Tensor`` in the form of ``(batch_size x seqlen x 3 x num_heads x head_size)``.
+      * ``attn_mask``: ``torch.Tensor`` in the form of ``(batch_size x 1 x 1 x seqlen)``. 
+        By default it is ``None``, and usage of this mask needs ``triton_flash_attention`` 
+        and ``use_alibi`` to be set. See how to generate the mask in the following code snippet.
+      * ``causal``: When passed, it uses the standard lower triangular mask. The default is ``False``.
+
+   When using ALiBi, it needs an attention mask prepared like the following.
+
+   .. code:: python
+
+      def generate_alibi_attn_mask(attention_mask, batch_size, seq_length, 
+         num_attention_heads, alibi_bias_max=8):
+         
+         device, dtype = attention_mask.device, attention_mask.dtype
+         alibi_attention_mask = torch.zeros(
+            1, num_attention_heads, 1, seq_length, dtype=dtype, device=device
+         )
+
+         alibi_bias = torch.arange(1 - seq_length, 1, dtype=dtype, device=device).view(
+            1, 1, 1, seq_length
+         )
+         m = torch.arange(1, num_attention_heads + 1, dtype=dtype, device=device)
+         m.mul_(alibi_bias_max / num_attention_heads)
+         alibi_bias = alibi_bias * (1.0 / (2 ** m.view(1, num_attention_heads, 1, 1)))
+
+         alibi_attention_mask.add_(alibi_bias)
+         alibi_attention_mask = alibi_attention_mask[..., :seq_length, :seq_length]
+         if attention_mask is not None and attention_mask.bool().any():
+            alibi_attention_mask.masked_fill(
+                  attention_mask.bool().view(batch_size, 1, 1, seq_length), float("-inf")
+            )
+
+         return alibi_attention_mask
+
+
+
+
+
 
 smdistributed.modelparallel.torch Context Managers and Util Functions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/api/training/smp_versions/latest/smd_model_parallel_pytorch.rst
+++ b/doc/api/training/smp_versions/latest/smd_model_parallel_pytorch.rst
@@ -502,7 +502,7 @@ smdistributed.modelparallel.torch.nn.FlashAttentionLayer
    This class supports
    `FlashAttention <https://github.com/HazyResearch/flash-attention>`_
    for PyTorch 2.0.
-   It takes the ``qkv`` matrix as an argument through its ``forward`` class method, 
+   It takes the ``qkv`` matrix as an argument through its ``forward`` class method,
    computes attention scores and probabilities,
    and then operates the matrix multiplication with value layers.
 

--- a/doc/api/training/smp_versions/latest/smd_model_parallel_pytorch.rst
+++ b/doc/api/training/smp_versions/latest/smd_model_parallel_pytorch.rst
@@ -499,34 +499,39 @@ smdistributed.modelparallel.torch.nn.FlashAttentionLayer
 
 .. function:: smdistributed.modelparallel.torch.nn.FlashAttentionLayer(attention_dropout_prob=0.1, attention_head_size=None, scale_attention_scores=True, scale_attn_by_layer_idx=False, layer_idx=None, scale=None, triton_flash_attention=False, use_alibi=False)
 
-   This FlashAttentionLayer class supports
-   `FlashAttention <https://github.com/HazyResearch/flash-attention>`_.
-   It takes the ``qkv`` matrix as argument, computes attention scores and probabilities,
-   and then does the matrix multiplication with value layer.
+   This class supports
+   `FlashAttention <https://github.com/HazyResearch/flash-attention>`_
+   for PyTorch 2.0.
+   It takes the ``qkv`` matrix as an argument through its ``forward`` class method, 
+   computes attention scores and probabilities,
+   and then operates the matrix multiplication with value layers.
 
-   Note that custom attention masks such as Attention with
-   Linear Biases (ALiBi) are only supported when
-   ``triton_flash_attention`` and ``use_alibi`` are set to ``True``.
+   Through this class, the smp library supports
+   custom attention masks such as Attention with
+   Linear Biases (ALiBi), and you can activate them by setting
+   ``triton_flash_attention`` and ``use_alibi`` to ``True``.
 
-   Note also that Triton flash attention does not support dropout
+   Note that the Triton flash attention does not support dropout
    on the attention probabilities. It uses standard lower triangular
    causal mask when causal mode is enabled. It also runs only
    on P4d and P4de instances, with fp16 or bf16.
 
    This class computes the scale factor to apply when computing attention.
-   By default, scale is ``None``, and it's automatically calculated.
-   When ``scale_attention_scores`` is ``True`` (which is default),
-   ``attention_head_size`` must be passed. When ``scale_attn_by_layer_idx`` is True,
-   then ``layer_idx`` must be passed. If both factors are used, they will
-   be multiplied ``(1/(sqrt(attention_head_size) * (layer_idx+1)))``.
-   This scale calculation can be bypassed by passing a custom scaling
-   factor if needed with ``scale`` parameter.
+   By default, ``scale`` is set to ``None``, and it's automatically calculated.
+   When ``scale_attention_scores`` is ``True`` (which is default), you must pass a value
+   to ``attention_head_size``. When ``scale_attn_by_layer_idx`` is ``True``,
+   you must pass a value to ``layer_idx``. If both factors are used, they are
+   multiplied as follows: ``(1/(sqrt(attention_head_size) * (layer_idx+1)))``.
+   This scale calculation can be bypassed if you specify a custom scaling
+   factor to ``scale``. In other words, if you specify a value to ``scale``, the set of parameters
+   (``scale_attention_scores``, ``attention_head_size``, ``scale_attn_by_layer_idx``, ``layer_idx``)
+   is overridden and ignored.
 
    **Parameters**
 
    * ``attention_dropout_prob`` (float): (default: 0.1) specifies dropout probability
      to apply to attention.
-   * ``attention_head_size`` (int): Required when scale_attention_scores is True.
+   * ``attention_head_size`` (int): Required when ``scale_attention_scores`` is True.
      When ``scale_attention_scores`` is passed, this contributes
      ``1/sqrt(attention_head_size)`` to the scale factor.
    * ``scale_attention_scores`` (boolean): (default: True) determines whether
@@ -537,7 +542,7 @@ smdistributed.modelparallel.torch.nn.FlashAttentionLayer
    * ``scale_attn_by_layer_idx`` (boolean): (default: False) determines whether
      to multiply 1/(layer_idx + 1) to the scale factor.
    * ``scale`` (float) (default: None): If passed, this scale factor will be
-     applied bypassing the above arguments.
+     applied bypassing the all of the previous arguments.
    * ``triton_flash_attention`` (bool): (default: False) If passed, Triton
      implementation of flash attention will be used. This is necessary to supports
      Attention with Linear Biases (ALiBi) (see next arg). Note that this version

--- a/doc/api/training/smp_versions/latest/smd_model_parallel_pytorch.rst
+++ b/doc/api/training/smp_versions/latest/smd_model_parallel_pytorch.rst
@@ -497,15 +497,7 @@ smdistributed.modelparallel.torch.DistributedOptimizer
 smdistributed.modelparallel.torch.nn.FlashAttentionLayer
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. function:: class smdistributed.modelparallel.torch.nn.FlashAttentionLayer(
-   attention_dropout_prob=0.1,
-   attention_head_size=None,
-   scale_attention_scores=True,
-   scale_attn_by_layer_idx=False,
-   layer_idx=None,
-   scale=None,
-   triton_flash_attention=False,
-   use_alibi=False)
+.. function:: smdistributed.modelparallel.torch.nn.FlashAttentionLayer(attention_dropout_prob=0.1, attention_head_size=None, scale_attention_scores=True, scale_attn_by_layer_idx=False, layer_idx=None, scale=None, triton_flash_attention=False, use_alibi=False)
 
    This FlashAttentionLayer class supports
    `FlashAttention <https://github.com/HazyResearch/flash-attention>`_.

--- a/doc/api/training/smp_versions/latest/smd_model_parallel_pytorch.rst
+++ b/doc/api/training/smp_versions/latest/smd_model_parallel_pytorch.rst
@@ -505,64 +505,64 @@ smdistributed.modelparallel.torch.nn.FlashAttentionLayer
    layer_idx=None,
    scale=None,
    triton_flash_attention=False,
-   use_alibi=False
-)
+   use_alibi=False)
 
-   This FlashAttentionLayer class supports 
-   `FlashAttention <https://github.com/HazyResearch/flash-attention>`_. 
-   It takes the ``qkv`` matrix as argument, computes attention scores and probabilities, 
-   and then does the matrix multiplication with value layer. 
+   This FlashAttentionLayer class supports
+   `FlashAttention <https://github.com/HazyResearch/flash-attention>`_.
+   It takes the ``qkv`` matrix as argument, computes attention scores and probabilities,
+   and then does the matrix multiplication with value layer.
 
-   Note that custom attention masks such as Attention with 
-   Linear Biases (ALiBi) are only supported when 
-   ``triton_flash_attention`` and ``use_alibi`` are set to ``True``. 
-   
-   Note also that Triton flash attention does not support dropout 
-   on the attention probabilities. It uses standard lower triangular 
-   causal mask when causal mode is enabled. It also runs only 
+   Note that custom attention masks such as Attention with
+   Linear Biases (ALiBi) are only supported when
+   ``triton_flash_attention`` and ``use_alibi`` are set to ``True``.
+
+   Note also that Triton flash attention does not support dropout
+   on the attention probabilities. It uses standard lower triangular
+   causal mask when causal mode is enabled. It also runs only
    on P4d and P4de instances, with fp16 or bf16.
 
-   This class computes the scale factor to apply when computing attention. 
-   By default, scale is ``None``, and it's automatically calculated. 
-   When ``scale_attention_scores`` is ``True`` (which is default), 
-   ``attention_head_size`` must be passed. When ``scale_attn_by_layer_idx`` is True, 
-   then ``layer_idx`` must be passed. If both factors are used, they will 
-   be multiplied ``(1/(sqrt(attention_head_size) * (layer_idx+1)))``. 
-   This scale calculation can be bypassed by passing a custom scaling 
+   This class computes the scale factor to apply when computing attention.
+   By default, scale is ``None``, and it's automatically calculated.
+   When ``scale_attention_scores`` is ``True`` (which is default),
+   ``attention_head_size`` must be passed. When ``scale_attn_by_layer_idx`` is True,
+   then ``layer_idx`` must be passed. If both factors are used, they will
+   be multiplied ``(1/(sqrt(attention_head_size) * (layer_idx+1)))``.
+   This scale calculation can be bypassed by passing a custom scaling
    factor if needed with ``scale`` parameter.
 
    **Parameters**
 
-   * ``attention_dropout_prob`` (float): (default: 0.1) specifies dropout probability 
+   * ``attention_dropout_prob`` (float): (default: 0.1) specifies dropout probability
      to apply to attention.
-   * ``attention_head_size`` (int): Required when scale_attention_scores is True. 
-     When ``scale_attention_scores`` is passed, this contributes 
+   * ``attention_head_size`` (int): Required when scale_attention_scores is True.
+     When ``scale_attention_scores`` is passed, this contributes
      ``1/sqrt(attention_head_size)`` to the scale factor.
-   * ``scale_attention_scores`` (boolean): (default: True) determines whether 
+   * ``scale_attention_scores`` (boolean): (default: True) determines whether
      to multiply 1/sqrt(attention_head_size) to the scale factor.
-   * ``layer_idx`` (int): Required when ``scale_attn_by_layer_idx`` is True. 
-     The layer id to use for scaling attention by layer id. 
+   * ``layer_idx`` (int): Required when ``scale_attn_by_layer_idx`` is ``True``.
+     The layer id to use for scaling attention by layer id.
      It contributes 1/(layer_idx + 1) to the scaling factor.
-   * ``scale_attn_by_layer_idx`` (boolean): (default: False) determines whether 
+   * ``scale_attn_by_layer_idx`` (boolean): (default: False) determines whether
      to multiply 1/(layer_idx + 1) to the scale factor.
-   * ``scale`` (float) (default: None): If passed, this scale factor will be 
+   * ``scale`` (float) (default: None): If passed, this scale factor will be
      applied bypassing the above arguments.
-   * ``triton_flash_attention`` (bool): (default: False) If passed, Triton 
-     implementation of flash attention will be used. This is necessary to supports 
-     Attention with Linear Biases (ALiBi) (see next arg). Note that this version of the kernel doesn’t support dropout.
-   * ``use_alibi`` (bool): (default: False) If passed, it enables Attention with 
-     Linear Biases (ALiBi) using the mask provided. 
+   * ``triton_flash_attention`` (bool): (default: False) If passed, Triton
+     implementation of flash attention will be used. This is necessary to supports
+     Attention with Linear Biases (ALiBi) (see next arg). Note that this version
+     of the kernel doesn’t support dropout.
+   * ``use_alibi`` (bool): (default: False) If passed, it enables Attention with
+     Linear Biases (ALiBi) using the mask provided.
 
    .. method:: forward(self, qkv, attn_mask=None, causal=False)
 
-      Returns a single ``torch.Tensor`` ``(batch_size x num_heads x seq_len x head_size)``, 
+      Returns a single ``torch.Tensor`` ``(batch_size x num_heads x seq_len x head_size)``,
       which represents the output of attention computation.
 
       **Parameters**
       
       * ``qkv``: ``torch.Tensor`` in the form of ``(batch_size x seqlen x 3 x num_heads x head_size)``.
-      * ``attn_mask``: ``torch.Tensor`` in the form of ``(batch_size x 1 x 1 x seqlen)``. 
-        By default it is ``None``, and usage of this mask needs ``triton_flash_attention`` 
+      * ``attn_mask``: ``torch.Tensor`` in the form of ``(batch_size x 1 x 1 x seqlen)``.
+        By default it is ``None``, and usage of this mask needs ``triton_flash_attention``
         and ``use_alibi`` to be set. See how to generate the mask in the following code snippet.
       * ``causal``: When passed, it uses the standard lower triangular mask. The default is ``False``.
 
@@ -593,11 +593,6 @@ smdistributed.modelparallel.torch.nn.FlashAttentionLayer
             )
 
          return alibi_attention_mask
-
-
-
-
-
 
 smdistributed.modelparallel.torch Context Managers and Util Functions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/api/training/smp_versions/latest/smd_model_parallel_pytorch.rst
+++ b/doc/api/training/smp_versions/latest/smd_model_parallel_pytorch.rst
@@ -559,7 +559,7 @@ smdistributed.modelparallel.torch.nn.FlashAttentionLayer
       which represents the output of attention computation.
 
       **Parameters**
-      
+
       * ``qkv``: ``torch.Tensor`` in the form of ``(batch_size x seqlen x 3 x num_heads x head_size)``.
       * ``attn_mask``: ``torch.Tensor`` in the form of ``(batch_size x 1 x 1 x seqlen)``.
         By default it is ``None``, and usage of this mask needs ``triton_flash_attention``
@@ -570,9 +570,9 @@ smdistributed.modelparallel.torch.nn.FlashAttentionLayer
 
    .. code:: python
 
-      def generate_alibi_attn_mask(attention_mask, batch_size, seq_length, 
+      def generate_alibi_attn_mask(attention_mask, batch_size, seq_length,
          num_attention_heads, alibi_bias_max=8):
-         
+
          device, dtype = attention_mask.device, attention_mask.dtype
          alibi_attention_mask = torch.zeros(
             1, num_attention_heads, 1, seq_length, dtype=dtype, device=device


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*  

Add an smp module for supporting flash attn

*Testing done:*

https://sagemaker--4009.org.readthedocs.build/en/4009/api/training/smp_versions/latest/smd_model_parallel_pytorch.html#smdistributed-modelparallel-torch-nn-flashattentionlayer

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
