### PR TITLE
feature: support online store ttl for records

### DIFF
--- a/src/sagemaker/feature_store/feature_group.py
+++ b/src/sagemaker/feature_store/feature_group.py
@@ -61,6 +61,8 @@ from sagemaker.feature_store.inputs import (
     FeatureParameter,
     TableFormatEnum,
     DeletionModeEnum,
+    TtlDuration,
+    OnlineStoreConfigUpdate,
 )
 from sagemaker.utils import resolve_value_from_config
 
@@ -523,6 +525,7 @@ class FeatureGroup:
         role_arn: str = None,
         online_store_kms_key_id: str = None,
         enable_online_store: bool = False,
+        ttl_duration: TtlDuration = None,
         offline_store_kms_key_id: str = None,
         disable_glue_table_creation: bool = False,
         data_catalog_config: DataCatalogConfig = None,
@@ -539,6 +542,7 @@ class FeatureGroup:
             event_time_feature_name (str): name of the event time feature.
             role_arn (str): ARN of the role used to call CreateFeatureGroup.
             online_store_kms_key_id (str): KMS key ARN for online store (default: None).
+            ttl_duration (TtlDuration): Default time to live duration for records (default: None).
             enable_online_store (bool): whether to enable online store or not (default: False).
             offline_store_kms_key_id (str): KMS key ARN for offline store (default: None).
                 If a KMS encryption key is not specified, SageMaker encrypts all data at
@@ -592,7 +596,10 @@ class FeatureGroup:
 
         # online store configuration
         if enable_online_store:
-            online_store_config = OnlineStoreConfig(enable_online_store=enable_online_store)
+            online_store_config = OnlineStoreConfig(
+                enable_online_store=enable_online_store,
+                ttl_duration=ttl_duration,
+            )
             if online_store_kms_key_id is not None:
                 online_store_config.online_store_security_config = OnlineStoreSecurityConfig(
                     kms_key_id=online_store_kms_key_id
@@ -633,21 +640,37 @@ class FeatureGroup:
             feature_group_name=self.name, next_token=next_token
         )
 
-    def update(self, feature_additions: Sequence[FeatureDefinition]) -> Dict[str, Any]:
+    def update(
+        self,
+        feature_additions: Sequence[FeatureDefinition] = None,
+        online_store_config: OnlineStoreConfigUpdate = None,
+    ) -> Dict[str, Any]:
         """Update a FeatureGroup and add new features from the given feature definitions.
 
         Args:
             feature_additions (Sequence[Dict[str, str]): list of feature definitions to be updated.
+            online_store_config (OnlineStoreConfigUpdate): online store config to be updated.
 
         Returns:
             Response dict from service.
         """
 
+        if feature_additions is None:
+            feature_additions_parameter = None
+        else:
+            feature_additions_parameter = [
+                feature_addition.to_dict() for feature_addition in feature_additions
+            ]
+
+        if online_store_config is None:
+            online_store_config_parameter = None
+        else:
+            online_store_config_parameter = online_store_config.to_dict()
+
         return self.sagemaker_session.update_feature_group(
             feature_group_name=self.name,
-            feature_additions=[
-                feature_addition.to_dict() for feature_addition in feature_additions
-            ],
+            feature_additions=feature_additions_parameter,
+            online_store_config=online_store_config_parameter,
         )
 
     def update_feature_metadata(
@@ -756,7 +779,9 @@ class FeatureGroup:
         return self.feature_definitions
 
     def get_record(
-        self, record_identifier_value_as_string: str, feature_names: Sequence[str] = None
+        self,
+        record_identifier_value_as_string: str,
+        feature_names: Sequence[str] = None,
     ) -> Sequence[Dict[str, str]]:
         """Get a single record in a FeatureGroup
 
@@ -772,14 +797,24 @@ class FeatureGroup:
             feature_names=feature_names,
         ).get("Record")
 
-    def put_record(self, record: Sequence[FeatureValue]):
+    def put_record(self, record: Sequence[FeatureValue], ttl_duration: TtlDuration = None):
         """Put a single record in the FeatureGroup.
 
         Args:
             record (Sequence[FeatureValue]): a list contains feature values.
+            ttl_duration (TtlDuration): customer specified ttl duration.
         """
+
+        if ttl_duration is not None:
+            return self.sagemaker_session.put_record(
+                feature_group_name=self.name,
+                record=[value.to_dict() for value in record],
+                ttl_duration=ttl_duration.to_dict(),
+            )
+
         return self.sagemaker_session.put_record(
-            feature_group_name=self.name, record=[value.to_dict() for value in record]
+            feature_group_name=self.name,
+            record=[value.to_dict() for value in record],
         )
 
     def delete_record(

--- a/src/sagemaker/feature_store/feature_store.py
+++ b/src/sagemaker/feature_store/feature_store.py
@@ -137,18 +137,26 @@ class FeatureStore:
             next_token=next_token,
         )
 
-    def batch_get_record(self, identifiers: Sequence[Identifier]) -> Dict[str, Any]:
+    def batch_get_record(
+        self,
+        identifiers: Sequence[Identifier],
+        expiration_time_response: str = None,
+    ) -> Dict[str, Any]:
         """Get record in batch from FeatureStore
 
         Args:
             identifiers (Sequence[Identifier]): A list of identifiers to uniquely identify records
                 in FeatureStore.
+            expiration_time_response (str): the field of expiration time response to toggle returning of expiresAt.
 
         Returns:
             Response dict from service.
         """
         batch_get_record_identifiers = [identifier.to_dict() for identifier in identifiers]
-        return self.sagemaker_session.batch_get_record(identifiers=batch_get_record_identifiers)
+        return self.sagemaker_session.batch_get_record(
+            identifiers=batch_get_record_identifiers,
+            expiration_time_response=expiration_time_response,
+        )
 
     def search(
         self,

--- a/src/sagemaker/feature_store/inputs.py
+++ b/src/sagemaker/feature_store/inputs.py
@@ -85,16 +85,42 @@ class OnlineStoreSecurityConfig(Config):
 
 
 @attr.s
+class TtlDuration(Config):
+    """TtlDuration for records in online FeatureStore.
+
+    Attributes:
+        unit (str): time unit.
+        value (int): time value.
+    """
+
+    unit: str = attr.ib()
+    value: int = attr.ib()
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Construct a dictionary based on the attributes.
+
+        Returns:
+            dict represents the attributes.
+        """
+        return Config.construct_dict(
+            Unit=self.unit,
+            Value=self.value,
+        )
+
+
+@attr.s
 class OnlineStoreConfig(Config):
     """OnlineStoreConfig for FeatureStore.
 
     Attributes:
         enable_online_store (bool): whether to enable the online store.
         online_store_security_config (OnlineStoreSecurityConfig): configuration of security setting.
+        ttl_duration (TtlDuration): Default time to live duration for records.
     """
 
     enable_online_store: bool = attr.ib(default=True)
     online_store_security_config: OnlineStoreSecurityConfig = attr.ib(default=None)
+    ttl_duration: TtlDuration = attr.ib(default=None)
 
     def to_dict(self) -> Dict[str, Any]:
         """Construct a dictionary based on the attributes.
@@ -105,6 +131,28 @@ class OnlineStoreConfig(Config):
         return Config.construct_dict(
             EnableOnlineStore=self.enable_online_store,
             SecurityConfig=self.online_store_security_config,
+            TtlDuration=self.ttl_duration,
+        )
+
+
+@attr.s
+class OnlineStoreConfigUpdate(Config):
+    """OnlineStoreConfigUpdate for FeatureStore.
+
+    Attributes:
+        ttl_duration (TtlDuration): Default time to live duration for records.
+    """
+
+    ttl_duration: TtlDuration = attr.ib(default=None)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Construct a dictionary based on the attributes.
+
+        Returns:
+            dict represents the attributes.
+        """
+        return Config.construct_dict(
+            TtlDuration=self.ttl_duration,
         )
 
 
@@ -379,3 +427,13 @@ class DeletionModeEnum(Enum):
 
     SOFT_DELETE = "SoftDelete"
     HARD_DELETE = "HardDelete"
+
+
+class ExpirationTimeResponseEnum(Enum):
+    """Enum of toggling the response of ExpiresAt.
+
+    The ExpirationTimeResponse for toggling the response of ExpiresAt can be Disabled or Enabled.
+    """
+
+    DISABLED = "Disabled"
+    ENABLED = "Enabled"

--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -5292,6 +5292,7 @@ class Session(object):  # pylint: disable=too-many-public-methods
             record_identifier_value_as_string (str): name of the record identifier.
             feature_group_name (str): name of the FeatureGroup.
             feature_names (Sequence[str]): list of feature names.
+            expiration_time_response (str): the field of expiration time response to toggle returning of expiresAt.
         """
         get_record_args = {
             "FeatureGroupName": feature_group_name,
@@ -5316,6 +5317,7 @@ class Session(object):  # pylint: disable=too-many-public-methods
         Args:
             identifiers (Sequence[Dict[str, Any]]): list of identifiers to uniquely identify records
                 in FeatureStore.
+            expiration_time_response (str): the field of expiration time response to toggle returning of expiresAt.
 
         Returns:
             Response dict from service.

--- a/tests/integ/test_feature_store.py
+++ b/tests/integ/test_feature_store.py
@@ -15,6 +15,7 @@ from __future__ import absolute_import
 import json
 import time
 import datetime
+import dateutil.parser as date_parser
 from contextlib import contextmanager
 
 import boto3
@@ -34,6 +35,8 @@ from sagemaker.feature_store.inputs import (
     ResourceEnum,
     Identifier,
     DeletionModeEnum,
+    TtlDuration,
+    OnlineStoreConfigUpdate,
 )
 from sagemaker.feature_store.dataset_builder import (
     JoinTypeEnum,
@@ -341,6 +344,147 @@ def test_create_feature_group_glue_table_format(
 
         table_format = feature_group.describe().get("OfflineStoreConfig").get("TableFormat")
         assert table_format == "Glue"
+
+
+def test_ttl_duration(
+    feature_store_session,
+    role,
+    feature_group_name,
+    pandas_data_frame,
+    record,
+):
+    feature_group = FeatureGroup(name=feature_group_name, sagemaker_session=feature_store_session)
+    feature_group.load_feature_definitions(data_frame=pandas_data_frame)
+
+    record_identifier_value_as_string = record[0].value_as_string
+
+    ttl_duration = TtlDuration(unit="Seconds", value=30)
+
+    with cleanup_feature_group(feature_group):
+        output = feature_group.create(
+            s3_uri=False,
+            record_identifier_name="feature1",
+            event_time_feature_name="feature3",
+            role_arn=role,
+            enable_online_store=True,
+            ttl_duration=ttl_duration,
+        )
+        _wait_for_feature_group_create(feature_group)
+
+        feature_store = FeatureStore(sagemaker_session=feature_store_session)
+
+        describe = feature_group.describe()
+
+        assert ttl_duration.unit == (
+            describe.get("OnlineStoreConfig").get("TtlDuration").get("Unit")
+        )
+
+        assert ttl_duration.value == (
+            describe.get("OnlineStoreConfig").get("TtlDuration").get("Value")
+        )
+
+        record[2].value_as_string = (
+            datetime.datetime.now(datetime.timezone.utc)
+            .replace(microsecond=0)
+            .isoformat()
+            .split("+")[0]
+            + "Z"
+        )
+
+        feature_group.put_record(record=record)
+
+        sample_record = feature_store_session.get_record(
+            feature_group_name=feature_group_name,
+            record_identifier_value_as_string=record_identifier_value_as_string,
+            feature_names=None,
+            expiration_time_response="Enabled",
+        )
+        assert sample_record.get("Record") is not None
+        _verify_expires_at(sample_record.get("ExpiresAt"), record[2].value_as_string, ttl_duration)
+
+        batch_records = feature_store.batch_get_record(
+            identifiers=[
+                Identifier(
+                    feature_group_name=feature_group_name,
+                    record_identifiers_value_as_string=[record_identifier_value_as_string],
+                )
+            ],
+            expiration_time_response="Enabled",
+        ).get("Records")
+        assert len(batch_records) == 1
+        assert batch_records[0].get("Record") == sample_record.get("Record")
+        assert batch_records[0].get("ExpiresAt") == sample_record.get("ExpiresAt")
+
+        retrieved_record = feature_group.get_record(
+            record_identifier_value_as_string=record_identifier_value_as_string
+        )
+
+        assert sample_record.get("Record") == retrieved_record
+
+        sample_record = feature_store_session.get_record(
+            feature_group_name=feature_group_name,
+            record_identifier_value_as_string=record_identifier_value_as_string,
+            feature_names=None,
+        )
+
+        assert sample_record.get("Record") is not None
+        assert sample_record.get("ExpiresAt") is None
+
+        batch_records = feature_store.batch_get_record(
+            identifiers=[
+                Identifier(
+                    feature_group_name=feature_group_name,
+                    record_identifiers_value_as_string=[record_identifier_value_as_string],
+                )
+            ],
+            expiration_time_response="Disabled",
+        ).get("Records")
+
+        assert len(batch_records) == 1
+        assert batch_records[0].get("Record") == sample_record.get("Record")
+        assert batch_records[0].get("ExpiresAt") is None
+
+        time.sleep(35)
+
+        sample_record = feature_store_session.get_record(
+            feature_group_name=feature_group_name,
+            record_identifier_value_as_string=record_identifier_value_as_string,
+            feature_names=None,
+        )
+        assert sample_record.get("Record") is None
+
+        retrieved_record = feature_group.get_record(
+            record_identifier_value_as_string=record_identifier_value_as_string
+        )
+        assert retrieved_record is None
+
+        batch_records = feature_store.batch_get_record(
+            identifiers=[
+                Identifier(
+                    feature_group_name=feature_group_name,
+                    record_identifiers_value_as_string=[record_identifier_value_as_string],
+                )
+            ],
+            expiration_time_response="Enabled",
+        )["Records"]
+        assert len(batch_records) == 0
+
+        ttl_duration = TtlDuration(unit="Days", value=10)
+
+        online_store_config = OnlineStoreConfigUpdate(ttl_duration=ttl_duration)
+        feature_group.update(online_store_config=online_store_config)
+
+        describe = feature_group.describe()
+
+        assert ttl_duration.unit == (
+            describe.get("OnlineStoreConfig").get("TtlDuration").get("Unit")
+        )
+
+        assert ttl_duration.value == (
+            describe.get("OnlineStoreConfig").get("TtlDuration").get("Value")
+        )
+
+    assert output["FeatureGroupArn"].endswith(f"feature-group/{feature_group_name}")
 
 
 def test_get_and_batch_get_record(
@@ -1043,6 +1187,25 @@ def test_create_dataset_with_feature_group_base_with_additional_params(
                 + ")\n"
                 + "WHERE row_recent <= 4"
             )
+
+
+def _verify_expires_at(expires_at: str, event_time: str, ttl_duration: TtlDuration):
+
+    if ttl_duration.unit == "Seconds":
+        ttl_duration_secs = ttl_duration.value
+    elif ttl_duration.unit == "Minutes":
+        ttl_duration_secs = ttl_duration.value * 60
+    elif ttl_duration.unit == "Hours":
+        ttl_duration_secs = ttl_duration.value * 60 * 60
+    elif ttl_duration.unit == "Days":
+        ttl_duration_secs = ttl_duration.value * 60 * 60 * 24
+    elif ttl_duration.unit == "Weeks":
+        ttl_duration_secs = ttl_duration.value * 60 * 60 * 24 * 7
+
+    expected_ttl_secs = date_parser.parse(event_time).timestamp() + ttl_duration_secs
+    actual_ttl_secs = date_parser.parse(expires_at).timestamp()
+
+    assert actual_ttl_secs == expected_ttl_secs
 
 
 def _create_feature_group_and_ingest_data(

--- a/tests/unit/sagemaker/feature_store/test_feature_group.py
+++ b/tests/unit/sagemaker/feature_store/test_feature_group.py
@@ -322,8 +322,8 @@ def test_get_record(sagemaker_session_mock):
         feature_names=feature_names,
     )
     sagemaker_session_mock.get_record.assert_called_with(
-        feature_group_name=feature_group_name,
         record_identifier_value_as_string=record_identifier_value_as_string,
+        feature_group_name=feature_group_name,
         feature_names=feature_names,
         expiration_time_response=None,
     )

--- a/tests/unit/sagemaker/feature_store/test_feature_store.py
+++ b/tests/unit/sagemaker/feature_store/test_feature_store.py
@@ -218,5 +218,31 @@ def test_batch_get_record(sagemaker_session_mock):
                 "RecordIdentifiersValueAsString": ["identifier"],
                 "FeatureNames": ["feature_1"],
             }
-        ]
+        ],
+        expiration_time_response=None,
+    )
+
+
+def test_batch_get_record_with_expiration_time_response(sagemaker_session_mock):
+    feature_store = FeatureStore(sagemaker_session=sagemaker_session_mock)
+    feature_store.batch_get_record(
+        identifiers=[
+            Identifier(
+                feature_group_name="name",
+                record_identifiers_value_as_string=["identifier"],
+                feature_names=["feature_1"],
+            )
+        ],
+        expiration_time_response="Enabled",
+    )
+
+    sagemaker_session_mock.batch_get_record.assert_called_with(
+        identifiers=[
+            {
+                "FeatureGroupName": "name",
+                "RecordIdentifiersValueAsString": ["identifier"],
+                "FeatureNames": ["feature_1"],
+            }
+        ],
+        expiration_time_response="Enabled",
     )

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -5192,6 +5192,33 @@ def test_batch_get_record(sagemaker_session):
     )
 
 
+def test_batch_get_record_expiration_time_response(sagemaker_session):
+    expected_batch_get_record_args = {
+        "Identifiers": [
+            {
+                "FeatureGroupName": "name",
+                "RecordIdentifiersValueAsString": ["identifier"],
+                "FeatureNames": ["feature_1"],
+            }
+        ],
+        "ExpirationTimeResponse": "Disabled",
+    }
+    sagemaker_session.batch_get_record(
+        identifiers=[
+            {
+                "FeatureGroupName": "name",
+                "RecordIdentifiersValueAsString": ["identifier"],
+                "FeatureNames": ["feature_1"],
+            }
+        ],
+        expiration_time_response="Disabled",
+    )
+    assert sagemaker_session.sagemaker_client.batch_get_record.called_once()
+    assert sagemaker_session.sagemaker_client.batch_get_record.called_with(
+        **expected_batch_get_record_args
+    )
+
+
 IR_USER_JOB_NAME = "custom-job-name"
 IR_JOB_NAME = "SMPYTHONSDK-sample-unique-uuid"
 IR_ADVANCED_JOB = "Advanced"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
