### PR TITLE
feat: Enable full tag propagation to lineage resources in feature processing

### DIFF
--- a/tests/unit/sagemaker/feature_store/feature_processor/lineage/test_constants.py
+++ b/tests/unit/sagemaker/feature_store/feature_processor/lineage/test_constants.py
@@ -313,7 +313,6 @@ PIPELINE = {
     },
 }
 
-
 PIPELINE_CONTEXT: Context = Context(
     context_arn=f"{PIPELINE_NAME}-context-arn",
     context_name=f"sm-fs-fe-{PIPELINE_NAME}-{CREATION_TIME}-fep",
@@ -340,7 +339,6 @@ TRANSFORMATION_CODE_INPUT_1: TransformationCode = TransformationCode(
     author="test-author",
     name="test-name",
 )
-
 
 TRANSFORMATION_CODE_INPUT_2: TransformationCode = TransformationCode(
     s3_uri="s3://sagemaker-us-west-2-789975069016/transform-2023-04-28-21-50-14-616/"

--- a/tests/unit/sagemaker/feature_store/feature_processor/test_feature_scheduler.py
+++ b/tests/unit/sagemaker/feature_store/feature_processor/test_feature_scheduler.py
@@ -85,6 +85,7 @@ CONTEXT_MOCK_02 = Mock(Context)
 CONTEXT_MOCK_03 = Mock(Context)
 FEATURE_GROUP = tdh.DESCRIBE_FEATURE_GROUP_RESPONSE.copy()
 PIPELINE = tdh.PIPELINE.copy()
+TAGS = [dict(Key="key_1", Value="value_1"), dict(Key="key_2", Value="value_2")]
 
 
 def mock_session():
@@ -593,6 +594,11 @@ def test_to_pipeline_used_reserved_tags(get_execution_role, mock_spark_image, se
 
 
 @patch(
+    "sagemaker.feature_store.feature_processor.feature_scheduler"
+    "._get_tags_from_pipeline_to_propagate_to_lineage_resources",
+    return_value=TAGS,
+)
+@patch(
     "sagemaker.feature_store.feature_processor.feature_scheduler._validate_pipeline_lineage_resources",
     return_value=None,
 )
@@ -604,7 +610,7 @@ def test_to_pipeline_used_reserved_tags(get_execution_role, mock_spark_image, se
     "sagemaker.feature_store.feature_processor.feature_scheduler.FeatureProcessorLineageHandler",
     return_value=mock_feature_processor_lineage(),
 )
-def test_schedule(lineage, helper, validation):
+def test_schedule(lineage, helper, validation, get_tags):
     session = Mock(Session, sagemaker_client=Mock(), boto_session=Mock())
     session.sagemaker_client.describe_pipeline = Mock(
         return_value={"PipelineArn": "my:arn", "CreationTime": NOW}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Propagate tags from pipeline to underlying lineage resources

*Testing done:*
- UT and manual testing from notebook

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
