### PR TITLE
feature: support online store ttl for records

### DIFF
--- a/doc/amazon_sagemaker_featurestore.rst
+++ b/doc/amazon_sagemaker_featurestore.rst
@@ -202,6 +202,7 @@ location of your offline store.
        role_arn = role,
        s3_uri = offline_feature_store_bucket,
        enable_online_store = True,
+       ttl_duration = None,
        online_store_kms_key_id = None,
        offline_store_kms_key_id = None,
        disable_glue_table_creation = False,

--- a/src/sagemaker/feature_store/feature_group.py
+++ b/src/sagemaker/feature_store/feature_group.py
@@ -61,6 +61,8 @@ from sagemaker.feature_store.inputs import (
     FeatureParameter,
     TableFormatEnum,
     DeletionModeEnum,
+    TtlDuration,
+    OnlineStoreConfigUpdate,
 )
 from sagemaker.utils import resolve_value_from_config
 
@@ -523,6 +525,7 @@ class FeatureGroup:
         role_arn: str = None,
         online_store_kms_key_id: str = None,
         enable_online_store: bool = False,
+        ttl_duration: TtlDuration = None,
         offline_store_kms_key_id: str = None,
         disable_glue_table_creation: bool = False,
         data_catalog_config: DataCatalogConfig = None,
@@ -539,6 +542,7 @@ class FeatureGroup:
             event_time_feature_name (str): name of the event time feature.
             role_arn (str): ARN of the role used to call CreateFeatureGroup.
             online_store_kms_key_id (str): KMS key ARN for online store (default: None).
+            ttl_duration (TtlDuration): Default time to live duration for records (default: None).
             enable_online_store (bool): whether to enable online store or not (default: False).
             offline_store_kms_key_id (str): KMS key ARN for offline store (default: None).
                 If a KMS encryption key is not specified, SageMaker encrypts all data at
@@ -592,7 +596,10 @@ class FeatureGroup:
 
         # online store configuration
         if enable_online_store:
-            online_store_config = OnlineStoreConfig(enable_online_store=enable_online_store)
+            online_store_config = OnlineStoreConfig(
+                enable_online_store=enable_online_store,
+                ttl_duration=ttl_duration,
+            )
             if online_store_kms_key_id is not None:
                 online_store_config.online_store_security_config = OnlineStoreSecurityConfig(
                     kms_key_id=online_store_kms_key_id
@@ -633,21 +640,37 @@ class FeatureGroup:
             feature_group_name=self.name, next_token=next_token
         )
 
-    def update(self, feature_additions: Sequence[FeatureDefinition]) -> Dict[str, Any]:
+    def update(
+        self,
+        feature_additions: Sequence[FeatureDefinition] = None,
+        online_store_config: OnlineStoreConfigUpdate = None,
+    ) -> Dict[str, Any]:
         """Update a FeatureGroup and add new features from the given feature definitions.
 
         Args:
             feature_additions (Sequence[Dict[str, str]): list of feature definitions to be updated.
+            online_store_config (OnlineStoreConfigUpdate): online store config to be updated.
 
         Returns:
             Response dict from service.
         """
 
+        if feature_additions is None:
+            feature_additions_parameter = None
+        else:
+            feature_additions_parameter = [
+                feature_addition.to_dict() for feature_addition in feature_additions
+            ]
+
+        if online_store_config is None:
+            online_store_config_parameter = None
+        else:
+            online_store_config_parameter = online_store_config.to_dict()
+
         return self.sagemaker_session.update_feature_group(
             feature_group_name=self.name,
-            feature_additions=[
-                feature_addition.to_dict() for feature_addition in feature_additions
-            ],
+            feature_additions=feature_additions_parameter,
+            online_store_config=online_store_config_parameter,
         )
 
     def update_feature_metadata(
@@ -756,7 +779,9 @@ class FeatureGroup:
         return self.feature_definitions
 
     def get_record(
-        self, record_identifier_value_as_string: str, feature_names: Sequence[str] = None
+        self,
+        record_identifier_value_as_string: str,
+        feature_names: Sequence[str] = None,
     ) -> Sequence[Dict[str, str]]:
         """Get a single record in a FeatureGroup
 
@@ -772,14 +797,24 @@ class FeatureGroup:
             feature_names=feature_names,
         ).get("Record")
 
-    def put_record(self, record: Sequence[FeatureValue]):
+    def put_record(self, record: Sequence[FeatureValue], ttl_duration: TtlDuration = None):
         """Put a single record in the FeatureGroup.
 
         Args:
             record (Sequence[FeatureValue]): a list contains feature values.
+            ttl_duration (TtlDuration): customer specified ttl duration.
         """
+
+        if ttl_duration is not None:
+            return self.sagemaker_session.put_record(
+                feature_group_name=self.name,
+                record=[value.to_dict() for value in record],
+                ttl_duration=ttl_duration.to_dict(),
+            )
+
         return self.sagemaker_session.put_record(
-            feature_group_name=self.name, record=[value.to_dict() for value in record]
+            feature_group_name=self.name,
+            record=[value.to_dict() for value in record],
         )
 
     def delete_record(

--- a/src/sagemaker/feature_store/feature_store.py
+++ b/src/sagemaker/feature_store/feature_store.py
@@ -137,18 +137,27 @@ class FeatureStore:
             next_token=next_token,
         )
 
-    def batch_get_record(self, identifiers: Sequence[Identifier]) -> Dict[str, Any]:
+    def batch_get_record(
+        self,
+        identifiers: Sequence[Identifier],
+        expiration_time_response: str = None,
+    ) -> Dict[str, Any]:
         """Get record in batch from FeatureStore
 
         Args:
             identifiers (Sequence[Identifier]): A list of identifiers to uniquely identify records
                 in FeatureStore.
+            expiration_time_response (str): the field of expiration time response
+                to toggle returning of expiresAt.
 
         Returns:
             Response dict from service.
         """
         batch_get_record_identifiers = [identifier.to_dict() for identifier in identifiers]
-        return self.sagemaker_session.batch_get_record(identifiers=batch_get_record_identifiers)
+        return self.sagemaker_session.batch_get_record(
+            identifiers=batch_get_record_identifiers,
+            expiration_time_response=expiration_time_response,
+        )
 
     def search(
         self,

--- a/src/sagemaker/feature_store/inputs.py
+++ b/src/sagemaker/feature_store/inputs.py
@@ -85,16 +85,42 @@ class OnlineStoreSecurityConfig(Config):
 
 
 @attr.s
+class TtlDuration(Config):
+    """TtlDuration for records in online FeatureStore.
+
+    Attributes:
+        unit (str): time unit.
+        value (int): time value.
+    """
+
+    unit: str = attr.ib()
+    value: int = attr.ib()
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Construct a dictionary based on the attributes.
+
+        Returns:
+            dict represents the attributes.
+        """
+        return Config.construct_dict(
+            Unit=self.unit,
+            Value=self.value,
+        )
+
+
+@attr.s
 class OnlineStoreConfig(Config):
     """OnlineStoreConfig for FeatureStore.
 
     Attributes:
         enable_online_store (bool): whether to enable the online store.
         online_store_security_config (OnlineStoreSecurityConfig): configuration of security setting.
+        ttl_duration (TtlDuration): Default time to live duration for records.
     """
 
     enable_online_store: bool = attr.ib(default=True)
     online_store_security_config: OnlineStoreSecurityConfig = attr.ib(default=None)
+    ttl_duration: TtlDuration = attr.ib(default=None)
 
     def to_dict(self) -> Dict[str, Any]:
         """Construct a dictionary based on the attributes.
@@ -105,6 +131,28 @@ class OnlineStoreConfig(Config):
         return Config.construct_dict(
             EnableOnlineStore=self.enable_online_store,
             SecurityConfig=self.online_store_security_config,
+            TtlDuration=self.ttl_duration,
+        )
+
+
+@attr.s
+class OnlineStoreConfigUpdate(Config):
+    """OnlineStoreConfigUpdate for FeatureStore.
+
+    Attributes:
+        ttl_duration (TtlDuration): Default time to live duration for records.
+    """
+
+    ttl_duration: TtlDuration = attr.ib(default=None)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Construct a dictionary based on the attributes.
+
+        Returns:
+            dict represents the attributes.
+        """
+        return Config.construct_dict(
+            TtlDuration=self.ttl_duration,
         )
 
 
@@ -379,3 +427,13 @@ class DeletionModeEnum(Enum):
 
     SOFT_DELETE = "SoftDelete"
     HARD_DELETE = "HardDelete"
+
+
+class ExpirationTimeResponseEnum(Enum):
+    """Enum of toggling the response of ExpiresAt.
+
+    The ExpirationTimeResponse for toggling the response of ExpiresAt can be Disabled or Enabled.
+    """
+
+    DISABLED = "Disabled"
+    ENABLED = "Enabled"

--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -2639,7 +2639,7 @@ class Session(object):  # pylint: disable=too-many-public-methods
             warm_start_config (dict): Configuration defining the type of warm start and
                 other required configurations.
             max_runtime_in_seconds (int or PipelineVariable): The maximum time in seconds
-                that a hyperparameter tuning job can run.
+                that a training job launched by a hyperparameter tuning job can run.
             completion_criteria_config (sagemaker.tuner.TuningJobCompletionCriteriaConfig): A
                 configuration for the completion criteria.
             early_stopping_type (str): Specifies whether early stopping is enabled for the job.
@@ -2894,7 +2894,7 @@ class Session(object):  # pylint: disable=too-many-public-methods
                 tuning job.
             max_parallel_jobs (int): Maximum number of parallel training jobs to start.
             max_runtime_in_seconds (int or PipelineVariable): The maximum time in seconds
-                that a hyperparameter tuning job can run.
+                that a training job launched by a hyperparameter tuning job can run.
             early_stopping_type (str): Specifies whether early stopping is enabled for the job.
                 Can be either 'Auto' or 'Off'. If set to 'Off', early stopping will not be
                 attempted. If set to 'Auto', early stopping of some training jobs may happen,
@@ -5097,9 +5097,15 @@ class Session(object):  # pylint: disable=too-many-public-methods
         return self.sagemaker_client.describe_feature_group(**kwargs)
 
     def update_feature_group(
-        self, feature_group_name: str, feature_additions: Sequence[Dict[str, str]]
+        self,
+        feature_group_name: str,
+        feature_additions: Sequence[Dict[str, str]] = None,
+        online_store_config: Dict[str, any] = None,
     ) -> Dict[str, Any]:
-        """Update a FeatureGroup and add new features from the given feature definitions.
+        """Update a FeatureGroup
+
+            either adding new features from the given feature definitions
+            or updating online store config
 
         Args:
             feature_group_name (str): name of the FeatureGroup to update.
@@ -5107,6 +5113,12 @@ class Session(object):  # pylint: disable=too-many-public-methods
         Returns:
             Response dict from service.
         """
+
+        if feature_additions is None:
+            return self.sagemaker_client.update_feature_group(
+                FeatureGroupName=feature_group_name,
+                OnlineStoreConfig=online_store_config,
+            )
 
         return self.sagemaker_client.update_feature_group(
             FeatureGroupName=feature_group_name, FeatureAdditions=feature_additions
@@ -5258,6 +5270,7 @@ class Session(object):  # pylint: disable=too-many-public-methods
         self,
         feature_group_name: str,
         record: Sequence[Dict[str, str]],
+        ttl_duration: Dict[str, str] = None,
     ):
         """Puts a single record in the FeatureGroup.
 
@@ -5266,6 +5279,14 @@ class Session(object):  # pylint: disable=too-many-public-methods
             record (Sequence[Dict[str, str]]): list of FeatureValue dicts to be ingested
                 into FeatureStore.
         """
+
+        if ttl_duration:
+            return self.sagemaker_featurestore_runtime_client.put_record(
+                FeatureGroupName=feature_group_name,
+                Record=record,
+                TtlDuration=ttl_duration,
+            )
+
         return self.sagemaker_featurestore_runtime_client.put_record(
             FeatureGroupName=feature_group_name,
             Record=record,
@@ -5298,6 +5319,7 @@ class Session(object):  # pylint: disable=too-many-public-methods
         record_identifier_value_as_string: str,
         feature_group_name: str,
         feature_names: Sequence[str],
+        expiration_time_response: str = None,
     ) -> Dict[str, Sequence[Dict[str, str]]]:
         """Gets a single record in the FeatureGroup.
 
@@ -5305,28 +5327,42 @@ class Session(object):  # pylint: disable=too-many-public-methods
             record_identifier_value_as_string (str): name of the record identifier.
             feature_group_name (str): name of the FeatureGroup.
             feature_names (Sequence[str]): list of feature names.
+            expiration_time_response (str): the field of expiration time response
+                to toggle returning of expiresAt.
         """
         get_record_args = {
             "FeatureGroupName": feature_group_name,
             "RecordIdentifierValueAsString": record_identifier_value_as_string,
         }
 
+        if expiration_time_response:
+            get_record_args["ExpirationTimeResponse"] = expiration_time_response
+
         if feature_names:
             get_record_args["FeatureNames"] = feature_names
 
         return self.sagemaker_featurestore_runtime_client.get_record(**get_record_args)
 
-    def batch_get_record(self, identifiers: Sequence[Dict[str, Any]]) -> Dict[str, Any]:
+    def batch_get_record(
+        self,
+        identifiers: Sequence[Dict[str, Any]],
+        expiration_time_response: str = None,
+    ) -> Dict[str, Any]:
         """Gets a batch of record from FeatureStore.
 
         Args:
             identifiers (Sequence[Dict[str, Any]]): list of identifiers to uniquely identify records
                 in FeatureStore.
+            expiration_time_response (str): the field of expiration time response
+                to toggle returning of expiresAt.
 
         Returns:
             Response dict from service.
         """
         batch_get_record_args = {"Identifiers": identifiers}
+
+        if expiration_time_response:
+            batch_get_record_args["ExpirationTimeResponse"] = expiration_time_response
 
         return self.sagemaker_featurestore_runtime_client.batch_get_record(**batch_get_record_args)
 

--- a/tests/integ/test_feature_store.py
+++ b/tests/integ/test_feature_store.py
@@ -15,6 +15,7 @@ from __future__ import absolute_import
 import json
 import time
 import datetime
+import dateutil.parser as date_parser
 from contextlib import contextmanager
 
 import boto3
@@ -34,6 +35,8 @@ from sagemaker.feature_store.inputs import (
     ResourceEnum,
     Identifier,
     DeletionModeEnum,
+    TtlDuration,
+    OnlineStoreConfigUpdate,
 )
 from sagemaker.feature_store.dataset_builder import (
     JoinTypeEnum,
@@ -341,6 +344,147 @@ def test_create_feature_group_glue_table_format(
 
         table_format = feature_group.describe().get("OfflineStoreConfig").get("TableFormat")
         assert table_format == "Glue"
+
+
+def test_ttl_duration(
+    feature_store_session,
+    role,
+    feature_group_name,
+    pandas_data_frame,
+    record,
+):
+    feature_group = FeatureGroup(name=feature_group_name, sagemaker_session=feature_store_session)
+    feature_group.load_feature_definitions(data_frame=pandas_data_frame)
+
+    record_identifier_value_as_string = record[0].value_as_string
+
+    ttl_duration = TtlDuration(unit="Seconds", value=30)
+
+    with cleanup_feature_group(feature_group):
+        output = feature_group.create(
+            s3_uri=False,
+            record_identifier_name="feature1",
+            event_time_feature_name="feature3",
+            role_arn=role,
+            enable_online_store=True,
+            ttl_duration=ttl_duration,
+        )
+        _wait_for_feature_group_create(feature_group)
+
+        feature_store = FeatureStore(sagemaker_session=feature_store_session)
+
+        describe = feature_group.describe()
+
+        assert ttl_duration.unit == (
+            describe.get("OnlineStoreConfig").get("TtlDuration").get("Unit")
+        )
+
+        assert ttl_duration.value == (
+            describe.get("OnlineStoreConfig").get("TtlDuration").get("Value")
+        )
+
+        record[2].value_as_string = (
+            datetime.datetime.now(datetime.timezone.utc)
+            .replace(microsecond=0)
+            .isoformat()
+            .split("+")[0]
+            + "Z"
+        )
+
+        feature_group.put_record(record=record)
+
+        sample_record = feature_store_session.get_record(
+            feature_group_name=feature_group_name,
+            record_identifier_value_as_string=record_identifier_value_as_string,
+            feature_names=None,
+            expiration_time_response="Enabled",
+        )
+        assert sample_record.get("Record") is not None
+        _verify_expires_at(sample_record.get("ExpiresAt"), record[2].value_as_string, ttl_duration)
+
+        batch_records = feature_store.batch_get_record(
+            identifiers=[
+                Identifier(
+                    feature_group_name=feature_group_name,
+                    record_identifiers_value_as_string=[record_identifier_value_as_string],
+                )
+            ],
+            expiration_time_response="Enabled",
+        ).get("Records")
+        assert len(batch_records) == 1
+        assert batch_records[0].get("Record") == sample_record.get("Record")
+        assert batch_records[0].get("ExpiresAt") == sample_record.get("ExpiresAt")
+
+        retrieved_record = feature_group.get_record(
+            record_identifier_value_as_string=record_identifier_value_as_string
+        )
+
+        assert sample_record.get("Record") == retrieved_record
+
+        sample_record = feature_store_session.get_record(
+            feature_group_name=feature_group_name,
+            record_identifier_value_as_string=record_identifier_value_as_string,
+            feature_names=None,
+        )
+
+        assert sample_record.get("Record") is not None
+        assert sample_record.get("ExpiresAt") is None
+
+        batch_records = feature_store.batch_get_record(
+            identifiers=[
+                Identifier(
+                    feature_group_name=feature_group_name,
+                    record_identifiers_value_as_string=[record_identifier_value_as_string],
+                )
+            ],
+            expiration_time_response="Disabled",
+        ).get("Records")
+
+        assert len(batch_records) == 1
+        assert batch_records[0].get("Record") == sample_record.get("Record")
+        assert batch_records[0].get("ExpiresAt") is None
+
+        time.sleep(35)
+
+        sample_record = feature_store_session.get_record(
+            feature_group_name=feature_group_name,
+            record_identifier_value_as_string=record_identifier_value_as_string,
+            feature_names=None,
+        )
+        assert sample_record.get("Record") is None
+
+        retrieved_record = feature_group.get_record(
+            record_identifier_value_as_string=record_identifier_value_as_string
+        )
+        assert retrieved_record is None
+
+        batch_records = feature_store.batch_get_record(
+            identifiers=[
+                Identifier(
+                    feature_group_name=feature_group_name,
+                    record_identifiers_value_as_string=[record_identifier_value_as_string],
+                )
+            ],
+            expiration_time_response="Enabled",
+        )["Records"]
+        assert len(batch_records) == 0
+
+        ttl_duration = TtlDuration(unit="Days", value=10)
+
+        online_store_config = OnlineStoreConfigUpdate(ttl_duration=ttl_duration)
+        feature_group.update(online_store_config=online_store_config)
+
+        describe = feature_group.describe()
+
+        assert ttl_duration.unit == (
+            describe.get("OnlineStoreConfig").get("TtlDuration").get("Unit")
+        )
+
+        assert ttl_duration.value == (
+            describe.get("OnlineStoreConfig").get("TtlDuration").get("Value")
+        )
+
+    assert output["FeatureGroupArn"].endswith(f"feature-group/{feature_group_name}")
 
 
 def test_get_and_batch_get_record(
@@ -1043,6 +1187,25 @@ def test_create_dataset_with_feature_group_base_with_additional_params(
                 + ")\n"
                 + "WHERE row_recent <= 4"
             )
+
+
+def _verify_expires_at(expires_at: str, event_time: str, ttl_duration: TtlDuration):
+
+    if ttl_duration.unit == "Seconds":
+        ttl_duration_secs = ttl_duration.value
+    elif ttl_duration.unit == "Minutes":
+        ttl_duration_secs = ttl_duration.value * 60
+    elif ttl_duration.unit == "Hours":
+        ttl_duration_secs = ttl_duration.value * 60 * 60
+    elif ttl_duration.unit == "Days":
+        ttl_duration_secs = ttl_duration.value * 60 * 60 * 24
+    elif ttl_duration.unit == "Weeks":
+        ttl_duration_secs = ttl_duration.value * 60 * 60 * 24 * 7
+
+    expected_ttl_secs = date_parser.parse(event_time).timestamp() + ttl_duration_secs
+    actual_ttl_secs = date_parser.parse(expires_at).timestamp()
+
+    assert actual_ttl_secs == expected_ttl_secs
 
 
 def _create_feature_group_and_ingest_data(

--- a/tests/unit/sagemaker/feature_store/test_feature_group.py
+++ b/tests/unit/sagemaker/feature_store/test_feature_group.py
@@ -31,7 +31,12 @@ from sagemaker.feature_store.feature_group import (
     AthenaQuery,
     IngestionError,
 )
-from sagemaker.feature_store.inputs import FeatureParameter, DeletionModeEnum
+from sagemaker.feature_store.inputs import (
+    FeatureParameter,
+    DeletionModeEnum,
+    TtlDuration,
+    OnlineStoreConfigUpdate,
+)
 
 from tests.unit import SAGEMAKER_CONFIG_FEATURE_GROUP
 
@@ -174,6 +179,39 @@ def test_feature_store_create(
     )
 
 
+def test_feature_store_create_with_ttl_duration(
+    sagemaker_session_mock, role_arn, feature_group_dummy_definitions, s3_uri
+):
+    feature_group = FeatureGroup(name="MyFeatureGroup", sagemaker_session=sagemaker_session_mock)
+    feature_group.feature_definitions = feature_group_dummy_definitions
+    ttl_duration = TtlDuration(unit="Minutes", value=123)
+    feature_group.create(
+        s3_uri=s3_uri,
+        record_identifier_name="feature1",
+        event_time_feature_name="feature2",
+        role_arn=role_arn,
+        enable_online_store=True,
+        ttl_duration=ttl_duration,
+    )
+    sagemaker_session_mock.create_feature_group.assert_called_with(
+        feature_group_name="MyFeatureGroup",
+        record_identifier_name="feature1",
+        event_time_feature_name="feature2",
+        feature_definitions=[fd.to_dict() for fd in feature_group_dummy_definitions],
+        role_arn=role_arn,
+        description=None,
+        tags=None,
+        online_store_config={
+            "EnableOnlineStore": True,
+            "TtlDuration": ttl_duration.to_dict(),
+        },
+        offline_store_config={
+            "DisableGlueTableCreation": False,
+            "S3StorageConfig": {"S3Uri": s3_uri},
+        },
+    )
+
+
 def test_feature_store_create_online_only(
     sagemaker_session_mock, role_arn, feature_group_dummy_definitions
 ):
@@ -220,6 +258,20 @@ def test_feature_store_update(sagemaker_session_mock, feature_group_dummy_defini
     sagemaker_session_mock.update_feature_group.assert_called_with(
         feature_group_name="MyFeatureGroup",
         feature_additions=[fd.to_dict() for fd in feature_group_dummy_definitions],
+        online_store_config=None,
+    )
+
+
+def test_feature_store_update_with_ttl_duration(sagemaker_session_mock):
+    feature_group = FeatureGroup(name="MyFeatureGroup", sagemaker_session=sagemaker_session_mock)
+    online_store_config = OnlineStoreConfigUpdate(
+        ttl_duration=TtlDuration(unit="Minutes", value=123)
+    )
+    feature_group.update(online_store_config=online_store_config)
+    sagemaker_session_mock.update_feature_group.assert_called_with(
+        feature_group_name="MyFeatureGroup",
+        feature_additions=None,
+        online_store_config=online_store_config.to_dict(),
     )
 
 
@@ -270,8 +322,8 @@ def test_get_record(sagemaker_session_mock):
         feature_names=feature_names,
     )
     sagemaker_session_mock.get_record.assert_called_with(
-        feature_group_name=feature_group_name,
         record_identifier_value_as_string=record_identifier_value_as_string,
+        feature_group_name=feature_group_name,
         feature_names=feature_names,
     )
 
@@ -281,6 +333,15 @@ def test_put_record(sagemaker_session_mock):
     feature_group.put_record(record=[])
     sagemaker_session_mock.put_record.assert_called_with(
         feature_group_name="MyFeatureGroup", record=[]
+    )
+
+
+def test_put_record_ttl_duration(sagemaker_session_mock):
+    feature_group = FeatureGroup(name="MyFeatureGroup", sagemaker_session=sagemaker_session_mock)
+    ttl_duration = TtlDuration(unit="Minutes", value=123)
+    feature_group.put_record(record=[], ttl_duration=ttl_duration)
+    sagemaker_session_mock.put_record.assert_called_with(
+        feature_group_name="MyFeatureGroup", record=[], ttl_duration=ttl_duration.to_dict()
     )
 
 

--- a/tests/unit/sagemaker/feature_store/test_feature_store.py
+++ b/tests/unit/sagemaker/feature_store/test_feature_store.py
@@ -218,5 +218,31 @@ def test_batch_get_record(sagemaker_session_mock):
                 "RecordIdentifiersValueAsString": ["identifier"],
                 "FeatureNames": ["feature_1"],
             }
-        ]
+        ],
+        expiration_time_response=None,
+    )
+
+
+def test_batch_get_record_with_expiration_time_response(sagemaker_session_mock):
+    feature_store = FeatureStore(sagemaker_session=sagemaker_session_mock)
+    feature_store.batch_get_record(
+        identifiers=[
+            Identifier(
+                feature_group_name="name",
+                record_identifiers_value_as_string=["identifier"],
+                feature_names=["feature_1"],
+            )
+        ],
+        expiration_time_response="Enabled",
+    )
+
+    sagemaker_session_mock.batch_get_record.assert_called_with(
+        identifiers=[
+            {
+                "FeatureGroupName": "name",
+                "RecordIdentifiersValueAsString": ["identifier"],
+                "FeatureNames": ["feature_1"],
+            }
+        ],
+        expiration_time_response="Enabled",
     )

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -5260,6 +5260,33 @@ def test_batch_get_record(sagemaker_session):
     )
 
 
+def test_batch_get_record_expiration_time_response(sagemaker_session):
+    expected_batch_get_record_args = {
+        "Identifiers": [
+            {
+                "FeatureGroupName": "name",
+                "RecordIdentifiersValueAsString": ["identifier"],
+                "FeatureNames": ["feature_1"],
+            }
+        ],
+        "ExpirationTimeResponse": "Disabled",
+    }
+    sagemaker_session.batch_get_record(
+        identifiers=[
+            {
+                "FeatureGroupName": "name",
+                "RecordIdentifiersValueAsString": ["identifier"],
+                "FeatureNames": ["feature_1"],
+            }
+        ],
+        expiration_time_response="Disabled",
+    )
+    assert sagemaker_session.sagemaker_client.batch_get_record.called_once()
+    assert sagemaker_session.sagemaker_client.batch_get_record.called_with(
+        **expected_batch_get_record_args
+    )
+
+
 IR_USER_JOB_NAME = "custom-job-name"
 IR_JOB_NAME = "SMPYTHONSDK-sample-unique-uuid"
 IR_ADVANCED_JOB = "Advanced"


### PR DESCRIPTION
- doc: add smp class for supporting flash attn (#4009)
- fix: Remove deleted notebook tests from test confg (#4013)
- build(deps): bump pygments from 2.11.2 to 2.15.0 in /requirements/tox (#4010)
- chore: jumpstart deprecation messages (#3992)
- fix: excessive jumpstart logging (#4023)
- feature: AutoGluon 0.8.2 image_uris update (#4012)
- feature: support online store ttl for records

*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
