### PR TITLE
fix: Pass kms_key to _upload_analysis_config when provided

### DIFF
--- a/src/sagemaker/model_monitor/clarify_model_monitoring.py
+++ b/src/sagemaker/model_monitor/clarify_model_monitoring.py
@@ -178,7 +178,7 @@ class ClarifyModelMonitor(mm.ModelMonitor):
         baselining_processor.base_job_name = self.base_job_name
         return baselining_processor
 
-    def _upload_analysis_config(self, analysis_config, output_s3_uri, job_definition_name):
+    def _upload_analysis_config(self, analysis_config, output_s3_uri, job_definition_name, kms_key):
         """Upload analysis config to s3://<output path>/<job name>/analysis_config.json
 
         Args:
@@ -187,6 +187,8 @@ class ClarifyModelMonitor(mm.ModelMonitor):
                 Default: "s3://<default_session_bucket>/<job_name>/output"
             job_definition_name (str): Job definition name.
                 If not specified then a default one will be generated.
+            kms_key( str): The ARN of the KMS key that is used to encrypt the
+            user code file (default: None).
 
         Returns:
             str: The S3 uri of the uploaded file(s).
@@ -202,6 +204,7 @@ class ClarifyModelMonitor(mm.ModelMonitor):
             json.dumps(analysis_config),
             desired_s3_uri=s3_uri,
             sagemaker_session=self.sagemaker_session,
+            kms_key=kms_key,
         )
 
     def _build_create_job_definition_request(
@@ -323,7 +326,7 @@ class ClarifyModelMonitor(mm.ModelMonitor):
             analysis_config_uri = analysis_config
         else:
             analysis_config_uri = self._upload_analysis_config(
-                analysis_config._to_dict(), output_s3_uri, job_definition_name
+                analysis_config._to_dict(), output_s3_uri, job_definition_name, output_kms_key
             )
         app_specification["ConfigUri"] = analysis_config_uri
         app_specification["ImageUri"] = image_uri

--- a/src/sagemaker/workflow/clarify_check_step.py
+++ b/src/sagemaker/workflow/clarify_check_step.py
@@ -435,7 +435,7 @@ class ClarifyCheckStep(Step):
             job_definition_name = name_from_base(f"{_BIAS_MONITORING_CFG_BASE_NAME}-config")
 
         return self._model_monitor._upload_analysis_config(
-            analysis_config, output_s3_uri, job_definition_name
+            analysis_config, output_s3_uri, job_definition_name, self.clarify_check_config.kms_key
         )
 
     def _get_s3_base_uri_for_monitoring_analysis_config(self) -> str:


### PR DESCRIPTION
*Description of changes:*
When ClarifyProcessor is create, we upload the analysis config as a json file to S3. When customer specifies a KMS key, we pass it along to the S3 object to write it by encrypting it with the key. However, when it is created through ModelMonitor, the key is not passed with to S3, and this is presumably writing it unencrypted. This CR fixes this. 

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
