### PR TITLE
deprecation: remove explicit `partitions` key requirement on pysdk side.

### DIFF
--- a/src/sagemaker/fw_utils.py
+++ b/src/sagemaker/fw_utils.py
@@ -327,9 +327,6 @@ def validate_mp_config(config):
         ValueError: If any of the keys have incorrect values.
     """
 
-    if "partitions" not in config:
-        raise ValueError("'partitions' is a required parameter.")
-
     def validate_positive(key):
         try:
             if not isinstance(config[key], int) or config[key] < 1:

--- a/tests/unit/test_fw_utils.py
+++ b/tests/unit/test_fw_utils.py
@@ -135,12 +135,6 @@ def test_tar_and_upload_dir_s3_without_kms_with_overridden_settings(utils, sagem
     obj.upload_file.assert_called_with(utils.create_tar_file(), ExtraArgs=None)
 
 
-def test_mp_config_partition_exists():
-    mp_parameters = {}
-    with pytest.raises(ValueError):
-        fw_utils.validate_mp_config(mp_parameters)
-
-
 @pytest.mark.parametrize(
     "pipeline, placement_strategy, optimize, trace_device",
     [


### PR DESCRIPTION
*Description of changes:*
Clean up API for SMP v2.
`partitions` key will still be checked on library side for SMP v1.

Remove related test checking that error is thrown if partitions is not passed.


*Testing done:*
Ran `tox -e py310 -- -s -vv tests/unit/test_fw_utils.py` which is passing.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
