### PR TITLE
fix: gated models unsupported region

### DIFF
--- a/src/sagemaker/jumpstart/artifacts/model_packages.py
+++ b/src/sagemaker/jumpstart/artifacts/model_packages.py
@@ -72,6 +72,13 @@ def _retrieve_model_package_arn(
 
         regional_arn = model_specs.hosting_model_package_arns.get(region)
 
+        if regional_arn is None:
+            raise ValueError(
+                f"Model package arn for '{model_id}' not supported in {region}. "
+                "Please try one of the following regions: "
+                f"{', '.join(model_specs.hosting_model_package_arns.keys())}."
+            )
+
         return regional_arn
 
     raise NotImplementedError(f"Model Package ARN not supported for scope: '{scope}'")
@@ -129,6 +136,13 @@ def _retrieve_model_package_model_artifact_s3_uri(
             return None
 
         model_s3_uri = model_specs.training_model_package_artifact_uris.get(region)
+
+        if model_s3_uri is None:
+            raise ValueError(
+                f"Model package artifact s3 uri for '{model_id}' not supported in {region}. "
+                "Please try one of the following regions: "
+                f"{', '.join(model_specs.training_model_package_artifact_uris.keys())}."
+            )
 
         return model_s3_uri
 

--- a/tests/unit/sagemaker/jumpstart/model/test_model.py
+++ b/tests/unit/sagemaker/jumpstart/model/test_model.py
@@ -646,6 +646,32 @@ class ModelTest(unittest.TestCase):
             },
         )
 
+    @mock.patch("sagemaker.jumpstart.model.is_valid_model_id")
+    @mock.patch("sagemaker.jumpstart.factory.model.Session")
+    @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
+    @mock.patch("sagemaker.jumpstart.factory.model.JUMPSTART_DEFAULT_REGION_NAME", region)
+    def test_jumpstart_model_package_arn_unsupported_region(
+        self,
+        mock_get_model_specs: mock.Mock,
+        mock_session: mock.Mock,
+        mock_is_valid_model_id: mock.Mock,
+    ):
+
+        mock_is_valid_model_id.return_value = True
+
+        model_id, _ = "js-model-package-arn", "*"
+
+        mock_get_model_specs.side_effect = get_special_model_spec
+
+        mock_session.return_value = MagicMock(sagemaker_config={})
+
+        with pytest.raises(ValueError) as e:
+            JumpStartModel(model_id=model_id, region="us-east-2")
+        assert (
+            str(e.value) == "Model package arn for 'js-model-package-arn' not supported in "
+            "us-east-2. Please try one of the following regions: us-west-2, us-east-1."
+        )
+
 
 def test_jumpstart_model_requires_model_id():
     with pytest.raises(ValueError):


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/amazon-sagemaker-examples/issues/4337

*Description of changes:*
fix: gated models unsupported region

*Testing done:*
Unit tests written

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
