### PR TITLE
feat: enable notebook instances to get presigned url

### DIFF
--- a/tests/unit/test_tensorboard.py
+++ b/tests/unit/test_tensorboard.py
@@ -44,17 +44,17 @@ REDIRECT_NON_STUDIO_FORMAT = "/{}"
 
 @patch("boto3.client")
 @patch("os.path.isfile")
-def test_tb_init_and_url_non_studio_user(mock_in_studio, mock_client):
+def test_tb_init_and_url_no_metadata_file(mock_metadata_file_present, mock_client):
     """
-    Test TensorBoardApp for non Studio users.
+    Test TensorBoardApp URL for the case when no metadata file is present.
     """
-    mock_in_studio.return_value = False
+    mock_metadata_file_present.return_value = False
     mock_client.return_value = boto3.client("sagemaker")
     tb_app = TensorBoardApp(TEST_REGION)
     assert tb_app.region == TEST_REGION
     assert tb_app._domain_id is None
     assert tb_app._user_profile_name is None
-    assert tb_app._validate_domain_and_user() is False
+    assert tb_app._in_studio_env is False
 
     # test url without job redirect
     assert tb_app.get_app_url(
@@ -72,21 +72,74 @@ def test_tb_init_and_url_non_studio_user(mock_in_studio, mock_client):
     with pytest.raises(ValueError):
         tb_app.get_app_url("invald_job_name!")
 
+    # test url when opened in web browser
+    with patch("webbrowser.open") as mock_web_browser_open:
+        url = tb_app.get_app_url(
+            open_in_default_web_browser=True,
+        )
+        mock_web_browser_open.assert_called_with(
+            BASE_URL_NON_STUDIO_FORMAT.format(region=TEST_REGION)
+        )
+        assert url == ""
+
 
 @patch("boto3.client")
-@patch("sagemaker.interactive_apps.base_interactive_app.BaseInteractiveApp._is_in_studio")
-def test_tb_init_and_url_studio_user_valid_medatada(mock_in_studio, mock_client):
+@patch("os.path.isfile")
+def test_tb_init_non_studio_metadata_file(mock_metadata_file_present, mock_client):
     """
-    Test TensorBoardApp for Studio user when the notebook metadata file provided by Studio is valid.
+    Test TensorBoardApp URL for the case when metadata file is present,
+    but domain id and/or user profile name are not present in it.
     """
-    mock_in_studio.return_value = True
+    mock_metadata_file_present.return_value = True
+    mock_client.return_value = boto3.client("sagemaker")
+    with patch("builtins.open", mock_open(read_data=json.dumps({"Fake": "Fake"}))):
+        tb_app = TensorBoardApp(TEST_REGION)
+        assert tb_app.region == TEST_REGION
+        assert tb_app._domain_id is None
+        assert tb_app._user_profile_name is None
+        assert tb_app._in_studio_env is False
+        assert tb_app.get_app_url(
+            open_in_default_web_browser=False
+        ) == BASE_URL_NON_STUDIO_FORMAT.format(region=TEST_REGION)
+
+    with patch("builtins.open", mock_open(read_data=json.dumps({"DomainId": TEST_DOMAIN}))):
+        tb_app = TensorBoardApp(TEST_REGION)
+        assert tb_app.region == TEST_REGION
+        assert tb_app._domain_id is None
+        assert tb_app._user_profile_name is None
+        assert tb_app._in_studio_env is False
+        assert tb_app.get_app_url(
+            open_in_default_web_browser=False
+        ) == BASE_URL_NON_STUDIO_FORMAT.format(region=TEST_REGION)
+
+    with patch(
+        "builtins.open", mock_open(read_data=json.dumps({"UserProfileName": TEST_USER_PROFILE}))
+    ):
+        tb_app = TensorBoardApp(TEST_REGION)
+        assert tb_app.region == TEST_REGION
+        assert tb_app._domain_id is None
+        assert tb_app._user_profile_name is None
+        assert tb_app._in_studio_env is False
+        assert tb_app.get_app_url(
+            open_in_default_web_browser=False
+        ) == BASE_URL_NON_STUDIO_FORMAT.format(region=TEST_REGION)
+
+
+@patch("boto3.client")
+@patch("os.path.isfile")
+def test_tb_init_and_url_valid_studio_medatada_file(mock_metadata_file_present, mock_client):
+    """
+    Test TensorBoardApp URL for the case when metadata file is present,
+    and contains valid domain id and user profile name.
+    """
+    mock_metadata_file_present.return_value = True
     mock_client.return_value = boto3.client("sagemaker")
     with patch("builtins.open", mock_open(read_data=TEST_NOTEBOOK_METADATA)):
         tb_app = TensorBoardApp(TEST_REGION)
         assert tb_app.region == TEST_REGION
         assert tb_app._domain_id == TEST_DOMAIN
         assert tb_app._user_profile_name == TEST_USER_PROFILE
-        assert tb_app._validate_domain_and_user() is True
+        assert tb_app._in_studio_env is True
 
         # test url without job redirect
         assert (
@@ -107,29 +160,37 @@ def test_tb_init_and_url_studio_user_valid_medatada(mock_in_studio, mock_client)
         with pytest.raises(ValueError):
             tb_app.get_app_url("invald_job_name!")
 
+        # test url when opened in web browser
+        with patch("webbrowser.open") as mock_web_browser_open:
+            url = tb_app.get_app_url(
+                open_in_default_web_browser=True,
+            )
+            mock_web_browser_open.assert_called_with(
+                BASE_URL_STUDIO_FORMAT.format(TEST_DOMAIN, TEST_REGION) + "/#sagemaker_data_manager"
+            )
+            assert url == ""
+
 
 @patch("boto3.client")
-@patch("sagemaker.interactive_apps.base_interactive_app.BaseInteractiveApp._is_in_studio")
-def test_tb_init_and_url_studio_user_invalid_medatada(mock_in_studio, mock_client):
+@patch("os.path.isfile")
+def test_tb_init_and_url_invalid_studio_medatada_file(mock_metadata_file_present, mock_client):
     """
-    Test TensorBoardApp for Amazon SageMaker Studio user when the notebook metadata file provided
-    by Studio is invalid.
+    Test TensorBoardApp URL for the case when metadata file is present,
+    and contains invalid domain id and/or user profile name.
     """
-    mock_in_studio.return_value = True
+    mock_metadata_file_present.return_value = True
     mock_client.return_value = boto3.client("sagemaker")
-
-    # test file does not contain domain and user profle
-    with patch("builtins.open", mock_open(read_data=json.dumps({"Fake": "Fake"}))):
-        assert TensorBoardApp(TEST_REGION).get_app_url(
-            open_in_default_web_browser=False
-        ) == BASE_URL_NON_STUDIO_FORMAT.format(region=TEST_REGION)
 
     # test invalid user profile name
     with patch(
         "builtins.open",
         mock_open(read_data=json.dumps({"DomainId": TEST_DOMAIN, "UserProfileName": "u" * 64})),
     ):
-        assert TensorBoardApp(TEST_REGION).get_app_url(
+        tb_app = TensorBoardApp(TEST_REGION)
+        assert tb_app.region == TEST_REGION
+        assert tb_app._domain_id == TEST_DOMAIN
+        assert tb_app._in_studio_env is True
+        assert tb_app.get_app_url(
             open_in_default_web_browser=False
         ) == BASE_URL_NON_STUDIO_FORMAT.format(region=TEST_REGION)
 
@@ -140,15 +201,19 @@ def test_tb_init_and_url_studio_user_invalid_medatada(mock_in_studio, mock_clien
             read_data=json.dumps({"DomainId": "d" * 64, "UserProfileName": TEST_USER_PROFILE})
         ),
     ):
-        assert TensorBoardApp(TEST_REGION).get_app_url(
+        tb_app = TensorBoardApp(TEST_REGION)
+        assert tb_app.region == TEST_REGION
+        assert tb_app._user_profile_name == TEST_USER_PROFILE
+        assert tb_app._in_studio_env is True
+        assert tb_app.get_app_url(
             open_in_default_web_browser=False
         ) == BASE_URL_NON_STUDIO_FORMAT.format(region=TEST_REGION)
 
 
 @patch("boto3.client")
-@patch("sagemaker.interactive_apps.base_interactive_app.BaseInteractiveApp._is_in_studio")
-def test_tb_presigned_url_success(mock_in_studio, mock_client):
-    mock_in_studio.return_value = False
+@patch("sagemaker.interactive_apps.base_interactive_app.BaseInteractiveApp.__init__")
+def test_tb_presigned_url_success(mock_init, mock_client):
+    mock_init.return_value = None
     resp = {
         "ResponseMetadata": {"HTTPStatusCode": 200},
         "AuthorizedUrl": TEST_PRESIGNED_URL,
@@ -156,38 +221,46 @@ def test_tb_presigned_url_success(mock_in_studio, mock_client):
     attrs = {"create_presigned_domain_url.return_value": resp}
     mock_client.return_value = Mock(**attrs)
 
-    url = TensorBoardApp(TEST_REGION).get_app_url(
+    tb_app = TensorBoardApp(TEST_REGION)
+    tb_app.region = TEST_REGION
+    tb_app._domain_id = None
+    tb_app._user_profile_name = None
+    tb_app._in_studio_env = False
+    tb_app._sagemaker_client = boto3.client("sagemaker", region_name=TEST_REGION)
+
+    # test url without job redirect
+    url = tb_app.get_app_url(
+        create_presigned_domain_url=True,
         domain_id=TEST_DOMAIN,
         user_profile_name=TEST_USER_PROFILE,
-        create_presigned_domain_url=True,
         open_in_default_web_browser=False,
     )
     assert url == f"{TEST_PRESIGNED_URL}&redirect=TensorBoard"
 
-    url = TensorBoardApp(TEST_REGION).get_app_url(
+    # test url with valid job redirect
+    url = tb_app.get_app_url(
         training_job_name=TEST_TRAINING_JOB,
+        create_presigned_domain_url=True,
         domain_id=TEST_DOMAIN,
         user_profile_name=TEST_USER_PROFILE,
-        create_presigned_domain_url=True,
         open_in_default_web_browser=False,
     )
     assert url.startswith(f"{TEST_PRESIGNED_URL}&redirect=TensorBoard&state=")
     assert url.endswith("==")
 
+    # test url with invalid job redirect
+    with pytest.raises(ValueError):
+        tb_app.get_app_url(
+            training_job_name="invald_job_name!",
+            create_presigned_domain_url=True,
+            domain_id=TEST_DOMAIN,
+            user_profile_name=TEST_USER_PROFILE,
+            open_in_default_web_browser=False,
+        )
 
-@patch("boto3.client")
-@patch("sagemaker.interactive_apps.base_interactive_app.BaseInteractiveApp._is_in_studio")
-def test_tb_presigned_url_success_open_in_web_browser(mock_in_studio, mock_client):
-    mock_in_studio.return_value = False
-    resp = {
-        "ResponseMetadata": {"HTTPStatusCode": 200},
-        "AuthorizedUrl": TEST_PRESIGNED_URL,
-    }
-    attrs = {"create_presigned_domain_url.return_value": resp}
-    mock_client.return_value = Mock(**attrs)
-
+    # test url when opened in web browser
     with patch("webbrowser.open") as mock_web_browser_open:
-        url = TensorBoardApp(TEST_REGION).get_app_url(
+        url = tb_app.get_app_url(
             domain_id=TEST_DOMAIN,
             user_profile_name=TEST_USER_PROFILE,
             create_presigned_domain_url=True,
@@ -198,30 +271,59 @@ def test_tb_presigned_url_success_open_in_web_browser(mock_in_studio, mock_clien
 
 
 @patch("boto3.client")
-@patch("sagemaker.interactive_apps.base_interactive_app.BaseInteractiveApp._is_in_studio")
-def test_tb_presigned_url_not_returned_without_presigned_flag(mock_in_studio, mock_client):
-    mock_in_studio.return_value = False
+@patch("sagemaker.interactive_apps.base_interactive_app.BaseInteractiveApp.__init__")
+def test_tb_presigned_url_invalid_params(mock_init, mock_client):
+    mock_init.return_value = None
     mock_client.return_value = boto3.client("sagemaker")
 
-    url = TensorBoardApp(TEST_REGION).get_app_url(
+    tb_app = TensorBoardApp(TEST_REGION)
+    tb_app.region = TEST_REGION
+    tb_app._domain_id = None
+    tb_app._user_profile_name = None
+    tb_app._in_studio_env = False
+
+    url = tb_app.get_app_url(
+        create_presigned_domain_url=False,
         domain_id=TEST_DOMAIN,
         user_profile_name=TEST_USER_PROFILE,
-        create_presigned_domain_url=False,
+        open_in_default_web_browser=False,
+    )
+    assert url == BASE_URL_NON_STUDIO_FORMAT.format(region=TEST_REGION)
+
+    url = tb_app.get_app_url(
+        create_presigned_domain_url=True,
+        domain_id="d" * 64,
+        user_profile_name=TEST_USER_PROFILE,
+        open_in_default_web_browser=False,
+    )
+    assert url == BASE_URL_NON_STUDIO_FORMAT.format(region=TEST_REGION)
+
+    url = tb_app.get_app_url(
+        create_presigned_domain_url=True,
+        domain_id=TEST_DOMAIN,
+        user_profile_name="u" * 64,
         open_in_default_web_browser=False,
     )
     assert url == BASE_URL_NON_STUDIO_FORMAT.format(region=TEST_REGION)
 
 
 @patch("boto3.client")
-@patch("sagemaker.interactive_apps.base_interactive_app.BaseInteractiveApp._is_in_studio")
-def test_tb_presigned_url_failure(mock_in_studio, mock_client):
-    mock_in_studio.return_value = False
+@patch("sagemaker.interactive_apps.base_interactive_app.BaseInteractiveApp.__init__")
+def test_tb_presigned_url_failure(mock_init, mock_client):
+    mock_init.return_value = None
     resp = {"ResponseMetadata": {"HTTPStatusCode": 400}}
     attrs = {"create_presigned_domain_url.return_value": resp}
     mock_client.return_value = Mock(**attrs)
 
+    tb_app = TensorBoardApp(TEST_REGION)
+    tb_app.region = TEST_REGION
+    tb_app._domain_id = None
+    tb_app._user_profile_name = None
+    tb_app._in_studio_env = False
+    tb_app._sagemaker_client = boto3.client("sagemaker", region_name=TEST_REGION)
+
     with pytest.raises(ValueError):
-        TensorBoardApp(TEST_REGION).get_app_url(
+        tb_app.get_app_url(
             domain_id=TEST_DOMAIN,
             user_profile_name=TEST_USER_PROFILE,
             create_presigned_domain_url=True,
@@ -229,45 +331,55 @@ def test_tb_presigned_url_failure(mock_in_studio, mock_client):
         )
 
 
-@patch("sagemaker.interactive_apps.base_interactive_app.BaseInteractiveApp._is_in_studio")
-def test_tb_invalid_presigned_kwargs(mock_in_studio):
-    mock_in_studio.return_value = False
-    invalid_kwargs = {
-        "fake-parameter": True,
-        "DomainId": TEST_DOMAIN,
-        "UserProfileName": TEST_USER_PROFILE,
-    }
+@patch("sagemaker.interactive_apps.base_interactive_app.BaseInteractiveApp.__init__")
+def test_tb_invalid_presigned_kwargs(mock_init):
+    mock_init.return_value = None
+    tb_app = TensorBoardApp(TEST_REGION)
+    tb_app.region = TEST_REGION
+    tb_app._domain_id = None
+    tb_app._user_profile_name = None
+    tb_app._in_studio_env = False
+    tb_app._sagemaker_client = boto3.client("sagemaker", region_name=TEST_REGION)
 
     with pytest.raises(botocore.exceptions.ParamValidationError):
-        TensorBoardApp(TEST_REGION).get_app_url(
-            optional_create_presigned_url_kwargs=invalid_kwargs,
+        invalid_kwargs = {"fake-parameter": True}
+        tb_app.get_app_url(
             create_presigned_domain_url=True,
+            domain_id=TEST_DOMAIN,
+            user_profile_name=TEST_USER_PROFILE,
+            open_in_default_web_browser=False,
+            optional_create_presigned_url_kwargs=invalid_kwargs,
         )
 
 
 @patch("boto3.client")
-@patch("sagemaker.interactive_apps.base_interactive_app.BaseInteractiveApp._is_in_studio")
-def test_tb_valid_presigned_kwargs(mock_in_studio, mock_client):
-    mock_in_studio.return_value = False
-
-    rsp = {
+@patch("sagemaker.interactive_apps.base_interactive_app.BaseInteractiveApp.__init__")
+def test_tb_valid_presigned_kwargs(mock_init, mock_client):
+    mock_init.return_value = None
+    resp = {
         "ResponseMetadata": {"HTTPStatusCode": 200},
         "AuthorizedUrl": TEST_PRESIGNED_URL,
     }
     mock_client = boto3.client("sagemaker")
     mock_client.create_presigned_domain_url = Mock(name="create_presigned_domain_url")
-    mock_client.create_presigned_domain_url.return_value = rsp
+    mock_client.create_presigned_domain_url.return_value = resp
 
-    valid_kwargs = {"DomainId": TEST_DOMAIN, "UserProfileName": TEST_USER_PROFILE}
+    tb_app = TensorBoardApp(TEST_REGION)
+    tb_app.region = TEST_REGION
+    tb_app._domain_id = None
+    tb_app._user_profile_name = None
+    tb_app._in_studio_env = False
+    tb_app._sagemaker_client = boto3.client("sagemaker", region_name=TEST_REGION)
 
-    url = TensorBoardApp(TEST_REGION).get_app_url(
-        optional_create_presigned_url_kwargs=valid_kwargs,
+    valid_kwargs = {"ExpiresInSeconds": 1500}
+    tb_app.get_app_url(
         create_presigned_domain_url=True,
+        domain_id=TEST_DOMAIN,
+        user_profile_name=TEST_USER_PROFILE,
         open_in_default_web_browser=False,
+        optional_create_presigned_url_kwargs=valid_kwargs,
     )
-
-    assert url == f"{TEST_PRESIGNED_URL}&redirect=TensorBoard"
-    mock_client.create_presigned_domain_url.assert_called_once_with(**valid_kwargs)
+    mock_client.create_presigned_domain_url.assert_called_with(**valid_kwargs)
 
 
 def test_tb_init_with_default_region():


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
In order to confirm that we are in Studio environment, we cannot just rely on the existence of NOTEBOOK_METADATA_FILE as this file exists for SM Notebook Instances as well. We also need to check if domain id and user profile name are present in the file.

Following are some notable minor changes:

-   Using variable _in_studio_env instead of function _is_in_studio()
-   Removing unused functions _is_in_studio() and _validate_domain_and_user()
-   No default value for domain id and user profile name in validate functions
-   Deduplicate calls to validate functions

*Testing done:*
-  Tested functionality in notebook instances, along with ec2 and studio.
-  Also added a unit test to cover notebook instance use case.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
