### PR TITLE
fix: handle bad jumpstart default session

### DIFF
--- a/src/sagemaker/jumpstart/constants.py
+++ b/src/sagemaker/jumpstart/constants.py
@@ -183,9 +183,9 @@ try:
     DEFAULT_JUMPSTART_SAGEMAKER_SESSION = Session(
         boto3.Session(region_name=JUMPSTART_DEFAULT_REGION_NAME)
     )
-except Exception as e:
+except Exception as e:  # pylint: disable=W0703
     DEFAULT_JUMPSTART_SAGEMAKER_SESSION = None
-    JUMPSTART_LOGGER.warn(
+    JUMPSTART_LOGGER.warning(
         "Unable to create default JumpStart SageMaker Session due to the following error: %s.",
         str(e),
     )

--- a/src/sagemaker/jumpstart/constants.py
+++ b/src/sagemaker/jumpstart/constants.py
@@ -179,6 +179,13 @@ MODEL_ID_LIST_WEB_URL = "https://sagemaker.readthedocs.io/en/stable/doc_utils/pr
 
 JUMPSTART_LOGGER = logging.getLogger("sagemaker.jumpstart")
 
-DEFAULT_JUMPSTART_SAGEMAKER_SESSION = Session(
-    boto3.Session(region_name=JUMPSTART_DEFAULT_REGION_NAME)
-)
+try:
+    DEFAULT_JUMPSTART_SAGEMAKER_SESSION = Session(
+        boto3.Session(region_name=JUMPSTART_DEFAULT_REGION_NAME)
+    )
+except Exception as e:
+    DEFAULT_JUMPSTART_SAGEMAKER_SESSION = None
+    JUMPSTART_LOGGER.warn(
+        "Unable to create default JumpStart SageMaker Session due to the following error: %s.",
+        str(e),
+    )


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/sagemaker-python-sdk/issues/4106

*Description of changes:*
fix: handle bad jumpstart default session

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
