### PR TITLE
feat: Local Mode - Add Support for Docker Compose V2

### DIFF
--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -1550,14 +1550,15 @@ them to your local environment. This is a great way to test your deep learning s
 managed training or hosting environments. Local Mode is supported for frameworks images (TensorFlow, MXNet, Chainer, PyTorch,
 and Scikit-Learn) and images you supply yourself.
 
-You can install necessary dependencies for this feature using pip; local mode also requires docker-compose which you can
-install using the following steps (More info - https://github.com/docker/compose#where-to-get-docker-compose ):
+You can install necessary dependencies for this feature using pip.
 
 ::
 
     pip install 'sagemaker[local]' --upgrade
-    curl -L "https://github.com/docker/compose/releases/download/v2.7.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-    chmod +x /usr/local/bin/docker-compose
+
+
+Additionally, Local Mode also requires Docker Compose V2. Follow the guidelines in https://docs.docker.com/compose/install/ to install.
+Make sure to have a Compose Version compatible with your Docker Engine installation. Check Docker Engine release notes https://docs.docker.com/engine/release-notes to find a compatible version.
 
 If you want to keep everything local, and not use Amazon S3 either, you can enable "local code" in one of two ways:
 

--- a/src/sagemaker/local/image.py
+++ b/src/sagemaker/local/image.py
@@ -134,7 +134,6 @@ class _SageMakerContainer(object):
                 "'Docker Compose' is not installed. "
                 "Proceeding to check for 'docker-compose' CLI."
             )
-            pass
 
         if output and "v2" in output.strip():
             logger.info("'Docker Compose' found using Docker CLI.")

--- a/src/sagemaker/local/image.py
+++ b/src/sagemaker/local/image.py
@@ -114,8 +114,13 @@ class _SageMakerContainer(object):
 
     @staticmethod
     def _get_compose_cmd_prefix():
-        """Gets the Docker Compose command. The method initially looks for 'docker compose' v2
+        """Gets the Docker Compose command.
+
+        The method initially looks for 'docker compose' v2
         executable, if not found looks for 'docker-compose' executable.
+
+        Returns:
+            Docker Compose executable split into list.
 
         Raises:
             ImportError: If Docker Compose executable was not found.

--- a/src/sagemaker/local/image.py
+++ b/src/sagemaker/local/image.py
@@ -114,6 +114,12 @@ class _SageMakerContainer(object):
 
     @staticmethod
     def _get_compose_cmd_prefix():
+        """Gets the Docker Compose command. The method initially looks for 'docker compose' v2
+        executable, if not found looks for 'docker-compose' executable.
+
+        Raises:
+            ImportError: If Docker Compose executable was not found.
+        """
         compose_cmd_prefix = []
 
         output = None

--- a/tests/scripts/run-notebook-test.sh
+++ b/tests/scripts/run-notebook-test.sh
@@ -141,9 +141,6 @@ echo "set SAGEMAKER_ROLE_ARN=$SAGEMAKER_ROLE_ARN"
 ./amazon-sagemaker-examples/sagemaker-python-sdk/scikit_learn_randomforest/Sklearn_on_SageMaker_end2end.ipynb \
 ./amazon-sagemaker-examples/sagemaker-pipelines/tabular/abalone_build_train_deploy/sagemaker-pipelines-preprocess-train-evaluate-batch-transform.ipynb \
 
-# Skipping test until fix in example notebook to move to new conda environment
-#./amazon-sagemaker-examples/advanced_functionality/kmeans_bring_your_own_model/kmeans_bring_your_own_model.ipynb \
-
 # Skipping test until fix in example notebook to install docker-compose is complete
 #./amazon-sagemaker-examples/sagemaker-python-sdk/tensorflow_moving_from_framework_mode_to_script_mode/tensorflow_moving_from_framework_mode_to_script_mode.ipynb \
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/sagemaker-python-sdk/issues/3659
https://github.com/aws/sagemaker-python-sdk/issues/4038

*Description of changes:*
 Local Mode - Add Support for Docker Compose V2

*Testing done:*
Added units and tested in a SageMaker NPI with G4DN instance - https://github.com/aws/amazon-sagemaker-examples/blob/main/sagemaker-python-sdk/pytorch_cnn_cifar10/pytorch_local_mode_cifar10.ipynb

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
