### PR TITLE
fix: use correct line endings and s3 uris on windows

### DIFF
--- a/src/sagemaker/remote_function/job.py
+++ b/src/sagemaker/remote_function/job.py
@@ -860,7 +860,7 @@ def _prepare_and_upload_runtime_scripts(
             )
             shutil.copy2(spark_script_path, bootstrap_scripts)
 
-        with open(entrypoint_script_path, "w") as file:
+        with open(entrypoint_script_path, "w", newline="\n") as file:
             file.writelines(entry_point_script)
 
         bootstrap_script_path = os.path.join(

--- a/src/sagemaker/remote_function/runtime_environment/bootstrap_runtime_environment.py
+++ b/src/sagemaker/remote_function/runtime_environment/bootstrap_runtime_environment.py
@@ -74,7 +74,7 @@ def _bootstrap_runtime_environment(
     Args:
         conda_env (str): conda environment to be activated. Default is None.
     """
-    workspace_archive_dir_path = os.path.join(BASE_CHANNEL_PATH, REMOTE_FUNCTION_WORKSPACE)
+    workspace_archive_dir_path = f"{BASE_CHANNEL_PATH}/{REMOTE_FUNCTION_WORKSPACE}"
 
     if not os.path.exists(workspace_archive_dir_path):
         logger.info(
@@ -84,7 +84,7 @@ def _bootstrap_runtime_environment(
         return
 
     # Unpack user workspace archive first.
-    workspace_archive_path = os.path.join(workspace_archive_dir_path, "workspace.zip")
+    workspace_archive_path = f"{workspace_archive_dir_path}/workspace.zip"
     if not os.path.isfile(workspace_archive_path):
         logger.info(
             "Workspace archive '%s' does not exist. Assuming no dependencies to bootstrap.",

--- a/tests/unit/sagemaker/remote_function/core/test_serialization.py
+++ b/tests/unit/sagemaker/remote_function/core/test_serialization.py
@@ -12,7 +12,6 @@
 # language governing permissions and limitations under the License.
 from __future__ import absolute_import
 
-import os.path
 import random
 import string
 import pytest
@@ -186,7 +185,7 @@ def test_deserialize_func_corrupt_metadata():
     serialize_func_to_s3(
         func=square, sagemaker_session=Mock(), s3_uri=s3_uri, s3_kms_key=KMS_KEY, hmac_key=HMAC_KEY
     )
-    mock_s3[os.path.join(s3_uri, "metadata.json")] = b"not json serializable"
+    mock_s3[f"{s3_uri}/metadata.json"] = b"not json serializable"
 
     del square
 

--- a/tests/unit/sagemaker/remote_function/runtime_environment/test_bootstrap_runtime_environment.py
+++ b/tests/unit/sagemaker/remote_function/runtime_environment/test_bootstrap_runtime_environment.py
@@ -199,7 +199,8 @@ def test_main_no_dependency_file(
     validate_python.assert_called_once_with(TEST_PYTHON_VERSION, TEST_JOB_CONDA_ENV)
     path_exists.assert_called_once_with(TEST_WORKSPACE_ARCHIVE_DIR_PATH)
     file_exists.assert_called_once_with(TEST_WORKSPACE_ARCHIVE_PATH)
-    get_cwd.assert_called_once()
+    # Called twice by pathlib on some platforms
+    get_cwd.assert_called()
     list_dir.assert_called_once_with(pathlib.Path(TEST_DEPENDENCIES_PATH))
     run_pre_exec_script.assert_called()
     bootstrap_runtime.assert_not_called()


### PR DESCRIPTION
Closes #4090

*Issue #, if available:*
#4090

*Description of changes:*
Fixes the `@remote` functionality on windows.

This request is coming from a github organization so you might not be able to edit it directly. Let me know if it needs rebased or any changes. Feel free to take the patch and apply it if that makes things easier.

*Testing done:*
Tested on multiple windows machines.

@diegodebrito @vadecp

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
