### PR TITLE
change: Enhance unit-tests to automatically consume image URIs config registries from config JSONs

### DIFF
--- a/tests/unit/sagemaker/image_uris/conftest.py
+++ b/tests/unit/sagemaker/image_uris/conftest.py
@@ -12,17 +12,26 @@
 # language governing permissions and limitations under the License.
 from __future__ import absolute_import
 
+import os
+import json
 import pytest
-from sagemaker import image_uris
-from tests.unit.sagemaker.image_uris import expected_uris
 
 
-@pytest.mark.parametrize("load_config", ["debugger.json"], indirect=True)
-def test_debugger(load_config):
-    ACCOUNTS = load_config["versions"]["latest"]["registries"]
-    for region in ACCOUNTS.keys():
-        uri = image_uris.retrieve("debugger", region=region)
-        expected = expected_uris.algo_uri(
-            "sagemaker-debugger-rules", ACCOUNTS[region], region, version="latest"
-        )
-        assert expected == uri
+@pytest.fixture(scope="module")
+def config_dir():
+    return "src/sagemaker/image_uri_config/"
+
+
+@pytest.fixture(scope="module")
+def load_config(config_dir, request):
+    config_file_name = request.param
+    config_file_path = os.path.join(config_dir, config_file_name)
+
+    with open(config_file_path, "r") as config_file:
+        return json.load(config_file)
+
+
+@pytest.fixture(scope="module")
+def extract_versions_for_image_scope(load_config, request):
+    scope_val = request.param
+    return load_config[scope_val]["versions"]

--- a/tests/unit/sagemaker/image_uris/test_base_python.py
+++ b/tests/unit/sagemaker/image_uris/test_base_python.py
@@ -15,39 +15,11 @@ import pytest
 from sagemaker import image_uris
 from tests.unit.sagemaker.image_uris import expected_uris
 
-REGISTRIES = {
-    "us-east-2": "429704687514",
-    "me-south-1": "117516905037",
-    "us-west-2": "236514542706",
-    "ca-central-1": "310906938811",
-    "ap-east-1": "493642496378",
-    "us-east-1": "081325390199",
-    "ap-northeast-2": "806072073708",
-    "eu-west-2": "712779665605",
-    "ap-southeast-2": "52832661640",
-    "cn-northwest-1": "390780980154",
-    "eu-north-1": "243637512696",
-    "cn-north-1": "390048526115",
-    "ap-south-1": "394103062818",
-    "eu-west-3": "615547856133",
-    "ap-southeast-3": "276181064229",
-    "af-south-1": "559312083959",
-    "eu-west-1": "470317259841",
-    "eu-central-1": "936697816551",
-    "sa-east-1": "782484402741",
-    "ap-northeast-3": "792733760839",
-    "eu-south-1": "592751261982",
-    "ap-northeast-1": "102112518831",
-    "us-west-1": "742091327244",
-    "ap-southeast-1": "492261229750",
-    "me-central-1": "103105715889",
-    "us-gov-east-1": "107072934176",
-    "us-gov-west-1": "107173498710",
-}
 
-
+@pytest.mark.parametrize("load_config", ["sagemaker-base-python.json"], indirect=True)
 @pytest.mark.parametrize("py_version", ["310", "38"])
-def test_get_base_python_image_uri(py_version):
+def test_get_base_python_image_uri(py_version, load_config):
+    REGISTRIES = load_config["versions"]["1.0"]["registries"]
     for region in REGISTRIES.keys():
         uri = image_uris.get_base_python_image_uri(
             region=region,

--- a/tests/unit/sagemaker/image_uris/test_data_wrangler.py
+++ b/tests/unit/sagemaker/image_uris/test_data_wrangler.py
@@ -12,41 +12,9 @@
 # language governing permissions and limitations under the License.
 from __future__ import absolute_import
 
+import pytest
 from sagemaker import image_uris
 from tests.unit.sagemaker.image_uris import expected_uris
-
-DATA_WRANGLER_ACCOUNTS = {
-    "af-south-1": "143210264188",
-    "ap-east-1": "707077482487",
-    "ap-northeast-1": "649008135260",
-    "ap-northeast-2": "131546521161",
-    "ap-northeast-3": "913387583493",
-    "ap-south-1": "089933028263",
-    "ap-southeast-1": "119527597002",
-    "ap-southeast-2": "422173101802",
-    "ca-central-1": "557239378090",
-    "eu-central-1": "024640144536",
-    "eu-north-1": "054986407534",
-    "eu-south-1": "488287956546",
-    "eu-west-1": "245179582081",
-    "eu-west-2": "894491911112",
-    "eu-west-3": "807237891255",
-    "me-south-1": "376037874950",
-    "sa-east-1": "424196993095",
-    "us-east-1": "663277389841",
-    "us-east-2": "415577184552",
-    "us-west-1": "926135532090",
-    "us-west-2": "174368400705",
-    "cn-north-1": "245909111842",
-    "cn-northwest-1": "249157047649",
-}
-
-# Accounts only supported in DW 3.x and beyond
-DATA_WRANGLER_3X_ACCOUNTS = {
-    "il-central-1": "406833011540",
-}
-
-VERSIONS = ["1.x", "2.x", "3.x"]
 
 
 def _test_ecr_uri(account, region, version):
@@ -60,23 +28,23 @@ def _test_ecr_uri(account, region, version):
     return expected_uri == actual_uri
 
 
-def test_data_wrangler_ecr_uri():
+@pytest.mark.parametrize("load_config", ["data-wrangler.json"], indirect=True)
+@pytest.mark.parametrize("extract_versions_for_image_scope", ["processing"], indirect=True)
+def test_data_wrangler_ecr_uri(load_config, extract_versions_for_image_scope):
+    VERSIONS = extract_versions_for_image_scope
     for version in VERSIONS:
+        DATA_WRANGLER_ACCOUNTS = load_config["processing"]["versions"][version]["registries"]
         for region in DATA_WRANGLER_ACCOUNTS.keys():
             assert _test_ecr_uri(
                 account=DATA_WRANGLER_ACCOUNTS[region], region=region, version=version
             )
 
 
-def test_data_wrangler_ecr_uri_3x():
-    for region in DATA_WRANGLER_3X_ACCOUNTS.keys():
-        assert _test_ecr_uri(
-            account=DATA_WRANGLER_3X_ACCOUNTS[region], region=region, version="3.x"
-        )
-
-
-def test_data_wrangler_ecr_uri_none():
+@pytest.mark.parametrize("load_config", ["data-wrangler.json"], indirect=True)
+def test_data_wrangler_ecr_uri_none(load_config):
     region = "us-west-2"
+    VERSIONS = ["1.x", "2.x", "3.x"]
+    DATA_WRANGLER_ACCOUNTS = load_config["processing"]["versions"]["1.x"]["registries"]
     actual_uri = image_uris.retrieve("data-wrangler", region=region)
     expected_uri = expected_uris.algo_uri(
         "sagemaker-data-wrangler-container",


### PR DESCRIPTION
from the config JSONs

*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
