### PR TITLE
change: allow smdistributed to be enabled with torch_distributed.

### DIFF
--- a/src/sagemaker/estimator.py
+++ b/src/sagemaker/estimator.py
@@ -3849,7 +3849,9 @@ class Framework(EstimatorBase):
             if get_mp_parameters(distribution):
                 distribution_config["mp_parameters"] = get_mp_parameters(distribution)
             # first make sure torch_distributed is enabled if instance type is p5
-            torch_distributed_enabled = distribution.get("torch_distributed").get("enabled", False)
+            torch_distributed_enabled = False
+            if "torch_distributed" in distribution:
+                torch_distributed_enabled = distribution.get("torch_distributed").get("enabled", False)
             smdistributed = distribution["smdistributed"]
             smdataparallel_enabled = smdistributed.get("dataparallel", {}).get("enabled", False)
             p5_enabled = "p5.48xlarge" in self.instance_type

--- a/src/sagemaker/estimator.py
+++ b/src/sagemaker/estimator.py
@@ -3852,13 +3852,22 @@ class Framework(EstimatorBase):
             torch_distributed_enabled = distribution.get("torch_distributed").get("enabled", False)
             smdistributed = distribution["smdistributed"]
             smdataparallel_enabled = smdistributed.get("dataparallel", {}).get("enabled", False)
-            p5_enabled = bool("p5.48xlarge" in self.instance_type)
+            p5_enabled = "p5.48xlarge" in self.instance_type
             img_uri = "" if self.image_uri is None else self.image_uri
             for unsupported_image in Framework.UNSUPPORTED_DLC_IMAGE_FOR_SM_PARALLELISM:
-                if unsupported_image in img_uri and not torch_distributed_enabled: #disabling DLC images with CUDA12
-                    raise ValueError(f"SMDistributed is currently incompatible with DLC image: {img_uri}. (Could be due to CUDA version being greater than 11.)")
-            if not torch_distributed_enabled and p5_enabled: #disabling p5 when torch distributed is disabled
-                raise ValueError("SMModelParallel and SMDataParallel currently do not support p5 instances.")
+                if (
+                    unsupported_image in img_uri and not torch_distributed_enabled
+                ):  # disabling DLC images with CUDA12
+                    raise ValueError(
+                        f"SMDistributed is currently incompatible with DLC image: {img_uri}. "
+                        "(Could be due to CUDA version being greater than 11.)"
+                    )
+            if (
+                not torch_distributed_enabled and p5_enabled
+            ):  # disabling p5 when torch distributed is disabled
+                raise ValueError(
+                    "SMModelParallel and SMDataParallel currently do not support p5 instances."
+                )
             # smdistributed strategy selected with supported instance type
             distribution_config[self.LAUNCH_SM_DDP_ENV_NAME] = smdataparallel_enabled
             distribution_config[self.INSTANCE_TYPE] = self.instance_type

--- a/src/sagemaker/estimator.py
+++ b/src/sagemaker/estimator.py
@@ -3415,6 +3415,7 @@ class Framework(EstimatorBase):
         self.checkpoint_s3_uri = checkpoint_s3_uri
         self.checkpoint_local_path = checkpoint_local_path
         self.enable_sagemaker_metrics = enable_sagemaker_metrics
+        self.unsupported_dlc_image_for_sm_parallelism = ["2.0.1-gpu-py310-cu121"]
 
     def _prepare_for_training(self, job_name=None):
         """Set hyperparameters needed for training. This method will also validate ``source_dir``.
@@ -3847,8 +3848,18 @@ class Framework(EstimatorBase):
             # smdistributed strategy selected
             if get_mp_parameters(distribution):
                 distribution_config["mp_parameters"] = get_mp_parameters(distribution)
+            # first make sure torch_distributed is enabled if instance type is p5
+            torch_distributed_enabled = distribution.get("torch_distributed").get("enabled", False)
             smdistributed = distribution["smdistributed"]
             smdataparallel_enabled = smdistributed.get("dataparallel", {}).get("enabled", False)
+            p5_enabled = bool("p5.48xlarge" in self.instance_type)
+            img_uri = "" if self.image_uri is None else self.image_uri
+            for unsupported_image in self.unsupported_dlc_image_for_sm_parallelism:
+                if unsupported_image in img_uri and not torch_distributed_enabled: #disabling DLC images with CUDA12
+                    raise ValueError(f"SMDistributed is currently incompatible with DLC image: {img_uri}. (Could be due to CUDA version being greater than 11.)")
+            if not torch_distributed_enabled and p5_enabled: #disabling p5 when torch distributed is disabled
+                raise ValueError("SMModelParallel and SMDataParallel currently do not support p5 instances.")
+            # smdistributed strategy selected with supported instance type
             distribution_config[self.LAUNCH_SM_DDP_ENV_NAME] = smdataparallel_enabled
             distribution_config[self.INSTANCE_TYPE] = self.instance_type
             if smdataparallel_enabled:

--- a/src/sagemaker/estimator.py
+++ b/src/sagemaker/estimator.py
@@ -3198,6 +3198,7 @@ class Framework(EstimatorBase):
     """
 
     _framework_name = None
+    UNSUPPORTED_DLC_IMAGE_FOR_SM_PARALLELISM = ("2.0.1-gpu-py310-cu121", "2.0-gpu-py310-cu121")
 
     def __init__(
         self,
@@ -3415,7 +3416,6 @@ class Framework(EstimatorBase):
         self.checkpoint_s3_uri = checkpoint_s3_uri
         self.checkpoint_local_path = checkpoint_local_path
         self.enable_sagemaker_metrics = enable_sagemaker_metrics
-        self.unsupported_dlc_image_for_sm_parallelism = ["2.0.1-gpu-py310-cu121"]
 
     def _prepare_for_training(self, job_name=None):
         """Set hyperparameters needed for training. This method will also validate ``source_dir``.
@@ -3854,7 +3854,7 @@ class Framework(EstimatorBase):
             smdataparallel_enabled = smdistributed.get("dataparallel", {}).get("enabled", False)
             p5_enabled = bool("p5.48xlarge" in self.instance_type)
             img_uri = "" if self.image_uri is None else self.image_uri
-            for unsupported_image in self.unsupported_dlc_image_for_sm_parallelism:
+            for unsupported_image in Framework.UNSUPPORTED_DLC_IMAGE_FOR_SM_PARALLELISM:
                 if unsupported_image in img_uri and not torch_distributed_enabled: #disabling DLC images with CUDA12
                     raise ValueError(f"SMDistributed is currently incompatible with DLC image: {img_uri}. (Could be due to CUDA version being greater than 11.)")
             if not torch_distributed_enabled and p5_enabled: #disabling p5 when torch distributed is disabled

--- a/src/sagemaker/estimator.py
+++ b/src/sagemaker/estimator.py
@@ -3851,7 +3851,9 @@ class Framework(EstimatorBase):
             # first make sure torch_distributed is enabled if instance type is p5
             torch_distributed_enabled = False
             if "torch_distributed" in distribution:
-                torch_distributed_enabled = distribution.get("torch_distributed").get("enabled", False)
+                torch_distributed_enabled = distribution.get("torch_distributed").get(
+                    "enabled", False
+                )
             smdistributed = distribution["smdistributed"]
             smdataparallel_enabled = smdistributed.get("dataparallel", {}).get("enabled", False)
             p5_enabled = "p5.48xlarge" in self.instance_type

--- a/src/sagemaker/estimator.py
+++ b/src/sagemaker/estimator.py
@@ -101,6 +101,7 @@ from sagemaker.utils import (
 )
 from sagemaker.workflow import is_pipeline_variable
 from sagemaker.workflow.entities import PipelineVariable
+from sagemaker.workflow.parameters import ParameterString
 from sagemaker.workflow.pipeline_context import PipelineSession, runnable_by_pipeline
 
 logger = logging.getLogger(__name__)
@@ -3856,7 +3857,15 @@ class Framework(EstimatorBase):
                 )
             smdistributed = distribution["smdistributed"]
             smdataparallel_enabled = smdistributed.get("dataparallel", {}).get("enabled", False)
-            p5_enabled = "p5.48xlarge" in self.instance_type
+            if isinstance(self.instance_type, ParameterString):
+                p5_enabled = "p5.48xlarge" in self.instance_type.default_value
+            elif isinstance(self.instance_type, str):
+                p5_enabled = "p5.48xlarge" in self.instance_type
+            else:
+                raise ValueError(
+                    "Invalid object type for instance_type argument. Expected "
+                    f"{type(str)} or {type(ParameterString)} but got {type(self.instance_type)}."
+                )
             img_uri = "" if self.image_uri is None else self.image_uri
             for unsupported_image in Framework.UNSUPPORTED_DLC_IMAGE_FOR_SM_PARALLELISM:
                 if (

--- a/src/sagemaker/estimator.py
+++ b/src/sagemaker/estimator.py
@@ -3843,14 +3843,10 @@ class Framework(EstimatorBase):
                 "custom_mpi_options", ""
             )
 
-            if get_mp_parameters(distribution):
-                distribution_config["mp_parameters"] = get_mp_parameters(distribution)
-
-        elif "modelparallel" in distribution.get("smdistributed", {}):
-            raise ValueError("Cannot use Model Parallelism without MPI enabled!")
-
         if "smdistributed" in distribution:
             # smdistributed strategy selected
+            if get_mp_parameters(distribution):
+                distribution_config["mp_parameters"] = get_mp_parameters(distribution)
             smdistributed = distribution["smdistributed"]
             smdataparallel_enabled = smdistributed.get("dataparallel", {}).get("enabled", False)
             distribution_config[self.LAUNCH_SM_DDP_ENV_NAME] = smdataparallel_enabled

--- a/src/sagemaker/pytorch/estimator.py
+++ b/src/sagemaker/pytorch/estimator.py
@@ -326,6 +326,9 @@ class PyTorch(Framework):
             if self.instance_type is not None:
                 distribution_config[self.INSTANCE_TYPE_ENV_NAME] = self.instance_type
         elif torch_distributed_enabled:
+            if "smdistributed" in distribution:
+                # Enable torch_distributed for smdistributed.
+                distribution_config = self._distribution_configuration(distribution=distribution)
             distribution_config[self.LAUNCH_TORCH_DISTRIBUTED_ENV_NAME] = torch_distributed_enabled
             if self.instance_type is not None:
                 distribution_config[self.INSTANCE_TYPE_ENV_NAME] = self.instance_type

--- a/tests/unit/test_estimator.py
+++ b/tests/unit/test_estimator.py
@@ -322,35 +322,57 @@ def training_job_description(sagemaker_session):
     sagemaker_session.describe_training_job = mock_describe_training_job
     return returned_job_description
 
+
+def test_validate_smdistributed_unsupported_image_raises(sagemaker_session):
+    # Test unsupported image raises error.
+    for unsupported_image in DummyFramework.UNSUPPORTED_DLC_IMAGE_FOR_SM_PARALLELISM:
+        # Fail due to unsupported CUDA12 DLC image.
+        f = DummyFramework(
+            "some_script.py",
+            role="DummyRole",
+            instance_type="ml.p4d.24xlarge",
+            sagemaker_session=sagemaker_session,
+            output_path="outputpath",
+            image_uri=unsupported_image,
+        )
+        with pytest.raises(ValueError):
+            f._distribution_configuration(DISTRIBUTION_SM_DDP_ENABLED)
+        with pytest.raises(ValueError):
+            f._distribution_configuration(DISTRIBUTION_SM_DDP_DISABLED)
+
+    # Test unsupported image with suffix raises error.
+    for unsupported_image in DummyFramework.UNSUPPORTED_DLC_IMAGE_FOR_SM_PARALLELISM:
+        # Fail due to unsupported CUDA12 DLC image.
+        f = DummyFramework(
+            "some_script.py",
+            role="DummyRole",
+            instance_type="ml.p4d.24xlarge",
+            sagemaker_session=sagemaker_session,
+            output_path="outputpath",
+            image_uri=unsupported_image + "-ubuntu20.04-sagemaker-pr-3303",
+        )
+        with pytest.raises(ValueError):
+            f._distribution_configuration(DISTRIBUTION_SM_DDP_ENABLED)
+        with pytest.raises(ValueError):
+            f._distribution_configuration(DISTRIBUTION_SM_DDP_DISABLED)
+
+
 def test_validate_smdistributed_p5_raises(sagemaker_session):
-    # supported DLC image
+    # Supported DLC image.
     f = DummyFramework(
         "some_script.py", 
         role="DummyRole",
         instance_type="ml.p5.48xlarge", 
         sagemaker_session=sagemaker_session,
         output_path="outputpath",
-        image_uri="some_acceptable_image"
+        image_uri="some_acceptable_image",
     )
-    #both fail because instance type is p5 and torch_distributed is off
+    # Both fail because instance type is p5 and torch_distributed is off.
     with pytest.raises(ValueError):
         f._distribution_configuration(DISTRIBUTION_SM_DDP_ENABLED) 
     with pytest.raises(ValueError):
         f._distribution_configuration(DISTRIBUTION_SM_DDP_DISABLED) 
-    # unsupported DLC image
-    f = DummyFramework(
-        "some_script.py",
-        role="DummyRole",
-        instance_type="ml.p5.48xlarge",
-        sagemaker_session=sagemaker_session,
-        output_path="outputpath",
-        image_uri="ecr-url/2.0.1-gpu-py310-cu121-ubuntu20.04-sagemaker-pr-3303"
-    )
-    #both fail due to unsupported CUDA12 DLC image
-    with pytest.raises(ValueError):
-        f._distribution_configuration(DISTRIBUTION_SM_DDP_ENABLED)
-    with pytest.raises(ValueError):
-        f._distribution_configuration(DISTRIBUTION_SM_DDP_DISABLED)
+
 
 def test_validate_smdistributed_p5_not_raises(sagemaker_session):
     f = DummyFramework(
@@ -359,20 +381,23 @@ def test_validate_smdistributed_p5_not_raises(sagemaker_session):
         instance_type="ml.p5.48xlarge",
         sagemaker_session=sagemaker_session,
         output_path="outputpath",
-        image_uri="ecr-url/2.0.1-gpu-py310-cu121-ubuntu20.04-sagemaker-pr-3303"
+        image_uri="ecr-url/2.0.1-gpu-py310-cu121-ubuntu20.04-sagemaker-pr-3303",
     )
-    #testing with p5 instance and torch_distributed enabled
+    # Testing with p5 instance and torch_distributed enabled.
     f._distribution_configuration(DISTRIBUTION_SM_TORCH_DIST_AND_DDP_ENABLED)
     f._distribution_configuration(DISTRIBUTION_SM_TORCH_DIST_AND_DDP_DISABLED)
+
+
+def test_validate_smdistributed_backward_compat_p4_not_raises(sagemaker_session):
     f = DummyFramework(
         "some_script.py",
         role="DummyRole",
-        instance_type="ml.p4.24xlarge",
+        instance_type="ml.p4d.24xlarge",
         sagemaker_session=sagemaker_session,
         output_path="outputpath",
-        image_uri="some_acceptable_image"
+        image_uri="some_acceptable_image",
     )
-    #testing backwards compatability with p4d instances
+    # Testing backwards compatability with p4d instances.
     f._distribution_configuration(DISTRIBUTION_SM_TORCH_DIST_AND_DDP_ENABLED)
     f._distribution_configuration(DISTRIBUTION_SM_TORCH_DIST_AND_DDP_DISABLED)
 

--- a/tests/unit/test_estimator.py
+++ b/tests/unit/test_estimator.py
@@ -170,19 +170,19 @@ DISTRIBUTION_MPI_ENABLED = {
 }
 DISTRIBUTION_SM_DDP_ENABLED = {
     "smdistributed": {"dataparallel": {"enabled": True, "custom_mpi_options": "options"}},
-    "torch_distributed": {"enabled": False}
+    "torch_distributed": {"enabled": False},
 }
 DISTRIBUTION_SM_DDP_DISABLED = {
     "smdistributed": {"enabled": True},
-    "torch_distributed": {"enabled": False}
+    "torch_distributed": {"enabled": False},
 }
 DISTRIBUTION_SM_TORCH_DIST_AND_DDP_ENABLED = {
     "smdistributed": {"dataparallel": {"enabled": True, "custom_mpi_options": "options"}},
-    "torch_distributed": {"enabled": True}
+    "torch_distributed": {"enabled": True},
 }
 DISTRIBUTION_SM_TORCH_DIST_AND_DDP_DISABLED = {
     "smdistributed": {"enabled": True},
-    "torch_distributed": {"enabled": True}
+    "torch_distributed": {"enabled": True},
 }
 MOCKED_S3_URI = "s3://mocked_s3_uri_from_source_dir"
 _DEFINITION_CONFIG = PipelineDefinitionConfig(use_custom_job_prefix=False)
@@ -360,18 +360,18 @@ def test_validate_smdistributed_unsupported_image_raises(sagemaker_session):
 def test_validate_smdistributed_p5_raises(sagemaker_session):
     # Supported DLC image.
     f = DummyFramework(
-        "some_script.py", 
+        "some_script.py",
         role="DummyRole",
-        instance_type="ml.p5.48xlarge", 
+        instance_type="ml.p5.48xlarge",
         sagemaker_session=sagemaker_session,
         output_path="outputpath",
         image_uri="some_acceptable_image",
     )
     # Both fail because instance type is p5 and torch_distributed is off.
     with pytest.raises(ValueError):
-        f._distribution_configuration(DISTRIBUTION_SM_DDP_ENABLED) 
+        f._distribution_configuration(DISTRIBUTION_SM_DDP_ENABLED)
     with pytest.raises(ValueError):
-        f._distribution_configuration(DISTRIBUTION_SM_DDP_DISABLED) 
+        f._distribution_configuration(DISTRIBUTION_SM_DDP_DISABLED)
 
 
 def test_validate_smdistributed_p5_not_raises(sagemaker_session):

--- a/tests/unit/test_estimator.py
+++ b/tests/unit/test_estimator.py
@@ -169,7 +169,20 @@ DISTRIBUTION_MPI_ENABLED = {
     "mpi": {"enabled": True, "custom_mpi_options": "options", "processes_per_host": 2}
 }
 DISTRIBUTION_SM_DDP_ENABLED = {
-    "smdistributed": {"dataparallel": {"enabled": True, "custom_mpi_options": "options"}}
+    "smdistributed": {"dataparallel": {"enabled": True, "custom_mpi_options": "options"}},
+    "torch_distributed": {"enabled": False}
+}
+DISTRIBUTION_SM_DDP_DISABLED = {
+    "smdistributed": {"enabled": True},
+    "torch_distributed": {"enabled": False}
+}
+DISTRIBUTION_SM_TORCH_DIST_AND_DDP_ENABLED = {
+    "smdistributed": {"dataparallel": {"enabled": True, "custom_mpi_options": "options"}},
+    "torch_distributed": {"enabled": True}
+}
+DISTRIBUTION_SM_TORCH_DIST_AND_DDP_DISABLED = {
+    "smdistributed": {"enabled": True},
+    "torch_distributed": {"enabled": True}
 }
 MOCKED_S3_URI = "s3://mocked_s3_uri_from_source_dir"
 _DEFINITION_CONFIG = PipelineDefinitionConfig(use_custom_job_prefix=False)
@@ -308,6 +321,60 @@ def training_job_description(sagemaker_session):
     sagemaker_session.sagemaker_client.describe_training_job = mock_describe_training_job
     sagemaker_session.describe_training_job = mock_describe_training_job
     return returned_job_description
+
+def test_validate_smdistributed_p5_raises(sagemaker_session):
+    # supported DLC image
+    f = DummyFramework(
+        "some_script.py", 
+        role="DummyRole",
+        instance_type="ml.p5.48xlarge", 
+        sagemaker_session=sagemaker_session,
+        output_path="outputpath",
+        image_uri="some_acceptable_image"
+    )
+    #both fail because instance type is p5 and torch_distributed is off
+    with pytest.raises(ValueError):
+        f._distribution_configuration(DISTRIBUTION_SM_DDP_ENABLED) 
+    with pytest.raises(ValueError):
+        f._distribution_configuration(DISTRIBUTION_SM_DDP_DISABLED) 
+    # unsupported DLC image
+    f = DummyFramework(
+        "some_script.py",
+        role="DummyRole",
+        instance_type="ml.p5.48xlarge",
+        sagemaker_session=sagemaker_session,
+        output_path="outputpath",
+        image_uri="ecr-url/2.0.1-gpu-py310-cu121-ubuntu20.04-sagemaker-pr-3303"
+    )
+    #both fail due to unsupported CUDA12 DLC image
+    with pytest.raises(ValueError):
+        f._distribution_configuration(DISTRIBUTION_SM_DDP_ENABLED)
+    with pytest.raises(ValueError):
+        f._distribution_configuration(DISTRIBUTION_SM_DDP_DISABLED)
+
+def test_validate_smdistributed_p5_not_raises(sagemaker_session):
+    f = DummyFramework(
+        "some_script.py",
+        role="DummyRole",
+        instance_type="ml.p5.48xlarge",
+        sagemaker_session=sagemaker_session,
+        output_path="outputpath",
+        image_uri="ecr-url/2.0.1-gpu-py310-cu121-ubuntu20.04-sagemaker-pr-3303"
+    )
+    #testing with p5 instance and torch_distributed enabled
+    f._distribution_configuration(DISTRIBUTION_SM_TORCH_DIST_AND_DDP_ENABLED)
+    f._distribution_configuration(DISTRIBUTION_SM_TORCH_DIST_AND_DDP_DISABLED)
+    f = DummyFramework(
+        "some_script.py",
+        role="DummyRole",
+        instance_type="ml.p4.24xlarge",
+        sagemaker_session=sagemaker_session,
+        output_path="outputpath",
+        image_uri="some_acceptable_image"
+    )
+    #testing backwards compatability with p4d instances
+    f._distribution_configuration(DISTRIBUTION_SM_TORCH_DIST_AND_DDP_ENABLED)
+    f._distribution_configuration(DISTRIBUTION_SM_TORCH_DIST_AND_DDP_DISABLED)
 
 
 def test_framework_all_init_args(sagemaker_session):


### PR DESCRIPTION
*Description of changes:*
Update estimator to allow `smdistributed` to be enabled with `torch_distributed` for a new `smdistributed` release that supports using `smdistributed` with `torch_distributed`.
Disable launching of jobs with smddp on p5 instances or using the p5 image (`2.0.1-gpu-py310-cu121-ubuntu20.04-sagemaker-pr-3303`) without `torch_distributed` enabled.

*Testing done:*
Ran and passed `tests/unit/test_estimator.py`, `tests/unit/test_pytorch.py` and `tests/unit/test_fw_utils.py` locally.

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
