### PR TITLE
fix: auto ml integ tests and add flaky test markers

### DIFF
--- a/tests/integ/auto_ml_utils.py
+++ b/tests/integ/auto_ml_utils.py
@@ -26,7 +26,7 @@ TARGET_ATTRIBUTE_NAME = "virginica"
 
 
 def create_auto_ml_job_if_not_exist(sagemaker_session):
-    auto_ml_job_name = "python-sdk-integ-test-base-job"
+    auto_ml_job_name = "python-sdk-integ-test-base-automl-job"
 
     try:
         sagemaker_session.describe_auto_ml_job(job_name=auto_ml_job_name)

--- a/tests/integ/auto_ml_utils.py
+++ b/tests/integ/auto_ml_utils.py
@@ -25,9 +25,7 @@ TRAINING_DATA = os.path.join(DATA_DIR, "iris_training.csv")
 TARGET_ATTRIBUTE_NAME = "virginica"
 
 
-def create_auto_ml_job_if_not_exist(sagemaker_session):
-    auto_ml_job_name = "python-sdk-integ-test-base-automl-job"
-
+def create_auto_ml_job_if_not_exist(sagemaker_session, auto_ml_job_name):
     try:
         sagemaker_session.describe_auto_ml_job(job_name=auto_ml_job_name)
     except Exception as e:  # noqa: F841

--- a/tests/integ/sagemaker/feature_store/feature_processor/test_feature_processor.py
+++ b/tests/integ/sagemaker/feature_store/feature_processor/test_feature_processor.py
@@ -223,6 +223,7 @@ def test_feature_processor_transform_online_only_store_ingestion(
 
 
 @pytest.mark.slow_test
+@pytest.mark.flaky(reruns=5, reruns_delay=2)
 def test_feature_processor_transform_offline_only_store_ingestion(
     sagemaker_session,
 ):

--- a/tests/integ/test_auto_ml.py
+++ b/tests/integ/test_auto_ml.py
@@ -40,7 +40,7 @@ BASE_JOB_NAME = "auto-ml"
 MODE = "ENSEMBLING"
 
 # use a succeeded AutoML job to test describe and list candidates method, otherwise tests will run too long
-AUTO_ML_JOB_NAME = "python-sdk-integ-test-base-job"
+AUTO_ML_JOB_NAME = "python-sdk-integ-test-base-automl-job"
 DEFAULT_MODEL_NAME = "python-sdk-automl"
 
 

--- a/tests/integ/test_auto_ml.py
+++ b/tests/integ/test_auto_ml.py
@@ -342,7 +342,9 @@ def test_deploy_best_candidate(sagemaker_session, cpu_instance_type, reusable_jo
 @pytest.mark.skip(
     reason="",
 )
-def test_candidate_estimator_default_rerun_and_deploy(sagemaker_session, cpu_instance_type, reusable_job_name):
+def test_candidate_estimator_default_rerun_and_deploy(
+    sagemaker_session, cpu_instance_type, reusable_job_name
+):
     auto_ml_utils.create_auto_ml_job_if_not_exist(sagemaker_session, reusable_job_name)
 
     auto_ml = AutoML(

--- a/tests/integ/test_auto_ml.py
+++ b/tests/integ/test_auto_ml.py
@@ -22,6 +22,7 @@ from sagemaker import AutoML, AutoMLInput, CandidateEstimator
 from sagemaker.utils import unique_name_from_base
 from tests.integ import AUTO_ML_DEFAULT_TIMEMOUT_MINUTES, DATA_DIR, auto_ml_utils
 from tests.integ.timeout import timeout
+from tests.conftest import CUSTOM_S3_OBJECT_KEY_PREFIX
 
 ROLE = "SageMakerRole"
 PREFIX = "sagemaker/beta-automl-xgboost"
@@ -198,8 +199,8 @@ def test_auto_ml_describe_auto_ml_job(sagemaker_session):
             "DataSource": {
                 "S3DataSource": {
                     "S3DataType": "S3Prefix",
-                    "S3Uri": "s3://{}/{}/input/iris_training.csv".format(
-                        sagemaker_session.default_bucket(), PREFIX
+                    "S3Uri": "s3://{}/{}/{}/input/iris_training.csv".format(
+                        sagemaker_session.default_bucket(), CUSTOM_S3_OBJECT_KEY_PREFIX, PREFIX
                     ),
                 }
             },
@@ -209,7 +210,9 @@ def test_auto_ml_describe_auto_ml_job(sagemaker_session):
         }
     ]
     expected_default_output_config = {
-        "S3OutputPath": "s3://{}/".format(sagemaker_session.default_bucket())
+        "S3OutputPath": "s3://{}/{}/".format(
+            sagemaker_session.default_bucket(), CUSTOM_S3_OBJECT_KEY_PREFIX
+        )
     }
 
     auto_ml_utils.create_auto_ml_job_if_not_exist(sagemaker_session)
@@ -236,8 +239,8 @@ def test_auto_ml_attach(sagemaker_session):
             "DataSource": {
                 "S3DataSource": {
                     "S3DataType": "S3Prefix",
-                    "S3Uri": "s3://{}/{}/input/iris_training.csv".format(
-                        sagemaker_session.default_bucket(), PREFIX
+                    "S3Uri": "s3://{}/{}/{}/input/iris_training.csv".format(
+                        sagemaker_session.default_bucket(), CUSTOM_S3_OBJECT_KEY_PREFIX, PREFIX
                     ),
                 }
             },
@@ -247,7 +250,9 @@ def test_auto_ml_attach(sagemaker_session):
         }
     ]
     expected_default_output_config = {
-        "S3OutputPath": "s3://{}/".format(sagemaker_session.default_bucket())
+        "S3OutputPath": "s3://{}/{}/".format(
+            sagemaker_session.default_bucket(), CUSTOM_S3_OBJECT_KEY_PREFIX
+        )
     }
 
     auto_ml_utils.create_auto_ml_job_if_not_exist(sagemaker_session)

--- a/tests/integ/test_auto_ml.py
+++ b/tests/integ/test_auto_ml.py
@@ -49,10 +49,10 @@ EXPECTED_DEFAULT_JOB_CONFIG = {
 
 
 # use a succeeded AutoML job to test describe and list candidates method, otherwise tests will run too long
-# reusable-job will be created once if it doesn't exist, and be reused in relevant tests.
+# test-session-job will be created once per session if it doesn't exist, and be reused in relevant tests.
 @pytest.fixture(scope="module")
-def reusable_job_name():
-    job_name = unique_name_from_base("reusable-job", max_length=32)
+def test_session_job_name():
+    job_name = unique_name_from_base("test-session-job", max_length=32)
     return job_name
 
 
@@ -199,7 +199,7 @@ def test_auto_ml_invalid_target_attribute(sagemaker_session):
     tests.integ.test_region() in tests.integ.NO_AUTO_ML_REGIONS,
     reason="AutoML is not supported in the region yet.",
 )
-def test_auto_ml_describe_auto_ml_job(sagemaker_session, reusable_job_name):
+def test_auto_ml_describe_auto_ml_job(sagemaker_session, test_session_job_name):
     expected_default_input_config = [
         {
             "DataSource": {
@@ -221,13 +221,13 @@ def test_auto_ml_describe_auto_ml_job(sagemaker_session, reusable_job_name):
         )
     }
 
-    auto_ml_utils.create_auto_ml_job_if_not_exist(sagemaker_session, reusable_job_name)
+    auto_ml_utils.create_auto_ml_job_if_not_exist(sagemaker_session, test_session_job_name)
     auto_ml = AutoML(
         role=ROLE, target_attribute_name=TARGET_ATTRIBUTE_NAME, sagemaker_session=sagemaker_session
     )
 
-    desc = auto_ml.describe_auto_ml_job(job_name=reusable_job_name)
-    assert desc["AutoMLJobName"] == reusable_job_name
+    desc = auto_ml.describe_auto_ml_job(job_name=test_session_job_name)
+    assert desc["AutoMLJobName"] == test_session_job_name
     assert desc["AutoMLJobStatus"] == "Completed"
     assert isinstance(desc["BestCandidate"], dict)
     assert desc["InputDataConfig"] == expected_default_input_config
@@ -239,7 +239,7 @@ def test_auto_ml_describe_auto_ml_job(sagemaker_session, reusable_job_name):
     tests.integ.test_region() in tests.integ.NO_AUTO_ML_REGIONS,
     reason="AutoML is not supported in the region yet.",
 )
-def test_auto_ml_attach(sagemaker_session, reusable_job_name):
+def test_auto_ml_attach(sagemaker_session, test_session_job_name):
     expected_default_input_config = [
         {
             "DataSource": {
@@ -261,13 +261,13 @@ def test_auto_ml_attach(sagemaker_session, reusable_job_name):
         )
     }
 
-    auto_ml_utils.create_auto_ml_job_if_not_exist(sagemaker_session, reusable_job_name)
+    auto_ml_utils.create_auto_ml_job_if_not_exist(sagemaker_session, test_session_job_name)
 
     attached_automl_job = AutoML.attach(
-        auto_ml_job_name=reusable_job_name, sagemaker_session=sagemaker_session
+        auto_ml_job_name=test_session_job_name, sagemaker_session=sagemaker_session
     )
     attached_desc = attached_automl_job.describe_auto_ml_job()
-    assert attached_desc["AutoMLJobName"] == reusable_job_name
+    assert attached_desc["AutoMLJobName"] == test_session_job_name
     assert attached_desc["AutoMLJobStatus"] == "Completed"
     assert isinstance(attached_desc["BestCandidate"], dict)
     assert attached_desc["InputDataConfig"] == expected_default_input_config
@@ -279,14 +279,14 @@ def test_auto_ml_attach(sagemaker_session, reusable_job_name):
     tests.integ.test_region() in tests.integ.NO_AUTO_ML_REGIONS,
     reason="AutoML is not supported in the region yet.",
 )
-def test_list_candidates(sagemaker_session, reusable_job_name):
-    auto_ml_utils.create_auto_ml_job_if_not_exist(sagemaker_session, reusable_job_name)
+def test_list_candidates(sagemaker_session, test_session_job_name):
+    auto_ml_utils.create_auto_ml_job_if_not_exist(sagemaker_session, test_session_job_name)
 
     auto_ml = AutoML(
         role=ROLE, target_attribute_name=TARGET_ATTRIBUTE_NAME, sagemaker_session=sagemaker_session
     )
 
-    candidates = auto_ml.list_candidates(job_name=reusable_job_name)
+    candidates = auto_ml.list_candidates(job_name=test_session_job_name)
     assert len(candidates) == 3
 
 
@@ -294,13 +294,13 @@ def test_list_candidates(sagemaker_session, reusable_job_name):
     tests.integ.test_region() in tests.integ.NO_AUTO_ML_REGIONS,
     reason="AutoML is not supported in the region yet.",
 )
-def test_best_candidate(sagemaker_session, reusable_job_name):
-    auto_ml_utils.create_auto_ml_job_if_not_exist(sagemaker_session, reusable_job_name)
+def test_best_candidate(sagemaker_session, test_session_job_name):
+    auto_ml_utils.create_auto_ml_job_if_not_exist(sagemaker_session, test_session_job_name)
 
     auto_ml = AutoML(
         role=ROLE, target_attribute_name=TARGET_ATTRIBUTE_NAME, sagemaker_session=sagemaker_session
     )
-    best_candidate = auto_ml.best_candidate(job_name=reusable_job_name)
+    best_candidate = auto_ml.best_candidate(job_name=test_session_job_name)
     assert len(best_candidate["InferenceContainers"]) == 3
     assert len(best_candidate["CandidateSteps"]) == 4
     assert best_candidate["CandidateStatus"] == "Completed"
@@ -311,13 +311,13 @@ def test_best_candidate(sagemaker_session, reusable_job_name):
     reason="AutoML is not supported in the region yet.",
 )
 @pytest.mark.release
-def test_deploy_best_candidate(sagemaker_session, cpu_instance_type, reusable_job_name):
-    auto_ml_utils.create_auto_ml_job_if_not_exist(sagemaker_session, reusable_job_name)
+def test_deploy_best_candidate(sagemaker_session, cpu_instance_type, test_session_job_name):
+    auto_ml_utils.create_auto_ml_job_if_not_exist(sagemaker_session, test_session_job_name)
 
     auto_ml = AutoML(
         role=ROLE, target_attribute_name=TARGET_ATTRIBUTE_NAME, sagemaker_session=sagemaker_session
     )
-    best_candidate = auto_ml.best_candidate(job_name=reusable_job_name)
+    best_candidate = auto_ml.best_candidate(job_name=test_session_job_name)
     endpoint_name = unique_name_from_base("sagemaker-auto-ml-best-candidate-test")
 
     with timeout(minutes=AUTO_ML_DEFAULT_TIMEMOUT_MINUTES):
@@ -343,15 +343,15 @@ def test_deploy_best_candidate(sagemaker_session, cpu_instance_type, reusable_jo
     reason="",
 )
 def test_candidate_estimator_default_rerun_and_deploy(
-    sagemaker_session, cpu_instance_type, reusable_job_name
+    sagemaker_session, cpu_instance_type, test_session_job_name
 ):
-    auto_ml_utils.create_auto_ml_job_if_not_exist(sagemaker_session, reusable_job_name)
+    auto_ml_utils.create_auto_ml_job_if_not_exist(sagemaker_session, test_session_job_name)
 
     auto_ml = AutoML(
         role=ROLE, target_attribute_name=TARGET_ATTRIBUTE_NAME, sagemaker_session=sagemaker_session
     )
 
-    candidates = auto_ml.list_candidates(job_name=reusable_job_name)
+    candidates = auto_ml.list_candidates(job_name=test_session_job_name)
     candidate = candidates[1]
 
     candidate_estimator = CandidateEstimator(candidate, sagemaker_session)
@@ -377,13 +377,13 @@ def test_candidate_estimator_default_rerun_and_deploy(
     tests.integ.test_region() in tests.integ.NO_AUTO_ML_REGIONS,
     reason="AutoML is not supported in the region yet.",
 )
-def test_candidate_estimator_get_steps(sagemaker_session, reusable_job_name):
-    auto_ml_utils.create_auto_ml_job_if_not_exist(sagemaker_session, reusable_job_name)
+def test_candidate_estimator_get_steps(sagemaker_session, test_session_job_name):
+    auto_ml_utils.create_auto_ml_job_if_not_exist(sagemaker_session, test_session_job_name)
 
     auto_ml = AutoML(
         role=ROLE, target_attribute_name=TARGET_ATTRIBUTE_NAME, sagemaker_session=sagemaker_session
     )
-    candidates = auto_ml.list_candidates(job_name=reusable_job_name)
+    candidates = auto_ml.list_candidates(job_name=test_session_job_name)
     candidate = candidates[1]
 
     candidate_estimator = CandidateEstimator(candidate, sagemaker_session)

--- a/tests/integ/test_inference_recommender.py
+++ b/tests/integ/test_inference_recommender.py
@@ -206,7 +206,7 @@ def default_right_sized_unregistered_model(sagemaker_session, cpu_instance_type)
                 ir_job_name,
             )
         except Exception:
-            sagemaker_session.delete_model(ModelName=sklearn_model.name)
+            sagemaker_session.delete_model(model_name=sklearn_model.name)
 
 
 @pytest.fixture(scope="module")
@@ -261,7 +261,7 @@ def advanced_right_sized_unregistered_model(sagemaker_session, cpu_instance_type
             )
 
         except Exception:
-            sagemaker_session.delete_model(ModelName=sklearn_model.name)
+            sagemaker_session.delete_model(model_name=sklearn_model.name)
 
 
 @pytest.fixture(scope="module")
@@ -300,7 +300,7 @@ def default_right_sized_unregistered_base_model(sagemaker_session, cpu_instance_
                 ir_job_name,
             )
         except Exception:
-            sagemaker_session.delete_model(ModelName=model.name)
+            sagemaker_session.delete_model(model_name=model.name)
 
 
 @pytest.fixture(scope="module")
@@ -328,6 +328,7 @@ def created_base_model(sagemaker_session, cpu_instance_type):
 
 
 @pytest.mark.slow_test
+@pytest.mark.flaky(reruns=3, reruns_delay=2)
 def test_default_right_size_and_deploy_registered_model_sklearn(
     default_right_sized_model, sagemaker_session
 ):
@@ -350,6 +351,7 @@ def test_default_right_size_and_deploy_registered_model_sklearn(
 
 
 @pytest.mark.slow_test
+@pytest.mark.flaky(reruns=3, reruns_delay=2)
 def test_default_right_size_and_deploy_unregistered_model_sklearn(
     default_right_sized_unregistered_model, sagemaker_session
 ):
@@ -372,6 +374,7 @@ def test_default_right_size_and_deploy_unregistered_model_sklearn(
 
 
 @pytest.mark.slow_test
+@pytest.mark.flaky(reruns=3, reruns_delay=2)
 def test_default_right_size_and_deploy_unregistered_base_model(
     default_right_sized_unregistered_base_model, sagemaker_session
 ):
@@ -394,6 +397,7 @@ def test_default_right_size_and_deploy_unregistered_base_model(
 
 
 @pytest.mark.slow_test
+@pytest.mark.flaky(reruns=3, reruns_delay=2)
 def test_advanced_right_size_and_deploy_unregistered_model_sklearn(
     advanced_right_sized_unregistered_model, sagemaker_session
 ):
@@ -416,6 +420,7 @@ def test_advanced_right_size_and_deploy_unregistered_model_sklearn(
 
 
 @pytest.mark.slow_test
+@pytest.mark.flaky(reruns=3, reruns_delay=2)
 def test_advanced_right_size_and_deploy_registered_model_sklearn(
     advanced_right_sized_model, sagemaker_session
 ):
@@ -446,6 +451,7 @@ def test_advanced_right_size_and_deploy_registered_model_sklearn(
 # TODO when we've added support for inference_recommendation_id
 # then add tests to test Framework models
 @pytest.mark.slow_test
+@pytest.mark.flaky(reruns=3, reruns_delay=2)
 def test_deploy_inference_recommendation_id_with_registered_model_sklearn(
     default_right_sized_model, sagemaker_session
 ):
@@ -480,6 +486,7 @@ def test_deploy_inference_recommendation_id_with_registered_model_sklearn(
 
 
 @pytest.mark.slow_test
+@pytest.mark.flaky(reruns=3, reruns_delay=2)
 def test_deploy_deployment_recommendation_id_with_model(created_base_model, sagemaker_session):
     with timeout(minutes=20):
         try:

--- a/tox.ini
+++ b/tox.ini
@@ -56,6 +56,8 @@ markers =
     canary_quick
     cron
     local_mode
+    slow_test
+    release
     timeout: mark a test as a timeout.
 
 [testenv]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fix auto ml tests:
* Add `CUSTOM_S3_OBJECT_KEY_PREFIX` to expected input and output path for `test_auto_ml_describe_auto_ml_job()` and `test_auto_ml_attach()`
* Required because [session object used in tests](https://github.com/aws/sagemaker-python-sdk/blob/cadd0a17f39640ecb3b2763cad903d4a77486967/tests/conftest.py#L142-L169) has `default_bucket_prefix` defined
* refactor to use `test_session_job_name` fixture instead of hardcoded name (`python-sdk-integ-test-base-job`). This way a new  test-session-job is created once each test session and can be reused in relevant tests
   * fix parity issue between new testing accounts and old testing accounts which created `python-sdk-integ-test-base-job` job once for lifetime of account. Old accounts created this automl job before intelligent defaults were added and new testing accounts created this automl job afterwards which created parity where the auto ml job in old accounts did not include `CUSTOM_S3_OBJECT_KEY_PREFIX` in input and output paths but the auto ml job in new accounts did include the prefix.


Temp fix for flaky tests:
* Add flaky test markers to rerun flaky tests
   * in `test_inference_recommender.py` and `test_feature_processor.py`
* Change `sagemaker_session.delete_model(ModelName=sklearn_model.name)` to `sagemaker_session.delete_model(model_name=sklearn_model.name)`
   * `delete_model()` in [`session.py`](https://github.com/aws/sagemaker-python-sdk/blob/d960e49a245d3fbccf5315ad646fc149126f3390/src/sagemaker/session.py#L4213) uses `model_name` param not `ModelName`


*Testing done:*
* `tox -e py310 -- -s -vv tests/integ/test_auto_ml.py::test_auto_ml_describe_auto_ml_job`
* `tox -e py310 -- -s -vv tests/integ/test_auto_ml.py::test_auto_ml_attach`

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
