### PR TITLE
feature: allow non-python files in job dependencies

### DIFF
--- a/src/sagemaker/feature_store/feature_processor/_config_uploader.py
+++ b/src/sagemaker/feature_store/feature_processor/_config_uploader.py
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 """Contains classes for preparing and uploading configs for a scheduled feature processor."""
 from __future__ import absolute_import
-from typing import Callable, Dict, Tuple, List
+from typing import Callable, Dict, Optional, Tuple, List
 
 import attr
 
@@ -70,6 +70,7 @@ class ConfigUploader:
             s3_base_uri,
             self.remote_decorator_config.s3_kms_key,
             sagemaker_session,
+            self.remote_decorator_config.custom_file_filter,
         )
 
         (
@@ -134,6 +135,7 @@ class ConfigUploader:
         s3_base_uri: str,
         s3_kms_key: str,
         sagemaker_session: Session,
+        custom_file_filter: Optional[Callable[[str, List], List]] = None,
     ) -> str:
         """Upload the training step dependencies to S3 if present"""
         return _prepare_and_upload_dependencies(
@@ -144,6 +146,7 @@ class ConfigUploader:
             s3_base_uri=s3_base_uri,
             s3_kms_key=s3_kms_key,
             sagemaker_session=sagemaker_session,
+            custom_file_filter=custom_file_filter,
         )
 
     def _prepare_and_upload_runtime_scripts(

--- a/tests/unit/sagemaker/feature_store/feature_processor/test_config_uploader.py
+++ b/tests/unit/sagemaker/feature_store/feature_processor/test_config_uploader.py
@@ -64,6 +64,7 @@ def remote_decorator_config(sagemaker_session):
         pre_execution_script="some_path",
         python_sdk_whl_s3_uri=SAGEMAKER_WHL_FILE_S3_PATH,
         environment_variables={"REMOTE_FUNCTION_SECRET_KEY": "some_secret_key"},
+        custom_file_filter=None,
     )
 
 
@@ -108,6 +109,7 @@ def test_prepare_and_upload_dependencies(mock_upload, config_uploader):
         s3_base_uri=remote_decorator_config.s3_root_uri,
         s3_kms_key=remote_decorator_config.s3_kms_key,
         sagemaker_session=sagemaker_session,
+        custom_file_filter=None,
     )
 
 
@@ -201,6 +203,7 @@ def test_prepare_step_input_channel(
         s3_base_uri=remote_decorator_config.s3_root_uri,
         s3_kms_key="some_kms",
         sagemaker_session=sagemaker_session,
+        custom_file_filter=None,
     )
 
     mock_spark_dependency_upload.assert_called_once_with(

--- a/tests/unit/sagemaker/feature_store/feature_processor/test_config_uploader.py
+++ b/tests/unit/sagemaker/feature_store/feature_processor/test_config_uploader.py
@@ -50,6 +50,10 @@ def runtime_env_manager():
     return mocked_runtime_env_manager
 
 
+def custom_file_filter():
+    pass
+
+
 @pytest.fixture
 def remote_decorator_config(sagemaker_session):
     return Mock(
@@ -71,6 +75,24 @@ def remote_decorator_config(sagemaker_session):
 @pytest.fixture
 def config_uploader(remote_decorator_config, runtime_env_manager):
     return ConfigUploader(remote_decorator_config, runtime_env_manager)
+
+
+@pytest.fixture
+def remote_decorator_config_with_filter(sagemaker_session):
+    return Mock(
+        _JobSettings,
+        sagemaker_session=sagemaker_session,
+        s3_root_uri="some_s3_uri",
+        s3_kms_key="some_kms",
+        spark_config=SparkConfig(),
+        dependencies=None,
+        include_local_workdir=True,
+        pre_execution_commands="some_commands",
+        pre_execution_script="some_path",
+        python_sdk_whl_s3_uri=SAGEMAKER_WHL_FILE_S3_PATH,
+        environment_variables={"REMOTE_FUNCTION_SECRET_KEY": "some_secret_key"},
+        custom_file_filter=custom_file_filter,
+    )
 
 
 @patch("sagemaker.feature_store.feature_processor._config_uploader.StoredFunction")
@@ -110,6 +132,41 @@ def test_prepare_and_upload_dependencies(mock_upload, config_uploader):
         s3_kms_key=remote_decorator_config.s3_kms_key,
         sagemaker_session=sagemaker_session,
         custom_file_filter=None,
+    )
+
+
+@patch(
+    "sagemaker.feature_store.feature_processor._config_uploader._prepare_and_upload_dependencies",
+    return_value="some_s3_uri",
+)
+def test_prepare_and_upload_dependencies_with_filter(
+    mock_job_upload, remote_decorator_config_with_filter, runtime_env_manager
+):
+    config_uploader_with_filter = ConfigUploader(
+        remote_decorator_config=remote_decorator_config_with_filter,
+        runtime_env_manager=runtime_env_manager,
+    )
+    remote_decorator_config = config_uploader_with_filter.remote_decorator_config
+    config_uploader_with_filter._prepare_and_upload_dependencies(
+        local_dependencies_path="some/path/to/dependency",
+        include_local_workdir=True,
+        pre_execution_commands=remote_decorator_config.pre_execution_commands,
+        pre_execution_script_local_path=remote_decorator_config.pre_execution_script,
+        s3_base_uri=remote_decorator_config.s3_root_uri,
+        s3_kms_key=remote_decorator_config.s3_kms_key,
+        sagemaker_session=sagemaker_session,
+        custom_file_filter=remote_decorator_config_with_filter.custom_file_filter,
+    )
+
+    mock_job_upload.assert_called_once_with(
+        local_dependencies_path="some/path/to/dependency",
+        include_local_workdir=True,
+        pre_execution_commands=remote_decorator_config.pre_execution_commands,
+        pre_execution_script_local_path=remote_decorator_config.pre_execution_script,
+        s3_base_uri=remote_decorator_config.s3_root_uri,
+        s3_kms_key=remote_decorator_config.s3_kms_key,
+        sagemaker_session=sagemaker_session,
+        custom_file_filter=custom_file_filter,
     )
 
 

--- a/tests/unit/sagemaker/feature_store/feature_processor/test_feature_scheduler.py
+++ b/tests/unit/sagemaker/feature_store/feature_processor/test_feature_scheduler.py
@@ -263,13 +263,7 @@ def test_to_pipeline(
     )
 
     mock_dependency_upload.assert_called_once_with(
-        local_dependencies_path,
-        True,
-        None,
-        None,
-        f"{S3_URI}/pipeline_name",
-        None,
-        session,
+        local_dependencies_path, True, None, None, f"{S3_URI}/pipeline_name", None, session, None
     )
 
     mock_spark_dependency_upload.assert_called_once_with(
@@ -875,6 +869,7 @@ def test_remote_decorator_fields_consistency(get_execution_role, session):
         "tags",
         "use_spot_instances",
         "max_wait_time_in_seconds",
+        "custom_file_filter",
     }
 
     job_settings = _JobSettings(


### PR DESCRIPTION
*Issue #, if available:*  closes #4094

*Description of changes:*
Users can provide a filter function to the `remote` decorator or the `RemoteExecutor` class, this function is used to select job dependencies to be uploaded. If the filter is not provided, the default behavior is uploading only python files.

- New argument `custom_file_filter` in the `remote` decorator and `RemoteExecutor` constructor.
- New argument `custom_file_filter` in the `_JobSettings` constructor and `remote_function.job._prepare_and_upload_dependencies` function.

*Testing done:*
- Unit tests added.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
