### PR TITLE
feature: Batch transform, add support for split_type == "None" in local mode

### DIFF
--- a/src/sagemaker/local/data.py
+++ b/src/sagemaker/local/data.py
@@ -69,7 +69,7 @@ def get_splitter_instance(split_type):
     Returns
         :class:`sagemaker.local.data.Splitter`: an Instance of a Splitter
     """
-    if split_type is None:
+    if split_type == "None" or split_type is None:
         return NoneSplitter()
     if split_type == "Line":
         return LineSplitter()


### PR DESCRIPTION
*Issue #, if available:* Fix https://github.com/aws/sagemaker-python-sdk/issues/2632

*Description of changes:*

This makes the local mode inline with the classic mode.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
