### PR TITLE
change: Add bucket owner check

### DIFF
--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -626,8 +626,19 @@ class Session(object):  # pylint: disable=too-many-public-methods
                     raise
 
     def _bucket_owner_check(self, bucket_name):
-        # Make sure the s3 bucket is configured in users account.
-        # https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucket-owner-condition.html
+        """Checks if the S3 Bucket exists in AWS account configured in Session.
+
+        More info: https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucket-owner-condition.html
+
+        Args:
+            bucket_name (str): Name of the S3 bucket.
+
+        Raises:
+            botocore.exceptions.ClientError: If S3 throws an unexpected exception during
+                head_bucket call. Only if the exception is due to the bucket exists but not in
+                AWS account configured in Session
+
+        """
         if self.s3_resource is None:
             s3 = self.boto_session.resource("s3", region_name=region)
         else:

--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -654,7 +654,9 @@ class Session(object):  # pylint: disable=too-many-public-methods
             message = e.response["Error"]["Message"]
             if error_code == "403" and message == "Forbidden":
                 LOGGER.error(
-                    "Bucket %s exists, but not in the AWS account configured in AWS Session."
+                    "Since default_bucket param was not set, SageMaker Python SDK tried to use "
+                    "%s bucket. The bucket exists, but not in the AWS account configured in "
+                    "SageMaker Session."
                     "Please reach out to AWS Security to verify on bucket ownership."
                     "To unblock it's recommended to use custom default_bucket "
                     "param in sagemaker.Session",

--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -557,9 +557,7 @@ class Session(object):  # pylint: disable=too-many-public-methods
 
         return self._default_bucket
 
-    def _create_s3_bucket_if_it_does_not_exist(
-        self, bucket_name, region
-    ):
+    def _create_s3_bucket_if_it_does_not_exist(self, bucket_name, region):
         """Creates an S3 Bucket if it does not exist.
 
         Also swallows a few common exceptions that indicate that the bucket already exists or

--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -640,7 +640,7 @@ class Session(object):  # pylint: disable=too-many-public-methods
 
         """
         if self.s3_resource is None:
-            s3 = self.boto_session.resource("s3", region_name=region)
+            s3 = self.boto_session.resource("s3", region_name=self.boto_session.region_name)
         else:
             s3 = self.s3_resource
 

--- a/tests/unit/test_default_bucket.py
+++ b/tests/unit/test_default_bucket.py
@@ -84,12 +84,7 @@ def test_default_bucket_s3_needs_bucket_owner_access(sagemaker_session, datetime
         ).creation_date = datetime_obj
         sagemaker_session.default_bucket()
 
-    error_message = (
-        " exists, but not in the AWS account configured in SageMaker Session."
-        "Please reach out to AWS Security to verify on bucket ownership."
-        "To unblock it's recommended to use custom default_bucket "
-        "param in sagemaker.Session"
-    )
+    error_message = "This bucket cannot be configured to use as it is not owned by Account"
     assert error_message in caplog.text
     assert sagemaker_session._default_bucket is None
 

--- a/tests/unit/test_default_bucket.py
+++ b/tests/unit/test_default_bucket.py
@@ -15,7 +15,7 @@ from __future__ import absolute_import
 import datetime
 import pytest
 from botocore.exceptions import ClientError
-from mock import MagicMock, patch
+from mock import MagicMock
 import sagemaker
 
 ACCOUNT_ID = "123"
@@ -65,7 +65,7 @@ def test_default_bucket_s3_needs_access(sagemaker_session, caplog):
         sagemaker_session.boto_session.resource("s3").meta.client.head_bucket.side_effect = error
         sagemaker_session.default_bucket()
     error_message = (
-        f" exists, but access is forbidden. Please try again after " f"adding appropriate access."
+        " exists, but access is forbidden. Please try again after adding appropriate access."
     )
     assert error_message in caplog.text
     assert sagemaker_session._default_bucket is None
@@ -84,10 +84,10 @@ def test_default_bucket_s3_needs_bucket_owner_access(sagemaker_session, datetime
         sagemaker_session.default_bucket()
 
     error_message = (
-        f" exists, but not in the AWS account configured in AWS Session."
-        f"Please reach out to AWS Security to verify on bucket ownership."
-        f"To unblock it's recommended to use custom default_bucket "
-        f"param in sagemaker.Session"
+        " exists, but not in the AWS account configured in AWS Session."
+        "Please reach out to AWS Security to verify on bucket ownership."
+        "To unblock it's recommended to use custom default_bucket "
+        "param in sagemaker.Session"
     )
     assert error_message in caplog.text
     assert sagemaker_session._default_bucket is None

--- a/tests/unit/test_default_bucket.py
+++ b/tests/unit/test_default_bucket.py
@@ -85,7 +85,7 @@ def test_default_bucket_s3_needs_bucket_owner_access(sagemaker_session, datetime
         sagemaker_session.default_bucket()
 
     error_message = (
-        " exists, but not in the AWS account configured in AWS Session."
+        " exists, but not in the AWS account configured in SageMaker Session."
         "Please reach out to AWS Security to verify on bucket ownership."
         "To unblock it's recommended to use custom default_bucket "
         "param in sagemaker.Session"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
For cases when SageMaker PySDK decides the bucket name on behalf of user, make sure that the bucket exists in Users AWS Session configured account.

*Testing done:*
Added unit tests.
Tested the logic by creating a test account A and created the bucket "sagemaker-us-west-2-A" in account B. With appropriate access setup, running sagemaker_session.default_bucket() in account A, the PYSDK shows the expected Error.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
