### PR TITLE
documentation: Add missing API docs for processors

### DIFF
--- a/doc/frameworks/huggingface/sagemaker.huggingface.rst
+++ b/doc/frameworks/huggingface/sagemaker.huggingface.rst
@@ -32,3 +32,11 @@ Hugging Face Predictor
     :members:
     :undoc-members:
     :show-inheritance:
+
+Hugging Face Processor
+----------------------
+
+.. autoclass:: sagemaker.huggingface.processing.HuggingFaceProcessor
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/frameworks/mxnet/sagemaker.mxnet.rst
+++ b/doc/frameworks/mxnet/sagemaker.mxnet.rst
@@ -3,7 +3,7 @@ MXNet Classes
 
 
 MXNet Estimator
----------------------------
+---------------
 
 .. autoclass:: sagemaker.mxnet.estimator.MXNet
     :members:
@@ -11,7 +11,7 @@ MXNet Estimator
     :show-inheritance:
 
 MXNet Model
----------------------------
+-----------
 
 .. autoclass:: sagemaker.mxnet.model.MXNetModel
     :members:
@@ -19,9 +19,17 @@ MXNet Model
     :show-inheritance:
 
 MXNet Predictor
----------------------------
+---------------
 
 .. autoclass:: sagemaker.mxnet.model.MXNetPredictor
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+MXNet Processor
+---------------
+
+.. autoclass:: sagemaker.mxnet.processing.MXNetProcessor
     :members:
     :undoc-members:
     :show-inheritance:

--- a/doc/frameworks/pytorch/sagemaker.pytorch.rst
+++ b/doc/frameworks/pytorch/sagemaker.pytorch.rst
@@ -24,3 +24,11 @@ PyTorch Predictor
     :members:
     :undoc-members:
     :show-inheritance:
+
+PyTorch Processor
+-----------------
+
+.. autoclass:: sagemaker.pytorch.processing.PyTorchProcessor
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/frameworks/tensorflow/sagemaker.tensorflow.rst
+++ b/doc/frameworks/tensorflow/sagemaker.tensorflow.rst
@@ -33,3 +33,12 @@ TensorFlow Serving Predictor
     :members:
     :undoc-members:
     :show-inheritance:
+
+
+TensorFlow Processor
+--------------------
+
+.. autoclass:: sagemaker.tensorflow.processing.TensorFlowProcessor
+    :members:
+    :undoc-members:
+    :show-inheritance:


### PR DESCRIPTION
*Issue #, if available:* Fix #3513

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
