### PR TITLE
feat: allow configuring docker container in local mode

### DIFF
--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -1560,9 +1560,20 @@ You can install necessary dependencies for this feature using pip.
 Additionally, Local Mode also requires Docker Compose V2. Follow the guidelines in https://docs.docker.com/compose/install/ to install.
 Make sure to have a Compose Version compatible with your Docker Engine installation. Check Docker Engine release notes https://docs.docker.com/engine/release-notes to find a compatible version.
 
-If you want to keep everything local, and not use Amazon S3 either, you can enable "local code" in one of two ways:
+Local mode configuration
+========================
 
-- Create a file at ``~/.sagemaker/config.yaml`` that contains:
+The local mode uses a YAML configuration file located at ``~/.sagemaker/config.yaml`` to define the default values that are automatically passed to the ``config`` attribute of ``LocalSession``. This is an example of the configuration, for the full schema, see `sagemaker.config.config_schema.SAGEMAKER_PYTHON_SDK_LOCAL_MODE_CONFIG_SCHEMA <https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/config/config_schema.py>`_.
+
+.. code:: yaml
+
+    local:
+        local_code: true # Using everything locally
+        region_name: "us-west-2" # Name of the region
+        container_config: # Additional docker container config
+            shm_size: "128M
+
+If you want to keep everything local, and not use Amazon S3 either, you can enable "local code" in one of two ways:
 
 .. code:: yaml
 
@@ -1582,6 +1593,9 @@ If you want to keep everything local, and not use Amazon S3 either, you can enab
 
 .. note::
     If you enable "local code," then you cannot use the ``dependencies`` parameter in your estimator or model.
+
+Activating local mode by ``instance_type`` argument
+====================================================
 
 We can take the example in  `Using Estimators <#using-estimators>`__ , and use either ``local`` or ``local_gpu`` as the instance type.
 

--- a/src/sagemaker/config/__init__.py
+++ b/src/sagemaker/config/__init__.py
@@ -13,7 +13,11 @@
 """This module configures the default values for SageMaker Python SDK."""
 
 from __future__ import absolute_import
-from sagemaker.config.config import load_sagemaker_config, validate_sagemaker_config  # noqa: F401
+from sagemaker.config.config import (  # noqa: F401
+    load_local_mode_config,
+    load_sagemaker_config,
+    validate_sagemaker_config,
+)
 from sagemaker.config.config_schema import (  # noqa: F401
     KEY,
     TRAINING_JOB,
@@ -161,4 +165,8 @@ from sagemaker.config.config_schema import (  # noqa: F401
     INFERENCE_SPECIFICATION,
     ESTIMATOR,
     DEBUG_HOOK_CONFIG,
+    SAGEMAKER_PYTHON_SDK_LOCAL_MODE_CONFIG_SCHEMA,
+    LOCAL,
+    LOCAL_CODE,
+    CONTAINER_CONFIG,
 )

--- a/src/sagemaker/config/config_schema.py
+++ b/src/sagemaker/config/config_schema.py
@@ -102,6 +102,11 @@ PROFILER_CONFIG = "ProfilerConfig"
 DISABLE_PROFILER = "DisableProfiler"
 ESTIMATOR = "Estimator"
 DEBUG_HOOK_CONFIG = "DebugHookConfig"
+LOCAL = "local"
+LOCAL_CODE = "local_code"
+SERVING_PORT = "serving_port"
+CONTAINER_CONFIG = "container_config"
+REGION_NAME = "region_name"
 
 
 def _simple_path(*args: str):
@@ -1067,4 +1072,29 @@ SAGEMAKER_PYTHON_SDK_CONFIG_SCHEMA = {
             },
         },
     },
+}
+
+SAGEMAKER_PYTHON_SDK_LOCAL_MODE_CONFIG_SCHEMA = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    TYPE: OBJECT,
+    ADDITIONAL_PROPERTIES: False,
+    PROPERTIES: {
+        LOCAL: {
+            TYPE: OBJECT,
+            ADDITIONAL_PROPERTIES: False,
+            PROPERTIES: {
+                LOCAL_CODE: {
+                    TYPE: "boolean",
+                },
+                REGION_NAME: {TYPE: "string"},
+                SERVING_PORT: {
+                    TYPE: "integer",
+                },
+                CONTAINER_CONFIG: {
+                    TYPE: OBJECT,
+                },
+            },
+        },
+    },
+    "required": [LOCAL],
 }

--- a/src/sagemaker/local/local_session.py
+++ b/src/sagemaker/local/local_session.py
@@ -128,6 +128,7 @@ class LocalSagemakerClient(object):  # pylint: disable=too-many-public-methods
             sagemaker_session=self.sagemaker_session,
             container_entrypoint=container_entrypoint,
             container_arguments=container_arguments,
+            container_default_config=self._container_default_config
         )
         processing_job = _LocalProcessingJob(container)
         logger.info("Starting processing job")
@@ -685,7 +686,7 @@ class LocalSession(Session):
             )
 
         self.sagemaker_client = LocalSagemakerClient(self)
-        self.sagemaker_runtime_client = LocalSagemakerRuntimeClient(self.config)
+
         self.local_mode = True
         sagemaker_config = kwargs.get("sagemaker_config", None)
         if sagemaker_config:
@@ -737,6 +738,8 @@ class LocalSession(Session):
             self.config = yaml.safe_load(open(local_mode_config_file, "r"))
             if self._disable_local_code and "local" in self.config:
                 self.config["local"]["local_code"] = False
+
+            self.sagemaker_runtime_client = LocalSagemakerRuntimeClient(self.config)
 
     def logs_for_job(self, job_name, wait=False, poll=5, log_type="All"):
         """A no-op method meant to override the sagemaker client.

--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -11,7 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 """Placeholder docstring"""
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, annotations, print_function
 
 import json
 import logging
@@ -239,7 +239,7 @@ class Session(object):  # pylint: disable=too-many-public-methods
         self.s3_client = None
         self.resource_groups_client = None
         self.resource_group_tagging_client = None
-        self.config = None
+        self._config = None
         self.lambda_client = None
         self.settings = settings
 
@@ -325,6 +325,16 @@ class Session(object):  # pylint: disable=too-many-public-methods
             config_path=SESSION_DEFAULT_S3_OBJECT_KEY_PREFIX_PATH,
             sagemaker_session=self,
         )
+
+    @property
+    def config(self) -> Dict | None:
+        """The config for the local mode, unused in a normal session"""
+        return self._config
+
+    @config.setter
+    def config(self, value: Dict | None):
+        """The config for the local mode, unused in a normal session"""
+        self._config = value
 
     @property
     def boto_region_name(self):

--- a/tests/unit/sagemaker/config/conftest.py
+++ b/tests/unit/sagemaker/config/conftest.py
@@ -292,3 +292,15 @@ def s3_resource_mock():
 @pytest.fixture()
 def get_data_dir():
     return os.path.join(os.path.dirname(__file__), "..", "..", "..", "data", "config")
+
+
+@pytest.fixture()
+def base_local_mode_config():
+    return {
+        "local": {
+            "local_code": True,
+            "region_name": "",
+            "serving_port": 8080,
+            "container_config": {"shm_size": "128M"},
+        }
+    }

--- a/tests/unit/sagemaker/config/test_config.py
+++ b/tests/unit/sagemaker/config/test_config.py
@@ -16,13 +16,15 @@ import os
 import pytest
 import yaml
 import logging
-from mock import Mock, MagicMock
+from mock import Mock, MagicMock, patch
 
 from sagemaker.config.config import (
+    load_local_mode_config,
     load_sagemaker_config,
     logger,
     _DEFAULT_ADMIN_CONFIG_FILE_PATH,
     _DEFAULT_USER_CONFIG_FILE_PATH,
+    _DEFAULT_LOCAL_MODE_CONFIG_FILE_PATH,
 )
 from jsonschema import exceptions
 from yaml.constructor import ConstructorError
@@ -402,3 +404,13 @@ def test_logging_with_additional_configs_and_none_are_found(caplog):
         in caplog.text
     )
     logger.propagate = False
+
+
+@patch("sagemaker.config.config._load_config_from_file")
+def test_load_local_mode_config(mock_load_config):
+    load_local_mode_config()
+    mock_load_config.assert_called_with(_DEFAULT_LOCAL_MODE_CONFIG_FILE_PATH)
+
+
+def test_load_local_mode_config_when_config_file_is_not_found():
+    assert load_local_mode_config() is None

--- a/tests/unit/sagemaker/config/test_config_schema.py
+++ b/tests/unit/sagemaker/config/test_config_schema.py
@@ -13,7 +13,10 @@
 from __future__ import absolute_import
 from jsonschema import validate, exceptions
 import pytest
-from sagemaker.config.config_schema import SAGEMAKER_PYTHON_SDK_CONFIG_SCHEMA
+from sagemaker.config.config_schema import (
+    SAGEMAKER_PYTHON_SDK_CONFIG_SCHEMA,
+    SAGEMAKER_PYTHON_SDK_LOCAL_MODE_CONFIG_SCHEMA,
+)
 
 
 def _validate_config(base_config_with_schema, sagemaker_config):
@@ -291,3 +294,19 @@ def test_session_s3_object_key_prefix_schema(base_config_with_schema, prefix_nam
 def test_invalid_session_s3_object_key_prefix_schema(base_config_with_schema, invalid_prefix_name):
     with pytest.raises(exceptions.ValidationError):
         test_session_s3_object_key_prefix_schema(base_config_with_schema, invalid_prefix_name)
+
+
+def test_validate_local_mode_schema(base_local_mode_config):
+    validate(base_local_mode_config, SAGEMAKER_PYTHON_SDK_LOCAL_MODE_CONFIG_SCHEMA)
+
+
+def test_validate_local_mode_schema_with_additional_key(base_local_mode_config):
+    config = dict(**base_local_mode_config)
+    config["foo"] = "bar"
+    with pytest.raises(exceptions.ValidationError):
+        validate(config, SAGEMAKER_PYTHON_SDK_LOCAL_MODE_CONFIG_SCHEMA)
+
+    config2 = dict(**base_local_mode_config)
+    config2["local"]["foo"] = "bar"
+    with pytest.raises(exceptions.ValidationError):
+        validate(config2, SAGEMAKER_PYTHON_SDK_LOCAL_MODE_CONFIG_SCHEMA)

--- a/tests/unit/sagemaker/local/test_local_image.py
+++ b/tests/unit/sagemaker/local/test_local_image.py
@@ -657,6 +657,23 @@ def test_container_does_not_enable_nvidia_docker_for_cpu_containers(sagemaker_se
     assert "runtime" not in docker_host
 
 
+def test_container_with_custom_config(sagemaker_session):
+    custom_config = {
+        "local": {
+            "container_config": {"shm_size": "128M"},
+        }
+    }
+    sagemaker_session.config = custom_config
+    instance_count = 1
+    image = "my-image"
+    sagemaker_container = _SageMakerContainer(
+        "local", instance_count, image, sagemaker_session=sagemaker_session
+    )
+
+    docker_host = sagemaker_container._create_docker_host("host-1", {}, set(), "train", [])
+    assert "shm_size" in docker_host
+
+
 @patch("sagemaker.local.image._HostingContainer.run", Mock())
 @patch("sagemaker.local.image._SageMakerContainer._prepare_serving_volumes", Mock(return_value=[]))
 @patch("shutil.copy", Mock())

--- a/tox.ini
+++ b/tox.ini
@@ -42,6 +42,7 @@ ignore =
     FI55,
     FI56,
     FI57,
+    FI58,
     W503
 
 require-code = True


### PR DESCRIPTION
*Issue #, if available:* 
- closes #4025 
- closes #3331 
- closes #2482
- closes #2729
*Description of changes:*
- Add schema to validate the local mode config file
- Add a new keyword: `container_config` to the local mode config file, this allows users to define configs for the container created by local mode.
- Add validation to the `LocalSession.config` attribute.
- Update documentation for the local mode
 
*Testing done:*
- Unit tests added
## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
