### PR TITLE
feat: feature-processor extra data sources support

### DIFF
--- a/src/sagemaker/feature_store/feature_processor/__init__.py
+++ b/src/sagemaker/feature_store/feature_processor/__init__.py
@@ -17,6 +17,8 @@ from sagemaker.feature_store.feature_processor._data_source import (  # noqa: F4
     CSVDataSource,
     FeatureGroupDataSource,
     ParquetDataSource,
+    BaseDataSource,
+    PySparkDataSource,
 )
 from sagemaker.feature_store.feature_processor._exceptions import (  # noqa: F401
     IngestionError,

--- a/src/sagemaker/feature_store/feature_processor/_config_uploader.py
+++ b/src/sagemaker/feature_store/feature_processor/_config_uploader.py
@@ -31,7 +31,7 @@ from sagemaker.remote_function.job import (
     _JobSettings,
     RUNTIME_SCRIPTS_CHANNEL_NAME,
     REMOTE_FUNCTION_WORKSPACE,
-    SPARK_CONF_WORKSPACE,
+    SPARK_CONF_CHANNEL_NAME,
     _prepare_and_upload_spark_dependent_files,
 )
 from sagemaker.remote_function.runtime_environment.runtime_environment_manager import (
@@ -99,7 +99,7 @@ class ConfigUploader:
             )
 
         if config_file_s3_uri:
-            input_data_config[SPARK_CONF_WORKSPACE] = TrainingInput(
+            input_data_config[SPARK_CONF_CHANNEL_NAME] = TrainingInput(
                 s3_data=config_file_s3_uri,
                 s3_data_type="S3Prefix",
                 distribution=S3_DATA_DISTRIBUTION_TYPE,

--- a/src/sagemaker/feature_store/feature_processor/_feature_processor_config.py
+++ b/src/sagemaker/feature_store/feature_processor/_feature_processor_config.py
@@ -21,6 +21,7 @@ from sagemaker.feature_store.feature_processor._data_source import (
     CSVDataSource,
     FeatureGroupDataSource,
     ParquetDataSource,
+    BaseDataSource,
 )
 from sagemaker.feature_store.feature_processor._enums import FeatureProcessorMode
 
@@ -37,21 +38,27 @@ class FeatureProcessorConfig:
     It only serves as an immutable data class.
     """
 
-    inputs: Sequence[Union[FeatureGroupDataSource, CSVDataSource, ParquetDataSource]] = attr.ib()
+    inputs: Sequence[
+        Union[FeatureGroupDataSource, CSVDataSource, ParquetDataSource, BaseDataSource]
+    ] = attr.ib()
     output: str = attr.ib()
     mode: FeatureProcessorMode = attr.ib()
     target_stores: Optional[List[str]] = attr.ib()
     parameters: Optional[Dict[str, Union[str, Dict]]] = attr.ib()
     enable_ingestion: bool = attr.ib()
+    spark_config: Dict[str, str] = attr.ib()
 
     @staticmethod
     def create(
-        inputs: Sequence[Union[FeatureGroupDataSource, CSVDataSource, ParquetDataSource]],
+        inputs: Sequence[
+            Union[FeatureGroupDataSource, CSVDataSource, ParquetDataSource, BaseDataSource]
+        ],
         output: str,
         mode: FeatureProcessorMode,
         target_stores: Optional[List[str]],
         parameters: Optional[Dict[str, Union[str, Dict]]],
         enable_ingestion: bool,
+        spark_config: Dict[str, str],
     ) -> "FeatureProcessorConfig":
         """Static initializer."""
         return FeatureProcessorConfig(
@@ -61,4 +68,5 @@ class FeatureProcessorConfig:
             target_stores=target_stores,
             parameters=parameters,
             enable_ingestion=enable_ingestion,
+            spark_config=spark_config,
         )

--- a/src/sagemaker/feature_store/feature_processor/_params_loader.py
+++ b/src/sagemaker/feature_store/feature_processor/_params_loader.py
@@ -72,7 +72,7 @@ class ParamsLoader:
                 feature_processor decorator.
 
         Returns:
-            Dict[str, Union[str, Dict]]: A dictionary containin both user provided
+            Dict[str, Union[str, Dict]]: A dictionary that contains both user provided
                 parameters (feature_processor argument) and system parameters.
         """
         return {

--- a/src/sagemaker/feature_store/feature_processor/feature_processor.py
+++ b/src/sagemaker/feature_store/feature_processor/feature_processor.py
@@ -19,6 +19,7 @@ from sagemaker.feature_store.feature_processor import (
     CSVDataSource,
     FeatureGroupDataSource,
     ParquetDataSource,
+    BaseDataSource,
 )
 from sagemaker.feature_store.feature_processor._enums import FeatureProcessorMode
 from sagemaker.feature_store.feature_processor._factory import (
@@ -31,11 +32,14 @@ from sagemaker.feature_store.feature_processor._feature_processor_config import 
 
 
 def feature_processor(
-    inputs: Sequence[Union[FeatureGroupDataSource, CSVDataSource, ParquetDataSource]],
+    inputs: Sequence[
+        Union[FeatureGroupDataSource, CSVDataSource, ParquetDataSource, BaseDataSource]
+    ],
     output: str,
     target_stores: Optional[List[str]] = None,
     parameters: Optional[Dict[str, Union[str, Dict]]] = None,
     enable_ingestion: bool = True,
+    spark_config: Dict[str, str] = None,
 ) -> Callable:
     """Decorator to facilitate feature engineering for Feature Groups.
 
@@ -46,7 +50,7 @@ def feature_processor(
 
     Decorated functions must conform to the expected signature. Parameters: one parameter of type
     pyspark.sql.DataFrame for each DataSource in 'inputs'; followed by the optional parameters with
-    names nand types in [params: Dict[str, Any], spark: SparkSession]. Outputs: a single return
+    names and types in [params: Dict[str, Any], spark: SparkSession]. Outputs: a single return
     value of type pyspark.sql.DataFrame. The function can have any name.
 
     **Example:**
@@ -75,8 +79,8 @@ def feature_processor(
             return ...
 
     Args:
-        inputs (Sequence[Union[FeatureGroupDataSource, CSVDataSource, ParquetDataSource]]): A list
-            of data sources.
+        inputs (Sequence[Union[FeatureGroupDataSource, CSVDataSource, ParquetDataSource,
+            BaseDataSource]]): A list of data sources.
         output (str): A Feature Group ARN to write results of this function to.
         target_stores (Optional[list[str]], optional): A list containing at least one of
             'OnlineStore' or 'OfflineStore'. If unspecified, data will be ingested to the enabled
@@ -91,6 +95,7 @@ def feature_processor(
             return value is ingested to the 'output' Feature Group. This flag is useful during the
             development phase to ensure that data is not used until the function is ready. It also
             useful for users that want to manage their own data ingestion. Defaults to True.
+        spark_config (Dict[str, str]): A dict contains the key-value paris for Spark configurations.
 
     Raises:
         IngestionError: If any rows are not ingested successfully then a sample of the records,
@@ -108,6 +113,7 @@ def feature_processor(
             target_stores=target_stores,
             parameters=parameters,
             enable_ingestion=enable_ingestion,
+            spark_config=spark_config,
         )
 
         validator_chain = ValidatorFactory.get_validation_chain(fp_config)

--- a/tests/unit/sagemaker/feature_store/feature_processor/lineage/test_constants.py
+++ b/tests/unit/sagemaker/feature_store/feature_processor/lineage/test_constants.py
@@ -18,12 +18,14 @@ from typing import List, Sequence, Union
 
 from botocore.exceptions import ClientError
 from mock import Mock
+from pyspark.sql import DataFrame
 
 from sagemaker import Session
 from sagemaker.feature_store.feature_processor._data_source import (
     CSVDataSource,
     FeatureGroupDataSource,
     ParquetDataSource,
+    BaseDataSource,
 )
 from sagemaker.feature_store.feature_processor.lineage._feature_group_contexts import (
     FeatureGroupContexts,
@@ -45,6 +47,16 @@ LAST_UPDATE_TIME = "234234234"
 SAGEMAKER_SESSION_MOCK = Mock(Session)
 CONTEXT_MOCK_01 = Mock(Context)
 CONTEXT_MOCK_02 = Mock(Context)
+
+
+class MockDataSource(BaseDataSource):
+
+    data_source_unique_id = "test_source_unique_id"
+    data_source_name = "test_source_name"
+
+    def read_data(self, spark, params) -> DataFrame:
+        return None
+
 
 FEATURE_GROUP_DATA_SOURCE: List[FeatureGroupDataSource] = [
     FeatureGroupDataSource(
@@ -68,16 +80,18 @@ FEATURE_GROUP_INPUT: List[FeatureGroupContexts] = [
     ),
 ]
 
-RAW_DATA_INPUT: Sequence[Union[CSVDataSource, ParquetDataSource]] = [
+RAW_DATA_INPUT: Sequence[Union[CSVDataSource, ParquetDataSource, BaseDataSource]] = [
     CSVDataSource(s3_uri="raw-data-uri-01"),
     CSVDataSource(s3_uri="raw-data-uri-02"),
     ParquetDataSource(s3_uri="raw-data-uri-03"),
+    MockDataSource(),
 ]
 
 RAW_DATA_INPUT_ARTIFACTS: List[Artifact] = [
     Artifact(artifact_arn="artifact-01-arn"),
     Artifact(artifact_arn="artifact-02-arn"),
     Artifact(artifact_arn="artifact-03-arn"),
+    Artifact(artifact_arn="artifact-04-arn"),
 ]
 
 PIPELINE_SCHEDULE = PipelineSchedule(

--- a/tests/unit/sagemaker/feature_store/feature_processor/lineage/test_feature_processor_lineage.py
+++ b/tests/unit/sagemaker/feature_store/feature_processor/lineage/test_feature_processor_lineage.py
@@ -119,6 +119,7 @@ def test_create_lineage_when_no_lineage_exists_with_fg_only():
             RAW_DATA_INPUT_ARTIFACTS[0],
             RAW_DATA_INPUT_ARTIFACTS[1],
             RAW_DATA_INPUT_ARTIFACTS[2],
+            RAW_DATA_INPUT_ARTIFACTS[3],
         ],
     ) as retrieve_raw_data_artifact_method, patch.object(
         S3LineageEntityHandler,
@@ -264,6 +265,7 @@ def test_create_lineage_when_no_lineage_exists_with_raw_data_only():
             RAW_DATA_INPUT_ARTIFACTS[0],
             RAW_DATA_INPUT_ARTIFACTS[1],
             RAW_DATA_INPUT_ARTIFACTS[2],
+            RAW_DATA_INPUT_ARTIFACTS[3],
         ],
     ) as retrieve_raw_data_artifact_method, patch.object(
         S3LineageEntityHandler,
@@ -329,9 +331,10 @@ def test_create_lineage_when_no_lineage_exists_with_raw_data_only():
             call(raw_data=RAW_DATA_INPUT[0], sagemaker_session=SAGEMAKER_SESSION_MOCK),
             call(raw_data=RAW_DATA_INPUT[1], sagemaker_session=SAGEMAKER_SESSION_MOCK),
             call(raw_data=RAW_DATA_INPUT[2], sagemaker_session=SAGEMAKER_SESSION_MOCK),
+            call(raw_data=RAW_DATA_INPUT[3], sagemaker_session=SAGEMAKER_SESSION_MOCK),
         ]
     )
-    assert 3 == retrieve_raw_data_artifact_method.call_count
+    assert 4 == retrieve_raw_data_artifact_method.call_count
 
     create_transformation_code_artifact_method.assert_called_once_with(
         transformation_code=TRANSFORMATION_CODE_INPUT_1,
@@ -411,6 +414,7 @@ def test_create_lineage_when_no_lineage_exists_with_fg_and_raw_data_with_tags():
             RAW_DATA_INPUT_ARTIFACTS[0],
             RAW_DATA_INPUT_ARTIFACTS[1],
             RAW_DATA_INPUT_ARTIFACTS[2],
+            RAW_DATA_INPUT_ARTIFACTS[3],
         ],
     ) as retrieve_raw_data_artifact_method, patch.object(
         S3LineageEntityHandler,
@@ -489,9 +493,10 @@ def test_create_lineage_when_no_lineage_exists_with_fg_and_raw_data_with_tags():
             call(raw_data=RAW_DATA_INPUT[0], sagemaker_session=SAGEMAKER_SESSION_MOCK),
             call(raw_data=RAW_DATA_INPUT[1], sagemaker_session=SAGEMAKER_SESSION_MOCK),
             call(raw_data=RAW_DATA_INPUT[2], sagemaker_session=SAGEMAKER_SESSION_MOCK),
+            call(raw_data=RAW_DATA_INPUT[3], sagemaker_session=SAGEMAKER_SESSION_MOCK),
         ]
     )
-    assert 3 == retrieve_raw_data_artifact_method.call_count
+    assert 4 == retrieve_raw_data_artifact_method.call_count
 
     create_transformation_code_artifact_method.assert_called_once_with(
         transformation_code=TRANSFORMATION_CODE_INPUT_1,
@@ -570,6 +575,7 @@ def test_create_lineage_when_no_lineage_exists_with_no_transformation_code():
             RAW_DATA_INPUT_ARTIFACTS[0],
             RAW_DATA_INPUT_ARTIFACTS[1],
             RAW_DATA_INPUT_ARTIFACTS[2],
+            RAW_DATA_INPUT_ARTIFACTS[3],
         ],
     ) as retrieve_raw_data_artifact_method, patch.object(
         S3LineageEntityHandler,
@@ -648,9 +654,10 @@ def test_create_lineage_when_no_lineage_exists_with_no_transformation_code():
             call(raw_data=RAW_DATA_INPUT[0], sagemaker_session=SAGEMAKER_SESSION_MOCK),
             call(raw_data=RAW_DATA_INPUT[1], sagemaker_session=SAGEMAKER_SESSION_MOCK),
             call(raw_data=RAW_DATA_INPUT[2], sagemaker_session=SAGEMAKER_SESSION_MOCK),
+            call(raw_data=RAW_DATA_INPUT[3], sagemaker_session=SAGEMAKER_SESSION_MOCK),
         ]
     )
-    assert 3 == retrieve_raw_data_artifact_method.call_count
+    assert 4 == retrieve_raw_data_artifact_method.call_count
 
     create_transformation_code_artifact_method.assert_called_once_with(
         transformation_code=None,
@@ -727,6 +734,7 @@ def test_create_lineage_when_already_exist_with_no_version_change():
             RAW_DATA_INPUT_ARTIFACTS[0],
             RAW_DATA_INPUT_ARTIFACTS[1],
             RAW_DATA_INPUT_ARTIFACTS[2],
+            RAW_DATA_INPUT_ARTIFACTS[3],
         ],
     ) as retrieve_raw_data_artifact_method, patch.object(
         S3LineageEntityHandler,
@@ -808,9 +816,10 @@ def test_create_lineage_when_already_exist_with_no_version_change():
             call(raw_data=RAW_DATA_INPUT[0], sagemaker_session=SAGEMAKER_SESSION_MOCK),
             call(raw_data=RAW_DATA_INPUT[1], sagemaker_session=SAGEMAKER_SESSION_MOCK),
             call(raw_data=RAW_DATA_INPUT[2], sagemaker_session=SAGEMAKER_SESSION_MOCK),
+            call(raw_data=RAW_DATA_INPUT[3], sagemaker_session=SAGEMAKER_SESSION_MOCK),
         ]
     )
-    assert 3 == retrieve_raw_data_artifact_method.call_count
+    assert 4 == retrieve_raw_data_artifact_method.call_count
 
     create_transformation_code_artifact_method.assert_called_once_with(
         transformation_code=TRANSFORMATION_CODE_INPUT_1,
@@ -1133,6 +1142,7 @@ def test_create_lineage_when_already_exist_with_changed_input_fg():
             RAW_DATA_INPUT_ARTIFACTS[0],
             RAW_DATA_INPUT_ARTIFACTS[1],
             RAW_DATA_INPUT_ARTIFACTS[2],
+            RAW_DATA_INPUT_ARTIFACTS[3],
         ],
     ) as retrieve_raw_data_artifact_method, patch.object(
         S3LineageEntityHandler,
@@ -1210,9 +1220,10 @@ def test_create_lineage_when_already_exist_with_changed_input_fg():
             call(raw_data=RAW_DATA_INPUT[0], sagemaker_session=SAGEMAKER_SESSION_MOCK),
             call(raw_data=RAW_DATA_INPUT[1], sagemaker_session=SAGEMAKER_SESSION_MOCK),
             call(raw_data=RAW_DATA_INPUT[2], sagemaker_session=SAGEMAKER_SESSION_MOCK),
+            call(raw_data=RAW_DATA_INPUT[3], sagemaker_session=SAGEMAKER_SESSION_MOCK),
         ]
     )
-    assert 3 == retrieve_raw_data_artifact_method.call_count
+    assert 4 == retrieve_raw_data_artifact_method.call_count
 
     create_transformation_code_artifact_method.assert_called_once_with(
         transformation_code=TRANSFORMATION_CODE_INPUT_1,
@@ -1349,6 +1360,7 @@ def test_create_lineage_when_already_exist_with_changed_output_fg():
             RAW_DATA_INPUT_ARTIFACTS[0],
             RAW_DATA_INPUT_ARTIFACTS[1],
             RAW_DATA_INPUT_ARTIFACTS[2],
+            RAW_DATA_INPUT_ARTIFACTS[3],
         ],
     ) as retrieve_raw_data_artifact_method, patch.object(
         S3LineageEntityHandler,
@@ -1430,9 +1442,10 @@ def test_create_lineage_when_already_exist_with_changed_output_fg():
             call(raw_data=RAW_DATA_INPUT[0], sagemaker_session=SAGEMAKER_SESSION_MOCK),
             call(raw_data=RAW_DATA_INPUT[1], sagemaker_session=SAGEMAKER_SESSION_MOCK),
             call(raw_data=RAW_DATA_INPUT[2], sagemaker_session=SAGEMAKER_SESSION_MOCK),
+            call(raw_data=RAW_DATA_INPUT[3], sagemaker_session=SAGEMAKER_SESSION_MOCK),
         ]
     )
-    assert 3 == retrieve_raw_data_artifact_method.call_count
+    assert 4 == retrieve_raw_data_artifact_method.call_count
 
     create_transformation_code_artifact_method.assert_called_once_with(
         transformation_code=TRANSFORMATION_CODE_INPUT_1,
@@ -1569,6 +1582,7 @@ def test_create_lineage_when_already_exist_with_changed_transformation_code():
             RAW_DATA_INPUT_ARTIFACTS[0],
             RAW_DATA_INPUT_ARTIFACTS[1],
             RAW_DATA_INPUT_ARTIFACTS[2],
+            RAW_DATA_INPUT_ARTIFACTS[3],
         ],
     ) as retrieve_raw_data_artifact_method, patch.object(
         S3LineageEntityHandler,
@@ -1650,9 +1664,10 @@ def test_create_lineage_when_already_exist_with_changed_transformation_code():
             call(raw_data=RAW_DATA_INPUT[0], sagemaker_session=SAGEMAKER_SESSION_MOCK),
             call(raw_data=RAW_DATA_INPUT[1], sagemaker_session=SAGEMAKER_SESSION_MOCK),
             call(raw_data=RAW_DATA_INPUT[2], sagemaker_session=SAGEMAKER_SESSION_MOCK),
+            call(raw_data=RAW_DATA_INPUT[3], sagemaker_session=SAGEMAKER_SESSION_MOCK),
         ]
     )
-    assert 3 == retrieve_raw_data_artifact_method.call_count
+    assert 4 == retrieve_raw_data_artifact_method.call_count
 
     create_transformation_code_artifact_method.assert_called_once_with(
         transformation_code=TRANSFORMATION_CODE_INPUT_2,
@@ -1769,6 +1784,7 @@ def test_create_lineage_when_already_exist_with_last_transformation_code_as_none
             RAW_DATA_INPUT_ARTIFACTS[0],
             RAW_DATA_INPUT_ARTIFACTS[1],
             RAW_DATA_INPUT_ARTIFACTS[2],
+            RAW_DATA_INPUT_ARTIFACTS[3],
         ],
     ) as retrieve_raw_data_artifact_method, patch.object(
         S3LineageEntityHandler,
@@ -1850,9 +1866,10 @@ def test_create_lineage_when_already_exist_with_last_transformation_code_as_none
             call(raw_data=RAW_DATA_INPUT[0], sagemaker_session=SAGEMAKER_SESSION_MOCK),
             call(raw_data=RAW_DATA_INPUT[1], sagemaker_session=SAGEMAKER_SESSION_MOCK),
             call(raw_data=RAW_DATA_INPUT[2], sagemaker_session=SAGEMAKER_SESSION_MOCK),
+            call(raw_data=RAW_DATA_INPUT[3], sagemaker_session=SAGEMAKER_SESSION_MOCK),
         ]
     )
-    assert 3 == retrieve_raw_data_artifact_method.call_count
+    assert 4 == retrieve_raw_data_artifact_method.call_count
 
     create_transformation_code_artifact_method.assert_called_once_with(
         transformation_code=TRANSFORMATION_CODE_INPUT_2,
@@ -1957,6 +1974,7 @@ def test_create_lineage_when_already_exist_with_all_previous_transformation_code
             RAW_DATA_INPUT_ARTIFACTS[0],
             RAW_DATA_INPUT_ARTIFACTS[1],
             RAW_DATA_INPUT_ARTIFACTS[2],
+            RAW_DATA_INPUT_ARTIFACTS[3],
         ],
     ) as retrieve_raw_data_artifact_method, patch.object(
         S3LineageEntityHandler,
@@ -2037,9 +2055,10 @@ def test_create_lineage_when_already_exist_with_all_previous_transformation_code
             call(raw_data=RAW_DATA_INPUT[0], sagemaker_session=SAGEMAKER_SESSION_MOCK),
             call(raw_data=RAW_DATA_INPUT[1], sagemaker_session=SAGEMAKER_SESSION_MOCK),
             call(raw_data=RAW_DATA_INPUT[2], sagemaker_session=SAGEMAKER_SESSION_MOCK),
+            call(raw_data=RAW_DATA_INPUT[3], sagemaker_session=SAGEMAKER_SESSION_MOCK),
         ]
     )
-    assert 3 == retrieve_raw_data_artifact_method.call_count
+    assert 4 == retrieve_raw_data_artifact_method.call_count
 
     create_transformation_code_artifact_method.assert_called_once_with(
         transformation_code=TRANSFORMATION_CODE_INPUT_2,
@@ -2141,6 +2160,7 @@ def test_create_lineage_when_already_exist_with_removed_transformation_code():
             RAW_DATA_INPUT_ARTIFACTS[0],
             RAW_DATA_INPUT_ARTIFACTS[1],
             RAW_DATA_INPUT_ARTIFACTS[2],
+            RAW_DATA_INPUT_ARTIFACTS[3],
         ],
     ) as retrieve_raw_data_artifact_method, patch.object(
         S3LineageEntityHandler,
@@ -2222,9 +2242,10 @@ def test_create_lineage_when_already_exist_with_removed_transformation_code():
             call(raw_data=RAW_DATA_INPUT[0], sagemaker_session=SAGEMAKER_SESSION_MOCK),
             call(raw_data=RAW_DATA_INPUT[1], sagemaker_session=SAGEMAKER_SESSION_MOCK),
             call(raw_data=RAW_DATA_INPUT[2], sagemaker_session=SAGEMAKER_SESSION_MOCK),
+            call(raw_data=RAW_DATA_INPUT[3], sagemaker_session=SAGEMAKER_SESSION_MOCK),
         ]
     )
-    assert 3 == retrieve_raw_data_artifact_method.call_count
+    assert 4 == retrieve_raw_data_artifact_method.call_count
 
     create_transformation_code_artifact_method.assert_called_once_with(
         transformation_code=None,
@@ -2471,6 +2492,7 @@ def test_upsert_tags_for_lineage_resources():
             RAW_DATA_INPUT_ARTIFACTS[0],
             RAW_DATA_INPUT_ARTIFACTS[1],
             RAW_DATA_INPUT_ARTIFACTS[2],
+            RAW_DATA_INPUT_ARTIFACTS[3],
         ],
     ) as retrieve_raw_data_artifact_method, patch.object(
         PipelineLineageEntityHandler,
@@ -2518,6 +2540,7 @@ def test_upsert_tags_for_lineage_resources():
             call(raw_data=RAW_DATA_INPUT[0], sagemaker_session=mock_session),
             call(raw_data=RAW_DATA_INPUT[1], sagemaker_session=mock_session),
             call(raw_data=RAW_DATA_INPUT[2], sagemaker_session=mock_session),
+            call(raw_data=RAW_DATA_INPUT[3], sagemaker_session=mock_session),
         ]
     )
 

--- a/tests/unit/sagemaker/feature_store/feature_processor/test_config_uploader.py
+++ b/tests/unit/sagemaker/feature_store/feature_processor/test_config_uploader.py
@@ -27,7 +27,7 @@ from sagemaker.remote_function.job import (
     _JobSettings,
     RUNTIME_SCRIPTS_CHANNEL_NAME,
     REMOTE_FUNCTION_WORKSPACE,
-    SPARK_CONF_WORKSPACE,
+    SPARK_CONF_CHANNEL_NAME,
 )
 from sagemaker.remote_function.spark_config import SparkConfig
 from sagemaker.session import Session
@@ -218,7 +218,7 @@ def test_prepare_step_input_channel(
             s3_data=f"{config_uploader.remote_decorator_config.s3_root_uri}/pipeline_name/sm_rf_user_ws",
             s3_data_type="S3Prefix",
         ),
-        SPARK_CONF_WORKSPACE: mock_training_input(s3_data="path_d", s3_data_type="S3Prefix"),
+        SPARK_CONF_CHANNEL_NAME: mock_training_input(s3_data="path_d", s3_data_type="S3Prefix"),
     }
 
     assert spark_dependency_paths == {

--- a/tests/unit/sagemaker/feature_store/feature_processor/test_data_helpers.py
+++ b/tests/unit/sagemaker/feature_store/feature_processor/test_data_helpers.py
@@ -137,6 +137,7 @@ def create_fp_config(
     target_stores=None,
     enable_ingestion=True,
     parameters=None,
+    spark_config=None,
 ):
     """Helper method to create a FeatureProcessorConfig with fewer arguments."""
 
@@ -147,4 +148,5 @@ def create_fp_config(
         target_stores=target_stores,
         enable_ingestion=enable_ingestion,
         parameters=parameters,
+        spark_config=spark_config,
     )

--- a/tests/unit/sagemaker/feature_store/feature_processor/test_data_source.py
+++ b/tests/unit/sagemaker/feature_store/feature_processor/test_data_source.py
@@ -1,0 +1,34 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+# language governing permissions and limitations under the License.
+from __future__ import absolute_import
+
+from pyspark.sql import DataFrame
+
+from sagemaker.feature_store.feature_processor._data_source import PySparkDataSource
+
+
+def test_pyspark_data_source():
+    class TestDataSource(PySparkDataSource):
+
+        data_source_unique_id = "test_unique_id"
+        data_source_name = "test_source_name"
+
+        def read_data(self, spark, params) -> DataFrame:
+            return None
+
+    test_data_source = TestDataSource()
+
+    assert test_data_source.data_source_name == "test_source_name"
+    assert test_data_source.data_source_unique_id == "test_unique_id"
+    assert test_data_source.read_data(spark=None, params=None) is None

--- a/tests/unit/sagemaker/feature_store/feature_processor/test_factory.py
+++ b/tests/unit/sagemaker/feature_store/feature_processor/test_factory.py
@@ -31,6 +31,7 @@ from sagemaker.feature_store.feature_processor._validation import (
     InputValidator,
     SparkUDFSignatureValidator,
     InputOffsetValidator,
+    BaseDataSourceValidator,
 )
 from sagemaker.session import Session
 
@@ -44,6 +45,7 @@ def test_get_validation_chain():
         InputValidator,
         FeatureProcessorArgValidator,
         InputOffsetValidator,
+        BaseDataSourceValidator,
         SparkUDFSignatureValidator,
     } == {type(instance) for instance in result.validators}
 
@@ -53,7 +55,7 @@ def test_get_udf_wrapper():
     udf_wrapper = Mock(UDFWrapper)
 
     with patch.object(
-        UDFWrapperFactory, "get_udf_wrapper", return_value=udf_wrapper
+        UDFWrapperFactory, "_get_spark_udf_wrapper", return_value=udf_wrapper
     ) as get_udf_wrapper_method:
         result = UDFWrapperFactory.get_udf_wrapper(fp_config)
 

--- a/tests/unit/sagemaker/feature_store/feature_processor/test_feature_processor_config.py
+++ b/tests/unit/sagemaker/feature_store/feature_processor/test_feature_processor_config.py
@@ -31,6 +31,7 @@ def test_feature_processor_config_is_immutable():
         target_stores=None,
         enable_ingestion=True,
         parameters=None,
+        spark_config=None,
     )
 
     with pytest.raises(attr.exceptions.FrozenInstanceError):

--- a/tests/unit/sagemaker/feature_store/feature_processor/test_feature_scheduler.py
+++ b/tests/unit/sagemaker/feature_store/feature_processor/test_feature_scheduler.py
@@ -49,8 +49,8 @@ from sagemaker.remote_function.job import (
     SPARK_APP_SCRIPT_PATH,
     RUNTIME_SCRIPTS_CHANNEL_NAME,
     REMOTE_FUNCTION_WORKSPACE,
-    SPARK_CONF_WORKSPACE,
     ENTRYPOINT_SCRIPT_NAME,
+    SPARK_CONF_CHANNEL_NAME,
 )
 from sagemaker.workflow.parameters import Parameter, ParameterTypeEnum
 from sagemaker.workflow.retry import (
@@ -316,7 +316,7 @@ def test_to_pipeline(
             REMOTE_FUNCTION_WORKSPACE: mock_training_input(
                 s3_data=f"{S3_URI}/pipeline_name/sm_rf_user_ws", s3_data_type="S3Prefix"
             ),
-            SPARK_CONF_WORKSPACE: mock_training_input(s3_data="path_d", s3_data_type="S3Prefix"),
+            SPARK_CONF_CHANNEL_NAME: mock_training_input(s3_data="path_d", s3_data_type="S3Prefix"),
         },
         retry_policies=[
             StepRetryPolicy(

--- a/tests/unit/sagemaker/feature_store/feature_processor/test_spark_session_factory.py
+++ b/tests/unit/sagemaker/feature_store/feature_processor/test_spark_session_factory.py
@@ -33,7 +33,8 @@ def env_helper():
 
 def test_spark_session_factory_configuration():
     env_helper = Mock()
-    spark_session_factory = SparkSessionFactory(env_helper)
+    spark_config = {"spark.test.key": "spark.test.value"}
+    spark_session_factory = SparkSessionFactory(env_helper, spark_config)
     spark_configs = dict(spark_session_factory._get_spark_configs(is_training_job=False))
     jsc_hadoop_configs = dict(spark_session_factory._get_jsc_hadoop_configs())
 
@@ -65,6 +66,8 @@ def test_spark_session_factory_configuration():
     assert spark_configs.get("spark.hadoop.fs.trash.interval") == "0"
     assert spark_configs.get("spark.port.maxRetries") == "50"
 
+    assert spark_configs.get("spark.test.key") == "spark.test.value"
+
     assert jsc_hadoop_configs.get("mapreduce.fileoutputcommitter.marksuccessfuljobs") == "false"
 
     # Verify configurations when not running on a training job
@@ -79,9 +82,11 @@ def test_spark_session_factory_configuration():
 
 def test_spark_session_factory_configuration_on_training_job():
     env_helper = Mock()
-    spark_session_factory = SparkSessionFactory(env_helper)
+    spark_config = {"spark.test.key": "spark.test.value"}
+    spark_session_factory = SparkSessionFactory(env_helper, spark_config)
 
     spark_config = spark_session_factory._get_spark_configs(is_training_job=True)
+    assert dict(spark_config).get("spark.test.key") == "spark.test.value"
 
     assert all(tup[0] != "spark.jars" for tup in spark_config)
     assert all(tup[0] != "spark.jars.packages" for tup in spark_config)


### PR DESCRIPTION
* Enable feature_processor to connect with user defined data sources

* Add local integration test for BaseDataSource

* Fix the integration tests

* Add custom data source name validations

* Remove test unused imports

* Fix the data source name invalid pattern

* Resolve minor PR comments

* Add extra abstraction layer for feature processor

* Fix the docstring of BaseDataSource

* Fix the failed integration test

*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
