### PR TITLE
fix: fix flaky Inference Recommender integration tests

### DIFF
--- a/src/sagemaker/inference_recommender/inference_recommender_mixin.py
+++ b/src/sagemaker/inference_recommender/inference_recommender_mixin.py
@@ -607,12 +607,12 @@ class InferenceRecommenderMixin:
             None,
         )
 
-        # TODO: until we have bandwidth to integrate right_size + deploy with serverless
+    # TODO: until we have bandwidth to integrate right_size + deploy with serverless
     def _filter_recommendations_for_realtime(self):
         instance_type = None
         initial_instance_count = None
         for recommendations in self.inference_recommendations:
-            if not "serverlessConfig" in recommendations["EndpointConfiguration"]:
+            if not "ServerlessConfig" in recommendations["EndpointConfiguration"]:
                 instance_type = recommendations["EndpointConfiguration"]["InstanceType"]
                 initial_instance_count = recommendations["EndpointConfiguration"][
                     "InitialInstanceCount"

--- a/src/sagemaker/inference_recommender/inference_recommender_mixin.py
+++ b/src/sagemaker/inference_recommender/inference_recommender_mixin.py
@@ -306,7 +306,7 @@ class InferenceRecommenderMixin:
         initial_instance_count = self.inference_recommendations[0]["EndpointConfiguration"][
             "InitialInstanceCount"
         ]
-        return (instance_type, initial_instance_count)
+        return self._filter_recommendations_for_realtime()
 
     def _update_params_for_recommendation_id(
         self,
@@ -610,3 +610,15 @@ class InferenceRecommenderMixin:
             ),
             None,
         )
+
+        # TODO: until we have bandwidth to integrate right_size + deploy with serverless
+    def _filter_recommendations_for_realtime(self):
+        instance_type = None
+        initial_instance_count = None
+        for recommendations in self.inference_recommendations:
+            if not "serverlessConfig" in recommendations["EndpointConfiguration"]:
+                instance_type = recommendations["EndpointConfiguration"]["InstanceType"]
+                initial_instance_count = recommendations["EndpointConfiguration"][
+                    "InitialInstanceCount"
+                ]
+        return (instance_type, initial_instance_count)

--- a/src/sagemaker/inference_recommender/inference_recommender_mixin.py
+++ b/src/sagemaker/inference_recommender/inference_recommender_mixin.py
@@ -609,6 +609,7 @@ class InferenceRecommenderMixin:
 
     # TODO: until we have bandwidth to integrate right_size + deploy with serverless
     def _filter_recommendations_for_realtime(self):
+        """Filter recommendations list to find a realtime instance"""
         instance_type = None
         initial_instance_count = None
         for recommendations in self.inference_recommendations:

--- a/src/sagemaker/inference_recommender/inference_recommender_mixin.py
+++ b/src/sagemaker/inference_recommender/inference_recommender_mixin.py
@@ -612,7 +612,7 @@ class InferenceRecommenderMixin:
         instance_type = None
         initial_instance_count = None
         for recommendations in self.inference_recommendations:
-            if not "ServerlessConfig" in recommendations["EndpointConfiguration"]:
+            if "ServerlessConfig" not in recommendations["EndpointConfiguration"]:
                 instance_type = recommendations["EndpointConfiguration"]["InstanceType"]
                 initial_instance_count = recommendations["EndpointConfiguration"][
                     "InitialInstanceCount"

--- a/src/sagemaker/inference_recommender/inference_recommender_mixin.py
+++ b/src/sagemaker/inference_recommender/inference_recommender_mixin.py
@@ -302,10 +302,6 @@ class InferenceRecommenderMixin:
             )
             return None
 
-        instance_type = self.inference_recommendations[0]["EndpointConfiguration"]["InstanceType"]
-        initial_instance_count = self.inference_recommendations[0]["EndpointConfiguration"][
-            "InitialInstanceCount"
-        ]
         return self._filter_recommendations_for_realtime()
 
     def _update_params_for_recommendation_id(

--- a/tests/integ/test_inference_recommender.py
+++ b/tests/integ/test_inference_recommender.py
@@ -461,9 +461,7 @@ def test_deploy_inference_recommendation_id_with_registered_model_sklearn(
         JobName=ir_job_name
     )
 
-    rec_id = get_realtime_recommendation_id(
-        recommendation_list=rec_res["InferenceRecommendations"]
-    )
+    rec_id = get_realtime_recommendation_id(recommendation_list=rec_res["InferenceRecommendations"])
 
     with timeout(minutes=45):
         try:
@@ -540,15 +538,11 @@ def poll_for_deployment_recommendation(created_base_model, sagemaker_session):
         except Exception as e:
             created_base_model.delete_model()
             raise e
-        
-def get_realtime_recommendation_id(recommendation_list):
-        """Search recommendation based on recommendation id"""
-        next(
-            (
-                rec["RecommendationId"]
-                for rec in recommendation_list
-                if "InstanceType" in rec
-            ),
-            None,
-        )
 
+
+def get_realtime_recommendation_id(recommendation_list):
+    """Search recommendation based on recommendation id"""
+    next(
+        (rec["RecommendationId"] for rec in recommendation_list if "InstanceType" in rec),
+        None,
+    )

--- a/tests/integ/test_inference_recommender.py
+++ b/tests/integ/test_inference_recommender.py
@@ -39,7 +39,7 @@ IR_SKLEARN_PAYLOAD = os.path.join(IR_DIR, "sklearn-payload.tar.gz")
 IR_SKLEARN_DATA = os.path.join(IR_DIR, "sample.csv")
 IR_SKLEARN_CONTENT_TYPE = ["text/csv"]
 IR_SKLEARN_FRAMEWORK = "SAGEMAKER-SCIKIT-LEARN"
-IR_SKLEARN_FRAMEWORK_VERSION = "0.20.0"
+IR_SKLEARN_FRAMEWORK_VERSION = "1.0-1"
 
 
 def retry_and_back_off(right_size_fn):

--- a/tests/integ/test_inference_recommender.py
+++ b/tests/integ/test_inference_recommender.py
@@ -39,7 +39,7 @@ IR_SKLEARN_PAYLOAD = os.path.join(IR_DIR, "sklearn-payload.tar.gz")
 IR_SKLEARN_DATA = os.path.join(IR_DIR, "sample.csv")
 IR_SKLEARN_CONTENT_TYPE = ["text/csv"]
 IR_SKLEARN_FRAMEWORK = "SAGEMAKER-SCIKIT-LEARN"
-IR_SKLEARN_FRAMEWORK_VERSION = "1.0-1"
+IR_SKLEARN_FRAMEWORK_VERSION = "0.20.0"
 
 
 def retry_and_back_off(right_size_fn):

--- a/tests/integ/test_inference_recommender.py
+++ b/tests/integ/test_inference_recommender.py
@@ -460,7 +460,10 @@ def test_deploy_inference_recommendation_id_with_registered_model_sklearn(
     rec_res = sagemaker_session.sagemaker_client.describe_inference_recommendations_job(
         JobName=ir_job_name
     )
-    rec_id = rec_res["InferenceRecommendations"][0]["RecommendationId"]
+
+    rec_id = get_realtime_recommendation_id(
+        recommendation_list=rec_res["InferenceRecommendations"]
+    )
 
     with timeout(minutes=45):
         try:
@@ -537,3 +540,14 @@ def poll_for_deployment_recommendation(created_base_model, sagemaker_session):
         except Exception as e:
             created_base_model.delete_model()
             raise e
+        
+def get_realtime_recommendation_id(recommendation_list):
+        """Search recommendation based on recommendation id"""
+        next(
+            (
+                rec["RecommendationId"]
+                for rec in recommendation_list
+                if "InstanceType" in rec
+            ),
+            None,
+        )

--- a/tests/integ/test_inference_recommender.py
+++ b/tests/integ/test_inference_recommender.py
@@ -551,3 +551,4 @@ def get_realtime_recommendation_id(recommendation_list):
             ),
             None,
         )
+


### PR DESCRIPTION
*Issue #, if available:*
[V1058341966]

*Description of changes:*
Inference Recommender integration tests are flaky when searching for InstanceType in recommendations due to serverless support launched 8/2023. Enforce realtime-only endpoints for integration tests.

*Testing done:*
`tox -e py310 -- tests/integ/test_inference_recommender.py`

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [X] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [X] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [X] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [X] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [X] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
