### PR TITLE
documentation: Include FeatureGroup's load_feature_definitions API documentation

### DIFF
--- a/doc/api/prep_data/feature_store.rst
+++ b/doc/api/prep_data/feature_store.rst
@@ -6,7 +6,6 @@ Feature Group
 
 .. autoclass:: sagemaker.feature_store.feature_group.FeatureGroup
     :members:
-    :exclude-members: load_feature_definitions
     :show-inheritance:
 
 .. autoclass:: sagemaker.feature_store.feature_group.AthenaQuery

--- a/src/sagemaker/feature_store/feature_group.py
+++ b/src/sagemaker/feature_store/feature_group.py
@@ -759,8 +759,8 @@ class FeatureGroup:
         """Load feature definitions from a Pandas DataFrame.
 
         Column name is used as feature name. Feature type is inferred from the dtype
-        of the column. Dtype int_, int8, int16, int32, int64, uint8, uint16, uint32
-        and uint64 are mapped to Integral feature type. Dtype float_, float16, float32
+        of the column. Dtype :literal:`int_`, int8, int16, int32, int64, uint8, uint16, uint32
+        and uint64 are mapped to Integral feature type. Dtype :literal:`float_`, float16, float32
         and float64 are mapped to Fractional feature type. string dtype is mapped to
         String feature type.
 


### PR DESCRIPTION
*Issue #, if available:* Fix #2677

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
