### PR TITLE
feat: Support job checkpoint in remote function

### DIFF
--- a/src/sagemaker/remote_function/__init__.py
+++ b/src/sagemaker/remote_function/__init__.py
@@ -14,3 +14,4 @@
 from __future__ import absolute_import
 
 from sagemaker.remote_function.client import remote, RemoteExecutor  # noqa: F401
+from sagemaker.remote_function.checkpoint_location import CheckpointLocation  # noqa: F401

--- a/src/sagemaker/remote_function/checkpoint_location.py
+++ b/src/sagemaker/remote_function/checkpoint_location.py
@@ -1,0 +1,47 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+"""This module is used to define the CheckpointLocation to remote function."""
+from __future__ import absolute_import
+
+from os import PathLike
+import re
+
+# Regex is taken from https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_CheckpointConfig.html
+S3_URI_REGEX_PATTERN = r"^(https|s3)://([^/]+)/?(.*)$"
+
+_JOB_CHECKPOINT_LOCATION = "/opt/ml/checkpoints/"
+
+
+def _validate_s3_uri_for_checkpoint(s3_uri: str):
+    """Validate if checkpoint location is specified with a valid s3 URI."""
+    return re.match(S3_URI_REGEX_PATTERN, s3_uri)
+
+
+class CheckpointLocation(PathLike):
+    """Class to represent the location where checkpoints are accessed in a remote function.
+
+    To save or load checkpoints in a remote function, pass an CheckpointLocation object as a
+    function parameter and use it as a os.PathLike object. This CheckpointLocation object
+    represents the local directory (/opt/ml/checkpoints/) of checkpoints in side the job.
+    """
+
+    _local_path = _JOB_CHECKPOINT_LOCATION
+
+    def __init__(self, s3_uri):
+        if not _validate_s3_uri_for_checkpoint(s3_uri):
+            raise ValueError("CheckpointLocation should be specified with valid s3 URI.")
+        self._s3_uri = s3_uri
+
+    def __fspath__(self):
+        """Return job local path where checkpoints are stored."""
+        return self._local_path

--- a/src/sagemaker/remote_function/job.py
+++ b/src/sagemaker/remote_function/job.py
@@ -46,6 +46,7 @@ from sagemaker.experiments._run_context import _RunContext
 from sagemaker.experiments.run import Run
 from sagemaker.image_uris import get_base_python_image_uri
 from sagemaker import image_uris
+from sagemaker.remote_function.checkpoint_location import CheckpointLocation
 from sagemaker.session import get_execution_role, _logs_for_job, Session
 from sagemaker.utils import name_from_base, _tmpdir, resolve_value_from_config
 from sagemaker.s3 import s3_path_join, S3Uploader
@@ -681,6 +682,8 @@ class _Job:
             RetryStrategy={"MaximumRetryAttempts": job_settings.max_retry_attempts},
         )
 
+        _update_job_request_with_checkpoint_config(func_args, func_kwargs, request_dict)
+
         if job_settings.tags:
             request_dict["Tags"] = job_settings.tags
 
@@ -1178,6 +1181,50 @@ def _extend_spark_config_to_request(
         container_entrypoint.extend([SPARK_APP_SCRIPT_PATH])
 
     return extended_request
+
+
+def _update_job_request_with_checkpoint_config(args, kwargs, request_dict):
+    """Extend job request with checkpoint config based on CheckpointLocation in function args.
+
+    Args:
+        args (tuple): The positional arguments of the remote function.
+        kwargs (Dict): The keyword arguments of the remote function.
+        request_dict (Dict): create training job request dict.
+    """
+    checkpoint_location_index_in_args = None
+    checkpoint_location_key_in_kwargs = None
+    checkpoint_location_count = 0
+
+    for index, arg in enumerate(args):
+        if isinstance(arg, CheckpointLocation):
+            checkpoint_location_index_in_args = index
+            checkpoint_location_count += 1
+
+    for key, value in kwargs.items():
+        if isinstance(value, CheckpointLocation):
+            checkpoint_location_key_in_kwargs = key
+            checkpoint_location_count += 1
+
+    if checkpoint_location_count < 1:
+        return
+
+    if checkpoint_location_count > 1:
+        raise ValueError(
+            "Remote function cannot have more than one argument of type CheckpointLocation."
+        )
+
+    if checkpoint_location_index_in_args is not None:
+        checkpoint_location_arg = args[checkpoint_location_index_in_args]
+    else:
+        checkpoint_location_arg = kwargs[checkpoint_location_key_in_kwargs]
+
+    checkpoint_s3_uri = checkpoint_location_arg._s3_uri
+    checkpoint_local_path = checkpoint_location_arg._local_path
+
+    request_dict["CheckpointConfig"] = {
+        "LocalPath": checkpoint_local_path,
+        "S3Uri": checkpoint_s3_uri,
+    }
 
 
 @dataclasses.dataclass

--- a/tests/integ/sagemaker/remote_function/test_decorator.py
+++ b/tests/integ/sagemaker/remote_function/test_decorator.py
@@ -12,6 +12,7 @@
 # language governing permissions and limitations under the License.
 from __future__ import absolute_import
 import time
+from typing import Union
 
 
 import pytest
@@ -23,6 +24,7 @@ import pandas as pd
 import subprocess
 import shlex
 from sagemaker.experiments.run import Run, load_run
+from sagemaker.remote_function import CheckpointLocation
 from tests.integ.sagemaker.experiments.helpers import cleanup_exp_resources
 from sagemaker.experiments.trial_component import _TrialComponent
 from sagemaker.experiments._api_types import _TrialComponentStatusType
@@ -40,13 +42,25 @@ from sagemaker.utils import unique_name_from_base
 
 from tests.integ.kms_utils import get_or_create_kms_key
 from tests.integ import DATA_DIR
+from tests.integ.s3_utils import assert_s3_files_exist
 
 ROLE = "SageMakerRole"
+CHECKPOINT_FILE_CONTENT = "test checkpoint file"
 
 
 @pytest.fixture(scope="module")
 def s3_kms_key(sagemaker_session):
     return get_or_create_kms_key(sagemaker_session=sagemaker_session)
+
+
+@pytest.fixture(scope="module")
+def checkpoint_s3_location(sagemaker_session):
+    def random_s3_uri():
+        return "".join(random.choices(string.ascii_uppercase + string.digits, k=10))
+
+    return "s3://{}/rm-func-checkpoints/{}".format(
+        sagemaker_session.default_bucket(), random_s3_uri()
+    )
 
 
 def test_decorator(sagemaker_session, dummy_container_without_error, cpu_instance_type):
@@ -624,6 +638,61 @@ def test_decorator_with_spot_instances(
 
     assert divide(10, 2) == 5
     assert divide(20, 2) == 10
+
+
+def test_decorator_with_spot_instances_save_and_load_checkpoints(
+    sagemaker_session,
+    dummy_container_without_error,
+    cpu_instance_type,
+    checkpoint_s3_location,
+):
+    @remote(
+        role=ROLE,
+        image_uri=dummy_container_without_error,
+        instance_type=cpu_instance_type,
+        sagemaker_session=sagemaker_session,
+        use_spot_instances=True,
+        max_wait_time_in_seconds=48 * 60 * 60,
+    )
+    def save_checkpoints(checkpoint_path: Union[str, os.PathLike]):
+        file_path_1 = os.path.join(checkpoint_path, "checkpoint_1.json")
+        with open(file_path_1, "w") as f:
+            f.write(CHECKPOINT_FILE_CONTENT)
+
+        file_path_2 = os.path.join(checkpoint_path, "checkpoint_2.json")
+        with open(file_path_2, "w") as f:
+            f.write(CHECKPOINT_FILE_CONTENT)
+
+        return CHECKPOINT_FILE_CONTENT
+
+    @remote(
+        role=ROLE,
+        image_uri=dummy_container_without_error,
+        instance_type=cpu_instance_type,
+        sagemaker_session=sagemaker_session,
+        use_spot_instances=True,
+        max_wait_time_in_seconds=48 * 60 * 60,
+    )
+    def load_checkpoints(checkpoint_path: Union[str, os.PathLike]):
+        file_path_1 = os.path.join(checkpoint_path, "checkpoint_1.json")
+        with open(file_path_1, "r") as file:
+            file_content_1 = file.read()
+
+        file_path_2 = os.path.join(checkpoint_path, "checkpoint_2.json")
+        with open(file_path_2, "r") as file:
+            file_content_2 = file.read()
+
+        return file_content_1 + file_content_2
+
+    assert save_checkpoints(CheckpointLocation(checkpoint_s3_location)) == CHECKPOINT_FILE_CONTENT
+    assert_s3_files_exist(
+        sagemaker_session, checkpoint_s3_location, ["checkpoint_1.json", "checkpoint_2.json"]
+    )
+
+    assert (
+        load_checkpoints(CheckpointLocation(checkpoint_s3_location))
+        == CHECKPOINT_FILE_CONTENT + CHECKPOINT_FILE_CONTENT
+    )
 
 
 @pytest.mark.skip

--- a/tests/unit/sagemaker/remote_function/test_job.py
+++ b/tests/unit/sagemaker/remote_function/test_job.py
@@ -19,6 +19,7 @@ import pytest
 from mock import patch, Mock, ANY
 
 from sagemaker.config import load_sagemaker_config
+from sagemaker.remote_function.checkpoint_location import CheckpointLocation
 from sagemaker.session_settings import SessionSettings
 
 from sagemaker.remote_function.spark_config import SparkConfig
@@ -119,6 +120,10 @@ def mock_session():
 
 def job_function(a, b=1, *, c, d=3):
     return a * b * c * d
+
+
+def job_function_with_checkpoint(a, checkpoint_1=None, *, b, checkpoint_2=None):
+    return a + b
 
 
 @patch("secrets.token_hex", return_value=HMAC_KEY)
@@ -340,6 +345,8 @@ def test_start(
         s3_kms_key=None,
     )
 
+    mock_stored_function().save.assert_called_once_with(job_function, *(1, 2), **{"c": 3, "d": 4})
+
     local_dependencies_path = mock_runtime_manager().snapshot()
     mock_python_version = mock_runtime_manager()._current_python_version()
 
@@ -416,6 +423,154 @@ def test_start(
         EnableManagedSpotTraining=False,
         Environment={"AWS_DEFAULT_REGION": "us-west-2", "REMOTE_FUNCTION_SECRET_KEY": HMAC_KEY},
     )
+
+
+@patch("sagemaker.experiments._run_context._RunContext.get_current_run", new=mock_get_current_run)
+@patch("secrets.token_hex", return_value=HMAC_KEY)
+@patch("sagemaker.remote_function.job._prepare_and_upload_dependencies", return_value="some_s3_uri")
+@patch(
+    "sagemaker.remote_function.job._prepare_and_upload_runtime_scripts", return_value="some_s3_uri"
+)
+@patch("sagemaker.remote_function.job.RuntimeEnvironmentManager")
+@patch("sagemaker.remote_function.job.StoredFunction")
+@patch("sagemaker.remote_function.job.Session", return_value=mock_session())
+def test_start_with_checkpoint_location(
+    session,
+    mock_stored_function,
+    mock_runtime_manager,
+    mock_script_upload,
+    mock_dependency_upload,
+    secret_token,
+):
+
+    job_settings = _JobSettings(
+        image_uri=IMAGE,
+        s3_root_uri=S3_URI,
+        role=ROLE_ARN,
+        include_local_workdir=True,
+        instance_type="ml.m5.large",
+        encrypt_inter_container_traffic=True,
+    )
+
+    input_checkpoint_location = CheckpointLocation("s3://my-bucket/my-checkpoints/")
+
+    job = _Job.start(
+        job_settings,
+        job_function_with_checkpoint,
+        func_args=(1,),
+        func_kwargs={"b": 2, "checkpoint_2": input_checkpoint_location},
+    )
+
+    assert job.job_name.startswith("job-function-with-checkpoint")
+
+    mock_stored_function.assert_called_once_with(
+        sagemaker_session=session(),
+        s3_base_uri=f"{S3_URI}/{job.job_name}",
+        hmac_key=HMAC_KEY,
+        s3_kms_key=None,
+    )
+
+    mock_stored_function().save.assert_called_once_with(
+        job_function_with_checkpoint, *(1,), **{"b": 2, "checkpoint_2": input_checkpoint_location}
+    )
+
+    mock_python_version = mock_runtime_manager()._current_python_version()
+
+    session().sagemaker_client.create_training_job.assert_called_once_with(
+        TrainingJobName=job.job_name,
+        RoleArn=ROLE_ARN,
+        StoppingCondition={"MaxRuntimeInSeconds": 86400},
+        RetryStrategy={"MaximumRetryAttempts": 1},
+        CheckpointConfig={
+            "LocalPath": "/opt/ml/checkpoints/",
+            "S3Uri": "s3://my-bucket/my-checkpoints/",
+        },
+        InputDataConfig=[
+            dict(
+                ChannelName=RUNTIME_SCRIPTS_CHANNEL_NAME,
+                DataSource={
+                    "S3DataSource": {
+                        "S3Uri": mock_script_upload.return_value,
+                        "S3DataType": "S3Prefix",
+                    }
+                },
+            ),
+            dict(
+                ChannelName=REMOTE_FUNCTION_WORKSPACE,
+                DataSource={
+                    "S3DataSource": {
+                        "S3Uri": f"{S3_URI}/{job.job_name}/sm_rf_user_ws",
+                        "S3DataType": "S3Prefix",
+                    }
+                },
+            ),
+        ],
+        OutputDataConfig={"S3OutputPath": f"{S3_URI}/{job.job_name}"},
+        AlgorithmSpecification=dict(
+            TrainingImage=IMAGE,
+            TrainingInputMode="File",
+            ContainerEntrypoint=[
+                "/bin/bash",
+                "/opt/ml/input/data/sagemaker_remote_function_bootstrap/job_driver.sh",
+            ],
+            ContainerArguments=[
+                "--s3_base_uri",
+                f"{S3_URI}/{job.job_name}",
+                "--region",
+                TEST_REGION,
+                "--client_python_version",
+                mock_python_version,
+                "--run_in_context",
+                '{"experiment_name": "my-exp-name", "run_name": "my-run-name"}',
+            ],
+        ),
+        ResourceConfig=dict(
+            VolumeSizeInGB=30,
+            InstanceCount=1,
+            InstanceType="ml.m5.large",
+            KeepAlivePeriodInSeconds=0,
+        ),
+        EnableNetworkIsolation=False,
+        EnableInterContainerTrafficEncryption=True,
+        EnableManagedSpotTraining=False,
+        Environment={"AWS_DEFAULT_REGION": "us-west-2", "REMOTE_FUNCTION_SECRET_KEY": HMAC_KEY},
+    )
+
+
+@patch("sagemaker.remote_function.job._prepare_and_upload_dependencies", return_value="some_s3_uri")
+@patch(
+    "sagemaker.remote_function.job._prepare_and_upload_runtime_scripts", return_value="some_s3_uri"
+)
+@patch("sagemaker.remote_function.job.RuntimeEnvironmentManager")
+@patch("sagemaker.remote_function.job.Session", return_value=mock_session())
+def test_start_with_checkpoint_location_failed_with_multiple_checkpoint_locations_in_args(
+    session,
+    mock_runtime_manager,
+    mock_script_upload,
+    mock_dependency_upload,
+):
+
+    job_settings = _JobSettings(
+        image_uri=IMAGE,
+        s3_root_uri=S3_URI,
+        role=ROLE_ARN,
+        include_local_workdir=True,
+        instance_type="ml.m5.large",
+        encrypt_inter_container_traffic=True,
+    )
+
+    input_checkpoint_location = CheckpointLocation("s3://my-bucket/my-checkpoints/")
+
+    with pytest.raises(
+        ValueError,
+        match="Remote function cannot have more than one argument of type CheckpointLocation.",
+    ):
+        _Job.start(
+            job_settings,
+            job_function_with_checkpoint,
+            func_args=(1, input_checkpoint_location),
+            func_kwargs={"b": 2, "checkpoint_2": input_checkpoint_location},
+        )
 
 
 @patch("secrets.token_hex", return_value=HMAC_KEY)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
feat: Support job checkpoint in remote function

*Testing done:*
unit and integ test cases

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
