### PR TITLE
feature: Accept user-defined env variables for the entry-point

### DIFF
--- a/src/sagemaker/model.py
+++ b/src/sagemaker/model.py
@@ -766,8 +766,8 @@ api/latest/reference/services/sagemaker.html#SageMaker.Client.add_tags>`_
 
     def _script_mode_env_vars(self):
         """Returns a mapping of environment variables for script mode execution"""
-        script_name = None
-        dir_name = None
+        script_name = self.env.get(SCRIPT_PARAM_NAME.upper(), "")
+        dir_name = self.env.get(DIR_PARAM_NAME.upper(), "")
         if self.uploaded_code:
             script_name = self.uploaded_code.script_name
             if self.repacked_model_data or self.enable_network_isolation():
@@ -783,8 +783,8 @@ api/latest/reference/services/sagemaker.html#SageMaker.Client.add_tags>`_
                     else "file://" + self.source_dir
                 )
         return {
-            SCRIPT_PARAM_NAME.upper(): script_name or str(),
-            DIR_PARAM_NAME.upper(): dir_name or str(),
+            SCRIPT_PARAM_NAME.upper(): script_name,
+            DIR_PARAM_NAME.upper(): dir_name,
             CONTAINER_LOG_LEVEL_PARAM_NAME.upper(): to_string(self.container_log_level),
             SAGEMAKER_REGION_PARAM_NAME.upper(): self.sagemaker_session.boto_region_name,
         }

--- a/tests/unit/sagemaker/training_compiler/test_huggingface_pytorch_compiler.py
+++ b/tests/unit/sagemaker/training_compiler/test_huggingface_pytorch_compiler.py
@@ -718,3 +718,32 @@ def test_register_hf_pytorch_model_auto_infer_framework(
     sagemaker_session.create_model_package_from_containers.assert_called_with(
         **expected_create_model_package_request
     )
+
+
+def test_accept_user_defined_environment_variables(
+    sagemaker_session,
+    huggingface_training_compiler_version,
+    huggingface_training_compiler_pytorch_version,
+    huggingface_training_compiler_pytorch_py_version,
+):
+    program = "inference.py"
+    directory = "/opt/ml/model/code"
+
+    hf_model = HuggingFaceModel(
+        model_data="s3://some/data.tar.gz",
+        role=ROLE,
+        transformers_version=huggingface_training_compiler_version,
+        pytorch_version=huggingface_training_compiler_pytorch_version,
+        py_version=huggingface_training_compiler_pytorch_py_version,
+        sagemaker_session=sagemaker_session,
+        env={
+            "SAGEMAKER_PROGRAM": program,
+            "SAGEMAKER_SUBMIT_DIRECTORY": directory,
+        },
+        image_uri="fakeimage",
+    )
+
+    container_env = hf_model.prepare_container_def("ml.m4.xlarge")["Environment"]
+
+    assert container_env["SAGEMAKER_PROGRAM"] == program
+    assert container_env["SAGEMAKER_SUBMIT_DIRECTORY"] == directory


### PR DESCRIPTION
Would fix #3361 

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
