### PR TITLE
fix: update local mode schema

### DIFF
--- a/src/sagemaker/config/config_schema.py
+++ b/src/sagemaker/config/config_schema.py
@@ -106,6 +106,7 @@ LOCAL = "local"
 LOCAL_CODE = "local_code"
 SERVING_PORT = "serving_port"
 CONTAINER_CONFIG = "container_config"
+CONTAINER_ROOT = "container_root"
 REGION_NAME = "region_name"
 
 
@@ -1089,6 +1090,9 @@ SAGEMAKER_PYTHON_SDK_LOCAL_MODE_CONFIG_SCHEMA = {
                 REGION_NAME: {TYPE: "string"},
                 SERVING_PORT: {
                     TYPE: "integer",
+                },
+                CONTAINER_ROOT: {
+                    TYPE: "string",
                 },
                 CONTAINER_CONFIG: {
                     TYPE: OBJECT,


### PR DESCRIPTION
*Issue #, if available:*
closes #4183 

*Description of changes:*

- Add `container_root` to the local mode config schema.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
