### PR TITLE
fix: import error in unsupported js regions

### DIFF
--- a/src/sagemaker/jumpstart/payload_utils.py
+++ b/src/sagemaker/jumpstart/payload_utils.py
@@ -37,12 +37,12 @@ class PayloadSerializer:
 
     def __init__(
         self,
-        bucket: str = get_jumpstart_content_bucket(),
+        bucket: Optional[str] = None,
         region: str = JUMPSTART_DEFAULT_REGION_NAME,
         s3_client: Optional[boto3.client] = None,
     ) -> None:
         """Initializes PayloadSerializer object."""
-        self.bucket = bucket
+        self.bucket = bucket or get_jumpstart_content_bucket()
         self.region = region
         self.s3_client = s3_client
 


### PR DESCRIPTION
*Description of changes:*
if `sagemaker` was imported in an unsupported JumpStart region, an exception would be thrown since `get_jumpstart_content_bucket()` was a default argument. This has been moved to the method body.

*Testing done:*
```
dev-dsk-evakravi-1e-d82d1ee5 % aws configure
AWS Access Key ID [****************JHE7]: 
AWS Secret Access Key [****************Pn46]: 
Default region name [ap-northeast-3]: 
Default output format [None]: 
(env) 
(23-10-12 17:58:31) <0> [~/workspace/github/sdk-fix-import-bug/sagemaker-python-sdk]  
dev-dsk-evakravi-1e-d82d1ee5 % python3 -c "import sagemaker"                              
sagemaker.config INFO - Not applying SDK defaults from location: /etc/xdg/sagemaker/config.yaml
sagemaker.config INFO - Not applying SDK defaults from location: /home/evakravi/.config/sagemaker/config.yaml
(env) 
(23-10-12 17:58:37) <0> [~/workspace/github/sdk-fix-import-bug/sagemaker-python-sdk]  
```

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
