### PR TITLE
change: add image_uris_unit_test pytest mark

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ from __future__ import absolute_import
 
 import json
 import os
+import pathlib
 
 import boto3
 import pytest
@@ -84,6 +85,16 @@ FRAMEWORKS_FOR_GENERATED_VERSION_FIXTURES = (
 )
 
 PYTORCH_RENEWED_GPU = "ml.g4dn.xlarge"
+
+
+image_uris_unit_tests_dir = pathlib.Path("tests/unit/sagemaker/image_uris")
+
+
+def pytest_collection_modifyitems(config, items):
+    for item in items:
+        testmod = pathlib.Path(item.fspath)
+        if config.rootdir / image_uris_unit_tests_dir in testmod.parents:
+            item.add_marker(pytest.mark.image_uris_unit_test)
 
 
 def pytest_addoption(parser):

--- a/tox.ini
+++ b/tox.ini
@@ -59,6 +59,7 @@ markers =
     local_mode
     slow_test
     release
+    image_uris_unit_test
     timeout: mark a test as a timeout.
 
 [testenv]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Add `pytest_collection_modifyitems` hook to mark all tests in `tests/unit/sagemaker/image_uris` with pytest.mark.image_uris_unit_test
   * `pytest_collection_modifyitems` is called after all test items collected
   *  https://docs.pytest.org/en/7.1.x/reference/reference.html#pytest.hookspec.pytest_collection_modifyitems
* add `image_uris_unit_test` pytest mark

*Testing done:*
   * `tox -e py310 -- -s -vv -m "image_uris_unit_test"  tests/unit`
## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
