### PR TITLE
feat: Added register step in Jumpstart model

### DIFF
--- a/src/sagemaker/jumpstart/factory/model.py
+++ b/src/sagemaker/jumpstart/factory/model.py
@@ -34,14 +34,19 @@ from sagemaker.jumpstart.constants import (
     JUMPSTART_DEFAULT_REGION_NAME,
     JUMPSTART_LOGGER,
 )
+from sagemaker.model_metrics import ModelMetrics
+from sagemaker.metadata_properties import MetadataProperties
+from sagemaker.drift_check_baselines import DriftCheckBaselines
 from sagemaker.jumpstart.enums import JumpStartScriptScope
 from sagemaker.jumpstart.types import (
     JumpStartModelDeployKwargs,
     JumpStartModelInitKwargs,
+    JumpStartModelRegisterKwargs,
 )
 from sagemaker.jumpstart.utils import (
     update_dict_if_key_not_present,
     resolve_model_sagemaker_config_field,
+    verify_model_region_and_return_specs,
 )
 
 from sagemaker.model_monitor.data_capture_config import DataCaptureConfig
@@ -505,6 +510,87 @@ def get_deploy_kwargs(
     deploy_kwargs = _add_deploy_extra_kwargs(kwargs=deploy_kwargs)
 
     return deploy_kwargs
+
+
+def get_register_kwargs(
+    model_id: str,
+    model_version: Optional[str] = None,
+    region: Optional[str] = None,
+    tolerate_deprecated_model: Optional[bool] = None,
+    tolerate_vulnerable_model: Optional[bool] = None,
+    sagemaker_session: Optional[Any] = None,
+    supported_content_types: List[str] = None,
+    response_types: List[str] = None,
+    inference_instances: Optional[List[str]] = None,
+    transform_instances: Optional[List[str]] = None,
+    model_package_group_name: Optional[str] = None,
+    image_uri: Optional[str] = None,
+    model_metrics: Optional[ModelMetrics] = None,
+    metadata_properties: Optional[MetadataProperties] = None,
+    approval_status: Optional[str] = None,
+    description: Optional[str] = None,
+    drift_check_baselines: Optional[DriftCheckBaselines] = None,
+    customer_metadata_properties: Optional[Dict[str, str]] = None,
+    validation_specification: Optional[str] = None,
+    domain: Optional[str] = None,
+    task: Optional[str] = None,
+    sample_payload_url: Optional[str] = None,
+    framework: Optional[str] = None,
+    framework_version: Optional[str] = None,
+    nearest_model_name: Optional[str] = None,
+    data_input_configuration: Optional[str] = None,
+    skip_model_validation: Optional[str] = None,
+) -> JumpStartModelRegisterKwargs:
+    """Returns kwargs required to call `register` on `sagemaker.estimator.Model` object."""
+
+    register_kwargs = JumpStartModelRegisterKwargs(
+        model_id=model_id,
+        model_version=model_version,
+        region=region,
+        tolerate_deprecated_model=tolerate_deprecated_model,
+        tolerate_vulnerable_model=tolerate_vulnerable_model,
+        sagemaker_session=sagemaker_session,
+        content_types=supported_content_types,
+        response_types=response_types,
+        inference_instances=inference_instances,
+        transform_instances=transform_instances,
+        model_package_group_name=model_package_group_name,
+        image_uri=image_uri,
+        model_metrics=model_metrics,
+        metadata_properties=metadata_properties,
+        approval_status=approval_status,
+        description=description,
+        drift_check_baselines=drift_check_baselines,
+        customer_metadata_properties=customer_metadata_properties,
+        validation_specification=validation_specification,
+        domain=domain,
+        task=task,
+        sample_payload_url=sample_payload_url,
+        framework=framework,
+        framework_version=framework_version,
+        nearest_model_name=nearest_model_name,
+        data_input_configuration=data_input_configuration,
+        skip_model_validation=skip_model_validation,
+    )
+
+    model_specs = verify_model_region_and_return_specs(
+        model_id=model_id,
+        version=model_version,
+        region=region,
+        scope=JumpStartScriptScope.INFERENCE,
+        sagemaker_session=sagemaker_session,
+        tolerate_deprecated_model=tolerate_deprecated_model,
+        tolerate_vulnerable_model=tolerate_vulnerable_model,
+    )
+
+    register_kwargs.content_types = (
+        register_kwargs.content_types or model_specs.predictor_specs.supported_content_types
+    )
+    register_kwargs.response_types = (
+        register_kwargs.response_types or model_specs.predictor_specs.supported_accept_types
+    )
+
+    return register_kwargs
 
 
 def get_init_kwargs(

--- a/src/sagemaker/jumpstart/types.py
+++ b/src/sagemaker/jumpstart/types.py
@@ -16,6 +16,9 @@ from copy import deepcopy
 from enum import Enum
 from typing import Any, Dict, List, Optional, Set, Union
 from sagemaker.utils import get_instance_type_family
+from sagemaker.model_metrics import ModelMetrics
+from sagemaker.metadata_properties import MetadataProperties
+from sagemaker.drift_check_baselines import DriftCheckBaselines
 
 from sagemaker.session import Session
 from sagemaker.workflow.entities import PipelineVariable
@@ -1486,3 +1489,107 @@ class JumpStartEstimatorDeployKwargs(JumpStartKwargs):
         self.tolerate_deprecated_model = tolerate_deprecated_model
         self.tolerate_vulnerable_model = tolerate_vulnerable_model
         self.use_compiled_model = use_compiled_model
+
+
+class JumpStartModelRegisterKwargs(JumpStartKwargs):
+    """Data class for the inputs to `JumpStartEstimator.deploy` method."""
+
+    __slots__ = [
+        "tolerate_vulnerable_model",
+        "tolerate_deprecated_model",
+        "region",
+        "model_id",
+        "model_version",
+        "sagemaker_session",
+        "content_types",
+        "response_types",
+        "inference_instances",
+        "transform_instances",
+        "model_package_group_name",
+        "image_uri",
+        "model_metrics",
+        "metadata_properties",
+        "approval_status",
+        "description",
+        "drift_check_baselines",
+        "customer_metadata_properties",
+        "validation_specification",
+        "domain",
+        "task",
+        "sample_payload_url",
+        "framework",
+        "framework_version",
+        "nearest_model_name",
+        "data_input_configuration",
+        "skip_model_validation",
+    ]
+
+    SERIALIZATION_EXCLUSION_SET = {
+        "tolerate_vulnerable_model",
+        "tolerate_deprecated_model",
+        "region",
+        "model_id",
+        "model_version",
+        "sagemaker_session",
+    }
+
+    def __init__(
+        self,
+        model_id: str,
+        model_version: Optional[str] = None,
+        region: Optional[str] = None,
+        tolerate_deprecated_model: Optional[bool] = None,
+        tolerate_vulnerable_model: Optional[bool] = None,
+        sagemaker_session: Optional[Any] = None,
+        content_types: List[str] = None,
+        response_types: List[str] = None,
+        inference_instances: Optional[List[str]] = None,
+        transform_instances: Optional[List[str]] = None,
+        model_package_group_name: Optional[str] = None,
+        image_uri: Optional[str] = None,
+        model_metrics: Optional[ModelMetrics] = None,
+        metadata_properties: Optional[MetadataProperties] = None,
+        approval_status: Optional[str] = None,
+        description: Optional[str] = None,
+        drift_check_baselines: Optional[DriftCheckBaselines] = None,
+        customer_metadata_properties: Optional[Dict[str, str]] = None,
+        validation_specification: Optional[str] = None,
+        domain: Optional[str] = None,
+        task: Optional[str] = None,
+        sample_payload_url: Optional[str] = None,
+        framework: Optional[str] = None,
+        framework_version: Optional[str] = None,
+        nearest_model_name: Optional[str] = None,
+        data_input_configuration: Optional[str] = None,
+        skip_model_validation: Optional[str] = None,
+    ) -> None:
+        """Instantiates JumpStartModelRegisterKwargs object."""
+
+        self.model_id = model_id
+        self.model_version = model_version
+        self.region = region
+        self.image_uri = image_uri
+        self.sagemaker_session = sagemaker_session
+        self.tolerate_deprecated_model = tolerate_deprecated_model
+        self.tolerate_vulnerable_model = tolerate_vulnerable_model
+        self.content_types = content_types
+        self.response_types = response_types
+        self.inference_instances = inference_instances
+        self.transform_instances = transform_instances
+        self.model_package_group_name = model_package_group_name
+        self.image_uri = image_uri
+        self.model_metrics = model_metrics
+        self.metadata_properties = metadata_properties
+        self.approval_status = approval_status
+        self.description = description
+        self.drift_check_baselines = drift_check_baselines
+        self.customer_metadata_properties = customer_metadata_properties
+        self.validation_specification = validation_specification
+        self.domain = domain
+        self.task = task
+        self.sample_payload_url = sample_payload_url
+        self.framework = framework
+        self.framework_version = framework_version
+        self.nearest_model_name = nearest_model_name
+        self.data_input_configuration = data_input_configuration
+        self.skip_model_validation = skip_model_validation


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
