### PR TITLE
change: enhance image_uris unit tests

### DIFF
--- a/tests/unit/sagemaker/image_uris/conftest.py
+++ b/tests/unit/sagemaker/image_uris/conftest.py
@@ -17,18 +17,25 @@ import json
 import pytest
 
 
-@pytest.fixture(scope="module")
-def config_dir():
-    return "src/sagemaker/image_uri_config/"
+CONFIG_DIR = "src/sagemaker/image_uri_config/"
 
 
-@pytest.fixture(scope="module")
-def load_config(config_dir, request):
-    config_file_name = request.param
-    config_file_path = os.path.join(config_dir, config_file_name)
-
+def get_config(config_file_name):
+    config_file_path = os.path.join(CONFIG_DIR, config_file_name)
     with open(config_file_path, "r") as config_file:
         return json.load(config_file)
+
+
+@pytest.fixture(scope="module")
+def load_config(request):
+    config_file_name = request.param
+    return get_config(config_file_name)
+
+
+@pytest.fixture(scope="module")
+def load_config_and_file_name(request):
+    config_file_name = request.param
+    return get_config(config_file_name), config_file_name
 
 
 @pytest.fixture(scope="module")

--- a/tests/unit/sagemaker/image_uris/expected_uris.py
+++ b/tests/unit/sagemaker/image_uris/expected_uris.py
@@ -74,9 +74,8 @@ def graviton_framework_uri(
     return IMAGE_URI_FORMAT.format(account, region, domain, repo, tag)
 
 
-def djl_framework_uri(repo, account, djl_version, primary_framework, region=REGION):
+def djl_framework_uri(repo, account, tag, region=REGION):
     domain = ALTERNATE_DOMAINS.get(region, DOMAIN)
-    tag = f"{djl_version}-{primary_framework}"
     return IMAGE_URI_FORMAT.format(account, region, domain, repo, tag)
 
 

--- a/tests/unit/sagemaker/image_uris/test_algos.py
+++ b/tests/unit/sagemaker/image_uris/test_algos.py
@@ -17,187 +17,33 @@ import pytest
 from sagemaker import image_uris
 from tests.unit.sagemaker.image_uris import expected_uris
 
-ALGO_NAMES = (
-    "blazingtext",
-    "factorization-machines",
-    "forecasting-deepar",
-    "image-classification",
-    "ipinsights",
-    "kmeans",
-    "knn",
-    "linear-learner",
-    "ntm",
-    "object-detection",
-    "object2vec",
-    "pca",
-    "randomcutforest",
-    "semantic-segmentation",
-    "seq2seq",
-    "lda",
-)
-ALGO_REGIONS_AND_ACCOUNTS = (
-    {
-        "algorithms": (
-            "pca",
-            "kmeans",
-            "linear-learner",
-            "factorization-machines",
-            "ntm",
-            "randomcutforest",
-            "knn",
-            "object2vec",
-            "ipinsights",
-        ),
-        "accounts": {
-            "af-south-1": "455444449433",
-            "ap-east-1": "286214385809",
-            "ap-northeast-1": "351501993468",
-            "ap-northeast-2": "835164637446",
-            "ap-northeast-3": "867004704886",
-            "ap-south-1": "991648021394",
-            "ap-south-2": "628508329040",
-            "ap-southeast-1": "475088953585",
-            "ap-southeast-2": "712309505854",
-            "ap-southeast-3": "951798379941",
-            "ap-southeast-4": "106583098589",
-            "ca-central-1": "469771592824",
-            "cn-north-1": "390948362332",
-            "cn-northwest-1": "387376663083",
-            "eu-central-1": "664544806723",
-            "eu-central-2": "680994064768",
-            "eu-north-1": "669576153137",
-            "eu-west-1": "438346466558",
-            "eu-west-2": "644912444149",
-            "eu-west-3": "749696950732",
-            "eu-south-1": "257386234256",
-            "eu-south-2": "104374241257",
-            "il-central-1": "898809789911",
-            "me-south-1": "249704162688",
-            "me-central-1": "272398656194",
-            "sa-east-1": "855470959533",
-            "us-east-1": "382416733822",
-            "us-east-2": "404615174143",
-            "us-gov-west-1": "226302683700",
-            "us-gov-east-1": "237065988967",
-            "us-iso-east-1": "490574956308",
-            "us-isob-east-1": "765400339828",
-            "us-west-1": "632365934929",
-            "us-west-2": "174872318107",
-        },
-    },
-    {
-        "algorithms": ("lda",),
-        "accounts": {
-            "ap-northeast-1": "258307448986",
-            "ap-northeast-2": "293181348795",
-            "ap-south-1": "991648021394",
-            "ap-southeast-1": "475088953585",
-            "ap-southeast-2": "297031611018",
-            "ca-central-1": "469771592824",
-            "eu-central-1": "353608530281",
-            "eu-west-1": "999678624901",
-            "eu-west-2": "644912444149",
-            "us-east-1": "766337827248",
-            "us-east-2": "999911452149",
-            "us-gov-west-1": "226302683700",
-            "us-iso-east-1": "490574956308",
-            "us-isob-east-1": "765400339828",
-            "us-west-1": "632365934929",
-            "us-west-2": "266724342769",
-        },
-    },
-    {
-        "algorithms": ("forecasting-deepar",),
-        "accounts": {
-            "af-south-1": "455444449433",
-            "ap-east-1": "286214385809",
-            "ap-northeast-1": "633353088612",
-            "ap-northeast-2": "204372634319",
-            "ap-northeast-3": "867004704886",
-            "ap-south-1": "991648021394",
-            "ap-southeast-1": "475088953585",
-            "ap-southeast-2": "514117268639",
-            "ca-central-1": "469771592824",
-            "cn-north-1": "390948362332",
-            "cn-northwest-1": "387376663083",
-            "eu-central-1": "495149712605",
-            "eu-north-1": "669576153137",
-            "eu-west-1": "224300973850",
-            "eu-west-2": "644912444149",
-            "eu-west-3": "749696950732",
-            "eu-south-1": "257386234256",
-            "me-south-1": "249704162688",
-            "sa-east-1": "855470959533",
-            "us-east-1": "522234722520",
-            "us-east-2": "566113047672",
-            "us-gov-west-1": "226302683700",
-            "us-iso-east-1": "490574956308",
-            "us-isob-east-1": "765400339828",
-            "us-west-1": "632365934929",
-            "us-west-2": "156387875391",
-        },
-    },
-    {
-        "algorithms": (
-            "seq2seq",
-            "image-classification",
-            "blazingtext",
-            "object-detection",
-            "semantic-segmentation",
-        ),
-        "accounts": {
-            "af-south-1": "455444449433",
-            "ap-east-1": "286214385809",
-            "ap-northeast-1": "501404015308",
-            "ap-northeast-2": "306986355934",
-            "ap-northeast-3": "867004704886",
-            "ap-south-1": "991648021394",
-            "ap-south-2": "628508329040",
-            "ap-southeast-1": "475088953585",
-            "ap-southeast-2": "544295431143",
-            "ap-southeast-3": "951798379941",
-            "ap-southeast-4": "106583098589",
-            "ca-central-1": "469771592824",
-            "cn-north-1": "390948362332",
-            "cn-northwest-1": "387376663083",
-            "eu-central-1": "813361260812",
-            "eu-central-2": "680994064768",
-            "eu-north-1": "669576153137",
-            "eu-west-1": "685385470294",
-            "eu-west-2": "644912444149",
-            "eu-west-3": "749696950732",
-            "eu-south-1": "257386234256",
-            "eu-south-2": "104374241257",
-            "il-central-1": "898809789911",
-            "me-south-1": "249704162688",
-            "me-central-1": "272398656194",
-            "sa-east-1": "855470959533",
-            "us-east-1": "811284229777",
-            "us-east-2": "825641698319",
-            "us-gov-west-1": "226302683700",
-            "us-gov-east-1": "237065988967",
-            "us-iso-east-1": "490574956308",
-            "us-isob-east-1": "765400339828",
-            "us-west-1": "632365934929",
-            "us-west-2": "433757028032",
-        },
-    },
-)
 
-IMAGE_URI_FORMAT = "{}.dkr.ecr.{}.{}/{}:1"
+ALGO_NAMES = [
+    "blazingtext.json",
+    "factorization-machines.json",
+    "forecasting-deepar.json",
+    "image-classification.json",
+    "ipinsights.json",
+    "kmeans.json",
+    "knn.json",
+    "linear-learner.json",
+    "ntm.json",
+    "object-detection.json",
+    "object2vec.json",
+    "pca.json",
+    "randomcutforest.json",
+    "semantic-segmentation.json",
+    "seq2seq.json",
+    "lda.json",
+]
 
 
-def _accounts_for_algo(algo):
-    for algo_account_dict in ALGO_REGIONS_AND_ACCOUNTS:
-        if algo in algo_account_dict["algorithms"]:
-            return algo_account_dict["accounts"]
-
-    return {}
-
-
-@pytest.mark.parametrize("algo", ALGO_NAMES)
-def test_algo_uris(algo):
-    accounts = _accounts_for_algo(algo)
-    for region in accounts:
-        uri = image_uris.retrieve(algo, region)
-        assert expected_uris.algo_uri(algo, accounts[region], region) == uri
+@pytest.mark.parametrize("load_config", ALGO_NAMES, indirect=True)
+def test_algo_uris(load_config):
+    VERSIONS = load_config["versions"]
+    for version in VERSIONS:
+        ACCOUNTS = load_config["versions"][version]["registries"]
+        algo_name = load_config["versions"][version]["repository"]
+        for region in ACCOUNTS.keys():
+            uri = image_uris.retrieve(algo_name, region)
+            assert expected_uris.algo_uri(algo_name, ACCOUNTS[region], region) == uri

--- a/tests/unit/sagemaker/image_uris/test_autogluon.py
+++ b/tests/unit/sagemaker/image_uris/test_autogluon.py
@@ -17,116 +17,55 @@ import pytest
 from sagemaker import image_uris
 from tests.unit.sagemaker.image_uris import expected_uris
 
-ACCOUNTS = {
-    "af-south-1": "626614931356",
-    "il-central-1": "780543022126",
-    "ap-east-1": "871362719292",
-    "ap-northeast-1": "763104351884",
-    "ap-northeast-2": "763104351884",
-    "ap-northeast-3": "364406365360",
-    "ap-south-1": "763104351884",
-    "ap-southeast-1": "763104351884",
-    "ap-southeast-2": "763104351884",
-    "ca-central-1": "763104351884",
-    "eu-central-1": "763104351884",
-    "eu-north-1": "763104351884",
-    "eu-west-1": "763104351884",
-    "eu-west-2": "763104351884",
-    "eu-west-3": "763104351884",
-    "eu-south-1": "692866216735",
-    "me-south-1": "217643126080",
-    "sa-east-1": "763104351884",
-    "us-east-1": "763104351884",
-    "us-east-2": "763104351884",
-    "us-gov-east-1": "446045086412",
-    "us-gov-west-1": "442386744353",
-    "us-iso-east-1": "886529160074",
-    "us-isob-east-1": "094389454867",
-    "us-west-1": "763104351884",
-    "us-west-2": "763104351884",
-}
-VERSIONS = [
-    "0.3.1",
-    "0.3.2",
-    "0.4.0",
-    "0.4.2",
-    "0.4.3",
-    "0.3",
-    "0.4",
-    "0.5.2",
-    "0.5",
-    "0.6.1",
-    "0.6",
-    "0.6.2",
-    "0.7.0",
-    "0.7",
-    "0.8",
-    "0.8.2",
-]
-
-SCOPES = ["training", "inference"]
-PROCESSORS = ["cpu", "gpu"]
+INSTANCE_TYPES = {"cpu": "ml.c4.xlarge", "gpu": "ml.p2.xlarge"}
 
 
-@pytest.mark.parametrize("version", VERSIONS)
-@pytest.mark.parametrize("scope", SCOPES)
-@pytest.mark.parametrize("processor", PROCESSORS)
-def test_valid_uris_training(version, scope, processor):
-    instance_type = "ml.c4.xlarge" if processor == "cpu" else "ml.p2.xlarge"
-    if version == "0.3.1":
-        py_version = "py37"
-    elif version < "0.7":
-        py_version = "py38"
-    else:
-        py_version = "py39"
-    if (
-        scope == "inference"
-        and processor == "gpu"
-        and version in ["0.3.1", "0.3.2", "0.4.0", "0.3"]
-    ):
+@pytest.mark.parametrize("load_config", ["autogluon.json"], indirect=True)
+@pytest.mark.parametrize("scope", ["training", "inference"])
+def test_autogluon_uris(load_config, scope):
+    VERSIONS = load_config[scope]["versions"]
+    for version in VERSIONS:
+        ACCOUNTS = load_config[scope]["versions"][version]["registries"]
+        py_versions = load_config[scope]["versions"][version]["py_versions"]
+        processors = load_config[scope]["versions"][version].get("processors", ["cpu"])
+
+        for processor in processors:
+            instance_type = INSTANCE_TYPES[processor]
+            for py_version in py_versions:
+                for region in ACCOUNTS.keys():
+                    uri = image_uris.retrieve(
+                        "autogluon",
+                        region=region,
+                        version=version,
+                        py_version=py_version,
+                        image_scope=scope,
+                        instance_type=instance_type,
+                    )
+                    expected = expected_uris.framework_uri(
+                        f"autogluon-{scope}",
+                        version,
+                        ACCOUNTS[region],
+                        py_version=py_version,
+                        region=region,
+                        processor=processor,
+                    )
+
+                    assert uri == expected
+
+
+@pytest.mark.parametrize("load_config", ["autogluon.json"], indirect=True)
+@pytest.mark.parametrize("scope", ["training"])
+def test_py3_error(load_config, scope):
+    VERSIONS = load_config[scope]["versions"]
+    for version in VERSIONS:
         with pytest.raises(ValueError) as e:
             image_uris.retrieve(
                 "autogluon",
                 region="us-west-2",
                 version=version,
-                py_version=py_version,
-                image_scope=scope,
-                instance_type=instance_type,
+                py_version="py3",
+                image_scope="training",
+                instance_type="ml.c4.xlarge",
             )
-
-        assert "Unsupported processor: gpu." in str(e.value)
-    else:
-        for region in ACCOUNTS.keys():
-            uri = image_uris.retrieve(
-                "autogluon",
-                region=region,
-                version=version,
-                py_version=py_version,
-                image_scope=scope,
-                instance_type=instance_type,
-            )
-
-            expected = expected_uris.framework_uri(
-                f"autogluon-{scope}",
-                version,
-                ACCOUNTS[region],
-                py_version=py_version,
-                region=region,
-                processor=processor,
-            )
-            assert uri == expected
-
-
-@pytest.mark.parametrize("version", VERSIONS)
-def test_py3_error(version):
-    with pytest.raises(ValueError) as e:
-        image_uris.retrieve(
-            "autogluon",
-            region="us-west-2",
-            version=version,
-            py_version="py3",
-            image_scope="training",
-            instance_type="ml.c4.xlarge",
-        )
 
     assert "Unsupported Python version: py3." in str(e.value)

--- a/tests/unit/sagemaker/image_uris/test_djl.py
+++ b/tests/unit/sagemaker/image_uris/test_djl.py
@@ -15,86 +15,29 @@ import pytest
 from sagemaker import image_uris
 from tests.unit.sagemaker.image_uris import expected_uris
 
-ACCOUNTS = {
-    "af-south-1": "626614931356",
-    "il-central-1": "780543022126",
-    "ap-east-1": "871362719292",
-    "ap-northeast-1": "763104351884",
-    "ap-northeast-2": "763104351884",
-    "ap-northeast-3": "364406365360",
-    "ap-south-1": "763104351884",
-    "ap-southeast-1": "763104351884",
-    "ap-southeast-2": "763104351884",
-    "ap-southeast-3": "907027046896",
-    "ca-central-1": "763104351884",
-    "cn-north-1": "727897471807",
-    "cn-northwest-1": "727897471807",
-    "eu-central-1": "763104351884",
-    "eu-north-1": "763104351884",
-    "eu-west-1": "763104351884",
-    "eu-west-2": "763104351884",
-    "eu-west-3": "763104351884",
-    "eu-south-1": "692866216735",
-    "me-south-1": "217643126080",
-    "sa-east-1": "763104351884",
-    "us-east-1": "763104351884",
-    "us-east-2": "763104351884",
-    "us-west-1": "763104351884",
-    "us-west-2": "763104351884",
-}
-DJL_DEEPSPEED_VERSIONS = ["0.24.0", "0.23.0", "0.22.1", "0.21.0", "0.20.0", "0.19.0"]
-DJL_FASTERTRANSFORMER_VERSIONS = ["0.24.0", "0.23.0", "0.22.1", "0.21.0"]
-DJL_NEURONX_VERSIONS = ["0.24.0", "0.23.0", "0.22.1"]
-DJL_VERSIONS_TO_FRAMEWORK = {
-    "0.19.0": {"djl-deepspeed": "deepspeed0.7.3-cu113"},
-    "0.20.0": {"djl-deepspeed": "deepspeed0.7.5-cu116"},
-    "0.21.0": {
-        "djl-deepspeed": "deepspeed0.8.3-cu117",
-        "djl-fastertransformer": "fastertransformer5.3.0-cu117",
-    },
-    "0.22.1": {
-        "djl-deepspeed": "deepspeed0.9.2-cu118",
-        "djl-fastertransformer": "fastertransformer5.3.0-cu118",
-        "djl-neuronx": "neuronx-sdk2.10.0",
-    },
-    "0.23.0": {
-        "djl-deepspeed": "deepspeed0.9.5-cu118",
-        "djl-fastertransformer": "fastertransformer5.3.0-cu118",
-        "djl-neuronx": "neuronx-sdk2.12.0",
-    },
-    "0.24.0": {
-        "djl-deepspeed": "deepspeed0.10.0-cu118",
-        "djl-fastertransformer": "fastertransformer5.3.0-cu118",
-        "djl-neuronx": "neuronx-sdk2.14.1",
-    },
-}
+
+@pytest.mark.parametrize(
+    "load_config_and_file_name",
+    ["djl-neuronx.json", "djl-fastertransformer.json", "djl-deepspeed.json"],
+    indirect=True,
+)
+def test_djl_uris(load_config_and_file_name):
+    config, file_name = load_config_and_file_name
+    framework = file_name.removesuffix(".json")
+    VERSIONS = config["versions"]
+    for version in VERSIONS:
+        ACCOUNTS = config["versions"][version]["registries"]
+        tag = config["versions"][version]["tag_prefix"]
+        for region in ACCOUNTS.keys():
+            _test_djl_uris(ACCOUNTS[region], region, version, tag, framework)
 
 
-@pytest.mark.parametrize("region", ACCOUNTS.keys())
-@pytest.mark.parametrize("version", DJL_DEEPSPEED_VERSIONS)
-def test_djl_deepspeed(region, version):
-    _test_djl_uris(region, version, "djl-deepspeed")
-
-
-@pytest.mark.parametrize("region", ACCOUNTS.keys())
-@pytest.mark.parametrize("version", DJL_FASTERTRANSFORMER_VERSIONS)
-def test_djl_fastertransformer(region, version):
-    _test_djl_uris(region, version, "djl-fastertransformer")
-
-
-@pytest.mark.parametrize("region", ACCOUNTS.keys())
-@pytest.mark.parametrize("version", DJL_NEURONX_VERSIONS)
-def test_djl_neuronx(region, version):
-    _test_djl_uris(region, version, "djl-neuronx")
-
-
-def _test_djl_uris(region, version, djl_framework):
+def _test_djl_uris(account, region, version, tag, djl_framework):
     uri = image_uris.retrieve(framework=djl_framework, region=region, version=version)
     expected = expected_uris.djl_framework_uri(
         "djl-inference",
-        ACCOUNTS[region],
-        version,
-        DJL_VERSIONS_TO_FRAMEWORK[version][djl_framework],
+        account,
+        tag,
         region,
     )
     assert expected == uri

--- a/tests/unit/sagemaker/image_uris/test_djl.py
+++ b/tests/unit/sagemaker/image_uris/test_djl.py
@@ -23,7 +23,7 @@ from tests.unit.sagemaker.image_uris import expected_uris
 )
 def test_djl_uris(load_config_and_file_name):
     config, file_name = load_config_and_file_name
-    framework = file_name.removesuffix(".json")
+    framework = file_name.split(".json")[0]
     VERSIONS = config["versions"]
     for version in VERSIONS:
         ACCOUNTS = config["versions"][version]["registries"]

--- a/tests/unit/sagemaker/image_uris/test_dlc_frameworks.py
+++ b/tests/unit/sagemaker/image_uris/test_dlc_frameworks.py
@@ -61,7 +61,7 @@ def test_chainer_uris(load_config):
 @pytest.mark.parametrize("scope", ["training", "inference", "eia"])
 def test_dlc_framework_uris(load_config_and_file_name, scope):
     config, file_name = load_config_and_file_name
-    framework = file_name.removesuffix(".json")
+    framework = file_name.split(".json")[0]
     VERSIONS = config[scope]["versions"]
 
     for version in VERSIONS:
@@ -115,7 +115,7 @@ def test_dlc_framework_uris(load_config_and_file_name, scope):
 )
 def test_uncommon_format_dlc_framework_version_uris(load_config_and_file_name):
     config, file_name = load_config_and_file_name
-    framework = file_name.removesuffix(".json")
+    framework = file_name.split(".json")[0]
     py_versions = ["py2", "py3"]
 
     # These versions are formatted differently than others for their framework

--- a/tests/unit/sagemaker/image_uris/test_dlc_frameworks.py
+++ b/tests/unit/sagemaker/image_uris/test_dlc_frameworks.py
@@ -19,419 +19,136 @@ from tests.unit.sagemaker.image_uris import expected_uris
 
 import pytest
 
-INSTANCE_TYPES_AND_PROCESSORS = (("ml.c4.xlarge", "cpu"), ("ml.p2.xlarge", "gpu"))
-RENEWED_PYTORCH_INSTANCE_TYPES_AND_PROCESSORS = (("ml.c4.xlarge", "cpu"), ("ml.g4dn.xlarge", "gpu"))
-REGION = "us-west-2"
-
-DLC_ACCOUNT = "763104351884"
-DLC_ALTERNATE_REGION_ACCOUNTS = {
-    "af-south-1": "626614931356",
-    "ap-east-1": "871362719292",
-    "cn-north-1": "727897471807",
-    "cn-northwest-1": "727897471807",
-    "eu-south-1": "692866216735",
-    "il-central-1": "780543022126",
-    "me-south-1": "217643126080",
-    "us-gov-west-1": "442386744353",
-    "us-iso-east-1": "886529160074",
-    "us-isob-east-1": "094389454867",
-}
-SAGEMAKER_ACCOUNT = "520713654638"
-SAGEMAKER_ALTERNATE_REGION_ACCOUNTS = {
-    "af-south-1": "313743910680",
-    "ap-east-1": "057415533634",
-    "cn-north-1": "422961961927",
-    "cn-northwest-1": "423003514399",
-    "eu-south-1": "048378556238",
-    "me-south-1": "724002660598",
-    "us-gov-west-1": "246785580436",
-    "us-iso-east-1": "744548109606",
-    "us-isob-east-1": "453391408702",
-}
-ELASTIC_INFERENCE_REGIONS = [
-    "ap-northeast-1",
-    "ap-northeast-2",
-    "eu-west-1",
-    "us-east-1",
-    "us-east-2",
-    "us-west-2",
-]
-
-
-def _test_image_uris(
-    framework,
-    fw_version,
-    py_version,
-    scope,
-    expected_fn,
-    expected_fn_args,
-    base_framework_version=None,
-):
-    base_args = {
-        "framework": framework,
-        "version": fw_version,
-        "py_version": py_version,
-        "image_scope": scope,
-    }
-
-    TYPES_AND_PROCESSORS = INSTANCE_TYPES_AND_PROCESSORS
-    if (framework == "pytorch" and Version(fw_version) >= Version("1.13")) or (
-        framework == "tensorflow" and Version(fw_version) >= Version("2.12")
-    ):
-        """Handle P2 deprecation"""
-        TYPES_AND_PROCESSORS = RENEWED_PYTORCH_INSTANCE_TYPES_AND_PROCESSORS
-
-    for instance_type, processor in TYPES_AND_PROCESSORS:
-        uri = image_uris.retrieve(region=REGION, instance_type=instance_type, **base_args)
-
-        expected = expected_fn(processor=processor, **expected_fn_args)
-        assert expected == uri
-
-    for region in SAGEMAKER_ALTERNATE_REGION_ACCOUNTS.keys():
-        if (
-            scope == "training"
-            and framework == "tensorflow"
-            and Version(fw_version) == Version("2.12")
-        ):
-            if region in ["cn-north-1", "cn-northwest-1", "us-iso-east-1", "us-isob-east-1"]:
-                pytest.skip(f"TF 2.12 SM DLC is not available in {region} region")
-
-        uri = image_uris.retrieve(region=region, instance_type="ml.c4.xlarge", **base_args)
-
-        expected = expected_fn(region=region, **expected_fn_args)
-        assert expected == uri
-
-
-def test_chainer(chainer_version, chainer_py_version):
-    expected_fn_args = {
-        "chainer_version": chainer_version,
-        "py_version": chainer_py_version,
-    }
-
-    _test_image_uris(
-        "chainer",
-        chainer_version,
-        chainer_py_version,
-        "training",
-        _expected_chainer_uri,
-        expected_fn_args,
-    )
-
-
-def _expected_chainer_uri(chainer_version, py_version, processor="cpu", region=REGION):
-    account = SAGEMAKER_ACCOUNT if region == REGION else SAGEMAKER_ALTERNATE_REGION_ACCOUNTS[region]
-    return expected_uris.framework_uri(
-        repo="sagemaker-chainer",
-        fw_version=chainer_version,
-        py_version=py_version,
-        processor=processor,
-        region=region,
-        account=account,
-    )
-
-
-def test_tensorflow_training(tensorflow_training_version, tensorflow_training_py_version):
-    expected_fn_args = {
-        "tf_training_version": tensorflow_training_version,
-        "py_version": tensorflow_training_py_version,
-    }
-
-    _test_image_uris(
-        "tensorflow",
-        tensorflow_training_version,
-        tensorflow_training_py_version,
-        "training",
-        _expected_tf_training_uri,
-        expected_fn_args,
-    )
-
-
-def _expected_tf_training_uri(tf_training_version, py_version, processor="cpu", region=REGION):
-    version = Version(tf_training_version)
-    if version < Version("1.11"):
-        repo = "sagemaker-tensorflow"
-    elif version < Version("1.13"):
-        repo = "sagemaker-tensorflow-scriptmode"
-    elif version >= Version("1.14"):
-        repo = "tensorflow-training"
-    else:
-        repo = "sagemaker-tensorflow-scriptmode" if py_version == "py2" else "tensorflow-training"
-
-    return expected_uris.framework_uri(
-        repo,
-        tf_training_version,
-        _sagemaker_or_dlc_account(repo, region),
-        py_version=py_version,
-        processor=processor,
-        region=region,
-    )
-
-
-def test_tensorflow_inference(tensorflow_inference_version, tensorflow_inference_py_version):
-    _test_image_uris(
-        "tensorflow",
-        tensorflow_inference_version,
-        tensorflow_inference_py_version,
-        "inference",
-        _expected_tf_inference_uri,
-        {"tf_inference_version": tensorflow_inference_version},
-    )
-
-
-def test_tensorflow_eia(tensorflow_eia_version):
-    base_args = {
-        "framework": "tensorflow",
-        "version": tensorflow_eia_version,
-        "py_version": "py2",
-        "instance_type": "ml.c4.xlarge",
-        "accelerator_type": "ml.eia1.medium",
-        "image_scope": "inference",
-    }
-
-    uri = image_uris.retrieve(region=REGION, **base_args)
-
-    expected = _expected_tf_inference_uri(tensorflow_eia_version, eia=True)
-    assert expected == uri
-
-    for region in SAGEMAKER_ALTERNATE_REGION_ACCOUNTS.keys():
-        uri = image_uris.retrieve(region=region, **base_args)
-
-        expected = _expected_tf_inference_uri(tensorflow_eia_version, region=region, eia=True)
-        assert expected == uri
-
-
-def _expected_tf_inference_uri(tf_inference_version, processor="cpu", region=REGION, eia=False):
-    version = Version(tf_inference_version)
-    repo = _expected_tf_inference_repo(version, eia)
-    py_version = "py2" if version < Version("1.11") else None
-
-    account = _sagemaker_or_dlc_account(repo, region)
-    return expected_uris.framework_uri(
-        repo,
-        tf_inference_version,
-        account,
-        py_version,
-        processor=processor,
-        region=region,
-    )
-
-
-def _expected_tf_inference_repo(version, eia):
-    if version < Version("1.11"):
-        repo = "sagemaker-tensorflow"
-    elif version < Version("1.13") or version == Version("1.13") and eia:
-        repo = "sagemaker-tensorflow-serving"
-    else:
-        repo = "tensorflow-inference"
-
-    if eia:
-        repo = "-".join((repo, "eia"))
-
-    return repo
-
-
-def test_mxnet_training(mxnet_training_version, mxnet_training_py_version):
-    expected_fn_args = {
-        "mxnet_version": mxnet_training_version,
-        "py_version": mxnet_training_py_version,
-    }
-
-    _test_image_uris(
-        "mxnet",
-        mxnet_training_version,
-        mxnet_training_py_version,
-        "training",
-        _expected_mxnet_training_uri,
-        expected_fn_args,
-    )
-
-
-def _expected_mxnet_training_uri(mxnet_version, py_version, processor="cpu", region=REGION):
-    version = Version(mxnet_version)
-    if version < Version("1.4") or mxnet_version == "1.4.0":
-        repo = "sagemaker-mxnet"
-    elif version >= Version("1.6.0"):
-        repo = "mxnet-training"
-    else:
-        repo = "sagemaker-mxnet" if py_version == "py2" else "mxnet-training"
-
-    return expected_uris.framework_uri(
-        repo,
-        mxnet_version,
-        _sagemaker_or_dlc_account(repo, region),
-        py_version=py_version,
-        processor=processor,
-        region=region,
-    )
-
-
-def test_mxnet_inference(mxnet_inference_version, mxnet_inference_py_version):
-    expected_fn_args = {
-        "mxnet_version": mxnet_inference_version,
-        "py_version": mxnet_inference_py_version,
-    }
-
-    _test_image_uris(
-        "mxnet",
-        mxnet_inference_version,
-        mxnet_inference_py_version,
-        "inference",
-        _expected_mxnet_inference_uri,
-        expected_fn_args,
-    )
-
-
-def test_mxnet_eia(mxnet_eia_version, mxnet_eia_py_version):
-    base_args = {
-        "framework": "mxnet",
-        "version": mxnet_eia_version,
-        "py_version": mxnet_eia_py_version,
-        "image_scope": "inference",
-        "instance_type": "ml.c4.xlarge",
-        "accelerator_type": "ml.eia1.medium",
-    }
-
-    uri = image_uris.retrieve(region=REGION, **base_args)
-
-    expected = _expected_mxnet_inference_uri(mxnet_eia_version, mxnet_eia_py_version, eia=True)
-    assert expected == uri
-
-    for region in SAGEMAKER_ALTERNATE_REGION_ACCOUNTS.keys():
-        uri = image_uris.retrieve(region=region, **base_args)
-
-        expected = _expected_mxnet_inference_uri(
-            mxnet_eia_version, mxnet_eia_py_version, region=region, eia=True
-        )
-        assert expected == uri
-
-
-def _expected_mxnet_inference_uri(
-    mxnet_version, py_version, processor="cpu", region=REGION, eia=False
-):
-    version = Version(mxnet_version)
-    if version < Version("1.4"):
-        repo = "sagemaker-mxnet"
-    elif mxnet_version == "1.4.0":
-        repo = "sagemaker-mxnet-serving"
-    elif version >= Version("1.5"):
-        repo = "mxnet-inference"
-    else:
-        repo = "sagemaker-mxnet-serving" if py_version == "py2" and not eia else "mxnet-inference"
-
-    if eia:
-        repo = "-".join((repo, "eia"))
-
-    return expected_uris.framework_uri(
-        repo,
-        mxnet_version,
-        _sagemaker_or_dlc_account(repo, region),
-        py_version=py_version,
-        processor=processor,
-        region=region,
-    )
-
-
-def test_pytorch_training(pytorch_training_version, pytorch_training_py_version):
-    _test_image_uris(
-        "pytorch",
-        pytorch_training_version,
-        pytorch_training_py_version,
-        "training",
-        _expected_pytorch_training_uri,
-        {
-            "pytorch_version": pytorch_training_version,
-            "py_version": pytorch_training_py_version,
-        },
-    )
-
-
-def _expected_pytorch_training_uri(pytorch_version, py_version, processor="cpu", region=REGION):
-    version = Version(pytorch_version)
-    if version < Version("1.2"):
-        repo = "sagemaker-pytorch"
-    else:
-        repo = "pytorch-training"
-
-    return expected_uris.framework_uri(
-        repo,
-        pytorch_version,
-        _sagemaker_or_dlc_account(repo, region),
-        py_version=py_version,
-        processor=processor,
-        region=region,
-    )
-
-
-def test_pytorch_inference(pytorch_inference_version, pytorch_inference_py_version):
-    _test_image_uris(
-        "pytorch",
-        pytorch_inference_version,
-        pytorch_inference_py_version,
-        "inference",
-        _expected_pytorch_inference_uri,
-        {
-            "pytorch_version": pytorch_inference_version,
-            "py_version": pytorch_inference_py_version,
-        },
-    )
-
-
-def _expected_pytorch_inference_uri(pytorch_version, py_version, processor="cpu", region=REGION):
-    version = Version(pytorch_version)
-    if version < Version("1.2"):
-        repo = "sagemaker-pytorch"
-    else:
-        repo = "pytorch-inference"
-
-    return expected_uris.framework_uri(
-        repo,
-        pytorch_version,
-        _sagemaker_or_dlc_account(repo, region),
-        py_version=py_version,
-        processor=processor,
-        region=region,
-    )
-
-
-def test_pytorch_eia(pytorch_eia_version, pytorch_eia_py_version):
-    base_args = {
-        "framework": "pytorch",
-        "version": pytorch_eia_version,
-        "py_version": pytorch_eia_py_version,
-        "image_scope": "inference",
-        "instance_type": "ml.c4.xlarge",
-        "accelerator_type": "ml.eia1.medium",
-    }
-
-    uri = image_uris.retrieve(region=REGION, **base_args)
-
-    expected = expected_uris.framework_uri(
-        "pytorch-inference-eia",
-        pytorch_eia_version,
-        DLC_ACCOUNT,
-        py_version=pytorch_eia_py_version,
-        region=REGION,
-    )
-    assert expected == uri
-
-    for region in ELASTIC_INFERENCE_REGIONS:
-        uri = image_uris.retrieve(region=region, **base_args)
-        account = DLC_ALTERNATE_REGION_ACCOUNTS.get(region, DLC_ACCOUNT)
-
-        expected = expected_uris.framework_uri(
-            "pytorch-inference-eia",
-            pytorch_eia_version,
-            account,
-            py_version=pytorch_eia_py_version,
-            region=region,
-        )
-        assert expected == uri
-
-
-def _sagemaker_or_dlc_account(repo, region):
-    if repo.startswith("sagemaker"):
-        return (
-            SAGEMAKER_ACCOUNT if region == REGION else SAGEMAKER_ALTERNATE_REGION_ACCOUNTS[region]
-        )
-    else:
-        return DLC_ACCOUNT if region == REGION else DLC_ALTERNATE_REGION_ACCOUNTS[region]
+COMMON_INSTANCE_TYPES = {"cpu": "ml.c4.xlarge", "gpu": "ml.p2.xlarge"}
+RENEWED_INSTANCE_TYPES = {"cpu": "ml.c4.xlarge", "gpu": "ml.g4dn.xlarge"}
+
+
+@pytest.mark.parametrize("load_config", ["chainer.json"], indirect=True)
+def test_chainer_uris(load_config):
+    VERSIONS = load_config["versions"]
+    for version in VERSIONS:
+        ALGO_ACCOUNTS = load_config["versions"][version]["registries"]
+        py_versions = load_config["versions"][version]["py_versions"]
+        repo = load_config["versions"][version]["repository"]
+        processors = load_config["processors"]
+
+        for processor in processors:
+            instance_type = COMMON_INSTANCE_TYPES[processor]
+            for py_version in py_versions:
+                for region in ALGO_ACCOUNTS.keys():
+                    uri = image_uris.retrieve(
+                        "chainer",
+                        region=region,
+                        version=version,
+                        py_version=py_version,
+                        image_scope="training",
+                        instance_type=instance_type,
+                    )
+                    expected = expected_uris.framework_uri(
+                        repo=repo,
+                        fw_version=version,
+                        py_version=py_version,
+                        processor=processor,
+                        region=region,
+                        account=ALGO_ACCOUNTS[region],
+                    )
+                    assert uri == expected
+
+
+@pytest.mark.parametrize(
+    "load_config_and_file_name", ["tensorflow.json", "mxnet.json", "pytorch.json"], indirect=True
+)
+@pytest.mark.parametrize("scope", ["training", "inference", "eia"])
+def test_dlc_framework_uris(load_config_and_file_name, scope):
+    config, file_name = load_config_and_file_name
+    framework = file_name.removesuffix(".json")
+    VERSIONS = config[scope]["versions"]
+
+    for version in VERSIONS:
+        if not config[scope]["versions"][version].get("registries"):
+            continue
+        ACCOUNTS = config[scope]["versions"][version]["registries"]
+        repo = config[scope]["versions"][version]["repository"]
+        py_versions = config[scope]["versions"][version].get("py_versions", [None])
+        processors = config[scope].get("processors", ["cpu", "gpu"])
+
+        for processor in processors:
+            instance_type = COMMON_INSTANCE_TYPES[processor]
+            if (framework == "pytorch" and Version(version) >= Version("1.13")) or (
+                framework == "tensorflow" and Version(version) >= Version("2.12")
+            ):
+                instance_type = RENEWED_INSTANCE_TYPES[processor]
+            for py_version in py_versions:
+                for region in ACCOUNTS.keys():
+                    if scope == "eia":
+                        uri = image_uris.retrieve(
+                            framework,
+                            region=region,
+                            version=version,
+                            py_version=py_version,
+                            image_scope="inference",
+                            instance_type=instance_type,
+                            accelerator_type="ml.eia1.medium",
+                        )
+                    else:
+                        uri = image_uris.retrieve(
+                            framework,
+                            region=region,
+                            version=version,
+                            py_version=py_version,
+                            image_scope=scope,
+                            instance_type=instance_type,
+                        )
+                    expected = expected_uris.framework_uri(
+                        repo=repo,
+                        fw_version=version,
+                        py_version=py_version,
+                        processor=processor,
+                        region=region,
+                        account=ACCOUNTS[region],
+                    )
+                    assert uri == expected
+
+
+@pytest.mark.parametrize(
+    "load_config_and_file_name", ["tensorflow.json", "mxnet.json"], indirect=True
+)
+def test_uncommon_format_dlc_framework_version_uris(load_config_and_file_name):
+    config, file_name = load_config_and_file_name
+    framework = file_name.removesuffix(".json")
+    py_versions = ["py2", "py3"]
+
+    # These versions are formatted differently than others for their framework
+    if framework == "tensorflow":
+        SCOPES = ["training"]
+        VERSIONS = ["1.13.1"]
+    elif framework == "mxnet":
+        SCOPES = ["training", "inference"]
+        VERSIONS = ["1.4.1"]
+
+    for scope in SCOPES:
+        for py_version in py_versions:
+            for version in VERSIONS:
+                ACCOUNTS = config[scope]["versions"][version][py_version]["registries"]
+                processors = config[scope].get("processors", ["cpu", "gpu"])
+                repo = config[scope]["versions"][version][py_version]["repository"]
+                for processor in processors:
+                    instance_type = COMMON_INSTANCE_TYPES[processor]
+                    for region in ACCOUNTS.keys():
+                        uri = image_uris.retrieve(
+                            framework,
+                            region=region,
+                            version=version,
+                            py_version=py_version,
+                            image_scope=scope,
+                            instance_type=instance_type,
+                        )
+                        expected = expected_uris.framework_uri(
+                            repo=repo,
+                            fw_version=version,
+                            py_version=py_version,
+                            processor=processor,
+                            region=region,
+                            account=ACCOUNTS[region],
+                        )
+                        assert uri == expected

--- a/tests/unit/sagemaker/image_uris/test_graviton.py
+++ b/tests/unit/sagemaker/image_uris/test_graviton.py
@@ -45,7 +45,7 @@ def _test_graviton_framework_uris(framework, version, py_version, account, regio
 @pytest.mark.parametrize("scope", ["inference_graviton"])
 def test_graviton_framework_uris(load_config_and_file_name, scope):
     config, file_name = load_config_and_file_name
-    framework = file_name.removesuffix(".json")
+    framework = file_name.split(".json")[0]
     VERSIONS = config[scope]["versions"]
     for version in VERSIONS:
         ACCOUNTS = config[scope]["versions"][version]["registries"]

--- a/tests/unit/sagemaker/image_uris/test_huggingface_llm.py
+++ b/tests/unit/sagemaker/image_uris/test_huggingface_llm.py
@@ -15,36 +15,8 @@ from __future__ import absolute_import
 import pytest
 
 from sagemaker.huggingface import get_huggingface_llm_image_uri
-from tests.unit.sagemaker.image_uris import expected_uris
+from tests.unit.sagemaker.image_uris import expected_uris, conftest
 
-ACCOUNTS = {
-    "af-south-1": "626614931356",
-    "il-central-1": "780543022126",
-    "ap-east-1": "871362719292",
-    "ap-northeast-1": "763104351884",
-    "ap-northeast-2": "763104351884",
-    "ap-northeast-3": "364406365360",
-    "ap-south-1": "763104351884",
-    "ap-southeast-1": "763104351884",
-    "ap-southeast-2": "763104351884",
-    "ap-southeast-3": "907027046896",
-    "ca-central-1": "763104351884",
-    "cn-north-1": "727897471807",
-    "cn-northwest-1": "727897471807",
-    "eu-central-1": "763104351884",
-    "eu-north-1": "763104351884",
-    "eu-west-1": "763104351884",
-    "eu-west-2": "763104351884",
-    "eu-west-3": "763104351884",
-    "eu-south-1": "692866216735",
-    "me-south-1": "217643126080",
-    "sa-east-1": "763104351884",
-    "us-east-1": "763104351884",
-    "us-east-2": "763104351884",
-    "us-west-1": "763104351884",
-    "us-west-2": "763104351884",
-}
-HF_VERSIONS = ["0.6.0", "0.8.2", "0.9.3", "1.0.3", "1.1.0"]
 LMI_VERSIONS = ["0.24.0"]
 HF_VERSIONS_MAPPING = {
     "0.6.0": "2.0.0-tgi0.6.0-gpu-py39-cu118-ubuntu20.04",
@@ -53,30 +25,43 @@ HF_VERSIONS_MAPPING = {
     "1.0.3": "2.0.1-tgi1.0.3-gpu-py39-cu118-ubuntu20.04",
     "1.1.0": "2.0.1-tgi1.1.0-gpu-py39-cu118-ubuntu20.04",
 }
-LMI_VERSIONS_MAPPING = {"0.24.0": "deepspeed0.10.0-cu118"}
 
 
-@pytest.mark.parametrize("version", HF_VERSIONS)
-def test_huggingface(version):
-    for region in ACCOUNTS.keys():
-        uri = get_huggingface_llm_image_uri("huggingface", region=region, version=version)
+@pytest.mark.parametrize("load_config", ["huggingface-llm.json"], indirect=True)
+def test_huggingface_uris(load_config):
+    VERSIONS = load_config["inference"]["versions"]
+    for version in VERSIONS:
+        ACCOUNTS = load_config["inference"]["versions"][version]["registries"]
+        for region in ACCOUNTS.keys():
+            uri = get_huggingface_llm_image_uri("huggingface", region=region, version=version)
+            expected = expected_uris.huggingface_llm_framework_uri(
+                "huggingface-pytorch-tgi-inference",
+                ACCOUNTS[region],
+                version,
+                HF_VERSIONS_MAPPING[version],
+                region=region,
+            )
+            assert expected == uri
 
-        expected = expected_uris.huggingface_llm_framework_uri(
-            "huggingface-pytorch-tgi-inference",
-            ACCOUNTS[region],
-            version,
-            HF_VERSIONS_MAPPING[version],
-            region=region,
-        )
-        assert expected == uri
 
+@pytest.mark.parametrize("load_config", ["huggingface-llm.json"], indirect=True)
+def test_lmi_uris(load_config):
+    VERSIONS = load_config["inference"]["versions"]
+    for version in VERSIONS:
+        ACCOUNTS = load_config["inference"]["versions"][version]["registries"]
+        for region in ACCOUNTS.keys():
+            for lmi_version in LMI_VERSIONS:
+                djl_deepspeed_config = conftest.get_config("djl-deepspeed.json")
+                DJL_DEEPSPEED_REGIONS = djl_deepspeed_config["versions"][lmi_version][
+                    "registries"
+                ].keys()
+                if region not in DJL_DEEPSPEED_REGIONS:
+                    continue
 
-@pytest.mark.parametrize("version", LMI_VERSIONS)
-def test_lmi(version):
-    for region in ACCOUNTS.keys():
-        uri = get_huggingface_llm_image_uri("lmi", region=region, version=version)
+                uri = get_huggingface_llm_image_uri("lmi", region=region, version=lmi_version)
+                tag = djl_deepspeed_config["versions"][lmi_version]["tag_prefix"]
 
-        expected = expected_uris.djl_framework_uri(
-            "djl-inference", ACCOUNTS[region], version, LMI_VERSIONS_MAPPING[version], region=region
-        )
-        assert expected == uri
+                expected = expected_uris.djl_framework_uri(
+                    "djl-inference", ACCOUNTS[region], tag, region=region
+                )
+                assert expected == uri

--- a/tests/unit/sagemaker/image_uris/test_model_monitor.py
+++ b/tests/unit/sagemaker/image_uris/test_model_monitor.py
@@ -12,41 +12,20 @@
 # language governing permissions and limitations under the License.
 from __future__ import absolute_import
 
+import pytest
+
 from sagemaker import image_uris
 from tests.unit.sagemaker.image_uris import expected_uris
 
-ACCOUNTS = {
-    "af-south-1": "875698925577",
-    "ap-east-1": "001633400207",
-    "ap-northeast-1": "574779866223",
-    "ap-northeast-2": "709848358524",
-    "ap-northeast-3": "990339680094",
-    "ap-south-1": "126357580389",
-    "ap-southeast-1": "245545462676",
-    "ap-southeast-2": "563025443158",
-    "ap-southeast-3": "669540362728",
-    "ca-central-1": "536280801234",
-    "cn-north-1": "453000072557",
-    "cn-northwest-1": "453252182341",
-    "eu-central-1": "048819808253",
-    "eu-north-1": "895015795356",
-    "eu-south-1": "933208885752",
-    "eu-west-1": "468650794304",
-    "eu-west-2": "749857270468",
-    "eu-west-3": "680080141114",
-    "me-south-1": "607024016150",
-    "sa-east-1": "539772159869",
-    "us-east-1": "156813124566",
-    "us-east-2": "777275614652",
-    "us-west-1": "890145073186",
-    "us-west-2": "159807026194",
-    "il-central-1": "843974653677",
-}
 
+@pytest.mark.parametrize("load_config", ["model-monitor.json"], indirect=True)
+def test_model_monitor(load_config):
+    VERSIONS = load_config["versions"]
+    for version in VERSIONS:
+        ACCOUNTS = load_config["versions"][version]["registries"]
+        for region in ACCOUNTS.keys():
+            print(region, ACCOUNTS[region])
+            uri = image_uris.retrieve("model-monitor", region=region)
 
-def test_model_monitor():
-    for region in ACCOUNTS.keys():
-        uri = image_uris.retrieve("model-monitor", region=region)
-
-        expected = expected_uris.monitor_uri(ACCOUNTS[region], region)
-        assert expected == uri
+            expected = expected_uris.monitor_uri(ACCOUNTS[region], region)
+            assert expected == uri

--- a/tests/unit/sagemaker/image_uris/test_neo.py
+++ b/tests/unit/sagemaker/image_uris/test_neo.py
@@ -17,106 +17,59 @@ import pytest
 from sagemaker import image_uris
 from tests.unit.sagemaker.image_uris import expected_uris
 
-NEO_ALGOS = ("image-classification-neo", "xgboost-neo")
+NEO_FRAMEWORK_INSTANCE_TYPES = {"cpu": "ml_c5", "gpu": "ml_p2"}
+INFERNTIA_FRAMEWORK_INSTANCE_TYPES = {"inf": "ml_inf1"}
 
-ACCOUNTS = {
-    "af-south-1": "774647643957",
-    "ap-east-1": "110948597952",
-    "ap-northeast-1": "941853720454",
-    "ap-northeast-2": "151534178276",
-    "ap-northeast-3": "925152966179",
-    "ap-south-1": "763008648453",
-    "ap-southeast-1": "324986816169",
-    "ap-southeast-2": "355873309152",
-    "ca-central-1": "464438896020",
-    "cn-north-1": "472730292857",
-    "cn-northwest-1": "474822919863",
-    "eu-central-1": "746233611703",
-    "eu-north-1": "601324751636",
-    "eu-south-1": "966458181534",
-    "eu-west-1": "802834080501",
-    "eu-west-2": "205493899709",
-    "eu-west-3": "254080097072",
-    "me-south-1": "836785723513",
-    "sa-east-1": "756306329178",
-    "us-east-1": "785573368785",
-    "us-east-2": "007439368137",
-    "us-gov-west-1": "263933020539",
-    "us-iso-east-1": "167761179201",
-    "us-isob-east-1": "406031935815",
-    "us-west-1": "710691900526",
-    "us-west-2": "301217895009",
-    "il-central-1": "275950707576",
-}
-
-INFERENTIA_REGIONS = ACCOUNTS.keys()
+NEO_ALGOS = ["image-classification-neo.json", "xgboost-neo.json"]
+NEO_FRAMEWORKS = ["neo-pytorch.json", "neo-tensorflow.json", "neo-mxnet.json"]
+INFERENTIA_FRAMEWORKS = [
+    "inferentia-mxnet.json",
+    "inferentia-pytorch.json",
+    "inferentia-tensorflow.json",
+]
+NEO_AND_INFERENTIA_FRAMEWORKS = NEO_FRAMEWORKS + INFERENTIA_FRAMEWORKS
 
 
-@pytest.mark.parametrize("algo", NEO_ALGOS)
-def test_algo_uris(algo):
-    for region in ACCOUNTS.keys():
-        uri = image_uris.retrieve(algo, region)
-        expected = expected_uris.algo_uri(algo, ACCOUNTS[region], region, version="latest")
-        assert expected == uri
+@pytest.mark.parametrize("load_config_and_file_name", NEO_ALGOS, indirect=True)
+def test_neo_alogos(load_config_and_file_name):
+    config, file_name = load_config_and_file_name
+    algo = file_name.removesuffix(".json")
+    VERSIONS = config["versions"]
+    for version in VERSIONS:
+        ACCOUNTS = config["versions"][version]["registries"]
+        for region in ACCOUNTS.keys():
+            uri = image_uris.retrieve(algo, region)
+            expected = expected_uris.algo_uri(algo, ACCOUNTS[region], region, version)
+            assert uri == expected
 
 
-def _test_neo_framework_uris(framework, version):
-    framework_in_config = f"neo-{framework}"
-    framework_in_uri = f"inference-{framework}"
+@pytest.mark.parametrize("load_config_and_file_name", NEO_AND_INFERENTIA_FRAMEWORKS, indirect=True)
+def test_neo_and_inferentia_frameworks(load_config_and_file_name):
+    config, file_name = load_config_and_file_name
+    framework = file_name.removesuffix(".json")
+    VERSIONS = config["versions"]
+    processors = config["processors"]
+    for version in VERSIONS:
+        ACCOUNTS = config["versions"][version]["registries"]
+        py_versions = config["versions"][version].get("py_versions", [None])
+        repo = config["versions"][version]["repository"]
+        for processor in processors:
+            if file_name in NEO_FRAMEWORKS:
+                instance_type = NEO_FRAMEWORK_INSTANCE_TYPES[processor]
+            else:
+                instance_type = INFERNTIA_FRAMEWORK_INSTANCE_TYPES[processor]
 
-    for region in ACCOUNTS.keys():
-        uri = image_uris.retrieve(
-            framework_in_config, region, instance_type="ml_c5", version=version
-        )
-        assert _expected_framework_uri(framework_in_uri, version, region=region) == uri
-
-    uri = image_uris.retrieve(
-        framework_in_config, "us-west-2", instance_type="ml_p2", version=version
-    )
-    assert _expected_framework_uri(framework_in_uri, version, processor="gpu") == uri
-
-
-def test_neo_mxnet(neo_mxnet_version):
-    _test_neo_framework_uris("mxnet", neo_mxnet_version)
-
-
-def test_neo_tf(neo_tensorflow_version):
-    _test_neo_framework_uris("tensorflow", neo_tensorflow_version)
-
-
-def test_neo_pytorch(neo_pytorch_version):
-    _test_neo_framework_uris("pytorch", neo_pytorch_version)
-
-
-def _test_inferentia_framework_uris(framework, version):
-    for region in INFERENTIA_REGIONS:
-        uri = image_uris.retrieve(
-            "inferentia-{}".format(framework), region, instance_type="ml_inf1", version=version
-        )
-        expected = _expected_framework_uri(
-            "neo-{}".format(framework), version, region=region, processor="inf"
-        )
-        assert expected == uri
-
-
-def test_inferentia_mxnet(inferentia_mxnet_version):
-    _test_inferentia_framework_uris("mxnet", inferentia_mxnet_version)
-
-
-def test_inferentia_tensorflow(inferentia_tensorflow_version):
-    _test_inferentia_framework_uris("tensorflow", inferentia_tensorflow_version)
-
-
-def test_inferentia_pytorch(inferentia_pytorch_version):
-    _test_inferentia_framework_uris("pytorch", inferentia_pytorch_version)
-
-
-def _expected_framework_uri(framework, version, region="us-west-2", processor="cpu"):
-    return expected_uris.framework_uri(
-        "sagemaker-{}".format(framework),
-        fw_version=version,
-        py_version="py3",
-        account=ACCOUNTS[region],
-        region=region,
-        processor=processor,
-    )
+            for py_version in py_versions:
+                for region in ACCOUNTS.keys():
+                    uri = image_uris.retrieve(
+                        framework, region, instance_type=instance_type, version=version
+                    )
+                    expected = expected_uris.framework_uri(
+                        repo,
+                        fw_version=version,
+                        py_version=py_version,
+                        account=ACCOUNTS[region],
+                        region=region,
+                        processor=processor,
+                    )
+                    assert uri == expected

--- a/tests/unit/sagemaker/image_uris/test_neo.py
+++ b/tests/unit/sagemaker/image_uris/test_neo.py
@@ -33,7 +33,7 @@ NEO_AND_INFERENTIA_FRAMEWORKS = NEO_FRAMEWORKS + INFERENTIA_FRAMEWORKS
 @pytest.mark.parametrize("load_config_and_file_name", NEO_ALGOS, indirect=True)
 def test_neo_alogos(load_config_and_file_name):
     config, file_name = load_config_and_file_name
-    algo = file_name.removesuffix(".json")
+    algo = file_name.split(".json")[0]
     VERSIONS = config["versions"]
     for version in VERSIONS:
         ACCOUNTS = config["versions"][version]["registries"]
@@ -46,7 +46,7 @@ def test_neo_alogos(load_config_and_file_name):
 @pytest.mark.parametrize("load_config_and_file_name", NEO_AND_INFERENTIA_FRAMEWORKS, indirect=True)
 def test_neo_and_inferentia_frameworks(load_config_and_file_name):
     config, file_name = load_config_and_file_name
-    framework = file_name.removesuffix(".json")
+    framework = file_name.split(".json")[0]
     VERSIONS = config["versions"]
     processors = config["processors"]
     for version in VERSIONS:

--- a/tests/unit/sagemaker/image_uris/test_rl.py
+++ b/tests/unit/sagemaker/image_uris/test_rl.py
@@ -12,126 +12,50 @@
 # language governing permissions and limitations under the License.
 from __future__ import absolute_import
 
-from packaging.version import Version
+import pytest
 
 from sagemaker import image_uris
 from tests.unit.sagemaker.image_uris import expected_uris
 
-INSTANCE_TYPES_AND_PROCESSORS = (("ml.c4.xlarge", "cpu"), ("ml.p2.xlarge", "gpu"))
-REGION = "us-west-2"
-
-RL_ACCOUNT = "462105765813"
-SAGEMAKER_ACCOUNT = "520713654638"
+INSTANCE_TYPES = {"cpu": "ml.c4.xlarge", "gpu": "ml.p2.xlarge"}
 
 
-def _version_for_tag(toolkit, toolkit_version, framework, framework_in_tag=False):
-    if framework_in_tag:
-        return "-".join((toolkit, toolkit_version, framework))
-    else:
-        return "{}{}".format(toolkit, toolkit_version)
+@pytest.mark.parametrize(
+    "load_config_and_file_name",
+    [
+        "coach-tensorflow.json",
+        "coach-mxnet.json",
+        "ray-tensorflow.json",
+        "ray-pytorch.json",
+        "vw.json",
+    ],
+    indirect=True,
+)
+def test_rl_image_uris(load_config_and_file_name):
+    config, filename = load_config_and_file_name
+    framework = filename.removesuffix(".json")
+    VERSIONS = config["versions"]
+    processors = config["processors"]
+    for version in VERSIONS:
+        ACCOUNTS = config["versions"][version]["registries"]
+        py_versions = config["versions"][version].get("py_versions", [None])
+        repo = config["versions"][version]["repository"]
+        tag_prefix = config["versions"][version]["tag_prefix"]
+        for processor in processors:
+            instance_type = INSTANCE_TYPES[processor]
+            for py_version in py_versions:
+                for region in ACCOUNTS.keys():
+                    uri = image_uris.retrieve(
+                        framework, region, version=version, instance_type=instance_type
+                    )
 
+                    expected = expected_uris.framework_uri(
+                        repo,
+                        tag_prefix,
+                        ACCOUNTS[region],
+                        py_version=py_version,
+                        processor=processor,
+                        region=region,
+                    )
 
-def test_coach_tf(coach_tensorflow_version):
-    for instance_type, processor in INSTANCE_TYPES_AND_PROCESSORS:
-        uri = image_uris.retrieve(
-            "coach-tensorflow",
-            REGION,
-            version=coach_tensorflow_version,
-            instance_type=instance_type,
-        )
-        assert _expected_coach_tf_uri(coach_tensorflow_version, processor) == uri
-
-
-def _expected_coach_tf_uri(coach_tf_version, processor):
-    if Version(coach_tf_version) > Version("0.11.1"):
-        return expected_uris.framework_uri(
-            "sagemaker-rl-coach-container",
-            _version_for_tag("coach", coach_tf_version, "tf", True),
-            RL_ACCOUNT,
-            py_version="py3",
-            processor=processor,
-        )
-    else:
-        return expected_uris.framework_uri(
-            "sagemaker-rl-tensorflow",
-            _version_for_tag("coach", coach_tf_version, "tf"),
-            SAGEMAKER_ACCOUNT,
-            py_version="py3",
-            processor=processor,
-        )
-
-
-def test_coach_mxnet(coach_mxnet_version):
-    for instance_type, processor in INSTANCE_TYPES_AND_PROCESSORS:
-        uri = image_uris.retrieve(
-            "coach-mxnet", REGION, version=coach_mxnet_version, instance_type=instance_type
-        )
-
-        expected = expected_uris.framework_uri(
-            "sagemaker-rl-mxnet",
-            "coach{}".format(coach_mxnet_version),
-            SAGEMAKER_ACCOUNT,
-            py_version="py3",
-            processor=processor,
-        )
-        assert expected == uri
-
-
-def test_ray_tf(ray_tensorflow_version):
-    for instance_type, processor in INSTANCE_TYPES_AND_PROCESSORS:
-        uri = image_uris.retrieve(
-            "ray-tensorflow", REGION, version=ray_tensorflow_version, instance_type=instance_type
-        )
-        assert _expected_ray_tf_uri(ray_tensorflow_version, processor) == uri
-
-
-def _expected_ray_tf_uri(ray_tf_version, processor):
-    if Version(ray_tf_version) > Version("1.0.0"):
-        return expected_uris.framework_uri(
-            "sagemaker-rl-ray-container",
-            _version_for_tag("ray", ray_tf_version, "tf", True),
-            RL_ACCOUNT,
-            py_version="py37",
-            processor=processor,
-        )
-    elif Version(ray_tf_version) > Version("0.6.5"):
-        return expected_uris.framework_uri(
-            "sagemaker-rl-ray-container",
-            _version_for_tag("ray", ray_tf_version, "tf", True),
-            RL_ACCOUNT,
-            py_version="py36",
-            processor=processor,
-        )
-    else:
-        return expected_uris.framework_uri(
-            "sagemaker-rl-tensorflow",
-            _version_for_tag("ray", ray_tf_version, "tf"),
-            SAGEMAKER_ACCOUNT,
-            py_version="py3",
-            processor=processor,
-        )
-
-
-def test_ray_pytorch(ray_pytorch_version):
-    for instance_type, processor in INSTANCE_TYPES_AND_PROCESSORS:
-        uri = image_uris.retrieve(
-            "ray-pytorch", REGION, version=ray_pytorch_version, instance_type=instance_type
-        )
-
-        expected = expected_uris.framework_uri(
-            "sagemaker-rl-ray-container",
-            "ray-{}-torch".format(ray_pytorch_version),
-            RL_ACCOUNT,
-            py_version="py36",
-            processor=processor,
-        )
-
-        assert expected == uri
-
-
-def test_vw(vw_version):
-    version = "vw-{}".format(vw_version)
-    uri = image_uris.retrieve("vw", REGION, version=version, instance_type="ml.c4.xlarge")
-
-    expected = expected_uris.framework_uri("sagemaker-rl-vw-container", version, RL_ACCOUNT)
-    assert expected == uri
+                    assert uri == expected

--- a/tests/unit/sagemaker/image_uris/test_rl.py
+++ b/tests/unit/sagemaker/image_uris/test_rl.py
@@ -33,7 +33,7 @@ INSTANCE_TYPES = {"cpu": "ml.c4.xlarge", "gpu": "ml.p2.xlarge"}
 )
 def test_rl_image_uris(load_config_and_file_name):
     config, filename = load_config_and_file_name
-    framework = filename.removesuffix(".json")
+    framework = filename.split(".json")[0]
     VERSIONS = config["versions"]
     processors = config["processors"]
     for version in VERSIONS:

--- a/tests/unit/sagemaker/image_uris/test_sklearn.py
+++ b/tests/unit/sagemaker/image_uris/test_sklearn.py
@@ -17,62 +17,30 @@ import pytest
 from sagemaker import image_uris
 from tests.unit.sagemaker.image_uris import expected_uris
 
-ACCOUNTS = {
-    "af-south-1": "510948584623",
-    "ap-east-1": "651117190479",
-    "ap-northeast-1": "354813040037",
-    "ap-northeast-2": "366743142698",
-    "ap-northeast-3": "867004704886",
-    "ap-south-1": "720646828776",
-    "ap-south-2": "628508329040",
-    "ap-southeast-1": "121021644041",
-    "ap-southeast-2": "783357654285",
-    "ap-southeast-3": "951798379941",
-    "ap-southeast-4": "106583098589",
-    "ca-central-1": "341280168497",
-    "cn-north-1": "450853457545",
-    "cn-northwest-1": "451049120500",
-    "eu-central-1": "492215442770",
-    "eu-central-2": "680994064768",
-    "eu-north-1": "662702820516",
-    "eu-west-1": "141502667606",
-    "eu-west-2": "764974769150",
-    "eu-west-3": "659782779980",
-    "eu-south-1": "978288397137",
-    "eu-south-2": "104374241257",
-    "il-central-1": "898809789911",
-    "me-south-1": "801668240914",
-    "me-central-1": "272398656194",
-    "sa-east-1": "737474898029",
-    "us-east-1": "683313688378",
-    "us-east-2": "257758044811",
-    "us-gov-west-1": "414596584902",
-    "us-gov-east-1": "237065988967",
-    "us-iso-east-1": "833128469047",
-    "us-isob-east-1": "281123927165",
-    "us-west-1": "746614075791",
-    "us-west-2": "246618743249",
-}
 
+@pytest.mark.parametrize("load_config", ["sklearn.json"], indirect=True)
+@pytest.mark.parametrize("scope", ["training", "inference"])
+def test_sklearn_uris(load_config, scope):
+    VERSIONS = load_config[scope]["versions"]
+    for version in VERSIONS:
+        ACCOUNTS = load_config[scope]["versions"][version]["registries"]
+        for region in ACCOUNTS.keys():
+            uri = image_uris.retrieve(
+                "sklearn",
+                region=region,
+                version=version,
+                py_version="py3",
+                instance_type="ml.c4.xlarge",
+            )
 
-def test_valid_uris(sklearn_version):
-    for region in ACCOUNTS.keys():
-        uri = image_uris.retrieve(
-            "sklearn",
-            region=region,
-            version=sklearn_version,
-            py_version="py3",
-            instance_type="ml.c4.xlarge",
-        )
-
-        expected = expected_uris.framework_uri(
-            "sagemaker-scikit-learn",
-            sklearn_version,
-            ACCOUNTS[region],
-            py_version="py3",
-            region=region,
-        )
-        assert expected == uri
+            expected = expected_uris.framework_uri(
+                "sagemaker-scikit-learn",
+                version,
+                ACCOUNTS[region],
+                py_version="py3",
+                region=region,
+            )
+            assert expected == uri
 
 
 def test_py2_error(sklearn_version):

--- a/tests/unit/sagemaker/image_uris/test_sparkml.py
+++ b/tests/unit/sagemaker/image_uris/test_sparkml.py
@@ -17,42 +17,16 @@ import pytest
 from sagemaker import image_uris
 from tests.unit.sagemaker.image_uris import expected_uris
 
-ACCOUNTS = {
-    "af-south-1": "510948584623",
-    "ap-east-1": "651117190479",
-    "ap-northeast-1": "354813040037",
-    "ap-northeast-2": "366743142698",
-    "ap-south-1": "720646828776",
-    "ap-southeast-1": "121021644041",
-    "ap-southeast-2": "783357654285",
-    "ca-central-1": "341280168497",
-    "cn-north-1": "450853457545",
-    "cn-northwest-1": "451049120500",
-    "eu-central-1": "492215442770",
-    "eu-north-1": "662702820516",
-    "eu-west-1": "141502667606",
-    "eu-west-2": "764974769150",
-    "eu-west-3": "659782779980",
-    "eu-south-1": "978288397137",
-    "me-south-1": "801668240914",
-    "sa-east-1": "737474898029",
-    "us-east-1": "683313688378",
-    "us-east-2": "257758044811",
-    "us-gov-west-1": "414596584902",
-    "us-iso-east-1": "833128469047",
-    "us-isob-east-1": "281123927165",
-    "us-west-1": "746614075791",
-    "us-west-2": "246618743249",
-}
-VERSIONS = ["2.2", "2.4", "3.3"]
 
+@pytest.mark.parametrize("load_config", ["sparkml-serving.json"], indirect=True)
+def test_sparkml(load_config):
+    VERSIONS = load_config["versions"]
+    for version in VERSIONS:
+        ACCOUNTS = load_config["versions"][version]["registries"]
+        for region in ACCOUNTS.keys():
+            uri = image_uris.retrieve("sparkml-serving", region=region, version=version)
 
-@pytest.mark.parametrize("version", VERSIONS)
-def test_sparkml(version):
-    for region in ACCOUNTS.keys():
-        uri = image_uris.retrieve("sparkml-serving", region=region, version=version)
-
-        expected = expected_uris.algo_uri(
-            "sagemaker-sparkml-serving", ACCOUNTS[region], region, version=version
-        )
-        assert expected == uri
+            expected = expected_uris.algo_uri(
+                "sagemaker-sparkml-serving", ACCOUNTS[region], region, version=version
+            )
+            assert expected == uri

--- a/tests/unit/sagemaker/image_uris/test_stabilityai.py
+++ b/tests/unit/sagemaker/image_uris/test_stabilityai.py
@@ -17,43 +17,22 @@ import pytest
 from sagemaker.stabilityai import get_stabilityai_image_uri
 from tests.unit.sagemaker.image_uris import expected_uris
 
-ACCOUNTS = {
-    "af-south-1": "626614931356",
-    "il-central-1": "780543022126",
-    "ap-east-1": "871362719292",
-    "ap-northeast-1": "763104351884",
-    "ap-northeast-2": "763104351884",
-    "ap-northeast-3": "364406365360",
-    "ap-south-1": "763104351884",
-    "ap-southeast-1": "763104351884",
-    "ap-southeast-2": "763104351884",
-    "ap-southeast-3": "907027046896",
-    "ca-central-1": "763104351884",
-    "eu-central-1": "763104351884",
-    "eu-north-1": "763104351884",
-    "eu-west-1": "763104351884",
-    "eu-west-2": "763104351884",
-    "eu-west-3": "763104351884",
-    "eu-south-1": "692866216735",
-    "me-south-1": "217643126080",
-    "sa-east-1": "763104351884",
-    "us-east-1": "763104351884",
-    "us-east-2": "763104351884",
-    "us-west-1": "763104351884",
-    "us-west-2": "763104351884",
-}
-SAI_VERSIONS = ["0.1.0"]
+
 SAI_VERSIONS_MAPPING = {"0.1.0": "2.0.1-sgm0.1.0-gpu-py310-cu118-ubuntu20.04-sagemaker"}
 
 
-@pytest.mark.parametrize("version", SAI_VERSIONS)
-def test_stabilityai_image_uris(version):
-    for region in ACCOUNTS.keys():
-        result = get_stabilityai_image_uri(region=region, version=version)
-        expected = expected_uris.stabilityai_framework_uri(
-            "stabilityai-pytorch-inference",
-            ACCOUNTS[region],
-            SAI_VERSIONS_MAPPING[version],
-            region=region,
-        )
-        assert expected == result
+@pytest.mark.parametrize("load_config", ["stabilityai.json"], indirect=True)
+@pytest.mark.parametrize("scope", ["inference"])
+def test_stabilityai_image_uris(load_config, scope):
+    VERSIONS = load_config[scope]["versions"]
+    for version in VERSIONS:
+        ACCOUNTS = load_config[scope]["versions"][version]["registries"]
+        for region in ACCOUNTS.keys():
+            uri = get_stabilityai_image_uri(region=region, version=version)
+            expected = expected_uris.stabilityai_framework_uri(
+                "stabilityai-pytorch-inference",
+                ACCOUNTS[region],
+                SAI_VERSIONS_MAPPING[version],
+                region=region,
+            )
+            assert expected == uri

--- a/tests/unit/sagemaker/image_uris/test_trainium.py
+++ b/tests/unit/sagemaker/image_uris/test_trainium.py
@@ -17,80 +17,56 @@ from tests.unit.sagemaker.image_uris import expected_uris
 
 import pytest
 
-ACCOUNTS = {
-    "af-south-1": "626614931356",
-    "il-central-1": "780543022126",
-    "ap-east-1": "871362719292",
-    "ap-northeast-1": "763104351884",
-    "ap-northeast-2": "763104351884",
-    "ap-northeast-3": "364406365360",
-    "ap-south-1": "763104351884",
-    "ap-southeast-1": "763104351884",
-    "ap-southeast-2": "763104351884",
-    "ca-central-1": "763104351884",
-    "cn-north-1": "727897471807",
-    "cn-northwest-1": "727897471807",
-    "eu-central-1": "763104351884",
-    "eu-north-1": "763104351884",
-    "eu-west-1": "763104351884",
-    "eu-west-2": "763104351884",
-    "eu-west-3": "763104351884",
-    "eu-south-1": "692866216735",
-    "me-south-1": "217643126080",
-    "sa-east-1": "763104351884",
-    "us-east-1": "763104351884",
-    "us-east-2": "763104351884",
-    "us-gov-west-1": "442386744353",
-    "us-iso-east-1": "886529160074",
-    "us-isob-east-1": "094389454867",
-    "us-west-1": "763104351884",
-    "us-west-2": "763104351884",
-}
 
-TRAINIUM_REGIONS = ACCOUNTS.keys()
 TRAINIUM_ALLOWED_FRAMEWORKS = "pytorch"
 
 
 def _expected_trainium_framework_uri(
-    framework, version, region="us-west-2", inference_tool="neuron"
+    framework, version, account, region="us-west-2", inference_tool="neuron"
 ):
     return expected_uris.neuron_framework_uri(
         "{}-neuron".format(framework),
         fw_version=version,
         py_version="py38",
-        account=ACCOUNTS[region],
+        account=account,
         region=region,
         inference_tool=inference_tool,
     )
 
 
-def _test_trainium_framework_uris(framework, version):
-    for region in TRAINIUM_REGIONS:
-        uri = image_uris.retrieve(
-            framework, region, instance_type="ml.trn1.xlarge", version=version
-        )
-        expected = _expected_trainium_framework_uri(
-            "{}-training".format(framework), version, region=region, inference_tool="neuron"
-        )
-        assert expected == uri
-
-
-def test_trainium_pytorch(pytorch_neuron_version):
-    _test_trainium_framework_uris("pytorch", pytorch_neuron_version)
-
-
-def _test_trainium_unsupported_framework(framework, framework_version):
-    for region in TRAINIUM_REGIONS:
-        with pytest.raises(ValueError) as error:
-            image_uris.retrieve(
-                framework, region, version=framework_version, instance_type="ml.trn1.xlarge"
+@pytest.mark.parametrize("load_config", ["pytorch-neuron.json"], indirect=True)
+@pytest.mark.parametrize("scope", ["training"])
+def test_trainium_pytorch_uris(load_config, scope):
+    VERSIONS = load_config[scope]["versions"]
+    for version in VERSIONS:
+        ACCOUNTS = load_config[scope]["versions"][version]["registries"]
+        for region in ACCOUNTS.keys():
+            uri = image_uris.retrieve(
+                "pytorch", region, instance_type="ml.trn1.xlarge", version=version
             )
-        expectedErr = (
-            f"Unsupported framework: {framework}. Supported framework(s) for Trainium instances: "
-            f"{TRAINIUM_ALLOWED_FRAMEWORKS}."
-        )
-        assert expectedErr in str(error)
+            expected = _expected_trainium_framework_uri(
+                "{}-training".format("pytorch"),
+                version,
+                ACCOUNTS[region],
+                region=region,
+                inference_tool="neuron",
+            )
+            assert expected == uri
 
 
-def test_trainium_unsupported_framework():
-    _test_trainium_unsupported_framework("autogluon", "0.6.1")
+@pytest.mark.parametrize("load_config", ["pytorch-neuron.json"], indirect=True)
+@pytest.mark.parametrize("scope", ["training"])
+def test_trainium_unsupported_framework(load_config, scope):
+    VERSIONS = load_config[scope]["versions"]
+    for version in VERSIONS:
+        ACCOUNTS = load_config[scope]["versions"][version]["registries"]
+        for region in ACCOUNTS.keys():
+            with pytest.raises(ValueError) as error:
+                image_uris.retrieve(
+                    "autogluon", region, instance_type="ml.trn1.xlarge", version=version
+                )
+                expectedErr = (
+                    f"Unsupported framework: autogluon. Supported framework(s) for Trainium instances: "
+                    f"{TRAINIUM_ALLOWED_FRAMEWORKS}."
+                )
+                assert expectedErr in str(error)

--- a/tests/unit/sagemaker/image_uris/test_xgboost.py
+++ b/tests/unit/sagemaker/image_uris/test_xgboost.py
@@ -15,134 +15,38 @@ import pytest
 from sagemaker import image_uris
 from tests.unit.sagemaker.image_uris import expected_uris
 
-ALGO_REGISTRIES = {
-    "af-south-1": "455444449433",
-    "ap-east-1": "286214385809",
-    "ap-northeast-1": "501404015308",
-    "ap-northeast-2": "306986355934",
-    "ap-northeast-3": "867004704886",
-    "ap-south-1": "991648021394",
-    "ap-south-2": "628508329040",
-    "ap-southeast-1": "475088953585",
-    "ap-southeast-2": "544295431143",
-    "ap-southeast-3": "951798379941",
-    "ap-southeast-4": "106583098589",
-    "ca-central-1": "469771592824",
-    "cn-north-1": "390948362332",
-    "cn-northwest-1": "387376663083",
-    "eu-central-1": "813361260812",
-    "eu-central-2": "680994064768",
-    "eu-north-1": "669576153137",
-    "eu-west-1": "685385470294",
-    "eu-west-2": "644912444149",
-    "eu-west-3": "749696950732",
-    "eu-south-1": "257386234256",
-    "eu-south-2": "104374241257",
-    "il-central-1": "898809789911",
-    "me-south-1": "249704162688",
-    "me-central-1": "272398656194",
-    "sa-east-1": "855470959533",
-    "us-east-1": "811284229777",
-    "us-east-2": "825641698319",
-    "us-gov-west-1": "226302683700",
-    "us-gov-east-1": "237065988967",
-    "us-iso-east-1": "490574956308",
-    "us-isob-east-1": "765400339828",
-    "us-west-1": "632365934929",
-    "us-west-2": "433757028032",
-}
 ALGO_VERSIONS = ("1", "latest")
-XGBOOST_FRAMEWORK_CPU_ONLY_VERSIONS = ("0.90-2", "0.90-1", "1.0-1")
-XGBOOST_FRAMEWORK_CPU_GPU_VERSIONS = ("1.2-1", "1.2-2", "1.3-1", "1.5-1", "1.7-1")
-
-FRAMEWORK_REGISTRIES = {
-    "af-south-1": "510948584623",
-    "ap-east-1": "651117190479",
-    "ap-northeast-1": "354813040037",
-    "ap-northeast-2": "366743142698",
-    "ap-northeast-3": "867004704886",
-    "ap-south-1": "720646828776",
-    "ap-south-2": "628508329040",
-    "ap-southeast-1": "121021644041",
-    "ap-southeast-2": "783357654285",
-    "ap-southeast-3": "951798379941",
-    "ap-southeast-4": "106583098589",
-    "ca-central-1": "341280168497",
-    "cn-north-1": "450853457545",
-    "cn-northwest-1": "451049120500",
-    "eu-central-1": "492215442770",
-    "eu-central-2": "680994064768",
-    "eu-north-1": "662702820516",
-    "eu-west-1": "141502667606",
-    "eu-west-2": "764974769150",
-    "eu-west-3": "659782779980",
-    "eu-south-1": "978288397137",
-    "eu-south-2": "104374241257",
-    "il-central-1": "898809789911",
-    "me-south-1": "801668240914",
-    "me-central-1": "272398656194",
-    "sa-east-1": "737474898029",
-    "us-east-1": "683313688378",
-    "us-east-2": "257758044811",
-    "us-gov-west-1": "414596584902",
-    "us-gov-east-1": "237065988967",
-    "us-iso-east-1": "833128469047",
-    "us-isob-east-1": "281123927165",
-    "us-west-1": "746614075791",
-    "us-west-2": "246618743249",
-}
 
 
-@pytest.mark.parametrize("xgboost_framework_version", XGBOOST_FRAMEWORK_CPU_GPU_VERSIONS)
-def test_xgboost_framework(xgboost_framework_version):
-    for region in FRAMEWORK_REGISTRIES.keys():
-        uri = image_uris.retrieve(
-            framework="xgboost",
-            region=region,
-            version=xgboost_framework_version,
-        )
+@pytest.mark.parametrize("load_config", ["xgboost.json"], indirect=True)
+@pytest.mark.parametrize("scope", ["training", "inference"])
+def test_xgboost_uris(load_config, scope):
+    VERSIONS = load_config[scope]["versions"]
+    for version in VERSIONS:
+        ACCOUNTS = load_config[scope]["versions"][version]["registries"]
 
-        expected = expected_uris.framework_uri(
-            "sagemaker-xgboost",
-            xgboost_framework_version,
-            FRAMEWORK_REGISTRIES[region],
-            py_version=None,
-            processor=None,
-            region=region,
-        )
-        assert expected == uri
+        processors = load_config[scope]["versions"][version].get("processors", [None])
+        py_versions = load_config[scope]["versions"][version].get("py_versions", [None])
+        repo = load_config[scope]["versions"][version]["repository"]
+        for processor in processors:
+            for py_version in py_versions:
+                for region in ACCOUNTS.keys():
+                    uri = image_uris.retrieve(
+                        framework="xgboost", py_version=py_version, region=region, version=version
+                    )
 
+                    if version in ALGO_VERSIONS:
+                        expected = expected_uris.algo_uri(
+                            "xgboost", ACCOUNTS[region], region, version=version
+                        )
+                    else:
+                        expected = expected_uris.framework_uri(
+                            repo,
+                            version,
+                            ACCOUNTS[region],
+                            region=region,
+                            py_version=py_version,
+                            processor=processor,
+                        )
 
-@pytest.mark.parametrize("xgboost_framework_version", XGBOOST_FRAMEWORK_CPU_ONLY_VERSIONS)
-def test_xgboost_framework_cpu_only(xgboost_framework_version):
-    for region in FRAMEWORK_REGISTRIES.keys():
-        if not (xgboost_framework_version in ["0.90-2", "0.90-1"] and region == "il-central-1"):
-            uri = image_uris.retrieve(
-                framework="xgboost",
-                region=region,
-                version=xgboost_framework_version,
-            )
-
-            expected = expected_uris.framework_uri(
-                "sagemaker-xgboost",
-                xgboost_framework_version,
-                FRAMEWORK_REGISTRIES[region],
-                region=region,
-                py_version="py3",
-                processor="cpu",
-            )
-            assert expected == uri
-
-
-@pytest.mark.parametrize("xgboost_algo_version", ALGO_VERSIONS)
-def test_xgboost_algo(xgboost_algo_version):
-    for region in ALGO_REGISTRIES.keys():
-        if region != "il-central-1":
-            uri = image_uris.retrieve(
-                framework="xgboost", region=region, version=xgboost_algo_version
-            )
-
-            expected = expected_uris.algo_uri(
-                "xgboost", ALGO_REGISTRIES[region], region, version=xgboost_algo_version
-            )
-            assert expected == uri
+                    assert uri == expected


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
   * Enhance image_uri_config unit tests to get image URIs config registries dynamically instead of using hardcoded values
  
*Testing done:*
   * tox -vv -e py39 -- tests/unit -m image_uris_unit_test
## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
