### PR TITLE
documentation: fix the ClarifyCheckStep documentation to mention PDP

### DIFF
--- a/src/sagemaker/workflow/clarify_check_step.py
+++ b/src/sagemaker/workflow/clarify_check_step.py
@@ -132,8 +132,9 @@ class ModelExplainabilityCheckConfig(ClarifyCheckConfig):
 
     Attributes:
         model_config (ModelConfig): Config of the model and its endpoint to be created.
-        explainability_config (SHAPConfig): Config of the specific explainability method.
-            Currently, only SHAP is supported.
+        explainability_config (SHAPConfig or PDPConfig): Config of the specific explainability method.
+            Supports SHAP or PDP.
+            For `PDPConfig`, `features` must be specified. `top_k_features` based on SHAP is currently not supported.
         model_scores (str or int or ModelPredictedLabelConfig): Index or JMESPath expression
             to locate the predicted scores in the model output (default: None).
             This is not required if the model output is a single score. Alternatively,

--- a/src/sagemaker/workflow/clarify_check_step.py
+++ b/src/sagemaker/workflow/clarify_check_step.py
@@ -132,9 +132,10 @@ class ModelExplainabilityCheckConfig(ClarifyCheckConfig):
 
     Attributes:
         model_config (ModelConfig): Config of the model and its endpoint to be created.
-        explainability_config (SHAPConfig or PDPConfig): Config of the specific explainability method.
+        explainability_config (SHAPConfig or PDPConfig): Config of the explainability method.
             Supports SHAP or PDP.
-            For `PDPConfig`, `features` must be specified. `top_k_features` based on SHAP is currently not supported.
+            For `PDPConfig`, `features` must be specified.
+            `top_k_features` based on SHAP is currently not supported.
         model_scores (str or int or ModelPredictedLabelConfig): Index or JMESPath expression
             to locate the predicted scores in the model output (default: None).
             This is not required if the model output is a single score. Alternatively,


### PR DESCRIPTION
…support

*Issue #, if available:* (internal ticket)

*Description of changes:* Fix the ClarifyCheckStep documentation to mention that PDP is also supported. 

*Testing done:* Only documentation change

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
