### PR TITLE
Change: Raise error if custom VPC is halfway defined

### DIFF
--- a/src/sagemaker/estimator.py
+++ b/src/sagemaker/estimator.py
@@ -578,6 +578,15 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):  # pylint: disable=too-man
         self.dependencies = dependencies or []
         self.uploaded_code: Optional[UploadedCode] = None
 
+        # Check that the user properly sets both subnet and secutiry_groupe_ids
+        if (
+            subnets is not None
+            and security_group_ids is None
+            or security_group_ids is not None
+            and subnets is None
+        ):
+            raise RuntimeError("When setting up custom VPC, both subnets and security_group_ids must be set")
+
         if self.instance_type in ("local", "local_gpu"):
             if self.instance_type == "local_gpu" and self.instance_count > 1:
                 raise RuntimeError("Distributed Training in Local GPU is not supported")

--- a/src/sagemaker/estimator.py
+++ b/src/sagemaker/estimator.py
@@ -585,7 +585,9 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):  # pylint: disable=too-man
             or security_group_ids is not None
             and subnets is None
         ):
-            raise RuntimeError("When setting up custom VPC, both subnets and security_group_ids must be set")
+            raise RuntimeError(
+                "When setting up custom VPC, both subnets and security_group_ids must be set"
+            )
 
         if self.instance_type in ("local", "local_gpu"):
             if self.instance_type == "local_gpu" and self.instance_count > 1:

--- a/tests/unit/test_estimator.py
+++ b/tests/unit/test_estimator.py
@@ -517,7 +517,7 @@ def test_subnets_without_security_groups(sagemaker_session):
         DummyFramework(
             entry_point=SCRIPT_PATH,
             sagemaker_session=sagemaker_session,
-            subnets=['123'],
+            subnets=["123"],
         )
 
 
@@ -526,7 +526,7 @@ def test_security_groups_without_subnets(sagemaker_session):
         DummyFramework(
             entry_point=SCRIPT_PATH,
             sagemaker_session=sagemaker_session,
-            security_group_ids=['123'],
+            security_group_ids=["123"],
         )
 
 

--- a/tests/unit/test_estimator.py
+++ b/tests/unit/test_estimator.py
@@ -512,6 +512,24 @@ def test_framework_all_init_args(sagemaker_session):
     }
 
 
+def test_subnets_without_security_groups(sagemaker_session):
+    with pytest.raises(RuntimeError):
+        DummyFramework(
+            entry_point=SCRIPT_PATH,
+            sagemaker_session=sagemaker_session,
+            subnets=['123'],
+        )
+
+
+def test_security_groups_without_subnets(sagemaker_session):
+    with pytest.raises(RuntimeError):
+        DummyFramework(
+            entry_point=SCRIPT_PATH,
+            sagemaker_session=sagemaker_session,
+            security_group_ids=['123'],
+        )
+
+
 def test_framework_without_role_parameter(sagemaker_session):
     with pytest.raises(ValueError):
         DummyFramework(


### PR DESCRIPTION
*Issue #, if available:* Fix https://github.com/aws/sagemaker-python-sdk/issues/2107

*Description of changes:*

Raise a runtime error whenever the custom VPC is not completely set.
