### PR TITLE
fix: fast follow on js uncompressed support - ModelBuilder

### DIFF
--- a/src/sagemaker/serve/model_server/tgi/prepare.py
+++ b/src/sagemaker/serve/model_server/tgi/prepare.py
@@ -17,16 +17,16 @@ def _copy_jumpstart_artifacts(model_data: str, js_id: str, code_dir: Path) -> bo
     """Placeholder Docstring"""
     logger.info("Downloading JumpStart artifacts from S3...")
     with _tmpdir(directory=str(code_dir)) as js_model_dir:
-        # TODO: remove if block after 10/30 once everything is shifted to uncompressed
-        if model_data.endswith("tar.gz"):
-            subprocess.run(["aws", "s3", "cp", model_data, js_model_dir])
-
+        js_model_data_loc = model_data.get("S3DataSource").get("S3Uri")
+        # TODO: leave this check here until we are sure every js model has moved to uncompressed
+        if js_model_data_loc.endswith("tar.gz"):
+            subprocess.run(["aws", "s3", "cp", js_model_data_loc, js_model_dir])
             logger.info("Uncompressing JumpStart artifacts for faster loading...")
             tmp_sourcedir = Path(js_model_dir).joinpath(f"infer-prepack-{js_id}.tar.gz")
             with tarfile.open(str(tmp_sourcedir)) as resources:
                 resources.extractall(path=code_dir)
         else:
-            subprocess.run(["aws", "s3", "cp", model_data, js_model_dir, "--recursive"])
+            subprocess.run(["aws", "s3", "cp", js_model_data_loc, js_model_dir, "--recursive"])
     return True
 
 


### PR DESCRIPTION
*Issue #, if available:*
JumpStart updated their `model_data` format when launching uncompressed artifacts. This introduced a bug in ModelBuilder as we expected the original S3 URI string not the new dictionary.

*Description of changes:*
Get the S3 URI from the dictionary.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
