### PR TITLE
change: update model path in local mode

### DIFF
--- a/src/sagemaker/local/image.py
+++ b/src/sagemaker/local/image.py
@@ -430,6 +430,7 @@ class _SageMakerContainer(object):
                 output_data_config["S3OutputPath"],
                 job_name,
                 self.sagemaker_session,
+                prefix="output",
             )
 
         _delete_tree(model_artifacts)

--- a/src/sagemaker/local/utils.py
+++ b/src/sagemaker/local/utils.py
@@ -53,7 +53,7 @@ def copy_directory_structure(destination_directory, relative_path):
     os.makedirs(destination_directory, relative_path)
 
 
-def move_to_destination(source, destination, job_name, sagemaker_session):
+def move_to_destination(source, destination, job_name, sagemaker_session, prefix=""):
     """Move source to destination.
 
     Can handle uploading to S3.
@@ -64,6 +64,8 @@ def move_to_destination(source, destination, job_name, sagemaker_session):
         job_name (str): SageMaker job name.
         sagemaker_session (sagemaker.Session): a sagemaker_session to interact
             with S3 if needed
+        prefix (str, optional): the directory on S3 used to save files, default
+            to the root of  ``destination``
 
     Returns:
         (str): destination URI
@@ -75,7 +77,7 @@ def move_to_destination(source, destination, job_name, sagemaker_session):
         final_uri = destination
     elif parsed_uri.scheme == "s3":
         bucket = parsed_uri.netloc
-        path = s3.s3_path_join(parsed_uri.path, job_name)
+        path = s3.s3_path_join(parsed_uri.path, job_name, prefix)
         final_uri = s3.s3_path_join("s3://", bucket, path)
         sagemaker_session.upload_data(source, bucket, path)
     else:

--- a/tests/unit/sagemaker/local/test_local_utils.py
+++ b/tests/unit/sagemaker/local/test_local_utils.py
@@ -66,6 +66,18 @@ def test_move_to_destination_s3(recursive_copy):
     sms.upload_data.assert_called_with("/tmp/data", "bucket", "job")
 
 
+@patch("shutil.rmtree", Mock())
+def test_move_to_destination_s3_with_prefix():
+    sms = Mock(
+        settings=SessionSettings(),
+    )
+    uri = sagemaker.local.utils.move_to_destination(
+        "/tmp/data", "s3://bucket/path", "job", sms, "foo_prefix"
+    )
+    sms.upload_data.assert_called_with("/tmp/data", "bucket", "path/job/foo_prefix")
+    assert uri == "s3://bucket/path/job/foo_prefix"
+
+
 def test_move_to_destination_illegal_destination():
     with pytest.raises(ValueError):
         sagemaker.local.utils.move_to_destination("/tmp/data", "ftp://ftp/in/2018", "job", None)


### PR DESCRIPTION
*Issue #, if available:*
 - Closes  https://github.com/aws/sagemaker-python-sdk/issues/1354

*Description of changes:*

*Testing done:*

- Unit test

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
