### PR TITLE
fix: mitigation of xgboost container incompatibility with new version

### DIFF
--- a/src/sagemaker/serve/builder/model_builder.py
+++ b/src/sagemaker/serve/builder/model_builder.py
@@ -514,6 +514,7 @@ class ModelBuilder(Triton, DJL, JumpStart, TGI):
             shared_libs=self.shared_libs,
             dependencies=self.dependencies,
             session=self.sagemaker_session,
+            image_uri=self.image_uri,
             inference_spec=self.inference_spec,
         )
 

--- a/src/sagemaker/serve/detector/dependency_manager.py
+++ b/src/sagemaker/serve/detector/dependency_manager.py
@@ -54,9 +54,9 @@ def capture_dependencies(dependencies: dict, work_dir: Path, capture_all: bool =
 
         with open(path, "r") as f:
             autodetect_depedencies = f.read().splitlines()
-        autodetect_depedencies.append("sagemaker")
+        autodetect_depedencies.append("sagemaker>=2.199")
     else:
-        autodetect_depedencies = ["sagemaker"]
+        autodetect_depedencies = ["sagemaker>=2.199"]
 
     module_version_dict = _parse_dependency_list(autodetect_depedencies)
 

--- a/src/sagemaker/serve/model_server/torchserve/server.py
+++ b/src/sagemaker/serve/model_server/torchserve/server.py
@@ -27,7 +27,7 @@ class LocalTorchServe:
             image,
             "serve",
             detach=True,
-            auto_remove=True,
+            # auto_remove=True,
             network_mode="host",
             volumes={
                 Path(model_path): {

--- a/src/sagemaker/serve/model_server/torchserve/server.py
+++ b/src/sagemaker/serve/model_server/torchserve/server.py
@@ -27,7 +27,7 @@ class LocalTorchServe:
             image,
             "serve",
             detach=True,
-            # auto_remove=True,
+            auto_remove=True,
             network_mode="host",
             volumes={
                 Path(model_path): {

--- a/src/sagemaker/serve/model_server/torchserve/xgboost_inference.py
+++ b/src/sagemaker/serve/model_server/torchserve/xgboost_inference.py
@@ -91,6 +91,8 @@ def output_fn(predictions, accept_type):
 
 
 def _run_preflight_diagnostics():
+    install_package("sagemaker")
+    install_package("boto3", "1.17.52")
     _py_vs_parity_check()
     _pickle_file_integrity_check()
 
@@ -128,10 +130,6 @@ def install_package(package_name, version=None):
     except subprocess.CalledProcessError as e:
         print(f"Failed to install {package_name}. Error: {e}")
 
-
-# Example usage
-install_package("sagemaker")
-install_package("boto3", "1.17.52")
 
 # on import, execute
 _run_preflight_diagnostics()

--- a/src/sagemaker/serve/model_server/torchserve/xgboost_inference.py
+++ b/src/sagemaker/serve/model_server/torchserve/xgboost_inference.py
@@ -1,0 +1,137 @@
+"""This module is for SageMaker inference.py."""
+from __future__ import absolute_import
+import os
+import io
+import subprocess
+import cloudpickle
+import shutil
+import platform
+from pathlib import Path
+from functools import partial
+import logging
+
+logger = logging.getLogger(__name__)
+
+inference_spec = None
+native_model = None
+schema_builder = None
+
+
+def model_fn(model_dir):
+    from sagemaker.serve.spec.inference_spec import InferenceSpec
+    from sagemaker.serve.detector.image_detector import (
+        _detect_framework_and_version,
+        _get_model_base,
+    )
+    from sagemaker.serve.detector.pickler import load_xgboost_from_json
+
+    """Placeholder docstring"""
+    shared_libs_path = Path(model_dir + "/shared_libs")
+
+    if shared_libs_path.exists():
+        # before importing, place dynamic linked libraries in shared lib path
+        shutil.copytree(shared_libs_path, "/lib", dirs_exist_ok=True)
+
+    serve_path = Path(__file__).parent.joinpath("serve.pkl")
+    with open(str(serve_path), mode="rb") as file:
+        global inference_spec, native_model, schema_builder
+        obj = cloudpickle.load(file)
+        if isinstance(obj[0], InferenceSpec):
+            inference_spec, schema_builder = obj
+        elif isinstance(obj[0], str) and obj[0] == "xgboost":
+            model_class_name = os.getenv("MODEL_CLASS_NAME")
+            model_save_path = Path(__file__).parent.joinpath("model.json")
+            native_model = load_xgboost_from_json(
+                model_save_path=str(model_save_path), class_name=model_class_name
+            )
+            schema_builder = obj[1]
+        else:
+            native_model, schema_builder = obj
+    if native_model:
+        framework, _ = _detect_framework_and_version(
+            model_base=str(_get_model_base(model=native_model))
+        )
+        if framework == "pytorch":
+            native_model.eval()
+        return native_model if callable(native_model) else native_model.predict
+    elif inference_spec:
+        return partial(inference_spec.invoke, model=inference_spec.load(model_dir))
+
+
+def input_fn(input_data, content_type):
+    """Placeholder docstring"""
+    try:
+        if hasattr(schema_builder, "custom_input_translator"):
+            return schema_builder.custom_input_translator.deserialize(
+                io.BytesIO(input_data), content_type
+            )
+        else:
+            return schema_builder.input_deserializer.deserialize(
+                io.BytesIO(input_data), content_type[0]
+            )
+    except Exception as e:
+        raise Exception("Encountered error in deserialize_request.") from e
+
+
+def predict_fn(input_data, predict_callable):
+    """Placeholder docstring"""
+    return predict_callable(input_data)
+
+
+def output_fn(predictions, accept_type):
+    """Placeholder docstring"""
+    try:
+        if hasattr(schema_builder, "custom_output_translator"):
+            return schema_builder.custom_output_translator.serialize(predictions, accept_type)
+        else:
+            return schema_builder.output_serializer.serialize(predictions)
+    except Exception as e:
+        logger.error("Encountered error: %s in serialize_response." % e)
+        raise Exception("Encountered error in serialize_response.") from e
+
+
+def _run_preflight_diagnostics():
+    _py_vs_parity_check()
+    _pickle_file_integrity_check()
+
+
+def _py_vs_parity_check():
+    container_py_vs = platform.python_version()
+    local_py_vs = os.getenv("LOCAL_PYTHON")
+
+    if not local_py_vs or container_py_vs.split(".")[1] != local_py_vs.split(".")[1]:
+        logger.warning(
+            f"The local python version {local_py_vs} differs from the python version "
+            f"{container_py_vs} on the container. Please align the two to avoid unexpected behavior"
+        )
+
+
+def _pickle_file_integrity_check():
+    from sagemaker.serve.validations.check_integrity import perform_integrity_check
+
+    with open("/opt/ml/model/code/serve.pkl", "rb") as f:
+        buffer = f.read()
+
+    metadeata_path = Path("/opt/ml/model/code/metadata.json")
+    perform_integrity_check(buffer=buffer, metadata_path=metadeata_path)
+
+
+def install_package(package_name, version=None):
+    if version:
+        command = f"pip install {package_name}=={version}"
+    else:
+        command = f"pip install {package_name}"
+
+    try:
+        subprocess.check_call(command, shell=True)
+        print(f"Successfully installed {package_name} using install_package")
+    except subprocess.CalledProcessError as e:
+        print(f"Failed to install {package_name}. Error: {e}")
+
+
+# Example usage
+install_package("sagemaker")
+install_package("boto3", "1.17.52")
+
+# on import, execute
+_run_preflight_diagnostics()

--- a/src/sagemaker/serve/model_server/torchserve/xgboost_inference.py
+++ b/src/sagemaker/serve/model_server/torchserve/xgboost_inference.py
@@ -18,6 +18,7 @@ schema_builder = None
 
 
 def model_fn(model_dir):
+    """Placeholder docstring"""
     from sagemaker.serve.spec.inference_spec import InferenceSpec
     from sagemaker.serve.detector.image_detector import (
         _detect_framework_and_version,
@@ -25,7 +26,6 @@ def model_fn(model_dir):
     )
     from sagemaker.serve.detector.pickler import load_xgboost_from_json
 
-    """Placeholder docstring"""
     shared_libs_path = Path(model_dir + "/shared_libs")
 
     if shared_libs_path.exists():
@@ -119,6 +119,7 @@ def _pickle_file_integrity_check():
 
 
 def install_package(package_name, version=None):
+    """Placeholder docstring"""
     if version:
         command = f"pip install {package_name}=={version}"
     else:

--- a/tests/unit/sagemaker/serve/builder/test_model_builder.py
+++ b/tests/unit/sagemaker/serve/builder/test_model_builder.py
@@ -149,11 +149,12 @@ class TestModelBuilder(unittest.TestCase):
         mock_detect_fw_version.return_value = framework, version
 
         mock_prepare_for_torchserve.side_effect = (
-            lambda model_path, shared_libs, dependencies, session, inference_spec: mock_secret_key
+            lambda model_path, shared_libs, dependencies, session, image_uri, inference_spec: mock_secret_key
             if model_path == MODEL_PATH
             and shared_libs == []
             and dependencies == {"auto": False}
             and session == session
+            and image_uri == mock_image_uri
             and inference_spec is None
             else None
         )
@@ -248,11 +249,12 @@ class TestModelBuilder(unittest.TestCase):
         mock_detect_fw_version.return_value = framework, version
 
         mock_prepare_for_torchserve.side_effect = (
-            lambda model_path, shared_libs, dependencies, session, inference_spec: mock_secret_key
+            lambda model_path, shared_libs, dependencies, session, image_uri, inference_spec: mock_secret_key
             if model_path == MODEL_PATH
             and shared_libs == []
             and dependencies == {"auto": False}
             and session == session
+            and image_uri == mock_1p_dlc_image_uri
             and inference_spec is None
             else None
         )
@@ -352,11 +354,12 @@ class TestModelBuilder(unittest.TestCase):
         )
 
         mock_prepare_for_torchserve.side_effect = (
-            lambda model_path, shared_libs, dependencies, session, inference_spec: mock_secret_key
+            lambda model_path, shared_libs, dependencies, session, image_uri, inference_spec: mock_secret_key
             if model_path == MODEL_PATH
             and shared_libs == []
             and dependencies == {"auto": False}
             and session == mock_session
+            and image_uri == mock_image_uri
             and inference_spec == mock_inference_spec
             else None
         )
@@ -447,11 +450,12 @@ class TestModelBuilder(unittest.TestCase):
         mock_detect_fw_version.return_value = framework, version
 
         mock_prepare_for_torchserve.side_effect = (
-            lambda model_path, shared_libs, dependencies, session, inference_spec: mock_secret_key
+            lambda model_path, shared_libs, dependencies, session, image_uri, inference_spec: mock_secret_key
             if model_path == MODEL_PATH
             and shared_libs == []
             and dependencies == {"auto": False}
             and session == session
+            and image_uri == mock_image_uri
             and inference_spec is None
             else None
         )
@@ -550,11 +554,12 @@ class TestModelBuilder(unittest.TestCase):
         mock_detect_fw_version.return_value = "xgboost", version
 
         mock_prepare_for_torchserve.side_effect = (
-            lambda model_path, shared_libs, dependencies, session, inference_spec: mock_secret_key
+            lambda model_path, shared_libs, dependencies, session, image_uri, inference_spec: mock_secret_key
             if model_path == MODEL_PATH
             and shared_libs == []
             and dependencies == {"auto": False}
             and session == session
+            and image_uri == mock_image_uri
             and inference_spec is None
             else None
         )
@@ -655,11 +660,12 @@ class TestModelBuilder(unittest.TestCase):
         )
 
         mock_prepare_for_torchserve.side_effect = (
-            lambda model_path, shared_libs, dependencies, session, inference_spec: mock_secret_key
+            lambda model_path, shared_libs, dependencies, session, image_uri, inference_spec: mock_secret_key
             if model_path == MODEL_PATH
             and shared_libs == []
             and dependencies == {"auto": False}
             and session == mock_session
+            and image_uri == mock_image_uri
             and inference_spec == mock_inference_spec
             else None
         )
@@ -752,11 +758,12 @@ class TestModelBuilder(unittest.TestCase):
         )
 
         mock_prepare_for_torchserve.side_effect = (
-            lambda model_path, shared_libs, dependencies, session, inference_spec: mock_secret_key
+            lambda model_path, shared_libs, dependencies, session, image_uri, inference_spec: mock_secret_key
             if model_path == MODEL_PATH
             and shared_libs == []
             and dependencies == {"auto": False}
             and session == mock_session
+            and image_uri == mock_image_uri
             and inference_spec == mock_inference_spec
             else None
         )
@@ -887,12 +894,13 @@ class TestModelBuilder(unittest.TestCase):
         )
 
         mock_prepare_for_torchserve.side_effect = (
-            lambda model_path, shared_libs, dependencies, session, inference_spec: mock_secret_key
+            lambda model_path, shared_libs, dependencies, image_uri, session, inference_spec: mock_secret_key
             if model_path == MODEL_PATH
             and shared_libs == []
             and dependencies == {"auto": False}
             and session == mock_session
             and inference_spec is None
+            and image_uri == mock_image_uri
             else None
         )
 

--- a/tests/unit/sagemaker/serve/detector/test_dependency_manager.py
+++ b/tests/unit/sagemaker/serve/detector/test_dependency_manager.py
@@ -99,7 +99,7 @@ class DepedencyManagerTest(unittest.TestCase):
             call("custom_module==1.2.3\n"),
             call("numpy==4.5\n"),
             call("boto3=1.28.*\n"),
-            call("sagemaker\n"),
+            call("sagemaker>=2.199\n"),
             call("other_module@http://some/website.whl\n"),
         ]
         mocked_writes.assert_has_calls(expected_calls)

--- a/tests/unit/sagemaker/serve/model_server/torchserve/test_prepare.py
+++ b/tests/unit/sagemaker/serve/model_server/torchserve/test_prepare.py
@@ -21,6 +21,8 @@ MODEL_PATH = "/path/to/your/model/dir"
 SHARED_LIBS = ["/path/to/shared/libs"]
 DEPENDENCIES = "dependencies"
 INFERENCE_SPEC = Mock()
+IMAGE_URI = "mock_image_uri"
+XGB_1P_IMAGE_URI = "246618743249.dkr.ecr.us-west-2.amazonaws.com/sagemaker-xgboost:1.7-1"
 INFERENCE_SPEC.prepare = Mock(return_value=None)
 
 SECRET_KEY = "secret-key"
@@ -29,6 +31,9 @@ mock_session = Mock()
 
 
 class PrepareForTorchServeTests(TestCase):
+    def setUp(self):
+        INFERENCE_SPEC.reset_mock()
+
     @patch("builtins.open", new_callable=mock_open, read_data=b"{}")
     @patch("sagemaker.serve.model_server.torchserve.prepare._MetaData")
     @patch("sagemaker.serve.model_server.torchserve.prepare.compute_hash")
@@ -58,9 +63,50 @@ class PrepareForTorchServeTests(TestCase):
             shared_libs=SHARED_LIBS,
             dependencies=DEPENDENCIES,
             session=mock_session,
+            image_uri=IMAGE_URI,
             inference_spec=INFERENCE_SPEC,
         )
 
+        mock_path_instance.mkdir.assert_not_called()
+        INFERENCE_SPEC.prepare.assert_called_once()
+        self.assertEqual(secret_key, SECRET_KEY)
+
+    @patch("os.rename")
+    @patch("builtins.open", new_callable=mock_open, read_data=b"{}")
+    @patch("sagemaker.serve.model_server.torchserve.prepare._MetaData")
+    @patch("sagemaker.serve.model_server.torchserve.prepare.compute_hash")
+    @patch("sagemaker.serve.model_server.torchserve.prepare.generate_secret_key")
+    @patch("sagemaker.serve.model_server.torchserve.prepare.capture_dependencies")
+    @patch("sagemaker.serve.model_server.torchserve.prepare.shutil")
+    @patch("sagemaker.serve.model_server.torchserve.prepare.Path")
+    def test_prepare_happy_xgboost(
+        self,
+        mock_path,
+        mock_shutil,
+        mock_capture_dependencies,
+        mock_generate_secret_key,
+        mock_compute_hash,
+        mock_metadata,
+        mock_open,
+        mock_rename,
+    ):
+
+        mock_path_instance = mock_path.return_value
+        mock_path_instance.exists.return_value = True
+        mock_path_instance.joinpath.return_value = Mock()
+
+        mock_generate_secret_key.return_value = SECRET_KEY
+
+        secret_key = prepare_for_torchserve(
+            model_path=MODEL_PATH,
+            shared_libs=SHARED_LIBS,
+            dependencies=DEPENDENCIES,
+            session=mock_session,
+            image_uri=XGB_1P_IMAGE_URI,
+            inference_spec=INFERENCE_SPEC,
+        )
+
+        mock_rename.assert_called_once()
         mock_path_instance.mkdir.assert_not_called()
         INFERENCE_SPEC.prepare.assert_called_once()
         self.assertEqual(secret_key, SECRET_KEY)


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/sagemaker-python-sdk/issues/4288

*Description of changes:*
- Install old version in `inference.py` when using 1P xgboost container
- Restrict `sagemaker>=2.199` to ensure it installed version with `ModelBuilder`

*Testing done:*
- Ran XGBoost notebook
- Ran pytorch notebook
- Unit testing all passed
- Formatting all passed

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
