### PR TITLE
feature: support model.register() with triton model

### DIFF
--- a/src/sagemaker/serve/marshalling/triton_translator.py
+++ b/src/sagemaker/serve/marshalling/triton_translator.py
@@ -16,6 +16,8 @@ class TorchTensorTranslator:
         import torch
 
         self.convert_from_numpy = torch.from_numpy  # pylint: disable=E1101
+        self.CONTENT_TYPE = "tensor/pt"
+        self.ACCEPT = "tensor/pt"
 
     def serialize(self, data, content_type: str = "tensor/pt"):
         """Translate torch.Tensor to numpy ndarray"""
@@ -45,6 +47,8 @@ class TensorflowTensorTranslator:
         import tensorflow as tf
 
         self.convert_to_tensor = tf.convert_to_tensor
+        self.CONTENT_TYPE = "tensor/tf"
+        self.ACCEPT = "tensor/tf"
 
     def serialize(self, data, content_type: str = "tensor/tf"):
         """Translate tf.Tensor to numpy ndarray"""
@@ -70,6 +74,10 @@ class TensorflowTensorTranslator:
 class NumpyTranslator:
     """A dummy class to make sure the translator interface is aligned"""
 
+    def __init__(self) -> None:
+        self.CONTENT_TYPE = "application/x-npy"
+        self.ACCEPT = "application/x-npy"
+
     def serialize(self, data, content_type: str = "application/x-npy"):
         """Placeholder docstring"""
         return data
@@ -85,6 +93,10 @@ class NumpyTranslator:
 
 class ListTranslator:
     """Translate python list from and to numpy.ndarray"""
+
+    def __init__(self) -> None:
+        self.CONTENT_TYPE = "application/list"
+        self.ACCEPT = "application/list"
 
     def serialize(self, data, content_type: str = "application/list"):
         """Placeholder docstring"""

--- a/src/sagemaker/serve/model_server/triton/triton_builder.py
+++ b/src/sagemaker/serve/model_server/triton/triton_builder.py
@@ -430,6 +430,9 @@ class Triton:
         # unique method to models created via ModelBuilder()
         self._original_deploy = self.pysdk_model.deploy
         self.pysdk_model.deploy = self._model_builder_deploy_wrapper
+        self._original_register = self.pysdk_model.register
+        self.pysdk_model.register = self._model_builder_register_wrapper
+        self.model_package = None
         return self.pysdk_model
 
     def _get_triton_predictor(self, endpoint_name: str, sagemaker_session: Session) -> Predictor:

--- a/tests/unit/sagemaker/serve/model_server/triton/test_triton_builder.py
+++ b/tests/unit/sagemaker/serve/model_server/triton/test_triton_builder.py
@@ -33,6 +33,7 @@ MOCK_SERVE_SETTINGS.role_arn = ROLE_ARN
 MOCK_SESSION = Mock()
 MOCK_MODES = Mock()
 MOCK_DEPLOY_WRAPPER = Mock()
+MOCK_RESIGTER_WRAPPER = Mock()
 
 
 class pytorch:
@@ -56,6 +57,7 @@ class TritonBuilderTests(TestCase):
         triton_builder.sagemaker_session = MOCK_SESSION
         triton_builder.modes = MOCK_MODES
         triton_builder._model_builder_deploy_wrapper = MOCK_DEPLOY_WRAPPER
+        triton_builder._model_builder_register_wrapper = MOCK_RESIGTER_WRAPPER
         triton_builder.inference_spec = None
 
         mock_export = Mock()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Allow `model.register()` for model built using triton model server
- Populate `CONTENT_TYPE` and `ACCEPT` field for Triton specific translators to be used in `model.register()`


*Testing done:*
- Unit test
- Formatting
- Ran Triton notebook and model.register()

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
