### PR TITLE
change: Support local mode for remote function

### DIFF
--- a/src/sagemaker/remote_function/job.py
+++ b/src/sagemaker/remote_function/job.py
@@ -891,7 +891,7 @@ class _Job:
         """
 
         self._last_describe_response = _logs_for_job(
-            boto_session=self.sagemaker_session.boto_session,
+            sagemaker_session=self.sagemaker_session,
             job_name=self.job_name,
             wait=True,
             timeout=timeout,

--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -5447,7 +5447,7 @@ class Session(object):  # pylint: disable=too-many-public-methods
             exceptions.CapacityError: If the training job fails with CapacityError.
             exceptions.UnexpectedStatusException: If waiting and the training job fails.
         """
-        _logs_for_job(self.boto_session, job_name, wait, poll, log_type, timeout)
+        _logs_for_job(self, job_name, wait, poll, log_type, timeout)
 
     def logs_for_processing_job(self, job_name, wait=False, poll=10):
         """Display logs for a given processing job, optionally tailing them until the is complete.
@@ -7330,7 +7330,7 @@ def _rule_statuses_changed(current_statuses, last_statuses):
 
 
 def _logs_for_job(  # noqa: C901 - suppress complexity warning for this method
-    boto_session, job_name, wait=False, poll=10, log_type="All", timeout=None
+    sagemaker_session, job_name, wait=False, poll=10, log_type="All", timeout=None
 ):
     """Display logs for a given training job, optionally tailing them until job is complete.
 
@@ -7338,9 +7338,8 @@ def _logs_for_job(  # noqa: C901 - suppress complexity warning for this method
     based on which instance the log entry is from.
 
     Args:
-        boto_session (boto3.session.Session): The underlying Boto3 session which AWS service
-                calls are delegated to (default: None). If not provided, one is created with
-                default AWS configuration chain.
+        sagemaker_session (sagemaker.session.Session): A SageMaker Session
+            object, used for SageMaker interactions.
         job_name (str): Name of the training job to display the logs for.
         wait (bool): Whether to keep looking for new log entries until the job completes
             (default: False).
@@ -7357,13 +7356,13 @@ def _logs_for_job(  # noqa: C901 - suppress complexity warning for this method
         exceptions.CapacityError: If the training job fails with CapacityError.
         exceptions.UnexpectedStatusException: If waiting and the training job fails.
     """
-    sagemaker_client = boto_session.client("sagemaker")
+    sagemaker_client = sagemaker_session.sagemaker_client
     request_end_time = time.time() + timeout if timeout else None
     description = sagemaker_client.describe_training_job(TrainingJobName=job_name)
     print(secondary_training_status_message(description, None), end="")
 
     instance_count, stream_names, positions, client, log_group, dot, color_wrap = _logs_init(
-        boto_session, description, job="Training"
+        sagemaker_session.boto_session, description, job="Training"
     )
 
     state = _get_initial_job_state(description, "TrainingJobStatus", wait)

--- a/tests/integ/sagemaker/remote_function/test_decorator.py
+++ b/tests/integ/sagemaker/remote_function/test_decorator.py
@@ -207,7 +207,7 @@ def test_with_additional_dependencies(
     def cuberoot(x):
         from scipy.special import cbrt
 
-        return cbrt(27)
+        return cbrt(x)
 
     assert cuberoot(27) == 3
 
@@ -742,7 +742,7 @@ def test_with_user_and_workdir_set_in_the_image(
     def cuberoot(x):
         from scipy.special import cbrt
 
-        return cbrt(27)
+        return cbrt(x)
 
     assert cuberoot(27) == 3
 

--- a/tests/unit/sagemaker/remote_function/test_job.py
+++ b/tests/unit/sagemaker/remote_function/test_job.py
@@ -1108,7 +1108,7 @@ def test_wait(session, mock_stored_function, mock_logs_for_job, *args):
     job.wait(timeout=10)
 
     mock_logs_for_job.assert_called_with(
-        boto_session=ANY, job_name=job.job_name, wait=True, timeout=10
+        sagemaker_session=ANY, job_name=job.job_name, wait=True, timeout=10
     )
 
 

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -2497,9 +2497,7 @@ def sagemaker_session_full_lifecycle(boto_session_full_lifecycle):
 def test_logs_for_job_no_wait(cw, sagemaker_session_complete):
     ims = sagemaker_session_complete
     ims.logs_for_job(JOB_NAME)
-    ims.boto_session.client.return_value.describe_training_job.assert_called_once_with(
-        TrainingJobName=JOB_NAME
-    )
+    ims.sagemaker_client.describe_training_job.assert_called_once_with(TrainingJobName=JOB_NAME)
     cw().assert_called_with(0, "hi there #1")
 
 
@@ -2507,9 +2505,7 @@ def test_logs_for_job_no_wait(cw, sagemaker_session_complete):
 def test_logs_for_job_no_wait_stopped_job(cw, sagemaker_session_stopped):
     ims = sagemaker_session_stopped
     ims.logs_for_job(JOB_NAME)
-    ims.boto_session.client.return_value.describe_training_job.assert_called_once_with(
-        TrainingJobName=JOB_NAME
-    )
+    ims.sagemaker_client.describe_training_job.assert_called_once_with(TrainingJobName=JOB_NAME)
     cw().assert_called_with(0, "hi there #1")
 
 
@@ -2517,7 +2513,7 @@ def test_logs_for_job_no_wait_stopped_job(cw, sagemaker_session_stopped):
 def test_logs_for_job_wait_on_completed(cw, sagemaker_session_complete):
     ims = sagemaker_session_complete
     ims.logs_for_job(JOB_NAME, wait=True, poll=0)
-    assert ims.boto_session.client.return_value.describe_training_job.call_args_list == [
+    assert ims.sagemaker_client.describe_training_job.call_args_list == [
         call(TrainingJobName=JOB_NAME)
     ]
     cw().assert_called_with(0, "hi there #1")
@@ -2527,7 +2523,7 @@ def test_logs_for_job_wait_on_completed(cw, sagemaker_session_complete):
 def test_logs_for_job_wait_on_stopped(cw, sagemaker_session_stopped):
     ims = sagemaker_session_stopped
     ims.logs_for_job(JOB_NAME, wait=True, poll=0)
-    assert ims.boto_session.client.return_value.describe_training_job.call_args_list == [
+    assert ims.sagemaker_client.describe_training_job.call_args_list == [
         call(TrainingJobName=JOB_NAME)
     ]
     cw().assert_called_with(0, "hi there #1")
@@ -2537,7 +2533,7 @@ def test_logs_for_job_wait_on_stopped(cw, sagemaker_session_stopped):
 def test_logs_for_job_no_wait_on_running(cw, sagemaker_session_ready_lifecycle):
     ims = sagemaker_session_ready_lifecycle
     ims.logs_for_job(JOB_NAME)
-    assert ims.boto_session.client.return_value.describe_training_job.call_args_list == [
+    assert ims.sagemaker_client.describe_training_job.call_args_list == [
         call(TrainingJobName=JOB_NAME)
     ]
     cw().assert_called_with(0, "hi there #1")
@@ -2549,7 +2545,7 @@ def test_logs_for_job_full_lifecycle(time, cw, sagemaker_session_full_lifecycle)
     ims = sagemaker_session_full_lifecycle
     ims.logs_for_job(JOB_NAME, wait=True, poll=0)
     assert (
-        ims.boto_session.client.return_value.describe_training_job.call_args_list
+        ims.sagemaker_client.describe_training_job.call_args_list
         == [call(TrainingJobName=JOB_NAME)] * 3
     )
     assert cw().call_args_list == [


### PR DESCRIPTION
*Issue #, if available:* As remote function serves as the foundation for step decorator, previously when we enabled local mode for step decorator, we have filled in most of the gaps for remote function local mode as well.

However, there is still an issue that the remote function result is not retrievable in local mode. The root cause is, when trying to retrieve the local job results, the current SDK is trying to describe the remote job rather than the local job as it uses the wrong client.

*Description of changes:* This PR fixes the issue mentioned above.

*Testing done:* Integ test

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
