### PR TITLE
Change: Mention "FastFile" support for s3_input_mode in docstrings

### DIFF
--- a/src/sagemaker/dataset_definition/inputs.py
+++ b/src/sagemaker/dataset_definition/inputs.py
@@ -198,7 +198,7 @@ class S3Input(ApiObject):
                 the path to a local directory. If not provided, skips data download
                 by SageMaker platform.
             s3_data_type (str, default="S3Prefix"): Valid options are "ManifestFile" or "S3Prefix".
-            s3_input_mode (str, default="File"): Valid options are "Pipe" or "File".
+            s3_input_mode (str, default="File"): Valid options are "Pipe", "File" or "FastFile".
             s3_data_distribution_type (str, default="FullyReplicated"):
                 Valid options are "FullyReplicated" or "ShardedByS3Key".
             s3_compression_type (str, default=None): Valid options are "None" or "Gzip".

--- a/src/sagemaker/model_monitor/model_monitoring.py
+++ b/src/sagemaker/model_monitor/model_monitoring.py
@@ -3933,7 +3933,8 @@ class EndpointInput(object):
         Args:
             endpoint_name (str): The name of the endpoint.
             destination (str): The destination of the input.
-            s3_input_mode (str): The S3 input mode. Can be one of: "File", "Pipe. Default: "File".
+            s3_input_mode (str): The S3 input mode. Can be one of: "File", "Pipe" or "FastFile".
+                Default: "File".
             s3_data_distribution_type (str): The S3 Data Distribution Type. Can be one of:
                 "FullyReplicated", "ShardedByS3Key"
             start_time_offset (str): Monitoring start time offset, e.g. "-PT1H"
@@ -4043,7 +4044,8 @@ class BatchTransformInput(MonitoringInput):
             data_captured_destination_s3_uri (str): Location to the batch transform captured data
                 file which needs to be analysed.
             destination (str): The destination of the input.
-            s3_input_mode (str): The S3 input mode. Can be one of: "File", "Pipe. (default: File)
+            s3_input_mode (str): The S3 input mode. Can be one of: "File", "Pipe" or
+                "FastFile". (default: File)
             s3_data_distribution_type (str): The S3 Data Distribution Type. Can be one of:
                 "FullyReplicated", "ShardedByS3Key" (default: FullyReplicated)
             start_time_offset (str): Monitoring start time offset, e.g. "-PT1H" (default: None)

--- a/src/sagemaker/processing.py
+++ b/src/sagemaker/processing.py
@@ -1242,7 +1242,7 @@ class ProcessingInput(object):
             input_name (str or PipelineVariable): The name for the input. If a name
                 is not provided, one will be generated (eg. "input-1").
             s3_data_type (str or PipelineVariable): Valid options are "ManifestFile" or "S3Prefix".
-            s3_input_mode (str or PipelineVariable): Valid options are "Pipe" or "File".
+            s3_input_mode (str or PipelineVariable): Valid options are "Pipe", "File" or "FastFile".
             s3_data_distribution_type (str or PipelineVariable): Valid options are "FullyReplicated"
                 or "ShardedByS3Key".
             s3_compression_type (str or PipelineVariable): Valid options are "None" or "Gzip".


### PR DESCRIPTION
*Issue #, if available:*

Raised in https://github.com/aws/sagemaker-python-sdk/issues/3962

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
