### PR TITLE
fix: Move func and args serialization of function step to step level

### DIFF
--- a/src/sagemaker/remote_function/core/serialization.py
+++ b/src/sagemaker/remote_function/core/serialization.py
@@ -161,17 +161,13 @@ def serialize_func_to_s3(
     Raises:
         SerializationError: when fail to serialize function to bytes.
     """
-    bytes_to_upload = CloudpickleSerializer.serialize(func)
 
-    _upload_bytes_to_s3(bytes_to_upload, f"{s3_uri}/payload.pkl", s3_kms_key, sagemaker_session)
-
-    sha256_hash = _compute_hash(bytes_to_upload, secret_key=hmac_key)
-
-    _upload_bytes_to_s3(
-        _MetaData(sha256_hash).to_json(),
-        f"{s3_uri}/metadata.json",
-        s3_kms_key,
-        sagemaker_session,
+    _upload_payload_and_metadata_to_s3(
+        bytes_to_upload=CloudpickleSerializer.serialize(func),
+        hmac_key=hmac_key,
+        s3_uri=s3_uri,
+        sagemaker_session=sagemaker_session,
+        s3_kms_key=s3_kms_key,
     )
 
 
@@ -220,17 +216,12 @@ def serialize_obj_to_s3(
         SerializationError: when fail to serialize object to bytes.
     """
 
-    bytes_to_upload = CloudpickleSerializer.serialize(obj)
-
-    _upload_bytes_to_s3(bytes_to_upload, f"{s3_uri}/payload.pkl", s3_kms_key, sagemaker_session)
-
-    sha256_hash = _compute_hash(bytes_to_upload, secret_key=hmac_key)
-
-    _upload_bytes_to_s3(
-        _MetaData(sha256_hash).to_json(),
-        f"{s3_uri}/metadata.json",
-        s3_kms_key,
-        sagemaker_session,
+    _upload_payload_and_metadata_to_s3(
+        bytes_to_upload=CloudpickleSerializer.serialize(obj),
+        hmac_key=hmac_key,
+        s3_uri=s3_uri,
+        sagemaker_session=sagemaker_session,
+        s3_kms_key=s3_kms_key,
     )
 
 
@@ -318,8 +309,32 @@ def serialize_exception_to_s3(
     """
     pickling_support.install()
 
-    bytes_to_upload = CloudpickleSerializer.serialize(exc)
+    _upload_payload_and_metadata_to_s3(
+        bytes_to_upload=CloudpickleSerializer.serialize(exc),
+        hmac_key=hmac_key,
+        s3_uri=s3_uri,
+        sagemaker_session=sagemaker_session,
+        s3_kms_key=s3_kms_key,
+    )
 
+
+def _upload_payload_and_metadata_to_s3(
+    bytes_to_upload: Union[bytes, io.BytesIO],
+    hmac_key: str,
+    s3_uri: str,
+    sagemaker_session: Session,
+    s3_kms_key,
+):
+    """Uploads serialized payload and metadata to s3.
+
+    Args:
+        bytes_to_upload (bytes): Serialized bytes to upload.
+        hmac_key (str): Key used to calculate hmac-sha256 hash of the serialized obj.
+        s3_uri (str): S3 root uri to which resulting serialized artifacts will be uploaded.
+        sagemaker_session (sagemaker.session.Session):
+            The underlying Boto3 session which AWS service calls are delegated to.
+        s3_kms_key (str): KMS key used to encrypt artifacts uploaded to S3.
+    """
     _upload_bytes_to_s3(bytes_to_upload, f"{s3_uri}/payload.pkl", s3_kms_key, sagemaker_session)
 
     sha256_hash = _compute_hash(bytes_to_upload, secret_key=hmac_key)

--- a/src/sagemaker/remote_function/core/stored_function.py
+++ b/src/sagemaker/remote_function/core/stored_function.py
@@ -14,6 +14,7 @@
 from __future__ import absolute_import
 
 import os
+from dataclasses import dataclass
 from typing import Any
 
 
@@ -34,6 +35,14 @@ RESULTS_FOLDER = "results"
 EXCEPTION_FOLDER = "exception"
 JSON_SERIALIZED_RESULT_KEY = "Result"
 JSON_RESULTS_FILE = "results.json"
+
+
+@dataclass
+class _SerializedData:
+    """Data class to store serialized function and arguments"""
+
+    func: bytes
+    args: bytes
 
 
 class StoredFunction:
@@ -105,6 +114,38 @@ class StoredFunction:
             s3_kms_key=self.s3_kms_key,
         )
 
+    def save_pipeline_step_function(self, serialized_data):
+        """Upload serialized function and arguments to s3.
+
+        Args:
+            serialized_data (_SerializedData): The serialized function
+                and function arguments of a function step.
+        """
+
+        logger.info(
+            "Uploading serialized function code to %s",
+            s3_path_join(self.func_upload_path, FUNCTION_FOLDER),
+        )
+        serialization._upload_payload_and_metadata_to_s3(
+            bytes_to_upload=serialized_data.func,
+            hmac_key=self.hmac_key,
+            s3_uri=s3_path_join(self.func_upload_path, FUNCTION_FOLDER),
+            sagemaker_session=self.sagemaker_session,
+            s3_kms_key=self.s3_kms_key,
+        )
+
+        logger.info(
+            "Uploading serialized function arguments to %s",
+            s3_path_join(self.func_upload_path, ARGUMENTS_FOLDER),
+        )
+        serialization._upload_payload_and_metadata_to_s3(
+            bytes_to_upload=serialized_data.args,
+            hmac_key=self.hmac_key,
+            s3_uri=s3_path_join(self.func_upload_path, ARGUMENTS_FOLDER),
+            sagemaker_session=self.sagemaker_session,
+            s3_kms_key=self.s3_kms_key,
+        )
+
     def load_and_invoke(self) -> Any:
         """Load and deserialize the function and the arguments and then execute it."""
 
@@ -134,6 +175,7 @@ class StoredFunction:
             args,
             kwargs,
             hmac_key=self.hmac_key,
+            s3_base_uri=self.s3_base_uri,
             sagemaker_session=self.sagemaker_session,
         )
 

--- a/src/sagemaker/remote_function/job.py
+++ b/src/sagemaker/remote_function/job.py
@@ -52,11 +52,8 @@ from sagemaker.session import get_execution_role, _logs_for_job, Session
 from sagemaker.utils import name_from_base, _tmpdir, resolve_value_from_config
 from sagemaker.s3 import s3_path_join, S3Uploader
 from sagemaker import vpc_utils
-from sagemaker.remote_function.core.stored_function import StoredFunction
-from sagemaker.remote_function.core.pipeline_variables import (
-    Context,
-    convert_pipeline_variables_to_pickleable,
-)
+from sagemaker.remote_function.core.stored_function import StoredFunction, _SerializedData
+from sagemaker.remote_function.core.pipeline_variables import Context
 from sagemaker.remote_function.runtime_environment.runtime_environment_manager import (
     RuntimeEnvironmentManager,
     _DependencySettings,
@@ -695,6 +692,7 @@ class _Job:
         func_args: tuple,
         func_kwargs: dict,
         run_info=None,
+        serialized_data: _SerializedData = None,
     ) -> dict:
         """Build the artifacts and generate the training job request."""
         from sagemaker.workflow.properties import Properties
@@ -732,12 +730,8 @@ class _Job:
                     func_step_s3_dir=step_compilation_context.pipeline_build_time,
                 ),
             )
-            converted_func_args, converted_func_kwargs = convert_pipeline_variables_to_pickleable(
-                s3_base_uri=s3_base_uri,
-                func_args=func_args,
-                func_kwargs=func_kwargs,
-            )
-            stored_function.save(func, *converted_func_args, **converted_func_kwargs)
+
+            stored_function.save_pipeline_step_function(serialized_data)
 
         stopping_condition = {
             "MaxRuntimeInSeconds": job_settings.max_runtime_in_seconds,

--- a/tests/integ/sagemaker/workflow/test_step_decorator.py
+++ b/tests/integ/sagemaker/workflow/test_step_decorator.py
@@ -858,3 +858,61 @@ def test_with_user_and_workdir_set_in_the_image(
             pipeline.delete()
         except Exception:
             pass
+
+
+def test_step_level_serialization(
+    sagemaker_session, role, pipeline_name, region_name, dummy_container_without_error
+):
+    os.environ["AWS_DEFAULT_REGION"] = region_name
+
+    _EXPECTED_STEP_A_OUTPUT = "This pipeline is a function."
+    _EXPECTED_STEP_B_OUTPUT = "This generates a function arg."
+
+    step_config = dict(
+        role=role,
+        image_uri=dummy_container_without_error,
+        instance_type=INSTANCE_TYPE,
+    )
+
+    # This pipeline function may clash with the pipeline object
+    # defined below.
+    # However, if the function and args serialization happen in
+    # step level, this clash won't happen.
+    def pipeline():
+        return _EXPECTED_STEP_A_OUTPUT
+
+    @step(**step_config)
+    def generator():
+        return _EXPECTED_STEP_B_OUTPUT
+
+    @step(**step_config)
+    def func_with_collision(var: str):
+        return f"{pipeline()} {var}"
+
+    step_output_a = generator()
+    step_output_b = func_with_collision(step_output_a)
+
+    pipeline = Pipeline(  # noqa: F811
+        name=pipeline_name,
+        steps=[step_output_b],
+        sagemaker_session=sagemaker_session,
+    )
+
+    try:
+        create_and_execute_pipeline(
+            pipeline=pipeline,
+            pipeline_name=pipeline_name,
+            region_name=region_name,
+            role=role,
+            no_of_steps=2,
+            last_step_name=get_step(step_output_b).name,
+            execution_parameters=dict(),
+            step_status="Succeeded",
+            step_result_type=str,
+            step_result_value=f"{_EXPECTED_STEP_A_OUTPUT} {_EXPECTED_STEP_B_OUTPUT}",
+        )
+    finally:
+        try:
+            pipeline.delete()
+        except Exception:
+            pass


### PR DESCRIPTION
*Issue #, if available:* For notebook users, if their custom step decorated function contains variables/classes with the same name of outer variables/classes, collision would take place and disrupt the pipeline compilation.
Moving the func and args serialization of function step from pipeline compilation to step level to resolve the issue.

*Description of changes:* Move func and args serialization of function step to step level

*Testing done:* unit and integ tests

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
