### PR TITLE
change: create role if needed in `get_execution_role`

### DIFF
--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -6908,8 +6908,8 @@ def get_execution_role(sagemaker_session=None, use_default=False):
     Throws an exception if role doesn't exist.
 
     Args:
-        sagemaker_session(Session): Current sagemaker session.
-        use_default(bool): Use a default role if `get_caller_identity_arn does not
+        sagemaker_session (Session): Current sagemaker session.
+        use_default (bool): Use a default role if ``get_caller_identity_arn`` does not
             return a correct role. This default role will be created if needed.
             Defaults to ``False``.
 

--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -6902,13 +6902,16 @@ def production_variant(
     return production_variant_configuration
 
 
-def get_execution_role(sagemaker_session=None):
+def get_execution_role(sagemaker_session=None, use_default=False):
     """Return the role ARN whose credentials are used to call the API.
 
     Throws an exception if role doesn't exist.
 
     Args:
-        sagemaker_session(Session): Current sagemaker session
+        sagemaker_session(Session): Current sagemaker session.
+        use_default(bool): Use a default role if `get_caller_identity_arn does not
+            return a correct role. This default role will be created if needed.
+            Defaults to ``False``.
 
     Returns:
         (str): The role ARN
@@ -6919,6 +6922,41 @@ def get_execution_role(sagemaker_session=None):
 
     if ":role/" in arn:
         return arn
+
+    if use_default:
+        default_role_name = "AmazonSageMaker-DefaultRole"
+
+        LOGGER.warning("Using default role: %s", default_role_name)
+
+        boto3_session = sagemaker_session.boto_session
+        permissions_policy = json.dumps(
+            {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Principal": {"Service": ["sagemaker.amazonaws.com"]},
+                        "Action": "sts:AssumeRole",
+                    }
+                ],
+            }
+        )
+        iam_client = boto3_session.client("iam")
+        try:
+            iam_client.get_role(RoleName=default_role_name)
+        except iam_client.exceptions.NoSuchEntityException:
+            iam_client.create_role(
+                RoleName=default_role_name, AssumeRolePolicyDocument=str(permissions_policy)
+            )
+
+            LOGGER.warning("Created new sagemaker execution role: %s", default_role_name)
+
+        iam_client.attach_role_policy(
+            PolicyArn="arn:aws:iam::aws:policy/AmazonSageMakerFullAccess",
+            RoleName=default_role_name,
+        )
+        return iam_client.get_role(RoleName=default_role_name)["Role"]["Arn"]
+
     message = (
         "The current AWS identity is not a role: {}, therefore it cannot be used as a "
         "SageMaker execution role"

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -15,6 +15,7 @@ from __future__ import absolute_import
 import copy
 import datetime
 import io
+import json
 import logging
 import os
 
@@ -530,6 +531,67 @@ def test_get_execution_role_throws_exception_if_arn_is_not_role_with_role_in_nam
     with pytest.raises(ValueError) as error:
         get_execution_role(session)
     assert "The current AWS identity is not a role" in str(error.value)
+
+
+def test_get_execution_role_get_default_role(caplog):
+    session = Mock()
+    session.get_caller_identity_arn.return_value = "arn:aws:iam::369233609183:user/marcos"
+
+    iam_client = Mock()
+    iam_client.get_role.return_value = {"Role": {"Arn": "foo-role"}}
+    boto_session = Mock()
+    boto_session.client.return_value = iam_client
+
+    session.boto_session = boto_session
+    actual = get_execution_role(session, use_default=True)
+
+    iam_client.get_role.assert_called_with(RoleName="AmazonSageMaker-DefaultRole")
+    iam_client.attach_role_policy.assert_called_with(
+        PolicyArn="arn:aws:iam::aws:policy/AmazonSageMakerFullAccess",
+        RoleName="AmazonSageMaker-DefaultRole",
+    )
+    assert "Using default role: AmazonSageMaker-DefaultRole" in caplog.text
+    assert actual == "foo-role"
+
+
+def test_get_execution_role_create_default_role(caplog):
+    session = Mock()
+    session.get_caller_identity_arn.return_value = "arn:aws:iam::369233609183:user/marcos"
+    permissions_policy = json.dumps(
+        {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Principal": {"Service": ["sagemaker.amazonaws.com"]},
+                    "Action": "sts:AssumeRole",
+                }
+            ],
+        }
+    )
+    iam_client = Mock()
+    iam_client.exceptions.NoSuchEntityException = Exception
+    iam_client.get_role = Mock(side_effect=[Exception(), {"Role": {"Arn": "foo-role"}}])
+
+    boto_session = Mock()
+    boto_session.client.return_value = iam_client
+
+    session.boto_session = boto_session
+
+    actual = get_execution_role(session, use_default=True)
+
+    iam_client.create_role.assert_called_with(
+        RoleName="AmazonSageMaker-DefaultRole", AssumeRolePolicyDocument=str(permissions_policy)
+    )
+
+    iam_client.attach_role_policy.assert_called_with(
+        PolicyArn="arn:aws:iam::aws:policy/AmazonSageMakerFullAccess",
+        RoleName="AmazonSageMaker-DefaultRole",
+    )
+
+    assert "Created new sagemaker execution role: AmazonSageMaker-DefaultRole" in caplog.text
+
+    assert actual == "foo-role"
 
 
 @patch(


### PR DESCRIPTION
*Issue #, if available:*

Closes https://github.com/aws/sagemaker-python-sdk/issues/300

*Description of changes:*

- New boolean argument `use_default` in `sagemaker.get_execution_role`: 
   - Use a default role if ``session.get_caller_identity_arn`` can not return a correct role. 
   - This default role will be created if needed. Defaults to ``False``.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
