### PR TITLE
fix: Add write permission to job output dirs for remote and step decorator running on non-root job user

### DIFF
--- a/tests/integ/sagemaker/conftest.py
+++ b/tests/integ/sagemaker/conftest.py
@@ -68,7 +68,12 @@ DOCKERFILE_TEMPLATE_WITH_USER_AND_WORKDIR = (
     "RUN curl 'https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip' -o 'awscliv2.zip' \
         && unzip awscliv2.zip \
         && ./aws/install\n\n"
+    "RUN apt install sudo\n"
     "RUN useradd -ms /bin/bash integ-test-user\n"
+    # Add the user to sudo group
+    "RUN usermod -aG sudo integ-test-user\n"
+    # Ensure passwords are not required for sudo group users
+    "RUN echo '%sudo ALL= (ALL) NOPASSWD:ALL' >> /etc/sudoers\n"
     "USER integ-test-user\n"
     "WORKDIR /home/integ-test-user\n"
     "COPY {source_archive} ./\n"

--- a/tests/integ/sagemaker/remote_function/test_decorator.py
+++ b/tests/integ/sagemaker/remote_function/test_decorator.py
@@ -747,6 +747,25 @@ def test_with_user_and_workdir_set_in_the_image(
     assert cuberoot(27) == 3
 
 
+def test_with_user_and_workdir_set_in_the_image_client_error_case(
+    sagemaker_session, dummy_container_with_user_and_workdir, cpu_instance_type
+):
+    client_error_message = "Testing client error in job."
+
+    @remote(
+        role=ROLE,
+        image_uri=dummy_container_with_user_and_workdir,
+        instance_type=cpu_instance_type,
+        sagemaker_session=sagemaker_session,
+    )
+    def my_func():
+        raise RuntimeError(client_error_message)
+
+    with pytest.raises(RuntimeError) as error:
+        my_func()
+    assert client_error_message in str(error)
+
+
 @pytest.mark.skip
 def test_decorator_with_spark_job(sagemaker_session, cpu_instance_type):
     @remote(

--- a/tests/unit/sagemaker/remote_function/runtime_environment/test_runtime_environment_manager.py
+++ b/tests/unit/sagemaker/remote_function/runtime_environment/test_runtime_environment_manager.py
@@ -12,11 +12,15 @@
 # language governing permissions and limitations under the License.
 from __future__ import absolute_import
 
+import subprocess
+
 import pytest
 from mock import patch, Mock
 import sys
 import shlex
 import os
+
+from mock.mock import MagicMock
 
 from sagemaker.remote_function.runtime_environment.runtime_environment_manager import (
     RuntimeEnvironmentManager,
@@ -413,3 +417,50 @@ def test_run_pre_exec_script_cmd_error(isfile):
         call_args = popen.call_args[0][0]
         expected_cmd = ["/bin/bash", "-eu", "path/to/pre_exec.sh"]
         assert call_args == expected_cmd
+
+
+@patch("subprocess.run")
+def test_change_dir_permission(mock_subprocess_run):
+    RuntimeEnvironmentManager().change_dir_permission(dirs=["a", "b", "c"], new_permission="777")
+    expected_command = ["sudo", "chmod", "-R", "777", "a", "b", "c"]
+    assert mock_subprocess_run.called_once_with(
+        expected_command, check=True, stderr=subprocess.PIPE
+    )
+
+
+@patch(
+    "subprocess.run",
+    MagicMock(side_effect=FileNotFoundError("[Errno 2] No such file or directory: 'sudo'")),
+)
+def test_change_dir_permission_and_no_sudo_installed():
+    with pytest.raises(RuntimeEnvironmentError) as error:
+        RuntimeEnvironmentManager().change_dir_permission(
+            dirs=["a", "b", "c"], new_permission="777"
+        )
+    assert (
+        "Please contact the image owner to install 'sudo' in the job container "
+        "and provide sudo privilege to the container user."
+    ) in str(error)
+
+
+@patch("subprocess.run", MagicMock(side_effect=FileNotFoundError("Other file not found error")))
+def test_change_dir_permission_and_sudo_installed_but_other_file_not_found_error():
+    with pytest.raises(RuntimeEnvironmentError) as error:
+        RuntimeEnvironmentManager().change_dir_permission(
+            dirs=["a", "b", "c"], new_permission="777"
+        )
+    assert "Other file not found error" in str(error)
+
+
+@patch("subprocess.run")
+def test_change_dir_permission_and_dir_not_exist(mock_subprocess_run):
+    mock_subprocess_run.side_effect = subprocess.CalledProcessError(
+        returncode=1,
+        cmd="sudo chmod ...",
+        stderr=b"chmod: cannot access ...: No such file or directory",
+    )
+    with pytest.raises(RuntimeEnvironmentError) as error:
+        RuntimeEnvironmentManager().change_dir_permission(
+            dirs=["a", "b", "c"], new_permission="777"
+        )
+    assert "chmod: cannot access ...: No such file or directory" in str(error)


### PR DESCRIPTION
*Issue #, if available:* This is a known issue on SageMaker Distribution image
If the step/remote decorated function is running in a job container with non-root user, it may not have the write permission to write job outputs to the following container folders: `/opt/ml/model /opt/ml/output /tmp`. 
This will lead to the job's silent failure as it's unable to write the exceptions to the output folder and as a result, the job is unaware that the invoked function has failed.

*Description of changes:*

*Testing done:* 
1. unit and integ tests
2. manually tested with the dev tar on SageMaker Distribution image

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [X] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [X] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [X] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [X] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [X] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [X] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [X] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [X] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [X] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
