### PR TITLE
Disable failed test in IR

### DIFF
--- a/tests/integ/test_inference_recommender.py
+++ b/tests/integ/test_inference_recommender.py
@@ -396,7 +396,6 @@ def test_default_right_size_and_deploy_unregistered_base_model(
             predictor.delete_model()
             predictor.delete_endpoint()
 
-
 @pytest.mark.slow_test
 @pytest.mark.flaky(reruns=3, reruns_delay=2)
 def test_advanced_right_size_and_deploy_unregistered_model_sklearn(
@@ -419,7 +418,7 @@ def test_advanced_right_size_and_deploy_unregistered_model_sklearn(
             predictor.delete_model()
             predictor.delete_endpoint()
 
-
+@pytest.mark.skip(reason="Skipping this test class for now")
 @pytest.mark.slow_test
 @pytest.mark.flaky(reruns=3, reruns_delay=2)
 def test_advanced_right_size_and_deploy_registered_model_sklearn(

--- a/tests/integ/test_inference_recommender.py
+++ b/tests/integ/test_inference_recommender.py
@@ -396,6 +396,7 @@ def test_default_right_size_and_deploy_unregistered_base_model(
             predictor.delete_model()
             predictor.delete_endpoint()
 
+
 @pytest.mark.slow_test
 @pytest.mark.flaky(reruns=3, reruns_delay=2)
 def test_advanced_right_size_and_deploy_unregistered_model_sklearn(
@@ -417,6 +418,7 @@ def test_advanced_right_size_and_deploy_unregistered_model_sklearn(
         finally:
             predictor.delete_model()
             predictor.delete_endpoint()
+
 
 @pytest.mark.skip(reason="Skipping this test class for now")
 @pytest.mark.slow_test


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
