### PR TITLE
fix: change ConditionNot incorrect property Expression to Condition

### DIFF
--- a/src/sagemaker/local/pipeline.py
+++ b/src/sagemaker/local/pipeline.py
@@ -444,7 +444,7 @@ class _ConditionStepExecutor(_StepExecutor):
             True if given ConditionNot evaluated as true,
             False otherwise.
         """
-        return not self._resolve_condition(not_condition["Expression"])
+        return not self._resolve_condition(not_condition["Condition"])
 
     def _resolve_or_condition(self, or_condition: dict):
         """Resolve given ConditionOr.

--- a/src/sagemaker/workflow/conditions.py
+++ b/src/sagemaker/workflow/conditions.py
@@ -259,7 +259,7 @@ class ConditionNot(Condition):
 
     def to_request(self) -> RequestType:
         """Get the request structure for workflow service calls."""
-        return {"Type": self.condition_type.value, "Expression": self.expression.to_request()}
+        return {"Type": self.condition_type.value, "Condition": self.expression.to_request()}
 
     @property
     def _referenced_steps(self) -> List[str]:

--- a/tests/integ/sagemaker/workflow/test_fail_steps.py
+++ b/tests/integ/sagemaker/workflow/test_fail_steps.py
@@ -17,7 +17,7 @@ import pytest
 from tests.integ.sagemaker.workflow.helpers import wait_pipeline_execution
 from sagemaker import get_execution_role, utils
 from sagemaker.workflow.condition_step import ConditionStep
-from sagemaker.workflow.conditions import ConditionEquals
+from sagemaker.workflow.conditions import ConditionEquals, ConditionNot
 from sagemaker.workflow.fail_step import FailStep
 
 from sagemaker.workflow.functions import Join
@@ -37,14 +37,15 @@ def pipeline_name():
 
 def test_two_step_fail_pipeline_with_str_err_msg(sagemaker_session, role, pipeline_name):
     param = ParameterInteger(name="MyInt", default_value=2)
-    cond = ConditionEquals(left=param, right=1)
+    cond_equal = ConditionEquals(left=param, right=2)
+    cond_not_equal = ConditionNot(cond_equal)
     step_fail = FailStep(
         name="FailStep",
         error_message="Failed due to hitting in else branch",
     )
     step_cond = ConditionStep(
         name="CondStep",
-        conditions=[cond],
+        conditions=[cond_not_equal],
         if_steps=[],
         else_steps=[step_fail],
     )

--- a/tests/unit/sagemaker/workflow/test_condition_step.py
+++ b/tests/unit/sagemaker/workflow/test_condition_step.py
@@ -202,7 +202,7 @@ def test_pipeline_condition_step_interpolated(sagemaker_session):
                         },
                         {
                             "Type": "Not",
-                            "Expression": {
+                            "Condition": {
                                 "Type": "Equals",
                                 "LeftValue": {"Get": "Parameters.MyInt1"},
                                 "RightValue": {"Get": "Parameters.MyInt2"},
@@ -210,7 +210,7 @@ def test_pipeline_condition_step_interpolated(sagemaker_session):
                         },
                         {
                             "Type": "Not",
-                            "Expression": {
+                            "Condition": {
                                 "Type": "In",
                                 "QueryValue": {"Get": "Parameters.MyStr"},
                                 "Values": ["abc", "def"],
@@ -533,9 +533,9 @@ def test_depends_on_condition_not_upstream_delayed_returns(sagemaker_session_moc
             assert len(step_dsl["Arguments"]["Conditions"]) == 1
             condition_dsl = step_dsl["Arguments"]["Conditions"][0]
             assert condition_dsl["Type"] == "Not"
-            cond_expr_dsl = condition_dsl["Expression"]
+            cond_expr_dsl = condition_dsl["Condition"]
             assert cond_expr_dsl["Type"] == "Not"
-            cond_inner_expr_dsl = cond_expr_dsl["Expression"]
+            cond_inner_expr_dsl = cond_expr_dsl["Condition"]
             assert cond_inner_expr_dsl["Type"] == "Or"
             assert len(cond_inner_expr_dsl["Conditions"]) == 2
             assert cond_inner_expr_dsl["Conditions"][0]["LeftValue"] == _get_expected_jsonget_expr(
@@ -602,7 +602,7 @@ def test_depends_on_condition_in_upstream_delayed_returns(sagemaker_session_mock
             assert len(step_dsl["Arguments"]["Conditions"]) == 1
             condition_dsl = step_dsl["Arguments"]["Conditions"][0]
             assert condition_dsl["Type"] == "Not"
-            cond_expr_dsl = condition_dsl["Expression"]
+            cond_expr_dsl = condition_dsl["Condition"]
             assert cond_expr_dsl["Type"] == "In"
             assert cond_expr_dsl["QueryValue"] == _get_expected_jsonget_expr(
                 step_name=step_output3._step.name, path="Result"

--- a/tests/unit/sagemaker/workflow/test_conditions.py
+++ b/tests/unit/sagemaker/workflow/test_conditions.py
@@ -122,7 +122,7 @@ def test_condition_not():
     cond_not = ConditionNot(expression=cond_eq)
     assert cond_not.to_request() == {
         "Type": "Not",
-        "Expression": {
+        "Condition": {
             "Type": "Equals",
             "LeftValue": param,
             "RightValue": "foo",
@@ -136,7 +136,7 @@ def test_condition_not_in():
     cond_not = ConditionNot(expression=cond_in)
     assert cond_not.to_request() == {
         "Type": "Not",
-        "Expression": {
+        "Condition": {
             "Type": "In",
             "QueryValue": param,
             "Values": ["abc", "def"],


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/sagemaker-python-sdk/issues/2746

*Description of changes:* change ConditionNot incorrect property Expression to Condition

*Testing done:* unit and integ tests

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
