### PR TITLE
fix: Support using PipelineDefinitionConfig in local mode

### DIFF
--- a/src/sagemaker/local/pipeline.py
+++ b/src/sagemaker/local/pipeline.py
@@ -273,8 +273,10 @@ class _TrainingStepExecutor(_StepExecutor):
     """Executor class to execute TrainingStep locally"""
 
     def execute(self):
-        job_name = unique_name_from_base(self.step.name)
         step_arguments = self.pipline_executor.evaluate_step_arguments(self.step)
+        job_name = step_arguments.pop("TrainingJobName", None) or unique_name_from_base(
+            self.step.name
+        )
         try:
             self.pipline_executor.local_sagemaker_client.create_training_job(
                 job_name, **step_arguments
@@ -290,8 +292,10 @@ class _ProcessingStepExecutor(_StepExecutor):
     """Executor class to execute ProcessingStep locally"""
 
     def execute(self):
-        job_name = unique_name_from_base(self.step.name)
         step_arguments = self.pipline_executor.evaluate_step_arguments(self.step)
+        job_name = step_arguments.pop("ProcessingJobName", None) or unique_name_from_base(
+            self.step.name
+        )
         try:
             self.pipline_executor.local_sagemaker_client.create_processing_job(
                 job_name, **step_arguments
@@ -482,8 +486,10 @@ class _TransformStepExecutor(_StepExecutor):
     """Executor class to execute TransformStep locally"""
 
     def execute(self):
-        job_name = unique_name_from_base(self.step.name)
         step_arguments = self.pipline_executor.evaluate_step_arguments(self.step)
+        job_name = step_arguments.pop("TransformJobName", None) or unique_name_from_base(
+            self.step.name
+        )
         try:
             self.pipline_executor.local_sagemaker_client.create_transform_job(
                 job_name, **step_arguments


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/sagemaker-python-sdk/issues/4307

Using PipelineDefinitionConfig in local mode would come across the error below:

```
Pipeline step 'preprocess-data' FAILED. Failure message is: TypeError: create_processing_job() got multiple values for argument 
```

*Description of changes:*  Honor the job name defined in base_job_name if PipelineDefinitionConfig is opted in. Otherwise, it falls back to the existing behavior, which is set the job name as per the step name

*Testing done:* Unit tests

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
