### PR TITLE
fix: Add validation for empty ParameterString value in start local pipeline

### DIFF
--- a/src/sagemaker/local/entities.py
+++ b/src/sagemaker/local/entities.py
@@ -845,6 +845,12 @@ class _LocalPipelineExecution(object):
                         "{}.".format(param_name, parameter_type.python_type, type(param_value))
                     )
                     raise ClientError(error_msg, "start_pipeline_execution")
+                if param_value == "":
+                    error_msg = self._construct_validation_exception_message(
+                        'Parameter {} value "" is too short (length: 0, '
+                        "required minimum: 1).".format(param_name)
+                    )
+                    raise ClientError(error_msg, "start_pipeline_execution")
                 merged_parameters[param_name] = param_value
         for param_name, default_parameter in default_parameters.items():
             if param_name not in merged_parameters:

--- a/tests/integ/test_local_mode.py
+++ b/tests/integ/test_local_mode.py
@@ -908,6 +908,7 @@ def test_local_pipeline_with_step_decorator_and_condition_step(
             assert exe_step_result["Metadata"]["Condition"]["Outcome"] is True
 
 
+@pytest.mark.local_mode
 def test_local_pipeline_with_step_decorator_data_referenced_by_other_steps(
     local_pipeline_session,
     dummy_container,
@@ -987,6 +988,7 @@ def test_local_pipeline_with_step_decorator_data_referenced_by_other_steps(
             assert exe_step_result["Metadata"]["Condition"]["Outcome"] is True
 
 
+@pytest.mark.local_mode
 def test_local_remote_function_with_additional_dependencies(
     local_pipeline_session, dummy_container
 ):


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/sagemaker-python-sdk/issues/4016

*Description of changes:* Add validation for empty ParameterString value in start local pipeline to make the behavior consistent with the remote mode

*Testing done:* unit test

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
