### PR TITLE
feat: add throughput management support for feature group

### DIFF
--- a/doc/api/prep_data/feature_store.rst
+++ b/doc/api/prep_data/feature_store.rst
@@ -75,6 +75,14 @@ Inputs
     :members:
     :show-inheritance:
 
+.. autoclass:: sagemaker.feature_store.inputs.ThroughputConfig
+    :members:
+    :show-inheritance:
+
+.. autoclass:: sagemaker.feature_store.inputs.ThroughputConfigUpdate
+    :members:
+    :show-inheritance:
+
 .. autoclass:: sagemaker.feature_store.inputs.OnlineStoreConfig
     :members:
     :show-inheritance:
@@ -96,6 +104,10 @@ Inputs
     :show-inheritance:
 
 .. autoclass:: sagemaker.feature_store.inputs.OnlineStoreStorageTypeEnum
+    :members:
+    :show-inheritance:
+
+.. autoclass:: sagemaker.feature_store.inputs.ThroughputModeEnum
     :members:
     :show-inheritance:
 

--- a/src/sagemaker/feature_store/feature_group.py
+++ b/src/sagemaker/feature_store/feature_group.py
@@ -64,6 +64,8 @@ from sagemaker.feature_store.inputs import (
     TtlDuration,
     OnlineStoreConfigUpdate,
     OnlineStoreStorageTypeEnum,
+    ThroughputConfig,
+    ThroughputConfigUpdate,
 )
 from sagemaker.utils import resolve_value_from_config, format_tags, Tags
 
@@ -541,6 +543,7 @@ class FeatureGroup:
         tags: Optional[Tags] = None,
         table_format: TableFormatEnum = None,
         online_store_storage_type: OnlineStoreStorageTypeEnum = None,
+        throughput_config: ThroughputConfig = None,
     ) -> Dict[str, Any]:
         """Create a SageMaker FeatureStore FeatureGroup.
 
@@ -570,6 +573,8 @@ class FeatureGroup:
             table_format (TableFormatEnum): format of the offline store table (default: None).
             online_store_storage_type (OnlineStoreStorageTypeEnum): storage type for the
                 online store (default: None).
+            throughput_config (ThroughputConfig): throughput configuration of the
+                feature group (default: None).
 
         Returns:
             Response dict from service.
@@ -618,6 +623,9 @@ class FeatureGroup:
                 )
             create_feature_store_args.update({"online_store_config": online_store_config.to_dict()})
 
+        if throughput_config:
+            create_feature_store_args.update({"throughput_config": throughput_config.to_dict()})
+
         # offline store configuration
         if s3_uri:
             s3_storage_config = S3StorageConfig(s3_uri=s3_uri)
@@ -656,17 +664,17 @@ class FeatureGroup:
         self,
         feature_additions: Sequence[FeatureDefinition] = None,
         online_store_config: OnlineStoreConfigUpdate = None,
+        throughput_config: ThroughputConfigUpdate = None,
     ) -> Dict[str, Any]:
         """Update a FeatureGroup and add new features from the given feature definitions.
 
         Args:
             feature_additions (Sequence[Dict[str, str]): list of feature definitions to be updated.
             online_store_config (OnlineStoreConfigUpdate): online store config to be updated.
-
+            throughput_config (ThroughputConfigUpdate): target throughput configuration
         Returns:
             Response dict from service.
         """
-
         if feature_additions is None:
             feature_additions_parameter = None
         else:
@@ -679,10 +687,15 @@ class FeatureGroup:
         else:
             online_store_config_parameter = online_store_config.to_dict()
 
+        throughput_config_parameter = (
+            None if throughput_config is None else throughput_config.to_dict()
+        )
+
         return self.sagemaker_session.update_feature_group(
             feature_group_name=self.name,
             feature_additions=feature_additions_parameter,
             online_store_config=online_store_config_parameter,
+            throughput_config=throughput_config_parameter,
         )
 
     def update_feature_metadata(

--- a/src/sagemaker/feature_store/inputs.py
+++ b/src/sagemaker/feature_store/inputs.py
@@ -453,3 +453,65 @@ class ExpirationTimeResponseEnum(Enum):
 
     DISABLED = "Disabled"
     ENABLED = "Enabled"
+
+
+class ThroughputModeEnum(Enum):
+    """Enum of throughput modes supported by feature group.
+
+    Throughput mode of feature group can be ON_DEMAND or PROVISIONED.
+    """
+
+    ON_DEMAND = "OnDemand"
+    PROVISIONED = "Provisioned"
+
+
+@attr.s
+class ThroughputConfig(Config):
+    """Throughput configuration of the feature group.
+
+    Throughput configuration can be ON_DEMAND, or PROVISIONED with valid values for
+    read and write capacity units. ON_DEMAND works best for less predictable traffic,
+    while PROVISIONED works best for consistent and predictable traffic.
+    """
+
+    mode: ThroughputModeEnum = attr.ib(default=None)
+    provisioned_read_capacity_units: int = attr.ib(default=None)
+    provisioned_write_capacity_units: int = attr.ib(default=None)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Construct a dictionary based on the attributes provided.
+
+        Returns:
+            dict represents the attributes.
+        """
+        return Config.construct_dict(
+            ThroughputMode=self.mode.value if self.mode else None,
+            ProvisionedReadCapacityUnits=self.provisioned_read_capacity_units,
+            ProvisionedWriteCapacityUnits=self.provisioned_write_capacity_units,
+        )
+
+
+@attr.s
+class ThroughputConfigUpdate(Config):
+    """Target throughput configuration of the feature group being updated.
+
+    Target throughput configuration can be ON_DEMAND, or PROVISIONED with valid values for
+    read and write capacity units. ON_DEMAND works best for less predictable traffic,
+    while PROVISIONED works best for consistent and predictable traffic.
+    """
+
+    mode: ThroughputModeEnum = attr.ib(default=None)
+    provisioned_read_capacity_units: int = attr.ib(default=None)
+    provisioned_write_capacity_units: int = attr.ib(default=None)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Construct a dictionary based on the attributes provided.
+
+        Returns:
+            dict represents the attributes.
+        """
+        return Config.construct_dict(
+            ThroughputMode=self.mode.value if self.mode else None,
+            ProvisionedReadCapacityUnits=self.provisioned_read_capacity_units,
+            ProvisionedWriteCapacityUnits=self.provisioned_write_capacity_units,
+        )

--- a/src/sagemaker/feature_store/inputs.py
+++ b/src/sagemaker/feature_store/inputs.py
@@ -472,6 +472,13 @@ class ThroughputConfig(Config):
     Throughput configuration can be ON_DEMAND, or PROVISIONED with valid values for
     read and write capacity units. ON_DEMAND works best for less predictable traffic,
     while PROVISIONED works best for consistent and predictable traffic.
+
+    Attributes:
+        mode (ThroughputModeEnum): Throughput mode
+        provisioned_read_capacity_units (int): For provisioned feature groups, this indicates
+            the read throughput you are billed for and can consume without throttling.
+        provisioned_write_capacity_units (int):  For provisioned feature groups, this indicates
+            the write throughput you are billed for and can consume without throttling.
     """
 
     mode: ThroughputModeEnum = attr.ib(default=None)
@@ -493,11 +500,18 @@ class ThroughputConfig(Config):
 
 @attr.s
 class ThroughputConfigUpdate(Config):
-    """Target throughput configuration of the feature group being updated.
+    """Target throughput configuration for the feature group.
 
     Target throughput configuration can be ON_DEMAND, or PROVISIONED with valid values for
     read and write capacity units. ON_DEMAND works best for less predictable traffic,
     while PROVISIONED works best for consistent and predictable traffic.
+
+    Attributes:
+        mode (ThroughputModeEnum): Target throughput mode
+        provisioned_read_capacity_units (int): For provisioned feature groups, this indicates
+            the read throughput you are billed for and can consume without throttling.
+        provisioned_write_capacity_units (int):  For provisioned feature groups, this indicates
+            the write throughput you are billed for and can consume without throttling.
     """
 
     mode: ThroughputModeEnum = attr.ib(default=None)

--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -5679,6 +5679,7 @@ class Session(object):  # pylint: disable=too-many-public-methods
         role_arn: str = None,
         online_store_config: Dict[str, str] = None,
         offline_store_config: Dict[str, str] = None,
+        throughput_config: Dict[str, Any] = None,
         description: str = None,
         tags: Optional[Tags] = None,
     ) -> Dict[str, Any]:
@@ -5694,6 +5695,8 @@ class Session(object):  # pylint: disable=too-many-public-methods
                 feature online store.
             offline_store_config (Dict[str, str]): dict contains configuration of the
                 feature offline store.
+            throughput_config (Dict[str, str]): dict contains throughput configuration
+                for the feature group.
             description (str): description of the FeatureGroup.
             tags (Optional[Tags]): tags for labeling a FeatureGroup.
 
@@ -5729,6 +5732,7 @@ class Session(object):  # pylint: disable=too-many-public-methods
             kwargs,
             OnlineStoreConfig=inferred_online_store_from_config,
             OfflineStoreConfig=inferred_offline_store_from_config,
+            ThroughputConfig=throughput_config,
             Description=description,
             Tags=tags,
         )
@@ -5757,28 +5761,32 @@ class Session(object):  # pylint: disable=too-many-public-methods
         feature_group_name: str,
         feature_additions: Sequence[Dict[str, str]] = None,
         online_store_config: Dict[str, any] = None,
+        throughput_config: Dict[str, Any] = None,
     ) -> Dict[str, Any]:
         """Update a FeatureGroup
 
-            either adding new features from the given feature definitions
-            or updating online store config
+            Supports modifications like adding new features from the given feature definitions,
+            updating online store and throughput configurations.
 
         Args:
             feature_group_name (str): name of the FeatureGroup to update.
             feature_additions (Sequence[Dict[str, str]): list of feature definitions to be updated.
+            online_store_config (Dict[str, Any]): updates to online store config
+            throughput_config (Dict[str, Any]): target throughput configuration of the feature group
         Returns:
             Response dict from service.
         """
+        update_req = {"FeatureGroupName": feature_group_name}
+        if online_store_config is not None:
+            update_req["OnlineStoreConfig"] = online_store_config
 
-        if feature_additions is None:
-            return self.sagemaker_client.update_feature_group(
-                FeatureGroupName=feature_group_name,
-                OnlineStoreConfig=online_store_config,
-            )
+        if throughput_config is not None:
+            update_req["ThroughputConfig"] = throughput_config
 
-        return self.sagemaker_client.update_feature_group(
-            FeatureGroupName=feature_group_name, FeatureAdditions=feature_additions
-        )
+        if feature_additions is not None:
+            update_req["FeatureAdditions"] = feature_additions
+
+        return self.sagemaker_client.update_feature_group(**update_req)
 
     def list_feature_groups(
         self,

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -5134,7 +5134,7 @@ def test_feature_group_describe(sagemaker_session):
     )
 
 
-def test_feature_group_update(sagemaker_session, feature_group_dummy_definitions):
+def test_feature_group_feature_additions_update(sagemaker_session, feature_group_dummy_definitions):
     sagemaker_session.update_feature_group(
         feature_group_name="MyFeatureGroup",
         feature_additions=feature_group_dummy_definitions,
@@ -5142,6 +5142,32 @@ def test_feature_group_update(sagemaker_session, feature_group_dummy_definitions
     assert sagemaker_session.sagemaker_client.update_feature_group.called_with(
         FeatureGroupName="MyFeatureGroup",
         FeatureAdditions=feature_group_dummy_definitions,
+    )
+
+
+def test_feature_group_online_store_config_update(sagemaker_session):
+    os_conf_update = {"TtlDuration": {"Unit": "Seconds", "Value": 123}}
+    sagemaker_session.update_feature_group(
+        feature_group_name="MyFeatureGroup",
+        online_store_config=os_conf_update,
+    )
+    assert sagemaker_session.sagemaker_client.update_feature_group.called_with(
+        FeatureGroupName="MyFeatureGroup", OnlineStoreConfig=os_conf_update
+    )
+
+
+def test_feature_group_throughput_config_update(sagemaker_session):
+    tp_update = {
+        "ThroughputMode": "Provisioned",
+        "ProvisionedReadCapacityUnits": 123,
+        "ProvisionedWriteCapacityUnits": 456,
+    }
+    sagemaker_session.update_feature_group(
+        feature_group_name="MyFeatureGroup",
+        throughput_config=tp_update,
+    )
+    assert sagemaker_session.sagemaker_client.update_feature_group.called_with(
+        FeatureGroupName="MyFeatureGroup", ThroughputConfig=tp_update
     )
 
 


### PR DESCRIPTION
**Issue #, if available:**
None. Feature addition PR. 

**Description of changes:**
SageMaker Feature store recently launched `Provisioned` throughput mode for Feature Groups. This PR is modifying feature store interface to accept an optional throughput configuration that will be included in `create_feature_group` and `update_feature_group` API invocations. 

[AWS documentation about throughput modes](https://docs.aws.amazon.com/sagemaker/latest/dg/feature-store-throughput-mode.html). 

Requires `boto3>=1.34.13`. 

**Testing done:**
* Wrote new unit tests and ran them successfully.
* Wrote new integ tests and ran them successfully.

## Merge Checklist

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
