### PR TITLE
fix: remove fastapi and uvicorn dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,8 +65,6 @@ required_packages = [
     "platformdirs",
     "tblib>=1.7.0,<3",
     "urllib3<1.27",
-    "uvicorn==0.22.0",
-    "fastapi==0.95.2",
     "requests",
     "docker",
     "tqdm",


### PR DESCRIPTION
They are not used in the codebase.

Closes #4361 #4295

*Issue #, if available:* #4361 #4295

*Description of changes:*
I cannot tell why these are in the install requirements. Searching the codebase for fastapi-related imports yields nothing. 

Happy to move them to an extra if there is a feature I'm missing but as far as I can tell they are never imported.

*Testing done:*
Noticed a bunch of web app related dependencies in our SBOM's and traced it back to this. git grepping for imports doesn't show they are used.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
