### PR TITLE
fix: add warning message for job-prefixed pipeline steps when no job name is provided

### DIFF
--- a/src/sagemaker/workflow/utilities.py
+++ b/src/sagemaker/workflow/utilities.py
@@ -41,6 +41,14 @@ DEF_CONFIG_WARN_MSG_TEMPLATE = (
     "if desired."
 )
 
+JOB_KEY_NONE_WARN_MSG_TEMPLATE = (
+    "Invalid input: use_custom_job_prefix flag is set but the name field [{}] has not been "
+    "specified. Please refer to the AWS Docs to identify which field should be set to enable the "
+    "custom-prefixing feature for jobs created via a pipeline execution. "
+    "https://docs.aws.amazon.com/sagemaker/latest/dg/"
+    "build-and-manage-access.html#build-and-manage-step-permissions-prefix"
+)
+
 if TYPE_CHECKING:
     from sagemaker.workflow.step_collections import StepCollection
 
@@ -458,6 +466,8 @@ def trim_request_dict(request_dict, job_key, config):
         request_dict.pop(job_key, None)  # safely return null in case of KeyError
     else:
         if job_key in request_dict:
+            if request_dict[job_key] is None or len(request_dict[job_key]) == 0:
+                raise ValueError(JOB_KEY_NONE_WARN_MSG_TEMPLATE.format(job_key))
             request_dict[job_key] = base_from_name(request_dict[job_key])  # trim timestamp
 
     return request_dict


### PR DESCRIPTION
*Issue #, if available:*
- Add warning message for when customers are using custom-prefixing in their pipelines and do NOT specify a job-name to prefix.
- E.G. Cx fails to provide model-name here
```
tuning_step_prefix = prefix + "/Training_Artifacts"
model = Model(
    image_uri=image_uri,
    model_data=step_tuning.get_top_model_s3_uri(
        top_k=0, s3_bucket=bucket, prefix=tuning_step_prefix
    ),
    sagemaker_session=pipeline_session,
    role=role,
    name="A_Name" <<<<<<<<<<<<<<<<<<<<<<<<<<<<
)
```
results in this error
```
TypeError: expected string or byte like object
```

*Description of changes:*

*Testing done:*
-unit 
## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
