### PR TITLE
feat: Support selective pipeline execution for function step

### DIFF
--- a/src/sagemaker/remote_function/runtime_environment/runtime_environment_manager.py
+++ b/src/sagemaker/remote_function/runtime_environment/runtime_environment_manager.py
@@ -252,7 +252,7 @@ class RuntimeEnvironmentManager:
 
     def _install_requirements_txt(self, local_path, python_executable):
         """Install requirements.txt file"""
-        cmd = f"{python_executable} -m pip install -r {local_path}"
+        cmd = f"{python_executable} -m pip install -r {local_path} -U"
         logger.info("Running command: '%s' in the dir: '%s' ", cmd, os.getcwd())
         _run_shell_cmd(cmd)
         logger.info("Command %s ran successfully", cmd)
@@ -268,7 +268,7 @@ class RuntimeEnvironmentManager:
     def _install_req_txt_in_conda_env(self, env_name, local_path):
         """Install requirements.txt in the given conda environment"""
 
-        cmd = f"{self._get_conda_exe()} run -n {env_name} pip install -r {local_path}"
+        cmd = f"{self._get_conda_exe()} run -n {env_name} pip install -r {local_path} -U"
         logger.info("Activating conda env and installing requirements: %s", cmd)
         _run_shell_cmd(cmd)
         logger.info("Requirements installed successfully in conda env %s", env_name)

--- a/src/sagemaker/workflow/function_step.py
+++ b/src/sagemaker/workflow/function_step.py
@@ -34,6 +34,7 @@ from sagemaker.workflow.entities import (
 )
 
 from sagemaker.workflow.execution_variables import ExecutionVariables
+from sagemaker.workflow.properties import Properties
 from sagemaker.workflow.retry import RetryPolicy
 from sagemaker.workflow.steps import Step, ConfigurableRetryStep, StepTypeEnum
 from sagemaker.workflow.step_collections import StepCollection
@@ -100,6 +101,12 @@ class _FunctionStep(ConfigurableRetryStep):
         self._step_kwargs = kwargs
 
         self.__job_settings = None
+
+        # It's for internal usage to retrieve execution id from the properties.
+        # However, we won't expose the properties of function step to customers.
+        self._properties = Properties(
+            step_name=name, step=self, shape_name="DescribeTrainingJobResponse"
+        )
 
         (
             self._converted_func_args,

--- a/src/sagemaker/workflow/pipeline.py
+++ b/src/sagemaker/workflow/pipeline.py
@@ -1039,11 +1039,19 @@ def get_function_step_result(
         raise ValueError(_ERROR_MSG_OF_WRONG_STEP_TYPE)
     s3_output_path = describe_training_job_response["OutputDataConfig"]["S3OutputPath"]
 
+    s3_uri_suffix = s3_path_join(execution_id, step_name, RESULTS_FOLDER)
+    if s3_output_path.endswith(s3_uri_suffix) or s3_output_path[0:-1].endswith(s3_uri_suffix):
+        s3_uri = s3_output_path
+    else:
+        # This is the obsoleted version of s3_output_path
+        # Keeping it for backward compatible
+        s3_uri = s3_path_join(s3_output_path, s3_uri_suffix)
+
     job_status = describe_training_job_response["TrainingJobStatus"]
     if job_status == "Completed":
         return deserialize_obj_from_s3(
             sagemaker_session=sagemaker_session,
-            s3_uri=s3_path_join(s3_output_path, execution_id, step_name, RESULTS_FOLDER),
+            s3_uri=s3_uri,
             hmac_key=describe_training_job_response["Environment"]["REMOTE_FUNCTION_SECRET_KEY"],
         )
 

--- a/tests/integ/sagemaker/workflow/helpers.py
+++ b/tests/integ/sagemaker/workflow/helpers.py
@@ -39,18 +39,24 @@ def create_and_execute_pipeline(
     step_result_type=None,
     step_result_value=None,
     wait_duration=400,  # seconds
+    selective_execution_config=None,
 ):
-    response = pipeline.create(role)
+    create_arn = None
+    if not selective_execution_config:
+        response = pipeline.create(role)
+        create_arn = response["PipelineArn"]
+        assert re.match(
+            rf"arn:aws:sagemaker:{region_name}:\d{{12}}:pipeline/{pipeline_name}",
+            create_arn,
+        )
 
-    create_arn = response["PipelineArn"]
-    assert re.match(
-        rf"arn:aws:sagemaker:{region_name}:\d{{12}}:pipeline/{pipeline_name}",
-        create_arn,
+    execution = pipeline.start(
+        parameters=execution_parameters, selective_execution_config=selective_execution_config
     )
 
-    execution = pipeline.start(parameters=execution_parameters)
-    response = execution.describe()
-    assert response["PipelineArn"] == create_arn
+    if create_arn:
+        response = execution.describe()
+        assert response["PipelineArn"] == create_arn
 
     wait_pipeline_execution(execution=execution, delay=20, max_attempts=int(wait_duration / 20))
 
@@ -71,6 +77,16 @@ def create_and_execute_pipeline(
     if step_result_value:
         result = execution.result(execution_steps[0]["StepName"])
         assert result == step_result_value, f"Expected {step_result_value}, instead found {result}"
+
+    if selective_execution_config:
+        for exe_step in execution_steps:
+            if exe_step["StepName"] in selective_execution_config.selected_steps:
+                continue
+            assert (
+                exe_step["SelectiveExecutionResult"]["SourcePipelineExecutionArn"]
+                == selective_execution_config.source_pipeline_execution_arn
+            )
+
     return execution, execution_steps
 
 

--- a/tests/integ/sagemaker/workflow/test_selective_execution.py
+++ b/tests/integ/sagemaker/workflow/test_selective_execution.py
@@ -1,0 +1,201 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from __future__ import absolute_import
+
+import os
+
+import pytest
+
+from tests.integ import DATA_DIR
+from sagemaker.sklearn import SKLearnProcessor
+from sagemaker.workflow.step_outputs import get_step
+
+from sagemaker.workflow.selective_execution_config import SelectiveExecutionConfig
+
+from tests.integ.sagemaker.workflow.helpers import create_and_execute_pipeline
+from sagemaker import utils, get_execution_role
+from sagemaker.workflow.function_step import step
+from sagemaker.workflow.pipeline import Pipeline
+from sagemaker.workflow.steps import ProcessingStep
+
+INSTANCE_TYPE = "ml.m5.large"
+
+
+@pytest.fixture
+def role(sagemaker_session):
+    return get_execution_role(sagemaker_session)
+
+
+@pytest.fixture
+def region_name(sagemaker_session):
+    return sagemaker_session.boto_session.region_name
+
+
+@pytest.fixture
+def pipeline_name():
+    return utils.unique_name_from_base("Selective-Pipeline")
+
+
+def test_selective_execution_among_pure_function_steps(
+    sagemaker_session, role, pipeline_name, region_name, dummy_container_without_error
+):
+    # Test Selective Pipeline Execution on function step1 -> [select: function step2]
+    os.environ["AWS_DEFAULT_REGION"] = region_name
+
+    step_settings = dict(
+        role=role,
+        instance_type=INSTANCE_TYPE,
+        image_uri=dummy_container_without_error,
+        keep_alive_period_in_seconds=60,
+    )
+
+    @step(**step_settings)
+    def generator() -> tuple:
+        return 3, 4
+
+    @step(**step_settings)
+    def sum(a, b):
+        """adds two numbers"""
+        return a + b
+
+    step_output_a = generator()
+    step_output_b = sum(step_output_a[0], step_output_a[1])
+
+    pipeline = Pipeline(
+        name=pipeline_name,
+        steps=[step_output_b],
+        sagemaker_session=sagemaker_session,
+    )
+
+    try:
+        execution, _ = create_and_execute_pipeline(
+            pipeline=pipeline,
+            pipeline_name=pipeline_name,
+            region_name=region_name,
+            role=role,
+            no_of_steps=2,
+            last_step_name="sum",
+            execution_parameters=dict(),
+            step_status="Succeeded",
+            step_result_type=int,
+            step_result_value=7,
+        )
+
+        create_and_execute_pipeline(
+            pipeline=pipeline,
+            pipeline_name=pipeline_name,
+            region_name=region_name,
+            role=role,
+            no_of_steps=2,
+            last_step_name="sum",
+            execution_parameters=dict(),
+            step_status="Succeeded",
+            step_result_type=int,
+            step_result_value=7,
+            selective_execution_config=SelectiveExecutionConfig(
+                source_pipeline_execution_arn=execution.arn,
+                selected_steps=[get_step(step_output_b).name],
+            ),
+        )
+
+    finally:
+        try:
+            pipeline.delete()
+        except Exception:
+            pass
+
+
+def test_selective_execution_of_regular_step_depended_by_function_step(
+    sagemaker_session,
+    role,
+    pipeline_name,
+    region_name,
+    dummy_container_without_error,
+    sklearn_latest_version,
+):
+    # Test Selective Pipeline Execution on regular step -> [select: function step]
+    os.environ["AWS_DEFAULT_REGION"] = region_name
+
+    script_path = os.path.join(DATA_DIR, "dummy_script.py")
+
+    sklearn_processor = SKLearnProcessor(
+        framework_version=sklearn_latest_version,
+        role=role,
+        instance_type=INSTANCE_TYPE,
+        instance_count=1,
+        command=["python3"],
+        sagemaker_session=sagemaker_session,
+        base_job_name="test-sklearn",
+    )
+
+    step_sklearn = ProcessingStep(
+        name="sklearn-process",
+        processor=sklearn_processor,
+        code=script_path,
+    )
+
+    @step(
+        role=role,
+        instance_type=INSTANCE_TYPE,
+        image_uri=dummy_container_without_error,
+        keep_alive_period_in_seconds=60,
+    )
+    def func_2(arg):
+        return arg
+
+    final_output = func_2(step_sklearn.properties.ProcessingJobStatus)
+
+    pipeline = Pipeline(
+        name=pipeline_name,
+        steps=[final_output],
+        sagemaker_session=sagemaker_session,
+    )
+
+    try:
+        execution, _ = create_and_execute_pipeline(
+            pipeline=pipeline,
+            pipeline_name=pipeline_name,
+            region_name=region_name,
+            role=role,
+            no_of_steps=2,
+            last_step_name="func",
+            execution_parameters=dict(),
+            step_status="Succeeded",
+            step_result_type=str,
+            step_result_value="Completed",
+            wait_duration=600,
+        )
+
+        create_and_execute_pipeline(
+            pipeline=pipeline,
+            pipeline_name=pipeline_name,
+            region_name=region_name,
+            role=role,
+            no_of_steps=2,
+            last_step_name="func",
+            execution_parameters=dict(),
+            step_status="Succeeded",
+            step_result_type=str,
+            step_result_value="Completed",
+            wait_duration=600,
+            selective_execution_config=SelectiveExecutionConfig(
+                source_pipeline_execution_arn=execution.arn,
+                selected_steps=[get_step(final_output).name],
+            ),
+        )
+
+    finally:
+        try:
+            pipeline.delete()
+        except Exception:
+            pass

--- a/tests/integ/sagemaker/workflow/test_step_decorator.py
+++ b/tests/integ/sagemaker/workflow/test_step_decorator.py
@@ -256,6 +256,7 @@ def test_step_decorator_with_data_dependencies(
             execution_parameters=dict(),
             step_status="Succeeded",
             step_result_type=int,
+            step_result_value=7,
         )
     finally:
         try:
@@ -784,12 +785,10 @@ def test_decorator_step_checksum_mismatch(
         pipeline.create(role)
 
         pipeline_definition = json.loads(pipeline.describe()["PipelineDefinition"])
-        s3_base_uri = pipeline_definition["Steps"][0]["Arguments"]["OutputDataConfig"][
-            "S3OutputPath"
-        ]
         step_container_args = pipeline_definition["Steps"][0]["Arguments"][
             "AlgorithmSpecification"
         ]["ContainerArguments"]
+        s3_base_uri = step_container_args[step_container_args.index("--s3_base_uri") + 1]
         build_time = step_container_args[step_container_args.index("--func_step_s3_dir") + 1]
 
         # some other user updates the pickled function code

--- a/tests/unit/sagemaker/remote_function/runtime_environment/test_runtime_environment_manager.py
+++ b/tests/unit/sagemaker/remote_function/runtime_environment/test_runtime_environment_manager.py
@@ -208,7 +208,7 @@ def test_bootstrap_req_txt():
         call_args = popen.call_args[0][0]
         assert call_args is not None
 
-        expected_cmd = "{} -m pip install -r {}".format(python_exe, TEST_REQUIREMENTS_TXT)
+        expected_cmd = "{} -m pip install -r {} -U".format(python_exe, TEST_REQUIREMENTS_TXT)
         assert call_args == expected_cmd
 
 
@@ -229,7 +229,7 @@ def test_bootstrap_req_txt_error():
         call_args = popen.call_args[0][0]
         assert call_args is not None
 
-        expected_cmd = "{} -m pip install -r {}".format(python_exe, TEST_REQUIREMENTS_TXT)
+        expected_cmd = "{} -m pip install -r {} -U".format(python_exe, TEST_REQUIREMENTS_TXT)
         assert call_args == expected_cmd
 
 
@@ -260,7 +260,7 @@ def test_bootstrap_req_txt_with_conda_env(mock_conda_exe):
         call_args = popen.call_args[0][0]
         assert call_args is not None
 
-        expected_cmd = f"{mock_conda_exe.return_value} run -n conda_env pip install -r usr/local/requirements.txt"
+        expected_cmd = f"{mock_conda_exe.return_value} run -n conda_env pip install -r usr/local/requirements.txt -U"
         assert call_args == expected_cmd
 
 

--- a/tests/unit/sagemaker/workflow/test_pipeline.py
+++ b/tests/unit/sagemaker/workflow/test_pipeline.py
@@ -19,6 +19,7 @@ import json
 import pytest
 
 from mock import Mock, call, patch
+from mock.mock import MagicMock
 
 from sagemaker import s3
 from sagemaker.remote_function.job import _JobSettings
@@ -198,12 +199,7 @@ def test_large_pipeline_create(sagemaker_session_mock, role_arn):
     )
 
 
-@patch("botocore.waiter.create_waiter_with_client")
-@patch("sagemaker.workflow.pipeline.deserialize_obj_from_s3")
-@patch("sagemaker.s3.S3Downloader")
-def test_pipeline_update(
-    waiter_mock, deserializer_mock, s3_downloader_mock, sagemaker_session_mock, role_arn
-):
+def test_pipeline_update(sagemaker_session_mock, role_arn):
     sagemaker_session_mock.sagemaker_config = {}
     pipeline = Pipeline(
         name="MyPipeline",
@@ -262,6 +258,46 @@ def test_pipeline_update(
         PipelineName="MyPipeline", PipelineDefinition=pipeline.definition(), RoleArn=role_arn
     )
 
+
+@pytest.mark.parametrize(
+    "s3_output_path, is_complete_path",
+    [
+        ("s3:/my-bucket/my-key", False),
+        ("s3:/my-bucket/my-key/myexecution/stepA/results", True),
+        ("s3:/my-bucket/my-key/myexecution/stepA/results/", True),
+    ],
+)
+@patch("botocore.waiter.create_waiter_with_client", MagicMock())
+@patch("sagemaker.workflow.pipeline.deserialize_obj_from_s3")
+def test_pipeline_execution_result(
+    mock_deserialize, s3_output_path, is_complete_path, sagemaker_session_mock, role_arn
+):
+    sagemaker_session_mock.sagemaker_config = {}
+
+    step1 = CustomStep(name="MyStep1")
+    dr_step_2 = DelayedReturn(
+        function_step=CustomFunctionStep(
+            func_args=(1, 2),
+            func=lambda x, y: x + y + 3,
+            job_settings=_JobSettings(
+                image_uri="image",
+                instance_type="ml.m4.xlarge",
+                sagemaker_session=sagemaker_session_mock,
+            ),
+            name="stepA",
+            description="",
+            display_name="",
+            depends_on=[step1],
+        )
+    )
+    pipeline = Pipeline(
+        name="MyPipeline",
+        parameters=[],
+        steps=[dr_step_2],
+        sagemaker_session=sagemaker_session_mock,
+    )
+    pipeline.create(role_arn=role_arn)
+
     sagemaker_session_mock.sagemaker_client.start_pipeline_execution.return_value = {
         "PipelineExecutionArn": "arn:aws:sagemaker:us-west-2:111111111111:pipeline/mypipeline/execution/myexecution",
     }
@@ -270,7 +306,7 @@ def test_pipeline_update(
     sagemaker_session_mock.sagemaker_client.list_pipeline_execution_steps.return_value = {
         "PipelineExecutionSteps": [
             {
-                "StepName": "stepC",
+                "StepName": "stepA",
                 "Metadata": {
                     "TrainingJob": {
                         "Arn": "arn:aws:sagemaker:us-west-2:111111111111:training-job/foo"
@@ -288,16 +324,15 @@ def test_pipeline_update(
             ]
         },
         "TrainingJobStatus": "Completed",
-        "OutputDataConfig": {"S3OutputPath": "s3:/my-bucket/my-key"},
+        "OutputDataConfig": {"S3OutputPath": s3_output_path},
         "Environment": {"REMOTE_FUNCTION_SECRET_KEY": "abcdefg"},
     }
-    execution.result("stepC")
-    assert s3_downloader_mock.read_bytes(
-        "s3:/my-bucket/my-key/myexecution/stepC/results/metadata.json"
+    execution.result("stepA")
+
+    expected_s3_uri = (
+        s3_output_path if is_complete_path else f"{s3_output_path}/myexecution/stepA/results"
     )
-    assert s3_downloader_mock.read_bytes(
-        "s3:/my-bucket/my-key/myexecution/stepC/results/payload.pkl"
-    )
+    assert mock_deserialize.call_args.kwargs["s3_uri"] == expected_s3_uri
 
 
 def test_pipeline_update_with_parallelism_config(sagemaker_session_mock, role_arn):


### PR DESCRIPTION
*Issue #, if available:* 
Currently configuring selective pipeline execution w.r.t the step decorated functions would fail as such functions' output are uploaded to the s3 path: `<root>/<pipeline_name>/<ExecutionVariables.PIPELINE_EXECUTION_ID>/<step_name>/results`

The `ExecutionVariables.PIPELINE_EXECUTION_ID` is always pointing to the current execution, but in selective pipeline execution, we may need to retrieve step output from the previous execution, which leads to the issue of unable to retrieve the dependent step output.

*Description of changes:* Support selective pipeline execution for function step.
As in backend, the selective pipeline execution logics would replace the step properties with the source execution steps' output, in SDK we can replace the entire s3 path `<root>/<pipeline_name>/<ExecutionVariables.PIPELINE_EXECUTION_ID>/<step_name>/results` with the properties `"Steps.{function_step.name}.OutputDataConfig.S3OutputPath"`. 
Accordingly, two additional updates to the S3OutputPath properties are also required: 
1) it should be a Join function:
```
Join(
                on="/",
                values=[
                    s3_base_uri,
                    ExecutionVariables.PIPELINE_EXECUTION_ID,
                    step_compilation_context.step_name,
                    "results",
                ],
            )
``` 
2)  it should be added to the container args' `--property_references` field.

Additionally, some extra changes are made to keep it backward compatible:
1) add the `-U` flag behind pip install command so that  if users specify dependency versions to be xxx >= yyy, < zzz, the more up to date version would be installed in the job container. As a result, if users bump up the SDK version locally, the SDK version in remote job would be able to catch up
- Note: this won’t help to upgrade the SDK version in job container if users lock the version in req.txt. However, in this case, users have the responsibility to make sure the versions to be sync between local and remote job.
  - I’ll submit a separate PR to add a warning message for such case
2) keep the old delayed return s3 uri resolver behavior though it's obsoleted to keep backward compatible.
Note: ideally, the new SDK deserializer/resolver should be able to parse the old serializer schema

*Testing done:* Integ tests
Tested two cases:
1. function step1 -> [select: function step2]
2. regular step -> [select: function step]

Note: For the third case:
3. function step -> [select: regular step]
it's not implemented nor tested because the **backend currently has a strict validation on JsonGet s3_uri, which allows Parameters and ExecutionVariables and primitive types only for Join function**.

*Next steps:*
1. loosen the backend validation logic on JsonGet s3_uri
2. add support for the third case `function step -> [select: regular step]` in SDK in a separate PR.
3. update the [doc](https://docs.aws.amazon.com/sagemaker/latest/dg/pipelines-step-decorator-limit.html#:~:text=%23%20raises%20AttributeError-,Existing%20pipeline%20features%20that%20are%20not%20supported,-You%20cannot%20use) to remove selective execution from limitations section

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
