### PR TITLE
Bugfix: fixed create monitoring schedule failing after validation error

### DIFF
--- a/src/sagemaker/model_monitor/clarify_model_monitoring.py
+++ b/src/sagemaker/model_monitor/clarify_model_monitoring.py
@@ -669,6 +669,7 @@ class ModelBiasMonitor(ClarifyModelMonitor):
             self.monitoring_schedule_name = monitor_schedule_name
         except Exception:
             logger.exception("Failed to create monitoring schedule.")
+            self.monitoring_schedule_name = None
             # noinspection PyBroadException
             try:
                 self.sagemaker_session.sagemaker_client.delete_model_bias_job_definition(
@@ -1109,6 +1110,7 @@ class ModelExplainabilityMonitor(ClarifyModelMonitor):
             self.monitoring_schedule_name = monitor_schedule_name
         except Exception:
             logger.exception("Failed to create monitoring schedule.")
+            self.monitoring_schedule_name = None
             # noinspection PyBroadException
             try:
                 self.sagemaker_session.sagemaker_client.delete_model_explainability_job_definition(

--- a/src/sagemaker/model_monitor/model_monitoring.py
+++ b/src/sagemaker/model_monitor/model_monitoring.py
@@ -415,30 +415,34 @@ class ModelMonitor(object):
         if arguments is not None:
             self.arguments = arguments
 
-        self.sagemaker_session.create_monitoring_schedule(
-            monitoring_schedule_name=self.monitoring_schedule_name,
-            schedule_expression=schedule_cron_expression,
-            statistics_s3_uri=statistics_s3_uri,
-            constraints_s3_uri=constraints_s3_uri,
-            monitoring_inputs=[normalized_monitoring_input],
-            monitoring_output_config=monitoring_output_config,
-            instance_count=self.instance_count,
-            instance_type=self.instance_type,
-            volume_size_in_gb=self.volume_size_in_gb,
-            volume_kms_key=self.volume_kms_key,
-            image_uri=self.image_uri,
-            entrypoint=self.entrypoint,
-            arguments=self.arguments,
-            record_preprocessor_source_uri=None,
-            post_analytics_processor_source_uri=None,
-            max_runtime_in_seconds=self.max_runtime_in_seconds,
-            environment=self.env,
-            network_config=network_config_dict,
-            role_arn=self.sagemaker_session.expand_role(self.role),
-            tags=self.tags,
-            data_analysis_start_time=data_analysis_start_time,
-            data_analysis_end_time=data_analysis_end_time,
-        )
+        try:
+            self.sagemaker_session.create_monitoring_schedule(
+                monitoring_schedule_name=self.monitoring_schedule_name,
+                schedule_expression=schedule_cron_expression,
+                statistics_s3_uri=statistics_s3_uri,
+                constraints_s3_uri=constraints_s3_uri,
+                monitoring_inputs=[normalized_monitoring_input],
+                monitoring_output_config=monitoring_output_config,
+                instance_count=self.instance_count,
+                instance_type=self.instance_type,
+                volume_size_in_gb=self.volume_size_in_gb,
+                volume_kms_key=self.volume_kms_key,
+                image_uri=self.image_uri,
+                entrypoint=self.entrypoint,
+                arguments=self.arguments,
+                record_preprocessor_source_uri=None,
+                post_analytics_processor_source_uri=None,
+                max_runtime_in_seconds=self.max_runtime_in_seconds,
+                environment=self.env,
+                network_config=network_config_dict,
+                role_arn=self.sagemaker_session.expand_role(self.role),
+                tags=self.tags,
+                data_analysis_start_time=data_analysis_start_time,
+                data_analysis_end_time=data_analysis_end_time,
+            )
+        except Exception:
+            self.monitoring_schedule_name = None
+            raise
 
     def update_monitoring_schedule(
         self,
@@ -2054,6 +2058,7 @@ class DefaultModelMonitor(ModelMonitor):
             self.monitoring_schedule_name = monitor_schedule_name
         except Exception:
             logger.exception("Failed to create monitoring schedule.")
+            self.monitoring_schedule_name = None
             # noinspection PyBroadException
             try:
                 self.sagemaker_session.sagemaker_client.delete_data_quality_job_definition(
@@ -3173,6 +3178,7 @@ class ModelQualityMonitor(ModelMonitor):
             self.monitoring_schedule_name = monitor_schedule_name
         except Exception:
             logger.exception("Failed to create monitoring schedule.")
+            self.monitoring_schedule_name = None
             # noinspection PyBroadException
             try:
                 self.sagemaker_session.sagemaker_client.delete_model_quality_job_definition(

--- a/tests/integ/test_model_monitor.py
+++ b/tests/integ/test_model_monitor.py
@@ -2488,3 +2488,83 @@ def test_one_time_monitoring_schedule(sagemaker_session):
         my_default_monitor.stop_monitoring_schedule()
         my_default_monitor.delete_monitoring_schedule()
         raise e
+
+
+def test_create_monitoring_schedule_with_validation_error(sagemaker_session):
+    my_default_monitor = DefaultModelMonitor(
+        role=ROLE,
+        instance_count=INSTANCE_COUNT,
+        instance_type=INSTANCE_TYPE,
+        volume_size_in_gb=VOLUME_SIZE_IN_GB,
+        max_runtime_in_seconds=MAX_RUNTIME_IN_SECONDS,
+        sagemaker_session=sagemaker_session,
+        env=ENVIRONMENT,
+        tags=TAGS,
+        network_config=NETWORK_CONFIG,
+    )
+
+    output_s3_uri = os.path.join(
+        "s3://",
+        sagemaker_session.default_bucket(),
+        "integ-test-monitoring-output-bucket",
+        str(uuid.uuid4()),
+    )
+
+    data_captured_destination_s3_uri = os.path.join(
+        "s3://",
+        sagemaker_session.default_bucket(),
+        "sagemaker-serving-batch-transform",
+        str(uuid.uuid4()),
+    )
+
+    batch_transform_input = BatchTransformInput(
+        data_captured_destination_s3_uri=data_captured_destination_s3_uri,
+        destination="/opt/ml/processing/output",
+        dataset_format=MonitoringDatasetFormat.csv(header=False),
+    )
+
+    statistics = Statistics.from_file_path(
+        statistics_file_path=os.path.join(tests.integ.DATA_DIR, "monitor/statistics.json"),
+        sagemaker_session=sagemaker_session,
+    )
+
+    constraints = Constraints.from_file_path(
+        constraints_file_path=os.path.join(tests.integ.DATA_DIR, "monitor/constraints.json"),
+        sagemaker_session=sagemaker_session,
+    )
+
+    try:
+        my_default_monitor.create_monitoring_schedule(
+            batch_transform_input=batch_transform_input,
+            output_s3_uri=output_s3_uri,
+            statistics=statistics,
+            constraints=constraints,
+            schedule_cron_expression="Daily",
+            data_analysis_start_time="-PT1H",
+            data_analysis_end_time="-PT0H",
+            enable_cloudwatch_metrics=ENABLE_CLOUDWATCH_METRICS,
+        )
+    except Exception as e:
+        assert "ValidationException" in str(e)
+
+    my_default_monitor.create_monitoring_schedule(
+        batch_transform_input=batch_transform_input,
+        output_s3_uri=output_s3_uri,
+        statistics=statistics,
+        constraints=constraints,
+        schedule_cron_expression=CronExpressionGenerator.now(),
+        data_analysis_start_time="-PT1H",
+        data_analysis_end_time="-PT0H",
+        enable_cloudwatch_metrics=ENABLE_CLOUDWATCH_METRICS,
+    )
+    try:
+
+        _wait_for_schedule_changes_to_apply(monitor=my_default_monitor)
+
+        my_default_monitor.stop_monitoring_schedule()
+        my_default_monitor.delete_monitoring_schedule()
+
+    except Exception as e:
+        my_default_monitor.stop_monitoring_schedule()
+        my_default_monitor.delete_monitoring_schedule()
+        raise e


### PR DESCRIPTION
*Issue #, if available:*
fix for - https://github.com/aws/sagemaker-python-sdk/issues/1624

*Description of changes:*
Resetting the monitoring schedule name so that the monitoring schedule can be created again in case of failure during creation.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
