### PR TITLE
fix: make sure gpus are found in local_gpu run

### DIFF
--- a/src/sagemaker/local/image.py
+++ b/src/sagemaker/local/image.py
@@ -861,11 +861,7 @@ class _SageMakerContainer(object):
         if self.instance_type == "local_gpu":
             host_config["deploy"] = {
                 "resources": {
-                    "reservations": {
-                        "devices": [
-                            {"count": "all", "capabilities": ["gpu"]}
-                        ]
-                    }
+                    "reservations": {"devices": [{"count": "all", "capabilities": ["gpu"]}]}
                 }
             }
 

--- a/src/sagemaker/local/image.py
+++ b/src/sagemaker/local/image.py
@@ -860,7 +860,13 @@ class _SageMakerContainer(object):
         # to setting --runtime=nvidia in the docker commandline.
         if self.instance_type == "local_gpu":
             host_config["deploy"] = {
-                "resources": {"reservations": {"devices": [{"capabilities": ["gpu"]}]}}
+                "resources": {
+                    "reservations": {
+                        "devices": [
+                            {"count": "all", "capabilities": ["gpu"]}
+                        ]
+                    }
+                }
             }
 
         if not self.is_studio and command == "serve":

--- a/tests/unit/sagemaker/local/test_local_image.py
+++ b/tests/unit/sagemaker/local/test_local_image.py
@@ -871,7 +871,7 @@ def test_container_has_gpu_support(tmpdir, sagemaker_session):
     docker_host = sagemaker_container._create_docker_host("host-1", {}, set(), "train", [])
     assert "deploy" in docker_host
     assert docker_host["deploy"] == {
-        "resources": {"reservations": {"devices": [{"capabilities": ["gpu"]}]}}
+        "resources": {"reservations": {"devices": [{"count": "all", "capabilities": ["gpu"]}]}}
     }
 
 


### PR DESCRIPTION
*Description of changes:*

when running sagemaker in `local_gpu` mode it does not find the GPUs. The following config:

```yaml
deploy:
    resources:
      reservations:
        devices:
          - capabilities: [gpu]
```

This will result in no GPUs being found (Docker Compose version v2.24.1).

Specifying `count: all` in the `docker-compose.yml` solves this issue, and shouldn't change the behaviour (according to docker compose doc this should be the default behaviour https://docs.docker.com/compose/gpu-support/).

```yaml
deploy:
    resources:
      reservations:
        devices:
          - count: all
            capabilities: [gpu]
```

*Testing done:*

Running without this change, no GPUs are found, with this change they are.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
