### PR TITLE
change: Add validation for sagemaker version on remote job

### DIFF
--- a/src/sagemaker/remote_function/core/serialization.py
+++ b/src/sagemaker/remote_function/core/serialization.py
@@ -141,7 +141,12 @@ class CloudpickleSerializer:
             return cloudpickle.loads(bytes_to_deserialize)
         except Exception as e:
             raise DeserializationError(
-                "Error when deserializing bytes downloaded from {}: {}".format(s3_uri, repr(e))
+                "Error when deserializing bytes downloaded from {}: {}. "
+                "NOTE: this may be caused by inconsistent sagemaker python sdk versions "
+                "where remote function runs versus the one used on client side. "
+                "If the sagemaker versions do not match, a warning message would "
+                "be logged starting with 'Inconsistent sagemaker versions found'. "
+                "Please check it to validate.".format(s3_uri, repr(e))
             ) from e
 
 

--- a/src/sagemaker/remote_function/job.py
+++ b/src/sagemaker/remote_function/job.py
@@ -788,6 +788,12 @@ class _Job:
         )
         container_args.extend(
             [
+                "--client_sagemaker_pysdk_version",
+                RuntimeEnvironmentManager()._current_sagemaker_pysdk_version(),
+            ]
+        )
+        container_args.extend(
+            [
                 "--dependency_settings",
                 _DependencySettings.from_dependency_file_path(
                     job_settings.dependencies

--- a/src/sagemaker/remote_function/runtime_environment/bootstrap_runtime_environment.py
+++ b/src/sagemaker/remote_function/runtime_environment/bootstrap_runtime_environment.py
@@ -56,6 +56,7 @@ def main(sys_args=None):
     try:
         args = _parse_args(sys_args)
         client_python_version = args.client_python_version
+        client_sagemaker_pysdk_version = args.client_sagemaker_pysdk_version
         job_conda_env = args.job_conda_env
         pipeline_execution_id = args.pipeline_execution_id
         dependency_settings = _DependencySettings.from_string(args.dependency_settings)
@@ -64,6 +65,9 @@ def main(sys_args=None):
         conda_env = job_conda_env or os.getenv("SAGEMAKER_JOB_CONDA_ENV")
 
         RuntimeEnvironmentManager()._validate_python_version(client_python_version, conda_env)
+        RuntimeEnvironmentManager()._validate_sagemaker_pysdk_version(
+            client_sagemaker_pysdk_version
+        )
 
         user = getpass.getuser()
         if user != "root":
@@ -274,6 +278,7 @@ def _parse_args(sys_args):
     parser = argparse.ArgumentParser()
     parser.add_argument("--job_conda_env", type=str)
     parser.add_argument("--client_python_version", type=str)
+    parser.add_argument("--client_sagemaker_pysdk_version", type=str, default=None)
     parser.add_argument("--pipeline_execution_id", type=str)
     parser.add_argument("--dependency_settings", type=str)
     parser.add_argument("--func_step_s3_dir", type=str)

--- a/src/sagemaker/remote_function/runtime_environment/runtime_environment_manager.py
+++ b/src/sagemaker/remote_function/runtime_environment/runtime_environment_manager.py
@@ -24,6 +24,8 @@ import time
 import dataclasses
 import json
 
+import sagemaker
+
 
 class _UTCFormatter(logging.Formatter):
     """Class that overrides the default local time provider in log formatter."""
@@ -326,6 +328,11 @@ class RuntimeEnvironmentManager:
 
         return f"{sys.version_info.major}.{sys.version_info.minor}".strip()
 
+    def _current_sagemaker_pysdk_version(self):
+        """Returns the current sagemaker python sdk version where program is running"""
+
+        return sagemaker.__version__
+
     def _validate_python_version(self, client_python_version: str, conda_env: str = None):
         """Validate the python version
 
@@ -342,6 +349,29 @@ class RuntimeEnvironmentManager:
                 f"does not match python version '{client_python_version}' on the local client. "
                 f"Please make sure that the python version used in the training container "
                 f"is same as the local python version."
+            )
+
+    def _validate_sagemaker_pysdk_version(self, client_sagemaker_pysdk_version):
+        """Validate the sagemaker python sdk version
+
+        Validates if the sagemaker python sdk version where remote function runs
+        matches the one used on client side.
+        Otherwise, log a warning to call out that unexpected behaviors
+        may occur in this case.
+        """
+        job_sagemaker_pysdk_version = self._current_sagemaker_pysdk_version()
+        if (
+            client_sagemaker_pysdk_version
+            and client_sagemaker_pysdk_version != job_sagemaker_pysdk_version
+        ):
+            logger.warning(
+                "Inconsistent sagemaker versions found: "
+                "sagemaker pysdk version found in the container is "
+                "'%s' which does not match the '%s' on the local client. "
+                "Please make sure that the python version used in the training container "
+                "is the same as the local python version in case of unexpected behaviors.",
+                job_sagemaker_pysdk_version,
+                client_sagemaker_pysdk_version,
             )
 
 

--- a/tests/unit/sagemaker/remote_function/core/test_serialization.py
+++ b/tests/unit/sagemaker/remote_function/core/test_serialization.py
@@ -198,7 +198,8 @@ def test_deserialize_func_deserialization_error(mock_cloudpickle_loads):
     with pytest.raises(
         DeserializationError,
         match=rf"Error when deserializing bytes downloaded from {s3_uri}/payload.pkl: "
-        + r"RuntimeError\('some failure when loads'\)",
+        + r"RuntimeError\('some failure when loads'\). "
+        + r"NOTE: this may be caused by inconsistent sagemaker python sdk versions",
     ):
         deserialize_func_from_s3(sagemaker_session=Mock(), s3_uri=s3_uri, hmac_key=HMAC_KEY)
 
@@ -397,7 +398,8 @@ def test_deserialize_obj_deserialization_error(mock_cloudpickle_loads):
     with pytest.raises(
         DeserializationError,
         match=rf"Error when deserializing bytes downloaded from {s3_uri}/payload.pkl: "
-        + r"RuntimeError\('some failure when loads'\)",
+        + r"RuntimeError\('some failure when loads'\). "
+        + r"NOTE: this may be caused by inconsistent sagemaker python sdk versions",
     ):
         deserialize_obj_from_s3(sagemaker_session=Mock(), s3_uri=s3_uri, hmac_key=HMAC_KEY)
 

--- a/tests/unit/sagemaker/remote_function/test_job.py
+++ b/tests/unit/sagemaker/remote_function/test_job.py
@@ -382,6 +382,7 @@ def test_start(
 
     local_dependencies_path = mock_runtime_manager().snapshot()
     mock_python_version = mock_runtime_manager()._current_python_version()
+    mock_sagemaker_pysdk_version = mock_runtime_manager()._current_sagemaker_pysdk_version()
 
     mock_script_upload.assert_called_once_with(
         spark_config=None,
@@ -441,6 +442,8 @@ def test_start(
                 TEST_REGION,
                 "--client_python_version",
                 mock_python_version,
+                "--client_sagemaker_pysdk_version",
+                mock_sagemaker_pysdk_version,
                 "--dependency_settings",
                 '{"dependency_file": null}',
                 "--run_in_context",
@@ -510,6 +513,7 @@ def test_start_with_checkpoint_location(
     )
 
     mock_python_version = mock_runtime_manager()._current_python_version()
+    mock_sagemaker_pysdk_version = mock_runtime_manager()._current_sagemaker_pysdk_version()
 
     session().sagemaker_client.create_training_job.assert_called_once_with(
         TrainingJobName=job.job_name,
@@ -555,6 +559,8 @@ def test_start_with_checkpoint_location(
                 TEST_REGION,
                 "--client_python_version",
                 mock_python_version,
+                "--client_sagemaker_pysdk_version",
+                mock_sagemaker_pysdk_version,
                 "--dependency_settings",
                 '{"dependency_file": null}',
                 "--run_in_context",
@@ -657,6 +663,7 @@ def test_start_with_complete_job_settings(
 
     local_dependencies_path = mock_runtime_manager().snapshot()
     mock_python_version = mock_runtime_manager()._current_python_version()
+    mock_sagemaker_pysdk_version = mock_runtime_manager()._current_sagemaker_pysdk_version()
 
     mock_bootstrap_script_upload.assert_called_once_with(
         spark_config=None,
@@ -716,6 +723,8 @@ def test_start_with_complete_job_settings(
                 TEST_REGION,
                 "--client_python_version",
                 mock_python_version,
+                "--client_sagemaker_pysdk_version",
+                mock_sagemaker_pysdk_version,
                 "--dependency_settings",
                 '{"dependency_file": "req.txt"}',
                 "--s3_kms_key",
@@ -824,6 +833,7 @@ def test_get_train_args_under_pipeline_context(
 
     local_dependencies_path = mock_runtime_manager().snapshot()
     mock_python_version = mock_runtime_manager()._current_python_version()
+    mock_sagemaker_pysdk_version = mock_runtime_manager()._current_sagemaker_pysdk_version()
 
     mock_bootstrap_scripts_upload.assert_called_once_with(
         spark_config=None,
@@ -905,6 +915,8 @@ def test_get_train_args_under_pipeline_context(
                 TEST_REGION,
                 "--client_python_version",
                 mock_python_version,
+                "--client_sagemaker_pysdk_version",
+                mock_sagemaker_pysdk_version,
                 "--dependency_settings",
                 '{"dependency_file": "req.txt"}',
                 "--s3_kms_key",
@@ -989,6 +1001,7 @@ def test_start_with_spark(
     job = _Job.start(job_settings, job_function, func_args=(1, 2), func_kwargs={"c": 3, "d": 4})
 
     mock_python_version = mock_runtime_manager()._current_python_version()
+    mock_sagemaker_pysdk_version = mock_runtime_manager()._current_sagemaker_pysdk_version()
 
     assert job.job_name.startswith("job-function")
 
@@ -1062,6 +1075,8 @@ def test_start_with_spark(
                 TEST_REGION,
                 "--client_python_version",
                 mock_python_version,
+                "--client_sagemaker_pysdk_version",
+                mock_sagemaker_pysdk_version,
                 "--dependency_settings",
                 '{"dependency_file": null}',
                 "--run_in_context",


### PR DESCRIPTION
*Issue #, if available:* As the sagemaker pysdk is installed in both local client side and job side, we've received issues reported relating to the inconsistent sagemaker versions. For example, if the local client side has more up-to-date  sagemaker version which introduces new serialization behavior that old sdk in the job side is unable to deserialize, a runtime error would be thrown.

*Description of changes:* Pass the local client side sagemaker pysdk version to the job and compare the version with that in the job side. If it does not match, log a warning to inform the user on potential unexpected behaviors

*Testing done:* unit tests

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
