### PR TITLE
Fetch HF metadata only when explicit type is not selected

### DIFF
--- a/src/sagemaker/serve/builder/model_builder.py
+++ b/src/sagemaker/serve/builder/model_builder.py
@@ -579,19 +579,19 @@ class ModelBuilder(Triton, DJL, JumpStart, TGI, Transformers):
 
         self.serve_settings = self._get_serve_setting()
 
-        hf_model_md = get_huggingface_model_metadata(
-            self.model, self.env_vars.get("HUGGING_FACE_HUB_TOKEN")
-        )
-
         if isinstance(self.model, str):
             if self._is_jumpstart_model_id():
                 return self._build_for_jumpstart()
-            if self._is_djl():
+            if self._is_djl():  # pylint: disable=R1705
                 return self._build_for_djl()
-            if hf_model_md.get("pipeline_tag") == "text-generation":  # pylint: disable=R1705
-                return self._build_for_tgi()
             else:
-                return self._build_for_transformers()
+                hf_model_md = get_huggingface_model_metadata(
+                    self.model, self.env_vars.get("HUGGING_FACE_HUB_TOKEN")
+                )
+                if hf_model_md.get("pipeline_tag") == "text-generation":  # pylint: disable=R1705
+                    return self._build_for_tgi()
+                else:
+                    return self._build_for_transformers()
 
         self._build_validations()
 

--- a/tests/integ/sagemaker/serve/test_serve_js_happy.py
+++ b/tests/integ/sagemaker/serve/test_serve_js_happy.py
@@ -13,7 +13,6 @@
 from __future__ import absolute_import
 
 import pytest
-from unittest.mock import patch, Mock
 from sagemaker.serve.builder.model_builder import ModelBuilder
 from sagemaker.serve.builder.schema_builder import SchemaBuilder
 from tests.integ.sagemaker.serve.constants import (
@@ -33,7 +32,6 @@ SAMPLE_RESPONSE = [
 ]
 JS_MODEL_ID = "huggingface-textgeneration1-gpt-neo-125m-fp16"
 ROLE_NAME = "SageMakerRole"
-MOCK_HF_MODEL_METADATA_JSON = {"mock_key": "mock_value"}
 
 
 @pytest.fixture
@@ -47,23 +45,14 @@ def happy_model_builder(sagemaker_session):
     )
 
 
-@patch("sagemaker.huggingface.llm_utils.urllib")
-@patch("sagemaker.huggingface.llm_utils.json")
 @pytest.mark.skipif(
     PYTHON_VERSION_IS_NOT_310,
     reason="The goal of these test are to test the serving components of our feature",
 )
 @pytest.mark.slow_test
-def test_happy_tgi_sagemaker_endpoint(
-    mock_urllib, mock_json, happy_model_builder, gpu_instance_type
-):
+def test_happy_tgi_sagemaker_endpoint(happy_model_builder, gpu_instance_type):
     logger.info("Running in SAGEMAKER_ENDPOINT mode...")
     caught_ex = None
-
-    mock_json.load.return_value = MOCK_HF_MODEL_METADATA_JSON
-    mock_hf_model_metadata_url = Mock()
-    mock_urllib.request.Request.side_effect = mock_hf_model_metadata_url
-
     model = happy_model_builder.build()
 
     with timeout(minutes=SERVE_SAGEMAKER_ENDPOINT_TIMEOUT):

--- a/tests/integ/sagemaker/serve/test_serve_pt_happy.py
+++ b/tests/integ/sagemaker/serve/test_serve_pt_happy.py
@@ -19,7 +19,6 @@ import os
 import io
 import numpy as np
 
-from unittest.mock import patch, Mock
 from sagemaker.serve.builder.model_builder import ModelBuilder, Mode
 from sagemaker.serve.builder.schema_builder import SchemaBuilder, CustomPayloadTranslator
 from sagemaker.serve.spec.inference_spec import InferenceSpec
@@ -38,7 +37,6 @@ import logging
 logger = logging.getLogger(__name__)
 
 ROLE_NAME = "SageMakerRole"
-MOCK_HF_MODEL_METADATA_JSON = {"mock_key": "mock_value"}
 
 
 @pytest.fixture
@@ -183,8 +181,6 @@ def model_builder(request):
 #                 ), f"{caught_ex} was thrown when running pytorch squeezenet local container test"
 
 
-@patch("sagemaker.huggingface.llm_utils.urllib")
-@patch("sagemaker.huggingface.llm_utils.json")
 @pytest.mark.skipif(
     PYTHON_VERSION_IS_NOT_310,  # or NOT_RUNNING_ON_INF_EXP_DEV_PIPELINE,
     reason="The goal of these test are to test the serving components of our feature",
@@ -194,17 +190,12 @@ def model_builder(request):
 )
 @pytest.mark.slow_test
 def test_happy_pytorch_sagemaker_endpoint(
-    mock_urllib,
-    mock_json,
     sagemaker_session,
     model_builder,
     cpu_instance_type,
     test_image,
 ):
     logger.info("Running in SAGEMAKER_ENDPOINT mode...")
-    mock_json.load.return_value = MOCK_HF_MODEL_METADATA_JSON
-    mock_hf_model_metadata_url = Mock()
-    mock_urllib.request.Request.side_effect = mock_hf_model_metadata_url
     caught_ex = None
 
     iam_client = sagemaker_session.boto_session.client("iam")

--- a/tests/unit/sagemaker/serve/builder/test_model_builder.py
+++ b/tests/unit/sagemaker/serve/builder/test_model_builder.py
@@ -42,7 +42,6 @@ mock_role_arn = "sample role arn"
 mock_s3_model_data_url = "sample s3 data url"
 mock_secret_key = "mock_secret_key"
 mock_instance_type = "mock instance type"
-MOCK_HF_MODEL_METADATA_JSON = {"mock_key": "mock_value"}
 
 supported_model_server = {
     ModelServer.TORCHSERVE,
@@ -55,15 +54,7 @@ mock_session = MagicMock()
 
 class TestModelBuilder(unittest.TestCase):
     @patch("sagemaker.serve.builder.model_builder._ServeSettings")
-    @patch("sagemaker.huggingface.llm_utils.urllib")
-    @patch("sagemaker.huggingface.llm_utils.json")
-    def test_validation_in_progress_mode_not_supported(
-        self, mock_serveSettings, mock_urllib, mock_json
-    ):
-        mock_json.load.return_value = MOCK_HF_MODEL_METADATA_JSON
-        mock_hf_model_metadata_url = Mock()
-        mock_urllib.request.Request.side_effect = mock_hf_model_metadata_url
-
+    def test_validation_in_progress_mode_not_supported(self, mock_serveSettings):
         builder = ModelBuilder()
         self.assertRaisesRegex(
             Exception,
@@ -75,15 +66,7 @@ class TestModelBuilder(unittest.TestCase):
         )
 
     @patch("sagemaker.serve.builder.model_builder._ServeSettings")
-    @patch("sagemaker.huggingface.llm_utils.urllib")
-    @patch("sagemaker.huggingface.llm_utils.json")
-    def test_validation_cannot_set_both_model_and_inference_spec(
-        self, mock_serveSettings, mock_urllib, mock_json
-    ):
-        mock_json.load.return_value = MOCK_HF_MODEL_METADATA_JSON
-        mock_hf_model_metadata_url = Mock()
-        mock_urllib.request.Request.side_effect = mock_hf_model_metadata_url
-
+    def test_validation_cannot_set_both_model_and_inference_spec(self, mock_serveSettings):
         builder = ModelBuilder(inference_spec="some value", model=Mock(spec=object))
         self.assertRaisesRegex(
             Exception,
@@ -95,15 +78,7 @@ class TestModelBuilder(unittest.TestCase):
         )
 
     @patch("sagemaker.serve.builder.model_builder._ServeSettings")
-    @patch("sagemaker.huggingface.llm_utils.urllib")
-    @patch("sagemaker.huggingface.llm_utils.json")
-    def test_validation_unsupported_model_server_type(
-        self, mock_serveSettings, mock_urllib, mock_json
-    ):
-        mock_json.load.return_value = MOCK_HF_MODEL_METADATA_JSON
-        mock_hf_model_metadata_url = Mock()
-        mock_urllib.request.Request.side_effect = mock_hf_model_metadata_url
-
+    def test_validation_unsupported_model_server_type(self, mock_serveSettings):
         builder = ModelBuilder(model_server="invalid_model_server")
         self.assertRaisesRegex(
             Exception,
@@ -116,15 +91,7 @@ class TestModelBuilder(unittest.TestCase):
         )
 
     @patch("sagemaker.serve.builder.model_builder._ServeSettings")
-    @patch("sagemaker.huggingface.llm_utils.urllib")
-    @patch("sagemaker.huggingface.llm_utils.json")
-    def test_validation_model_server_not_set_with_image_uri(
-        self, mock_serveSettings, mock_urllib, mock_json
-    ):
-        mock_json.load.return_value = MOCK_HF_MODEL_METADATA_JSON
-        mock_hf_model_metadata_url = Mock()
-        mock_urllib.request.Request.side_effect = mock_hf_model_metadata_url
-
+    def test_validation_model_server_not_set_with_image_uri(self, mock_serveSettings):
         builder = ModelBuilder(image_uri="image_uri")
         self.assertRaisesRegex(
             Exception,
@@ -137,15 +104,9 @@ class TestModelBuilder(unittest.TestCase):
         )
 
     @patch("sagemaker.serve.builder.model_builder._ServeSettings")
-    @patch("sagemaker.huggingface.llm_utils.urllib")
-    @patch("sagemaker.huggingface.llm_utils.json")
     def test_save_model_throw_exception_when_none_of_model_and_inference_spec_is_set(
-        self, mock_serveSettings, mock_urllib, mock_json
+        self, mock_serveSettings
     ):
-        mock_json.load.return_value = MOCK_HF_MODEL_METADATA_JSON
-        mock_hf_model_metadata_url = Mock()
-        mock_urllib.request.Request.side_effect = mock_hf_model_metadata_url
-
         builder = ModelBuilder(inference_spec=None, model=None)
         self.assertRaisesRegex(
             Exception,
@@ -165,12 +126,8 @@ class TestModelBuilder(unittest.TestCase):
     @patch("sagemaker.serve.builder.model_builder.SageMakerEndpointMode")
     @patch("sagemaker.serve.builder.model_builder.Model")
     @patch("os.path.exists")
-    @patch("sagemaker.huggingface.llm_utils.urllib")
-    @patch("sagemaker.huggingface.llm_utils.json")
     def test_build_happy_path_with_sagemaker_endpoint_mode_and_byoc(
         self,
-        mock_urllib,
-        mock_json,
         mock_path_exists,
         mock_sdk_model,
         mock_sageMakerEndpointMode,
@@ -188,10 +145,6 @@ class TestModelBuilder(unittest.TestCase):
             and instance_type == "ml.c5.xlarge"
             else None
         )
-
-        mock_json.load.return_value = MOCK_HF_MODEL_METADATA_JSON
-        mock_hf_model_metadata_url = Mock()
-        mock_urllib.request.Request.side_effect = mock_hf_model_metadata_url
 
         mock_detect_fw_version.return_value = framework, version
 
@@ -273,12 +226,8 @@ class TestModelBuilder(unittest.TestCase):
     @patch("sagemaker.serve.builder.model_builder.SageMakerEndpointMode")
     @patch("sagemaker.serve.builder.model_builder.Model")
     @patch("os.path.exists")
-    @patch("sagemaker.huggingface.llm_utils.urllib")
-    @patch("sagemaker.huggingface.llm_utils.json")
     def test_build_happy_path_with_sagemaker_endpoint_mode_and_1p_dlc_as_byoc(
         self,
-        mock_urllib,
-        mock_json,
         mock_path_exists,
         mock_sdk_model,
         mock_sageMakerEndpointMode,
@@ -296,11 +245,6 @@ class TestModelBuilder(unittest.TestCase):
             and instance_type == "ml.c5.xlarge"
             else None
         )
-
-        mock_json.load.return_value = MOCK_HF_MODEL_METADATA_JSON
-        mock_hf_model_metadata_url = Mock()
-        mock_urllib.request.Request.side_effect = mock_hf_model_metadata_url
-
         mock_detect_fw_version.return_value = framework, version
 
         mock_prepare_for_torchserve.side_effect = (
@@ -381,12 +325,8 @@ class TestModelBuilder(unittest.TestCase):
     @patch("sagemaker.serve.builder.model_builder.SageMakerEndpointMode")
     @patch("sagemaker.serve.builder.model_builder.Model")
     @patch("os.path.exists")
-    @patch("sagemaker.huggingface.llm_utils.urllib")
-    @patch("sagemaker.huggingface.llm_utils.json")
     def test_build_happy_path_with_sagemaker_endpoint_mode_and_inference_spec(
         self,
-        mock_urllib,
-        mock_json,
         mock_path_exists,
         mock_sdk_model,
         mock_sageMakerEndpointMode,
@@ -401,10 +341,6 @@ class TestModelBuilder(unittest.TestCase):
         mock_inference_spec.load = (
             lambda model_path: mock_native_model if model_path == MODEL_PATH else None
         )
-
-        mock_json.load.return_value = MOCK_HF_MODEL_METADATA_JSON
-        mock_hf_model_metadata_url = Mock()
-        mock_urllib.request.Request.side_effect = mock_hf_model_metadata_url
 
         mock_detect_fw_version.return_value = framework, version
 
@@ -490,12 +426,8 @@ class TestModelBuilder(unittest.TestCase):
     @patch("sagemaker.serve.builder.model_builder.SageMakerEndpointMode")
     @patch("sagemaker.serve.builder.model_builder.Model")
     @patch("os.path.exists")
-    @patch("sagemaker.huggingface.llm_utils.urllib")
-    @patch("sagemaker.huggingface.llm_utils.json")
     def test_build_happy_path_with_sagemakerEndpoint_mode_and_model(
         self,
-        mock_urllib,
-        mock_json,
         mock_path_exists,
         mock_sdk_model,
         mock_sageMakerEndpointMode,
@@ -513,10 +445,6 @@ class TestModelBuilder(unittest.TestCase):
             and instance_type == "ml.c5.xlarge"
             else None
         )
-
-        mock_json.load.return_value = MOCK_HF_MODEL_METADATA_JSON
-        mock_hf_model_metadata_url = Mock()
-        mock_urllib.request.Request.side_effect = mock_hf_model_metadata_url
 
         mock_detect_fw_version.return_value = framework, version
 
@@ -601,12 +529,8 @@ class TestModelBuilder(unittest.TestCase):
     @patch("sagemaker.serve.builder.model_builder.SageMakerEndpointMode")
     @patch("sagemaker.serve.builder.model_builder.Model")
     @patch("os.path.exists")
-    @patch("sagemaker.huggingface.llm_utils.urllib")
-    @patch("sagemaker.huggingface.llm_utils.json")
     def test_build_happy_path_with_sagemakerEndpoint_mode_and_xgboost_model(
         self,
-        mock_urllib,
-        mock_json,
         mock_path_exists,
         mock_sdk_model,
         mock_sageMakerEndpointMode,
@@ -625,10 +549,6 @@ class TestModelBuilder(unittest.TestCase):
             and instance_type == "ml.c5.xlarge"
             else None
         )
-
-        mock_json.load.return_value = MOCK_HF_MODEL_METADATA_JSON
-        mock_hf_model_metadata_url = Mock()
-        mock_urllib.request.Request.side_effect = mock_hf_model_metadata_url
 
         mock_detect_fw_version.return_value = "xgboost", version
 
@@ -714,12 +634,8 @@ class TestModelBuilder(unittest.TestCase):
     @patch("sagemaker.serve.builder.model_builder.LocalContainerMode")
     @patch("sagemaker.serve.builder.model_builder.Model")
     @patch("os.path.exists")
-    @patch("sagemaker.huggingface.llm_utils.urllib")
-    @patch("sagemaker.huggingface.llm_utils.json")
     def test_build_happy_path_with_local_container_mode(
         self,
-        mock_urllib,
-        mock_json,
         mock_path_exists,
         mock_sdk_model,
         mock_localContainerMode,
@@ -733,10 +649,6 @@ class TestModelBuilder(unittest.TestCase):
         mock_inference_spec.load = (
             lambda model_path: mock_native_model if model_path == MODEL_PATH else None
         )
-
-        mock_json.load.return_value = MOCK_HF_MODEL_METADATA_JSON
-        mock_hf_model_metadata_url = Mock()
-        mock_urllib.request.Request.side_effect = mock_hf_model_metadata_url
 
         mock_detect_container.side_effect = (
             lambda model, region, instance_type: mock_image_uri
@@ -816,12 +728,8 @@ class TestModelBuilder(unittest.TestCase):
     @patch("sagemaker.serve.builder.model_builder.LocalContainerMode")
     @patch("sagemaker.serve.builder.model_builder.Model")
     @patch("os.path.exists")
-    @patch("sagemaker.huggingface.llm_utils.urllib")
-    @patch("sagemaker.huggingface.llm_utils.json")
     def test_build_happy_path_with_localContainer_mode_overwritten_with_sagemaker_mode(
         self,
-        mock_urllib,
-        mock_json,
         mock_path_exists,
         mock_sdk_model,
         mock_localContainerMode,
@@ -837,10 +745,6 @@ class TestModelBuilder(unittest.TestCase):
         mock_inference_spec.load = (
             lambda model_path: mock_native_model if model_path == MODEL_PATH else None
         )
-
-        mock_json.load.return_value = MOCK_HF_MODEL_METADATA_JSON
-        mock_hf_model_metadata_url = Mock()
-        mock_urllib.request.Request.side_effect = mock_hf_model_metadata_url
 
         mock_detect_fw_version.return_value = framework, version
 
@@ -965,12 +869,8 @@ class TestModelBuilder(unittest.TestCase):
     @patch("sagemaker.serve.builder.model_builder.LocalContainerMode")
     @patch("sagemaker.serve.builder.model_builder.Model")
     @patch("os.path.exists")
-    @patch("sagemaker.huggingface.llm_utils.urllib")
-    @patch("sagemaker.huggingface.llm_utils.json")
     def test_build_happy_path_with_sagemaker_endpoint_mode_overwritten_with_local_container(
         self,
-        mock_urllib,
-        mock_json,
         mock_path_exists,
         mock_sdk_model,
         mock_localContainerMode,
@@ -983,10 +883,6 @@ class TestModelBuilder(unittest.TestCase):
     ):
         # setup mocks
         mock_detect_fw_version.return_value = framework, version
-
-        mock_json.load.return_value = MOCK_HF_MODEL_METADATA_JSON
-        mock_hf_model_metadata_url = Mock()
-        mock_urllib.request.Request.side_effect = mock_hf_model_metadata_url
 
         mock_detect_container.side_effect = (
             lambda model, region, instance_type: mock_image_uri


### PR DESCRIPTION
*Issue #, if available:*
We've introduced a new transformers builder logic that relies on the pipeline tag in HF metadata. Move the Hub token fetching step to be only when we don't explicitly set the flags for jumpstart or djl.

*Description of changes:*
Move HUB token fetch step to be in else block.
Remove changes to UT, and Integ test as they don't exercise that code path.

*Testing done:*
Reran UT, and Integ tests

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [X] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [X] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [X] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [X] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [X] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [X] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [X] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [X] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [X] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
