### PR TITLE
Add telemetry metrics on usage of default images for ModelBuilder

### DIFF
--- a/src/sagemaker/serve/builder/djl_builder.py
+++ b/src/sagemaker/serve/builder/djl_builder.py
@@ -83,6 +83,7 @@ class DJL(ABC):
         self.mode = None
         self.model_server = None
         self.image_uri = None
+        self._is_custom_image_uri = False
         self.image_config = None
         self.vpc_config = None
         self._original_deploy = None

--- a/src/sagemaker/serve/builder/jumpstart_builder.py
+++ b/src/sagemaker/serve/builder/jumpstart_builder.py
@@ -57,6 +57,8 @@ class JumpStart(ABC):
         self.mode = None
         self.model_server = None
         self.image_uri = None
+        self._is_custom_image_uri = False
+        self.vpc_config = None
         self._original_deploy = None
         self.secret_key = None
         self.js_model_config = None
@@ -94,7 +96,7 @@ class JumpStart(ABC):
 
     def _create_pre_trained_js_model(self) -> Type[Model]:
         """Placeholder docstring"""
-        pysdk_model = JumpStartModel(self.model)
+        pysdk_model = JumpStartModel(self.model, vpc_config=self.vpc_config)
         pysdk_model.sagemaker_session = self.sagemaker_session
 
         self._original_deploy = pysdk_model.deploy

--- a/src/sagemaker/serve/builder/model_builder.py
+++ b/src/sagemaker/serve/builder/model_builder.py
@@ -294,6 +294,7 @@ class ModelBuilder(Triton, DJL, JumpStart, TGI, Transformers):
                 "Skipping auto detection as the image uri is provided %s",
                 self.image_uri,
             )
+            self._is_custom_image_uri = True
             return
 
         if self.model:
@@ -604,6 +605,8 @@ class ModelBuilder(Triton, DJL, JumpStart, TGI, Transformers):
         )
 
         self.serve_settings = self._get_serve_setting()
+
+        self._is_custom_image_uri = self.image_uri is None
 
         if isinstance(self.model, str):
             if self._is_jumpstart_model_id():

--- a/src/sagemaker/serve/builder/model_builder.py
+++ b/src/sagemaker/serve/builder/model_builder.py
@@ -294,7 +294,6 @@ class ModelBuilder(Triton, DJL, JumpStart, TGI, Transformers):
                 "Skipping auto detection as the image uri is provided %s",
                 self.image_uri,
             )
-            self._is_custom_image_uri = True
             return
 
         if self.model:

--- a/src/sagemaker/serve/builder/tgi_builder.py
+++ b/src/sagemaker/serve/builder/tgi_builder.py
@@ -76,6 +76,7 @@ class TGI(ABC):
         self.mode = None
         self.model_server = None
         self.image_uri = None
+        self._is_custom_image_uri = False
         self.image_config = None
         self.vpc_config = None
         self._original_deploy = None

--- a/src/sagemaker/serve/builder/transformers_builder.py
+++ b/src/sagemaker/serve/builder/transformers_builder.py
@@ -56,6 +56,8 @@ class Transformers(ABC):
         self.mode = None
         self.model_server = None
         self.image_uri = None
+        self._is_custom_image_uri = False
+        self.vpc_config = None
         self._original_deploy = None
         self.hf_model_config = None
         self._default_data_type = None
@@ -111,6 +113,7 @@ class Transformers(ABC):
                 py_version=self.py_version,
                 transformers_version=base_hf_version,
                 pytorch_version=self.pytorch_version,
+                vpc_config=self.vpc_config,
             )
         elif "keras" in hf_model_md.get("tags") or "tensorflow" in hf_model_md.get("tags"):
             self.tensorflow_version = self._get_supported_version(
@@ -126,6 +129,7 @@ class Transformers(ABC):
                 py_version=self.py_version,
                 transformers_version=base_hf_version,
                 tensorflow_version=self.tensorflow_version,
+                vpc_config=self.vpc_config,
             )
 
         if self.mode == Mode.LOCAL_CONTAINER:

--- a/src/sagemaker/serve/utils/telemetry_logger.py
+++ b/src/sagemaker/serve/utils/telemetry_logger.py
@@ -13,7 +13,6 @@
 """Placeholder docstring"""
 from __future__ import absolute_import
 import logging
-from typing import Optional
 from time import perf_counter
 
 import requests
@@ -69,6 +68,7 @@ def _capture_telemetry(func_name: str):
                 f"&x-modelServer={MODEL_SERVER_TO_CODE[str(self.model_server)]}"
                 f"&x-imageTag={image_uri_tail}"
                 f"&x-sdkVersion={SDK_VERSION}"
+                f"&x-defaultImageUsage={_get_image_uri_option(self.image_uri, self._is_custom_image_uri)}"
             )
 
             if self.model_server == ModelServer.DJL_SERVING or self.model_server == ModelServer.TGI:
@@ -76,8 +76,6 @@ def _capture_telemetry(func_name: str):
 
             if self.sagemaker_session and self.sagemaker_session.endpoint_arn:
                 extra += f"&x-endpointArn={self.sagemaker_session.endpoint_arn}"
-
-            extra += f"&x-defaultImageUsage={_get_image_uri_option(self.image_uri, self._is_custom_image_uri)}"
 
             start_timer = perf_counter()
             try:
@@ -95,10 +93,10 @@ def _capture_telemetry(func_name: str):
                         extra,
                     )
             except (
-                    ModelBuilderException,
-                    exceptions.CapacityError,
-                    exceptions.UnexpectedStatusException,
-                    exceptions.AsyncInferenceError,
+                ModelBuilderException,
+                exceptions.CapacityError,
+                exceptions.UnexpectedStatusException,
+                exceptions.AsyncInferenceError,
             ) as e:
                 stop_timer = perf_counter()
                 elapsed = stop_timer - start_timer
@@ -126,12 +124,12 @@ def _capture_telemetry(func_name: str):
 
 
 def _send_telemetry(
-        status: str,
-        mode: int,
-        session: Session,
-        failure_reason: str = None,
-        failure_type: str = None,
-        extra_info: str = None,
+    status: str,
+    mode: int,
+    session: Session,
+    failure_reason: str = None,
+    failure_type: str = None,
+    extra_info: str = None,
 ) -> None:
     """Make GET request to an empty object in S3 bucket"""
     try:
@@ -153,13 +151,13 @@ def _send_telemetry(
 
 
 def _construct_url(
-        accountId: str,
-        mode: str,
-        status: str,
-        failure_reason: str,
-        failure_type: str,
-        extra_info: str,
-        region: str,
+    accountId: str,
+    mode: str,
+    status: str,
+    failure_reason: str,
+    failure_type: str,
+    extra_info: str,
+    region: str,
 ) -> str:
     """Placeholder docstring"""
 

--- a/src/sagemaker/serve/utils/telemetry_logger.py
+++ b/src/sagemaker/serve/utils/telemetry_logger.py
@@ -63,12 +63,13 @@ def _capture_telemetry(func_name: str):
             caught_ex = None
 
             image_uri_tail = self.image_uri.split("/")[1]
+            image_uri_option = _get_image_uri_option(self.image_uri, self._is_custom_image_uri)
             extra = (
                 f"{func_name}"
                 f"&x-modelServer={MODEL_SERVER_TO_CODE[str(self.model_server)]}"
                 f"&x-imageTag={image_uri_tail}"
                 f"&x-sdkVersion={SDK_VERSION}"
-                f"&x-defaultImageUsage={_get_image_uri_option(self.image_uri, self._is_custom_image_uri)}"
+                f"&x-defaultImageUsage={image_uri_option}"
             )
 
             if self.model_server == ModelServer.DJL_SERVING or self.model_server == ModelServer.TGI:

--- a/src/sagemaker/serve/utils/types.py
+++ b/src/sagemaker/serve/utils/types.py
@@ -43,3 +43,15 @@ class HardwareType(Enum):
     INFERENTIA_1 = 3
     INFERENTIA_2 = 4
     GRAVITON = 5
+
+
+class ImageUriOption(Enum):
+    "Enum type for image uri options"
+
+    def __str__(self) -> str:
+        """Convert enum to string"""
+        return str(self.name)
+
+    CUSTOM_IMAGE = 1
+    CUSTOM_1P_IMAGE = 2
+    DEFAULT_IMAGE = 3

--- a/src/sagemaker/serve/utils/types.py
+++ b/src/sagemaker/serve/utils/types.py
@@ -46,7 +46,7 @@ class HardwareType(Enum):
 
 
 class ImageUriOption(Enum):
-    "Enum type for image uri options"
+    """Enum type for image uri options"""
 
     def __str__(self) -> str:
         """Convert enum to string"""

--- a/tests/unit/sagemaker/serve/builder/test_transformers_builder.py
+++ b/tests/unit/sagemaker/serve/builder/test_transformers_builder.py
@@ -16,6 +16,7 @@ from unittest.mock import MagicMock, patch
 import unittest
 from sagemaker.serve.builder.model_builder import ModelBuilder
 from sagemaker.serve.mode.function_pointers import Mode
+from tests.unit.sagemaker.serve.constants import MOCK_VPC_CONFIG
 
 from sagemaker.serve.utils.predictors import TransformersLocalModePredictor
 
@@ -74,6 +75,7 @@ class TestTransformersBuilder(unittest.TestCase):
             model=mock_model_id,
             schema_builder=mock_schema_builder,
             mode=Mode.LOCAL_CONTAINER,
+            vpc_config=MOCK_VPC_CONFIG,
         )
 
         builder._prepare_for_mode = MagicMock()
@@ -85,6 +87,7 @@ class TestTransformersBuilder(unittest.TestCase):
         builder.modes[str(Mode.LOCAL_CONTAINER)] = MagicMock()
         predictor = model.deploy(model_data_download_timeout=1800)
 
+        assert model.vpc_config == MOCK_VPC_CONFIG
         assert builder.env_vars["MODEL_LOADING_TIMEOUT"] == "1800"
         assert isinstance(predictor, TransformersLocalModePredictor)
 

--- a/tests/unit/sagemaker/serve/utils/test_telemetry_logger.py
+++ b/tests/unit/sagemaker/serve/utils/test_telemetry_logger.py
@@ -87,10 +87,10 @@ class TestTelemetryLogger(unittest.TestCase):
             "&x-modelServer=4"
             "&x-imageTag=djl-inference:0.25.0-deepspeed0.11.0-cu118"
             f"&x-sdkVersion={SDK_VERSION}"
+            f"&x-defaultImageUsage={ImageUriOption.DEFAULT_IMAGE.value}"
             f"&x-modelName={MOCK_HUGGINGFACE_ID}"
             f"&x-endpointArn={MOCK_ENDPOINT_ARN}"
             f"&x-latency={latency}"
-            f"&x-defaultImageUsage={ImageUriOption.DEFAULT_IMAGE.value}"
         )
 
         mock_send_telemetry.assert_called_once_with(
@@ -117,10 +117,10 @@ class TestTelemetryLogger(unittest.TestCase):
             "&x-modelServer=4"
             "&x-imageTag=djl-inference:0.25.0-deepspeed0.11.0-cu118"
             f"&x-sdkVersion={SDK_VERSION}"
+            f"&x-defaultImageUsage={ImageUriOption.CUSTOM_1P_IMAGE.value}"
             f"&x-modelName={MOCK_HUGGINGFACE_ID}"
             f"&x-endpointArn={MOCK_ENDPOINT_ARN}"
             f"&x-latency={latency}"
-            f"&x-defaultImageUsage={ImageUriOption.CUSTOM_1P_IMAGE.value}"
         )
 
         mock_send_telemetry.assert_called_once_with(
@@ -147,10 +147,10 @@ class TestTelemetryLogger(unittest.TestCase):
             "&x-modelServer=6"
             "&x-imageTag=huggingface-pytorch-inference:2.0.0-transformers4.28.1-cpu-py310-ubuntu20.04"
             f"&x-sdkVersion={SDK_VERSION}"
+            f"&x-defaultImageUsage={ImageUriOption.DEFAULT_IMAGE.value}"
             f"&x-modelName={MOCK_HUGGINGFACE_ID}"
             f"&x-endpointArn={MOCK_ENDPOINT_ARN}"
             f"&x-latency={latency}"
-            f"&x-defaultImageUsage={ImageUriOption.DEFAULT_IMAGE.value}"
         )
 
         mock_send_telemetry.assert_called_once_with(
@@ -194,10 +194,10 @@ class TestTelemetryLogger(unittest.TestCase):
             "&x-modelServer=4"
             "&x-imageTag=djl-inference:0.25.0-deepspeed0.11.0-cu118"
             f"&x-sdkVersion={SDK_VERSION}"
+            f"&x-defaultImageUsage={ImageUriOption.DEFAULT_IMAGE.value}"
             f"&x-modelName={MOCK_HUGGINGFACE_ID}"
             f"&x-endpointArn={MOCK_ENDPOINT_ARN}"
             f"&x-latency={latency}"
-            f"&x-defaultImageUsage={ImageUriOption.DEFAULT_IMAGE.value}"
         )
 
         mock_send_telemetry.assert_called_once_with(

--- a/tests/unit/sagemaker/serve/utils/test_telemetry_logger.py
+++ b/tests/unit/sagemaker/serve/utils/test_telemetry_logger.py
@@ -162,6 +162,7 @@ class TestTelemetryLogger(unittest.TestCase):
         mock_model_builder = ModelBuilderMock()
         mock_model_builder.serve_settings.telemetry_opt_out = True
         mock_model_builder.image_uri = MOCK_DJL_CONTAINER
+        mock_model_builder._is_custom_image_uri = False
         mock_model_builder.model = MOCK_HUGGINGFACE_ID
         mock_model_builder.model_server = ModelServer.DJL_SERVING
 

--- a/tests/unit/sagemaker/serve/utils/test_telemetry_logger.py
+++ b/tests/unit/sagemaker/serve/utils/test_telemetry_logger.py
@@ -20,6 +20,7 @@ from sagemaker.serve.utils.telemetry_logger import (
     _construct_url,
 )
 from sagemaker.serve.utils.exceptions import ModelBuilderException, LocalModelOutOfMemoryException
+from sagemaker.serve.utils.types import ImageUriOption
 from sagemaker.user_agent import SDK_VERSION
 
 MOCK_SESSION = Mock()
@@ -71,6 +72,7 @@ class TestTelemetryLogger(unittest.TestCase):
         mock_model_builder = ModelBuilderMock()
         mock_model_builder.serve_settings.telemetry_opt_out = False
         mock_model_builder.image_uri = MOCK_DJL_CONTAINER
+        mock_model_builder._is_custom_image_uri = False
         mock_model_builder.model = MOCK_HUGGINGFACE_ID
         mock_model_builder.mode = Mode.LOCAL_CONTAINER
         mock_model_builder.model_server = ModelServer.DJL_SERVING
@@ -88,6 +90,37 @@ class TestTelemetryLogger(unittest.TestCase):
             f"&x-modelName={MOCK_HUGGINGFACE_ID}"
             f"&x-endpointArn={MOCK_ENDPOINT_ARN}"
             f"&x-latency={latency}"
+            f"&x-defaultImageUsage={ImageUriOption.DEFAULT_IMAGE.value}"
+        )
+
+        mock_send_telemetry.assert_called_once_with(
+            "1", 2, MOCK_SESSION, None, None, expected_extra_str
+        )
+
+    @patch("sagemaker.serve.utils.telemetry_logger._send_telemetry")
+    def test_capture_telemetry_decorator_djl_success_with_custom_image(self, mock_send_telemetry):
+        mock_model_builder = ModelBuilderMock()
+        mock_model_builder.serve_settings.telemetry_opt_out = False
+        mock_model_builder.image_uri = MOCK_DJL_CONTAINER
+        mock_model_builder._is_custom_image_uri = True
+        mock_model_builder.model = MOCK_HUGGINGFACE_ID
+        mock_model_builder.mode = Mode.LOCAL_CONTAINER
+        mock_model_builder.model_server = ModelServer.DJL_SERVING
+        mock_model_builder.sagemaker_session.endpoint_arn = MOCK_ENDPOINT_ARN
+
+        mock_model_builder.mock_deploy()
+
+        args = mock_send_telemetry.call_args.args
+        latency = str(args[5]).split("latency=")[1]
+        expected_extra_str = (
+            f"{MOCK_FUNC_NAME}"
+            "&x-modelServer=4"
+            "&x-imageTag=djl-inference:0.25.0-deepspeed0.11.0-cu118"
+            f"&x-sdkVersion={SDK_VERSION}"
+            f"&x-modelName={MOCK_HUGGINGFACE_ID}"
+            f"&x-endpointArn={MOCK_ENDPOINT_ARN}"
+            f"&x-latency={latency}"
+            f"&x-defaultImageUsage={ImageUriOption.CUSTOM_1P_IMAGE.value}"
         )
 
         mock_send_telemetry.assert_called_once_with(
@@ -99,6 +132,7 @@ class TestTelemetryLogger(unittest.TestCase):
         mock_model_builder = ModelBuilderMock()
         mock_model_builder.serve_settings.telemetry_opt_out = False
         mock_model_builder.image_uri = MOCK_TGI_CONTAINER
+        mock_model_builder._is_custom_image_uri = False
         mock_model_builder.model = MOCK_HUGGINGFACE_ID
         mock_model_builder.mode = Mode.LOCAL_CONTAINER
         mock_model_builder.model_server = ModelServer.TGI
@@ -116,6 +150,7 @@ class TestTelemetryLogger(unittest.TestCase):
             f"&x-modelName={MOCK_HUGGINGFACE_ID}"
             f"&x-endpointArn={MOCK_ENDPOINT_ARN}"
             f"&x-latency={latency}"
+            f"&x-defaultImageUsage={ImageUriOption.DEFAULT_IMAGE.value}"
         )
 
         mock_send_telemetry.assert_called_once_with(
@@ -139,6 +174,7 @@ class TestTelemetryLogger(unittest.TestCase):
         mock_model_builder = ModelBuilderMock()
         mock_model_builder.serve_settings.telemetry_opt_out = False
         mock_model_builder.image_uri = MOCK_DJL_CONTAINER
+        mock_model_builder._is_custom_image_uri = False
         mock_model_builder.model = MOCK_HUGGINGFACE_ID
         mock_model_builder.mode = Mode.LOCAL_CONTAINER
         mock_model_builder.model_server = ModelServer.DJL_SERVING
@@ -161,6 +197,7 @@ class TestTelemetryLogger(unittest.TestCase):
             f"&x-modelName={MOCK_HUGGINGFACE_ID}"
             f"&x-endpointArn={MOCK_ENDPOINT_ARN}"
             f"&x-latency={latency}"
+            f"&x-defaultImageUsage={ImageUriOption.DEFAULT_IMAGE.value}"
         )
 
         mock_send_telemetry.assert_called_once_with(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Add telemetry metrics on usage of default images for ModelBuilder
- Enable vpc_config in jumpstart models and transformer models
*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
