### PR TITLE
feat: Add new Triton DLC URIs

### DIFF
--- a/src/sagemaker/image_uri_config/sagemaker-tritonserver.json
+++ b/src/sagemaker/image_uri_config/sagemaker-tritonserver.json
@@ -1,0 +1,75 @@
+{
+	"processors": [
+		"cpu",
+		"gpu"
+	],
+	"scope": [
+		"inference"
+	],
+	"versions": {
+		"23.12": {
+			"registries": {
+				"af-south-1": "626614931356",
+				"il-central-1": "780543022126",
+				"ap-east-1": "871362719292",
+				"ap-northeast-1": "763104351884",
+				"ap-northeast-2": "763104351884",
+				"ap-northeast-3": "364406365360",
+				"ap-south-1": "763104351884",
+				"ap-southeast-1": "763104351884",
+				"ap-southeast-2": "763104351884",
+				"ap-southeast-3": "907027046896",
+				"ca-central-1": "763104351884",
+				"cn-north-1": "727897471807",
+				"cn-northwest-1": "727897471807",
+				"eu-central-1": "763104351884",
+				"eu-north-1": "763104351884",
+				"eu-west-1": "763104351884",
+				"eu-west-2": "763104351884",
+				"eu-west-3": "763104351884",
+				"eu-south-1": "692866216735",
+				"me-south-1": "217643126080",
+				"sa-east-1": "763104351884",
+				"us-east-1": "763104351884",
+				"us-east-2": "763104351884",
+				"us-west-1": "763104351884",
+				"us-west-2": "763104351884",
+				"ca-west-1": "204538143572"
+			},
+			"repository": "sagemaker-tritonserver",
+			"tag_prefix": "23.12-py3"
+		},
+		"24.01": {
+			"registries": {
+				"af-south-1": "626614931356",
+				"il-central-1": "780543022126",
+				"ap-east-1": "871362719292",
+				"ap-northeast-1": "763104351884",
+				"ap-northeast-2": "763104351884",
+				"ap-northeast-3": "364406365360",
+				"ap-south-1": "763104351884",
+				"ap-southeast-1": "763104351884",
+				"ap-southeast-2": "763104351884",
+				"ap-southeast-3": "907027046896",
+				"ca-central-1": "763104351884",
+				"cn-north-1": "727897471807",
+				"cn-northwest-1": "727897471807",
+				"eu-central-1": "763104351884",
+				"eu-north-1": "763104351884",
+				"eu-west-1": "763104351884",
+				"eu-west-2": "763104351884",
+				"eu-west-3": "763104351884",
+				"eu-south-1": "692866216735",
+				"me-south-1": "217643126080",
+				"sa-east-1": "763104351884",
+				"us-east-1": "763104351884",
+				"us-east-2": "763104351884",
+				"us-west-1": "763104351884",
+				"us-west-2": "763104351884",
+				"ca-west-1": "204538143572"
+			},
+			"repository": "sagemaker-tritonserver",
+			"tag_prefix": "24.01-py3"
+		}
+	}
+}

--- a/src/sagemaker/image_uris.py
+++ b/src/sagemaker/image_uris.py
@@ -339,7 +339,7 @@ def _get_image_tag(
     # Triton images don't have a trailing -gpu tag. Only -cpu images do.
     if framework == SAGEMAKER_TRITONSERVER_FRAMEWORK:
         if processor == "gpu":
-            tag = tag.rstrip(f"-gpu")
+            tag = tag.rstrip("-gpu")
 
     return tag
 

--- a/src/sagemaker/image_uris.py
+++ b/src/sagemaker/image_uris.py
@@ -44,6 +44,7 @@ TRAINIUM_ALLOWED_FRAMEWORKS = "pytorch"
 INFERENCE_GRAVITON = "inference_graviton"
 DATA_WRANGLER_FRAMEWORK = "data-wrangler"
 STABILITYAI_FRAMEWORK = "stabilityai"
+SAGEMAKER_TRITONSERVER_FRAMEWORK = "sagemaker-tritonserver"
 
 
 @override_pipeline_parameter_var
@@ -334,6 +335,11 @@ def _get_image_tag(
             key = "-".join([framework, tag])
             if key in container_versions:
                 tag = "-".join([tag, container_versions[key]])
+
+    # Triton images don't have a trailing -gpu tag. Only -cpu images do.
+    if framework == SAGEMAKER_TRITONSERVER_FRAMEWORK:
+        if processor == "gpu":
+            tag = tag.rstrip(f"-gpu")
 
     return tag
 

--- a/tests/unit/sagemaker/image_uris/expected_uris.py
+++ b/tests/unit/sagemaker/image_uris/expected_uris.py
@@ -83,6 +83,7 @@ def djl_framework_uri(repo, account, tag, region=REGION):
     domain = ALTERNATE_DOMAINS.get(region, DOMAIN)
     return IMAGE_URI_FORMAT.format(account, region, domain, repo, tag)
 
+
 def sagemaker_triton_framework_uri(repo, account, tag, processor="gpu", region=REGION):
     domain = ALTERNATE_DOMAINS.get(region, DOMAIN)
     if processor == "cpu":

--- a/tests/unit/sagemaker/image_uris/expected_uris.py
+++ b/tests/unit/sagemaker/image_uris/expected_uris.py
@@ -83,6 +83,12 @@ def djl_framework_uri(repo, account, tag, region=REGION):
     domain = ALTERNATE_DOMAINS.get(region, DOMAIN)
     return IMAGE_URI_FORMAT.format(account, region, domain, repo, tag)
 
+def sagemaker_triton_framework_uri(repo, account, tag, processor="gpu", region=REGION):
+    domain = ALTERNATE_DOMAINS.get(region, DOMAIN)
+    if processor == "cpu":
+        tag = f"{tag}-cpu"
+    return IMAGE_URI_FORMAT.format(account, region, domain, repo, tag)
+
 
 def huggingface_llm_framework_uri(
     repo,

--- a/tests/unit/sagemaker/image_uris/test_sagemaker_tritonserver.py
+++ b/tests/unit/sagemaker/image_uris/test_sagemaker_tritonserver.py
@@ -17,11 +17,10 @@ from tests.unit.sagemaker.image_uris import expected_uris
 
 INSTANCE_TYPES = {"cpu": "ml.c4.xlarge", "gpu": "ml.p2.xlarge"}
 
+
 @pytest.mark.parametrize(
     "load_config_and_file_name",
-    [
-        "sagemaker-tritonserver.json"
-    ],
+    ["sagemaker-tritonserver.json"],
     indirect=True,
 )
 def test_sagemaker_tritonserver_uris(load_config_and_file_name):
@@ -35,11 +34,17 @@ def test_sagemaker_tritonserver_uris(load_config_and_file_name):
         for processor in processors:
             instance_type = INSTANCE_TYPES[processor]
             for region in ACCOUNTS.keys():
-                _test_sagemaker_tritonserver_uris(ACCOUNTS[region], region, version, tag, framework, instance_type, processor)
+                _test_sagemaker_tritonserver_uris(
+                    ACCOUNTS[region], region, version, tag, framework, instance_type, processor
+                )
 
 
-def _test_sagemaker_tritonserver_uris(account, region, version, tag, triton_framework, instance_type, processor):
-    uri = image_uris.retrieve(framework=triton_framework, region=region, version=version, instance_type=instance_type)
+def _test_sagemaker_tritonserver_uris(
+    account, region, version, tag, triton_framework, instance_type, processor
+):
+    uri = image_uris.retrieve(
+        framework=triton_framework, region=region, version=version, instance_type=instance_type
+    )
     expected = expected_uris.sagemaker_triton_framework_uri(
         "sagemaker-tritonserver",
         account,

--- a/tests/unit/sagemaker/image_uris/test_sagemaker_tritonserver.py
+++ b/tests/unit/sagemaker/image_uris/test_sagemaker_tritonserver.py
@@ -1,0 +1,50 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from __future__ import absolute_import
+import pytest
+from sagemaker import image_uris
+from tests.unit.sagemaker.image_uris import expected_uris
+
+INSTANCE_TYPES = {"cpu": "ml.c4.xlarge", "gpu": "ml.p2.xlarge"}
+
+@pytest.mark.parametrize(
+    "load_config_and_file_name",
+    [
+        "sagemaker-tritonserver.json"
+    ],
+    indirect=True,
+)
+def test_sagemaker_tritonserver_uris(load_config_and_file_name):
+    config, file_name = load_config_and_file_name
+    framework = file_name.split(".json")[0]
+    VERSIONS = config["versions"]
+    processors = config["processors"]
+    for version in VERSIONS:
+        ACCOUNTS = config["versions"][version]["registries"]
+        tag = config["versions"][version]["tag_prefix"]
+        for processor in processors:
+            instance_type = INSTANCE_TYPES[processor]
+            for region in ACCOUNTS.keys():
+                _test_sagemaker_tritonserver_uris(ACCOUNTS[region], region, version, tag, framework, instance_type, processor)
+
+
+def _test_sagemaker_tritonserver_uris(account, region, version, tag, triton_framework, instance_type, processor):
+    uri = image_uris.retrieve(framework=triton_framework, region=region, version=version, instance_type=instance_type)
+    expected = expected_uris.sagemaker_triton_framework_uri(
+        "sagemaker-tritonserver",
+        account,
+        tag,
+        processor,
+        region,
+    )
+    assert expected == uri


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Starting Triton version 23.12, sagemaker tritonserver is available in a different set of accounts, similar to other model servers such as djl-serving, torchserve etc. i.e. original DLC accounts, as opposed to SageMaker Neo accounts. Triton on SageMaker will be available on both Neo accounts and new DLC accounts until v23.05. After v23.05, Triton will only be available in the new DLC URIs (i.e. accounts listed in this PR).
2. Adding the account id and region map for DLC accounts.

*Testing done:*
```
 pytest -s tests/unit/sagemaker/image_uris/test_sagemaker_tritonserver.py 
```

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
