### PR TITLE
feat: Prepend SageMaker Studio App Type to boto3 User Agent string

### DIFF
--- a/src/sagemaker/user_agent.py
+++ b/src/sagemaker/user_agent.py
@@ -15,8 +15,17 @@ from __future__ import absolute_import
 
 import platform
 import sys
+import json
+import os
 
 import importlib_metadata
+
+SDK_PREFIX = "AWS-SageMaker-Python-SDK"
+STUDIO_PREFIX = "AWS-SageMaker-Studio"
+NOTEBOOK_PREFIX = "AWS-SageMaker-Notebook-Instance"
+
+NOTEBOOK_METADATA_FILE = "/etc/opt/ml/sagemaker-notebook-instance-version.txt"
+STUDIO_METADATA_FILE = "/opt/ml/metadata/resource-metadata.json"
 
 SDK_VERSION = importlib_metadata.version("sagemaker")
 OS_NAME = platform.system() or "UnresolvedOS"
@@ -27,9 +36,43 @@ PYTHON_VERSION = "Python/{}.{}.{}".format(
 )
 
 
+def process_notebook_metadata_file():
+    """Check if the platform is SageMaker Notebook, if yes, return the InstanceType
+
+    Returns:
+        str: The InstanceType of the SageMaker Notebook if it exists, otherwise None
+    """
+    if os.path.exists(NOTEBOOK_METADATA_FILE):
+        with open(NOTEBOOK_METADATA_FILE, "r") as sagemaker_nbi_file:
+            return sagemaker_nbi_file.read().strip()
+
+    return None
+
+
+def process_studio_metadata_file():
+    """Check if the platform is SageMaker Studio, if yes, return the AppType
+
+    Returns:
+        str: The AppType of the SageMaker Studio if it exists, otherwise None
+    """
+    if os.path.exists(STUDIO_METADATA_FILE):
+        with open(STUDIO_METADATA_FILE, "r") as sagemaker_studio_file:
+            metadata = json.load(sagemaker_studio_file)
+            return metadata.get("AppType")
+
+    return None
+
+
 def determine_prefix(user_agent=""):
-    """Placeholder docstring"""
-    prefix = "AWS-SageMaker-Python-SDK/{}".format(SDK_VERSION)
+    """Determines the prefix for the user agent string.
+
+    Args:
+        user_agent (str): The user agent string to prepend the prefix to.
+
+    Returns:
+        str: The user agent string with the prefix prepended.
+    """
+    prefix = "{}/{}".format(SDK_PREFIX, SDK_VERSION)
 
     if PYTHON_VERSION not in user_agent:
         prefix = "{} {}".format(prefix, PYTHON_VERSION)
@@ -37,20 +80,25 @@ def determine_prefix(user_agent=""):
     if OS_NAME_VERSION not in user_agent:
         prefix = "{} {}".format(prefix, OS_NAME_VERSION)
 
-    try:
-        with open("/etc/opt/ml/sagemaker-notebook-instance-version.txt") as sagemaker_nbi_file:
-            prefix = "{} AWS-SageMaker-Notebook-Instance/{}".format(
-                prefix, sagemaker_nbi_file.read().strip()
-            )
-    except IOError:
-        # This file isn't expected to always exist, and we DO want to silently ignore failures.
-        pass
+    # Get the notebook instance type and prepend it to the user agent string if exists
+    notebook_instance_type = process_notebook_metadata_file()
+    if notebook_instance_type:
+        prefix = "{} {}/{}".format(prefix, NOTEBOOK_PREFIX, notebook_instance_type)
+
+    # Get the studio app type and prepend it to the user agent string if exists
+    studio_app_type = process_studio_metadata_file()
+    if studio_app_type:
+        prefix = "{} {}/{}".format(prefix, STUDIO_PREFIX, studio_app_type)
 
     return prefix
 
 
 def prepend_user_agent(client):
-    """Placeholder docstring"""
+    """Prepends the user agent string with the SageMaker Python SDK version.
+
+    Args:
+        client (botocore.client.BaseClient): The client to prepend the user agent string for.
+    """
     prefix = determine_prefix(client._client_config.user_agent)
 
     if client._client_config.user_agent is None:

--- a/tests/unit/test_user_agent.py
+++ b/tests/unit/test_user_agent.py
@@ -1,0 +1,104 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from __future__ import absolute_import
+
+import json
+from mock import MagicMock, patch, mock_open
+
+
+from sagemaker.user_agent import (
+    SDK_PREFIX,
+    SDK_VERSION,
+    PYTHON_VERSION,
+    OS_NAME_VERSION,
+    NOTEBOOK_PREFIX,
+    STUDIO_PREFIX,
+    process_notebook_metadata_file,
+    process_studio_metadata_file,
+    determine_prefix,
+    prepend_user_agent,
+)
+
+
+# Test process_notebook_metadata_file function
+def test_process_notebook_metadata_file_exists(tmp_path):
+    notebook_file = tmp_path / "sagemaker-notebook-instance-version.txt"
+    notebook_file.write_text("instance_type")
+
+    with patch("os.path.exists", return_value=True):
+        with patch("builtins.open", mock_open(read_data=notebook_file.read_text())):
+            assert process_notebook_metadata_file() == "instance_type"
+
+
+def test_process_notebook_metadata_file_not_exists(tmp_path):
+    with patch("os.path.exists", return_value=False):
+        assert process_notebook_metadata_file() is None
+
+
+# Test process_studio_metadata_file function
+def test_process_studio_metadata_file_exists(tmp_path):
+    studio_file = tmp_path / "resource-metadata.json"
+    studio_file.write_text(json.dumps({"AppType": "studio_type"}))
+
+    with patch("os.path.exists", return_value=True):
+        with patch("builtins.open", mock_open(read_data=studio_file.read_text())):
+            assert process_studio_metadata_file() == "studio_type"
+
+
+def test_process_studio_metadata_file_not_exists(tmp_path):
+    with patch("os.path.exists", return_value=False):
+        assert process_studio_metadata_file() is None
+
+
+# Test determine_prefix function
+def test_determine_prefix_notebook_instance_type(monkeypatch):
+    monkeypatch.setattr(
+        "sagemaker.user_agent.process_notebook_metadata_file", lambda: "instance_type"
+    )
+    assert (
+        determine_prefix()
+        == f"{SDK_PREFIX}/{SDK_VERSION} {PYTHON_VERSION} {OS_NAME_VERSION} {NOTEBOOK_PREFIX}/instance_type"
+    )
+
+
+def test_determine_prefix_studio_app_type(monkeypatch):
+    monkeypatch.setattr(
+        "sagemaker.user_agent.process_studio_metadata_file", lambda: "studio_app_type"
+    )
+    assert (
+        determine_prefix()
+        == f"{SDK_PREFIX}/{SDK_VERSION} {PYTHON_VERSION} {OS_NAME_VERSION} {STUDIO_PREFIX}/studio_app_type"
+    )
+
+
+def test_determine_prefix_no_metadata(monkeypatch):
+    monkeypatch.setattr("sagemaker.user_agent.process_notebook_metadata_file", lambda: None)
+    monkeypatch.setattr("sagemaker.user_agent.process_studio_metadata_file", lambda: None)
+    assert determine_prefix() == f"{SDK_PREFIX}/{SDK_VERSION} {PYTHON_VERSION} {OS_NAME_VERSION}"
+
+
+# Test prepend_user_agent function
+def test_prepend_user_agent_existing_user_agent(monkeypatch):
+    client = MagicMock()
+    client._client_config.user_agent = "existing_user_agent"
+    monkeypatch.setattr("sagemaker.user_agent.determine_prefix", lambda _: "prefix")
+    prepend_user_agent(client)
+    assert client._client_config.user_agent == "prefix existing_user_agent"
+
+
+def test_prepend_user_agent_no_user_agent(monkeypatch):
+    client = MagicMock()
+    client._client_config.user_agent = None
+    monkeypatch.setattr("sagemaker.user_agent.determine_prefix", lambda _: "prefix")
+    prepend_user_agent(client)
+    assert client._client_config.user_agent == "prefix"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Basic test to verify User Agent propagation by adding test_user_agent.py
* Test to ensure that notebook instance is injected
* Test to ensure that studio app type is injected

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
