### PR TITLE
feat: JumpStart proprietary model deploy

### DIFF
--- a/src/sagemaker/accept_types.py
+++ b/src/sagemaker/accept_types.py
@@ -16,6 +16,7 @@ from typing import List, Optional
 
 from sagemaker.jumpstart import artifacts, utils as jumpstart_utils
 from sagemaker.jumpstart.constants import DEFAULT_JUMPSTART_SAGEMAKER_SESSION
+from sagemaker.jumpstart.enums import JumpStartModelType
 from sagemaker.session import Session
 
 
@@ -72,6 +73,7 @@ def retrieve_default(
     region: Optional[str] = None,
     model_id: Optional[str] = None,
     model_version: Optional[str] = None,
+    model_type: Optional[JumpStartModelType] = JumpStartModelType.OPEN_SOURCE,
     tolerate_vulnerable_model: bool = False,
     tolerate_deprecated_model: bool = False,
     sagemaker_session: Session = DEFAULT_JUMPSTART_SAGEMAKER_SESSION,

--- a/src/sagemaker/base_predictor.py
+++ b/src/sagemaker/base_predictor.py
@@ -58,7 +58,9 @@ from sagemaker.utils import name_from_base, stringify_object, format_tags
 from sagemaker.model_monitor.model_monitoring import DEFAULT_REPOSITORY_NAME
 
 from sagemaker.lineage.context import EndpointContext
-from sagemaker.compute_resource_requirements.resource_requirements import ResourceRequirements
+from sagemaker.compute_resource_requirements.resource_requirements import (
+    ResourceRequirements,
+)
 
 LOGGER = logging.getLogger("sagemaker")
 

--- a/src/sagemaker/content_types.py
+++ b/src/sagemaker/content_types.py
@@ -16,6 +16,7 @@ from typing import List, Optional
 
 from sagemaker.jumpstart import artifacts, utils as jumpstart_utils
 from sagemaker.jumpstart.constants import DEFAULT_JUMPSTART_SAGEMAKER_SESSION
+from sagemaker.jumpstart.enums import JumpStartModelType
 from sagemaker.session import Session
 
 
@@ -72,6 +73,7 @@ def retrieve_default(
     region: Optional[str] = None,
     model_id: Optional[str] = None,
     model_version: Optional[str] = None,
+    model_type: Optional[JumpStartModelType] = JumpStartModelType.OPEN_SOURCE,
     tolerate_vulnerable_model: bool = False,
     tolerate_deprecated_model: bool = False,
     sagemaker_session: Session = DEFAULT_JUMPSTART_SAGEMAKER_SESSION,

--- a/src/sagemaker/deserializers.py
+++ b/src/sagemaker/deserializers.py
@@ -35,6 +35,7 @@ from sagemaker.base_deserializers import (  # noqa: F401 # pylint: disable=W0611
 
 from sagemaker.jumpstart import artifacts, utils as jumpstart_utils
 from sagemaker.jumpstart.constants import DEFAULT_JUMPSTART_SAGEMAKER_SESSION
+from sagemaker.jumpstart.enums import JumpStartModelType
 from sagemaker.session import Session
 
 
@@ -95,6 +96,7 @@ def retrieve_default(
     tolerate_vulnerable_model: bool = False,
     tolerate_deprecated_model: bool = False,
     sagemaker_session: Session = DEFAULT_JUMPSTART_SAGEMAKER_SESSION,
+    model_type: Optional[JumpStartModelType] = JumpStartModelType.OPEN_SOURCE,
 ) -> BaseDeserializer:
     """Retrieves the default deserializer for the model matching the given arguments.
 

--- a/src/sagemaker/jumpstart/accessors.py
+++ b/src/sagemaker/jumpstart/accessors.py
@@ -18,6 +18,7 @@ import boto3
 
 from sagemaker.deprecations import deprecated
 from sagemaker.jumpstart.types import JumpStartModelHeader, JumpStartModelSpecs
+from sagemaker.jumpstart.enums import JumpStartModelType
 from sagemaker.jumpstart import cache
 from sagemaker.jumpstart.constants import JUMPSTART_DEFAULT_REGION_NAME
 
@@ -197,7 +198,9 @@ class JumpStartModelsAccessor(object):
 
     @staticmethod
     def _get_manifest(
-        region: str = JUMPSTART_DEFAULT_REGION_NAME, s3_client: Optional[boto3.client] = None
+        region: str = JUMPSTART_DEFAULT_REGION_NAME,
+        s3_client: Optional[boto3.client] = None,
+        model_type: JumpStartModelType = JumpStartModelType.OPEN_SOURCE,
     ) -> List[JumpStartModelHeader]:
         """Return entire JumpStart models manifest.
 
@@ -215,13 +218,19 @@ class JumpStartModelsAccessor(object):
             additional_kwargs.update({"s3_client": s3_client})
 
         cache_kwargs = JumpStartModelsAccessor._validate_and_mutate_region_cache_kwargs(
-            {**JumpStartModelsAccessor._cache_kwargs, **additional_kwargs}, region
+            {**JumpStartModelsAccessor._cache_kwargs, **additional_kwargs},
+            region,
         )
         JumpStartModelsAccessor._set_cache_and_region(region, cache_kwargs)
-        return JumpStartModelsAccessor._cache.get_manifest()  # type: ignore
+        return JumpStartModelsAccessor._cache.get_manifest(model_type)  # type: ignore
 
     @staticmethod
-    def get_model_header(region: str, model_id: str, version: str) -> JumpStartModelHeader:
+    def get_model_header(
+        region: str,
+        model_id: str,
+        version: str,
+        model_type: JumpStartModelType = JumpStartModelType.OPEN_SOURCE,
+    ) -> JumpStartModelHeader:
         """Returns model header from JumpStart models cache.
 
         Args:
@@ -234,12 +243,18 @@ class JumpStartModelsAccessor(object):
         )
         JumpStartModelsAccessor._set_cache_and_region(region, cache_kwargs)
         return JumpStartModelsAccessor._cache.get_header(  # type: ignore
-            model_id=model_id, semantic_version_str=version
+            model_id=model_id,
+            semantic_version_str=version,
+            model_type=model_type,
         )
 
     @staticmethod
     def get_model_specs(
-        region: str, model_id: str, version: str, s3_client: Optional[boto3.client] = None
+        region: str,
+        model_id: str,
+        version: str,
+        s3_client: Optional[boto3.client] = None,
+        model_type=JumpStartModelType.OPEN_SOURCE,
     ) -> JumpStartModelSpecs:
         """Returns model specs from JumpStart models cache.
 
@@ -260,7 +275,7 @@ class JumpStartModelsAccessor(object):
         )
         JumpStartModelsAccessor._set_cache_and_region(region, cache_kwargs)
         return JumpStartModelsAccessor._cache.get_specs(  # type: ignore
-            model_id=model_id, semantic_version_str=version
+            model_id=model_id, version_str=version, model_type=model_type
         )
 
     @staticmethod

--- a/src/sagemaker/jumpstart/cache.py
+++ b/src/sagemaker/jumpstart/cache.py
@@ -25,9 +25,12 @@ from sagemaker.jumpstart.constants import (
     ENV_VARIABLE_JUMPSTART_MANIFEST_LOCAL_ROOT_DIR_OVERRIDE,
     ENV_VARIABLE_JUMPSTART_SPECS_LOCAL_ROOT_DIR_OVERRIDE,
     JUMPSTART_DEFAULT_MANIFEST_FILE_S3_KEY,
+    JUMPSTART_DEFAULT_PROPRIETARY_MANIFEST_KEY,
     JUMPSTART_DEFAULT_REGION_NAME,
     JUMPSTART_LOGGER,
     MODEL_ID_LIST_WEB_URL,
+    MODEL_TYPE_TO_MANIFEST_MAP,
+    MODEL_TYPE_TO_SPECS_MAP,
 )
 from sagemaker.jumpstart.exceptions import get_wildcard_model_version_msg
 from sagemaker.jumpstart.parameters import (
@@ -44,6 +47,7 @@ from sagemaker.jumpstart.types import (
     JumpStartS3FileType,
     JumpStartVersionedModelId,
 )
+from sagemaker.jumpstart.enums import JumpStartModelType
 from sagemaker.jumpstart import utils
 from sagemaker.utilities.cache import LRUCache
 
@@ -68,6 +72,7 @@ class JumpStartModelsCache:
         JUMPSTART_DEFAULT_SEMANTIC_VERSION_CACHE_EXPIRATION_HORIZON,
         manifest_file_s3_key: str =
         JUMPSTART_DEFAULT_MANIFEST_FILE_S3_KEY,
+        proprietary_manifest_s3_key: str = JUMPSTART_DEFAULT_PROPRIETARY_MANIFEST_KEY,
         s3_bucket_name: Optional[str] = None,
         s3_client_config: Optional[botocore.config.Config] = None,
         s3_client: Optional[boto3.client] = None,
@@ -100,14 +105,26 @@ class JumpStartModelsCache:
             expiration_horizon=s3_cache_expiration_horizon,
             retrieval_function=self._retrieval_function,
         )
-        self._model_id_semantic_version_manifest_key_cache = LRUCache[
+        self._open_source_model_id_manifest_key_cache = LRUCache[
             JumpStartVersionedModelId, JumpStartVersionedModelId
         ](
             max_cache_items=max_semantic_version_cache_items,
             expiration_horizon=semantic_version_cache_expiration_horizon,
-            retrieval_function=self._get_manifest_key_from_model_id_semantic_version,
+            retrieval_function=self._get_open_source_manifest_key_from_model_id,
+        )
+        self._proprietary_model_id_manifest_key_cache = LRUCache[
+            JumpStartVersionedModelId, JumpStartVersionedModelId
+        ](
+            max_cache_items=max_semantic_version_cache_items,
+            expiration_horizon=semantic_version_cache_expiration_horizon,
+            retrieval_function=self._get_proprietary_manifest_key_from_model_id,
         )
         self._manifest_file_s3_key = manifest_file_s3_key
+        self._proprietary_manifest_s3_key = proprietary_manifest_s3_key
+        self._manifest_file_s3_map = {
+            JumpStartModelType.OPEN_SOURCE: self._manifest_file_s3_key,
+            JumpStartModelType.PROPRIETARY: self._proprietary_manifest_s3_key,
+        }
         self.s3_bucket_name = (
             utils.get_jumpstart_content_bucket(self._region)
             if s3_bucket_name is None
@@ -129,15 +146,44 @@ class JumpStartModelsCache:
         """Return region for cache."""
         return self._region
 
-    def set_manifest_file_s3_key(self, key: str) -> None:
-        """Set manifest file s3 key. Clears cache after new key is set."""
-        if key != self._manifest_file_s3_key:
-            self._manifest_file_s3_key = key
+    def set_manifest_file_s3_key(
+        self,
+        key: str,
+        file_type: JumpStartS3FileType = JumpStartS3FileType.OPEN_SOURCE_MANIFEST,
+    ) -> None:
+        """Set manifest file s3 key. Clears cache after new key is set.
+
+        Raises:
+            ValueError: if the file type is not recognized
+        """
+        file_mapping = {
+            JumpStartS3FileType.OPEN_SOURCE_MANIFEST: self._manifest_file_s3_key,
+            JumpStartS3FileType.PROPRIETARY_MANIFEST: self._proprietary_manifest_s3_key,
+        }
+        property_name = file_mapping.get(file_type)
+        if not property_name:
+            raise ValueError(
+                f"Bad value when setting manifest '{file_type}': must be in"
+                f"{JumpStartS3FileType.OPEN_SOURCE_MANIFEST}"
+                f"{JumpStartS3FileType.PROPRIETARY_MANIFEST}"
+            )
+        if key != property_name:
+            setattr(self, property_name, key)
             self.clear()
 
-    def get_manifest_file_s3_key(self) -> str:
+    def get_manifest_file_s3_key(
+        self, file_type: JumpStartS3FileType = JumpStartS3FileType.OPEN_SOURCE_MANIFEST
+    ) -> str:
         """Return manifest file s3 key for cache."""
-        return self._manifest_file_s3_key
+        if file_type == JumpStartS3FileType.OPEN_SOURCE_MANIFEST:
+            return self._manifest_file_s3_key
+        if file_type == JumpStartS3FileType.PROPRIETARY_MANIFEST:
+            return self._proprietary_manifest_s3_key
+        raise ValueError(
+            f"Bad value when getting manifest '{file_type}':"
+            f"must be in {JumpStartS3FileType.OPEN_SOURCE_MANIFEST}"
+            f"{JumpStartS3FileType.PROPRIETARY_MANIFEST}"
+        )
 
     def set_s3_bucket_name(self, s3_bucket_name: str) -> None:
         """Set s3 bucket used for cache."""
@@ -149,10 +195,11 @@ class JumpStartModelsCache:
         """Return bucket used for cache."""
         return self.s3_bucket_name
 
-    def _get_manifest_key_from_model_id_semantic_version(
+    def _model_id_retrieval_function(
         self,
         key: JumpStartVersionedModelId,
         value: Optional[JumpStartVersionedModelId],  # pylint: disable=W0613
+        model_type: JumpStartModelType
     ) -> JumpStartVersionedModelId:
         """Return model ID and version in manifest that matches semantic version/id.
 
@@ -164,6 +211,8 @@ class JumpStartModelsCache:
             key (JumpStartVersionedModelId): Key for which to fetch versioned model ID.
             value (Optional[JumpStartVersionedModelId]): Unused variable for current value of
                 old cached model ID/version.
+            UseSematicVersion (bool): boolean value to indicate whether the model versions follow
+                sematic versioning.
 
         Raises:
             KeyError: If the semantic version is not found in the manifest, or is found but
@@ -172,14 +221,14 @@ class JumpStartModelsCache:
 
         model_id, version = key.model_id, key.version
 
+        sm_version = utils.get_sagemaker_version()
         manifest = self._s3_cache.get(
-            JumpStartCachedS3ContentKey(JumpStartS3FileType.MANIFEST, self._manifest_file_s3_key)
+            JumpStartCachedS3ContentKey(
+                MODEL_TYPE_TO_MANIFEST_MAP[model_type], self._manifest_file_s3_map[model_type])
         )[0].formatted_content
 
-        sm_version = utils.get_sagemaker_version()
-
         versions_compatible_with_sagemaker = [
-            Version(header.version)
+            header.version
             for header in manifest.values()  # type: ignore
             if header.model_id == model_id and Version(header.min_version) <= Version(sm_version)
         ]
@@ -242,6 +291,26 @@ class JumpStartModelsCache:
 
         raise KeyError(error_msg)
 
+    def _get_open_source_manifest_key_from_model_id(
+        self,
+        key: JumpStartVersionedModelId,
+        value: Optional[JumpStartVersionedModelId],  # pylint: disable=W0613
+    ) -> JumpStartVersionedModelId:
+        """Get open source manifest key from model id."""
+        return self._model_id_retrieval_function(
+            key, value, model_type=JumpStartModelType.OPEN_SOURCE
+        )
+
+    def _get_proprietary_manifest_key_from_model_id(
+        self,
+        key: JumpStartVersionedModelId,
+        value: Optional[JumpStartVersionedModelId],  # pylint: disable=W0613
+    ) -> JumpStartVersionedModelId:
+        """Get proprietary manifest key from model id."""
+        return self._model_id_retrieval_function(
+            key, value, model_type=JumpStartModelType.PROPRIETARY
+        )
+
     def _get_json_file_and_etag_from_s3(self, key: str) -> Tuple[Union[dict, list], str]:
         """Returns json file from s3, along with its etag."""
         response = self._s3_client.get_object(Bucket=self.s3_bucket_name, Key=key)
@@ -286,11 +355,11 @@ class JumpStartModelsCache:
         filetype: JumpStartS3FileType
     ) -> Union[dict, list]:
         """Reads json file from local filesystem and returns data."""
-        if filetype == JumpStartS3FileType.MANIFEST:
+        if filetype == JumpStartS3FileType.OPEN_SOURCE_MANIFEST:
             metadata_local_root = (
                 os.environ[ENV_VARIABLE_JUMPSTART_MANIFEST_LOCAL_ROOT_DIR_OVERRIDE]
             )
-        elif filetype == JumpStartS3FileType.SPECS:
+        elif filetype == JumpStartS3FileType.OPEN_SOURCE_SPECS:
             metadata_local_root = os.environ[ENV_VARIABLE_JUMPSTART_SPECS_LOCAL_ROOT_DIR_OVERRIDE]
         else:
             raise ValueError(f"Unsupported file type for local override: {filetype}")
@@ -318,8 +387,10 @@ class JumpStartModelsCache:
         """
 
         file_type, s3_key = key.file_type, key.s3_key
-
-        if file_type == JumpStartS3FileType.MANIFEST:
+        if file_type in {
+            JumpStartS3FileType.OPEN_SOURCE_MANIFEST,
+            JumpStartS3FileType.PROPRIETARY_MANIFEST,
+        }:
             if value is not None and not self._is_local_metadata_mode():
                 etag = self._get_json_md5_hash(s3_key)
                 if etag == value.md5_hash:
@@ -329,27 +400,38 @@ class JumpStartModelsCache:
                 formatted_content=utils.get_formatted_manifest(formatted_body),
                 md5_hash=etag,
             )
-        if file_type == JumpStartS3FileType.SPECS:
+        if file_type in {
+            JumpStartS3FileType.OPEN_SOURCE_SPECS,
+            JumpStartS3FileType.PROPRIETARY_SPECS,
+        }:
             formatted_body, _ = self._get_json_file(s3_key, file_type)
             model_specs = JumpStartModelSpecs(formatted_body)
             utils.emit_logs_based_on_model_specs(model_specs, self.get_region(), self._s3_client)
-            return JumpStartCachedS3ContentValue(
-                formatted_content=model_specs
-            )
+            return JumpStartCachedS3ContentValue(formatted_content=model_specs)
         raise ValueError(
-            f"Bad value for key '{key}': must be in {[JumpStartS3FileType.MANIFEST, JumpStartS3FileType.SPECS]}"
+            f"Bad value for key '{key}': must be in"
+            f"{JumpStartS3FileType.OPEN_SOURCE_MANIFEST, JumpStartS3FileType.OPEN_SOURCE_SPECS}"
+            f"{JumpStartS3FileType.PROPRIETARY_SPECS, JumpStartS3FileType.PROPRIETARY_MANIFEST}"
         )
 
-    def get_manifest(self) -> List[JumpStartModelHeader]:
+    def get_manifest(
+        self,
+        model_type: JumpStartModelType = JumpStartModelType.OPEN_SOURCE,
+    ) -> List[JumpStartModelHeader]:
         """Return entire JumpStart models manifest."""
-
         manifest_dict = self._s3_cache.get(
-            JumpStartCachedS3ContentKey(JumpStartS3FileType.MANIFEST, self._manifest_file_s3_key)
+            JumpStartCachedS3ContentKey(
+                MODEL_TYPE_TO_MANIFEST_MAP[model_type], self._manifest_file_s3_map[model_type])
         )[0].formatted_content
         manifest = list(manifest_dict.values())  # type: ignore
         return manifest
 
-    def get_header(self, model_id: str, semantic_version_str: str) -> JumpStartModelHeader:
+    def get_header(
+        self,
+        model_id: str,
+        semantic_version_str: str,
+        model_type: JumpStartModelType = JumpStartModelType.OPEN_SOURCE,
+    ) -> JumpStartModelHeader:
         """Return header for a given JumpStart model ID and semantic version.
 
         Args:
@@ -357,8 +439,9 @@ class JumpStartModelsCache:
             semantic_version_str (str): The semantic version for which to get a
                 header.
         """
-
-        return self._get_header_impl(model_id, semantic_version_str=semantic_version_str)
+        return self._get_header_impl(
+            model_id, semantic_version_str=semantic_version_str, model_type=model_type
+        )
 
     def _select_version(
         self,
@@ -391,6 +474,7 @@ class JumpStartModelsCache:
         model_id: str,
         semantic_version_str: str,
         attempt: int = 0,
+        model_type: JumpStartModelType = JumpStartModelType.OPEN_SOURCE
     ) -> JumpStartModelHeader:
         """Lower-level function to return header.
 
@@ -402,14 +486,21 @@ class JumpStartModelsCache:
                 header.
             attempt (int): attempt number at retrieving a header.
         """
+        if model_type == JumpStartModelType.OPEN_SOURCE:
+            versioned_model_id = self._open_source_model_id_manifest_key_cache.get(
+                JumpStartVersionedModelId(model_id, semantic_version_str)
+            )[0]
 
-        versioned_model_id = self._model_id_semantic_version_manifest_key_cache.get(
-            JumpStartVersionedModelId(model_id, semantic_version_str)
-        )[0]
+        elif model_type == JumpStartModelType.PROPRIETARY:
+            versioned_model_id = self._proprietary_model_id_manifest_key_cache.get(
+                JumpStartVersionedModelId(model_id, semantic_version_str)
+            )[0]
 
         manifest = self._s3_cache.get(
-            JumpStartCachedS3ContentKey(JumpStartS3FileType.MANIFEST, self._manifest_file_s3_key)
+            JumpStartCachedS3ContentKey(
+                MODEL_TYPE_TO_MANIFEST_MAP[model_type], self._manifest_file_s3_map[model_type])
         )[0].formatted_content
+
         try:
             header = manifest[versioned_model_id]  # type: ignore
             return header
@@ -419,7 +510,12 @@ class JumpStartModelsCache:
             self.clear()
             return self._get_header_impl(model_id, semantic_version_str, attempt + 1)
 
-    def get_specs(self, model_id: str, semantic_version_str: str) -> JumpStartModelSpecs:
+    def get_specs(
+        self,
+        model_id: str,
+        version_str: str,
+        model_type: JumpStartModelType = JumpStartModelType.OPEN_SOURCE
+    ) -> JumpStartModelSpecs:
         """Return specs for a given JumpStart model ID and semantic version.
 
         Args:
@@ -427,18 +523,18 @@ class JumpStartModelsCache:
             semantic_version_str (str): The semantic version for which to get
                 specs.
         """
-
-        header = self.get_header(model_id, semantic_version_str)
+        header = self.get_header(model_id, version_str, model_type)
         spec_key = header.spec_key
         specs, cache_hit = self._s3_cache.get(
-            JumpStartCachedS3ContentKey(JumpStartS3FileType.SPECS, spec_key)
+            JumpStartCachedS3ContentKey(
+                MODEL_TYPE_TO_SPECS_MAP[model_type], spec_key
+            )
         )
-        if not cache_hit and "*" in semantic_version_str:
+
+        if not cache_hit and "*" in version_str:
             JUMPSTART_LOGGER.warning(
                 get_wildcard_model_version_msg(
-                    header.model_id,
-                    semantic_version_str,
-                    header.version
+                    header.model_id, version_str, header.version
                 )
             )
         return specs.formatted_content
@@ -446,4 +542,5 @@ class JumpStartModelsCache:
     def clear(self) -> None:
         """Clears the model ID/version and s3 cache."""
         self._s3_cache.clear()
-        self._model_id_semantic_version_manifest_key_cache.clear()
+        self._open_source_model_id_manifest_key_cache.clear()
+        self._proprietary_model_id_manifest_key_cache.clear()

--- a/src/sagemaker/jumpstart/constants.py
+++ b/src/sagemaker/jumpstart/constants.py
@@ -22,8 +22,9 @@ from sagemaker.jumpstart.enums import (
     SerializerType,
     DeserializerType,
     MIMEType,
+    JumpStartModelType,
 )
-from sagemaker.jumpstart.types import JumpStartLaunchedRegionInfo
+from sagemaker.jumpstart.types import JumpStartLaunchedRegionInfo, JumpStartS3FileType
 from sagemaker.base_serializers import (
     BaseSerializer,
     CSVSerializer,
@@ -169,6 +170,7 @@ JUMPSTART_GATED_AND_PUBLIC_BUCKET_NAME_SET = JUMPSTART_BUCKET_NAME_SET.union(
 JUMPSTART_DEFAULT_REGION_NAME = boto3.session.Session().region_name or "us-west-2"
 
 JUMPSTART_DEFAULT_MANIFEST_FILE_S3_KEY = "models_manifest.json"
+JUMPSTART_DEFAULT_PROPRIETARY_MANIFEST_KEY = "proprietary-sdk-manifest.json"
 
 INFERENCE_ENTRY_POINT_SCRIPT_NAME = "inference.py"
 TRAINING_ENTRY_POINT_SCRIPT_NAME = "transfer_learning.py"
@@ -211,6 +213,16 @@ SERIALIZER_TYPE_TO_CLASS_MAP: Dict[SerializerType, Type[BaseSerializer]] = {
 
 DESERIALIZER_TYPE_TO_CLASS_MAP: Dict[DeserializerType, Type[BaseDeserializer]] = {
     DeserializerType.JSON: JSONDeserializer,
+}
+
+MODEL_TYPE_TO_MANIFEST_MAP: Dict[Type[JumpStartModelType], Type[JumpStartS3FileType]] = {
+    JumpStartModelType.OPEN_SOURCE: JumpStartS3FileType.OPEN_SOURCE_MANIFEST,
+    JumpStartModelType.PROPRIETARY: JumpStartS3FileType.PROPRIETARY_MANIFEST,
+}
+
+MODEL_TYPE_TO_SPECS_MAP: Dict[Type[JumpStartModelType], Type[JumpStartS3FileType]] = {
+    JumpStartModelType.OPEN_SOURCE: JumpStartS3FileType.OPEN_SOURCE_SPECS,
+    JumpStartModelType.PROPRIETARY: JumpStartS3FileType.PROPRIETARY_SPECS,
 }
 
 MODEL_ID_LIST_WEB_URL = "https://sagemaker.readthedocs.io/en/stable/doc_utils/pretrainedmodels.html"

--- a/src/sagemaker/jumpstart/enums.py
+++ b/src/sagemaker/jumpstart/enums.py
@@ -34,6 +34,17 @@ class ModelFramework(str, Enum):
     SKLEARN = "sklearn"
 
 
+class JumpStartModelType(str, Enum):
+    """Enum class for JumpStart model type.
+
+    Open source model refers to JumpStart owned community models.
+    Proprietary model refers to external provider owned Marketplace models.
+    """
+
+    OPEN_SOURCE = "opensource"
+    PROPRIETARY = "proprietary"
+
+
 class VariableScope(str, Enum):
     """Possible value of the ``scope`` attribute for a hyperparameter or environment variable.
 

--- a/src/sagemaker/jumpstart/estimator.py
+++ b/src/sagemaker/jumpstart/estimator.py
@@ -35,7 +35,7 @@ from sagemaker.jumpstart.factory.estimator import get_deploy_kwargs, get_fit_kwa
 from sagemaker.jumpstart.factory.model import get_default_predictor
 from sagemaker.jumpstart.session_utils import get_model_id_version_from_training_job
 from sagemaker.jumpstart.utils import (
-    is_valid_model_id,
+    validate_model_id_and_get_type,
     resolve_model_sagemaker_config_field,
 )
 from sagemaker.utils import stringify_object, format_tags, Tags
@@ -504,8 +504,8 @@ class JumpStartEstimator(Estimator):
             ValueError: If the model ID is not recognized by JumpStart.
         """
 
-        def _is_valid_model_id_hook():
-            return is_valid_model_id(
+        def _validate_model_id_and_get_type_hook():
+            return validate_model_id_and_get_type(
                 model_id=model_id,
                 model_version=model_version,
                 region=region,
@@ -513,9 +513,9 @@ class JumpStartEstimator(Estimator):
                 sagemaker_session=sagemaker_session,
             )
 
-        if not _is_valid_model_id_hook():
+        if not _validate_model_id_and_get_type_hook():
             JumpStartModelsAccessor.reset_cache()
-            if not _is_valid_model_id_hook():
+            if not _validate_model_id_and_get_type_hook():
                 raise ValueError(INVALID_MODEL_ID_ERROR_MSG.format(model_id=model_id))
 
         estimator_init_kwargs = get_init_kwargs(

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -14,7 +14,7 @@
 from __future__ import absolute_import
 import logging
 import os
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Set, Optional, Tuple, Union
 from urllib.parse import urlparse
 import boto3
 from packaging.version import Version
@@ -26,6 +26,7 @@ from sagemaker.config.config_schema import (
     TRAINING_JOB_INTER_CONTAINER_ENCRYPTION_PATH,
     TRAINING_JOB_ROLE_ARN_PATH,
 )
+
 from sagemaker.jumpstart import constants, enums
 from sagemaker.jumpstart import accessors
 from sagemaker.s3 import parse_s3_url
@@ -572,12 +573,16 @@ def verify_model_region_and_return_specs(
             "JumpStart models only support scopes: "
             f"{', '.join(constants.SUPPORTED_JUMPSTART_SCOPES)}."
         )
+    model_type = validate_model_id_and_get_type(
+        model_id=model_id, region=region, model_version=version, script=scope
+    )
 
     model_specs = accessors.JumpStartModelsAccessor.get_model_specs(  # type: ignore
         region=region,
         model_id=model_id,
         version=version,
         s3_client=sagemaker_session.s3_client,
+        model_type=model_type,
     )
 
     if (
@@ -732,36 +737,52 @@ def resolve_estimator_sagemaker_config_field(
     return field_val
 
 
-def is_valid_model_id(
+def validate_model_id_and_get_type(
     model_id: Optional[str],
     region: Optional[str] = None,
     model_version: Optional[str] = None,
     script: enums.JumpStartScriptScope = enums.JumpStartScriptScope.INFERENCE,
     sagemaker_session: Optional[Session] = constants.DEFAULT_JUMPSTART_SAGEMAKER_SESSION,
-) -> bool:
-    """Returns True if the model ID is supported for the given script.
+) -> Optional[enums.JumpStartModelType]:
+    """Returns model type if the model ID is supported for the given script.
 
     Raises:
         ValueError: If the script is not supported by JumpStart.
     """
+
+    def _get_model_type(
+        model_id: str,
+        open_source_models: Set[str],
+        proprietary_models: Set[str],
+        script: enums.JumpStartScriptScope,
+    ) -> Optional[enums.JumpStartModelType]:
+        if model_id in open_source_models:
+            return enums.JumpStartModelType.OPEN_SOURCE
+        if model_id in proprietary_models:
+            if script == enums.JumpStartScriptScope.INFERENCE:
+                return enums.JumpStartModelType.PROPRIETARY
+            raise ValueError(f"Unsupported script for Marketplace models: {script}")
+        return None
+
     if model_id in {None, ""}:
-        return False
+        return None
     if not isinstance(model_id, str):
-        return False
+        return None
 
     s3_client = sagemaker_session.s3_client if sagemaker_session else None
     region = region or constants.JUMPSTART_DEFAULT_REGION_NAME
     model_version = model_version or "*"
-
     models_manifest_list = accessors.JumpStartModelsAccessor._get_manifest(
-        region=region, s3_client=s3_client
+        region=region, s3_client=s3_client, model_type=enums.JumpStartModelType.OPEN_SOURCE
     )
-    model_id_set = {model.model_id for model in models_manifest_list}
-    if script == enums.JumpStartScriptScope.INFERENCE:
-        return model_id in model_id_set
-    if script == enums.JumpStartScriptScope.TRAINING:
-        return model_id in model_id_set
-    raise ValueError(f"Unsupported script: {script}")
+    open_source_model_id_set = {model.model_id for model in models_manifest_list}
+
+    proprietary_manifest_list = accessors.JumpStartModelsAccessor._get_manifest(
+        region=region, s3_client=s3_client, model_type=enums.JumpStartModelType.PROPRIETARY
+    )
+
+    proprietary_model_id_set = {model.model_id for model in proprietary_manifest_list}
+    return _get_model_type(model_id, open_source_model_id_set, proprietary_model_id_set, script)
 
 
 def get_jumpstart_model_id_version_from_resource_arn(

--- a/src/sagemaker/serializers.py
+++ b/src/sagemaker/serializers.py
@@ -34,6 +34,7 @@ from sagemaker.base_serializers import (  # noqa: F401 # pylint: disable=W0611
 
 from sagemaker.jumpstart import artifacts, utils as jumpstart_utils
 from sagemaker.jumpstart.constants import DEFAULT_JUMPSTART_SAGEMAKER_SESSION
+from sagemaker.jumpstart.enums import JumpStartModelType
 from sagemaker.session import Session
 
 
@@ -91,6 +92,7 @@ def retrieve_default(
     region: Optional[str] = None,
     model_id: Optional[str] = None,
     model_version: Optional[str] = None,
+    model_type: Optional[JumpStartModelType] = JumpStartModelType.OPEN_SOURCE,
     tolerate_vulnerable_model: bool = False,
     tolerate_deprecated_model: bool = False,
     sagemaker_session: Session = DEFAULT_JUMPSTART_SAGEMAKER_SESSION,

--- a/tests/integ/sagemaker/jumpstart/model/test_jumpstart_model.py
+++ b/tests/integ/sagemaker/jumpstart/model/test_jumpstart_model.py
@@ -39,7 +39,7 @@ INF2_SUPPORTED_REGIONS = {
     "us-east-2",
 }
 
-MAX_INIT_TIME_SECONDS = 5
+MAX_INIT_TIME_SECONDS = 15
 
 GATED_INFERENCE_MODEL_PACKAGE_SUPPORTED_REGIONS = {
     "us-west-2",
@@ -237,8 +237,6 @@ def test_instatiating_model(mock_warning_logger, setup):
 
     assert elapsed_time <= MAX_INIT_TIME_SECONDS
 
-    mock_warning_logger.assert_called_once()
-
 
 def test_jumpstart_model_register(setup):
     model_id = "huggingface-txt2img-conflictx-complex-lineart"
@@ -260,5 +258,27 @@ def test_jumpstart_model_register(setup):
     )
 
     response = predictor.predict("hello world!")
+
+    assert response is not None
+
+
+@pytest.mark.skipif(
+    True,
+    reason="Only enable if test account is subscribed to the proprietary model",
+)
+def test_proprietary_jumpstart_model(setup):
+
+    model_id = "ai21-jurassic-2-light"
+
+    model = JumpStartModel(
+        model_id=model_id,
+        role=get_sm_session().get_caller_identity_arn(),
+        sagemaker_session=get_sm_session(),
+    )
+
+    predictor = model.deploy()
+    payload = {"prompt": "To be, or", "maxTokens": 4, "temperature": 0, "numResults": 1}
+
+    response = predictor.predict(payload)
 
     assert response is not None

--- a/tests/unit/sagemaker/accept_types/jumpstart/test_accept_types.py
+++ b/tests/unit/sagemaker/accept_types/jumpstart/test_accept_types.py
@@ -17,21 +17,27 @@ from mock.mock import patch, Mock
 
 from sagemaker import accept_types
 from sagemaker.jumpstart.utils import verify_model_region_and_return_specs
+from sagemaker.jumpstart.enums import JumpStartModelType
 
 from tests.unit.sagemaker.jumpstart.utils import get_special_model_spec
+
 
 mock_client = boto3.client("s3")
 mock_session = Mock(s3_client=mock_client)
 
 
+@patch("sagemaker.jumpstart.utils.validate_model_id_and_get_type")
 @patch("sagemaker.jumpstart.artifacts.predictors.verify_model_region_and_return_specs")
 @patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
 def test_jumpstart_default_accept_types(
-    patched_get_model_specs, patched_verify_model_region_and_return_specs
+    patched_get_model_specs,
+    patched_verify_model_region_and_return_specs,
+    patched_validate_model_id_and_get_type,
 ):
 
     patched_verify_model_region_and_return_specs.side_effect = verify_model_region_and_return_specs
     patched_get_model_specs.side_effect = get_special_model_spec
+    patched_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
     model_id, model_version = "predictor-specs-model", "*"
     region = "us-west-2"
@@ -45,18 +51,26 @@ def test_jumpstart_default_accept_types(
     assert default_accept_type == "application/json"
 
     patched_get_model_specs.assert_called_once_with(
-        region=region, model_id=model_id, version=model_version, s3_client=mock_client
+        region=region,
+        model_id=model_id,
+        version=model_version,
+        s3_client=mock_client,
+        model_type=JumpStartModelType.OPEN_SOURCE,
     )
 
 
+@patch("sagemaker.jumpstart.utils.validate_model_id_and_get_type")
 @patch("sagemaker.jumpstart.artifacts.predictors.verify_model_region_and_return_specs")
 @patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
 def test_jumpstart_supported_accept_types(
-    patched_get_model_specs, patched_verify_model_region_and_return_specs
+    patched_get_model_specs,
+    patched_verify_model_region_and_return_specs,
+    patched_validate_model_id_and_get_type,
 ):
 
     patched_verify_model_region_and_return_specs.side_effect = verify_model_region_and_return_specs
     patched_get_model_specs.side_effect = get_special_model_spec
+    patched_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
     model_id, model_version = "predictor-specs-model", "*"
     region = "us-west-2"
@@ -73,5 +87,9 @@ def test_jumpstart_supported_accept_types(
     ]
 
     patched_get_model_specs.assert_called_once_with(
-        region=region, model_id=model_id, version=model_version, s3_client=mock_client
+        region=region,
+        model_id=model_id,
+        version=model_version,
+        s3_client=mock_client,
+        model_type=JumpStartModelType.OPEN_SOURCE,
     )

--- a/tests/unit/sagemaker/content_types/jumpstart/test_content_types.py
+++ b/tests/unit/sagemaker/content_types/jumpstart/test_content_types.py
@@ -17,6 +17,7 @@ from mock.mock import patch, Mock
 
 from sagemaker import content_types
 from sagemaker.jumpstart.utils import verify_model_region_and_return_specs
+from sagemaker.jumpstart.enums import JumpStartModelType
 
 from tests.unit.sagemaker.jumpstart.utils import get_special_model_spec
 
@@ -24,14 +25,18 @@ mock_client = boto3.client("s3")
 mock_session = Mock(s3_client=mock_client)
 
 
+@patch("sagemaker.jumpstart.utils.validate_model_id_and_get_type")
 @patch("sagemaker.jumpstart.artifacts.predictors.verify_model_region_and_return_specs")
 @patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
 def test_jumpstart_default_content_types(
-    patched_get_model_specs, patched_verify_model_region_and_return_specs
+    patched_get_model_specs,
+    patched_verify_model_region_and_return_specs,
+    patched_validate_model_id_and_get_type,
 ):
 
     patched_verify_model_region_and_return_specs.side_effect = verify_model_region_and_return_specs
     patched_get_model_specs.side_effect = get_special_model_spec
+    patched_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
     model_id, model_version = "predictor-specs-model", "*"
     region = "us-west-2"
@@ -45,18 +50,26 @@ def test_jumpstart_default_content_types(
     assert default_content_type == "application/x-text"
 
     patched_get_model_specs.assert_called_once_with(
-        region=region, model_id=model_id, version=model_version, s3_client=mock_client
+        region=region,
+        model_id=model_id,
+        version=model_version,
+        s3_client=mock_client,
+        model_type=JumpStartModelType.OPEN_SOURCE,
     )
 
 
+@patch("sagemaker.jumpstart.utils.validate_model_id_and_get_type")
 @patch("sagemaker.jumpstart.artifacts.predictors.verify_model_region_and_return_specs")
 @patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
 def test_jumpstart_supported_content_types(
-    patched_get_model_specs, patched_verify_model_region_and_return_specs
+    patched_get_model_specs,
+    patched_verify_model_region_and_return_specs,
+    patched_validate_model_id_and_get_type,
 ):
 
     patched_verify_model_region_and_return_specs.side_effect = verify_model_region_and_return_specs
     patched_get_model_specs.side_effect = get_special_model_spec
+    patched_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
     model_id, model_version = "predictor-specs-model", "*"
     region = "us-west-2"
@@ -72,5 +85,9 @@ def test_jumpstart_supported_content_types(
     ]
 
     patched_get_model_specs.assert_called_once_with(
-        region=region, model_id=model_id, version=model_version, s3_client=mock_client
+        region=region,
+        model_id=model_id,
+        version=model_version,
+        s3_client=mock_client,
+        model_type=JumpStartModelType.OPEN_SOURCE,
     )

--- a/tests/unit/sagemaker/deserializers/jumpstart/test_deserializers.py
+++ b/tests/unit/sagemaker/deserializers/jumpstart/test_deserializers.py
@@ -18,6 +18,7 @@ from mock.mock import patch, Mock
 
 from sagemaker import base_deserializers, deserializers
 from sagemaker.jumpstart.utils import verify_model_region_and_return_specs
+from sagemaker.jumpstart.enums import JumpStartModelType
 
 from tests.unit.sagemaker.jumpstart.utils import get_special_model_spec
 
@@ -26,14 +27,18 @@ mock_client = boto3.client("s3")
 mock_session = Mock(s3_client=mock_client)
 
 
+@patch("sagemaker.jumpstart.utils.validate_model_id_and_get_type")
 @patch("sagemaker.jumpstart.artifacts.predictors.verify_model_region_and_return_specs")
 @patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
 def test_jumpstart_default_deserializers(
-    patched_get_model_specs, patched_verify_model_region_and_return_specs
+    patched_get_model_specs,
+    patched_verify_model_region_and_return_specs,
+    patched_validate_model_id_and_get_type,
 ):
 
     patched_verify_model_region_and_return_specs.side_effect = verify_model_region_and_return_specs
     patched_get_model_specs.side_effect = get_special_model_spec
+    patched_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
     model_id, model_version = "predictor-specs-model", "*"
     region = "us-west-2"
@@ -47,18 +52,26 @@ def test_jumpstart_default_deserializers(
     assert isinstance(default_deserializer, base_deserializers.JSONDeserializer)
 
     patched_get_model_specs.assert_called_once_with(
-        region=region, model_id=model_id, version=model_version, s3_client=mock_client
+        region=region,
+        model_id=model_id,
+        version=model_version,
+        s3_client=mock_client,
+        model_type=JumpStartModelType.OPEN_SOURCE,
     )
 
 
+@patch("sagemaker.jumpstart.utils.validate_model_id_and_get_type")
 @patch("sagemaker.jumpstart.artifacts.predictors.verify_model_region_and_return_specs")
 @patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
 def test_jumpstart_deserializer_options(
-    patched_get_model_specs, patched_verify_model_region_and_return_specs
+    patched_get_model_specs,
+    patched_verify_model_region_and_return_specs,
+    patched_validate_model_id_and_get_type,
 ):
 
     patched_verify_model_region_and_return_specs.side_effect = verify_model_region_and_return_specs
     patched_get_model_specs.side_effect = get_special_model_spec
+    patched_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
     model_id, model_version = "predictor-specs-model", "*"
     region = "us-west-2"
@@ -79,5 +92,9 @@ def test_jumpstart_deserializer_options(
     )
 
     patched_get_model_specs.assert_called_once_with(
-        region=region, model_id=model_id, version=model_version, s3_client=mock_client
+        region=region,
+        model_id=model_id,
+        version=model_version,
+        s3_client=mock_client,
+        model_type=JumpStartModelType.OPEN_SOURCE,
     )

--- a/tests/unit/sagemaker/environment_variables/jumpstart/test_default.py
+++ b/tests/unit/sagemaker/environment_variables/jumpstart/test_default.py
@@ -18,17 +18,23 @@ from mock.mock import patch, Mock
 import pytest
 
 from sagemaker import environment_variables
+from sagemaker.jumpstart.enums import JumpStartModelType
 
 from tests.unit.sagemaker.jumpstart.utils import get_spec_from_base_spec, get_special_model_spec
+
 
 mock_client = boto3.client("s3")
 mock_session = Mock(s3_client=mock_client)
 
 
+@patch("sagemaker.jumpstart.utils.validate_model_id_and_get_type")
 @patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
-def test_jumpstart_default_environment_variables(patched_get_model_specs):
+def test_jumpstart_default_environment_variables(
+    patched_get_model_specs, patched_validate_model_id_and_get_type
+):
 
     patched_get_model_specs.side_effect = get_spec_from_base_spec
+    patched_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
     model_id = "pytorch-eqa-bert-base-cased"
     region = "us-west-2"
@@ -48,7 +54,11 @@ def test_jumpstart_default_environment_variables(patched_get_model_specs):
     }
 
     patched_get_model_specs.assert_called_once_with(
-        region=region, model_id=model_id, version="*", s3_client=mock_client
+        region=region,
+        model_id=model_id,
+        version="*",
+        s3_client=mock_client,
+        model_type=JumpStartModelType.OPEN_SOURCE,
     )
 
     patched_get_model_specs.reset_mock()
@@ -68,7 +78,11 @@ def test_jumpstart_default_environment_variables(patched_get_model_specs):
     }
 
     patched_get_model_specs.assert_called_once_with(
-        region=region, model_id=model_id, version="1.*", s3_client=mock_client
+        region=region,
+        model_id=model_id,
+        version="1.*",
+        s3_client=mock_client,
+        model_type=JumpStartModelType.OPEN_SOURCE,
     )
 
     patched_get_model_specs.reset_mock()
@@ -98,10 +112,14 @@ def test_jumpstart_default_environment_variables(patched_get_model_specs):
         )
 
 
+@patch("sagemaker.jumpstart.utils.validate_model_id_and_get_type")
 @patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
-def test_jumpstart_sdk_environment_variables(patched_get_model_specs):
+def test_jumpstart_sdk_environment_variables(
+    patched_get_model_specs, patched_validate_model_id_and_get_type
+):
 
     patched_get_model_specs.side_effect = get_spec_from_base_spec
+    patched_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
     model_id = "pytorch-eqa-bert-base-cased"
     region = "us-west-2"
@@ -122,7 +140,11 @@ def test_jumpstart_sdk_environment_variables(patched_get_model_specs):
     }
 
     patched_get_model_specs.assert_called_once_with(
-        region=region, model_id=model_id, version="*", s3_client=mock_client
+        region=region,
+        model_id=model_id,
+        version="*",
+        s3_client=mock_client,
+        model_type=JumpStartModelType.OPEN_SOURCE,
     )
 
     patched_get_model_specs.reset_mock()
@@ -143,7 +165,11 @@ def test_jumpstart_sdk_environment_variables(patched_get_model_specs):
     }
 
     patched_get_model_specs.assert_called_once_with(
-        region=region, model_id=model_id, version="1.*", s3_client=mock_client
+        region=region,
+        model_id=model_id,
+        version="1.*",
+        s3_client=mock_client,
+        model_type=JumpStartModelType.OPEN_SOURCE,
     )
 
     patched_get_model_specs.reset_mock()

--- a/tests/unit/sagemaker/hyperparameters/jumpstart/test_default.py
+++ b/tests/unit/sagemaker/hyperparameters/jumpstart/test_default.py
@@ -18,6 +18,7 @@ from mock.mock import patch, Mock
 import pytest
 
 from sagemaker import hyperparameters
+from sagemaker.jumpstart.enums import JumpStartModelType
 
 from tests.unit.sagemaker.jumpstart.utils import get_spec_from_base_spec, get_special_model_spec
 
@@ -26,10 +27,14 @@ mock_client = boto3.client("s3")
 mock_session = Mock(s3_client=mock_client)
 
 
+@patch("sagemaker.jumpstart.utils.validate_model_id_and_get_type")
 @patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
-def test_jumpstart_default_hyperparameters(patched_get_model_specs):
+def test_jumpstart_default_hyperparameters(
+    patched_get_model_specs, patched_validate_model_id_and_get_type
+):
 
     patched_get_model_specs.side_effect = get_spec_from_base_spec
+    patched_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
     model_id = "pytorch-eqa-bert-base-cased"
     region = "us-west-2"
@@ -47,6 +52,7 @@ def test_jumpstart_default_hyperparameters(patched_get_model_specs):
         model_id=model_id,
         version="*",
         s3_client=mock_client,
+        model_type=JumpStartModelType.OPEN_SOURCE,
     )
 
     patched_get_model_specs.reset_mock()
@@ -64,6 +70,7 @@ def test_jumpstart_default_hyperparameters(patched_get_model_specs):
         model_id=model_id,
         version="1.*",
         s3_client=mock_client,
+        model_type=JumpStartModelType.OPEN_SOURCE,
     )
 
     patched_get_model_specs.reset_mock()
@@ -89,6 +96,7 @@ def test_jumpstart_default_hyperparameters(patched_get_model_specs):
         model_id=model_id,
         version="1.*",
         s3_client=mock_client,
+        model_type=JumpStartModelType.OPEN_SOURCE,
     )
 
     patched_get_model_specs.reset_mock()

--- a/tests/unit/sagemaker/hyperparameters/jumpstart/test_validate.py
+++ b/tests/unit/sagemaker/hyperparameters/jumpstart/test_validate.py
@@ -17,7 +17,7 @@ from mock.mock import patch, Mock
 import pytest
 import boto3
 from sagemaker import hyperparameters
-from sagemaker.jumpstart.enums import HyperparameterValidationMode
+from sagemaker.jumpstart.enums import HyperparameterValidationMode, JumpStartModelType
 from sagemaker.jumpstart.exceptions import JumpStartHyperparametersError
 from sagemaker.jumpstart.types import JumpStartHyperparameter
 
@@ -27,8 +27,11 @@ mock_client = boto3.client("s3")
 mock_session = Mock(s3_client=mock_client)
 
 
+@patch("sagemaker.jumpstart.utils.validate_model_id_and_get_type")
 @patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
-def test_jumpstart_validate_provided_hyperparameters(patched_get_model_specs):
+def test_jumpstart_validate_provided_hyperparameters(
+    patched_get_model_specs, patched_validate_model_id_and_get_type
+):
     def add_options_to_hyperparameter(*largs, **kwargs):
         spec = get_spec_from_base_spec(*largs, **kwargs)
         spec.hyperparameters.extend(
@@ -109,6 +112,7 @@ def test_jumpstart_validate_provided_hyperparameters(patched_get_model_specs):
         return spec
 
     patched_get_model_specs.side_effect = add_options_to_hyperparameter
+    patched_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
     model_id, model_version = "pytorch-eqa-bert-base-cased", "*"
     region = "us-west-2"
@@ -140,6 +144,7 @@ def test_jumpstart_validate_provided_hyperparameters(patched_get_model_specs):
         model_id=model_id,
         version=model_version,
         s3_client=mock_client,
+        model_type=JumpStartModelType.OPEN_SOURCE,
     )
 
     patched_get_model_specs.reset_mock()
@@ -398,8 +403,11 @@ def test_jumpstart_validate_provided_hyperparameters(patched_get_model_specs):
     )
 
 
+@patch("sagemaker.jumpstart.utils.validate_model_id_and_get_type")
 @patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
-def test_jumpstart_validate_algorithm_hyperparameters(patched_get_model_specs):
+def test_jumpstart_validate_algorithm_hyperparameters(
+    patched_get_model_specs, patched_validate_model_id_and_get_type
+):
     def add_options_to_hyperparameter(*largs, **kwargs):
         spec = get_spec_from_base_spec(*largs, **kwargs)
         spec.hyperparameters.append(
@@ -416,6 +424,7 @@ def test_jumpstart_validate_algorithm_hyperparameters(patched_get_model_specs):
         return spec
 
     patched_get_model_specs.side_effect = add_options_to_hyperparameter
+    patched_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
     model_id, model_version = "pytorch-eqa-bert-base-cased", "*"
     region = "us-west-2"
@@ -437,7 +446,11 @@ def test_jumpstart_validate_algorithm_hyperparameters(patched_get_model_specs):
     )
 
     patched_get_model_specs.assert_called_once_with(
-        region=region, model_id=model_id, version=model_version, s3_client=mock_client
+        region=region,
+        model_id=model_id,
+        version=model_version,
+        s3_client=mock_client,
+        model_type=JumpStartModelType.OPEN_SOURCE,
     )
 
     patched_get_model_specs.reset_mock()
@@ -464,10 +477,14 @@ def test_jumpstart_validate_algorithm_hyperparameters(patched_get_model_specs):
     assert str(e.value) == "Cannot find algorithm hyperparameter for 'adam-learning-rate'."
 
 
+@patch("sagemaker.jumpstart.utils.validate_model_id_and_get_type")
 @patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
-def test_jumpstart_validate_all_hyperparameters(patched_get_model_specs):
+def test_jumpstart_validate_all_hyperparameters(
+    patched_get_model_specs, patched_validate_model_id_and_get_type
+):
 
     patched_get_model_specs.side_effect = get_spec_from_base_spec
+    patched_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
     model_id, model_version = "pytorch-eqa-bert-base-cased", "*"
     region = "us-west-2"
@@ -491,7 +508,11 @@ def test_jumpstart_validate_all_hyperparameters(patched_get_model_specs):
     )
 
     patched_get_model_specs.assert_called_once_with(
-        region=region, model_id=model_id, version=model_version, s3_client=mock_client
+        region=region,
+        model_id=model_id,
+        version=model_version,
+        s3_client=mock_client,
+        model_type=JumpStartModelType.OPEN_SOURCE,
     )
 
     patched_get_model_specs.reset_mock()

--- a/tests/unit/sagemaker/image_uris/jumpstart/test_common.py
+++ b/tests/unit/sagemaker/image_uris/jumpstart/test_common.py
@@ -18,19 +18,24 @@ import pytest
 
 from sagemaker import image_uris
 from sagemaker.jumpstart.utils import verify_model_region_and_return_specs
+from sagemaker.jumpstart.enums import JumpStartModelType
 
 from tests.unit.sagemaker.jumpstart.utils import get_spec_from_base_spec
 from sagemaker.jumpstart import constants as sagemaker_constants
 
 
+@patch("sagemaker.jumpstart.utils.validate_model_id_and_get_type")
 @patch("sagemaker.jumpstart.artifacts.image_uris.verify_model_region_and_return_specs")
 @patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
 def test_jumpstart_common_image_uri(
-    patched_get_model_specs, patched_verify_model_region_and_return_specs
+    patched_get_model_specs,
+    patched_verify_model_region_and_return_specs,
+    patched_validate_model_id_and_get_type,
 ):
 
     patched_verify_model_region_and_return_specs.side_effect = verify_model_region_and_return_specs
     patched_get_model_specs.side_effect = get_spec_from_base_spec
+    patched_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
     mock_client = boto3.client("s3")
     mock_session = Mock(s3_client=mock_client)
@@ -49,6 +54,7 @@ def test_jumpstart_common_image_uri(
         model_id="pytorch-ic-mobilenet-v2",
         version="*",
         s3_client=mock_client,
+        model_type=JumpStartModelType.OPEN_SOURCE,
     )
     patched_verify_model_region_and_return_specs.assert_called_once()
 
@@ -69,6 +75,7 @@ def test_jumpstart_common_image_uri(
         model_id="pytorch-ic-mobilenet-v2",
         version="1.*",
         s3_client=mock_client,
+        model_type=JumpStartModelType.OPEN_SOURCE,
     )
     patched_verify_model_region_and_return_specs.assert_called_once()
 
@@ -89,6 +96,7 @@ def test_jumpstart_common_image_uri(
         model_id="pytorch-ic-mobilenet-v2",
         version="*",
         s3_client=mock_client,
+        model_type=JumpStartModelType.OPEN_SOURCE,
     )
     patched_verify_model_region_and_return_specs.assert_called_once()
 
@@ -109,6 +117,7 @@ def test_jumpstart_common_image_uri(
         model_id="pytorch-ic-mobilenet-v2",
         version="1.*",
         s3_client=mock_client,
+        model_type=JumpStartModelType.OPEN_SOURCE,
     )
     patched_verify_model_region_and_return_specs.assert_called_once()
 

--- a/tests/unit/sagemaker/instance_types/jumpstart/test_instance_types.py
+++ b/tests/unit/sagemaker/instance_types/jumpstart/test_instance_types.py
@@ -18,14 +18,17 @@ from mock.mock import patch
 import pytest
 
 from sagemaker import instance_types
+from sagemaker.jumpstart.enums import JumpStartModelType
 
 from tests.unit.sagemaker.jumpstart.utils import get_spec_from_base_spec, get_special_model_spec
 
 
+@patch("sagemaker.jumpstart.utils.validate_model_id_and_get_type")
 @patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
-def test_jumpstart_instance_types(patched_get_model_specs):
+def test_jumpstart_instance_types(patched_get_model_specs, patched_validate_model_id_and_get_type):
 
     patched_get_model_specs.side_effect = get_spec_from_base_spec
+    patched_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
     model_id, model_version = "huggingface-eqa-bert-base-cased", "*"
     region = "us-west-2"
@@ -47,6 +50,7 @@ def test_jumpstart_instance_types(patched_get_model_specs):
         model_id=model_id,
         version=model_version,
         s3_client=mock_client,
+        model_type=JumpStartModelType.OPEN_SOURCE,
     )
 
     patched_get_model_specs.reset_mock()
@@ -65,6 +69,7 @@ def test_jumpstart_instance_types(patched_get_model_specs):
         model_id=model_id,
         version=model_version,
         s3_client=mock_client,
+        model_type=JumpStartModelType.OPEN_SOURCE,
     )
 
     patched_get_model_specs.reset_mock()
@@ -89,6 +94,7 @@ def test_jumpstart_instance_types(patched_get_model_specs):
         model_id=model_id,
         version=model_version,
         s3_client=mock_client,
+        model_type=JumpStartModelType.OPEN_SOURCE,
     )
 
     patched_get_model_specs.reset_mock()
@@ -111,7 +117,11 @@ def test_jumpstart_instance_types(patched_get_model_specs):
     ]
 
     patched_get_model_specs.assert_called_once_with(
-        region=region, model_id=model_id, version=model_version, s3_client=mock_client
+        region=region,
+        model_id=model_id,
+        version=model_version,
+        s3_client=mock_client,
+        model_type=JumpStartModelType.OPEN_SOURCE,
     )
 
     patched_get_model_specs.reset_mock()

--- a/tests/unit/sagemaker/jumpstart/constants.py
+++ b/tests/unit/sagemaker/jumpstart/constants.py
@@ -6289,3 +6289,83 @@ BASE_MANIFEST = [
         "imagenet-inception-v3-classification-4/specs_v3.0.0.json",
     },
 ]
+
+BASE_PROPRIETARY_HEADER = {
+    "model_id": "ai21-summarization",
+    "version": "1.1.003",
+    "min_version": "2.0.0",
+    "spec_key": "proprietary-models/ai21-summarization/proprietary_specs_1.1.003.json",
+    "search_keywords": ["Text2Text", "Generation"],
+}
+
+BASE_PROPRIETARY_MANIFEST = [
+    {
+        "model_id": "ai21-summarization",
+        "version": "1.1.003",
+        "min_version": "2.0.0",
+        "spec_key": "proprietary-models/ai21-summarization/proprietary_specs_1.1.003.json",
+        "search_keywords": ["Text2Text", "Generation"],
+    },
+    {
+        "model_id": "lighton-mini-instruct40b",
+        "version": "v1.0",
+        "min_version": "2.0.0",
+        "spec_key": "proprietary-models/lighton-mini-instruct40b/proprietary_specs_v1.0.json",
+        "search_keywords": ["Text2Text", "Generation"],
+    },
+    {
+        "model_id": "ai21-paraphrase",
+        "version": "1.0.005",
+        "min_version": "2.0.0",
+        "spec_key": "proprietary-models/ai21-paraphrase/proprietary_specs_1.0.005.json",
+        "search_keywords": ["Text2Text", "Generation"],
+    },
+]
+
+BASE_PROPRIETARY_SPEC = {
+    "model_id": "ai21-jurassic-2-light",
+    "version": "2.0.004",
+    "min_sdk_version": "2.999.0",
+    "listing_id": "prodview-roz6zicyvi666",
+    "product_id": "1bd680a0-f29b-479d-91c3-9899743021cf",
+    "model_subscription_link": "https://aws.amazon.com/marketplace/ai/procurement?productId=1bd680a0",
+    "hosting_notebook_key": "pmm-notebooks/pmm-notebook-ai21-jurassic-2-light.ipynb",
+    "deploy_kwargs": {
+        "model_data_download_timeout": 3600,
+        "container_startup_health_check_timeout": 600,
+    },
+    "default_payloads": {
+        "Shakespeare": {
+            "content_type": "application/json",
+            "prompt_key": "prompt",
+            "output_keys": {"generated_text": "[0].completions[0].data.text"},
+            "body": {"prompt": "To be, or", "maxTokens": 1, "temperature": 0},
+        }
+    },
+    "predictor_specs": {
+        "supported_content_types": ["application/json"],
+        "supported_accept_types": ["application/json"],
+        "default_content_type": "application/json",
+        "default_accept_type": "application/json",
+    },
+    "default_inference_instance_type": "ml.p4de.24xlarge",
+    "supported_inference_instance_types": ["ml.p4de.24xlarge"],
+    "hosting_model_package_arns": {
+        "us-east-1": "arn:aws:sagemaker:us-east-1:865070037744:model-package/j2-light-v2-0-004",
+        "us-east-2": "arn:aws:sagemaker:us-east-2:057799348421:model-package/j2-light-v2-0-004",
+        "us-west-1": "arn:aws:sagemaker:us-west-1:382657785993:model-package/j2-light-v2-0-004",
+        "us-west-2": "arn:aws:sagemaker:us-west-2:594846645681:model-package/j2-light-v2-0-004",
+        "ca-central-1": "arn:aws:sagemaker:ca-central-1:470592106596:model-package/j2-light-v2-0-004",
+        "eu-central-1": "arn:aws:sagemaker:eu-central-1:446921602837:model-package/j2-light-v2-0-004",
+        "eu-west-1": "arn:aws:sagemaker:eu-west-1:985815980388:model-package/j2-light-v2-0-004",
+        "eu-west-2": "arn:aws:sagemaker:eu-west-2:856760150666:model-package/j2-light-v2-0-004",
+        "eu-west-3": "arn:aws:sagemaker:eu-west-3:843114510376:model-package/j2-light-v2-0-004",
+        "eu-north-1": "arn:aws:sagemaker:eu-north-1:136758871317:model-package/j2-light-v2-0-004",
+        "ap-southeast-1": "arn:aws:sagemaker:ap-southeast-1:192199979996:model-package/j2-light-v2-0-004",
+        "ap-southeast-2": "arn:aws:sagemaker:ap-southeast-2:666831318237:model-package/j2-light-v2-0-004",
+        "ap-northeast-2": "arn:aws:sagemaker:ap-northeast-2:745090734665:model-package/j2-light-v2-0-004",
+        "ap-northeast-1": "arn:aws:sagemaker:ap-northeast-1:977537786026:model-package/j2-light-v2-0-004",
+        "ap-south-1": "arn:aws:sagemaker:ap-south-1:077584701553:model-package/j2-light-v2-0-004",
+        "sa-east-1": "arn:aws:sagemaker:sa-east-1:270155090741:model-package/j2-light-v2-0-004",
+    },
+}

--- a/tests/unit/sagemaker/jumpstart/estimator/test_estimator.py
+++ b/tests/unit/sagemaker/jumpstart/estimator/test_estimator.py
@@ -31,7 +31,7 @@ from sagemaker.jumpstart.artifacts.metric_definitions import (
     _retrieve_default_training_metric_definitions,
 )
 from sagemaker.jumpstart.constants import DEFAULT_JUMPSTART_SAGEMAKER_SESSION
-from sagemaker.jumpstart.enums import JumpStartScriptScope, JumpStartTag
+from sagemaker.jumpstart.enums import JumpStartScriptScope, JumpStartTag, JumpStartModelType
 
 from sagemaker.jumpstart.estimator import JumpStartEstimator
 
@@ -60,9 +60,10 @@ class EstimatorTest(unittest.TestCase):
     @mock.patch("sagemaker.jumpstart.factory.estimator.JUMPSTART_LOGGER")
     @mock.patch("sagemaker.jumpstart.factory.model.JUMPSTART_LOGGER")
     @mock.patch("sagemaker.utils.sagemaker_timestamp")
-    @mock.patch("sagemaker.jumpstart.estimator.is_valid_model_id")
+    @mock.patch("sagemaker.jumpstart.estimator.validate_model_id_and_get_type")
     @mock.patch("sagemaker.jumpstart.factory.model.Session")
     @mock.patch("sagemaker.jumpstart.factory.estimator.Session")
+    @mock.patch("sagemaker.jumpstart.utils.validate_model_id_and_get_type")
     @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
     @mock.patch("sagemaker.jumpstart.estimator.Estimator.__init__")
     @mock.patch("sagemaker.jumpstart.estimator.Estimator.fit")
@@ -75,14 +76,15 @@ class EstimatorTest(unittest.TestCase):
         mock_estimator_fit: mock.Mock,
         mock_estimator_init: mock.Mock,
         mock_get_model_specs: mock.Mock,
+        mock_get_model_type: mock.Mock,
         mock_session_estimator: mock.Mock,
         mock_session_model: mock.Mock,
-        mock_is_valid_model_id: mock.Mock,
+        mock_validate_model_id_and_get_type: mock.Mock,
         mock_sagemaker_timestamp: mock.Mock,
         mock_jumpstart_model_factory_logger: mock.Mock,
         mock_jumpstart_estimator_factory_logger: mock.Mock,
     ):
-        mock_is_valid_model_id.return_value = True
+        mock_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
         mock_sagemaker_timestamp.return_value = "9876"
 
@@ -91,6 +93,8 @@ class EstimatorTest(unittest.TestCase):
         model_id, model_version = "js-trainable-model", "*"
 
         mock_get_model_specs.side_effect = get_special_model_spec
+
+        mock_get_model_type.return_value = JumpStartModelType.OPEN_SOURCE
 
         mock_session_estimator.return_value = sagemaker_session
         mock_session_model.return_value = sagemaker_session
@@ -182,7 +186,7 @@ class EstimatorTest(unittest.TestCase):
             ],
         )
 
-    @mock.patch("sagemaker.jumpstart.estimator.is_valid_model_id")
+    @mock.patch("sagemaker.jumpstart.estimator.validate_model_id_and_get_type")
     @mock.patch("sagemaker.jumpstart.factory.model.Session")
     @mock.patch("sagemaker.jumpstart.factory.estimator.Session")
     @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
@@ -199,11 +203,11 @@ class EstimatorTest(unittest.TestCase):
         mock_get_model_specs: mock.Mock,
         mock_session_estimator: mock.Mock,
         mock_session_model: mock.Mock,
-        mock_is_valid_model_id: mock.Mock,
+        mock_validate_model_id_and_get_type: mock.Mock,
     ):
         mock_estimator_deploy.return_value = default_predictor
 
-        mock_is_valid_model_id.return_value = True
+        mock_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
         model_id, _ = "js-trainable-model-prepacked", "*"
 
@@ -282,7 +286,7 @@ class EstimatorTest(unittest.TestCase):
         )
 
     @mock.patch("sagemaker.utils.sagemaker_timestamp")
-    @mock.patch("sagemaker.jumpstart.estimator.is_valid_model_id")
+    @mock.patch("sagemaker.jumpstart.estimator.validate_model_id_and_get_type")
     @mock.patch("sagemaker.jumpstart.factory.model.Session")
     @mock.patch("sagemaker.jumpstart.factory.estimator.Session")
     @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
@@ -299,14 +303,14 @@ class EstimatorTest(unittest.TestCase):
         mock_get_model_specs: mock.Mock,
         mock_session_estimator: mock.Mock,
         mock_session_model: mock.Mock,
-        mock_is_valid_model_id: mock.Mock,
+        mock_validate_model_id_and_get_type: mock.Mock,
         mock_timestamp: mock.Mock,
     ):
         mock_estimator_deploy.return_value = default_predictor
 
         mock_timestamp.return_value = "8675309"
 
-        mock_is_valid_model_id.return_value = True
+        mock_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
         model_id, _ = "js-gated-artifact-trainable-model", "*"
 
@@ -418,7 +422,7 @@ class EstimatorTest(unittest.TestCase):
         "sagemaker.jumpstart.artifacts.environment_variables.get_jumpstart_gated_content_bucket"
     )
     @mock.patch("sagemaker.utils.sagemaker_timestamp")
-    @mock.patch("sagemaker.jumpstart.estimator.is_valid_model_id")
+    @mock.patch("sagemaker.jumpstart.estimator.validate_model_id_and_get_type")
     @mock.patch("sagemaker.jumpstart.factory.model.Session")
     @mock.patch("sagemaker.jumpstart.factory.estimator.Session")
     @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
@@ -435,7 +439,7 @@ class EstimatorTest(unittest.TestCase):
         mock_get_model_specs: mock.Mock,
         mock_session_estimator: mock.Mock,
         mock_session_model: mock.Mock,
-        mock_is_valid_model_id: mock.Mock,
+        mock_validate_model_id_and_get_type: mock.Mock,
         mock_timestamp: mock.Mock,
         mock_get_jumpstart_gated_content_bucket: mock.Mock,
     ):
@@ -444,7 +448,7 @@ class EstimatorTest(unittest.TestCase):
         mock_get_jumpstart_gated_content_bucket.return_value = "top-secret-private-models-bucket"
         mock_timestamp.return_value = "8675309"
 
-        mock_is_valid_model_id.return_value = True
+        mock_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
         model_id, _ = "js-gated-artifact-non-model-package-trainable-model", "*"
 
@@ -566,7 +570,7 @@ class EstimatorTest(unittest.TestCase):
         )
 
     @mock.patch("sagemaker.utils.sagemaker_timestamp")
-    @mock.patch("sagemaker.jumpstart.estimator.is_valid_model_id")
+    @mock.patch("sagemaker.jumpstart.estimator.validate_model_id_and_get_type")
     @mock.patch("sagemaker.jumpstart.factory.model.Session")
     @mock.patch("sagemaker.jumpstart.factory.estimator.Session")
     @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
@@ -583,14 +587,12 @@ class EstimatorTest(unittest.TestCase):
         mock_get_model_specs: mock.Mock,
         mock_session_estimator: mock.Mock,
         mock_session_model: mock.Mock,
-        mock_is_valid_model_id: mock.Mock,
+        mock_validate_model_id_and_get_type: mock.Mock,
         mock_timestamp: mock.Mock,
     ):
         mock_estimator_deploy.return_value = default_predictor
 
         mock_timestamp.return_value = "8675309"
-
-        mock_is_valid_model_id.return_value = True
 
         model_id, _ = "js-gated-artifact-trainable-model", "*"
 
@@ -598,6 +600,8 @@ class EstimatorTest(unittest.TestCase):
 
         mock_session_estimator.return_value = sagemaker_session
         mock_session_model.return_value = sagemaker_session
+
+        mock_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
         with pytest.raises(ValueError) as e:
             JumpStartEstimator(model_id=model_id, region="eu-north-1")
@@ -608,7 +612,7 @@ class EstimatorTest(unittest.TestCase):
             "us-west-2, us-east-1, eu-west-1, ap-southeast-1."
         )
 
-    @mock.patch("sagemaker.jumpstart.estimator.is_valid_model_id")
+    @mock.patch("sagemaker.jumpstart.estimator.validate_model_id_and_get_type")
     @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
     @mock.patch("sagemaker.jumpstart.estimator.Estimator.__init__")
     @mock.patch("sagemaker.jumpstart.estimator.Estimator.fit")
@@ -621,10 +625,10 @@ class EstimatorTest(unittest.TestCase):
         mock_estimator_fit: mock.Mock,
         mock_estimator_init: mock.Mock,
         mock_get_model_specs: mock.Mock,
-        mock_is_valid_model_id: mock.Mock,
+        mock_validate_model_id_and_get_type: mock.Mock,
     ):
 
-        mock_is_valid_model_id.return_value = True
+        mock_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
         model_id, _ = "deprecated_model", "*"
 
@@ -642,7 +646,7 @@ class EstimatorTest(unittest.TestCase):
 
         JumpStartEstimator(model_id=model_id, tolerate_deprecated_model=True).fit(channels).deploy()
 
-    @mock.patch("sagemaker.jumpstart.estimator.is_valid_model_id")
+    @mock.patch("sagemaker.jumpstart.estimator.validate_model_id_and_get_type")
     @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
     @mock.patch("sagemaker.jumpstart.estimator.Estimator.__init__")
     @mock.patch("sagemaker.jumpstart.estimator.Estimator.fit")
@@ -655,9 +659,9 @@ class EstimatorTest(unittest.TestCase):
         mock_estimator_fit: mock.Mock,
         mock_estimator_init: mock.Mock,
         mock_get_model_specs: mock.Mock,
-        mock_is_valid_model_id: mock.Mock,
+        mock_validate_model_id_and_get_type: mock.Mock,
     ):
-        mock_is_valid_model_id.return_value = True
+        mock_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
         model_id, _ = "vulnerable_model", "*"
 
         mock_get_model_specs.side_effect = get_special_model_spec
@@ -758,7 +762,7 @@ class EstimatorTest(unittest.TestCase):
     @mock.patch("sagemaker.jumpstart.factory.estimator.metric_definitions_utils.retrieve_default")
     @mock.patch("sagemaker.jumpstart.factory.estimator.environment_variables.retrieve_default")
     @mock.patch("sagemaker.utils.sagemaker_timestamp")
-    @mock.patch("sagemaker.jumpstart.estimator.is_valid_model_id")
+    @mock.patch("sagemaker.jumpstart.estimator.validate_model_id_and_get_type")
     @mock.patch("sagemaker.jumpstart.factory.model.Session")
     @mock.patch("sagemaker.jumpstart.factory.estimator.Session")
     @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
@@ -775,7 +779,7 @@ class EstimatorTest(unittest.TestCase):
         mock_get_model_specs: mock.Mock,
         mock_session_estimator: mock.Mock,
         mock_session_model: mock.Mock,
-        mock_is_valid_model_id: mock.Mock,
+        mock_validate_model_id_and_get_type: mock.Mock,
         mock_timestamp: mock.Mock,
         mock_retrieve_default_environment_variables: mock.Mock,
         mock_retrieve_metric_definitions: mock.Mock,
@@ -806,7 +810,7 @@ class EstimatorTest(unittest.TestCase):
 
         mock_estimator_deploy.return_value = default_predictor
 
-        mock_is_valid_model_id.return_value = True
+        mock_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
         model_id, model_version = "js-trainable-model", "*"
 
@@ -908,16 +912,16 @@ class EstimatorTest(unittest.TestCase):
 
         mock_estimator_deploy.assert_called_once_with(**expected_deploy_kwargs)
 
-    @mock.patch("sagemaker.jumpstart.estimator.is_valid_model_id")
+    @mock.patch("sagemaker.jumpstart.estimator.validate_model_id_and_get_type")
     @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
     @mock.patch("sagemaker.jumpstart.factory.estimator.JUMPSTART_DEFAULT_REGION_NAME", region)
     def test_jumpstart_estimator_tags_disabled(
         self,
         mock_get_model_specs: mock.Mock,
-        mock_is_valid_model_id: mock.Mock,
+        mock_validate_model_id_and_get_type: mock.Mock,
     ):
 
-        mock_is_valid_model_id.return_value = True
+        mock_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
         model_id, _ = "js-trainable-model-prepacked", "*"
 
@@ -947,16 +951,16 @@ class EstimatorTest(unittest.TestCase):
             [{"Key": "blah", "Value": "blahagain"}],
         )
 
-    @mock.patch("sagemaker.jumpstart.estimator.is_valid_model_id")
+    @mock.patch("sagemaker.jumpstart.estimator.validate_model_id_and_get_type")
     @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
     @mock.patch("sagemaker.jumpstart.factory.estimator.JUMPSTART_DEFAULT_REGION_NAME", region)
     def test_jumpstart_estimator_tags(
         self,
         mock_get_model_specs: mock.Mock,
-        mock_is_valid_model_id: mock.Mock,
+        mock_validate_model_id_and_get_type: mock.Mock,
     ):
 
-        mock_is_valid_model_id.return_value = True
+        mock_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
         model_id, _ = "js-trainable-model-prepacked", "*"
 
@@ -989,18 +993,18 @@ class EstimatorTest(unittest.TestCase):
 
     @mock.patch("sagemaker.jumpstart.estimator.JumpStartEstimator._attach")
     @mock.patch("sagemaker.jumpstart.estimator.get_model_id_version_from_training_job")
-    @mock.patch("sagemaker.jumpstart.estimator.is_valid_model_id")
+    @mock.patch("sagemaker.jumpstart.estimator.validate_model_id_and_get_type")
     @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
     @mock.patch("sagemaker.jumpstart.factory.estimator.JUMPSTART_DEFAULT_REGION_NAME", region)
     def test_jumpstart_estimator_attach_no_model_id_happy_case(
         self,
         mock_get_model_specs: mock.Mock,
-        mock_is_valid_model_id: mock.Mock,
+        mock_validate_model_id_and_get_type: mock.Mock,
         get_model_id_version_from_training_job: mock.Mock,
         mock_attach: mock.Mock,
     ):
 
-        mock_is_valid_model_id.return_value = True
+        mock_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
         get_model_id_version_from_training_job.return_value = (
             "js-trainable-model-prepacked",
@@ -1032,18 +1036,18 @@ class EstimatorTest(unittest.TestCase):
 
     @mock.patch("sagemaker.jumpstart.estimator.JumpStartEstimator._attach")
     @mock.patch("sagemaker.jumpstart.estimator.get_model_id_version_from_training_job")
-    @mock.patch("sagemaker.jumpstart.estimator.is_valid_model_id")
+    @mock.patch("sagemaker.jumpstart.estimator.validate_model_id_and_get_type")
     @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
     @mock.patch("sagemaker.jumpstart.factory.estimator.JUMPSTART_DEFAULT_REGION_NAME", region)
     def test_jumpstart_estimator_attach_no_model_id_sad_case(
         self,
         mock_get_model_specs: mock.Mock,
-        mock_is_valid_model_id: mock.Mock,
+        mock_validate_model_id_and_get_type: mock.Mock,
         get_model_id_version_from_training_job: mock.Mock,
         mock_attach: mock.Mock,
     ):
 
-        mock_is_valid_model_id.return_value = True
+        mock_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
         get_model_id_version_from_training_job.side_effect = ValueError()
 
@@ -1115,22 +1119,22 @@ class EstimatorTest(unittest.TestCase):
 
     @mock.patch("sagemaker.jumpstart.estimator.get_init_kwargs")
     @mock.patch("sagemaker.jumpstart.estimator.Estimator.__init__")
-    @mock.patch("sagemaker.jumpstart.estimator.is_valid_model_id")
-    def test_is_valid_model_id(
+    @mock.patch("sagemaker.jumpstart.estimator.validate_model_id_and_get_type")
+    def test_validate_model_id_and_get_type(
         self,
-        mock_is_valid_model_id: mock.Mock,
+        mock_validate_model_id_and_get_type: mock.Mock,
         mock_init: mock.Mock,
         mock_get_init_kwargs: mock.Mock,
     ):
-        mock_is_valid_model_id.return_value = True
+        mock_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
         JumpStartEstimator(model_id="valid_model_id")
 
-        mock_is_valid_model_id.return_value = False
+        mock_validate_model_id_and_get_type.return_value = False
         with pytest.raises(ValueError):
             JumpStartEstimator(model_id="invalid_model_id")
 
     @mock.patch("sagemaker.jumpstart.estimator.get_default_predictor")
-    @mock.patch("sagemaker.jumpstart.estimator.is_valid_model_id")
+    @mock.patch("sagemaker.jumpstart.estimator.validate_model_id_and_get_type")
     @mock.patch("sagemaker.jumpstart.factory.model.Session")
     @mock.patch("sagemaker.jumpstart.factory.estimator.Session")
     @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
@@ -1147,14 +1151,14 @@ class EstimatorTest(unittest.TestCase):
         mock_get_model_specs: mock.Mock,
         mock_session_estimator: mock.Mock,
         mock_session_model: mock.Mock,
-        mock_is_valid_model_id: mock.Mock,
+        mock_validate_model_id_and_get_type: mock.Mock,
         mock_get_default_predictor: mock.Mock,
     ):
         mock_estimator_deploy.return_value = default_predictor
 
         mock_get_default_predictor.return_value = default_predictor_with_presets
 
-        mock_is_valid_model_id.return_value = True
+        mock_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
         model_id, _ = "js-trainable-model-prepacked", "*"
 
@@ -1189,7 +1193,7 @@ class EstimatorTest(unittest.TestCase):
         self.assertEqual(predictor, default_predictor_with_presets)
 
     @mock.patch("sagemaker.jumpstart.estimator.get_default_predictor")
-    @mock.patch("sagemaker.jumpstart.estimator.is_valid_model_id")
+    @mock.patch("sagemaker.jumpstart.estimator.validate_model_id_and_get_type")
     @mock.patch("sagemaker.jumpstart.factory.model.Session")
     @mock.patch("sagemaker.jumpstart.factory.estimator.Session")
     @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
@@ -1206,14 +1210,14 @@ class EstimatorTest(unittest.TestCase):
         mock_get_model_specs: mock.Mock,
         mock_session_estimator: mock.Mock,
         mock_session_model: mock.Mock,
-        mock_is_valid_model_id: mock.Mock,
+        mock_validate_model_id_and_get_type: mock.Mock,
         mock_get_default_predictor: mock.Mock,
     ):
         mock_estimator_deploy.return_value = default_predictor
 
         mock_get_default_predictor.return_value = default_predictor_with_presets
 
-        mock_is_valid_model_id.return_value = True
+        mock_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
         model_id, _ = "js-trainable-model-prepacked", "*"
 
@@ -1239,7 +1243,7 @@ class EstimatorTest(unittest.TestCase):
         self.assertEqual(type(predictor), Predictor)
 
     @mock.patch("sagemaker.jumpstart.estimator.get_default_predictor")
-    @mock.patch("sagemaker.jumpstart.estimator.is_valid_model_id")
+    @mock.patch("sagemaker.jumpstart.estimator.validate_model_id_and_get_type")
     @mock.patch("sagemaker.jumpstart.factory.model.Session")
     @mock.patch("sagemaker.jumpstart.factory.estimator.Session")
     @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
@@ -1256,14 +1260,14 @@ class EstimatorTest(unittest.TestCase):
         mock_get_model_specs: mock.Mock,
         mock_session_estimator: mock.Mock,
         mock_session_model: mock.Mock,
-        mock_is_valid_model_id: mock.Mock,
+        mock_validate_model_id_and_get_type: mock.Mock,
         mock_get_default_predictor: mock.Mock,
     ):
         mock_estimator_deploy.return_value = default_predictor
 
         mock_get_default_predictor.return_value = default_predictor_with_presets
 
-        mock_is_valid_model_id.return_value = True
+        mock_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
         model_id, _ = "js-trainable-model-prepacked", "*"
 
@@ -1289,7 +1293,7 @@ class EstimatorTest(unittest.TestCase):
         self.assertEqual(type(predictor), Predictor)
         self.assertEqual(predictor, default_predictor)
 
-    @mock.patch("sagemaker.jumpstart.estimator.is_valid_model_id")
+    @mock.patch("sagemaker.jumpstart.estimator.validate_model_id_and_get_type")
     @mock.patch("sagemaker.jumpstart.factory.estimator._model_supports_incremental_training")
     @mock.patch("sagemaker.jumpstart.factory.estimator.JUMPSTART_LOGGER.warning")
     @mock.patch("sagemaker.jumpstart.factory.model.Session")
@@ -1310,9 +1314,9 @@ class EstimatorTest(unittest.TestCase):
         mock_session_model: mock.Mock,
         mock_logger_warning: mock.Mock,
         mock_supports_incremental_training: mock.Mock,
-        mock_is_valid_model_id: mock.Mock,
+        mock_validate_model_id_and_get_type: mock.Mock,
     ):
-        mock_is_valid_model_id.return_value = True
+        mock_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
         mock_estimator_deploy.return_value = default_predictor
 
@@ -1343,7 +1347,7 @@ class EstimatorTest(unittest.TestCase):
             sagemaker_session=sagemaker_session,
         )
 
-    @mock.patch("sagemaker.jumpstart.estimator.is_valid_model_id")
+    @mock.patch("sagemaker.jumpstart.estimator.validate_model_id_and_get_type")
     @mock.patch("sagemaker.jumpstart.factory.estimator._model_supports_incremental_training")
     @mock.patch("sagemaker.jumpstart.factory.estimator.JUMPSTART_LOGGER.warning")
     @mock.patch("sagemaker.jumpstart.factory.model.Session")
@@ -1364,9 +1368,9 @@ class EstimatorTest(unittest.TestCase):
         mock_session_model: mock.Mock,
         mock_logger_warning: mock.Mock,
         mock_supports_incremental_training: mock.Mock,
-        mock_is_valid_model_id: mock.Mock,
+        mock_validate_model_id_and_get_type: mock.Mock,
     ):
-        mock_is_valid_model_id.return_value = True
+        mock_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
         mock_estimator_deploy.return_value = default_predictor
 
@@ -1395,7 +1399,7 @@ class EstimatorTest(unittest.TestCase):
         )
 
     @mock.patch("sagemaker.utils.sagemaker_timestamp")
-    @mock.patch("sagemaker.jumpstart.estimator.is_valid_model_id")
+    @mock.patch("sagemaker.jumpstart.estimator.validate_model_id_and_get_type")
     @mock.patch("sagemaker.jumpstart.factory.model.Session")
     @mock.patch("sagemaker.jumpstart.factory.estimator.Session")
     @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
@@ -1412,10 +1416,10 @@ class EstimatorTest(unittest.TestCase):
         mock_get_model_specs: mock.Mock,
         mock_session_estimator: mock.Mock,
         mock_session_model: mock.Mock,
-        mock_is_valid_model_id: mock.Mock,
+        mock_validate_model_id_and_get_type: mock.Mock,
         mock_sagemaker_timestamp: mock.Mock,
     ):
-        mock_is_valid_model_id.return_value = True
+        mock_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
         mock_sagemaker_timestamp.return_value = "3456"
 
@@ -1456,7 +1460,7 @@ class EstimatorTest(unittest.TestCase):
         assert mock_estimator_deploy.call_args[1]["instance_type"] == "ml.p4de.24xlarge"
 
     @mock.patch("sagemaker.utils.sagemaker_timestamp")
-    @mock.patch("sagemaker.jumpstart.estimator.is_valid_model_id")
+    @mock.patch("sagemaker.jumpstart.estimator.validate_model_id_and_get_type")
     @mock.patch("sagemaker.jumpstart.factory.model.Session")
     @mock.patch("sagemaker.jumpstart.factory.estimator.Session")
     @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
@@ -1473,10 +1477,10 @@ class EstimatorTest(unittest.TestCase):
         mock_get_model_specs: mock.Mock,
         mock_session_estimator: mock.Mock,
         mock_session_model: mock.Mock,
-        mock_is_valid_model_id: mock.Mock,
+        mock_validate_model_id_and_get_type: mock.Mock,
         mock_sagemaker_timestamp: mock.Mock,
     ):
-        mock_is_valid_model_id.return_value = True
+        mock_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
         mock_sagemaker_timestamp.return_value = "3456"
 
@@ -1533,7 +1537,7 @@ class EstimatorTest(unittest.TestCase):
         )
 
     @mock.patch("sagemaker.utils.sagemaker_timestamp")
-    @mock.patch("sagemaker.jumpstart.estimator.is_valid_model_id")
+    @mock.patch("sagemaker.jumpstart.estimator.validate_model_id_and_get_type")
     @mock.patch(
         "sagemaker.jumpstart.factory.model.DEFAULT_JUMPSTART_SAGEMAKER_SESSION", sagemaker_session
     )
@@ -1553,10 +1557,10 @@ class EstimatorTest(unittest.TestCase):
         mock_estimator_fit: mock.Mock,
         mock_estimator_init: mock.Mock,
         mock_get_model_specs: mock.Mock,
-        mock_is_valid_model_id: mock.Mock,
+        mock_validate_model_id_and_get_type: mock.Mock,
         mock_sagemaker_timestamp: mock.Mock,
     ):
-        mock_is_valid_model_id.return_value = True
+        mock_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
         mock_sagemaker_timestamp.return_value = "3456"
 
@@ -1611,7 +1615,7 @@ class EstimatorTest(unittest.TestCase):
             ],
         )
 
-    @mock.patch("sagemaker.jumpstart.estimator.is_valid_model_id")
+    @mock.patch("sagemaker.jumpstart.estimator.validate_model_id_and_get_type")
     @mock.patch("sagemaker.jumpstart.estimator.Estimator.deploy")
     @mock.patch("sagemaker.jumpstart.estimator.Estimator.__init__")
     @mock.patch("sagemaker.jumpstart.factory.estimator._retrieve_estimator_init_kwargs")
@@ -1627,11 +1631,11 @@ class EstimatorTest(unittest.TestCase):
         mock_retrieve_kwargs: mock.Mock,
         mock_estimator_init: mock.Mock,
         mock_estimator_deploy: mock.Mock,
-        mock_is_valid_model_id: mock.Mock,
+        mock_validate_model_id_and_get_type: mock.Mock,
     ):
         mock_estimator_deploy.return_value = default_predictor
 
-        mock_is_valid_model_id.side_effect = [False, False]
+        mock_validate_model_id_and_get_type.side_effect = [False, False]
 
         model_id, _ = "js-trainable-model", "*"
 
@@ -1647,7 +1651,7 @@ class EstimatorTest(unittest.TestCase):
             )
 
         mock_reset_cache.assert_called_once_with()
-        mock_is_valid_model_id.assert_has_calls(
+        mock_validate_model_id_and_get_type.assert_has_calls(
             calls=[
                 mock.call(
                     model_id="js-trainable-model",
@@ -1666,16 +1670,16 @@ class EstimatorTest(unittest.TestCase):
             ]
         )
 
-        mock_is_valid_model_id.reset_mock()
+        mock_validate_model_id_and_get_type.reset_mock()
         mock_reset_cache.reset_mock()
 
-        mock_is_valid_model_id.side_effect = [False, True]
+        mock_validate_model_id_and_get_type.side_effect = [False, True]
         JumpStartEstimator(
             model_id=model_id,
         )
 
         mock_reset_cache.assert_called_once_with()
-        mock_is_valid_model_id.assert_has_calls(
+        mock_validate_model_id_and_get_type.assert_has_calls(
             calls=[
                 mock.call(
                     model_id="js-trainable-model",
@@ -1694,7 +1698,7 @@ class EstimatorTest(unittest.TestCase):
             ]
         )
 
-    @mock.patch("sagemaker.jumpstart.estimator.is_valid_model_id")
+    @mock.patch("sagemaker.jumpstart.estimator.validate_model_id_and_get_type")
     @mock.patch("sagemaker.jumpstart.factory.model.Session")
     @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
     @mock.patch("sagemaker.jumpstart.estimator.Estimator.__init__")
@@ -1704,10 +1708,10 @@ class EstimatorTest(unittest.TestCase):
         mock_estimator_init: mock.Mock,
         mock_get_model_specs: mock.Mock,
         mock_session: mock.Mock,
-        mock_is_valid_model_id: mock.Mock,
+        mock_validate_model_id_and_get_type: mock.Mock,
     ):
 
-        mock_is_valid_model_id.return_value = True
+        mock_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
         model_id, _ = "model-artifact-variant-model", "*"
 

--- a/tests/unit/sagemaker/jumpstart/estimator/test_sagemaker_config.py
+++ b/tests/unit/sagemaker/jumpstart/estimator/test_sagemaker_config.py
@@ -25,6 +25,7 @@ from sagemaker.config.config_schema import (
 from sagemaker.jumpstart.constants import DEFAULT_JUMPSTART_SAGEMAKER_SESSION
 
 from sagemaker.jumpstart.estimator import JumpStartEstimator
+from sagemaker.jumpstart.enums import JumpStartModelType
 from sagemaker.session import Session
 from sagemaker.utils import resolve_value_from_config
 
@@ -78,7 +79,7 @@ def config_value_impl(sagemaker_session: Session, config_path: str, sagemaker_co
 
 
 class IntelligentDefaultsEstimatorTest(unittest.TestCase):
-    @mock.patch("sagemaker.jumpstart.estimator.is_valid_model_id")
+    @mock.patch("sagemaker.jumpstart.estimator.validate_model_id_and_get_type")
     @mock.patch("sagemaker.jumpstart.estimator.Estimator.deploy")
     @mock.patch("sagemaker.jumpstart.estimator.Estimator.__init__")
     @mock.patch("sagemaker.jumpstart.factory.model._retrieve_model_init_kwargs")
@@ -98,12 +99,12 @@ class IntelligentDefaultsEstimatorTest(unittest.TestCase):
         mock_retrieve_model_init_kwargs: mock.Mock,
         mock_estimator_init: mock.Mock,
         mock_estimator_deploy: mock.Mock,
-        mock_is_valid_model_id: mock.Mock,
+        mock_validate_model_id_and_get_type: mock.Mock,
     ):
 
         mock_estimator_deploy.return_value = default_predictor
 
-        mock_is_valid_model_id.return_value = True
+        mock_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
         model_id, _ = "js-trainable-model", "*"
 
@@ -135,7 +136,7 @@ class IntelligentDefaultsEstimatorTest(unittest.TestCase):
 
         assert "enable_network_isolation" not in mock_estimator_deploy.call_args[1]
 
-    @mock.patch("sagemaker.jumpstart.estimator.is_valid_model_id")
+    @mock.patch("sagemaker.jumpstart.estimator.validate_model_id_and_get_type")
     @mock.patch("sagemaker.jumpstart.estimator.Estimator.deploy")
     @mock.patch("sagemaker.jumpstart.estimator.Estimator.__init__")
     @mock.patch("sagemaker.jumpstart.factory.model._retrieve_model_init_kwargs")
@@ -155,12 +156,12 @@ class IntelligentDefaultsEstimatorTest(unittest.TestCase):
         mock_model_retrieve_kwargs: mock.Mock,
         mock_estimator_init: mock.Mock,
         mock_estimator_deploy: mock.Mock,
-        mock_is_valid_model_id: mock.Mock,
+        mock_validate_model_id_and_get_type: mock.Mock,
     ):
 
         mock_estimator_deploy.return_value = default_predictor
 
-        mock_is_valid_model_id.return_value = True
+        mock_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
         model_id, _ = "js-trainable-model", "*"
 
@@ -208,7 +209,7 @@ class IntelligentDefaultsEstimatorTest(unittest.TestCase):
             config_inference_enable_network_isolation,
         )
 
-    @mock.patch("sagemaker.jumpstart.estimator.is_valid_model_id")
+    @mock.patch("sagemaker.jumpstart.estimator.validate_model_id_and_get_type")
     @mock.patch("sagemaker.jumpstart.estimator.Estimator.deploy")
     @mock.patch("sagemaker.jumpstart.estimator.Estimator.__init__")
     @mock.patch("sagemaker.jumpstart.factory.model._retrieve_model_init_kwargs")
@@ -228,12 +229,12 @@ class IntelligentDefaultsEstimatorTest(unittest.TestCase):
         mock_model_retrieve_kwargs: mock.Mock,
         mock_estimator_init: mock.Mock,
         mock_estimator_deploy: mock.Mock,
-        mock_is_valid_model_id: mock.Mock,
+        mock_validate_model_id_and_get_type: mock.Mock,
     ):
 
         mock_estimator_deploy.return_value = default_predictor
 
-        mock_is_valid_model_id.return_value = True
+        mock_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
         model_id, _ = "js-trainable-model", "*"
 
@@ -290,7 +291,7 @@ class IntelligentDefaultsEstimatorTest(unittest.TestCase):
             override_inference_enable_network_isolation,
         )
 
-    @mock.patch("sagemaker.jumpstart.estimator.is_valid_model_id")
+    @mock.patch("sagemaker.jumpstart.estimator.validate_model_id_and_get_type")
     @mock.patch("sagemaker.jumpstart.estimator.Estimator.deploy")
     @mock.patch("sagemaker.jumpstart.estimator.Estimator.__init__")
     @mock.patch("sagemaker.jumpstart.factory.model._retrieve_model_init_kwargs")
@@ -310,12 +311,12 @@ class IntelligentDefaultsEstimatorTest(unittest.TestCase):
         mock_model_retrieve_kwargs: mock.Mock,
         mock_estimator_init: mock.Mock,
         mock_estimator_deploy: mock.Mock,
-        mock_is_valid_model_id: mock.Mock,
+        mock_validate_model_id_and_get_type: mock.Mock,
     ):
 
         mock_estimator_deploy.return_value = default_predictor
 
-        mock_is_valid_model_id.return_value = True
+        mock_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
         model_id, _ = "js-trainable-model", "*"
 
@@ -365,7 +366,7 @@ class IntelligentDefaultsEstimatorTest(unittest.TestCase):
             override_inference_enable_network_isolation,
         )
 
-    @mock.patch("sagemaker.jumpstart.estimator.is_valid_model_id")
+    @mock.patch("sagemaker.jumpstart.estimator.validate_model_id_and_get_type")
     @mock.patch("sagemaker.session.Session.get_caller_identity_arn")
     @mock.patch("sagemaker.jumpstart.estimator.Estimator.deploy")
     @mock.patch("sagemaker.jumpstart.estimator.Estimator.__init__")
@@ -387,12 +388,12 @@ class IntelligentDefaultsEstimatorTest(unittest.TestCase):
         mock_estimator_init: mock.Mock,
         mock_estimator_deploy: mock.Mock,
         mock_get_caller_identity_arn: mock.Mock,
-        mock_is_valid_model_id: mock.Mock,
+        mock_validate_model_id_and_get_type: mock.Mock,
     ):
 
         mock_estimator_deploy.return_value = default_predictor
 
-        mock_is_valid_model_id.return_value = True
+        mock_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
         model_id, _ = "js-trainable-model", "*"
 
@@ -426,7 +427,7 @@ class IntelligentDefaultsEstimatorTest(unittest.TestCase):
 
         assert "enable_network_isolation" not in mock_estimator_deploy.call_args[1]
 
-    @mock.patch("sagemaker.jumpstart.estimator.is_valid_model_id")
+    @mock.patch("sagemaker.jumpstart.estimator.validate_model_id_and_get_type")
     @mock.patch("sagemaker.session.Session.get_caller_identity_arn")
     @mock.patch("sagemaker.jumpstart.estimator.Estimator.deploy")
     @mock.patch("sagemaker.jumpstart.estimator.Estimator.__init__")
@@ -448,12 +449,12 @@ class IntelligentDefaultsEstimatorTest(unittest.TestCase):
         mock_estimator_init: mock.Mock,
         mock_estimator_deploy: mock.Mock,
         mock_get_caller_identity_arn: mock.Mock,
-        mock_is_valid_model_id: mock.Mock,
+        mock_validate_model_id_and_get_type: mock.Mock,
     ):
 
         mock_estimator_deploy.return_value = default_predictor
 
-        mock_is_valid_model_id.return_value = True
+        mock_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
         mock_get_caller_identity_arn.return_value = execution_role
         model_id, _ = "js-trainable-model", "*"
@@ -500,7 +501,7 @@ class IntelligentDefaultsEstimatorTest(unittest.TestCase):
             metadata_inference_enable_network_isolation,
         )
 
-    @mock.patch("sagemaker.jumpstart.estimator.is_valid_model_id")
+    @mock.patch("sagemaker.jumpstart.estimator.validate_model_id_and_get_type")
     @mock.patch("sagemaker.jumpstart.estimator.Estimator.deploy")
     @mock.patch("sagemaker.jumpstart.estimator.Estimator.__init__")
     @mock.patch("sagemaker.jumpstart.factory.model._retrieve_model_init_kwargs")
@@ -520,11 +521,11 @@ class IntelligentDefaultsEstimatorTest(unittest.TestCase):
         mock_model_retrieve_kwargs: mock.Mock,
         mock_estimator_init: mock.Mock,
         mock_estimator_deploy: mock.Mock,
-        mock_is_valid_model_id: mock.Mock,
+        mock_validate_model_id_and_get_type: mock.Mock,
     ):
         mock_estimator_deploy.return_value = default_predictor
 
-        mock_is_valid_model_id.return_value = True
+        mock_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
         model_id, _ = "js-trainable-model", "*"
 
@@ -576,7 +577,7 @@ class IntelligentDefaultsEstimatorTest(unittest.TestCase):
             override_inference_enable_network_isolation,
         )
 
-    @mock.patch("sagemaker.jumpstart.estimator.is_valid_model_id")
+    @mock.patch("sagemaker.jumpstart.estimator.validate_model_id_and_get_type")
     @mock.patch("sagemaker.jumpstart.estimator.Estimator.deploy")
     @mock.patch("sagemaker.jumpstart.estimator.Estimator.__init__")
     @mock.patch("sagemaker.jumpstart.factory.estimator._retrieve_estimator_init_kwargs")
@@ -594,11 +595,11 @@ class IntelligentDefaultsEstimatorTest(unittest.TestCase):
         mock_retrieve_kwargs: mock.Mock,
         mock_estimator_init: mock.Mock,
         mock_estimator_deploy: mock.Mock,
-        mock_is_valid_model_id: mock.Mock,
+        mock_validate_model_id_and_get_type: mock.Mock,
     ):
         mock_estimator_deploy.return_value = default_predictor
 
-        mock_is_valid_model_id.return_value = True
+        mock_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
         model_id, _ = "js-trainable-model", "*"
 

--- a/tests/unit/sagemaker/jumpstart/model/test_model.py
+++ b/tests/unit/sagemaker/jumpstart/model/test_model.py
@@ -22,7 +22,7 @@ from sagemaker.jumpstart.artifacts.environment_variables import (
     _retrieve_default_environment_variables,
 )
 from sagemaker.jumpstart.constants import DEFAULT_JUMPSTART_SAGEMAKER_SESSION
-from sagemaker.jumpstart.enums import JumpStartScriptScope, JumpStartTag
+from sagemaker.jumpstart.enums import JumpStartScriptScope, JumpStartTag, JumpStartModelType
 
 from sagemaker.jumpstart.model import JumpStartModel
 from sagemaker.model import Model
@@ -32,6 +32,7 @@ from sagemaker.enums import EndpointType
 from sagemaker.compute_resource_requirements.resource_requirements import ResourceRequirements
 
 from tests.unit.sagemaker.jumpstart.utils import (
+    get_spec_from_base_spec,
     get_special_model_spec,
     overwrite_dictionary,
     get_special_model_spec_for_inference_component_based_endpoint,
@@ -53,7 +54,7 @@ class ModelTest(unittest.TestCase):
 
     @mock.patch("sagemaker.jumpstart.factory.model.JUMPSTART_LOGGER")
     @mock.patch("sagemaker.utils.sagemaker_timestamp")
-    @mock.patch("sagemaker.jumpstart.model.is_valid_model_id")
+    @mock.patch("sagemaker.jumpstart.model.validate_model_id_and_get_type")
     @mock.patch("sagemaker.jumpstart.factory.model.Session")
     @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
     @mock.patch("sagemaker.jumpstart.model.Model.__init__")
@@ -65,7 +66,7 @@ class ModelTest(unittest.TestCase):
         mock_model_init: mock.Mock,
         mock_get_model_specs: mock.Mock,
         mock_session: mock.Mock,
-        mock_is_valid_model_id: mock.Mock,
+        mock_validate_model_id_and_get_type: mock.Mock,
         mock_sagemaker_timestamp: mock.Mock,
         mock_jumpstart_model_factory_logger: mock.Mock,
     ):
@@ -73,7 +74,7 @@ class ModelTest(unittest.TestCase):
 
         mock_sagemaker_timestamp.return_value = "7777"
 
-        mock_is_valid_model_id.return_value = True
+        mock_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
         model_id, _ = "js-trainable-model", "*"
 
         mock_get_model_specs.side_effect = get_special_model_spec
@@ -128,7 +129,7 @@ class ModelTest(unittest.TestCase):
         )
 
     @mock.patch("sagemaker.utils.sagemaker_timestamp")
-    @mock.patch("sagemaker.jumpstart.model.is_valid_model_id")
+    @mock.patch("sagemaker.jumpstart.model.validate_model_id_and_get_type")
     @mock.patch("sagemaker.jumpstart.factory.model.Session")
     @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
     @mock.patch("sagemaker.jumpstart.model.Model.__init__")
@@ -140,14 +141,14 @@ class ModelTest(unittest.TestCase):
         mock_model_init: mock.Mock,
         mock_get_model_specs: mock.Mock,
         mock_session: mock.Mock,
-        mock_is_valid_model_id: mock.Mock,
+        mock_validate_model_id_and_get_type: mock.Mock,
         mock_sagemaker_timestamp: mock.Mock,
     ):
         mock_model_deploy.return_value = default_predictor
 
         mock_sagemaker_timestamp.return_value = "7777"
 
-        mock_is_valid_model_id.return_value = True
+        mock_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
         model_id, _ = "js-trainable-model", "*"
 
         mock_get_model_specs.side_effect = (
@@ -208,7 +209,7 @@ class ModelTest(unittest.TestCase):
         )
 
     @mock.patch("sagemaker.utils.sagemaker_timestamp")
-    @mock.patch("sagemaker.jumpstart.model.is_valid_model_id")
+    @mock.patch("sagemaker.jumpstart.model.validate_model_id_and_get_type")
     @mock.patch("sagemaker.jumpstart.factory.model.Session")
     @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
     @mock.patch("sagemaker.jumpstart.model.Model.__init__")
@@ -220,14 +221,14 @@ class ModelTest(unittest.TestCase):
         mock_model_init: mock.Mock,
         mock_get_model_specs: mock.Mock,
         mock_session: mock.Mock,
-        mock_is_valid_model_id: mock.Mock,
+        mock_validate_model_id_and_get_type: mock.Mock,
         mock_sagemaker_timestamp: mock.Mock,
     ):
         mock_model_deploy.return_value = default_predictor
 
         mock_sagemaker_timestamp.return_value = "7777"
 
-        mock_is_valid_model_id.return_value = True
+        mock_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
         model_id, _ = "js-model-class-model-prepacked", "*"
 
         mock_get_model_specs.side_effect = get_special_model_spec
@@ -282,7 +283,7 @@ class ModelTest(unittest.TestCase):
             endpoint_type=EndpointType.INFERENCE_COMPONENT_BASED,
         )
 
-    @mock.patch("sagemaker.jumpstart.model.is_valid_model_id")
+    @mock.patch("sagemaker.jumpstart.model.validate_model_id_and_get_type")
     @mock.patch("sagemaker.jumpstart.factory.model.Session")
     @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
     @mock.patch("sagemaker.jumpstart.model.Model.__init__")
@@ -294,11 +295,11 @@ class ModelTest(unittest.TestCase):
         mock_model_init: mock.Mock,
         mock_get_model_specs: mock.Mock,
         mock_session: mock.Mock,
-        mock_is_valid_model_id: mock.Mock,
+        mock_validate_model_id_and_get_type: mock.Mock,
     ):
         mock_model_deploy.return_value = default_predictor
 
-        mock_is_valid_model_id.return_value = True
+        mock_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
         model_id, _ = "js-model-class-model-prepacked", "*"
 
@@ -345,7 +346,7 @@ class ModelTest(unittest.TestCase):
     @mock.patch("sagemaker.utils.sagemaker_timestamp")
     @mock.patch("sagemaker.session.Session.endpoint_from_production_variants")
     @mock.patch("sagemaker.session.Session.create_model")
-    @mock.patch("sagemaker.jumpstart.model.is_valid_model_id")
+    @mock.patch("sagemaker.jumpstart.model.validate_model_id_and_get_type")
     @mock.patch("sagemaker.jumpstart.factory.model.Session")
     @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
     @mock.patch("sagemaker.jumpstart.factory.model.JUMPSTART_DEFAULT_REGION_NAME", region)
@@ -353,7 +354,7 @@ class ModelTest(unittest.TestCase):
         self,
         mock_get_model_specs: mock.Mock,
         mock_session: mock.Mock,
-        mock_is_valid_model_id: mock.Mock,
+        mock_validate_model_id_and_get_type: mock.Mock,
         mock_create_model: mock.Mock,
         mock_endpoint_from_production_variants: mock.Mock,
         mock_timestamp: mock.Mock,
@@ -362,7 +363,7 @@ class ModelTest(unittest.TestCase):
 
         mock_timestamp.return_value = "1234"
 
-        mock_is_valid_model_id.return_value = True
+        mock_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
         model_id, _ = "gated_llama_neuron_model", "*"
 
@@ -381,7 +382,7 @@ class ModelTest(unittest.TestCase):
     @mock.patch("sagemaker.utils.sagemaker_timestamp")
     @mock.patch("sagemaker.session.Session.endpoint_from_production_variants")
     @mock.patch("sagemaker.session.Session.create_model")
-    @mock.patch("sagemaker.jumpstart.model.is_valid_model_id")
+    @mock.patch("sagemaker.jumpstart.model.validate_model_id_and_get_type")
     @mock.patch("sagemaker.jumpstart.factory.model.Session")
     @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
     @mock.patch("sagemaker.jumpstart.factory.model.JUMPSTART_DEFAULT_REGION_NAME", region)
@@ -389,7 +390,7 @@ class ModelTest(unittest.TestCase):
         self,
         mock_get_model_specs: mock.Mock,
         mock_session: mock.Mock,
-        mock_is_valid_model_id: mock.Mock,
+        mock_validate_model_id_and_get_type: mock.Mock,
         mock_create_model: mock.Mock,
         mock_endpoint_from_production_variants: mock.Mock,
         mock_timestamp: mock.Mock,
@@ -397,7 +398,7 @@ class ModelTest(unittest.TestCase):
 
         mock_timestamp.return_value = "1234"
 
-        mock_is_valid_model_id.return_value = True
+        mock_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
         model_id, _ = "gated_variant-model", "*"
 
@@ -441,7 +442,64 @@ class ModelTest(unittest.TestCase):
             ],
         )
 
-    @mock.patch("sagemaker.jumpstart.model.is_valid_model_id")
+    @mock.patch("sagemaker.utils.sagemaker_timestamp")
+    @mock.patch("sagemaker.jumpstart.utils.validate_model_id_and_get_type")
+    @mock.patch("sagemaker.jumpstart.factory.model.Session")
+    @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
+    @mock.patch("sagemaker.jumpstart.model.Model.__init__")
+    @mock.patch("sagemaker.jumpstart.model.Model.deploy")
+    @mock.patch("sagemaker.jumpstart.factory.model.JUMPSTART_DEFAULT_REGION_NAME", region)
+    def test_proprietary_model_endpoint(
+        self,
+        mock_model_deploy: mock.Mock,
+        mock_model_init: mock.Mock,
+        mock_get_model_specs: mock.Mock,
+        mock_session: mock.Mock,
+        mock_validate_model_id_and_get_type: mock.Mock,
+        mock_sagemaker_timestamp: mock.Mock,
+    ):
+        mock_model_deploy.return_value = default_predictor
+
+        mock_sagemaker_timestamp.return_value = "7777"
+
+        mock_validate_model_id_and_get_type.return_value = JumpStartModelType.PROPRIETARY
+        model_id, _ = "ai21-summarization", "*"
+
+        mock_get_model_specs.side_effect = get_spec_from_base_spec
+
+        mock_session.return_value = sagemaker_session
+
+        model = JumpStartModel(
+            model_id=model_id,
+        )
+
+        mock_model_init.assert_called_once_with(
+            image_uri="",
+            model_data="s3://jumpstart-cache-prod-us-west-2/None",
+            source_dir="s3://jumpstart-cache-prod-us-west-2/None",
+            entry_point="inference.py",
+            predictor_cls=Predictor,
+            role=execution_role,
+            sagemaker_session=sagemaker_session,
+            enable_network_isolation=False,
+        )
+
+        model.deploy()
+
+        mock_model_deploy.assert_called_once_with(
+            initial_instance_count=1,
+            instance_type="ml.p4de.24xlarge",
+            wait=True,
+            tags=[
+                {"Key": JumpStartTag.MODEL_ID, "Value": "ai21-summarization"},
+                {"Key": JumpStartTag.MODEL_VERSION, "Value": "*"},
+            ],
+            endpoint_logging=False,
+            model_data_download_timeout=3600,
+            container_startup_health_check_timeout=600,
+        )
+
+    @mock.patch("sagemaker.jumpstart.model.validate_model_id_and_get_type")
     @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
     @mock.patch("sagemaker.jumpstart.model.Model.__init__")
     @mock.patch("sagemaker.jumpstart.model.Model.deploy")
@@ -451,11 +509,11 @@ class ModelTest(unittest.TestCase):
         mock_model_deploy: mock.Mock,
         mock_model_init: mock.Mock,
         mock_get_model_specs: mock.Mock,
-        mock_is_valid_model_id: mock.Mock,
+        mock_validate_model_id_and_get_type: mock.Mock,
     ):
         mock_model_deploy.return_value = default_predictor
 
-        mock_is_valid_model_id.return_value = True
+        mock_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
         model_id, _ = "deprecated_model", "*"
 
@@ -468,7 +526,7 @@ class ModelTest(unittest.TestCase):
 
         JumpStartModel(model_id=model_id, tolerate_deprecated_model=True).deploy()
 
-    @mock.patch("sagemaker.jumpstart.model.is_valid_model_id")
+    @mock.patch("sagemaker.jumpstart.model.validate_model_id_and_get_type")
     @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
     @mock.patch("sagemaker.jumpstart.model.Model.__init__")
     @mock.patch("sagemaker.jumpstart.model.Model.deploy")
@@ -478,9 +536,9 @@ class ModelTest(unittest.TestCase):
         mock_model_deploy: mock.Mock,
         mock_model_init: mock.Mock,
         mock_get_model_specs: mock.Mock,
-        mock_is_valid_model_id: mock.Mock,
+        mock_validate_model_id_and_get_type: mock.Mock,
     ):
-        mock_is_valid_model_id.return_value = True
+        mock_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
         mock_model_deploy.return_value = default_predictor
 
@@ -543,7 +601,7 @@ class ModelTest(unittest.TestCase):
         )
 
     @mock.patch("sagemaker.jumpstart.factory.model.environment_variables.retrieve_default")
-    @mock.patch("sagemaker.jumpstart.model.is_valid_model_id")
+    @mock.patch("sagemaker.jumpstart.model.validate_model_id_and_get_type")
     @mock.patch("sagemaker.jumpstart.factory.model.Session")
     @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
     @mock.patch("sagemaker.jumpstart.model.Model.__init__")
@@ -555,7 +613,7 @@ class ModelTest(unittest.TestCase):
         mock_model_init: mock.Mock,
         mock_get_model_specs: mock.Mock,
         mock_session: mock.Mock,
-        mock_is_valid_model_id: mock.Mock,
+        mock_validate_model_id_and_get_type: mock.Mock,
         mock_retrieve_environment_variables: mock.Mock,
         init_kwargs: Optional[dict] = None,
         deploy_kwargs: Optional[dict] = None,
@@ -565,7 +623,7 @@ class ModelTest(unittest.TestCase):
 
         mock_model_deploy.return_value = default_predictor
 
-        mock_is_valid_model_id.return_value = True
+        mock_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
         mock_session.return_value = sagemaker_session
 
@@ -661,22 +719,22 @@ class ModelTest(unittest.TestCase):
 
     @mock.patch("sagemaker.jumpstart.model.get_init_kwargs")
     @mock.patch("sagemaker.jumpstart.model.Model.__init__")
-    @mock.patch("sagemaker.jumpstart.model.is_valid_model_id")
-    def test_is_valid_model_id(
+    @mock.patch("sagemaker.jumpstart.model.validate_model_id_and_get_type")
+    def test_validate_model_id_and_get_type(
         self,
-        mock_is_valid_model_id: mock.Mock,
+        mock_validate_model_id_and_get_type: mock.Mock,
         mock_init: mock.Mock,
         mock_get_init_kwargs: mock.Mock,
     ):
-        mock_is_valid_model_id.return_value = True
+        mock_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
         JumpStartModel(model_id="valid_model_id")
 
-        mock_is_valid_model_id.return_value = False
+        mock_validate_model_id_and_get_type.return_value = False
         with pytest.raises(ValueError):
             JumpStartModel(model_id="invalid_model_id")
 
     @mock.patch("sagemaker.jumpstart.model.get_default_predictor")
-    @mock.patch("sagemaker.jumpstart.model.is_valid_model_id")
+    @mock.patch("sagemaker.jumpstart.model.validate_model_id_and_get_type")
     @mock.patch("sagemaker.jumpstart.factory.model.Session")
     @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
     @mock.patch("sagemaker.jumpstart.model.Model.__init__")
@@ -688,14 +746,14 @@ class ModelTest(unittest.TestCase):
         mock_model_init: mock.Mock,
         mock_get_model_specs: mock.Mock,
         mock_session: mock.Mock,
-        mock_is_valid_model_id: mock.Mock,
+        mock_validate_model_id_and_get_type: mock.Mock,
         mock_get_default_predictor: mock.Mock,
     ):
         mock_get_default_predictor.return_value = default_predictor_with_presets
 
         mock_model_deploy.return_value = default_predictor
 
-        mock_is_valid_model_id.return_value = True
+        mock_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
         model_id, _ = "js-model-class-model-prepacked", "*"
 
@@ -717,12 +775,13 @@ class ModelTest(unittest.TestCase):
             tolerate_deprecated_model=False,
             tolerate_vulnerable_model=False,
             sagemaker_session=model.sagemaker_session,
+            model_type=JumpStartModelType.OPEN_SOURCE,
         )
         self.assertEqual(type(predictor), Predictor)
         self.assertEqual(predictor, default_predictor_with_presets)
 
     @mock.patch("sagemaker.jumpstart.model.get_default_predictor")
-    @mock.patch("sagemaker.jumpstart.model.is_valid_model_id")
+    @mock.patch("sagemaker.jumpstart.model.validate_model_id_and_get_type")
     @mock.patch("sagemaker.jumpstart.factory.model.Session")
     @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
     @mock.patch("sagemaker.jumpstart.model.Model.__init__")
@@ -734,14 +793,14 @@ class ModelTest(unittest.TestCase):
         mock_model_init: mock.Mock,
         mock_get_model_specs: mock.Mock,
         mock_session: mock.Mock,
-        mock_is_valid_model_id: mock.Mock,
+        mock_validate_model_id_and_get_type: mock.Mock,
         mock_get_default_predictor: mock.Mock,
     ):
         mock_get_default_predictor.return_value = default_predictor_with_presets
 
         mock_model_deploy.return_value = default_predictor
 
-        mock_is_valid_model_id.return_value = True
+        mock_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
         model_id, _ = "js-model-class-model-prepacked", "*"
 
@@ -758,7 +817,7 @@ class ModelTest(unittest.TestCase):
         mock_get_default_predictor.assert_not_called()
 
     @mock.patch("sagemaker.jumpstart.model.get_default_predictor")
-    @mock.patch("sagemaker.jumpstart.model.is_valid_model_id")
+    @mock.patch("sagemaker.jumpstart.model.validate_model_id_and_get_type")
     @mock.patch("sagemaker.jumpstart.factory.model.Session")
     @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
     @mock.patch("sagemaker.jumpstart.model.Model.__init__")
@@ -770,14 +829,14 @@ class ModelTest(unittest.TestCase):
         mock_model_init: mock.Mock,
         mock_get_model_specs: mock.Mock,
         mock_session: mock.Mock,
-        mock_is_valid_model_id: mock.Mock,
+        mock_validate_model_id_and_get_type: mock.Mock,
         mock_get_default_predictor: mock.Mock,
     ):
         mock_get_default_predictor.return_value = default_predictor_with_presets
 
         mock_model_deploy.return_value = default_predictor
 
-        mock_is_valid_model_id.return_value = True
+        mock_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
         model_id, _ = "js-model-class-model-prepacked", "*"
 
@@ -793,24 +852,24 @@ class ModelTest(unittest.TestCase):
         self.assertEqual(type(predictor), Predictor)
         self.assertEqual(predictor, default_predictor)
 
-    @mock.patch("sagemaker.jumpstart.model.is_valid_model_id")
+    @mock.patch("sagemaker.jumpstart.model.validate_model_id_and_get_type")
     @mock.patch("sagemaker.jumpstart.model.Model.__init__")
     @mock.patch("sagemaker.jumpstart.factory.model._retrieve_model_init_kwargs")
     @mock.patch("sagemaker.jumpstart.factory.model.Session")
     @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
     @mock.patch("sagemaker.jumpstart.model.JumpStartModelsAccessor.reset_cache")
     @mock.patch("sagemaker.jumpstart.factory.estimator.JUMPSTART_DEFAULT_REGION_NAME", region)
-    def test_model_id_not_found_refeshes_cach_inference(
+    def test_model_id_not_found_refeshes_cache_inference(
         self,
         mock_reset_cache: mock.Mock,
         mock_get_model_specs: mock.Mock,
         mock_session: mock.Mock,
         mock_retrieve_kwargs: mock.Mock,
         mock_model_init: mock.Mock,
-        mock_is_valid_model_id: mock.Mock,
+        mock_validate_model_id_and_get_type: mock.Mock,
     ):
 
-        mock_is_valid_model_id.side_effect = [False, False]
+        mock_validate_model_id_and_get_type.side_effect = [False, False]
 
         model_id, _ = "js-trainable-model", "*"
 
@@ -826,7 +885,7 @@ class ModelTest(unittest.TestCase):
             )
 
         mock_reset_cache.assert_called_once_with()
-        mock_is_valid_model_id.assert_has_calls(
+        mock_validate_model_id_and_get_type.assert_has_calls(
             calls=[
                 mock.call(
                     model_id="js-trainable-model",
@@ -845,16 +904,19 @@ class ModelTest(unittest.TestCase):
             ]
         )
 
-        mock_is_valid_model_id.reset_mock()
+        mock_validate_model_id_and_get_type.reset_mock()
         mock_reset_cache.reset_mock()
 
-        mock_is_valid_model_id.side_effect = [False, True]
+        mock_validate_model_id_and_get_type.side_effect = [
+            False,
+            JumpStartModelType.OPEN_SOURCE,
+        ]
         JumpStartModel(
             model_id=model_id,
         )
 
         mock_reset_cache.assert_called_once_with()
-        mock_is_valid_model_id.assert_has_calls(
+        mock_validate_model_id_and_get_type.assert_has_calls(
             calls=[
                 mock.call(
                     model_id="js-trainable-model",
@@ -873,16 +935,16 @@ class ModelTest(unittest.TestCase):
             ]
         )
 
-    @mock.patch("sagemaker.jumpstart.model.is_valid_model_id")
+    @mock.patch("sagemaker.jumpstart.model.validate_model_id_and_get_type")
     @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
     @mock.patch("sagemaker.jumpstart.factory.model.JUMPSTART_DEFAULT_REGION_NAME", region)
     def test_jumpstart_model_tags(
         self,
         mock_get_model_specs: mock.Mock,
-        mock_is_valid_model_id: mock.Mock,
+        mock_validate_model_id_and_get_type: mock.Mock,
     ):
 
-        mock_is_valid_model_id.return_value = True
+        mock_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
         model_id, _ = "env-var-variant-model", "*"
 
@@ -909,16 +971,16 @@ class ModelTest(unittest.TestCase):
             [{"Key": "blah", "Value": "blahagain"}] + js_tags,
         )
 
-    @mock.patch("sagemaker.jumpstart.model.is_valid_model_id")
+    @mock.patch("sagemaker.jumpstart.model.validate_model_id_and_get_type")
     @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
     @mock.patch("sagemaker.jumpstart.factory.model.JUMPSTART_DEFAULT_REGION_NAME", region)
     def test_jumpstart_model_tags_disabled(
         self,
         mock_get_model_specs: mock.Mock,
-        mock_is_valid_model_id: mock.Mock,
+        mock_validate_model_id_and_get_type: mock.Mock,
     ):
 
-        mock_is_valid_model_id.return_value = True
+        mock_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
         model_id, _ = "env-var-variant-model", "*"
 
@@ -941,16 +1003,16 @@ class ModelTest(unittest.TestCase):
             [{"Key": "blah", "Value": "blahagain"}],
         )
 
-    @mock.patch("sagemaker.jumpstart.model.is_valid_model_id")
+    @mock.patch("sagemaker.jumpstart.model.validate_model_id_and_get_type")
     @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
     @mock.patch("sagemaker.jumpstart.factory.model.JUMPSTART_DEFAULT_REGION_NAME", region)
     def test_jumpstart_model_package_arn(
         self,
         mock_get_model_specs: mock.Mock,
-        mock_is_valid_model_id: mock.Mock,
+        mock_validate_model_id_and_get_type: mock.Mock,
     ):
 
-        mock_is_valid_model_id.return_value = True
+        mock_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
         model_id, _ = "js-model-package-arn", "*"
 
@@ -975,16 +1037,16 @@ class ModelTest(unittest.TestCase):
 
         self.assertIn(tag, mock_session.create_model.call_args[1]["tags"])
 
-    @mock.patch("sagemaker.jumpstart.model.is_valid_model_id")
+    @mock.patch("sagemaker.jumpstart.model.validate_model_id_and_get_type")
     @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
     @mock.patch("sagemaker.jumpstart.factory.model.JUMPSTART_DEFAULT_REGION_NAME", region)
     def test_jumpstart_model_package_arn_override(
         self,
         mock_get_model_specs: mock.Mock,
-        mock_is_valid_model_id: mock.Mock,
+        mock_validate_model_id_and_get_type: mock.Mock,
     ):
 
-        mock_is_valid_model_id.return_value = True
+        mock_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
         # arbitrary model without model packarn arn
         model_id, _ = "js-trainable-model", "*"
@@ -1017,7 +1079,7 @@ class ModelTest(unittest.TestCase):
             },
         )
 
-    @mock.patch("sagemaker.jumpstart.model.is_valid_model_id")
+    @mock.patch("sagemaker.jumpstart.model.validate_model_id_and_get_type")
     @mock.patch("sagemaker.jumpstart.factory.model.Session")
     @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
     @mock.patch("sagemaker.jumpstart.factory.model.JUMPSTART_DEFAULT_REGION_NAME", region)
@@ -1025,10 +1087,10 @@ class ModelTest(unittest.TestCase):
         self,
         mock_get_model_specs: mock.Mock,
         mock_session: mock.Mock,
-        mock_is_valid_model_id: mock.Mock,
+        mock_validate_model_id_and_get_type: mock.Mock,
     ):
 
-        mock_is_valid_model_id.return_value = True
+        mock_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
         model_id, _ = "js-model-package-arn", "*"
 
@@ -1044,7 +1106,7 @@ class ModelTest(unittest.TestCase):
         )
 
     @mock.patch("sagemaker.utils.sagemaker_timestamp")
-    @mock.patch("sagemaker.jumpstart.model.is_valid_model_id")
+    @mock.patch("sagemaker.jumpstart.model.validate_model_id_and_get_type")
     @mock.patch("sagemaker.jumpstart.factory.model.Session")
     @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
     @mock.patch("sagemaker.jumpstart.model.Model.__init__")
@@ -1058,14 +1120,14 @@ class ModelTest(unittest.TestCase):
         mock_model_init: mock.Mock,
         mock_get_model_specs: mock.Mock,
         mock_session: mock.Mock,
-        mock_is_valid_model_id: mock.Mock,
+        mock_validate_model_id_and_get_type: mock.Mock,
         mock_sagemaker_timestamp: mock.Mock,
     ):
         mock_model_deploy.return_value = default_predictor
 
         mock_sagemaker_timestamp.return_value = "7777"
 
-        mock_is_valid_model_id.return_value = True
+        mock_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
         model_id, _ = "js-trainable-model", "*"
 
         mock_get_model_specs.side_effect = get_special_model_spec
@@ -1109,7 +1171,7 @@ class ModelTest(unittest.TestCase):
             '"S3DataType": "S3Prefix", "CompressionType": "None"}}',
         )
 
-    @mock.patch("sagemaker.jumpstart.model.is_valid_model_id")
+    @mock.patch("sagemaker.jumpstart.model.validate_model_id_and_get_type")
     @mock.patch("sagemaker.jumpstart.factory.model.Session")
     @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
     @mock.patch("sagemaker.jumpstart.model.Model.__init__")
@@ -1123,11 +1185,11 @@ class ModelTest(unittest.TestCase):
         mock_model_init: mock.Mock,
         mock_get_model_specs: mock.Mock,
         mock_session: mock.Mock,
-        mock_is_valid_model_id: mock.Mock,
+        mock_validate_model_id_and_get_type: mock.Mock,
     ):
         mock_model_deploy.return_value = default_predictor
 
-        mock_is_valid_model_id.return_value = True
+        mock_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
         model_id, _ = "model_data_s3_prefix_model", "*"
 
         mock_get_model_specs.side_effect = get_special_model_spec
@@ -1153,7 +1215,7 @@ class ModelTest(unittest.TestCase):
 
         mock_js_info_logger.assert_not_called()
 
-    @mock.patch("sagemaker.jumpstart.model.is_valid_model_id")
+    @mock.patch("sagemaker.jumpstart.model.validate_model_id_and_get_type")
     @mock.patch("sagemaker.jumpstart.factory.model.Session")
     @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
     @mock.patch("sagemaker.jumpstart.model.Model.__init__")
@@ -1167,11 +1229,11 @@ class ModelTest(unittest.TestCase):
         mock_model_init: mock.Mock,
         mock_get_model_specs: mock.Mock,
         mock_session: mock.Mock,
-        mock_is_valid_model_id: mock.Mock,
+        mock_validate_model_id_and_get_type: mock.Mock,
     ):
         mock_model_deploy.return_value = default_predictor
 
-        mock_is_valid_model_id.return_value = True
+        mock_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
         model_id, _ = "model-artifact-variant-model", "*"
 
         mock_get_model_specs.side_effect = get_special_model_spec
@@ -1218,7 +1280,7 @@ class ModelTest(unittest.TestCase):
             enable_network_isolation=True,
         )
 
-    @mock.patch("sagemaker.jumpstart.model.is_valid_model_id")
+    @mock.patch("sagemaker.jumpstart.model.validate_model_id_and_get_type")
     @mock.patch("sagemaker.jumpstart.factory.model.Session")
     @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
     @mock.patch("sagemaker.jumpstart.model.Model.deploy")
@@ -1230,11 +1292,11 @@ class ModelTest(unittest.TestCase):
         mock_model_deploy: mock.Mock,
         mock_get_model_specs: mock.Mock,
         mock_session: mock.Mock,
-        mock_is_valid_model_id: mock.Mock,
+        mock_validate_model_id_and_get_type: mock.Mock,
     ):
         mock_model_deploy.return_value = default_predictor
 
-        mock_is_valid_model_id.return_value = True
+        mock_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
         model_id, _ = "model_data_s3_prefix_model", "*"
 
         mock_get_model_specs.side_effect = get_special_model_spec

--- a/tests/unit/sagemaker/jumpstart/model/test_sagemaker_config.py
+++ b/tests/unit/sagemaker/jumpstart/model/test_sagemaker_config.py
@@ -21,6 +21,7 @@ from sagemaker.config.config_schema import (
 from sagemaker.jumpstart.constants import DEFAULT_JUMPSTART_SAGEMAKER_SESSION
 
 from sagemaker.jumpstart.model import JumpStartModel
+from sagemaker.jumpstart.enums import JumpStartModelType
 from sagemaker.session import Session
 from sagemaker.utils import resolve_value_from_config
 
@@ -59,7 +60,7 @@ class IntelligentDefaultsModelTest(unittest.TestCase):
     region = "us-west-2"
     sagemaker_session = DEFAULT_JUMPSTART_SAGEMAKER_SESSION
 
-    @mock.patch("sagemaker.jumpstart.model.is_valid_model_id")
+    @mock.patch("sagemaker.jumpstart.model.validate_model_id_and_get_type")
     @mock.patch("sagemaker.jumpstart.model.Model.__init__")
     @mock.patch("sagemaker.jumpstart.factory.model._retrieve_model_init_kwargs")
     @mock.patch("sagemaker.utils.get_sagemaker_config_value")
@@ -75,10 +76,10 @@ class IntelligentDefaultsModelTest(unittest.TestCase):
         mock_get_sagemaker_config_value: mock.Mock,
         mock_retrieve_kwargs: mock.Mock,
         mock_model_init: mock.Mock,
-        mock_is_valid_model_id: mock.Mock,
+        mock_validate_model_id_and_get_type: mock.Mock,
     ):
 
-        mock_is_valid_model_id.return_value = True
+        mock_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
         model_id, _ = "js-trainable-model", "*"
 
         mock_retrieve_kwargs.return_value = {}
@@ -100,7 +101,7 @@ class IntelligentDefaultsModelTest(unittest.TestCase):
 
         assert "enable_network_isolation" not in mock_model_init.call_args[1]
 
-    @mock.patch("sagemaker.jumpstart.model.is_valid_model_id")
+    @mock.patch("sagemaker.jumpstart.model.validate_model_id_and_get_type")
     @mock.patch("sagemaker.jumpstart.model.Model.__init__")
     @mock.patch("sagemaker.jumpstart.factory.model._retrieve_model_init_kwargs")
     @mock.patch("sagemaker.utils.get_sagemaker_config_value")
@@ -116,10 +117,10 @@ class IntelligentDefaultsModelTest(unittest.TestCase):
         mock_get_sagemaker_config_value: mock.Mock,
         mock_retrieve_kwargs: mock.Mock,
         mock_model_init: mock.Mock,
-        mock_is_valid_model_id: mock.Mock,
+        mock_validate_model_id_and_get_type: mock.Mock,
     ):
 
-        mock_is_valid_model_id.return_value = True
+        mock_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
         model_id, _ = "js-trainable-model", "*"
 
@@ -146,7 +147,7 @@ class IntelligentDefaultsModelTest(unittest.TestCase):
             override_enable_network_isolation,
         )
 
-    @mock.patch("sagemaker.jumpstart.model.is_valid_model_id")
+    @mock.patch("sagemaker.jumpstart.model.validate_model_id_and_get_type")
     @mock.patch("sagemaker.jumpstart.model.Model.__init__")
     @mock.patch("sagemaker.jumpstart.factory.model._retrieve_model_init_kwargs")
     @mock.patch("sagemaker.utils.get_sagemaker_config_value")
@@ -162,10 +163,10 @@ class IntelligentDefaultsModelTest(unittest.TestCase):
         mock_get_sagemaker_config_value: mock.Mock,
         mock_retrieve_kwargs: mock.Mock,
         mock_model_init: mock.Mock,
-        mock_is_valid_model_id: mock.Mock,
+        mock_validate_model_id_and_get_type: mock.Mock,
     ):
 
-        mock_is_valid_model_id.return_value = True
+        mock_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
         model_id, _ = "js-trainable-model", "*"
 
@@ -192,7 +193,7 @@ class IntelligentDefaultsModelTest(unittest.TestCase):
             config_enable_network_isolation,
         )
 
-    @mock.patch("sagemaker.jumpstart.model.is_valid_model_id")
+    @mock.patch("sagemaker.jumpstart.model.validate_model_id_and_get_type")
     @mock.patch("sagemaker.jumpstart.model.Model.__init__")
     @mock.patch("sagemaker.jumpstart.factory.model._retrieve_model_init_kwargs")
     @mock.patch("sagemaker.utils.get_sagemaker_config_value")
@@ -208,10 +209,10 @@ class IntelligentDefaultsModelTest(unittest.TestCase):
         mock_get_sagemaker_config_value: mock.Mock,
         mock_retrieve_kwargs: mock.Mock,
         mock_model_init: mock.Mock,
-        mock_is_valid_model_id: mock.Mock,
+        mock_validate_model_id_and_get_type: mock.Mock,
     ):
 
-        mock_is_valid_model_id.return_value = True
+        mock_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
         model_id, _ = "js-trainable-model", "*"
 
@@ -240,7 +241,7 @@ class IntelligentDefaultsModelTest(unittest.TestCase):
             override_enable_network_isolation,
         )
 
-    @mock.patch("sagemaker.jumpstart.model.is_valid_model_id")
+    @mock.patch("sagemaker.jumpstart.model.validate_model_id_and_get_type")
     @mock.patch("sagemaker.jumpstart.model.Model.__init__")
     @mock.patch("sagemaker.jumpstart.factory.model._retrieve_model_init_kwargs")
     @mock.patch("sagemaker.utils.get_sagemaker_config_value")
@@ -256,10 +257,10 @@ class IntelligentDefaultsModelTest(unittest.TestCase):
         mock_get_sagemaker_config_value: mock.Mock,
         mock_retrieve_kwargs: mock.Mock,
         mock_model_init: mock.Mock,
-        mock_is_valid_model_id: mock.Mock,
+        mock_validate_model_id_and_get_type: mock.Mock,
     ):
 
-        mock_is_valid_model_id.return_value = True
+        mock_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
         model_id, _ = "js-trainable-model", "*"
 
@@ -286,7 +287,7 @@ class IntelligentDefaultsModelTest(unittest.TestCase):
             metadata_enable_network_isolation,
         )
 
-    @mock.patch("sagemaker.jumpstart.model.is_valid_model_id")
+    @mock.patch("sagemaker.jumpstart.model.validate_model_id_and_get_type")
     @mock.patch("sagemaker.jumpstart.model.Model.__init__")
     @mock.patch("sagemaker.jumpstart.factory.model._retrieve_model_init_kwargs")
     @mock.patch("sagemaker.utils.get_sagemaker_config_value")
@@ -302,9 +303,9 @@ class IntelligentDefaultsModelTest(unittest.TestCase):
         mock_get_sagemaker_config_value: mock.Mock,
         mock_retrieve_kwargs: mock.Mock,
         mock_model_init: mock.Mock,
-        mock_is_valid_model_id: mock.Mock,
+        mock_validate_model_id_and_get_type: mock.Mock,
     ):
-        mock_is_valid_model_id.return_value = True
+        mock_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
         model_id, _ = "js-trainable-model", "*"
 
@@ -333,7 +334,7 @@ class IntelligentDefaultsModelTest(unittest.TestCase):
             override_enable_network_isolation,
         )
 
-    @mock.patch("sagemaker.jumpstart.model.is_valid_model_id")
+    @mock.patch("sagemaker.jumpstart.model.validate_model_id_and_get_type")
     @mock.patch("sagemaker.jumpstart.model.Model.__init__")
     @mock.patch("sagemaker.jumpstart.factory.model._retrieve_model_init_kwargs")
     @mock.patch("sagemaker.utils.get_sagemaker_config_value")
@@ -349,10 +350,10 @@ class IntelligentDefaultsModelTest(unittest.TestCase):
         mock_get_sagemaker_config_value: mock.Mock,
         mock_retrieve_kwargs: mock.Mock,
         mock_model_init: mock.Mock,
-        mock_is_valid_model_id: mock.Mock,
+        mock_validate_model_id_and_get_type: mock.Mock,
     ):
 
-        mock_is_valid_model_id.return_value = True
+        mock_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
         model_id, _ = "js-trainable-model", "*"
 
@@ -374,7 +375,7 @@ class IntelligentDefaultsModelTest(unittest.TestCase):
         self.assertEquals(mock_model_init.call_args[1].get("role"), execution_role)
         assert "enable_network_isolation" not in mock_model_init.call_args[1]
 
-    @mock.patch("sagemaker.jumpstart.model.is_valid_model_id")
+    @mock.patch("sagemaker.jumpstart.model.validate_model_id_and_get_type")
     @mock.patch("sagemaker.jumpstart.model.Model.__init__")
     @mock.patch("sagemaker.jumpstart.factory.model._retrieve_model_init_kwargs")
     @mock.patch("sagemaker.utils.get_sagemaker_config_value")
@@ -390,10 +391,10 @@ class IntelligentDefaultsModelTest(unittest.TestCase):
         mock_get_sagemaker_config_value: mock.Mock,
         mock_retrieve_kwargs: mock.Mock,
         mock_model_init: mock.Mock,
-        mock_is_valid_model_id: mock.Mock,
+        mock_validate_model_id_and_get_type: mock.Mock,
     ):
 
-        mock_is_valid_model_id.return_value = True
+        mock_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
         model_id, _ = "js-trainable-model", "*"
 

--- a/tests/unit/sagemaker/jumpstart/test_accessors.py
+++ b/tests/unit/sagemaker/jumpstart/test_accessors.py
@@ -18,6 +18,7 @@ from mock.mock import Mock, patch
 import pytest
 
 from sagemaker.jumpstart import accessors
+from sagemaker.jumpstart.enums import JumpStartModelType
 from tests.unit.sagemaker.jumpstart.constants import BASE_MANIFEST
 from tests.unit.sagemaker.jumpstart.utils import (
     get_header_from_base_header,
@@ -58,6 +59,49 @@ def test_jumpstart_models_cache_get_fxs(mock_cache):
     )
 
     assert len(accessors.JumpStartModelsAccessor._get_manifest()) > 0
+
+    # necessary because accessors is a static module
+    reload(accessors)
+
+
+@patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor._cache")
+def test_jumpstart_proprietary_models_cache_get_fxs(mock_cache):
+
+    mock_cache.get_manifest = Mock(return_value=BASE_MANIFEST)
+    mock_cache.get_header = Mock(side_effect=get_header_from_base_header)
+    mock_cache.get_specs = Mock(side_effect=get_spec_from_base_spec)
+
+    assert get_header_from_base_header(
+        region="us-west-2",
+        model_id="ai21-summarization",
+        version="*",
+        model_type=JumpStartModelType.PROPRIETARY,
+    ) == accessors.JumpStartModelsAccessor.get_model_header(
+        region="us-west-2",
+        model_id="ai21-summarization",
+        version="*",
+        model_type=JumpStartModelType.PROPRIETARY,
+    )
+    assert get_spec_from_base_spec(
+        region="us-west-2",
+        model_id="ai21-summarization",
+        version="*",
+        model_type=JumpStartModelType.PROPRIETARY,
+    ) == accessors.JumpStartModelsAccessor.get_model_specs(
+        region="us-west-2",
+        model_id="ai21-summarization",
+        version="*",
+        model_type=JumpStartModelType.PROPRIETARY,
+    )
+
+    assert (
+        len(
+            accessors.JumpStartModelsAccessor._get_manifest(
+                model_type=JumpStartModelType.PROPRIETARY
+            )
+        )
+        > 0
+    )
 
     # necessary because accessors is a static module
     reload(accessors)
@@ -133,6 +177,50 @@ def test_jumpstart_models_cache_set_reset_fxs(mock_model_cache: Mock):
         accessors.JumpStartModelsAccessor._validate_and_mutate_region_cache_kwargs(
             {"some": "kwarg", "region": "us-east-2"}, "us-west-2"
         )
+
+    # necessary because accessors is a static module
+    reload(accessors)
+
+
+@patch("sagemaker.jumpstart.cache.JumpStartModelsCache")
+def test_jumpstart_proprietary_models_cache_set_reset_fxs(mock_model_cache: Mock):
+
+    # test change of region resets cache
+    accessors.JumpStartModelsAccessor.get_model_header(
+        region="us-west-2",
+        model_id="ai21-summarization",
+        version="*",
+        model_type=JumpStartModelType.PROPRIETARY,
+    )
+
+    accessors.JumpStartModelsAccessor.get_model_specs(
+        region="us-west-2",
+        model_id="ai21-summarization",
+        version="*",
+        model_type=JumpStartModelType.PROPRIETARY,
+    )
+
+    mock_model_cache.assert_called_once()
+    mock_model_cache.reset_mock()
+
+    accessors.JumpStartModelsAccessor.get_model_header(
+        region="us-east-2",
+        model_id="ai21-summarization",
+        version="*",
+        model_type=JumpStartModelType.PROPRIETARY,
+    )
+
+    mock_model_cache.assert_called_once()
+    mock_model_cache.reset_mock()
+
+    accessors.JumpStartModelsAccessor.get_model_specs(
+        region="us-west-1",
+        model_id="ai21-summarization",
+        version="*",
+        model_type=JumpStartModelType.PROPRIETARY,
+    )
+    mock_model_cache.assert_called_once()
+    mock_model_cache.reset_mock()
 
     # necessary because accessors is a static module
     reload(accessors)

--- a/tests/unit/sagemaker/jumpstart/test_artifacts.py
+++ b/tests/unit/sagemaker/jumpstart/test_artifacts.py
@@ -32,7 +32,7 @@ from tests.unit.sagemaker.jumpstart.constants import (
 
 from sagemaker.jumpstart.artifacts.model_packages import _retrieve_model_package_arn
 from sagemaker.jumpstart.artifacts.model_uris import _retrieve_model_uri
-from sagemaker.jumpstart.enums import JumpStartScriptScope
+from sagemaker.jumpstart.enums import JumpStartScriptScope, JumpStartModelType
 
 from tests.unit.sagemaker.jumpstart.utils import get_spec_from_base_spec, get_special_model_spec
 from tests.unit.sagemaker.workflow.conftest import mock_client
@@ -331,9 +331,13 @@ class RetrieveModelPackageArnTest(unittest.TestCase):
 
     mock_session = Mock(s3_client=mock_client)
 
+    @patch("sagemaker.jumpstart.utils.validate_model_id_and_get_type")
     @patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
-    def test_retrieve_model_package_arn(self, patched_get_model_specs):
+    def test_retrieve_model_package_arn(
+        self, patched_get_model_specs: Mock, patched_validate_model_id_and_get_type: Mock
+    ):
         patched_get_model_specs.side_effect = get_special_model_spec
+        patched_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
         model_id = "variant-model"
         region = "us-west-2"
@@ -437,9 +441,13 @@ class PrivateJumpStartBucketTest(unittest.TestCase):
 
     mock_session = Mock(s3_client=mock_client)
 
+    @patch("sagemaker.jumpstart.utils.validate_model_id_and_get_type")
     @patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
-    def test_retrieve_uri_from_gated_bucket(self, patched_get_model_specs):
+    def test_retrieve_uri_from_gated_bucket(
+        self, patched_get_model_specs, patched_validate_model_id_and_get_type
+    ):
         patched_get_model_specs.side_effect = get_special_model_spec
+        patched_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
         model_id = "private-model"
         region = "us-west-2"

--- a/tests/unit/sagemaker/jumpstart/test_cache.py
+++ b/tests/unit/sagemaker/jumpstart/test_cache.py
@@ -23,7 +23,11 @@ from mock.mock import MagicMock
 import pytest
 from mock import patch
 
-from sagemaker.jumpstart.cache import JUMPSTART_DEFAULT_MANIFEST_FILE_S3_KEY, JumpStartModelsCache
+from sagemaker.jumpstart.cache import (
+    JUMPSTART_DEFAULT_MANIFEST_FILE_S3_KEY,
+    JUMPSTART_DEFAULT_PROPRIETARY_MANIFEST_KEY,
+    JumpStartModelsCache,
+)
 from sagemaker.jumpstart.constants import (
     ENV_VARIABLE_JUMPSTART_MANIFEST_LOCAL_ROOT_DIR_OVERRIDE,
     ENV_VARIABLE_JUMPSTART_SPECS_LOCAL_ROOT_DIR_OVERRIDE,
@@ -33,6 +37,7 @@ from sagemaker.jumpstart.types import (
     JumpStartModelSpecs,
     JumpStartVersionedModelId,
 )
+from sagemaker.jumpstart.enums import JumpStartModelType
 from tests.unit.sagemaker.jumpstart.utils import (
     get_spec_from_base_spec,
     patched_retrieval_function,
@@ -41,6 +46,8 @@ from tests.unit.sagemaker.jumpstart.utils import (
 from tests.unit.sagemaker.jumpstart.constants import (
     BASE_MANIFEST,
     BASE_SPEC,
+    BASE_PROPRIETARY_SPEC,
+    BASE_PROPRIETARY_MANIFEST,
 )
 from sagemaker.jumpstart.utils import get_jumpstart_content_bucket
 
@@ -152,6 +159,34 @@ def test_jumpstart_cache_get_header():
         semantic_version_str="1.0.*",
     )
 
+    assert JumpStartModelHeader(
+        {
+            "model_id": "ai21-summarization",
+            "version": "1.1.003",
+            "min_version": "2.0.0",
+            "spec_key": "proprietary-models/ai21-summarization/proprietary_specs_1.1.003.json",
+            "search_keywords": ["Text2Text", "Generation"],
+        }
+    ) == cache.get_header(
+        model_id="ai21-summarization",
+        semantic_version_str="1.1.003",
+        model_type=JumpStartModelType.PROPRIETARY,
+    )
+
+    assert JumpStartModelHeader(
+        {
+            "model_id": "ai21-summarization",
+            "version": "1.1.003",
+            "min_version": "2.0.0",
+            "spec_key": "proprietary-models/ai21-summarization/proprietary_specs_1.1.003.json",
+            "search_keywords": ["Text2Text", "Generation"],
+        }
+    ) == cache.get_header(
+        model_id="ai21-summarization",
+        semantic_version_str="*",
+        model_type=JumpStartModelType.PROPRIETARY,
+    )
+
     with pytest.raises(KeyError) as e:
         cache.get_header(
             model_id="tensorflow-ic-imagenet-inception-v3-classification-4",
@@ -194,6 +229,32 @@ def test_jumpstart_cache_get_header():
         "v3-classification-4'?"
     ) in str(e.value)
 
+    with pytest.raises(KeyError) as e:
+        cache.get_header(
+            model_id="ai21-summarize",
+            semantic_version_str="1.1.003",
+            model_type=JumpStartModelType.PROPRIETARY,
+        )
+    assert (
+        "Unable to find model manifest for 'ai21-summarize' with version '1.1.003'. "
+        "Visit https://sagemaker.readthedocs.io/en/stable/doc_utils/pretrainedmodels.html "
+        "for updated list of models. "
+        "Did you mean to use model ID 'ai21-summarization'?"
+    ) in str(e.value)
+
+    with pytest.raises(KeyError) as e:
+        cache.get_header(
+            model_id="ai21-summarize",
+            semantic_version_str="*",
+            model_type=JumpStartModelType.PROPRIETARY,
+        )
+    assert (
+        "Unable to find model manifest for 'ai21-summarize' with version '*'. "
+        "Visit https://sagemaker.readthedocs.io/en/stable/doc_utils/pretrainedmodels.html "
+        "for updated list of models. "
+        "Did you mean to use model ID 'ai21-summarization'?"
+    ) in str(e.value)
+
     with pytest.raises(KeyError):
         cache.get_header(
             model_id="tensorflow-ic-imagenet-inception-v3-classification-4",
@@ -222,6 +283,27 @@ def test_jumpstart_cache_get_header():
         cache.get_header(
             model_id="tensorflow-ic-imagenet-inception-v3-classification-4-bak",
             semantic_version_str="*",
+        )
+
+    with pytest.raises(KeyError):
+        cache.get_header(
+            model_id="tensorflow-ic-imagenet-inception-v3-classification-4",
+            semantic_version_str="*",
+            model_type=JumpStartModelType.PROPRIETARY,
+        )
+
+    with pytest.raises(KeyError):
+        cache.get_header(
+            model_id="tensorflow-ic-imagenet-inception-v3-classification-4",
+            semantic_version_str="1.1.004",
+            model_type=JumpStartModelType.PROPRIETARY,
+        )
+
+    with pytest.raises(KeyError):
+        cache.get_header(
+            model_id="ai21-summarization",
+            semantic_version_str="2.*",
+            model_type=JumpStartModelType.PROPRIETARY,
         )
 
 
@@ -423,11 +505,11 @@ def test_jumpstart_cache_accepts_input_parameters():
     assert cache._s3_cache._max_cache_items == max_s3_cache_items
     assert cache._s3_cache._expiration_horizon == s3_cache_expiration_horizon
     assert (
-        cache._model_id_semantic_version_manifest_key_cache._max_cache_items
+        cache._open_source_model_id_manifest_key_cache._max_cache_items
         == max_semantic_version_cache_items
     )
     assert (
-        cache._model_id_semantic_version_manifest_key_cache._expiration_horizon
+        cache._open_source_model_id_manifest_key_cache._expiration_horizon
         == semantic_version_cache_expiration_horizon
     )
 
@@ -583,7 +665,7 @@ def test_jumpstart_cache_makes_correct_s3_calls(
 
     with patch("logging.Logger.warning") as mocked_warning_log:
         cache.get_specs(
-            model_id="pytorch-ic-imagenet-inception-v3-classification-4", semantic_version_str="*"
+            model_id="pytorch-ic-imagenet-inception-v3-classification-4", version_str="*"
         )
         mocked_warning_log.assert_called_once_with(
             "Using model 'pytorch-ic-imagenet-inception-v3-classification-4' with wildcard "
@@ -593,7 +675,7 @@ def test_jumpstart_cache_makes_correct_s3_calls(
         )
         mocked_warning_log.reset_mock()
         cache.get_specs(
-            model_id="pytorch-ic-imagenet-inception-v3-classification-4", semantic_version_str="*"
+            model_id="pytorch-ic-imagenet-inception-v3-classification-4", version_str="*"
         )
         mocked_warning_log.assert_not_called()
 
@@ -605,13 +687,97 @@ def test_jumpstart_cache_makes_correct_s3_calls(
     mock_boto3_client.return_value.head_object.assert_not_called()
 
 
+@patch("sagemaker.jumpstart.cache.utils.emit_logs_based_on_model_specs")
+@patch("boto3.client")
+def test_jumpstart_cache_proprietary_manifest_makes_correct_s3_calls(
+    mock_boto3_client, mock_emit_logs_based_on_model_specs
+):
+
+    # test get_header
+    mock_manifest_json = json.dumps(
+        [
+            {
+                "model_id": "ai21-summarization",
+                "version": "1.1.003",
+                "min_version": "2.0.0",
+                "spec_key": "proprietary-models/ai21-summarization/proprietary_specs_1.1.003.json",
+                "search_keywords": ["Text2Text", "Generation"],
+            },
+        ]
+    )
+    mock_boto3_client.return_value.get_object.return_value = {
+        "Body": botocore.response.StreamingBody(
+            io.BytesIO(bytes(mock_manifest_json, "utf-8")), content_length=len(mock_manifest_json)
+        ),
+        "ETag": "etag",
+    }
+
+    mock_boto3_client.return_value.head_object.return_value = {"ETag": "some-hash"}
+
+    bucket_name = get_jumpstart_content_bucket("us-west-2")
+    client_config = botocore.config.Config(signature_version="my_signature_version")
+    cache = JumpStartModelsCache(
+        s3_bucket_name=bucket_name, s3_client_config=client_config, region="us-west-2"
+    )
+    cache.get_header(
+        model_id="ai21-summarization",
+        semantic_version_str="*",
+        model_type=JumpStartModelType.PROPRIETARY,
+    )
+
+    mock_boto3_client.return_value.get_object.assert_called_with(
+        Bucket=bucket_name, Key=JUMPSTART_DEFAULT_PROPRIETARY_MANIFEST_KEY
+    )
+    mock_boto3_client.return_value.head_object.assert_not_called()
+
+    mock_boto3_client.assert_called_with("s3", region_name="us-west-2", config=client_config)
+
+    # test get_specs. manifest already in cache, so only s3 call will be to get specs.
+    mock_json = json.dumps(BASE_PROPRIETARY_SPEC)
+
+    mock_boto3_client.return_value.reset_mock()
+
+    mock_boto3_client.return_value.get_object.return_value = {
+        "Body": botocore.response.StreamingBody(
+            io.BytesIO(bytes(mock_json, "utf-8")), content_length=len(mock_json)
+        ),
+        "ETag": "etag",
+    }
+
+    with patch("logging.Logger.warning") as mocked_warning_log:
+        cache.get_specs(
+            model_id="ai21-summarization",
+            version_str="*",
+            model_type=JumpStartModelType.PROPRIETARY,
+        )
+        mocked_warning_log.assert_called_once_with(
+            "Using model 'ai21-summarization' with wildcard "
+            "version identifier '*'. You can pin to version '1.1.003' for more "
+            "stable results. Note that models may have different input/output "
+            "signatures after a major version upgrade."
+        )
+        mocked_warning_log.reset_mock()
+        cache.get_specs(
+            model_id="ai21-summarization",
+            version_str="*",
+            model_type=JumpStartModelType.PROPRIETARY,
+        )
+        mocked_warning_log.assert_not_called()
+
+    mock_boto3_client.return_value.get_object.assert_called_with(
+        Bucket=bucket_name,
+        Key="proprietary-models/ai21-summarization/proprietary_specs_1.1.003.json",
+    )
+    mock_boto3_client.return_value.head_object.assert_not_called()
+
+
 @patch.object(JumpStartModelsCache, "_retrieval_function", patched_retrieval_function)
 def test_jumpstart_cache_handles_bad_semantic_version_manifest_key_cache():
     cache = JumpStartModelsCache(s3_bucket_name="some_bucket")
 
     cache.clear = MagicMock()
-    cache._model_id_semantic_version_manifest_key_cache = MagicMock()
-    cache._model_id_semantic_version_manifest_key_cache.get.side_effect = [
+    cache._open_source_model_id_manifest_key_cache = MagicMock()
+    cache._open_source_model_id_manifest_key_cache.get.side_effect = [
         (
             JumpStartVersionedModelId(
                 "tensorflow-ic-imagenet-inception-v3-classification-4", "999.0.0"
@@ -640,7 +806,7 @@ def test_jumpstart_cache_handles_bad_semantic_version_manifest_key_cache():
     cache.clear.assert_called_once()
     cache.clear.reset_mock()
 
-    cache._model_id_semantic_version_manifest_key_cache.get.side_effect = [
+    cache._open_source_model_id_manifest_key_cache.get.side_effect = [
         (
             JumpStartVersionedModelId(
                 "tensorflow-ic-imagenet-inception-v3-classification-4", "999.0.0"
@@ -668,7 +834,18 @@ def test_jumpstart_get_full_manifest():
     cache = JumpStartModelsCache(s3_bucket_name="some_bucket")
     raw_manifest = [header.to_json() for header in cache.get_manifest()]
 
-    raw_manifest == BASE_MANIFEST
+    assert raw_manifest == BASE_MANIFEST
+
+
+@patch.object(JumpStartModelsCache, "_retrieval_function", patched_retrieval_function)
+@patch("sagemaker.jumpstart.utils.get_sagemaker_version", lambda: "2.68.3")
+def test_jumpstart_get_full_proprietary_manifest():
+    cache = JumpStartModelsCache(s3_bucket_name="some_bucket")
+    raw_manifest = [
+        header.to_json() for header in cache.get_manifest(model_type=JumpStartModelType.PROPRIETARY)
+    ]
+
+    assert raw_manifest == BASE_PROPRIETARY_MANIFEST
 
 
 @patch.object(JumpStartModelsCache, "_retrieval_function", patched_retrieval_function)
@@ -678,54 +855,89 @@ def test_jumpstart_cache_get_specs():
 
     model_id, version = "tensorflow-ic-imagenet-inception-v3-classification-4", "2.0.0"
     assert get_spec_from_base_spec(model_id=model_id, version=version) == cache.get_specs(
-        model_id=model_id, semantic_version_str=version
+        model_id=model_id, version_str=version
     )
 
     model_id = "tensorflow-ic-imagenet-inception-v3-classification-4"
     assert get_spec_from_base_spec(model_id=model_id, version="2.0.0") == cache.get_specs(
-        model_id=model_id, semantic_version_str="2.0.*"
+        model_id=model_id, version_str="2.0.*"
     )
 
     model_id, version = "tensorflow-ic-imagenet-inception-v3-classification-4", "1.0.0"
     assert get_spec_from_base_spec(model_id=model_id, version=version) == cache.get_specs(
-        model_id=model_id, semantic_version_str=version
+        model_id=model_id, version_str=version
     )
 
     model_id = "pytorch-ic-imagenet-inception-v3-classification-4"
     assert get_spec_from_base_spec(model_id=model_id, version="1.0.0") == cache.get_specs(
-        model_id=model_id, semantic_version_str="1.*"
+        model_id=model_id, version_str="1.*"
     )
 
     model_id = "pytorch-ic-imagenet-inception-v3-classification-4"
     assert get_spec_from_base_spec(model_id=model_id, version="1.0.0") == cache.get_specs(
-        model_id=model_id, semantic_version_str="1.0.*"
+        model_id=model_id, version_str="1.0.*"
+    )
+
+    assert get_spec_from_base_spec(
+        model_id="ai21-summarization",
+        version="1.1.003",
+        model_type=JumpStartModelType.PROPRIETARY,
+    ) == cache.get_specs(
+        model_id="ai21-summarization",
+        version_str="1.1.003",
+        model_type=JumpStartModelType.PROPRIETARY,
+    )
+
+    assert get_spec_from_base_spec(
+        model_id="ai21-summarization",
+        version="1.1.003",
+        model_type=JumpStartModelType.PROPRIETARY,
+    ) == cache.get_specs(
+        model_id="ai21-summarization",
+        version_str="*",
+        model_type=JumpStartModelType.PROPRIETARY,
     )
 
     with pytest.raises(KeyError):
-        cache.get_specs(model_id=model_id + "bak", semantic_version_str="*")
+        cache.get_specs(model_id=model_id + "bak", version_str="*")
 
     with pytest.raises(KeyError):
-        cache.get_specs(model_id=model_id, semantic_version_str="9.*")
+        cache.get_specs(model_id=model_id, version_str="9.*")
 
     with pytest.raises(KeyError):
-        cache.get_specs(model_id=model_id, semantic_version_str="BAD")
+        cache.get_specs(model_id=model_id, version_str="BAD")
 
     with pytest.raises(KeyError):
         cache.get_specs(
             model_id=model_id,
-            semantic_version_str="2.1.*",
+            version_str="2.1.*",
         )
 
     with pytest.raises(KeyError):
         cache.get_specs(
             model_id=model_id,
-            semantic_version_str="3.9.*",
+            version_str="3.9.*",
         )
 
     with pytest.raises(KeyError):
         cache.get_specs(
             model_id=model_id,
-            semantic_version_str="5.*",
+            version_str="5.*",
+        )
+
+    model_id, version = "ai21-summarization", "2.0.0"
+    with pytest.raises(KeyError):
+        cache.get_specs(
+            model_id=model_id,
+            version_str="BAD",
+            model_type=JumpStartModelType.PROPRIETARY,
+        )
+
+    with pytest.raises(KeyError):
+        cache.get_specs(
+            model_id=model_id,
+            version_str="9.*",
+            model_type=JumpStartModelType.PROPRIETARY,
         )
 
 
@@ -794,9 +1006,7 @@ def test_jumpstart_local_metadata_override_specs(
     cache = JumpStartModelsCache(s3_bucket_name="some_bucket")
 
     model_id, version = "tensorflow-ic-imagenet-inception-v3-classification-4", "2.0.0"
-    assert JumpStartModelSpecs(BASE_SPEC) == cache.get_specs(
-        model_id=model_id, semantic_version_str=version
-    )
+    assert JumpStartModelSpecs(BASE_SPEC) == cache.get_specs(model_id=model_id, version_str=version)
 
     mocked_is_dir.assert_any_call("/some/directory/metadata/specs/root")
     mocked_is_dir.assert_any_call("/some/directory/metadata/manifest/root")
@@ -840,7 +1050,7 @@ def test_jumpstart_local_metadata_override_specs_not_exist_both_directories(
     cache = JumpStartModelsCache(s3_bucket_name="some_bucket")
 
     assert get_spec_from_base_spec(model_id=model_id, version=version) == cache.get_specs(
-        model_id=model_id, semantic_version_str=version
+        model_id=model_id, version_str=version
     )
 
     mocked_is_dir.assert_any_call("/some/directory/metadata/manifest/root")

--- a/tests/unit/sagemaker/jumpstart/test_notebook_utils.py
+++ b/tests/unit/sagemaker/jumpstart/test_notebook_utils.py
@@ -17,6 +17,7 @@ from tests.unit.sagemaker.jumpstart.utils import (
     get_prototype_manifest,
     get_prototype_model_spec,
 )
+from sagemaker.jumpstart.enums import JumpStartModelType
 from sagemaker.jumpstart.notebook_utils import (
     _generate_jumpstart_model_versions,
     get_model_url,
@@ -63,7 +64,7 @@ def test_list_jumpstart_scripts(
     patched_generate_jumpstart_models.assert_called_once_with(
         **kwargs, sagemaker_session=DEFAULT_JUMPSTART_SAGEMAKER_SESSION
     )
-    patched_get_manifest.assert_called_once()
+    assert patched_get_manifest.call_count == 3
     assert patched_get_model_specs.call_count == 1
 
     patched_get_model_specs.reset_mock()
@@ -670,12 +671,12 @@ class ListJumpStartModels(TestCase):
             list_jumpstart_models("hosting_ecr_specs.py_version == py3")
 
 
+@patch("sagemaker.jumpstart.utils.validate_model_id_and_get_type")
 @patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
-def test_get_model_url(
-    patched_get_model_specs: Mock,
-):
+def test_get_model_url(patched_get_model_specs: Mock, patched_validate_model_id_and_get_type: Mock):
 
     patched_get_model_specs.side_effect = get_prototype_model_spec
+    patched_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
     model_id, version = "xgboost-classification-model", "1.0.0"
     assert "https://xgboost.readthedocs.io/en/latest/" == get_model_url(model_id, version)
@@ -702,4 +703,5 @@ def test_get_model_url(
         version=version,
         region=region,
         s3_client=DEFAULT_JUMPSTART_SAGEMAKER_SESSION.s3_client,
+        model_type=JumpStartModelType.OPEN_SOURCE,
     )

--- a/tests/unit/sagemaker/jumpstart/test_predictor.py
+++ b/tests/unit/sagemaker/jumpstart/test_predictor.py
@@ -14,10 +14,8 @@ from sagemaker.jumpstart.model import JumpStartModel
 
 
 from sagemaker.jumpstart.utils import verify_model_region_and_return_specs
-from sagemaker.serializers import IdentitySerializer
-from tests.unit.sagemaker.jumpstart.utils import (
-    get_special_model_spec,
-)
+from sagemaker.serializers import IdentitySerializer, JSONSerializer
+from tests.unit.sagemaker.jumpstart.utils import get_special_model_spec, get_spec_from_base_spec
 
 
 @patch("sagemaker.predictor.get_model_id_version_from_endpoint")
@@ -49,6 +47,40 @@ def test_jumpstart_predictor_support(
 
     assert js_predictor.content_type == MIMEType.X_TEXT
     assert isinstance(js_predictor.serializer, IdentitySerializer)
+
+    assert isinstance(js_predictor.deserializer, JSONDeserializer)
+    assert js_predictor.accept == MIMEType.JSON
+
+
+@patch("sagemaker.predictor.get_model_id_version_from_endpoint")
+@patch("sagemaker.jumpstart.utils.verify_model_region_and_return_specs")
+@patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
+def test_proprietary_predictor_support(
+    patched_get_model_specs,
+    patched_verify_model_region_and_return_specs,
+    patched_get_jumpstart_model_id_version_from_endpoint,
+):
+
+    patched_verify_model_region_and_return_specs.side_effect = verify_model_region_and_return_specs
+    patched_get_model_specs.side_effect = get_spec_from_base_spec
+
+    # version not needed for JumpStart predictor
+    model_id, model_version = "ai21-summarization", "*"
+
+    patched_get_jumpstart_model_id_version_from_endpoint.return_value = (
+        model_id,
+        model_version,
+        None,
+    )
+
+    js_predictor = predictor.retrieve_default(
+        endpoint_name="blah", model_id=model_id, model_version=model_version
+    )
+
+    patched_get_jumpstart_model_id_version_from_endpoint.assert_not_called()
+
+    assert js_predictor.content_type == MIMEType.JSON
+    assert isinstance(js_predictor.serializer, JSONSerializer)
 
     assert isinstance(js_predictor.deserializer, JSONDeserializer)
     assert js_predictor.accept == MIMEType.JSON
@@ -125,19 +157,19 @@ def test_jumpstart_predictor_support_no_model_id_supplied_sad_case(
 
 @patch("sagemaker.predictor.get_model_id_version_from_endpoint")
 @patch("sagemaker.jumpstart.payload_utils.JumpStartS3PayloadAccessor.get_object_cached")
-@patch("sagemaker.jumpstart.model.is_valid_model_id")
+@patch("sagemaker.jumpstart.model.validate_model_id_and_get_type")
 @patch("sagemaker.jumpstart.utils.verify_model_region_and_return_specs")
 @patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
 def test_jumpstart_serializable_payload_with_predictor(
     patched_get_model_specs,
     patched_verify_model_region_and_return_specs,
-    patched_is_valid_model_id,
+    patched_validate_model_id_and_get_type,
     patched_get_object_cached,
     patched_get_model_id_version_from_endpoint,
 ):
 
     patched_get_object_cached.return_value = base64.b64decode("encodedimage")
-    patched_is_valid_model_id.return_value = True
+    patched_validate_model_id_and_get_type.return_value = True
 
     patched_verify_model_region_and_return_specs.side_effect = verify_model_region_and_return_specs
     patched_get_model_specs.side_effect = get_special_model_spec

--- a/tests/unit/sagemaker/jumpstart/test_utils.py
+++ b/tests/unit/sagemaker/jumpstart/test_utils.py
@@ -32,7 +32,7 @@ from sagemaker.jumpstart.constants import (
     JumpStartScriptScope,
 )
 from functools import partial
-from sagemaker.jumpstart.enums import JumpStartTag, MIMEType
+from sagemaker.jumpstart.enums import JumpStartTag, MIMEType, JumpStartModelType
 from sagemaker.jumpstart.exceptions import (
     DeprecatedJumpStartModelError,
     VulnerableJumpStartModelError,
@@ -68,7 +68,7 @@ def test_get_jumpstart_content_bucket_override():
         with patch("logging.Logger.info") as mocked_info_log:
             random_region = "random_region"
             assert "some-val" == utils.get_jumpstart_content_bucket(random_region)
-            mocked_info_log.assert_called_once_with("Using JumpStart bucket override: 'some-val'")
+            mocked_info_log.assert_called_with("Using JumpStart bucket override: 'some-val'")
 
 
 def test_get_jumpstart_gated_content_bucket():
@@ -1180,7 +1180,7 @@ def test_mime_type_enum_from_str():
 class TestIsValidModelId(TestCase):
     @patch("sagemaker.jumpstart.utils.accessors.JumpStartModelsAccessor._get_manifest")
     @patch("sagemaker.jumpstart.utils.accessors.JumpStartModelsAccessor.get_model_specs")
-    def test_is_valid_model_id_true(
+    def test_validate_model_id_and_get_type_true(
         self,
         mock_get_model_specs: Mock,
         mock_get_manifest: Mock,
@@ -1194,12 +1194,16 @@ class TestIsValidModelId(TestCase):
         mock_session_value = DEFAULT_JUMPSTART_SAGEMAKER_SESSION
         mock_s3_client_value = mock_session_value.s3_client
 
-        patched = partial(utils.is_valid_model_id, sagemaker_session=mock_session_value)
+        patched = partial(
+            utils.validate_model_id_and_get_type, sagemaker_session=mock_session_value
+        )
 
-        with patch("sagemaker.jumpstart.utils.is_valid_model_id", patched):
-            self.assertTrue(utils.is_valid_model_id("bee"))
-            mock_get_manifest.assert_called_once_with(
-                region=JUMPSTART_DEFAULT_REGION_NAME, s3_client=mock_s3_client_value
+        with patch("sagemaker.jumpstart.utils.validate_model_id_and_get_type", patched):
+            self.assertTrue(utils.validate_model_id_and_get_type("bee"))
+            mock_get_manifest.assert_called_with(
+                region=JUMPSTART_DEFAULT_REGION_NAME,
+                s3_client=mock_s3_client_value,
+                model_type=JumpStartModelType.PROPRIETARY,
             )
             mock_get_model_specs.assert_not_called()
 
@@ -1213,14 +1217,20 @@ class TestIsValidModelId(TestCase):
             ]
 
             mock_get_model_specs.return_value = Mock(training_supported=True)
-            self.assertTrue(utils.is_valid_model_id("bee", script=JumpStartScriptScope.TRAINING))
-            mock_get_manifest.assert_called_once_with(
-                region=JUMPSTART_DEFAULT_REGION_NAME, s3_client=mock_s3_client_value
+            self.assertTrue(
+                utils.validate_model_id_and_get_type("bee", script=JumpStartScriptScope.TRAINING)
+            )
+            mock_get_manifest.assert_called_with(
+                region=JUMPSTART_DEFAULT_REGION_NAME,
+                s3_client=mock_s3_client_value,
+                model_type=JumpStartModelType.PROPRIETARY,
             )
 
     @patch("sagemaker.jumpstart.utils.accessors.JumpStartModelsAccessor._get_manifest")
     @patch("sagemaker.jumpstart.utils.accessors.JumpStartModelsAccessor.get_model_specs")
-    def test_is_valid_model_id_false(self, mock_get_model_specs: Mock, mock_get_manifest: Mock):
+    def test_validate_model_id_and_get_type_false(
+        self, mock_get_model_specs: Mock, mock_get_manifest: Mock
+    ):
         mock_get_manifest.return_value = [
             Mock(model_id="ay"),
             Mock(model_id="bee"),
@@ -1230,18 +1240,18 @@ class TestIsValidModelId(TestCase):
         mock_session_value = DEFAULT_JUMPSTART_SAGEMAKER_SESSION
         mock_s3_client_value = mock_session_value.s3_client
 
-        patched = partial(utils.is_valid_model_id, sagemaker_session=mock_session_value)
+        patched = partial(
+            utils.validate_model_id_and_get_type, sagemaker_session=mock_session_value
+        )
 
-        with patch("sagemaker.jumpstart.utils.is_valid_model_id", patched):
+        with patch("sagemaker.jumpstart.utils.validate_model_id_and_get_type", patched):
 
-            self.assertFalse(utils.is_valid_model_id("dee"))
-            self.assertFalse(utils.is_valid_model_id(""))
-            self.assertFalse(utils.is_valid_model_id(None))
-            self.assertFalse(utils.is_valid_model_id(set()))
+            self.assertFalse(utils.validate_model_id_and_get_type("dee"))
+            self.assertFalse(utils.validate_model_id_and_get_type(""))
+            self.assertFalse(utils.validate_model_id_and_get_type(None))
+            self.assertFalse(utils.validate_model_id_and_get_type(set()))
 
-            mock_get_manifest.assert_called_once_with(
-                region=JUMPSTART_DEFAULT_REGION_NAME, s3_client=mock_s3_client_value
-            )
+            mock_get_manifest.assert_called()
 
             mock_get_model_specs.assert_not_called()
 
@@ -1253,30 +1263,48 @@ class TestIsValidModelId(TestCase):
                 Mock(model_id="bee"),
                 Mock(model_id="see"),
             ]
-            self.assertFalse(utils.is_valid_model_id("dee", script=JumpStartScriptScope.TRAINING))
-            mock_get_manifest.assert_called_once_with(
-                region=JUMPSTART_DEFAULT_REGION_NAME, s3_client=mock_s3_client_value
+            self.assertFalse(
+                utils.validate_model_id_and_get_type("dee", script=JumpStartScriptScope.TRAINING)
+            )
+            mock_get_manifest.assert_called_with(
+                region=JUMPSTART_DEFAULT_REGION_NAME,
+                s3_client=mock_s3_client_value,
+                model_type=JumpStartModelType.PROPRIETARY,
             )
 
             mock_get_manifest.reset_mock()
 
-            self.assertFalse(utils.is_valid_model_id("dee", script=JumpStartScriptScope.TRAINING))
-            self.assertFalse(utils.is_valid_model_id("", script=JumpStartScriptScope.TRAINING))
-            self.assertFalse(utils.is_valid_model_id(None, script=JumpStartScriptScope.TRAINING))
-            self.assertFalse(utils.is_valid_model_id(set(), script=JumpStartScriptScope.TRAINING))
+            self.assertFalse(
+                utils.validate_model_id_and_get_type("dee", script=JumpStartScriptScope.TRAINING)
+            )
+            self.assertFalse(
+                utils.validate_model_id_and_get_type("", script=JumpStartScriptScope.TRAINING)
+            )
+            self.assertFalse(
+                utils.validate_model_id_and_get_type(None, script=JumpStartScriptScope.TRAINING)
+            )
+            self.assertFalse(
+                utils.validate_model_id_and_get_type(set(), script=JumpStartScriptScope.TRAINING)
+            )
 
             mock_get_model_specs.assert_not_called()
-            mock_get_manifest.assert_called_once_with(
-                region=JUMPSTART_DEFAULT_REGION_NAME, s3_client=mock_s3_client_value
+            mock_get_manifest.assert_called_with(
+                region=JUMPSTART_DEFAULT_REGION_NAME,
+                s3_client=mock_s3_client_value,
+                model_type=JumpStartModelType.PROPRIETARY,
             )
 
             mock_get_manifest.reset_mock()
             mock_get_model_specs.reset_mock()
 
             mock_get_model_specs.return_value = Mock(training_supported=False)
-            self.assertTrue(utils.is_valid_model_id("ay", script=JumpStartScriptScope.TRAINING))
-            mock_get_manifest.assert_called_once_with(
-                region=JUMPSTART_DEFAULT_REGION_NAME, s3_client=mock_s3_client_value
+            self.assertTrue(
+                utils.validate_model_id_and_get_type("ay", script=JumpStartScriptScope.TRAINING)
+            )
+            mock_get_manifest.assert_called_with(
+                region=JUMPSTART_DEFAULT_REGION_NAME,
+                s3_client=mock_s3_client_value,
+                model_type=JumpStartModelType.PROPRIETARY,
             )
 
 

--- a/tests/unit/sagemaker/jumpstart/utils.py
+++ b/tests/unit/sagemaker/jumpstart/utils.py
@@ -28,12 +28,16 @@ from sagemaker.jumpstart.types import (
     JumpStartS3FileType,
     JumpStartModelHeader,
 )
+from sagemaker.jumpstart.enums import JumpStartModelType
 from sagemaker.jumpstart.utils import get_formatted_manifest
 from tests.unit.sagemaker.jumpstart.constants import (
     PROTOTYPICAL_MODEL_SPECS_DICT,
     BASE_MANIFEST,
     BASE_SPEC,
+    BASE_PROPRIETARY_MANIFEST,
+    BASE_PROPRIETARY_SPEC,
     BASE_HEADER,
+    BASE_PROPRIETARY_HEADER,
     SPECIAL_MODEL_SPECS_DICT,
 )
 
@@ -44,10 +48,18 @@ def get_header_from_base_header(
     model_id: str = None,
     semantic_version_str: str = None,
     version: str = None,
+    model_type: JumpStartModelType = JumpStartModelType.OPEN_SOURCE,
 ) -> JumpStartModelHeader:
 
     if version and semantic_version_str:
         raise ValueError("Cannot specify both `version` and `semantic_version_str` fields.")
+
+    if model_type == JumpStartModelType.PROPRIETARY:
+        spec = copy.deepcopy(BASE_PROPRIETARY_HEADER)
+        spec["version"] = version or semantic_version_str
+        spec["model_id"] = model_id
+
+        return JumpStartModelHeader(spec)
 
     if all(
         [
@@ -92,6 +104,7 @@ def get_prototype_model_spec(
     model_id: str = None,
     version: str = None,
     s3_client: boto3.client = None,
+    model_type: JumpStartModelType = JumpStartModelType.OPEN_SOURCE,
 ) -> JumpStartModelSpecs:
     """This function mocks cache accessor functions. For this mock,
     we only retrieve model specs based on the model ID.
@@ -107,6 +120,7 @@ def get_special_model_spec(
     model_id: str = None,
     version: str = None,
     s3_client: boto3.client = None,
+    model_type: JumpStartModelType = JumpStartModelType.OPEN_SOURCE,
 ) -> JumpStartModelSpecs:
     """This function mocks cache accessor functions. For this mock,
     we only retrieve model specs based on the model ID. This is reserved
@@ -122,6 +136,7 @@ def get_special_model_spec_for_inference_component_based_endpoint(
     model_id: str = None,
     version: str = None,
     s3_client: boto3.client = None,
+    model_type: JumpStartModelType = JumpStartModelType.OPEN_SOURCE,
 ) -> JumpStartModelSpecs:
     """This function mocks cache accessor functions. For this mock,
     we only retrieve model specs based on the model ID and adding
@@ -142,13 +157,21 @@ def get_spec_from_base_spec(
     _obj: JumpStartModelsCache = None,
     region: str = None,
     model_id: str = None,
-    semantic_version_str: str = None,
+    version_str: str = None,
     version: str = None,
     s3_client: boto3.client = None,
+    model_type: JumpStartModelType = JumpStartModelType.OPEN_SOURCE,
 ) -> JumpStartModelSpecs:
 
-    if version and semantic_version_str:
+    if version and version_str:
         raise ValueError("Cannot specify both `version` and `semantic_version_str` fields.")
+
+    if model_type == JumpStartModelType.PROPRIETARY:
+        spec = copy.deepcopy(BASE_PROPRIETARY_SPEC)
+        spec["version"] = version or version_str
+        spec["model_id"] = model_id
+
+        return JumpStartModelSpecs(spec)
 
     if all(
         [
@@ -172,7 +195,7 @@ def get_spec_from_base_spec(
 
     spec = copy.deepcopy(BASE_SPEC)
 
-    spec["version"] = version or semantic_version_str
+    spec["version"] = version or version_str
     spec["model_id"] = model_id
 
     return JumpStartModelSpecs(spec)
@@ -185,17 +208,33 @@ def patched_retrieval_function(
 ) -> JumpStartCachedS3ContentValue:
 
     filetype, s3_key = key.file_type, key.s3_key
-    if filetype == JumpStartS3FileType.MANIFEST:
+    if filetype == JumpStartS3FileType.OPEN_SOURCE_MANIFEST:
 
         return JumpStartCachedS3ContentValue(
             formatted_content=get_formatted_manifest(BASE_MANIFEST)
         )
 
-    if filetype == JumpStartS3FileType.SPECS:
+    if filetype == JumpStartS3FileType.OPEN_SOURCE_SPECS:
         _, model_id, specs_version = s3_key.split("/")
         version = specs_version.replace("specs_v", "").replace(".json", "")
         return JumpStartCachedS3ContentValue(
             formatted_content=get_spec_from_base_spec(model_id=model_id, version=version)
+        )
+
+    if filetype == JumpStartS3FileType.PROPRIETARY_MANIFEST:
+        return JumpStartCachedS3ContentValue(
+            formatted_content=get_formatted_manifest(BASE_PROPRIETARY_MANIFEST)
+        )
+
+    if filetype == JumpStartS3FileType.PROPRIETARY_SPECS:
+        _, model_id, specs_version = s3_key.split("/")
+        version = specs_version.replace("proprietary_specs_", "").replace(".json", "")
+        return JumpStartCachedS3ContentValue(
+            formatted_content=get_spec_from_base_spec(
+                model_id=model_id,
+                version=version,
+                model_type=JumpStartModelType.PROPRIETARY,
+            )
         )
 
     raise ValueError(f"Bad value for filetype: {filetype}")

--- a/tests/unit/sagemaker/metric_definitions/jumpstart/test_default.py
+++ b/tests/unit/sagemaker/metric_definitions/jumpstart/test_default.py
@@ -18,6 +18,7 @@ from mock.mock import patch
 import pytest
 
 from sagemaker import metric_definitions
+from sagemaker.jumpstart.enums import JumpStartModelType
 
 from tests.unit.sagemaker.jumpstart.utils import get_spec_from_base_spec, get_special_model_spec
 
@@ -25,10 +26,14 @@ mock_client = boto3.client("s3")
 mock_session = Mock(s3_client=mock_client)
 
 
+@patch("sagemaker.jumpstart.utils.validate_model_id_and_get_type")
 @patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
-def test_jumpstart_default_metric_definitions(patched_get_model_specs):
+def test_jumpstart_default_metric_definitions(
+    patched_get_model_specs, patched_validate_model_id_and_get_type
+):
 
     patched_get_model_specs.side_effect = get_spec_from_base_spec
+    patched_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
     mock_client = boto3.client("s3")
     mock_session = Mock(s3_client=mock_client)
@@ -47,7 +52,11 @@ def test_jumpstart_default_metric_definitions(patched_get_model_specs):
     ]
 
     patched_get_model_specs.assert_called_once_with(
-        region=region, model_id=model_id, version="*", s3_client=mock_client
+        region=region,
+        model_id=model_id,
+        version="*",
+        s3_client=mock_client,
+        model_type=JumpStartModelType.OPEN_SOURCE,
     )
 
     patched_get_model_specs.reset_mock()
@@ -63,7 +72,11 @@ def test_jumpstart_default_metric_definitions(patched_get_model_specs):
     ]
 
     patched_get_model_specs.assert_called_once_with(
-        region=region, model_id=model_id, version="1.*", s3_client=mock_client
+        region=region,
+        model_id=model_id,
+        version="1.*",
+        s3_client=mock_client,
+        model_type=JumpStartModelType.OPEN_SOURCE,
     )
 
     patched_get_model_specs.reset_mock()

--- a/tests/unit/sagemaker/model_uris/jumpstart/test_common.py
+++ b/tests/unit/sagemaker/model_uris/jumpstart/test_common.py
@@ -19,19 +19,24 @@ import pytest
 
 from sagemaker import model_uris
 from sagemaker.jumpstart.utils import verify_model_region_and_return_specs
+from sagemaker.jumpstart.enums import JumpStartModelType
 
 from tests.unit.sagemaker.jumpstart.utils import get_spec_from_base_spec
 from sagemaker.jumpstart import constants as sagemaker_constants
 
 
+@patch("sagemaker.jumpstart.utils.validate_model_id_and_get_type")
 @patch("sagemaker.jumpstart.artifacts.model_uris.verify_model_region_and_return_specs")
 @patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
 def test_jumpstart_common_model_uri(
-    patched_get_model_specs, patched_verify_model_region_and_return_specs
+    patched_get_model_specs,
+    patched_verify_model_region_and_return_specs,
+    patched_validate_model_id_and_get_type,
 ):
 
     patched_verify_model_region_and_return_specs.side_effect = verify_model_region_and_return_specs
     patched_get_model_specs.side_effect = get_spec_from_base_spec
+    patched_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
     mock_client = boto3.client("s3")
     mock_session = Mock(s3_client=mock_client)
@@ -47,6 +52,7 @@ def test_jumpstart_common_model_uri(
         model_id="pytorch-ic-mobilenet-v2",
         version="*",
         s3_client=mock_client,
+        model_type=JumpStartModelType.OPEN_SOURCE,
     )
     patched_verify_model_region_and_return_specs.assert_called_once()
 
@@ -64,6 +70,7 @@ def test_jumpstart_common_model_uri(
         model_id="pytorch-ic-mobilenet-v2",
         version="1.*",
         s3_client=mock_client,
+        model_type=JumpStartModelType.OPEN_SOURCE,
     )
     patched_verify_model_region_and_return_specs.assert_called_once()
 
@@ -82,6 +89,7 @@ def test_jumpstart_common_model_uri(
         model_id="pytorch-ic-mobilenet-v2",
         version="*",
         s3_client=mock_client,
+        model_type=JumpStartModelType.OPEN_SOURCE,
     )
     patched_verify_model_region_and_return_specs.assert_called_once()
 
@@ -100,6 +108,7 @@ def test_jumpstart_common_model_uri(
         model_id="pytorch-ic-mobilenet-v2",
         version="1.*",
         s3_client=mock_client,
+        model_type=JumpStartModelType.OPEN_SOURCE,
     )
     patched_verify_model_region_and_return_specs.assert_called_once()
 

--- a/tests/unit/sagemaker/resource_requirements/jumpstart/test_resource_requirements.py
+++ b/tests/unit/sagemaker/resource_requirements/jumpstart/test_resource_requirements.py
@@ -18,14 +18,19 @@ from mock.mock import patch
 import pytest
 
 from sagemaker import resource_requirements
+from sagemaker.jumpstart.enums import JumpStartModelType
 
 from tests.unit.sagemaker.jumpstart.utils import get_spec_from_base_spec, get_special_model_spec
 
 
+@patch("sagemaker.jumpstart.utils.validate_model_id_and_get_type")
 @patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
-def test_jumpstart_resource_requirements(patched_get_model_specs):
+def test_jumpstart_resource_requirements(
+    patched_get_model_specs, patched_validate_model_id_and_get_type
+):
 
     patched_get_model_specs.side_effect = get_spec_from_base_spec
+    patched_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
     region = "us-west-2"
     mock_client = boto3.client("s3")
     mock_session = Mock(s3_client=mock_client)
@@ -46,13 +51,18 @@ def test_jumpstart_resource_requirements(patched_get_model_specs):
         model_id=model_id,
         version=model_version,
         s3_client=mock_client,
+        model_type=JumpStartModelType.OPEN_SOURCE,
     )
     patched_get_model_specs.reset_mock()
 
 
+@patch("sagemaker.jumpstart.utils.validate_model_id_and_get_type")
 @patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
-def test_jumpstart_no_supported_resource_requirements(patched_get_model_specs):
+def test_jumpstart_no_supported_resource_requirements(
+    patched_get_model_specs, patched_validate_model_id_and_get_type
+):
     patched_get_model_specs.side_effect = get_special_model_spec
+    patched_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
     model_id, model_version = "no-supported-instance-types-model", "*"
     region = "us-west-2"
@@ -73,6 +83,7 @@ def test_jumpstart_no_supported_resource_requirements(patched_get_model_specs):
         model_id=model_id,
         version=model_version,
         s3_client=mock_client,
+        model_type=JumpStartModelType.OPEN_SOURCE,
     )
     patched_get_model_specs.reset_mock()
 

--- a/tests/unit/sagemaker/script_uris/jumpstart/test_common.py
+++ b/tests/unit/sagemaker/script_uris/jumpstart/test_common.py
@@ -19,19 +19,24 @@ from mock.mock import patch
 
 from sagemaker import script_uris
 from sagemaker.jumpstart.utils import verify_model_region_and_return_specs
+from sagemaker.jumpstart.enums import JumpStartModelType
 
 from tests.unit.sagemaker.jumpstart.utils import get_spec_from_base_spec
 from sagemaker.jumpstart import constants as sagemaker_constants
 
 
+@patch("sagemaker.jumpstart.utils.validate_model_id_and_get_type")
 @patch("sagemaker.jumpstart.artifacts.script_uris.verify_model_region_and_return_specs")
 @patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
 def test_jumpstart_common_script_uri(
-    patched_get_model_specs, patched_verify_model_region_and_return_specs
+    patched_get_model_specs,
+    patched_verify_model_region_and_return_specs,
+    patched_validate_model_id_and_get_type,
 ):
 
     patched_verify_model_region_and_return_specs.side_effect = verify_model_region_and_return_specs
     patched_get_model_specs.side_effect = get_spec_from_base_spec
+    patched_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
     mock_client = boto3.client("s3")
     mock_session = Mock(s3_client=mock_client)
@@ -47,6 +52,7 @@ def test_jumpstart_common_script_uri(
         model_id="pytorch-ic-mobilenet-v2",
         version="*",
         s3_client=mock_client,
+        model_type=JumpStartModelType.OPEN_SOURCE,
     )
     patched_verify_model_region_and_return_specs.assert_called_once()
 
@@ -64,6 +70,7 @@ def test_jumpstart_common_script_uri(
         model_id="pytorch-ic-mobilenet-v2",
         version="1.*",
         s3_client=mock_client,
+        model_type=JumpStartModelType.OPEN_SOURCE,
     )
     patched_verify_model_region_and_return_specs.assert_called_once()
 
@@ -78,7 +85,11 @@ def test_jumpstart_common_script_uri(
         sagemaker_session=mock_session,
     )
     patched_get_model_specs.assert_called_once_with(
-        region="us-west-2", model_id="pytorch-ic-mobilenet-v2", version="*", s3_client=mock_client
+        region="us-west-2",
+        model_id="pytorch-ic-mobilenet-v2",
+        version="*",
+        s3_client=mock_client,
+        model_type=JumpStartModelType.OPEN_SOURCE,
     )
     patched_verify_model_region_and_return_specs.assert_called_once()
 
@@ -97,6 +108,7 @@ def test_jumpstart_common_script_uri(
         model_id="pytorch-ic-mobilenet-v2",
         version="1.*",
         s3_client=mock_client,
+        model_type=JumpStartModelType.OPEN_SOURCE,
     )
     patched_verify_model_region_and_return_specs.assert_called_once()
 

--- a/tests/unit/sagemaker/serializers/jumpstart/test_serializers.py
+++ b/tests/unit/sagemaker/serializers/jumpstart/test_serializers.py
@@ -19,18 +19,23 @@ from mock.mock import patch
 
 from sagemaker import base_serializers, serializers
 from sagemaker.jumpstart.utils import verify_model_region_and_return_specs
+from sagemaker.jumpstart.enums import JumpStartModelType
 
 from tests.unit.sagemaker.jumpstart.utils import get_special_model_spec
 
 
+@patch("sagemaker.jumpstart.utils.validate_model_id_and_get_type")
 @patch("sagemaker.jumpstart.artifacts.predictors.verify_model_region_and_return_specs")
 @patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
 def test_jumpstart_default_serializers(
-    patched_get_model_specs, patched_verify_model_region_and_return_specs
+    patched_get_model_specs,
+    patched_verify_model_region_and_return_specs,
+    patched_validate_model_id_and_get_type,
 ):
 
     patched_verify_model_region_and_return_specs.side_effect = verify_model_region_and_return_specs
     patched_get_model_specs.side_effect = get_special_model_spec
+    patched_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
     model_id, model_version = "predictor-specs-model", "*"
     region = "us-west-2"
@@ -50,19 +55,24 @@ def test_jumpstart_default_serializers(
         model_id=model_id,
         version=model_version,
         s3_client=mock_client,
+        model_type=JumpStartModelType.OPEN_SOURCE,
     )
 
     patched_get_model_specs.reset_mock()
 
 
+@patch("sagemaker.jumpstart.utils.validate_model_id_and_get_type")
 @patch("sagemaker.jumpstart.artifacts.predictors.verify_model_region_and_return_specs")
 @patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
 def test_jumpstart_serializer_options(
-    patched_get_model_specs, patched_verify_model_region_and_return_specs
+    patched_get_model_specs,
+    patched_verify_model_region_and_return_specs,
+    patched_validate_model_id_and_get_type,
 ):
 
     patched_verify_model_region_and_return_specs.side_effect = verify_model_region_and_return_specs
     patched_get_model_specs.side_effect = get_special_model_spec
+    patched_validate_model_id_and_get_type.return_value = JumpStartModelType.OPEN_SOURCE
 
     mock_client = boto3.client("s3")
     mock_session = Mock(s3_client=mock_client)
@@ -89,4 +99,5 @@ def test_jumpstart_serializer_options(
         model_id=model_id,
         version=model_version,
         s3_client=mock_client,
+        model_type=JumpStartModelType.OPEN_SOURCE,
     )


### PR DESCRIPTION

*Issue #, if available:* Support deploy proprietary models in JumpStart model class and return predictors

*Description of changes:*

This change supports reading/parsing proprietary model metadata and support deploy proprietary models. 

*Testing done:*

Unittests/Integ tests on AI21 Jurassic light model.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
