### PR TITLE
feature: Add ModelDataSource and SourceUri support for model package.

### DIFF
--- a/src/sagemaker/chainer/model.py
+++ b/src/sagemaker/chainer/model.py
@@ -174,6 +174,7 @@ class ChainerModel(FrameworkModel):
         nearest_model_name: Optional[Union[str, PipelineVariable]] = None,
         data_input_configuration: Optional[Union[str, PipelineVariable]] = None,
         skip_model_validation: Optional[Union[str, PipelineVariable]] = None,
+        source_uri: Optional[Union[str, PipelineVariable]] = None,
     ):
         """Creates a model package for creating SageMaker models or listing on Marketplace.
 
@@ -223,6 +224,8 @@ class ChainerModel(FrameworkModel):
                 (default: None).
             skip_model_validation (str or PipelineVariable): Indicates if you want to skip model
                 validation. Values can be "All" or "None" (default: None).
+            source_uri (str or PipelineVariable): The URI of the source for the model package
+                (default: None).
 
         Returns:
             str: A string of SageMaker Model Package ARN.
@@ -262,6 +265,7 @@ class ChainerModel(FrameworkModel):
             nearest_model_name=nearest_model_name,
             data_input_configuration=data_input_configuration,
             skip_model_validation=skip_model_validation,
+            source_uri=source_uri,
         )
 
     def prepare_container_def(

--- a/src/sagemaker/estimator.py
+++ b/src/sagemaker/estimator.py
@@ -1718,6 +1718,7 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):  # pylint: disable=too-man
         nearest_model_name=None,
         data_input_configuration=None,
         skip_model_validation=None,
+        source_uri=None,
         **kwargs,
     ):
         """Creates a model package for creating SageMaker models or listing on Marketplace.
@@ -1765,6 +1766,7 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):  # pylint: disable=too-man
             data_input_configuration (str): Input object for the model (default: None).
             skip_model_validation (str): Indicates if you want to skip model validation.
                 Values can be "All" or "None" (default: None).
+            source_uri (str): The URI of the source for the model package (default: None).
             **kwargs: Passed to invocation of ``create_model()``. Implementations may customize
                 ``create_model()`` to accept ``**kwargs`` to customize model creation during
                 deploy. For more, see the implementation docs.
@@ -1809,6 +1811,7 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):  # pylint: disable=too-man
             nearest_model_name=nearest_model_name,
             data_input_configuration=data_input_configuration,
             skip_model_validation=skip_model_validation,
+            source_uri=source_uri,
         )
 
     @property

--- a/src/sagemaker/huggingface/model.py
+++ b/src/sagemaker/huggingface/model.py
@@ -360,6 +360,7 @@ class HuggingFaceModel(FrameworkModel):
         nearest_model_name: Optional[Union[str, PipelineVariable]] = None,
         data_input_configuration: Optional[Union[str, PipelineVariable]] = None,
         skip_model_validation: Optional[Union[str, PipelineVariable]] = None,
+        source_uri: Optional[Union[str, PipelineVariable]] = None,
     ):
         """Creates a model package for creating SageMaker models or listing on Marketplace.
 
@@ -410,6 +411,8 @@ class HuggingFaceModel(FrameworkModel):
                 (default: None).
             skip_model_validation (str or PipelineVariable): Indicates if you want to skip model
                 validation. Values can be "All" or "None" (default: None).
+            source_uri (str or PipelineVariable): The URI of the source for the model package
+                (default: None).
 
         Returns:
             A `sagemaker.model.ModelPackage` instance.
@@ -457,6 +460,7 @@ class HuggingFaceModel(FrameworkModel):
             nearest_model_name=nearest_model_name,
             data_input_configuration=data_input_configuration,
             skip_model_validation=skip_model_validation,
+            source_uri=source_uri,
         )
 
     def prepare_container_def(

--- a/src/sagemaker/jumpstart/factory/model.py
+++ b/src/sagemaker/jumpstart/factory/model.py
@@ -598,6 +598,7 @@ def get_register_kwargs(
     nearest_model_name: Optional[str] = None,
     data_input_configuration: Optional[str] = None,
     skip_model_validation: Optional[str] = None,
+    source_uri: Optional[str] = None,
 ) -> JumpStartModelRegisterKwargs:
     """Returns kwargs required to call `register` on `sagemaker.estimator.Model` object."""
 
@@ -629,6 +630,7 @@ def get_register_kwargs(
         nearest_model_name=nearest_model_name,
         data_input_configuration=data_input_configuration,
         skip_model_validation=skip_model_validation,
+        source_uri=source_uri,
     )
 
     model_specs = verify_model_region_and_return_specs(

--- a/src/sagemaker/jumpstart/model.py
+++ b/src/sagemaker/jumpstart/model.py
@@ -631,6 +631,7 @@ class JumpStartModel(Model):
         nearest_model_name: Optional[Union[str, PipelineVariable]] = None,
         data_input_configuration: Optional[Union[str, PipelineVariable]] = None,
         skip_model_validation: Optional[Union[str, PipelineVariable]] = None,
+        source_uri: Optional[Union[str, PipelineVariable]] = None,
     ):
         """Creates a model package for creating SageMaker models or listing on Marketplace.
 
@@ -676,6 +677,8 @@ class JumpStartModel(Model):
                 (default: None).
             skip_model_validation (str or PipelineVariable): Indicates if you want to skip model
                 validation. Values can be "All" or "None" (default: None).
+            source_uri (str or PipelineVariable): The URI of the source for the model package
+                (default: None).
 
         Returns:
             A `sagemaker.model.ModelPackage` instance.
@@ -709,6 +712,7 @@ class JumpStartModel(Model):
             nearest_model_name=nearest_model_name,
             data_input_configuration=data_input_configuration,
             skip_model_validation=skip_model_validation,
+            source_uri=source_uri,
         )
 
         model_package = super(JumpStartModel, self).register(**register_kwargs.to_kwargs_dict())

--- a/src/sagemaker/jumpstart/types.py
+++ b/src/sagemaker/jumpstart/types.py
@@ -1659,6 +1659,7 @@ class JumpStartModelRegisterKwargs(JumpStartKwargs):
         "nearest_model_name",
         "data_input_configuration",
         "skip_model_validation",
+        "source_uri",
     ]
 
     SERIALIZATION_EXCLUSION_SET = {
@@ -1699,6 +1700,7 @@ class JumpStartModelRegisterKwargs(JumpStartKwargs):
         nearest_model_name: Optional[str] = None,
         data_input_configuration: Optional[str] = None,
         skip_model_validation: Optional[str] = None,
+        source_uri: Optional[str] = None,
     ) -> None:
         """Instantiates JumpStartModelRegisterKwargs object."""
 
@@ -1730,3 +1732,4 @@ class JumpStartModelRegisterKwargs(JumpStartKwargs):
         self.nearest_model_name = nearest_model_name
         self.data_input_configuration = data_input_configuration
         self.skip_model_validation = skip_model_validation
+        self.source_uri = source_uri

--- a/src/sagemaker/model.py
+++ b/src/sagemaker/model.py
@@ -77,7 +77,10 @@ from sagemaker.inference_recommender.inference_recommender_mixin import (
 )
 from sagemaker.compute_resource_requirements.resource_requirements import ResourceRequirements
 from sagemaker.enums import EndpointType
-from sagemaker.session import get_add_model_package_inference_args
+from sagemaker.session import (
+    get_add_model_package_inference_args,
+    get_update_model_package_inference_args,
+)
 
 # Setting LOGGER for backward compatibility, in case users import it...
 logger = LOGGER = logging.getLogger("sagemaker")
@@ -423,6 +426,7 @@ class Model(ModelBase, InferenceRecommenderMixin):
         nearest_model_name: Optional[Union[str, PipelineVariable]] = None,
         data_input_configuration: Optional[Union[str, PipelineVariable]] = None,
         skip_model_validation: Optional[Union[str, PipelineVariable]] = None,
+        source_uri: Optional[Union[str, PipelineVariable]] = None,
     ):
         """Creates a model package for creating SageMaker models or listing on Marketplace.
 
@@ -472,17 +476,14 @@ class Model(ModelBase, InferenceRecommenderMixin):
                 (default: None).
             skip_model_validation (str or PipelineVariable): Indicates if you want to skip model
                 validation. Values can be "All" or "None" (default: None).
+            source_uri (str or PipelineVariable): The URI of the source for the model package
+                (default: None).
 
         Returns:
             A `sagemaker.model.ModelPackage` instance or pipeline step arguments
             in case the Model instance is built with
             :class:`~sagemaker.workflow.pipeline_context.PipelineSession`
         """
-        if isinstance(self.model_data, dict):
-            raise ValueError(
-                "SageMaker Model Package currently cannot be created with ModelDataSource."
-            )
-
         if content_types is not None:
             self.content_types = content_types
 
@@ -513,6 +514,12 @@ class Model(ModelBase, InferenceRecommenderMixin):
                 "Image": self.image_uri,
             }
 
+            if isinstance(self.model_data, dict):
+                raise ValueError(
+                    "Un-versioned SageMaker Model Package currently cannot be "
+                    "created with ModelDataSource."
+                )
+
             if self.model_data is not None:
                 container_def["ModelDataUrl"] = self.model_data
 
@@ -536,6 +543,7 @@ class Model(ModelBase, InferenceRecommenderMixin):
             sample_payload_url=sample_payload_url,
             task=task,
             skip_model_validation=skip_model_validation,
+            source_uri=source_uri,
         )
         model_package = self.sagemaker_session.create_model_package_from_containers(
             **model_pkg_args
@@ -2040,8 +2048,9 @@ class ModelPackage(Model):
                 endpoints use this role to access training data and model
                 artifacts. After the endpoint is created, the inference code
                 might use the IAM role, if it needs to access an AWS resource.
-            model_data (str): The S3 location of a SageMaker model data
-                ``.tar.gz`` file. Must be provided if algorithm_arn is provided.
+            model_data (str or dict[str, Any]): The S3 location of a SageMaker model data
+                ``.tar.gz`` file or a dictionary representing a ``ModelDataSource``
+                object. Must be provided if algorithm_arn is provided.
             algorithm_arn (str): algorithm arn used to train the model, can be
                 just the name if your account owns the algorithm. Must also
                 provide ``model_data``.
@@ -2050,11 +2059,6 @@ class ModelPackage(Model):
                 ``model_data`` is not required.
             **kwargs: Additional kwargs passed to the Model constructor.
         """
-        if isinstance(model_data, dict):
-            raise ValueError(
-                "Creating ModelPackage with ModelDataSource is currently not supported"
-            )
-
         super(ModelPackage, self).__init__(
             role=role, model_data=model_data, image_uri=None, **kwargs
         )
@@ -2221,6 +2225,74 @@ class ModelPackage(Model):
 
         sagemaker_session = self.sagemaker_session or sagemaker.Session()
         sagemaker_session.sagemaker_client.update_model_package(**update_metadata_args)
+
+    def update_inference_specification(
+        self,
+        containers: Dict = None,
+        image_uris: List[str] = None,
+        content_types: List[str] = None,
+        response_types: List[str] = None,
+        inference_instances: List[str] = None,
+        transform_instances: List[str] = None,
+    ):
+        """Inference specification to be set for the model package
+
+        Args:
+            containers (dict): The Amazon ECR registry path of the Docker image
+                that contains the inference code.
+            image_uris (List[str]): The ECR path where inference code is stored.
+            content_types (list[str]): The supported MIME types
+                for the input data.
+            response_types (list[str]): The supported MIME types
+                for the output data.
+            inference_instances (list[str]): A list of the instance
+                types that are used to generate inferences in real-time (default: None).
+            transform_instances (list[str]): A list of the instance
+                types on which a transformation job can be run or on which an endpoint can be
+                deployed (default: None).
+
+        """
+        sagemaker_session = self.sagemaker_session or sagemaker.Session()
+        if (containers is not None) ^ (image_uris is None):
+            raise ValueError("Should have either containers or image_uris for inference.")
+        container_def = []
+        if image_uris:
+            for uri in image_uris:
+                container_def.append(
+                    {
+                        "Image": uri,
+                    }
+                )
+        else:
+            container_def = containers
+
+        model_package_update_args = get_update_model_package_inference_args(
+            model_package_arn=self.model_package_arn,
+            containers=container_def,
+            content_types=content_types,
+            response_types=response_types,
+            inference_instances=inference_instances,
+            transform_instances=transform_instances,
+        )
+
+        sagemaker_session.sagemaker_client.update_model_package(**model_package_update_args)
+
+    def update_source_uri(
+        self,
+        source_uri: str,
+    ):
+        """Source uri to be set for the model package
+
+        Args:
+            source_uri (str): The URI of the source for the model package.
+
+        """
+        update_source_uri_args = {
+            "ModelPackageArn": self.model_package_arn,
+            "SourceUri": source_uri,
+        }
+        sagemaker_session = self.sagemaker_session or sagemaker.Session()
+        sagemaker_session.sagemaker_client.update_model_package(**update_source_uri_args)
 
     def remove_customer_metadata_properties(
         self, customer_metadata_properties_to_remove: List[str]

--- a/src/sagemaker/mxnet/model.py
+++ b/src/sagemaker/mxnet/model.py
@@ -176,6 +176,7 @@ class MXNetModel(FrameworkModel):
         nearest_model_name: Optional[Union[str, PipelineVariable]] = None,
         data_input_configuration: Optional[Union[str, PipelineVariable]] = None,
         skip_model_validation: Optional[Union[str, PipelineVariable]] = None,
+        source_uri: Optional[Union[str, PipelineVariable]] = None,
     ):
         """Creates a model package for creating SageMaker models or listing on Marketplace.
 
@@ -225,6 +226,8 @@ class MXNetModel(FrameworkModel):
                 (default: None).
             skip_model_validation (str or PipelineVariable): Indicates if you want to skip model
                 validation. Values can be "All" or "None" (default: None).
+            source_uri (str or PipelineVariable): The URI of the source for the model package
+                (default: None).
 
         Returns:
             A `sagemaker.model.ModelPackage` instance.
@@ -264,6 +267,7 @@ class MXNetModel(FrameworkModel):
             nearest_model_name=nearest_model_name,
             data_input_configuration=data_input_configuration,
             skip_model_validation=skip_model_validation,
+            source_uri=source_uri,
         )
 
     def prepare_container_def(

--- a/src/sagemaker/pipeline.py
+++ b/src/sagemaker/pipeline.py
@@ -360,6 +360,7 @@ class PipelineModel(object):
         nearest_model_name: Optional[Union[str, PipelineVariable]] = None,
         data_input_configuration: Optional[Union[str, PipelineVariable]] = None,
         skip_model_validation: Optional[Union[str, PipelineVariable]] = None,
+        source_uri: Optional[Union[str, PipelineVariable]] = None,
     ):
         """Creates a model package for creating SageMaker models or listing on Marketplace.
 
@@ -409,6 +410,8 @@ class PipelineModel(object):
                 (default: None).
             skip_model_validation (str or PipelineVariable): Indicates if you want to skip model
                 validation. Values can be "All" or "None" (default: None).
+            source_uri (str or PipelineVariable): The URI of the source for the model package
+                (default: None).
 
         Returns:
             If ``sagemaker_session`` is a ``PipelineSession`` instance, returns pipeline step
@@ -456,6 +459,7 @@ class PipelineModel(object):
             sample_payload_url=sample_payload_url,
             task=task,
             skip_model_validation=skip_model_validation,
+            source_uri=source_uri,
         )
 
         self.sagemaker_session.create_model_package_from_containers(**model_pkg_args)

--- a/src/sagemaker/pytorch/model.py
+++ b/src/sagemaker/pytorch/model.py
@@ -178,6 +178,7 @@ class PyTorchModel(FrameworkModel):
         nearest_model_name: Optional[Union[str, PipelineVariable]] = None,
         data_input_configuration: Optional[Union[str, PipelineVariable]] = None,
         skip_model_validation: Optional[Union[str, PipelineVariable]] = None,
+        source_uri: Optional[Union[str, PipelineVariable]] = None,
     ):
         """Creates a model package for creating SageMaker models or listing on Marketplace.
 
@@ -227,6 +228,8 @@ class PyTorchModel(FrameworkModel):
                 (default: None).
             skip_model_validation (str or PipelineVariable): Indicates if you want to skip model
                 validation. Values can be "All" or "None" (default: None).
+            source_uri (str or PipelineVariable): The URI of the source for the model package
+                (default: None).
 
         Returns:
             A `sagemaker.model.ModelPackage` instance.
@@ -266,6 +269,7 @@ class PyTorchModel(FrameworkModel):
             nearest_model_name=nearest_model_name,
             data_input_configuration=data_input_configuration,
             skip_model_validation=skip_model_validation,
+            source_uri=source_uri,
         )
 
     def prepare_container_def(

--- a/src/sagemaker/sklearn/model.py
+++ b/src/sagemaker/sklearn/model.py
@@ -171,6 +171,7 @@ class SKLearnModel(FrameworkModel):
         nearest_model_name: Optional[Union[str, PipelineVariable]] = None,
         data_input_configuration: Optional[Union[str, PipelineVariable]] = None,
         skip_model_validation: Optional[Union[str, PipelineVariable]] = None,
+        source_uri: Optional[Union[str, PipelineVariable]] = None,
     ):
         """Creates a model package for creating SageMaker models or listing on Marketplace.
 
@@ -220,6 +221,8 @@ class SKLearnModel(FrameworkModel):
                 (default: None).
             skip_model_validation (str or PipelineVariable): Indicates if you want to skip model
                 validation. Values can be "All" or "None" (default: None).
+            source_uri (str or PipelineVariable): The URI of the source for the model package
+                (default: None).
 
         Returns:
             A `sagemaker.model.ModelPackage` instance.
@@ -259,6 +262,7 @@ class SKLearnModel(FrameworkModel):
             nearest_model_name=nearest_model_name,
             data_input_configuration=data_input_configuration,
             skip_model_validation=skip_model_validation,
+            source_uri=source_uri,
         )
 
     def prepare_container_def(

--- a/src/sagemaker/tensorflow/model.py
+++ b/src/sagemaker/tensorflow/model.py
@@ -233,6 +233,7 @@ class TensorFlowModel(sagemaker.model.FrameworkModel):
         nearest_model_name: Optional[Union[str, PipelineVariable]] = None,
         data_input_configuration: Optional[Union[str, PipelineVariable]] = None,
         skip_model_validation: Optional[Union[str, PipelineVariable]] = None,
+        source_uri: Optional[Union[str, PipelineVariable]] = None,
     ):
         """Creates a model package for creating SageMaker models or listing on Marketplace.
 
@@ -282,6 +283,8 @@ class TensorFlowModel(sagemaker.model.FrameworkModel):
                 (default: None).
             skip_model_validation (str or PipelineVariable): Indicates if you want to skip model
                 validation. Values can be "All" or "None" (default: None).
+            source_uri (str or PipelineVariable): The URI of the source for the model package
+                (default: None).
 
         Returns:
             A `sagemaker.model.ModelPackage` instance.
@@ -321,6 +324,7 @@ class TensorFlowModel(sagemaker.model.FrameworkModel):
             nearest_model_name=nearest_model_name,
             data_input_configuration=data_input_configuration,
             skip_model_validation=skip_model_validation,
+            source_uri=source_uri,
         )
 
     def deploy(

--- a/src/sagemaker/utils.py
+++ b/src/sagemaker/utils.py
@@ -48,6 +48,10 @@ from sagemaker.workflow import is_pipeline_variable, is_pipeline_parameter_strin
 from sagemaker.workflow.entities import PipelineVariable
 
 ECR_URI_PATTERN = r"^(\d+)(\.)dkr(\.)ecr(\.)(.+)(\.)(.*)(/)(.*:.*)$"
+MODEL_PACKAGE_ARN_PATTERN = (
+    r"arn:aws([a-z\-]*)?:sagemaker:([a-z0-9\-]*):([0-9]{12}):model-package/(.*)"
+)
+MODEL_ARN_PATTERN = r"arn:aws([a-z\-]*):sagemaker:([a-z0-9\-]*):([0-9]{12}):model/(.*)"
 MAX_BUCKET_PATHS_COUNT = 5
 S3_PREFIX = "s3://"
 HTTP_PREFIX = "http://"
@@ -1581,3 +1585,17 @@ def custom_extractall_tarfile(tar, extract_path):
         tar.extractall(path=extract_path, filter="data")
     else:
         tar.extractall(path=extract_path, members=_get_safe_members(tar))
+
+
+def can_model_package_source_uri_autopopulate(source_uri: str):
+    """Checks if the source_uri can lead to auto-population of information in the Model registry.
+
+    Args:
+        source_uri (str): The source uri.
+
+    Returns:
+        bool: True if the source_uri can lead to auto-population, False otherwise.
+    """
+    return bool(
+        re.match(MODEL_PACKAGE_ARN_PATTERN, source_uri) or re.match(MODEL_ARN_PATTERN, source_uri)
+    )

--- a/src/sagemaker/workflow/_utils.py
+++ b/src/sagemaker/workflow/_utils.py
@@ -328,6 +328,7 @@ class _RegisterModelStep(ConfigurableRetryStep):
         sample_payload_url=None,
         task=None,
         skip_model_validation=None,
+        source_uri=None,
         **kwargs,
     ):
         """Constructor of a register model step.
@@ -379,6 +380,7 @@ class _RegisterModelStep(ConfigurableRetryStep):
                 "CLASSIFICATION", "REGRESSION", "OTHER" (default: None).
             skip_model_validation (str): Indicates if you want to skip model validation.
                 Values can be "All" or "None" (default: None).
+            source_uri (str): The URI of the source for the model package (default: None).
             **kwargs: additional arguments to `create_model`.
         """
         super(_RegisterModelStep, self).__init__(
@@ -415,6 +417,7 @@ class _RegisterModelStep(ConfigurableRetryStep):
         self.kwargs = kwargs
         self.container_def_list = container_def_list
         self.skip_model_validation = skip_model_validation
+        self.source_uri = source_uri
 
         self._properties = Properties(
             step_name=name, step=self, shape_name="DescribeModelPackageOutput"
@@ -489,6 +492,7 @@ class _RegisterModelStep(ConfigurableRetryStep):
                 sample_payload_url=self.sample_payload_url,
                 task=self.task,
                 skip_model_validation=self.skip_model_validation,
+                source_uri=self.source_uri,
             )
 
             request_dict = get_create_model_package_request(**model_package_args)

--- a/src/sagemaker/workflow/step_collections.py
+++ b/src/sagemaker/workflow/step_collections.py
@@ -96,6 +96,7 @@ class RegisterModel(StepCollection):  # pragma: no cover
         nearest_model_name=None,
         data_input_configuration=None,
         skip_model_validation=None,
+        source_uri=None,
         **kwargs,
     ):
         """Construct steps `_RepackModelStep` and `_RegisterModelStep` based on the estimator.
@@ -153,6 +154,7 @@ class RegisterModel(StepCollection):  # pragma: no cover
             data_input_configuration (str): Input object for the model (default: None).
             skip_model_validation (str): Indicates if you want to skip model
                 validation. Values can be "All" or "None" (default: None).
+            source_uri (str): The URI of the source for the model package (default: None).
 
             **kwargs: additional arguments to `create_model`.
         """
@@ -291,6 +293,7 @@ class RegisterModel(StepCollection):  # pragma: no cover
             sample_payload_url=sample_payload_url,
             task=task,
             skip_model_validation=skip_model_validation,
+            source_uri=source_uri,
             **kwargs,
         )
         if not repack_model:

--- a/src/sagemaker/xgboost/model.py
+++ b/src/sagemaker/xgboost/model.py
@@ -159,6 +159,7 @@ class XGBoostModel(FrameworkModel):
         nearest_model_name: Optional[Union[str, PipelineVariable]] = None,
         data_input_configuration: Optional[Union[str, PipelineVariable]] = None,
         skip_model_validation: Optional[Union[str, PipelineVariable]] = None,
+        source_uri: Optional[Union[str, PipelineVariable]] = None,
     ):
         """Creates a model package for creating SageMaker models or listing on Marketplace.
 
@@ -208,6 +209,8 @@ class XGBoostModel(FrameworkModel):
                 (default: None).
             skip_model_validation (str or PipelineVariable): Indicates if you want to skip model
                 validation. Values can be "All" or "None" (default: None).
+            source_uri (str or PipelineVariable): The URI of the source for the model package
+                (default: None).
 
         Returns:
             str: A string of SageMaker Model Package ARN.
@@ -247,6 +250,7 @@ class XGBoostModel(FrameworkModel):
             nearest_model_name=nearest_model_name,
             data_input_configuration=data_input_configuration,
             skip_model_validation=skip_model_validation,
+            source_uri=source_uri,
         )
 
     def prepare_container_def(

--- a/tests/integ/test_model_package.py
+++ b/tests/integ/test_model_package.py
@@ -18,6 +18,8 @@ from sagemaker.utils import unique_name_from_base
 from tests.integ import DATA_DIR
 from sagemaker.xgboost import XGBoostModel
 from sagemaker import image_uris
+from sagemaker.session import get_execution_role
+from sagemaker.model import ModelPackage
 
 _XGBOOST_PATH = os.path.join(DATA_DIR, "xgboost_abalone")
 
@@ -104,3 +106,207 @@ def test_inference_specification_addition(sagemaker_session):
     sagemaker_session.sagemaker_client.delete_model_package_group(
         ModelPackageGroupName=model_group_name
     )
+
+
+def test_update_inference_specification(sagemaker_session):
+    model_group_name = unique_name_from_base("test-model-group")
+    source_uri = "dummy source uri"
+
+    sagemaker_session.sagemaker_client.create_model_package_group(
+        ModelPackageGroupName=model_group_name
+    )
+
+    model_package = sagemaker_session.sagemaker_client.create_model_package(
+        ModelPackageGroupName=model_group_name, SourceUri=source_uri
+    )
+
+    mp = ModelPackage(
+        role=get_execution_role(sagemaker_session),
+        model_package_arn=model_package["ModelPackageArn"],
+        sagemaker_session=sagemaker_session,
+    )
+
+    xgb_image = image_uris.retrieve(
+        "xgboost", sagemaker_session.boto_region_name, version="1", image_scope="inference"
+    )
+
+    mp.update_inference_specification(image_uris=[xgb_image])
+
+    desc_model_package = sagemaker_session.sagemaker_client.describe_model_package(
+        ModelPackageName=model_package["ModelPackageArn"]
+    )
+
+    sagemaker_session.sagemaker_client.delete_model_package(
+        ModelPackageName=model_package["ModelPackageArn"]
+    )
+    sagemaker_session.sagemaker_client.delete_model_package_group(
+        ModelPackageGroupName=model_group_name
+    )
+
+    assert len(desc_model_package["InferenceSpecification"]["Containers"]) == 1
+    assert desc_model_package["InferenceSpecification"]["Containers"][0]["Image"] == xgb_image
+
+
+def test_update_source_uri(sagemaker_session):
+    model_group_name = unique_name_from_base("test-model-group")
+    source_uri = "dummy source uri"
+
+    sagemaker_session.sagemaker_client.create_model_package_group(
+        ModelPackageGroupName=model_group_name
+    )
+
+    xgb_model_data_s3 = sagemaker_session.upload_data(
+        path=os.path.join(_XGBOOST_PATH, "xgb_model.tar.gz"),
+        key_prefix="integ-test-data/xgboost/model",
+    )
+    model = XGBoostModel(
+        model_data=xgb_model_data_s3, framework_version="1.3-1", sagemaker_session=sagemaker_session
+    )
+
+    model_package = model.register(
+        content_types=["text/csv"],
+        response_types=["text/csv"],
+        inference_instances=["ml.m5.large"],
+        transform_instances=["ml.m5.large"],
+        model_package_group_name=model_group_name,
+    )
+
+    desc_model_package = sagemaker_session.sagemaker_client.describe_model_package(
+        ModelPackageName=model_package.model_package_arn
+    )
+
+    model_package.update_source_uri(source_uri=source_uri)
+    desc_model_package = sagemaker_session.sagemaker_client.describe_model_package(
+        ModelPackageName=model_package.model_package_arn
+    )
+
+    assert desc_model_package["SourceUri"] == source_uri
+
+
+def test_clone_model_package_using_source_uri(sagemaker_session):
+    model_group_name = unique_name_from_base("test-model-group")
+
+    sagemaker_session.sagemaker_client.create_model_package_group(
+        ModelPackageGroupName=model_group_name
+    )
+
+    xgb_model_data_s3 = sagemaker_session.upload_data(
+        path=os.path.join(_XGBOOST_PATH, "xgb_model.tar.gz"),
+        key_prefix="integ-test-data/xgboost/model",
+    )
+    model = XGBoostModel(
+        model_data=xgb_model_data_s3, framework_version="1.3-1", sagemaker_session=sagemaker_session
+    )
+
+    model_package = model.register(
+        content_types=["text/csv"],
+        response_types=["text/csv"],
+        inference_instances=["ml.m5.large"],
+        transform_instances=["ml.m5.large"],
+        model_package_group_name=model_group_name,
+        source_uri="dummy-source-uri",
+    )
+
+    desc_model_package = sagemaker_session.sagemaker_client.describe_model_package(
+        ModelPackageName=model_package.model_package_arn
+    )
+
+    model2 = XGBoostModel(
+        model_data=xgb_model_data_s3, framework_version="1.3-1", sagemaker_session=sagemaker_session
+    )
+    cloned_model_package = model2.register(
+        content_types=["text/csv"],
+        response_types=["text/csv"],
+        inference_instances=["ml.m5.large"],
+        transform_instances=["ml.m5.large"],
+        model_package_group_name=model_group_name,
+        source_uri=model_package.model_package_arn,
+    )
+
+    desc_cloned_model_package = sagemaker_session.sagemaker_client.describe_model_package(
+        ModelPackageName=cloned_model_package.model_package_arn
+    )
+
+    sagemaker_session.sagemaker_client.delete_model_package(
+        ModelPackageName=model_package.model_package_arn
+    )
+    sagemaker_session.sagemaker_client.delete_model_package(
+        ModelPackageName=cloned_model_package.model_package_arn
+    )
+    sagemaker_session.sagemaker_client.delete_model_package_group(
+        ModelPackageGroupName=model_group_name
+    )
+
+    assert len(desc_cloned_model_package["InferenceSpecification"]["Containers"]) == len(
+        desc_model_package["InferenceSpecification"]["Containers"]
+    )
+    assert len(
+        desc_cloned_model_package["InferenceSpecification"]["SupportedTransformInstanceTypes"]
+    ) == len(desc_model_package["InferenceSpecification"]["SupportedTransformInstanceTypes"])
+    assert len(
+        desc_cloned_model_package["InferenceSpecification"][
+            "SupportedRealtimeInferenceInstanceTypes"
+        ]
+    ) == len(
+        desc_model_package["InferenceSpecification"]["SupportedRealtimeInferenceInstanceTypes"]
+    )
+    assert len(desc_cloned_model_package["InferenceSpecification"]["SupportedContentTypes"]) == len(
+        desc_model_package["InferenceSpecification"]["SupportedContentTypes"]
+    )
+    assert len(
+        desc_cloned_model_package["InferenceSpecification"]["SupportedResponseMIMETypes"]
+    ) == len(desc_model_package["InferenceSpecification"]["SupportedResponseMIMETypes"])
+    assert desc_cloned_model_package["SourceUri"] == model_package.model_package_arn
+
+
+def test_register_model_using_source_uri(sagemaker_session):
+    model_name = unique_name_from_base("test-model")
+    model_group_name = unique_name_from_base("test-model-group")
+
+    sagemaker_session.sagemaker_client.create_model_package_group(
+        ModelPackageGroupName=model_group_name
+    )
+
+    xgb_model_data_s3 = sagemaker_session.upload_data(
+        path=os.path.join(_XGBOOST_PATH, "xgb_model.tar.gz"),
+        key_prefix="integ-test-data/xgboost/model",
+    )
+
+    model = XGBoostModel(
+        model_data=xgb_model_data_s3,
+        framework_version="1.3-1",
+        sagemaker_session=sagemaker_session,
+        role=get_execution_role(sagemaker_session),
+    )
+
+    model.name = model_name
+    model.create()
+    desc_model = sagemaker_session.sagemaker_client.describe_model(ModelName=model_name)
+
+    model = XGBoostModel(
+        model_data=xgb_model_data_s3,
+        framework_version="1.3-1",
+        sagemaker_session=sagemaker_session,
+        role=get_execution_role(sagemaker_session),
+    )
+    registered_model_package = model.register(
+        inference_instances=["ml.m5.xlarge"],
+        model_package_group_name=model_group_name,
+        source_uri=desc_model["ModelArn"],
+    )
+
+    desc_registered_model_package = sagemaker_session.sagemaker_client.describe_model_package(
+        ModelPackageName=registered_model_package.model_package_arn
+    )
+
+    sagemaker_session.sagemaker_client.delete_model(ModelName=model_name)
+    sagemaker_session.sagemaker_client.delete_model_package(
+        ModelPackageName=registered_model_package.model_package_arn
+    )
+    sagemaker_session.sagemaker_client.delete_model_package_group(
+        ModelPackageGroupName=model_group_name
+    )
+
+    assert desc_registered_model_package["SourceUri"] == desc_model["ModelArn"]
+    assert "InferenceSpecification" in desc_registered_model_package
+    assert desc_registered_model_package["InferenceSpecification"] is not None

--- a/tests/unit/sagemaker/model/test_model_package.py
+++ b/tests/unit/sagemaker/model/test_model_package.py
@@ -223,22 +223,21 @@ def test_create_sagemaker_model_include_tags(sagemaker_session):
     )
 
 
-def test_model_package_model_data_source_not_supported(sagemaker_session):
-    with pytest.raises(
-        ValueError, match="Creating ModelPackage with ModelDataSource is currently not supported"
-    ):
-        ModelPackage(
-            role="role",
-            model_package_arn="my-model-package",
-            model_data={
-                "S3DataSource": {
-                    "S3Uri": "s3://bucket/model/prefix/",
-                    "S3DataType": "S3Prefix",
-                    "CompressionType": "None",
-                }
-            },
-            sagemaker_session=sagemaker_session,
-        )
+def test_model_package_model_data_source_supported(sagemaker_session):
+    model_data_source = {
+        "S3DataSource": {
+            "S3Uri": "s3://bucket/model/prefix/",
+            "S3DataType": "S3Prefix",
+            "CompressionType": "None",
+        }
+    }
+    model_package = ModelPackage(
+        role="role",
+        model_package_arn="my-model-package",
+        model_data=model_data_source,
+        sagemaker_session=sagemaker_session,
+    )
+    assert model_package.model_data == model_package.model_data
 
 
 @patch("sagemaker.utils.name_from_base")
@@ -398,4 +397,48 @@ def test_add_inference_specification(sagemaker_session):
                 "Name": "Inference",
             }
         ],
+    )
+
+
+def test_update_inference_specification(sagemaker_session):
+    model_package = ModelPackage(
+        role="role",
+        model_package_arn=MODEL_PACKAGE_VERSIONED_ARN,
+        sagemaker_session=sagemaker_session,
+    )
+
+    image_uris = ["image_uri"]
+
+    containers = [{"Image": "image_uri"}]
+
+    try:
+        model_package.update_inference_specification(image_uris=image_uris, containers=containers)
+    except ValueError as ve:
+        assert "Should have either containers or image_uris for inference." in str(ve)
+
+    try:
+        model_package.update_inference_specification()
+    except ValueError as ve:
+        assert "Should have either containers or image_uris for inference." in str(ve)
+
+    model_package.update_inference_specification(image_uris=image_uris)
+
+    sagemaker_session.sagemaker_client.update_model_package.assert_called_with(
+        ModelPackageArn=MODEL_PACKAGE_VERSIONED_ARN,
+        InferenceSpecification={
+            "Containers": [{"Image": "image_uri"}],
+        },
+    )
+
+
+def test_update_source_uri(sagemaker_session):
+    source_uri = "dummy_source_uri"
+    model_package = ModelPackage(
+        role="role",
+        model_package_arn=MODEL_PACKAGE_VERSIONED_ARN,
+        sagemaker_session=sagemaker_session,
+    )
+    model_package.update_source_uri(source_uri=source_uri)
+    sagemaker_session.sagemaker_client.update_model_package.assert_called_with(
+        ModelPackageArn=MODEL_PACKAGE_VERSIONED_ARN, SourceUri=source_uri
     )

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -46,6 +46,7 @@ from sagemaker.utils import (
     _is_bad_path,
     _is_bad_link,
     custom_extractall_tarfile,
+    can_model_package_source_uri_autopopulate,
 )
 from tests.unit.sagemaker.workflow.helpers import CustomStep
 from sagemaker.workflow.parameters import ParameterString, ParameterInteger
@@ -1796,3 +1797,15 @@ def test_is_bad_link(link_name, base, expected):
 def test_custom_extractall_tarfile(mock_custom_tarfile, data_filter, expected_extract_path):
     tar = mock_custom_tarfile(data_filter)
     custom_extractall_tarfile(tar, "/extract/path")
+
+
+def test_can_model_package_source_uri_autopopulate():
+    test_data = [
+        ("arn:aws:sagemaker:us-west-2:012345678912:model-package/dummy-mpg/1", True),
+        ("arn:aws:sagemaker:us-west-2:012345678912:model-package/dummy-mp", True),
+        ("arn:aws:sagemaker:us-west-2:012345678912:model/dummy-model", True),
+        ("https://path/to/model", False),
+        ("/home/path/to/model", False),
+    ]
+    for source_uri, expected in test_data:
+        assert can_model_package_source_uri_autopopulate(source_uri) == expected


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Supporting Model Data Source and Source Uri parameter for model package and register steps. Involves:
   - Adding source_uri to register step of Model class and other children classes. 
   - Removal of existing checks for disallowing `dict` form for model data when registering/ creating model package, instead disallow only if it is un-versioned model package. Also disallow source uri usage if un-versioned.
   -  when source_uri and containers are specified during registration:
      - if source_uri is not a model package or model arn:
         - first make model package with inference spec derived from containers and then update the model package with source_uri. This is done since the base sdk disallows providing source uri and inference spec simultaneously while creating model package.
      -  if source_uri is a model package or model arn
         - Ignore containers/inference spec passed as these are supposed to be auto populated by model registry from the source uri and also passing source uri and inference spec simultaneously is not allowed in the base sdk.
- Add support to allow Inference spec to be added later for model packages.
- Add support to allow source uri to be added later for model packages.

*Testing done:*
- Ran unit tests and added additional ones as well.
- Ran additionally added integ tests.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
