### PR TITLE
change: split coverage out from testenv in tox.ini

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,8 +77,8 @@ Before sending us a pull request, please ensure that:
 1. Install coverage using `pip install .[test]`
 1. cd into the sagemaker-python-sdk folder: `cd sagemaker-python-sdk` or `cd /environment/sagemaker-python-sdk`
 1. Run the following tox command and verify that all code checks and unit tests pass: `tox tests/unit`
-
-You can also run a single test with the following command: `tox -e py310 -- -s -vv <path_to_file><file_name>::<test_function_name>`
+1. You can also run a single test with the following command: `tox -e py310 -- -s -vv <path_to_file><file_name>::<test_function_name>`
+1. You can run coverage via runcvoerage env : `tox -e runcoverage -- tests/unit` or `tox -e py310 -- tests/unit --cov=sagemaker --cov-append --cov-report xml`
   * Note that the coverage test will fail if you only run a single test, so make sure to surround the command with `export IGNORE_COVERAGE=-` and `unset IGNORE_COVERAGE`
   * Example: `export IGNORE_COVERAGE=- ; tox -e py310 -- -s -vv tests/unit/test_estimator.py::test_sagemaker_model_s3_uri_invalid ; unset IGNORE_COVERAGE`
 

--- a/tox.ini
+++ b/tox.ini
@@ -86,11 +86,16 @@ commands =
     pip install 'torchvision==0.15.2+cpu' -f 'https://download.pytorch.org/whl/torch_stable.html'
     pip install 'dill>=0.3.8'
 
-    pytest --cov=sagemaker --cov-append {posargs}
-{env:IGNORE_COVERAGE:} coverage report -i --fail-under=86
+    pytest {posargs}
 deps = .[test]
 depends =
     {py38,py39,py310,p311}: clean
+
+[testenv:runcoverage]
+description = run unit tests with coverage 
+commands =
+    pytest --cov=sagemaker --cov-append {posargs} 
+    {env:IGNORE_COVERAGE:} coverage report -i --fail-under=86
 
 [testenv:flake8]
 skipdist = true


### PR DESCRIPTION
*Issue #, if available:*

Remove default coverage flags from tox.ini to prevent it from running 
during integ and other tests

This will prevent slug trace pr checks from hanging and remove one type of the flakiness 

*Description of changes:*

Remove --cov and --cov append from default testenv
& allow it via {pos args} if needed.

Added a runcoverage testenv to perform the same if required.

*Testing done:*

`tox -e runcoverage -- tests/unit/test_knn.py `
`tox -e py311 -- tests/unit/test_knn.py --cov=sagemaker --cov-append --cov-report xml`


## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ X] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [X ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ X] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [X ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [X ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [X ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ X] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ X] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
