### PR TITLE
Improvement of the tuner documentation

### DIFF
--- a/src/sagemaker/tuner.py
+++ b/src/sagemaker/tuner.py
@@ -11,6 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 """Placeholder docstring"""
+
 from __future__ import absolute_import
 
 import importlib
@@ -641,8 +642,11 @@ class HyperparameterTuner(object):
                 extract the metric from the logs. This should be defined only
                 for hyperparameter tuning jobs that don't use an Amazon
                 algorithm.
-            strategy (str or PipelineVariable): Strategy to be used for hyperparameter estimations
-                (default: 'Bayesian').
+            strategy (str or PipelineVariable): Strategy to be used for hyperparameter estimations.
+                More information about different strategies:
+                https://docs.aws.amazon.com/sagemaker/latest/dg/automatic-model-tuning-how-it-works.html.
+                Available options are: 'Bayesian', 'Random', 'Hyperband',
+                'Grid' (default: 'Bayesian')
             objective_type (str or PipelineVariable): The type of the objective metric for
                 evaluating training jobs. This value can be either 'Minimize' or
                 'Maximize' (default: 'Maximize').
@@ -759,7 +763,8 @@ class HyperparameterTuner(object):
         self.autotune = autotune
 
     def override_resource_config(
-        self, instance_configs: Union[List[InstanceConfig], Dict[str, List[InstanceConfig]]]
+        self,
+        instance_configs: Union[List[InstanceConfig], Dict[str, List[InstanceConfig]]],
     ):
         """Override the instance configuration of the estimators used by the tuner.
 
@@ -966,7 +971,7 @@ class HyperparameterTuner(object):
         include_cls_metadata: Union[bool, Dict[str, bool]] = False,
         estimator_kwargs: Optional[Dict[str, dict]] = None,
         wait: bool = True,
-        **kwargs
+        **kwargs,
     ):
         """Start a hyperparameter tuning job.
 
@@ -1055,7 +1060,7 @@ class HyperparameterTuner(object):
             allowed_keys=estimator_names,
         )
 
-        for (estimator_name, estimator) in self.estimator_dict.items():
+        for estimator_name, estimator in self.estimator_dict.items():
             ins = inputs.get(estimator_name, None) if inputs is not None else None
             args = estimator_kwargs.get(estimator_name, {}) if estimator_kwargs is not None else {}
             self._prepare_estimator_for_tuning(estimator, ins, job_name, **args)
@@ -1282,7 +1287,7 @@ class HyperparameterTuner(object):
             objective_metric_name_dict=objective_metric_name_dict,
             hyperparameter_ranges_dict=hyperparameter_ranges_dict,
             metric_definitions_dict=metric_definitions_dict,
-            **init_params
+            **init_params,
         )
 
     def deploy(
@@ -1297,7 +1302,7 @@ class HyperparameterTuner(object):
         model_name=None,
         kms_key=None,
         data_capture_config=None,
-        **kwargs
+        **kwargs,
     ):
         """Deploy the best trained or user specified model to an Amazon SageMaker endpoint.
 
@@ -1363,7 +1368,7 @@ class HyperparameterTuner(object):
             model_name=model_name,
             kms_key=kms_key,
             data_capture_config=data_capture_config,
-            **kwargs
+            **kwargs,
         )
 
     def stop_tuning_job(self):


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Just a small improvement of the HPO Tuner documentation (add list of the strategies and link to the proper documentation).

*Testing done:*
Manual testing + documentation review after the build.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
