### PR TITLE
fix: list jumpstart models with invalid version strings

### DIFF
--- a/src/sagemaker/jumpstart/notebook_utils.py
+++ b/src/sagemaker/jumpstart/notebook_utils.py
@@ -261,6 +261,16 @@ def list_jumpstart_scripts(  # pylint: disable=redefined-builtin
             break
     return sorted(list(scripts))
 
+def _is_valid_version(version: str) -> bool:
+    """
+    Checks if the version is convertable to Version class
+    """
+    try:
+        Version(version)
+        return True
+    except Exception:
+        return False
+
 
 def list_jumpstart_models(  # pylint: disable=redefined-builtin
     filter: Union[Operator, str] = Constant(BooleanValues.TRUE),
@@ -304,7 +314,8 @@ def list_jumpstart_models(  # pylint: disable=redefined-builtin
     ):
         if model_id not in model_id_version_dict:
             model_id_version_dict[model_id] = list()
-        model_id_version_dict[model_id].append(Version(version))
+        model_version = Version(version) if _is_valid_version(version) else version
+        model_id_version_dict[model_id].append(model_version)
 
     if not list_versions:
         return sorted(list(model_id_version_dict.keys()))

--- a/src/sagemaker/jumpstart/notebook_utils.py
+++ b/src/sagemaker/jumpstart/notebook_utils.py
@@ -263,9 +263,7 @@ def list_jumpstart_scripts(  # pylint: disable=redefined-builtin
 
 
 def _is_valid_version(version: str) -> bool:
-    """
-    Checks if the version is convertable to Version class
-    """
+    """Checks if the version is convertable to Version class."""
     try:
         Version(version)
         return True

--- a/src/sagemaker/jumpstart/notebook_utils.py
+++ b/src/sagemaker/jumpstart/notebook_utils.py
@@ -267,7 +267,7 @@ def _is_valid_version(version: str) -> bool:
     try:
         Version(version)
         return True
-    except Exception:
+    except Exception:  # pylint: disable=broad-except
         return False
 
 

--- a/src/sagemaker/jumpstart/notebook_utils.py
+++ b/src/sagemaker/jumpstart/notebook_utils.py
@@ -261,6 +261,7 @@ def list_jumpstart_scripts(  # pylint: disable=redefined-builtin
             break
     return sorted(list(scripts))
 
+
 def _is_valid_version(version: str) -> bool:
     """
     Checks if the version is convertable to Version class

--- a/tests/unit/sagemaker/jumpstart/constants.py
+++ b/tests/unit/sagemaker/jumpstart/constants.py
@@ -7577,6 +7577,20 @@ BASE_PROPRIETARY_MANIFEST = [
         "spec_key": "proprietary-models/ai21-paraphrase/proprietary_specs_1.0.005.json",
         "search_keywords": ["Text2Text", "Generation"],
     },
+    {
+        "model_id": "ai21-paraphrase",
+        "version": "v1.00-rc2-not-valid-version",
+        "min_version": "2.0.0",
+        "spec_key": "proprietary-models/ai21-paraphrase/proprietary_specs_1.0.005.json",
+        "search_keywords": ["Text2Text", "Generation"],
+    },
+    {
+        "model_id": "nc-soft-model-1",
+        "version": "v3.0-not-valid-version!",
+        "min_version": "2.0.0",
+        "spec_key": "proprietary-models/nc-soft-model-1/proprietary_specs_1.0.005.json",
+        "search_keywords": ["Text2Text", "Generation"],
+    },
 ]
 
 BASE_PROPRIETARY_SPEC = {

--- a/tests/unit/sagemaker/jumpstart/test_notebook_utils.py
+++ b/tests/unit/sagemaker/jumpstart/test_notebook_utils.py
@@ -188,7 +188,7 @@ def test_list_jumpstart_frameworks(
 
 def test_is_valid_version():
     valid_version_strs = ["1.0", "1.0.0", "2012.4", "1!1.0", "1.dev0", "1.2.3+abc.dev1"]
-    invalid_version_strs = ["1.1.053_m", "invalid version", "v1-1.0-v2"]
+    invalid_version_strs = ["1.1.053_m", "invalid version", "v1-1.0-v2", "@"]
     assert all(_is_valid_version(v) for v in valid_version_strs)
     assert not any(_is_valid_version(v) for v in invalid_version_strs)
 

--- a/tests/unit/sagemaker/jumpstart/test_notebook_utils.py
+++ b/tests/unit/sagemaker/jumpstart/test_notebook_utils.py
@@ -626,6 +626,7 @@ class ListJumpStartModels(TestCase):
             "ai21-paraphrase",
             "ai21-summarization",
             "lighton-mini-instruct40b",
+            "nc-soft-model-1",
         ]
 
         all_open_weight_model_ids = [

--- a/tests/unit/sagemaker/jumpstart/test_notebook_utils.py
+++ b/tests/unit/sagemaker/jumpstart/test_notebook_utils.py
@@ -25,6 +25,7 @@ from sagemaker.jumpstart.notebook_utils import (
     list_jumpstart_models,
     list_jumpstart_scripts,
     list_jumpstart_tasks,
+    _is_valid_version,
 )
 
 
@@ -183,6 +184,13 @@ def test_list_jumpstart_frameworks(
     )
     assert patched_get_manifest.call_count == 4
     patched_get_model_specs.assert_not_called()
+
+
+def test_is_valid_version():
+    valid_version_strs = ["1.0", "1.0.0", "2012.4", "1!1.0", "1.dev0", "1.2.3+abc.dev1"]
+    invalid_version_strs = ["1.1.053_m", "invalid version", "v1-1.0-v2"]
+    assert all(_is_valid_version(v) for v in valid_version_strs)
+    assert not any(_is_valid_version(v) for v in invalid_version_strs)
 
 
 class ListJumpStartModels(TestCase):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This change fixes the list jumpstart model experience when there are multiple versions of the same proprietary model and some of the versions are not a valid `Version` object.

This change is done in the doc utils in the main PR but missed in the notebook_utils in the previous PR.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
