### PR TITLE
fix: Simplify how we process test dependencies, which are supposed to include all extras.

### DIFF
--- a/requirements/extras/test_requirements.txt
+++ b/requirements/extras/test_requirements.txt
@@ -23,12 +23,7 @@ pyvis==0.2.1
 pandas>=1.3.5,<1.5
 scikit-learn==1.3.0
 cloudpickle==2.2.1
-scipy==1.10.1
-urllib3>=1.26.8,<3.0.0
-docker>=5.0.2,<7.0.0
 PyYAML==6.0
-pyspark==3.3.1
-sagemaker-feature-store-pyspark-3.3
 # TODO find workaround
 xgboost>=1.6.2,<=1.7.6
 pillow>=10.0.1,<=11
@@ -39,4 +34,3 @@ tritonclient[http]<2.37.0
 onnx==1.14.1
 # tf2onnx==1.15.1
 nbformat>=5.9,<6
-accelerate>=0.24.1,<=0.27.0

--- a/setup.py
+++ b/setup.py
@@ -85,6 +85,8 @@ extras = {
 extras["all"] = [item for group in extras.values() for item in group]
 # Tests specific dependencies (do not need to be included in 'all')
 test_dependencies = read_requirements("requirements/extras/test_requirements.txt")
+# test dependencies are a superset of testing and extra dependencies
+test_dependencies.extend(extras["all"])
 # remove torch and torchvision if python version is not 3.10
 if sys.version_info.minor != 10:
     test_dependencies = [


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_

Change: An alternative to adding extras to test requirements explicitly, all the time. 
- Test dependencise should not have to be duplicated from extras files to the test reqs file - which is error prone and can lead to asynch versions (depends on the developer remembering to update the requirement explicitly in multiple locations) 
- Test dependencies are a superset of all extras. 

_Testing done:_

pip install . 

## Merge Checklist
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General
* [x]  I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
* [x]  I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
* [x]  I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
* [ ]  I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
* [x]  I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests
* [x]  I have added tests that prove my fix is effective or that my feature works (if appropriate)
* [ ]  I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
* [ ]  I have checked that my tests are not configured for a specific region or account (if appropriate)
* [ ]  I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

