### PR TITLE
fix: Create workflow module scoped sagemaker_session to resolve test race condition

### DIFF
--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -189,7 +189,7 @@ class Session(object):  # pylint: disable=too-many-public-methods
         sagemaker_runtime_client=None,
         sagemaker_featurestore_runtime_client=None,
         default_bucket=None,
-        settings=SessionSettings(),
+        settings=None,
         sagemaker_metrics_client=None,
         sagemaker_config: dict = None,
         default_bucket_prefix: str = None,
@@ -260,7 +260,7 @@ class Session(object):  # pylint: disable=too-many-public-methods
         self.resource_group_tagging_client = None
         self._config = None
         self.lambda_client = None
-        self.settings = settings
+        self.settings = settings if settings else SessionSettings()
 
         self._initialize(
             boto_session=boto_session,

--- a/tests/integ/sagemaker/workflow/conftest.py
+++ b/tests/integ/sagemaker/workflow/conftest.py
@@ -1,0 +1,65 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from __future__ import absolute_import
+
+import os
+
+import pytest
+from botocore.config import Config
+
+from tests.integ import DATA_DIR
+from sagemaker import Session, get_execution_role
+
+CUSTOM_S3_OBJECT_KEY_PREFIX = "session-default-prefix"
+
+
+# Create a sagemaker_session in workflow scope to prevent race condition
+# with other tests. Some other tests may change the session `settings`.
+@pytest.fixture(scope="module")
+def sagemaker_session_for_pipeline(
+    sagemaker_client_config,
+    boto_session,
+):
+    sagemaker_client_config.setdefault("config", Config(retries=dict(max_attempts=10)))
+    sagemaker_client = (
+        boto_session.client("sagemaker", **sagemaker_client_config)
+        if sagemaker_client_config
+        else None
+    )
+
+    return Session(
+        boto_session=boto_session,
+        sagemaker_client=sagemaker_client,
+        sagemaker_config={},
+        default_bucket_prefix=CUSTOM_S3_OBJECT_KEY_PREFIX,
+    )
+
+
+@pytest.fixture(scope="module")
+def smclient(sagemaker_session):
+    return sagemaker_session.boto_session.client("sagemaker")
+
+
+@pytest.fixture(scope="module")
+def role(sagemaker_session_for_pipeline):
+    return get_execution_role(sagemaker_session_for_pipeline)
+
+
+@pytest.fixture(scope="module")
+def region_name(sagemaker_session_for_pipeline):
+    return sagemaker_session_for_pipeline.boto_session.region_name
+
+
+@pytest.fixture(scope="module")
+def script_dir():
+    return os.path.join(DATA_DIR, "sklearn_processing")

--- a/tests/integ/sagemaker/workflow/test_pipeline_var_behaviors.py
+++ b/tests/integ/sagemaker/workflow/test_pipeline_var_behaviors.py
@@ -15,7 +15,7 @@ from __future__ import absolute_import
 import pytest
 
 from tests.integ.sagemaker.workflow.helpers import wait_pipeline_execution
-from sagemaker import get_execution_role, utils
+from sagemaker import utils
 from sagemaker.workflow.condition_step import ConditionStep
 from sagemaker.workflow.conditions import ConditionGreaterThan
 from sagemaker.workflow.fail_step import FailStep
@@ -25,16 +25,11 @@ from sagemaker.workflow.pipeline import Pipeline
 
 
 @pytest.fixture
-def role(sagemaker_session):
-    return get_execution_role(sagemaker_session)
-
-
-@pytest.fixture
 def pipeline_name():
     return utils.unique_name_from_base("my-pipeline-vars")
 
 
-def test_ppl_var_to_string_and_add(sagemaker_session, role, pipeline_name):
+def test_ppl_var_to_string_and_add(sagemaker_session_for_pipeline, role, pipeline_name):
     param_str = ParameterString(name="MyString", default_value="1")
     param_int = ParameterInteger(name="MyInteger", default_value=3)
 
@@ -65,7 +60,7 @@ def test_ppl_var_to_string_and_add(sagemaker_session, role, pipeline_name):
         name=pipeline_name,
         parameters=[param_str, param_int],
         steps=[step_cond, step_fail],
-        sagemaker_session=sagemaker_session,
+        sagemaker_session=sagemaker_session_for_pipeline,
     )
 
     try:

--- a/tests/integ/sagemaker/workflow/test_selective_execution.py
+++ b/tests/integ/sagemaker/workflow/test_selective_execution.py
@@ -24,7 +24,7 @@ from sagemaker.workflow.step_outputs import get_step
 from sagemaker.workflow.selective_execution_config import SelectiveExecutionConfig
 
 from tests.integ.sagemaker.workflow.helpers import create_and_execute_pipeline
-from sagemaker import utils, get_execution_role
+from sagemaker import utils
 from sagemaker.workflow.function_step import step
 from sagemaker.workflow.pipeline import Pipeline
 from sagemaker.workflow.steps import ProcessingStep
@@ -33,22 +33,12 @@ INSTANCE_TYPE = "ml.m5.large"
 
 
 @pytest.fixture
-def role(sagemaker_session):
-    return get_execution_role(sagemaker_session)
-
-
-@pytest.fixture
-def region_name(sagemaker_session):
-    return sagemaker_session.boto_session.region_name
-
-
-@pytest.fixture
 def pipeline_name():
     return utils.unique_name_from_base("Selective-Pipeline")
 
 
 def test_selective_execution_among_pure_function_steps(
-    sagemaker_session, role, pipeline_name, region_name, dummy_container_without_error
+    sagemaker_session_for_pipeline, role, pipeline_name, region_name, dummy_container_without_error
 ):
     # Test Selective Pipeline Execution on function step1 -> [select: function step2]
     os.environ["AWS_DEFAULT_REGION"] = region_name
@@ -75,7 +65,7 @@ def test_selective_execution_among_pure_function_steps(
     pipeline = Pipeline(
         name=pipeline_name,
         steps=[step_output_b],
-        sagemaker_session=sagemaker_session,
+        sagemaker_session=sagemaker_session_for_pipeline,
     )
 
     try:
@@ -117,7 +107,7 @@ def test_selective_execution_among_pure_function_steps(
 
 
 def test_selective_execution_of_regular_step_referenced_by_function_step(
-    sagemaker_session,
+    sagemaker_session_for_pipeline,
     role,
     pipeline_name,
     region_name,
@@ -135,7 +125,7 @@ def test_selective_execution_of_regular_step_referenced_by_function_step(
         instance_type=INSTANCE_TYPE,
         instance_count=1,
         command=["python3"],
-        sagemaker_session=sagemaker_session,
+        sagemaker_session=sagemaker_session_for_pipeline,
         base_job_name="test-sklearn",
     )
 
@@ -159,7 +149,7 @@ def test_selective_execution_of_regular_step_referenced_by_function_step(
     pipeline = Pipeline(
         name=pipeline_name,
         steps=[final_output],
-        sagemaker_session=sagemaker_session,
+        sagemaker_session=sagemaker_session_for_pipeline,
     )
 
     try:


### PR DESCRIPTION
*Issue #, if available:* 
Workflow integ tests (e.g. `test_model_registration_with_model_repack `) have race condition with model_builder tests. The latter[ changes the `sagemaker_session.settings._local_download_dir` when doing the `model_builder.build`](https://github.com/aws/sagemaker-python-sdk/blame/c8d1428b1176e020c5225161d0426d3dc8853289/src/sagemaker/serve/builder/model_builder.py#L610) and when the test is done, the tmp file in` _local_download_dir`  is cleaned up but the field is not reset, which blocks the workflow integ tests to upload model inference entry point file to S3. See the error thrown in 

https://github.com/aws/sagemaker-python-sdk/blame/c8d1428b1176e020c5225161d0426d3dc8853289/src/sagemaker/fw_utils.py#L453-L464

```
        if (
            settings is not None
            and settings.local_download_dir is not None
            and not (
                os.path.exists(settings.local_download_dir)
                and os.path.isdir(settings.local_download_dir)
            )
        ):
>           raise ValueError(
                "Inputted directory for storing newly generated temporary directory does "
                f"not exist: '{settings.local_download_dir}'"
            )
E           ValueError: Inputted directory for storing newly generated temporary directory does not exist: '/tmp/sagemaker/model-builder/40e2b7d2e61c11ee99ba0242ac110002'
```


*Description of changes:* Create a separate sagemaker_session in workflow scope

*Testing done:* Integ tests

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
