### PR TITLE
fix: skip test_experiment_analytics to unblock release

### DIFF
--- a/tests/integ/test_experiments_analytics.py
+++ b/tests/integ/test_experiments_analytics.py
@@ -123,7 +123,7 @@ def experiment_with_artifacts(sagemaker_session):
 
 @pytest.mark.release
 @pytest.mark.skipif(
-    integ.test_region() is "us-east-2", reason="Currently issues in this region NonSDK related"
+    integ.test_region() == "us-east-2", reason="Currently issues in this region NonSDK related"
 )
 def test_experiment_analytics_artifacts(sagemaker_session):
     with experiment_with_artifacts(sagemaker_session) as experiment_name:

--- a/tests/integ/test_experiments_analytics.py
+++ b/tests/integ/test_experiments_analytics.py
@@ -122,7 +122,9 @@ def experiment_with_artifacts(sagemaker_session):
 
 
 @pytest.mark.release
-@pytest.mark.skipif(integ.test_region() is "us-east-2", reason="Currently issues in this region NonSDK related")
+@pytest.mark.skipif(
+    integ.test_region() is "us-east-2", reason="Currently issues in this region NonSDK related"
+)
 def test_experiment_analytics_artifacts(sagemaker_session):
     with experiment_with_artifacts(sagemaker_session) as experiment_name:
         analytics = ExperimentAnalytics(

--- a/tests/integ/test_experiments_analytics.py
+++ b/tests/integ/test_experiments_analytics.py
@@ -19,6 +19,7 @@ from contextlib import contextmanager
 import pytest
 
 from sagemaker.analytics import ExperimentAnalytics
+from tests import integ
 
 
 @contextmanager
@@ -121,6 +122,7 @@ def experiment_with_artifacts(sagemaker_session):
 
 
 @pytest.mark.release
+@pytest.mark.skipif(integ.test_region() is "us-east-2", reason="Currently issues in this region NonSDK related")
 def test_experiment_analytics_artifacts(sagemaker_session):
     with experiment_with_artifacts(sagemaker_session) as experiment_name:
         analytics = ExperimentAnalytics(


### PR DESCRIPTION
Doesn't appear to be an sdk issue. Search is returning 0 results. Thus the test is failing.

*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
