### PR TITLE
fix: remove pytorch test for deprecated function

### DIFF
--- a/tests/integ/test_pytorch.py
+++ b/tests/integ/test_pytorch.py
@@ -230,41 +230,6 @@ def test_deploy_packed_model_with_entry_point_name(
 
         assert output.shape == (batch_size, 10)
 
-
-@pytest.mark.skipif(
-    test_region() not in EI_SUPPORTED_REGIONS, reason="EI isn't supported in that specific region."
-)
-def test_deploy_model_with_accelerator(
-    sagemaker_session,
-    cpu_instance_type,
-    pytorch_eia_latest_version,
-    pytorch_eia_latest_py_version,
-):
-    endpoint_name = unique_name_from_base("test-pytorch-deploy-eia")
-    model_data = sagemaker_session.upload_data(path=EIA_MODEL)
-    pytorch = PyTorchModel(
-        model_data,
-        "SageMakerRole",
-        entry_point=EIA_SCRIPT,
-        framework_version=pytorch_eia_latest_version,
-        py_version=pytorch_eia_latest_py_version,
-        sagemaker_session=sagemaker_session,
-    )
-    with timeout_and_delete_endpoint_by_name(endpoint_name, sagemaker_session):
-        predictor = pytorch.deploy(
-            initial_instance_count=1,
-            instance_type=cpu_instance_type,
-            accelerator_type="ml.eia1.medium",
-            endpoint_name=endpoint_name,
-        )
-
-        batch_size = 100
-        data = numpy.random.rand(batch_size, 1, 28, 28).astype(numpy.float32)
-        output = predictor.predict(data)
-
-        assert output.shape == (batch_size, 10)
-
-
 def test_deploy_model_with_serverless_inference_config(
     pytorch_training_job,
     sagemaker_session,

--- a/tests/integ/test_pytorch.py
+++ b/tests/integ/test_pytorch.py
@@ -22,10 +22,8 @@ from sagemaker.pytorch.processing import PyTorchProcessor
 from sagemaker.serverless import ServerlessInferenceConfig
 from sagemaker.utils import unique_name_from_base
 from tests.integ import (
-    test_region,
     DATA_DIR,
     TRAINING_DEFAULT_TIMEOUT_MINUTES,
-    EI_SUPPORTED_REGIONS,
 )
 from tests.integ.timeout import timeout, timeout_and_delete_endpoint_by_name
 

--- a/tests/integ/test_pytorch.py
+++ b/tests/integ/test_pytorch.py
@@ -230,6 +230,7 @@ def test_deploy_packed_model_with_entry_point_name(
 
         assert output.shape == (batch_size, 10)
 
+
 def test_deploy_model_with_serverless_inference_config(
     pytorch_training_job,
     sagemaker_session,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Remove test for deprecated feature that is blocking release.

Fails like: 

```
E           botocore.exceptions.ClientError: An error occurred (ValidationException) when calling the CreateEndpoint operation: AcceleratorType is no longer a supported feature. Please see https://aws.amazon.com/machine-learning/elastic-inference/faqs/ for more information.
```

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
