### PR TITLE
fix: JumpStart list models flaky tests

### DIFF
--- a/src/sagemaker/jumpstart/notebook_utils.py
+++ b/src/sagemaker/jumpstart/notebook_utils.py
@@ -178,7 +178,10 @@ def list_jumpstart_tasks(  # pylint: disable=redefined-builtin
     )
     tasks: Set[str] = set()
     for model_id, _ in _generate_jumpstart_model_versions(
-        filter=filter, region=region, sagemaker_session=sagemaker_session
+        filter=filter,
+        region=region,
+        sagemaker_session=sagemaker_session,
+        model_type=JumpStartModelType.OPEN_WEIGHTS,
     ):
         _, task, _ = extract_framework_task_model(model_id)
         tasks.add(task)
@@ -209,7 +212,10 @@ def list_jumpstart_frameworks(  # pylint: disable=redefined-builtin
     )
     frameworks: Set[str] = set()
     for model_id, _ in _generate_jumpstart_model_versions(
-        filter=filter, region=region, sagemaker_session=sagemaker_session
+        filter=filter,
+        region=region,
+        sagemaker_session=sagemaker_session,
+        model_type=JumpStartModelType.OPEN_WEIGHTS,
     ):
         framework, _, _ = extract_framework_task_model(model_id)
         frameworks.add(framework)
@@ -244,7 +250,10 @@ def list_jumpstart_scripts(  # pylint: disable=redefined-builtin
 
     scripts: Set[str] = set()
     for model_id, version in _generate_jumpstart_model_versions(
-        filter=filter, region=region, sagemaker_session=sagemaker_session
+        filter=filter,
+        region=region,
+        sagemaker_session=sagemaker_session,
+        model_type=JumpStartModelType.OPEN_WEIGHTS,
     ):
         scripts.add(JumpStartScriptScope.INFERENCE)
         model_specs = verify_model_region_and_return_specs(
@@ -337,6 +346,7 @@ def _generate_jumpstart_model_versions(  # pylint: disable=redefined-builtin
     region: Optional[str] = None,
     list_incomplete_models: bool = False,
     sagemaker_session: Session = DEFAULT_JUMPSTART_SAGEMAKER_SESSION,
+    model_type: Optional[JumpStartModelType] = None,
 ) -> Generator:
     """Generate models for JumpStart, and optionally apply filters to result.
 
@@ -370,12 +380,20 @@ def _generate_jumpstart_model_versions(  # pylint: disable=redefined-builtin
         s3_client=sagemaker_session.s3_client,
         model_type=JumpStartModelType.OPEN_WEIGHTS,
     )
-    models_manifest_list = open_weight_manifest_list + prop_models_manifest_list
+    models_manifest_list = (
+        open_weight_manifest_list
+        if model_type == JumpStartModelType.OPEN_WEIGHTS
+        else (
+            prop_models_manifest_list
+            if model_type == JumpStartModelType.PROPRIETARY
+            else open_weight_manifest_list + prop_models_manifest_list
+        )
+    )
 
     if isinstance(filter, str):
         filter = Identity(filter)
 
-    manifest_keys = set(models_manifest_list[0].__slots__ + prop_models_manifest_list[0].__slots__)
+    manifest_keys = set(models_manifest_list[0].__slots__)
 
     all_keys: Set[str] = set()
 

--- a/src/sagemaker/jumpstart/notebook_utils.py
+++ b/src/sagemaker/jumpstart/notebook_utils.py
@@ -393,7 +393,9 @@ def _generate_jumpstart_model_versions(  # pylint: disable=redefined-builtin
     if isinstance(filter, str):
         filter = Identity(filter)
 
-    manifest_keys = set(models_manifest_list[0].__slots__)
+    manifest_keys = set(
+        open_weight_manifest_list[0].__slots__ + prop_models_manifest_list[0].__slots__
+    )
 
     all_keys: Set[str] = set()
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This change fixes the list models flaky unittests by making sure the mocks are set up correctly.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
