### PR TITLE
fix: Distutils removal

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -310,7 +310,7 @@ ignore-mixin-members=yes
 # (useful for modules/projects where namespaces are manipulated during runtime
 # and thus existing member attributes cannot be deduced by static analysis. It
 # supports qualified module names, as well as Unix pattern matching.
-ignored-modules=distutils
+ignored-modules=
 
 # List of class names for which member attributes should not be checked (useful
 # for classes with dynamically set attributes). This supports the use of

--- a/src/sagemaker/local/image.py
+++ b/src/sagemaker/local/image.py
@@ -30,7 +30,6 @@ import sys
 import tarfile
 import tempfile
 
-from distutils.spawn import find_executable
 from threading import Thread
 from typing import Dict, List
 from six.moves.urllib.parse import urlparse
@@ -170,7 +169,7 @@ class _SageMakerContainer(object):
             compose_cmd_prefix.extend(["docker", "compose"])
             return compose_cmd_prefix
 
-        if find_executable("docker-compose") is not None:
+        if shutil.which("docker-compose") is not None:
             logger.info("'Docker Compose' found using Docker Compose CLI.")
             compose_cmd_prefix.extend(["docker-compose"])
             return compose_cmd_prefix

--- a/src/sagemaker/local/utils.py
+++ b/src/sagemaker/local/utils.py
@@ -21,7 +21,6 @@ import json
 import re
 import errno
 
-from distutils.dir_util import copy_tree
 from six.moves.urllib.parse import urlparse
 
 from sagemaker import s3
@@ -102,7 +101,7 @@ def move_to_destination(source, destination, job_name, sagemaker_session, prefix
 
 
 def recursive_copy(source, destination):
-    """A wrapper around distutils.dir_util.copy_tree.
+    """A wrapper around shutil.copy_tree.
 
     This won't throw any exception when the source directory does not exist.
 
@@ -111,7 +110,7 @@ def recursive_copy(source, destination):
         destination (str): destination path
     """
     if os.path.isdir(source):
-        copy_tree(source, destination)
+        shutil.copytree(source, destination, dirs_exist_ok=True)
 
 
 def kill_child_processes(pid):

--- a/src/sagemaker/workflow/_repack_model.py
+++ b/src/sagemaker/workflow/_repack_model.py
@@ -27,13 +27,6 @@ import tempfile
 # is unpacked for inference, the custom entry point will be used.
 # Reference: https://docs.aws.amazon.com/sagemaker/latest/dg/amazon-sagemaker-toolkits.html
 
-# distutils.dir_util.copy_tree works way better than the half-baked
-# shutil.copytree which bombs on previously existing target dirs...
-# alas ... https://bugs.python.org/issue10948
-# we'll go ahead and use the copy_tree function anyways because this
-# repacking is some short-lived hackery, right??
-from distutils.dir_util import copy_tree
-
 from os.path import abspath, realpath, dirname, normpath, join as joinpath
 
 logger = logging.getLogger(__name__)
@@ -188,7 +181,7 @@ def repack(inference_script, model_archive, dependencies=None, source_dir=None):
 
         # copy the "src" dir, which includes the previous training job's model and the
         # custom inference script, to the output of this training job
-        copy_tree(src_dir, "/opt/ml/model")
+        shutil.copytree(src_dir, "/opt/ml/model", dirs_exist_ok=True)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/data/_repack_model.py
+++ b/tests/data/_repack_model.py
@@ -26,13 +26,6 @@ import tempfile
 # is unpacked for inference, the custom entry point will be used.
 # Reference: https://docs.aws.amazon.com/sagemaker/latest/dg/amazon-sagemaker-toolkits.html
 
-# distutils.dir_util.copy_tree works way better than the half-baked
-# shutil.copytree which bombs on previously existing target dirs...
-# alas ... https://bugs.python.org/issue10948
-# we'll go ahead and use the copy_tree function anyways because this
-# repacking is some short-lived hackery, right??
-from distutils.dir_util import copy_tree
-
 
 def repack(inference_script, model_archive, dependencies=None, source_dir=None):  # pragma: no cover
     """Repack custom dependencies and code into an existing model TAR archive
@@ -92,7 +85,7 @@ def repack(inference_script, model_archive, dependencies=None, source_dir=None):
 
         # copy the "src" dir, which includes the previous training job's model and the
         # custom inference script, to the output of this training job
-        copy_tree(src_dir, "/opt/ml/model")
+        shutil.copytree(src_dir, "/opt/ml/model", dirs_exist_ok=True)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/unit/sagemaker/local/test_local_image.py
+++ b/tests/unit/sagemaker/local/test_local_image.py
@@ -160,7 +160,7 @@ def test_get_compose_cmd_prefix_with_docker_cli():
     "subprocess.check_output",
     side_effect=subprocess.CalledProcessError(returncode=1, cmd="docker compose version"),
 )
-@patch("sagemaker.local.image.find_executable", Mock(return_value="/usr/bin/docker-compose"))
+@patch("sagemaker.local.image.shutil.which", Mock(return_value="/usr/bin/docker-compose"))
 def test_get_compose_cmd_prefix_with_docker_compose_cli(check_output):
     compose_cmd_prefix = _SageMakerContainer._get_compose_cmd_prefix()
     assert compose_cmd_prefix == ["docker-compose"]
@@ -170,7 +170,7 @@ def test_get_compose_cmd_prefix_with_docker_compose_cli(check_output):
     "subprocess.check_output",
     side_effect=subprocess.CalledProcessError(returncode=1, cmd="docker compose version"),
 )
-@patch("sagemaker.local.image.find_executable", Mock(return_value=None))
+@patch("sagemaker.local.image.shutil.which", Mock(return_value=None))
 def test_get_compose_cmd_prefix_raises_import_error(check_output):
     with pytest.raises(ImportError) as e:
         _SageMakerContainer._get_compose_cmd_prefix()

--- a/tests/unit/sagemaker/local/test_local_utils.py
+++ b/tests/unit/sagemaker/local/test_local_utils.py
@@ -85,11 +85,11 @@ def test_move_to_destination_illegal_destination():
 
 
 @patch("sagemaker.local.utils.os.path")
-@patch("sagemaker.local.utils.copy_tree")
+@patch("sagemaker.local.utils.shutil.copytree")
 def test_recursive_copy(copy_tree, m_os_path):
     m_os_path.isdir.return_value = True
     sagemaker.local.utils.recursive_copy("source", "destination")
-    copy_tree.assert_called_with("source", "destination")
+    copy_tree.assert_called_with("source", "destination", dirs_exist_ok=True)
 
 
 @patch("sagemaker.local.utils.os")

--- a/tests/unit/test_chainer.py
+++ b/tests/unit/test_chainer.py
@@ -174,7 +174,15 @@ def test_additional_hyperparameters(sagemaker_session, chainer_version, chainer_
         framework_version=chainer_version,
         py_version=chainer_py_version,
     )
-    assert bool(strtobool(chainer.hyperparameters()["sagemaker_use_mpi"]))
+
+    assert chainer.hyperparameters()["sagemaker_use_mpi"].lower() in (
+        "y",
+        "yes",
+        "t",
+        "true",
+        "on",
+        "1",
+    )
     assert int(chainer.hyperparameters()["sagemaker_num_processes"]) == 4
     assert int(chainer.hyperparameters()["sagemaker_process_slots_per_host"]) == 10
     assert (

--- a/tests/unit/test_chainer.py
+++ b/tests/unit/test_chainer.py
@@ -15,7 +15,6 @@ from __future__ import absolute_import
 import logging
 import json
 import os
-from distutils.util import strtobool
 
 import pytest
 from mock import MagicMock, Mock, ANY


### PR DESCRIPTION
Closes #4534 #3028

*Issue #, if available:* #4534

*Description of changes:* Remove runtime dependency on setuptools. Remove reliance on deprecated distutils.

*Testing done:* Unit, these functions are drop in replacements now that dirs_exist_ok is a parameter in shutil.copytree.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
