### PR TITLE
fix: Remove space specific business logic from Python SDK function to fetch execution role

### DIFF
--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -5668,7 +5668,6 @@ class Session(object):  # pylint: disable=too-many-public-methods
                 instance_name = metadata.get("ResourceName")
                 domain_id = metadata.get("DomainId")
                 user_profile_name = metadata.get("UserProfileName")
-                space_name = metadata.get("SpaceName")
                 execution_role_arn = metadata.get("ExecutionRoleArn")
             try:
                 if domain_id is None:
@@ -5680,11 +5679,6 @@ class Session(object):  # pylint: disable=too-many-public-methods
                 # find execution role from the metadata file if present
                 if execution_role_arn is not None:
                     return execution_role_arn
-
-                # In Shared Space app, find execution role from DefaultSpaceSettings on domain level
-                if space_name is not None:
-                    domain_desc = self.sagemaker_client.describe_domain(DomainId=domain_id)
-                    return domain_desc["DefaultSpaceSettings"]["ExecutionRole"]
 
                 user_profile_desc = self.sagemaker_client.describe_user_profile(
                     DomainId=domain_id, UserProfileName=user_profile_name

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -725,28 +725,6 @@ def test_get_caller_identity_arn_from_metadata_file_for_space(boto_session):
 
 @patch(
     "six.moves.builtins.open",
-    mock_open(
-        read_data='{"ResourceName": "SageMakerInstance", '
-        '"DomainId": "d-kbnw5yk6tg8j", '
-        '"SpaceName": "space_name"}'
-    ),
-)
-@patch("os.path.exists", side_effect=mock_exists(NOTEBOOK_METADATA_FILE, True))
-def test_get_caller_identity_arn_from_describe_domain_for_space(boto_session):
-    sess = Session(boto_session)
-    expected_role = "arn:aws:iam::369233609183:role/service-role/SageMakerRole-20171129T072388"
-    sess.sagemaker_client.describe_domain.return_value = {
-        "DefaultSpaceSettings": {"ExecutionRole": expected_role}
-    }
-
-    actual = sess.get_caller_identity_arn()
-
-    assert actual == expected_role
-    sess.sagemaker_client.describe_domain.assert_called_once_with(DomainId="d-kbnw5yk6tg8j")
-
-
-@patch(
-    "six.moves.builtins.open",
     mock_open(read_data='{"ResourceName": "SageMakerInstance"}'),
 )
 @patch("os.path.exists", side_effect=mock_exists(NOTEBOOK_METADATA_FILE, True))


### PR DESCRIPTION
*Issue #, if available:*

SAV-1014

*Description of changes:*

*Testing done:*

Unit tests/integ tests

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
