### PR TITLE
[Fix] Switch to subprocess in ModelBuilder when capturing dependencies

### DIFF
--- a/src/sagemaker/serve/save_retrive/version_1_0_0/save/utils.py
+++ b/src/sagemaker/serve/save_retrive/version_1_0_0/save/utils.py
@@ -100,9 +100,9 @@ def capture_dependencies(requirements_path: str):
         return
 
     command = ["pigar", "gen", "-f", str(Path(requirements_path)), str(os.getcwd())]
-    logging.info("Running command: %s", ' '.join(command))
+    logging.info("Running command: %s", " ".join(command))
 
-    subprocess.run(command)
+    subprocess.run(command, check=True, capture_output=True)
     logger.info("Dependencies captured successfully")
 
 

--- a/src/sagemaker/serve/save_retrive/version_1_0_0/save/utils.py
+++ b/src/sagemaker/serve/save_retrive/version_1_0_0/save/utils.py
@@ -5,6 +5,7 @@ import hmac
 import hashlib
 import os
 import logging
+import subprocess
 import sys
 import platform
 from collections import defaultdict
@@ -98,10 +99,10 @@ def capture_dependencies(requirements_path: str):
             f.write(sagemaker_dependency)
         return
 
-    command = f"pigar gen -f {Path(requirements_path)} {os.getcwd()}"
-    logging.info("Running command %s", command)
+    command = ["pigar", "gen", "-f", str(Path(requirements_path)), str(os.getcwd())]
+    logging.info("Running command: %s", ' '.join(command))
 
-    os.system(command)
+    subprocess.run(command)
     logger.info("Dependencies captured successfully")
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Switch to subprocess in ModelBuilder when capturing dependencies

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
