### PR TITLE
feature: set default allow_pickle param to False

### DIFF
--- a/src/sagemaker/base_deserializers.py
+++ b/src/sagemaker/base_deserializers.py
@@ -230,14 +230,18 @@ class NumpyDeserializer(SimpleBaseDeserializer):
                 try:
                     return np.load(io.BytesIO(stream.read()), allow_pickle=self.allow_pickle)
                 except ValueError as ve:
-                    raise ValueError("Please set the param allow_pickle=True \
-                        to deserialize pickle objects in NumpyDeserializer").with_traceback(ve.__traceback__)
+                    raise ValueError(
+                        "Please set the param allow_pickle=True \
+                        to deserialize pickle objects in NumpyDeserializer"
+                    ).with_traceback(ve.__traceback__)
             if content_type == "application/x-npz":
                 try:
                     return np.load(io.BytesIO(stream.read()), allow_pickle=self.allow_pickle)
                 except ValueError as ve:
-                    raise ValueError("Please set the param allow_pickle=True \
-                        to deserialize pickle objectsin NumpyDeserializer").with_traceback(ve.__traceback__)
+                    raise ValueError(
+                        "Please set the param allow_pickle=True \
+                        to deserialize pickle objectsin NumpyDeserializer"
+                    ).with_traceback(ve.__traceback__)
                 finally:
                     stream.close()
         finally:

--- a/src/sagemaker/base_deserializers.py
+++ b/src/sagemaker/base_deserializers.py
@@ -196,14 +196,14 @@ class NumpyDeserializer(SimpleBaseDeserializer):
     single array.
     """
 
-    def __init__(self, dtype=None, accept="application/x-npy", allow_pickle=True):
+    def __init__(self, dtype=None, accept="application/x-npy", allow_pickle=False):
         """Initialize a ``NumpyDeserializer`` instance.
 
         Args:
             dtype (str): The dtype of the data (default: None).
             accept (union[str, tuple[str]]): The MIME type (or tuple of allowable MIME types) that
                 is expected from the inference endpoint (default: "application/x-npy").
-            allow_pickle (bool): Allow loading pickled object arrays (default: True).
+            allow_pickle (bool): Allow loading pickled object arrays (default: False).
         """
         super(NumpyDeserializer, self).__init__(accept=accept)
         self.dtype = dtype
@@ -227,10 +227,17 @@ class NumpyDeserializer(SimpleBaseDeserializer):
             if content_type == "application/json":
                 return np.array(json.load(codecs.getreader("utf-8")(stream)), dtype=self.dtype)
             if content_type == "application/x-npy":
-                return np.load(io.BytesIO(stream.read()), allow_pickle=self.allow_pickle)
+                try:
+                    return np.load(io.BytesIO(stream.read()), allow_pickle=self.allow_pickle)
+                except ValueError as  ve:
+                    error_message = "Please set the param allow_pickle=True to deserialize pickle objects" + str(ve)
+                    raise ValueError(error_message)   
             if content_type == "application/x-npz":
                 try:
                     return np.load(io.BytesIO(stream.read()), allow_pickle=self.allow_pickle)
+                except ValueError as  ve:
+                    error_message = "Please set the param allow_pickle=True to deserialize pickle objects" + str(ve)
+                    raise ValueError(error_message)   
                 finally:
                     stream.close()
         finally:

--- a/src/sagemaker/base_deserializers.py
+++ b/src/sagemaker/base_deserializers.py
@@ -229,15 +229,15 @@ class NumpyDeserializer(SimpleBaseDeserializer):
             if content_type == "application/x-npy":
                 try:
                     return np.load(io.BytesIO(stream.read()), allow_pickle=self.allow_pickle)
-                except ValueError as  ve:
-                    error_message = "Please set the param allow_pickle=True to deserialize pickle objects" + str(ve)
-                    raise ValueError(error_message)   
+                except ValueError as ve:
+                    raise ValueError("Please set the param allow_pickle=True \
+                        to deserialize pickle objects in NumpyDeserializer").with_traceback(ve.__traceback__)
             if content_type == "application/x-npz":
                 try:
                     return np.load(io.BytesIO(stream.read()), allow_pickle=self.allow_pickle)
-                except ValueError as  ve:
-                    error_message = "Please set the param allow_pickle=True to deserialize pickle objects" + str(ve)
-                    raise ValueError(error_message)   
+                except ValueError as ve:
+                    raise ValueError("Please set the param allow_pickle=True \
+                        to deserialize pickle objectsin NumpyDeserializer").with_traceback(ve.__traceback__)
                 finally:
                     stream.close()
         finally:

--- a/tests/unit/sagemaker/deserializers/test_deserializers.py
+++ b/tests/unit/sagemaker/deserializers/test_deserializers.py
@@ -142,7 +142,8 @@ def test_numpy_deserializer_from_npy(numpy_deserializer):
     assert np.array_equal(array, result)
 
 
-def test_numpy_deserializer_from_npy_object_array(numpy_deserializer):
+def test_numpy_deserializer_from_npy_object_array():
+    numpy_deserializer = NumpyDeserializer(allow_pickle=True)
     array = np.array([{"a": "", "b": ""}, {"c": "", "d": ""}])
     stream = io.BytesIO()
     np.save(stream, array)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Setting the NumpyDeserializer allow_pickle default value to False. 


All Base predictor class will now require an instantiation of the NumpyDeserializer with the allow_pickle=True explicitly
if not error message "Please set the param allow_pickle=True to deserialize pickle objects" will be thrown. 

*Testing done:*

Local testing with UTs

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
