### PR TITLE
fix: typo in jumpstart manifest and refine tests

### DIFF
--- a/src/sagemaker/jumpstart/types.py
+++ b/src/sagemaker/jumpstart/types.py
@@ -105,7 +105,7 @@ class JumpStartS3FileType(str, Enum):
 
     OPEN_WEIGHT_MANIFEST = "manifest"
     OPEN_WEIGHT_SPECS = "specs"
-    PROPRIETARY_MANIFEST = "proptietary_manifest"
+    PROPRIETARY_MANIFEST = "proprietary_manifest"
     PROPRIETARY_SPECS = "proprietary_specs"
 
 

--- a/tests/unit/sagemaker/jumpstart/constants.py
+++ b/tests/unit/sagemaker/jumpstart/constants.py
@@ -6350,6 +6350,12 @@ PROTOTYPICAL_MODEL_SPECS_DICT = {
             "py_version": "py3",
         },
         "training_artifact_key": "pytorch-training/train-pytorch-eqa-bert-base-cased.tar.gz",
+        "predictor_specs": {
+            "supported_content_types": ["application/x-image"],
+            "supported_accept_types": ["application/json;verbose", "application/json"],
+            "default_content_type": "application/x-image",
+            "default_accept_type": "application/json",
+        },
         "inference_environment_variables": [
             {
                 "name": "SAGEMAKER_PROGRAM",

--- a/tests/unit/sagemaker/jumpstart/test_utils.py
+++ b/tests/unit/sagemaker/jumpstart/test_utils.py
@@ -1291,6 +1291,11 @@ class TestIsValidModelId(TestCase):
                 model_type=JumpStartModelType.OPEN_WEIGHTS,
             )
 
+        with pytest.raises(ValueError):
+            utils.validate_model_id_and_get_type(
+                "ai21-summarization", script=JumpStartScriptScope.TRAINING
+            )
+
 
 class TestGetModelIdVersionFromResourceArn(TestCase):
     def test_no_model_id_no_version_found(self):

--- a/tests/unit/sagemaker/jumpstart/test_utils.py
+++ b/tests/unit/sagemaker/jumpstart/test_utils.py
@@ -40,7 +40,7 @@ from sagemaker.jumpstart.exceptions import (
     VulnerableJumpStartModelError,
 )
 from sagemaker.jumpstart.types import JumpStartModelHeader, JumpStartVersionedModelId
-from tests.unit.sagemaker.jumpstart.utils import get_spec_from_base_spec
+from tests.unit.sagemaker.jumpstart.utils import get_spec_from_base_spec, get_prototype_manifest
 from mock import MagicMock
 
 
@@ -1178,7 +1178,7 @@ def test_mime_type_enum_from_str():
 class TestIsValidModelId(TestCase):
     @patch("sagemaker.jumpstart.utils.accessors.JumpStartModelsAccessor._get_manifest")
     @patch("sagemaker.jumpstart.utils.accessors.JumpStartModelsAccessor.get_model_specs")
-    def test_validate_model_id_and_get_type_true(
+    def test_validate_model_id_and_get_type_open_weights(
         self,
         mock_get_model_specs: Mock,
         mock_get_manifest: Mock,
@@ -1197,11 +1197,11 @@ class TestIsValidModelId(TestCase):
         )
 
         with patch("sagemaker.jumpstart.utils.validate_model_id_and_get_type", patched):
-            self.assertTrue(utils.validate_model_id_and_get_type("bee"))
+            assert utils.validate_model_id_and_get_type("bee") == JumpStartModelType.OPEN_WEIGHTS
             mock_get_manifest.assert_called_with(
                 region=JUMPSTART_DEFAULT_REGION_NAME,
                 s3_client=mock_s3_client_value,
-                model_type=JumpStartModelType.PROPRIETARY,
+                model_type=JumpStartModelType.OPEN_WEIGHTS,
             )
             mock_get_model_specs.assert_not_called()
 
@@ -1215,25 +1215,25 @@ class TestIsValidModelId(TestCase):
             ]
 
             mock_get_model_specs.return_value = Mock(training_supported=True)
-            self.assertTrue(
+            assert (
                 utils.validate_model_id_and_get_type("bee", script=JumpStartScriptScope.TRAINING)
+                == JumpStartModelType.OPEN_WEIGHTS
             )
+
             mock_get_manifest.assert_called_with(
                 region=JUMPSTART_DEFAULT_REGION_NAME,
                 s3_client=mock_s3_client_value,
-                model_type=JumpStartModelType.PROPRIETARY,
+                model_type=JumpStartModelType.OPEN_WEIGHTS,
             )
 
     @patch("sagemaker.jumpstart.utils.accessors.JumpStartModelsAccessor._get_manifest")
     @patch("sagemaker.jumpstart.utils.accessors.JumpStartModelsAccessor.get_model_specs")
-    def test_validate_model_id_and_get_type_false(
+    def test_validate_model_id_and_get_type_invalid(
         self, mock_get_model_specs: Mock, mock_get_manifest: Mock
     ):
-        mock_get_manifest.return_value = [
-            Mock(model_id="ay"),
-            Mock(model_id="bee"),
-            Mock(model_id="see"),
-        ]
+        mock_get_manifest.side_effect = (
+            lambda region, model_type, *args, **kwargs: get_prototype_manifest(region, model_type)
+        )
 
         mock_session_value = DEFAULT_JUMPSTART_SAGEMAKER_SESSION
         mock_s3_client_value = mock_session_value.s3_client
@@ -1244,10 +1244,10 @@ class TestIsValidModelId(TestCase):
 
         with patch("sagemaker.jumpstart.utils.validate_model_id_and_get_type", patched):
 
-            self.assertFalse(utils.validate_model_id_and_get_type("dee"))
-            self.assertFalse(utils.validate_model_id_and_get_type(""))
-            self.assertFalse(utils.validate_model_id_and_get_type(None))
-            self.assertFalse(utils.validate_model_id_and_get_type(set()))
+            self.assertIsNone(utils.validate_model_id_and_get_type("dee"))
+            self.assertIsNone(utils.validate_model_id_and_get_type(""))
+            self.assertIsNone(utils.validate_model_id_and_get_type(None))
+            self.assertIsNone(utils.validate_model_id_and_get_type(set()))
 
             mock_get_manifest.assert_called()
 
@@ -1256,53 +1256,26 @@ class TestIsValidModelId(TestCase):
             mock_get_manifest.reset_mock()
             mock_get_model_specs.reset_mock()
 
-            mock_get_manifest.return_value = [
-                Mock(model_id="ay"),
-                Mock(model_id="bee"),
-                Mock(model_id="see"),
-            ]
-            self.assertFalse(
-                utils.validate_model_id_and_get_type("dee", script=JumpStartScriptScope.TRAINING)
+            assert (
+                utils.validate_model_id_and_get_type("ai21-summarization")
+                == JumpStartModelType.PROPRIETARY
             )
+            self.assertIsNone(utils.validate_model_id_and_get_type("ai21-summarization-2"))
+
             mock_get_manifest.assert_called_with(
                 region=JUMPSTART_DEFAULT_REGION_NAME,
                 s3_client=mock_s3_client_value,
                 model_type=JumpStartModelType.PROPRIETARY,
             )
 
-            mock_get_manifest.reset_mock()
-
-            self.assertFalse(
-                utils.validate_model_id_and_get_type("dee", script=JumpStartScriptScope.TRAINING)
-            )
-            self.assertFalse(
-                utils.validate_model_id_and_get_type("", script=JumpStartScriptScope.TRAINING)
-            )
-            self.assertFalse(
-                utils.validate_model_id_and_get_type(None, script=JumpStartScriptScope.TRAINING)
-            )
-            self.assertFalse(
-                utils.validate_model_id_and_get_type(set(), script=JumpStartScriptScope.TRAINING)
-            )
-
-            mock_get_model_specs.assert_not_called()
-            mock_get_manifest.assert_called_with(
-                region=JUMPSTART_DEFAULT_REGION_NAME,
-                s3_client=mock_s3_client_value,
-                model_type=JumpStartModelType.PROPRIETARY,
-            )
-
-            mock_get_manifest.reset_mock()
-            mock_get_model_specs.reset_mock()
-
-            mock_get_model_specs.return_value = Mock(training_supported=False)
-            self.assertTrue(
-                utils.validate_model_id_and_get_type("ay", script=JumpStartScriptScope.TRAINING)
+            assert (
+                utils.validate_model_id_and_get_type("pytorch-eqa-bert-base-cased")
+                == JumpStartModelType.OPEN_WEIGHTS
             )
             mock_get_manifest.assert_called_with(
                 region=JUMPSTART_DEFAULT_REGION_NAME,
                 s3_client=mock_s3_client_value,
-                model_type=JumpStartModelType.PROPRIETARY,
+                model_type=JumpStartModelType.OPEN_WEIGHTS,
             )
 
 

--- a/tests/unit/sagemaker/jumpstart/test_utils.py
+++ b/tests/unit/sagemaker/jumpstart/test_utils.py
@@ -1267,7 +1267,7 @@ class TestIsValidModelId(TestCase):
                 s3_client=mock_s3_client_value,
                 model_type=JumpStartModelType.PROPRIETARY,
             )
-            
+
             self.assertIsNone(
                 utils.validate_model_id_and_get_type("dee", script=JumpStartScriptScope.TRAINING)
             )

--- a/tests/unit/sagemaker/jumpstart/test_utils.py
+++ b/tests/unit/sagemaker/jumpstart/test_utils.py
@@ -1267,6 +1267,19 @@ class TestIsValidModelId(TestCase):
                 s3_client=mock_s3_client_value,
                 model_type=JumpStartModelType.PROPRIETARY,
             )
+            
+            self.assertIsNone(
+                utils.validate_model_id_and_get_type("dee", script=JumpStartScriptScope.TRAINING)
+            )
+            self.assertIsNone(
+                utils.validate_model_id_and_get_type("", script=JumpStartScriptScope.TRAINING)
+            )
+            self.assertIsNone(
+                utils.validate_model_id_and_get_type(None, script=JumpStartScriptScope.TRAINING)
+            )
+            self.assertIsNone(
+                utils.validate_model_id_and_get_type(set(), script=JumpStartScriptScope.TRAINING)
+            )
 
             assert (
                 utils.validate_model_id_and_get_type("pytorch-eqa-bert-base-cased")

--- a/tests/unit/sagemaker/jumpstart/test_utils.py
+++ b/tests/unit/sagemaker/jumpstart/test_utils.py
@@ -1215,6 +1215,11 @@ class TestIsValidModelId(TestCase):
             ]
 
             mock_get_model_specs.return_value = Mock(training_supported=True)
+            self.assertIsNone(
+                utils.validate_model_id_and_get_type(
+                    "invalid", script=JumpStartScriptScope.TRAINING
+                )
+            )
             assert (
                 utils.validate_model_id_and_get_type("bee", script=JumpStartScriptScope.TRAINING)
                 == JumpStartModelType.OPEN_WEIGHTS


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fixes a typo in JumpStart manifest enum, and refine the logic to retrieve manifest files.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
