### PR TITLE
feature: Changes to support remote schema retrieval for task types (question-answering, fill-mask) and added e2e tests for both local and remote hf schema logic. 

### DIFF
--- a/requirements/extras/huggingface_requirements.txt
+++ b/requirements/extras/huggingface_requirements.txt
@@ -1,2 +1,2 @@
 accelerate>=0.24.1,<=0.27.0
-sagemaker_schema_inference_artifacts>=0.0.2
+sagemaker_schema_inference_artifacts>=0.0.5

--- a/requirements/extras/huggingface_requirements.txt
+++ b/requirements/extras/huggingface_requirements.txt
@@ -1,1 +1,2 @@
 accelerate>=0.24.1,<=0.27.0
+sagemaker_schema_inference_artifacts>=0.0.2

--- a/src/sagemaker/base_serializers.py
+++ b/src/sagemaker/base_serializers.py
@@ -397,6 +397,8 @@ class DataSerializer(SimpleBaseSerializer):
                 raise ValueError(f"Could not open/read file: {data}. {e}")
         if isinstance(data, bytes):
             return data
+        if isinstance(data, dict) and "data" in data:
+            return self.serialize(data["data"])
 
         raise ValueError(f"Object of type {type(data)} is not Data serializable.")
 

--- a/src/sagemaker/serve/builder/model_builder.py
+++ b/src/sagemaker/serve/builder/model_builder.py
@@ -64,6 +64,7 @@ from sagemaker.serve.validations.check_image_and_hardware_type import (
 )
 from sagemaker.workflow.entities import PipelineVariable
 from sagemaker.huggingface.llm_utils import get_huggingface_model_metadata
+from sagemaker_schema_inference_artifacts.huggingface import remote_schema_retriever
 
 logger = logging.getLogger(__name__)
 
@@ -637,7 +638,7 @@ class ModelBuilder(Triton, DJL, JumpStart, TGI, Transformers):
                 if model_task is None:
                     model_task = hf_model_md.get("pipeline_tag")
                 if self.schema_builder is None and model_task is not None:
-                    self._schema_builder_init(model_task)
+                    self._hf_schema_builder_init(model_task)
                 if model_task == "text-generation":  # pylint: disable=R1705
                     return self._build_for_tgi()
                 elif self._can_fit_on_single_gpu():
@@ -704,8 +705,8 @@ class ModelBuilder(Triton, DJL, JumpStart, TGI, Transformers):
 
         return get_metadata(model_dir)
 
-    def _schema_builder_init(self, model_task: str):
-        """Initialize the schema builder
+    def _hf_schema_builder_init(self, model_task: str):
+        """Initialize the schema builder for the given HF_TASK
 
         Args:
             model_task (str): Required, the task name
@@ -714,10 +715,16 @@ class ModelBuilder(Triton, DJL, JumpStart, TGI, Transformers):
             TaskNotFoundException: If the I/O schema for the given task is not found.
         """
         try:
-            sample_inputs, sample_outputs = task.retrieve_local_schemas(model_task)
+            try:
+                sample_inputs, sample_outputs = task.retrieve_local_schemas(model_task)
+            except ValueError:
+                # samples could not be loaded locally, try to fetch it from sagemaker_schema_inference_artifacts
+                remote_hf_schema_helper = remote_schema_retriever.RemoteSchemaRetriever()
+                sample_inputs, sample_outputs = remote_hf_schema_helper.get_resolved_hf_schema_for_task(model_task)
             self.schema_builder = SchemaBuilder(sample_inputs, sample_outputs)
         except ValueError:
-            raise TaskNotFoundException(f"Schema builder for {model_task} could not be found.")
+            raise TaskNotFoundException(f"HuggingFace Schema builder samples for {model_task} could not be found "
+                                        f"locally or via remote.")
 
     def _can_fit_on_single_gpu(self) -> Type[bool]:
         """Check if model can fit on a single GPU

--- a/src/sagemaker/serve/builder/schema_builder.py
+++ b/src/sagemaker/serve/builder/schema_builder.py
@@ -164,6 +164,15 @@ class SchemaBuilder(TritonSchemaBuilder):
             return StringSerializer()
         if _is_jsonable(obj):
             return JSONSerializerWrapper()
+        if isinstance(obj, dict) and "content_type" in obj:
+            try:
+                return DataSerializer(content_type=obj["content_type"])
+            except ValueError as e:
+                logger.error(
+                    "Unable to determine serializer for content_type %s."
+                    % obj['content_type']
+                )
+                logger.error(e)
 
         raise ValueError(
             (

--- a/src/sagemaker/serve/schema/task.json
+++ b/src/sagemaker/serve/schema/task.json
@@ -1,38 +1,4 @@
 {
-	"fill-mask": {
-		"sample_inputs": {
-			"properties": {
-				"inputs": "Paris is the [MASK] of France.",
-				"parameters": {}
-			}
-		},
-		"sample_outputs": {
-			"properties": [
-				{
-					"sequence": "Paris is the capital of France.",
-					"score": 0.7
-				}
-			]
-		}
-	},
-	"question-answering": {
-		"sample_inputs": {
-			"properties": {
-				"context": "I have a German Shepherd dog, named Coco.",
-				"question": "What is my dog's breed?"
-			}
-		},
-		"sample_outputs": {
-			"properties": [
-				{
-					"answer": "German Shepherd",
-					"score": 0.972,
-					"start": 9,
-					"end": 24
-				}
-			]
-		}
-	},
 	"text-classification": {
 		"sample_inputs": {
 			"properties": {

--- a/tests/unit/sagemaker/serve/builder/test_model_builder.py
+++ b/tests/unit/sagemaker/serve/builder/test_model_builder.py
@@ -1062,7 +1062,7 @@ class TestModelBuilder(unittest.TestCase):
 
         # HF Pipeline Tag
         mock_model_uris_retrieve.side_effect = KeyError
-        mock_llm_utils_json.load.return_value = {"pipeline_tag": "text-to-image"}
+        mock_llm_utils_json.load.return_value = {"pipeline_tag": "unsupported-task"}
         mock_llm_utils_urllib.request.Request.side_effect = Mock()
 
         # HF Model config
@@ -1075,7 +1075,8 @@ class TestModelBuilder(unittest.TestCase):
 
         self.assertRaisesRegex(
             TaskNotFoundException,
-            "Error Message: Schema builder for text-to-image could not be found.",
+            "Error Message: HuggingFace Schema builder samples for unsupported-task could not be found locally or via "
+            "remote.",
             lambda: model_builder.build(sagemaker_session=mock_session),
         )
 
@@ -1627,7 +1628,8 @@ class TestModelBuilder(unittest.TestCase):
 
             self.assertRaisesRegex(
                 TaskNotFoundException,
-                f"Error Message: Schema builder for {provided_task} could not be found.",
+                f"Error Message: HuggingFace Schema builder samples for {provided_task} could not be found locally or "
+                f"via remote.",
                 lambda: model_builder.build(sagemaker_session=mock_session),
             )
 

--- a/tests/unit/sagemaker/serve/utils/test_task.py
+++ b/tests/unit/sagemaker/serve/utils/test_task.py
@@ -18,23 +18,29 @@ import pytest
 
 from sagemaker.serve.utils import task
 
-EXPECTED_INPUTS = {"inputs": "Paris is the [MASK] of France.", "parameters": {}}
-EXPECTED_OUTPUTS = [{"sequence": "Paris is the capital of France.", "score": 0.7}]
 HF_INVALID_TASK = "not-present-task"
-
-
-def test_retrieve_local_schemas_success():
-    inputs, outputs = task.retrieve_local_schemas("fill-mask")
-
-    assert inputs == EXPECTED_INPUTS
-    assert outputs == EXPECTED_OUTPUTS
 
 
 def test_retrieve_local_schemas_text_generation_success():
     inputs, outputs = task.retrieve_local_schemas("text-generation")
 
-    assert inputs is not None
-    assert outputs is not None
+    assert inputs == {"inputs": "Hello, I'm a language model", "parameters": {}}
+    assert outputs == [
+        {
+            "generated_text": "Hello, I'm a language modeler. So while writing this, when I went out to "
+            "meet my wife or come home she told me that my"
+        }
+    ]
+
+
+def test_retrieve_local_schemas_text_classification_success():
+    inputs, outputs = task.retrieve_local_schemas("text-classification")
+
+    assert inputs == {
+        "inputs": "Where is the capital of France?, Paris is the capital of France.",
+        "parameters": {},
+    }
+    assert outputs == [{"label": "entailment", "score": 0.997}]
 
 
 def test_retrieve_local_schemas_throws():


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

*Testing done:*


tox -e py310 -- -v -s tests/integ/sagemaker/serve/test_schema_builder.py::test_model_builder_happy_path_with_task_provided_remote_schema_mode
[Output](https://paste.amazon.com/show/shailav/1712252727) 


tox -e py310 -- -v -s tests/unit/sagemaker/serve/builder/test_model_builder.py
[Output](https://paste.amazon.com/show/shailav/1712253071)

tox -e py310 -- -v -s tests/unit/sagemaker/serve/utils/test_task.py
[Output](https://paste.amazon.com/show/shailav/1712253462)

tox -e py310 -- -v -s tests/integ/sagemaker/serve/test_schema_builder.py::test_model_builder_happy_path_with_task_provided_local_schema_mode
[Output](https://paste.amazon.com/show/shailav/1712259866)

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
