### PR TITLE
fix: remove trailing slash when uploading to S3 with dataset_builder.to_csv_file

### DIFF
--- a/src/sagemaker/feature_store/dataset_builder.py
+++ b/src/sagemaker/feature_store/dataset_builder.py
@@ -427,7 +427,7 @@ class DatasetBuilder:
         if isinstance(self._base, pd.DataFrame):
             temp_id = utils.unique_name_from_base("dataframe-base")
             local_file_name = f"{temp_id}.csv"
-            desired_s3_folder = f"{self._output_path}/{temp_id}"
+            desired_s3_folder = os.path.join(self._output_path, temp_id)
             self._base.to_csv(local_file_name, index=False, header=False)
             s3.S3Uploader.upload(
                 local_path=local_file_name,


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/sagemaker-python-sdk/issues/4569

*Description of changes:* Use `rstrip` to remove trailing slash when uploading the temp file to s3 during dataset creation.

*Testing done:* Installed the modified version and ran the code that was previously failing

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
