### PR TITLE
Flaky test

### DIFF
--- a/tests/integ/sagemaker/serve/test_serve_js_happy.py
+++ b/tests/integ/sagemaker/serve/test_serve_js_happy.py
@@ -31,7 +31,7 @@ SAMPLE_PROMPT = {"inputs": "Hello, I'm a language model,", "parameters": {}}
 SAMPLE_RESPONSE = [
     {"generated_text": "Hello, I'm a language model, and I'm here to help you with your English."}
 ]
-JS_GATED_MODEL_ID = "meta-textgeneration-llama-2-7b-f"
+JS_MODEL_ID = "huggingface-textgeneration1-gpt-neo-125m-fp16"
 ROLE_NAME = "SageMakerRole"
 
 
@@ -39,7 +39,7 @@ ROLE_NAME = "SageMakerRole"
 def happy_model_builder(sagemaker_session):
     iam_client = sagemaker_session.boto_session.client("iam")
     return ModelBuilder(
-        model=JS_GATED_MODEL_ID,
+        model=JS_MODEL_ID,
         schema_builder=SchemaBuilder(SAMPLE_PROMPT, SAMPLE_RESPONSE),
         role_arn=iam_client.get_role(RoleName=ROLE_NAME)["Role"]["Arn"],
         sagemaker_session=sagemaker_session,
@@ -59,9 +59,7 @@ def test_happy_tgi_sagemaker_endpoint(happy_model_builder, gpu_instance_type):
     with timeout(minutes=SERVE_SAGEMAKER_ENDPOINT_TIMEOUT):
         try:
             logger.info("Deploying and predicting in SAGEMAKER_ENDPOINT mode...")
-            predictor = model.deploy(
-                instance_type=gpu_instance_type, endpoint_logging=False, accept_eula=True
-            )
+            predictor = model.deploy(instance_type=gpu_instance_type, endpoint_logging=False)
             logger.info("Endpoint successfully deployed.")
 
             updated_sample_input = happy_model_builder.schema_builder.sample_input


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
ModelBuilder JS Gated model test failed because container failed to start, see below error.

```
torch.cuda.OutOfMemoryError: CUDA out of memory. 
Tried to allocate 172.00 MiB. GPU 0 has a total capacty of 
15.78 GiB of which 37.75 MiB is free. Process 11089 has 15.74 GiB memory in use. Of the allocated memory 14.06 GiB is allocated by PyTorch, and 470.23 MiB is reserved by PyTorch but unallocated.
 If reserved but unallocated memory is large try setting max_split_size_mb to avoid fragmentation.  See documentation for Memory Management and PYTORCH_CUDA_ALLOC_CONF
```

Revert to using stable JS non-gated model to unblock. 

*Testing done:*
tox -e py39 -- tests/integ/sagemaker/serve/test_serve_js_happy.py

```
===================================================================================== 1 passed, 1 warning in 401.77s (0:06:41) =====================================================================================
.pkg: _exit> python /Users/makung/Documents/github/sagemaker-python-sdk/venv/lib/python3.9/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
  py39: OK (418.62=setup[4.99]+cmd[0.04,3.06,1.71,1.65,2.89,404.28] seconds)
  congratulations :) (418.78 seconds)
```

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
