### PR TITLE
Documentation: Add supported task types to schema builder omission

### DIFF
--- a/src/sagemaker/serve/builder/model_builder.py
+++ b/src/sagemaker/serve/builder/model_builder.py
@@ -143,7 +143,7 @@ class ModelBuilder(Triton, DJL, JumpStart, TGI, Transformers):
             automatically with the specified input and output.
             The schema builder can be omitted for HuggingFace models with task types TextGeneration,
             TextClassification, and QuestionAnswering. Omitting SchemaBuilder is in
-            beta for FillMask, and  AutomaticSpeechRecognition use-cases.
+            beta for FillMask, and AutomaticSpeechRecognition use-cases.
         model (Optional[Union[object, str]): Model object (with ``predict`` method to perform
             inference) or a HuggingFace/JumpStart Model ID. Either ``model`` or ``inference_spec``
             is required for the model builder to build the artifact.

--- a/src/sagemaker/serve/builder/model_builder.py
+++ b/src/sagemaker/serve/builder/model_builder.py
@@ -141,6 +141,9 @@ class ModelBuilder(Triton, DJL, JumpStart, TGI, Transformers):
             The schema builder translates the input into bytes and converts the response
             into a stream. All translations between the server and the client are handled
             automatically with the specified input and output.
+            The schema builder can be omitted for HuggingFace models with task types TextGeneration,
+            TextClassification, and QuestionAnswering. Omitting SchemaBuilder is in
+            beta for FillMask, and  AutomaticSpeechRecognition use-cases.
         model (Optional[Union[object, str]): Model object (with ``predict`` method to perform
             inference) or a HuggingFace/JumpStart Model ID. Either ``model`` or ``inference_spec``
             is required for the model builder to build the artifact.
@@ -164,10 +167,11 @@ class ModelBuilder(Triton, DJL, JumpStart, TGI, Transformers):
             ``TORCHSERVE``, ``MMS``, ``TENSORFLOW_SERVING``, ``DJL_SERVING``,
             ``TRITON``, and``TGI``.
         model_metadata (Optional[Dict[str, Any]): Dictionary used to override model metadata.
-            Currently, ``HF_TASK`` is overridable for HuggingFace model. ``MLFLOW_MODEL_PATH``
-            is available for providing local path or s3 path to MLflow artifacts. However,
-            ``MLFLOW_MODEL_PATH`` is experimental and is not intended for production use
-            at this moment.
+            Currently, ``HF_TASK`` is overridable for HuggingFace model. HF_TASK should be set for
+            new models without task metadata in the Hub, adding unsupported task types will throw
+            an exception. ``MLFLOW_MODEL_PATH`` is available for providing local path or s3 path
+            to MLflow artifacts. However, ``MLFLOW_MODEL_PATH`` is experimental and is not
+            intended for production use at this moment.
     """
 
     model_path: Optional[str] = field(
@@ -268,7 +272,8 @@ class ModelBuilder(Triton, DJL, JumpStart, TGI, Transformers):
         default=None,
         metadata={
             "help": "Define the model metadata to override, currently supports `HF_TASK`, "
-            "`MLFLOW_MODEL_PATH`"
+            "`MLFLOW_MODEL_PATH`. HF_TASK should be set for new models without task metadata in "
+                    "the Hub, Adding unsupported task types will throw an exception"
         },
     )
 

--- a/src/sagemaker/serve/builder/model_builder.py
+++ b/src/sagemaker/serve/builder/model_builder.py
@@ -273,7 +273,7 @@ class ModelBuilder(Triton, DJL, JumpStart, TGI, Transformers):
         metadata={
             "help": "Define the model metadata to override, currently supports `HF_TASK`, "
             "`MLFLOW_MODEL_PATH`. HF_TASK should be set for new models without task metadata in "
-                    "the Hub, Adding unsupported task types will throw an exception"
+            "the Hub, Adding unsupported task types will throw an exception"
         },
     )
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add supported hugging face task types for schema builder omission/automatic inference in the ModelBuilder interface. 

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [X] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [X] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [X] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [X] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [X] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [X] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [X] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [X] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [X] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
