### PR TITLE
fix: Add back serialization for automatic speech recognition

### DIFF
--- a/src/sagemaker/base_serializers.py
+++ b/src/sagemaker/base_serializers.py
@@ -397,6 +397,8 @@ class DataSerializer(SimpleBaseSerializer):
                 raise ValueError(f"Could not open/read file: {data}. {e}")
         if isinstance(data, bytes):
             return data
+        if isinstance(data, dict) and "data" in data:
+            return self.serialize(data["data"])
 
         raise ValueError(f"Object of type {type(data)} is not Data serializable.")
 

--- a/src/sagemaker/serve/builder/schema_builder.py
+++ b/src/sagemaker/serve/builder/schema_builder.py
@@ -164,6 +164,11 @@ class SchemaBuilder(TritonSchemaBuilder):
             return StringSerializer()
         if _is_jsonable(obj):
             return JSONSerializerWrapper()
+        if isinstance(obj, dict) and "content_type" in obj:
+            try:
+                return DataSerializer(content_type=obj["content_type"])
+            except ValueError as e:
+                logger.error(e)
 
         raise ValueError(
             (

--- a/src/sagemaker/serve/builder/transformers_builder.py
+++ b/src/sagemaker/serve/builder/transformers_builder.py
@@ -94,7 +94,7 @@ class Transformers(ABC):
         )
         hf_config = image_uris.config_for_framework("huggingface").get("inference")
         config = hf_config["versions"]
-        base_hf_version = sorted(config.keys(), key=lambda v: Version(v))[0]
+        base_hf_version = sorted(config.keys(), key=lambda v: Version(v), reverse=True)[0]
 
         if hf_model_md is None:
             raise ValueError("Could not fetch HF metadata")
@@ -269,7 +269,7 @@ class Transformers(ABC):
                 if len(hugging_face_version.split(".")) == 2:
                     base_fw_version = ".".join(base_fw_version.split(".")[:-1])
                 versions_to_return.append(base_fw_version)
-        return sorted(versions_to_return)[0]
+        return sorted(versions_to_return, reverse=True)[0]
 
     def _build_for_transformers(self):
         """Method that triggers model build

--- a/tests/integ/sagemaker/serve/test_schema_builder.py
+++ b/tests/integ/sagemaker/serve/test_schema_builder.py
@@ -153,6 +153,7 @@ def test_model_builder_happy_path_with_task_provided_local_schema_mode(
             "ml.m5.xlarge",
         ),
         ("deepset/roberta-base-squad2", "question-answering", "ml.m5.xlarge"),
+        ("openai/whisper-large-v3", "automatic-speech-recognition", "ml.m5.xlarge")
     ],
 )
 def test_model_builder_happy_path_with_task_provided_remote_schema_mode(

--- a/tests/integ/sagemaker/serve/test_schema_builder.py
+++ b/tests/integ/sagemaker/serve/test_schema_builder.py
@@ -152,7 +152,7 @@ def test_model_builder_happy_path_with_task_provided_local_schema_mode(
             "question-answering",
             "ml.m5.xlarge",
         ),
-        ("deepset/roberta-base-squad2", "question-answering", "ml.m5.xlarge")
+        ("deepset/roberta-base-squad2", "question-answering", "ml.m5.xlarge"),
     ],
 )
 def test_model_builder_happy_path_with_task_provided_remote_schema_mode(
@@ -208,12 +208,10 @@ def test_model_builder_happy_path_with_task_provided_remote_schema_mode(
 )
 @pytest.mark.parametrize(
     "model_id, task_provided, instance_type_provided",
-    [
-        ("openai/whisper-large-v3", "automatic-speech-recognition", "ml.m5.xlarge")
-    ],
+    [("openai/whisper-large-v3", "automatic-speech-recognition", "ml.m5.xlarge")],
 )
 def test_model_builder_happy_path_with_task_provided_remote_schema_mode_asr(
-        model_id, task_provided, sagemaker_session, instance_type_provided
+    model_id, task_provided, sagemaker_session, instance_type_provided
 ):
     model_builder = ModelBuilder(
         model=model_id,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add back automatic speech recognition task serialization (This feature is in BETA). Ensure latest version of transformers is picked in transformers builder. This allows the latest whisper models to be detected.

E.g.
`Detected 763104351884.dkr.ecr.us-west-2.amazonaws.com/huggingface-pytorch-inference:2.1.0-transformers4.37.0-cpu-py310-ubuntu22.04. Proceeding with the the deployment.`

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [X] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [X] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [X] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [X] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [X] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [X] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [X] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [X] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [X] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
