### PR TITLE
change: bump djl-inference 0.27.0 neuronx sdk to 2.18.1

### DIFF
--- a/src/sagemaker/image_uri_config/djl-neuronx.json
+++ b/src/sagemaker/image_uri_config/djl-neuronx.json
@@ -19,7 +19,7 @@
                 "ca-west-1": "204538143572"
             },
             "repository": "djl-inference",
-            "tag_prefix": "0.27.0-neuronx-sdk2.18.0"
+            "tag_prefix": "0.27.0-neuronx-sdk2.18.1"
         },
          "0.26.0": {
             "registries": {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This is updating our latest version in image_uri_config, so while our users retrieve the image using the latest version in sagemaker-python-sdk, it would work.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
