### PR TITLE
ModelBuilder: Add functionalities to get and set deployment config.

### DIFF
--- a/src/sagemaker/jumpstart/model.py
+++ b/src/sagemaker/jumpstart/model.py
@@ -446,7 +446,7 @@ class JumpStartModel(Model):
         """The deployment config that will be applied to the model.
 
         Returns:
-            Union[Dict[str, Any], None]: Deployment config that will be applied to the model.
+            Optional[Dict[str, Any]]: Deployment config that will be applied to the model.
         """
         return self._retrieve_selected_deployment_config(self.config_name)
 

--- a/src/sagemaker/jumpstart/model.py
+++ b/src/sagemaker/jumpstart/model.py
@@ -15,7 +15,7 @@
 from __future__ import absolute_import
 
 from functools import lru_cache
-from typing import Dict, List, Optional, Union, Any
+from typing import Dict, List, Optional, Any, Union
 import pandas as pd
 from botocore.exceptions import ClientError
 
@@ -442,7 +442,7 @@ class JumpStartModel(Model):
         )
 
     @property
-    def deployment_config(self) -> Union[Dict[str, Any], None]:
+    def deployment_config(self) -> Optional[Dict[str, Any]]:
         """The deployment config to apply to the model.
 
         Returns:
@@ -859,7 +859,7 @@ class JumpStartModel(Model):
 
         return model_package
 
-    @lru_cache(typed=True)
+    @lru_cache
     def _get_benchmarks_data(self, config_name: str) -> Dict[str, List[str]]:
         """Constructs deployment configs benchmark data.
 
@@ -873,8 +873,8 @@ class JumpStartModel(Model):
             config_name,
         )
 
-    @lru_cache(typed=True)
-    def _retrieve_selected_deployment_config(self, config_name: str) -> Union[Dict[str, Any], None]:
+    @lru_cache
+    def _retrieve_selected_deployment_config(self, config_name: str) -> Optional[Dict[str, Any]]:
         """Retrieve the deployment config to apply to the model.
 
         Args:

--- a/src/sagemaker/jumpstart/model.py
+++ b/src/sagemaker/jumpstart/model.py
@@ -442,13 +442,22 @@ class JumpStartModel(Model):
         )
 
     @property
+    def deployment_config(self) -> Union[Dict[str, Any], None]:
+        """The deployment config to apply to the model.
+
+        Returns:
+            Union[Dict[str, Any], None]: Deployment config to apply to this model.
+        """
+        return self._retrieve_selected_deployment_config(self.config_name)
+
+    @property
     def benchmark_metrics(self) -> pd.DataFrame:
         """Benchmark Metrics for deployment configs
 
         Returns:
             Metrics: Pandas DataFrame object.
         """
-        return pd.DataFrame(self._get_benchmark_data(self.config_name))
+        return pd.DataFrame(self._get_benchmarks_data(self.config_name))
 
     def display_benchmark_metrics(self) -> None:
         """Display Benchmark Metrics for deployment configs."""
@@ -850,8 +859,8 @@ class JumpStartModel(Model):
 
         return model_package
 
-    @lru_cache
-    def _get_benchmark_data(self, config_name: str) -> Dict[str, List[str]]:
+    @lru_cache(typed=True)
+    def _get_benchmarks_data(self, config_name: str) -> Dict[str, List[str]]:
         """Constructs deployment configs benchmark data.
 
         Args:
@@ -863,6 +872,23 @@ class JumpStartModel(Model):
             self._deployment_configs,
             config_name,
         )
+
+    @lru_cache(typed=True)
+    def _retrieve_selected_deployment_config(self, config_name: str) -> Union[Dict[str, Any], None]:
+        """Retrieve the deployment config to apply to the model.
+
+        Args:
+            config_name (str): The name of the selected deployment config.
+        Returns:
+            Union[Dict[str, Any], None]: The deployment config to apply to the model.
+        """
+        if config_name is None:
+            return None
+
+        for deployment_config in self._deployment_configs:
+            if deployment_config.get("ConfigName") == config_name:
+                return deployment_config
+        return None
 
     def _convert_to_deployment_config_metadata(
         self, config_name: str, metadata_config: JumpStartMetadataConfig

--- a/src/sagemaker/jumpstart/model.py
+++ b/src/sagemaker/jumpstart/model.py
@@ -886,7 +886,7 @@ class JumpStartModel(Model):
             return None
 
         for deployment_config in self._deployment_configs:
-            if deployment_config.get("ConfigName") == config_name:
+            if deployment_config.get("DeploymentConfigName") == config_name:
                 return deployment_config
         return None
 

--- a/src/sagemaker/jumpstart/model.py
+++ b/src/sagemaker/jumpstart/model.py
@@ -443,10 +443,10 @@ class JumpStartModel(Model):
 
     @property
     def deployment_config(self) -> Optional[Dict[str, Any]]:
-        """The deployment config to apply to the model.
+        """The deployment config that will be applied to the model.
 
         Returns:
-            Union[Dict[str, Any], None]: Deployment config to apply to this model.
+            Union[Dict[str, Any], None]: Deployment config that will be applied to the model.
         """
         return self._retrieve_selected_deployment_config(self.config_name)
 
@@ -861,7 +861,7 @@ class JumpStartModel(Model):
 
     @lru_cache
     def _get_benchmarks_data(self, config_name: str) -> Dict[str, List[str]]:
-        """Constructs deployment configs benchmark data.
+        """Deployment configs benchmark metrics.
 
         Args:
             config_name (str): The name of the selected deployment config.
@@ -878,9 +878,9 @@ class JumpStartModel(Model):
         """Retrieve the deployment config to apply to the model.
 
         Args:
-            config_name (str): The name of the selected deployment config.
+            config_name (str): The name of the deployment config to retrieve.
         Returns:
-            Union[Dict[str, Any], None]: The deployment config to apply to the model.
+            Optional[Dict[str, Any]]: The retrieved deployment config.
         """
         if config_name is None:
             return None

--- a/src/sagemaker/jumpstart/types.py
+++ b/src/sagemaker/jumpstart/types.py
@@ -2286,7 +2286,6 @@ class DeploymentConfigMetadata(BaseDeploymentConfigDataHolder):
     """Dataclass representing a Deployment Config Metadata"""
 
     __slots__ = [
-        "version",
         "deployment_config_name",
         "deployment_args",
         "acceleration_configs",
@@ -2301,7 +2300,6 @@ class DeploymentConfigMetadata(BaseDeploymentConfigDataHolder):
         deploy_kwargs: JumpStartModelDeployKwargs,
     ):
         """Instantiates DeploymentConfigMetadata object."""
-        self.version = "1.0.0"
         self.deployment_config_name = config_name
         self.deployment_args = DeploymentArgs(init_kwargs, deploy_kwargs)
         self.acceleration_configs = None

--- a/src/sagemaker/jumpstart/types.py
+++ b/src/sagemaker/jumpstart/types.py
@@ -2249,17 +2249,17 @@ class BaseDeploymentConfigDataHolder(JumpStartDataHolderType):
         return json_obj
 
 
-class DeploymentConfig(BaseDeploymentConfigDataHolder):
+class DeploymentArgs(BaseDeploymentConfigDataHolder):
     """Dataclass representing a Deployment Config."""
 
     __slots__ = [
-        "model_data_download_timeout",
-        "container_startup_health_check_timeout",
         "image_uri",
         "model_data",
-        "instance_type",
         "environment",
+        "instance_type",
         "compute_resource_requirements",
+        "model_data_download_timeout",
+        "container_startup_health_check_timeout",
     ]
 
     def __init__(
@@ -2286,9 +2286,11 @@ class DeploymentConfigMetadata(BaseDeploymentConfigDataHolder):
     """Dataclass representing a Deployment Config Metadata"""
 
     __slots__ = [
-        "config_name",
+        "version",
+        "deployment_config_name",
+        "deployment_args",
+        "acceleration_configs",
         "benchmark_metrics",
-        "deployment_config",
     ]
 
     def __init__(
@@ -2299,6 +2301,8 @@ class DeploymentConfigMetadata(BaseDeploymentConfigDataHolder):
         deploy_kwargs: JumpStartModelDeployKwargs,
     ):
         """Instantiates DeploymentConfigMetadata object."""
-        self.config_name = config_name
+        self.version = "1.0.0"
+        self.deployment_config_name = config_name
+        self.deployment_args = DeploymentArgs(init_kwargs, deploy_kwargs)
+        self.acceleration_configs = None
         self.benchmark_metrics = benchmark_metrics
-        self.deployment_config = DeploymentConfig(init_kwargs, deploy_kwargs)

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -1011,23 +1011,39 @@ def extract_metrics_from_deployment_configs(
         config_name (str): The name of the deployment config use by the model.
     """
 
-    data = {"Config Name": [], "Instance Type": [], "Selected": []}
+    data = {"Config Name": [], "Instance Type": [], "Selected": [], "Accelerated": []}
 
     for index, deployment_config in enumerate(deployment_configs):
-        if deployment_config.get("DeploymentConfig") is None:
+        if deployment_config.get("DeploymentArgs") is None:
             continue
 
         benchmark_metrics = deployment_config.get("BenchmarkMetrics")
         if benchmark_metrics is not None:
-            data["Config Name"].append(deployment_config.get("ConfigName"))
+            data["Config Name"].append(deployment_config.get("DeploymentConfigName"))
             data["Instance Type"].append(
-                deployment_config.get("DeploymentConfig").get("InstanceType")
+                deployment_config.get("DeploymentArgs").get("InstanceType")
             )
             data["Selected"].append(
                 "Yes"
-                if (config_name is not None and config_name == deployment_config.get("ConfigName"))
+                if (
+                    config_name is not None
+                    and config_name == deployment_config.get("DeploymentConfigName")
+                )
                 else "No"
             )
+
+            accelerated_configs = deployment_config.get("AccelerationConfigs")
+            if accelerated_configs is None:
+                data["Accelerated"].append("No")
+            else:
+                data["Accelerated"].append(
+                    "Yes"
+                    if (
+                        len(accelerated_configs) > 0
+                        and accelerated_configs[0].get("Enabled", False)
+                    )
+                    else "No"
+                )
 
             if index == 0:
                 for benchmark_metric in benchmark_metrics:

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -1084,4 +1084,6 @@ def extract_metrics_from_deployment_configs(
                 if column_name in data.keys():
                     data[column_name].append(benchmark_metric.get("value"))
 
+    if "Yes" not in data["Accelerated"]:
+        del data["Accelerated"]
     return data

--- a/src/sagemaker/serve/builder/jumpstart_builder.py
+++ b/src/sagemaker/serve/builder/jumpstart_builder.py
@@ -439,9 +439,6 @@ class JumpStart(ABC):
                 The name of the deployment config. Set to None to unset
                 any existing config that is applied to the model.
         """
-        if self.pysdk_model is None:
-            self.pysdk_model = self._create_pre_trained_js_model()
-
         self.pysdk_model.set_deployment_config(config_name)
 
     def get_deployment_config(self) -> Optional[Dict[str, Any]]:
@@ -450,17 +447,13 @@ class JumpStart(ABC):
         Returns:
             Union[Dict[str, Any], None]: Deployment config to apply to this model.
         """
-        if self.pysdk_model is None:
-            self.pysdk_model = self._create_pre_trained_js_model()
-
-        return self.pysdk_model.deployment_config
+        return getattr(self, "pysdk_model", self._create_pre_trained_js_model()).deployment_config
 
     def display_benchmark_metrics(self):
         """Display Markdown Benchmark Metrics for deployment configs."""
-        if self.pysdk_model is None:
-            self.pysdk_model = self._create_pre_trained_js_model()
-
-        self.pysdk_model.display_benchmark_metrics()
+        getattr(
+            self, "pysdk_model", self._create_pre_trained_js_model()
+        ).display_benchmark_metrics()
 
     def list_deployment_configs(self) -> List[Dict[str, Any]]:
         """List deployment configs for ``This`` model in the current region.
@@ -468,10 +461,9 @@ class JumpStart(ABC):
         Returns:
             List[Dict[str, Any]]: A list of deployment configs.
         """
-        if self.pysdk_model is None:
-            self.pysdk_model = self._create_pre_trained_js_model()
-
-        return self.pysdk_model.list_deployment_configs()
+        return getattr(
+            self, "pysdk_model", self._create_pre_trained_js_model()
+        ).list_deployment_configs()
 
     def _build_for_jumpstart(self):
         """Placeholder docstring"""
@@ -479,11 +471,7 @@ class JumpStart(ABC):
         self.secret_key = None
         self.jumpstart = True
 
-        pysdk_model = (
-            self.pysdk_model
-            if self.pysdk_model is not None
-            else self._create_pre_trained_js_model()
-        )
+        pysdk_model = getattr(self, "pysdk_model", self._create_pre_trained_js_model())
 
         image_uri = pysdk_model.image_uri
 

--- a/src/sagemaker/serve/builder/jumpstart_builder.py
+++ b/src/sagemaker/serve/builder/jumpstart_builder.py
@@ -439,6 +439,9 @@ class JumpStart(ABC):
                 The name of the deployment config. Set to None to unset
                 any existing config that is applied to the model.
         """
+        if self.pysdk_model is None:
+            self.pysdk_model = self._create_pre_trained_js_model()
+
         self.pysdk_model.set_deployment_config(config_name)
 
     def get_deployment_config(self) -> Optional[Dict[str, Any]]:
@@ -447,10 +450,16 @@ class JumpStart(ABC):
         Returns:
             Union[Dict[str, Any], None]: Deployment config to apply to this model.
         """
+        if self.pysdk_model is None:
+            self.pysdk_model = self._create_pre_trained_js_model()
+
         return self.pysdk_model.deployment_config
 
     def display_benchmark_metrics(self):
         """Display Markdown Benchmark Metrics for deployment configs."""
+        if self.pysdk_model is None:
+            self.pysdk_model = self._create_pre_trained_js_model()
+
         self.pysdk_model.display_benchmark_metrics()
 
     def list_deployment_configs(self) -> List[Dict[str, Any]]:
@@ -459,6 +468,9 @@ class JumpStart(ABC):
         Returns:
             List[Dict[str, Any]]: A list of deployment configs.
         """
+        if self.pysdk_model is None:
+            self.pysdk_model = self._create_pre_trained_js_model()
+
         return self.pysdk_model.list_deployment_configs()
 
     def _build_for_jumpstart(self):
@@ -467,7 +479,11 @@ class JumpStart(ABC):
         self.secret_key = None
         self.jumpstart = True
 
-        pysdk_model = self._create_pre_trained_js_model()
+        pysdk_model = (
+            self.pysdk_model
+            if self.pysdk_model is not None
+            else self._create_pre_trained_js_model()
+        )
 
         image_uri = pysdk_model.image_uri
 

--- a/src/sagemaker/serve/builder/jumpstart_builder.py
+++ b/src/sagemaker/serve/builder/jumpstart_builder.py
@@ -448,7 +448,7 @@ class JumpStart(ABC):
         """Gets the deployment config to apply to the model.
 
         Returns:
-            Union[Dict[str, Any], None]: Deployment config to apply to this model.
+            Optional[Dict[str, Any]]: Deployment config to apply to this model.
         """
         if not hasattr(self, "pysdk_model") or self.pysdk_model is None:
             self.pysdk_model = self._create_pre_trained_js_model()

--- a/src/sagemaker/serve/builder/jumpstart_builder.py
+++ b/src/sagemaker/serve/builder/jumpstart_builder.py
@@ -451,14 +451,14 @@ class JumpStart(ABC):
             Union[Dict[str, Any], None]: Deployment config to apply to this model.
         """
         if not hasattr(self, "pysdk_model") or self.pysdk_model is None:
-            self._build_for_jumpstart()
+            self.pysdk_model = self._create_pre_trained_js_model()
 
         return self.pysdk_model.deployment_config
 
     def display_benchmark_metrics(self):
         """Display Markdown Benchmark Metrics for deployment configs."""
         if not hasattr(self, "pysdk_model") or self.pysdk_model is None:
-            self._build_for_jumpstart()
+            self.pysdk_model = self._create_pre_trained_js_model()
 
         self.pysdk_model.display_benchmark_metrics()
 
@@ -469,7 +469,7 @@ class JumpStart(ABC):
             List[Dict[str, Any]]: A list of deployment configs.
         """
         if not hasattr(self, "pysdk_model") or self.pysdk_model is None:
-            self._build_for_jumpstart()
+            self.pysdk_model = self._create_pre_trained_js_model()
 
         return self.pysdk_model.list_deployment_configs()
 

--- a/src/sagemaker/serve/builder/jumpstart_builder.py
+++ b/src/sagemaker/serve/builder/jumpstart_builder.py
@@ -16,7 +16,7 @@ from __future__ import absolute_import
 import copy
 from abc import ABC, abstractmethod
 from datetime import datetime, timedelta
-from typing import Type, Any, List, Dict, Optional, Union
+from typing import Type, Any, List, Dict, Optional
 import logging
 
 from sagemaker.model import Model
@@ -441,7 +441,7 @@ class JumpStart(ABC):
         """
         self.pysdk_model.set_deployment_config(config_name)
 
-    def get_deployment_config(self) -> Union[Dict[str, Any], None]:
+    def get_deployment_config(self) -> Optional[Dict[str, Any]]:
         """Gets the deployment config to apply to the model.
 
         Returns:

--- a/src/sagemaker/serve/builder/jumpstart_builder.py
+++ b/src/sagemaker/serve/builder/jumpstart_builder.py
@@ -440,7 +440,7 @@ class JumpStart(ABC):
                 any existing config that is applied to the model.
         """
         if not hasattr(self, "pysdk_model") or self.pysdk_model is None:
-            raise Exception("Cannot set deployment config to an uninitialized model")
+            raise Exception("Cannot set deployment config to an uninitialized model.")
 
         self.pysdk_model.set_deployment_config(config_name)
 

--- a/src/sagemaker/serve/builder/jumpstart_builder.py
+++ b/src/sagemaker/serve/builder/jumpstart_builder.py
@@ -16,7 +16,7 @@ from __future__ import absolute_import
 import copy
 from abc import ABC, abstractmethod
 from datetime import datetime, timedelta
-from typing import Type, Any, List, Dict
+from typing import Type, Any, List, Dict, Optional, Union
 import logging
 
 from sagemaker.model import Model
@@ -430,6 +430,24 @@ class JumpStart(ABC):
         return self._tune_for_js(
             sharded_supported=sharded_supported, max_tuning_duration=max_tuning_duration
         )
+
+    def set_deployment_config(self, config_name: Optional[str]) -> None:
+        """Sets the deployment config to apply to the model.
+
+        Args:
+            config_name (Optional[str]):
+                The name of the deployment config. Set to None to unset
+                any existing config that is applied to the model.
+        """
+        self.pysdk_model.set_deployment_config(config_name)
+
+    def get_deployment_config(self) -> Union[Dict[str, Any], None]:
+        """Gets the deployment config to apply to the model.
+
+        Returns:
+            Union[Dict[str, Any], None]: Deployment config to apply to this model.
+        """
+        return self.pysdk_model.deployment_config
 
     def display_benchmark_metrics(self):
         """Display Markdown Benchmark Metrics for deployment configs."""

--- a/src/sagemaker/utils.py
+++ b/src/sagemaker/utils.py
@@ -1660,7 +1660,7 @@ def deep_override_dict(
     return unflatten_dict(flattened_dict1) if flattened_dict1 else {}
 
 
-@lru_cache(typed=True)
+@lru_cache
 def get_instance_rate_per_hour(
     instance_type: str,
     region: str,

--- a/src/sagemaker/utils.py
+++ b/src/sagemaker/utils.py
@@ -1660,7 +1660,7 @@ def deep_override_dict(
     return unflatten_dict(flattened_dict1) if flattened_dict1 else {}
 
 
-@lru_cache
+@lru_cache(typed=True)
 def get_instance_rate_per_hour(
     instance_type: str,
     region: str,

--- a/tests/unit/sagemaker/jumpstart/constants.py
+++ b/tests/unit/sagemaker/jumpstart/constants.py
@@ -7911,7 +7911,6 @@ TRAINING_CONFIG_RANKINGS = {
 
 DEPLOYMENT_CONFIGS = [
     {
-        "Version": "1.0.0",
         "DeploymentConfigName": "neuron-inference",
         "DeploymentArgs": {
             "ImageUri": "763104351884.dkr.ecr.us-west-2.amazonaws.com/huggingface-pytorch-tgi-inference:2.1.1-tgi1.4"
@@ -7944,7 +7943,6 @@ DEPLOYMENT_CONFIGS = [
         "BenchmarkMetrics": [{"name": "Instance Rate", "value": "0.0083000000", "unit": "USD/Hrs"}],
     },
     {
-        "Version": "1.0.0",
         "DeploymentConfigName": "neuron-inference-budget",
         "DeploymentArgs": {
             "ImageUri": "763104351884.dkr.ecr.us-west-2.amazonaws.com/huggingface-pytorch-tgi-inference:2.1.1-tgi1.4"
@@ -7977,7 +7975,6 @@ DEPLOYMENT_CONFIGS = [
         "BenchmarkMetrics": [{"name": "Instance Rate", "value": "0.0083000000", "unit": "USD/Hrs"}],
     },
     {
-        "Version": "1.0.0",
         "DeploymentConfigName": "gpu-inference-budget",
         "DeploymentArgs": {
             "ImageUri": "763104351884.dkr.ecr.us-west-2.amazonaws.com/huggingface-pytorch-tgi-inference:2.1.1-tgi1.4"
@@ -8010,7 +8007,6 @@ DEPLOYMENT_CONFIGS = [
         "BenchmarkMetrics": [{"name": "Instance Rate", "value": "0.0083000000", "unit": "USD/Hrs"}],
     },
     {
-        "Version": "1.0.0",
         "DeploymentConfigName": "gpu-inference",
         "DeploymentArgs": {
             "ImageUri": "763104351884.dkr.ecr.us-west-2.amazonaws.com/huggingface-pytorch-tgi-inference:2.1.1-tgi1.4"

--- a/tests/unit/sagemaker/jumpstart/constants.py
+++ b/tests/unit/sagemaker/jumpstart/constants.py
@@ -7911,11 +7911,9 @@ TRAINING_CONFIG_RANKINGS = {
 
 DEPLOYMENT_CONFIGS = [
     {
-        "ConfigName": "neuron-inference",
-        "BenchmarkMetrics": [{"name": "Instance Rate", "value": "0.0083000000", "unit": "USD/Hrs"}],
-        "DeploymentConfig": {
-            "ModelDataDownloadTimeout": None,
-            "ContainerStartupHealthCheckTimeout": None,
+        "Version": "1.0.0",
+        "DeploymentConfigName": "neuron-inference",
+        "DeploymentArgs": {
             "ImageUri": "763104351884.dkr.ecr.us-west-2.amazonaws.com/huggingface-pytorch-tgi-inference:2.1.1-tgi1.4"
             ".0-gpu-py310-cu121-ubuntu20.04",
             "ModelData": {
@@ -7926,7 +7924,6 @@ DEPLOYMENT_CONFIGS = [
                     "CompressionType": "None",
                 }
             },
-            "InstanceType": "ml.p2.xlarge",
             "Environment": {
                 "SAGEMAKER_PROGRAM": "inference.py",
                 "ENDPOINT_SERVER_TIMEOUT": "3600",
@@ -7938,15 +7935,18 @@ DEPLOYMENT_CONFIGS = [
                 "MAX_TOTAL_TOKENS": "2048",
                 "SAGEMAKER_MODEL_SERVER_WORKERS": "1",
             },
+            "InstanceType": "ml.p2.xlarge",
             "ComputeResourceRequirements": {"MinMemoryRequiredInMb": None},
+            "ModelDataDownloadTimeout": None,
+            "ContainerStartupHealthCheckTimeout": None,
         },
+        "AccelerationConfigs": None,
+        "BenchmarkMetrics": [{"name": "Instance Rate", "value": "0.0083000000", "unit": "USD/Hrs"}],
     },
     {
-        "ConfigName": "neuron-inference-budget",
-        "BenchmarkMetrics": [{"name": "Instance Rate", "value": "0.0083000000", "unit": "USD/Hrs"}],
-        "DeploymentConfig": {
-            "ModelDataDownloadTimeout": None,
-            "ContainerStartupHealthCheckTimeout": None,
+        "Version": "1.0.0",
+        "DeploymentConfigName": "neuron-inference-budget",
+        "DeploymentArgs": {
             "ImageUri": "763104351884.dkr.ecr.us-west-2.amazonaws.com/huggingface-pytorch-tgi-inference:2.1.1-tgi1.4"
             ".0-gpu-py310-cu121-ubuntu20.04",
             "ModelData": {
@@ -7957,7 +7957,6 @@ DEPLOYMENT_CONFIGS = [
                     "CompressionType": "None",
                 }
             },
-            "InstanceType": "ml.p2.xlarge",
             "Environment": {
                 "SAGEMAKER_PROGRAM": "inference.py",
                 "ENDPOINT_SERVER_TIMEOUT": "3600",
@@ -7969,15 +7968,18 @@ DEPLOYMENT_CONFIGS = [
                 "MAX_TOTAL_TOKENS": "2048",
                 "SAGEMAKER_MODEL_SERVER_WORKERS": "1",
             },
+            "InstanceType": "ml.p2.xlarge",
             "ComputeResourceRequirements": {"MinMemoryRequiredInMb": None},
+            "ModelDataDownloadTimeout": None,
+            "ContainerStartupHealthCheckTimeout": None,
         },
+        "AccelerationConfigs": None,
+        "BenchmarkMetrics": [{"name": "Instance Rate", "value": "0.0083000000", "unit": "USD/Hrs"}],
     },
     {
-        "ConfigName": "gpu-inference-budget",
-        "BenchmarkMetrics": [{"name": "Instance Rate", "value": "0.0083000000", "unit": "USD/Hrs"}],
-        "DeploymentConfig": {
-            "ModelDataDownloadTimeout": None,
-            "ContainerStartupHealthCheckTimeout": None,
+        "Version": "1.0.0",
+        "DeploymentConfigName": "gpu-inference-budget",
+        "DeploymentArgs": {
             "ImageUri": "763104351884.dkr.ecr.us-west-2.amazonaws.com/huggingface-pytorch-tgi-inference:2.1.1-tgi1.4"
             ".0-gpu-py310-cu121-ubuntu20.04",
             "ModelData": {
@@ -7988,7 +7990,6 @@ DEPLOYMENT_CONFIGS = [
                     "CompressionType": "None",
                 }
             },
-            "InstanceType": "ml.p2.xlarge",
             "Environment": {
                 "SAGEMAKER_PROGRAM": "inference.py",
                 "ENDPOINT_SERVER_TIMEOUT": "3600",
@@ -8000,15 +8001,18 @@ DEPLOYMENT_CONFIGS = [
                 "MAX_TOTAL_TOKENS": "2048",
                 "SAGEMAKER_MODEL_SERVER_WORKERS": "1",
             },
+            "InstanceType": "ml.p2.xlarge",
             "ComputeResourceRequirements": {"MinMemoryRequiredInMb": None},
+            "ModelDataDownloadTimeout": None,
+            "ContainerStartupHealthCheckTimeout": None,
         },
+        "AccelerationConfigs": None,
+        "BenchmarkMetrics": [{"name": "Instance Rate", "value": "0.0083000000", "unit": "USD/Hrs"}],
     },
     {
-        "ConfigName": "gpu-inference",
-        "BenchmarkMetrics": [{"name": "Instance Rate", "value": "0.0083000000", "unit": "USD/Hrs"}],
-        "DeploymentConfig": {
-            "ModelDataDownloadTimeout": None,
-            "ContainerStartupHealthCheckTimeout": None,
+        "Version": "1.0.0",
+        "DeploymentConfigName": "gpu-inference",
+        "DeploymentArgs": {
             "ImageUri": "763104351884.dkr.ecr.us-west-2.amazonaws.com/huggingface-pytorch-tgi-inference:2.1.1-tgi1.4"
             ".0-gpu-py310-cu121-ubuntu20.04",
             "ModelData": {
@@ -8019,7 +8023,6 @@ DEPLOYMENT_CONFIGS = [
                     "CompressionType": "None",
                 }
             },
-            "InstanceType": "ml.p2.xlarge",
             "Environment": {
                 "SAGEMAKER_PROGRAM": "inference.py",
                 "ENDPOINT_SERVER_TIMEOUT": "3600",
@@ -8031,8 +8034,13 @@ DEPLOYMENT_CONFIGS = [
                 "MAX_TOTAL_TOKENS": "2048",
                 "SAGEMAKER_MODEL_SERVER_WORKERS": "1",
             },
+            "InstanceType": "ml.p2.xlarge",
             "ComputeResourceRequirements": {"MinMemoryRequiredInMb": None},
+            "ModelDataDownloadTimeout": None,
+            "ContainerStartupHealthCheckTimeout": None,
         },
+        "AccelerationConfigs": None,
+        "BenchmarkMetrics": [{"name": "Instance Rate", "value": "0.0083000000", "unit": "USD/Hrs"}],
     },
 ]
 

--- a/tests/unit/sagemaker/jumpstart/model/test_model.py
+++ b/tests/unit/sagemaker/jumpstart/model/test_model.py
@@ -1723,6 +1723,11 @@ class ModelTest(unittest.TestCase):
 
         configs = model.list_deployment_configs()
 
+        print("******************************")
+        for config in configs:
+            print(config)
+            print()
+
         self.assertEqual(configs, get_base_deployment_configs())
 
     @mock.patch("sagemaker.jumpstart.utils.verify_model_region_and_return_specs")
@@ -1805,7 +1810,7 @@ class ModelTest(unittest.TestCase):
         model = JumpStartModel(model_id=model_id)
 
         expected = get_base_deployment_configs()[0]
-        model.set_deployment_config(expected.get("ConfigName"))
+        model.set_deployment_config(expected.get("DeploymentConfigName"))
 
         self.assertEqual(model.deployment_config, expected)
 

--- a/tests/unit/sagemaker/jumpstart/model/test_model.py
+++ b/tests/unit/sagemaker/jumpstart/model/test_model.py
@@ -1773,6 +1773,54 @@ class ModelTest(unittest.TestCase):
     @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
     @mock.patch("sagemaker.jumpstart.model.Model.deploy")
     @mock.patch("sagemaker.jumpstart.factory.model.JUMPSTART_DEFAULT_REGION_NAME", region)
+    def test_model_retrieve_deployment_config(
+        self,
+        mock_model_deploy: mock.Mock,
+        mock_get_model_specs: mock.Mock,
+        mock_session: mock.Mock,
+        mock_get_manifest: mock.Mock,
+        mock_get_instance_rate_per_hour: mock.Mock,
+        mock_verify_model_region_and_return_specs: mock.Mock,
+        mock_get_init_kwargs: mock.Mock,
+    ):
+        model_id, _ = "pytorch-eqa-bert-base-cased", "*"
+
+        mock_get_init_kwargs.side_effect = lambda *args, **kwargs: get_mock_init_kwargs(model_id)
+        mock_verify_model_region_and_return_specs.side_effect = (
+            lambda *args, **kwargs: get_base_spec_with_prototype_configs()
+        )
+        mock_get_instance_rate_per_hour.side_effect = lambda *args, **kwargs: {
+            "name": "Instance Rate",
+            "unit": "USD/Hrs",
+            "value": "0.0083000000",
+        }
+        mock_get_model_specs.side_effect = get_prototype_spec_with_configs
+        mock_get_manifest.side_effect = (
+            lambda region, model_type, *args, **kwargs: get_prototype_manifest(region, model_type)
+        )
+        mock_model_deploy.return_value = default_predictor
+
+        mock_session.return_value = sagemaker_session
+
+        model = JumpStartModel(model_id=model_id)
+
+        expected = get_base_deployment_configs()[0]
+        model.set_deployment_config(expected.get("ConfigName"))
+
+        self.assertEqual(model.deployment_config, expected)
+
+        # Unset
+        model.set_deployment_config(None)
+        self.assertIsNone(model.deployment_config)
+
+    @mock.patch("sagemaker.jumpstart.model.get_init_kwargs")
+    @mock.patch("sagemaker.jumpstart.utils.verify_model_region_and_return_specs")
+    @mock.patch("sagemaker.jumpstart.model.get_instance_rate_per_hour")
+    @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor._get_manifest")
+    @mock.patch("sagemaker.jumpstart.factory.model.Session")
+    @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
+    @mock.patch("sagemaker.jumpstart.model.Model.deploy")
+    @mock.patch("sagemaker.jumpstart.factory.model.JUMPSTART_DEFAULT_REGION_NAME", region)
     def test_model_display_benchmark_metrics(
         self,
         mock_model_deploy: mock.Mock,

--- a/tests/unit/sagemaker/jumpstart/model/test_model.py
+++ b/tests/unit/sagemaker/jumpstart/model/test_model.py
@@ -1723,11 +1723,6 @@ class ModelTest(unittest.TestCase):
 
         configs = model.list_deployment_configs()
 
-        print("******************************")
-        for config in configs:
-            print(config)
-            print()
-
         self.assertEqual(configs, get_base_deployment_configs())
 
     @mock.patch("sagemaker.jumpstart.utils.verify_model_region_and_return_specs")

--- a/tests/unit/sagemaker/jumpstart/test_utils.py
+++ b/tests/unit/sagemaker/jumpstart/test_utils.py
@@ -50,6 +50,7 @@ from tests.unit.sagemaker.jumpstart.utils import (
     get_special_model_spec,
     get_prototype_manifest,
     get_base_deployment_configs,
+    get_base_deployment_configs_with_acceleration_configs,
 )
 from mock import MagicMock
 
@@ -1763,10 +1764,11 @@ class TestBenchmarkStats:
 
 
 @pytest.mark.parametrize(
-    "config_name, expected",
+    "config_name, configs, expected",
     [
         (
             None,
+            get_base_deployment_configs(),
             {
                 "Config Name": [
                     "neuron-inference",
@@ -1776,7 +1778,6 @@ class TestBenchmarkStats:
                 ],
                 "Instance Type": ["ml.p2.xlarge", "ml.p2.xlarge", "ml.p2.xlarge", "ml.p2.xlarge"],
                 "Selected": ["No", "No", "No", "No"],
-                "Accelerated": ["Yes", "No", "No", "No"],
                 "Instance Rate (USD/Hrs)": [
                     "0.0083000000",
                     "0.0083000000",
@@ -1787,6 +1788,7 @@ class TestBenchmarkStats:
         ),
         (
             "neuron-inference",
+            get_base_deployment_configs_with_acceleration_configs(),
             {
                 "Config Name": [
                     "neuron-inference",
@@ -1807,12 +1809,7 @@ class TestBenchmarkStats:
         ),
     ],
 )
-def test_extract_metrics_from_deployment_configs(config_name, expected):
-    configs = get_base_deployment_configs()
-    configs[0]["AccelerationConfigs"] = [
-        {"Type": "Speculative-Decoding", "Enabled": True, "Spec": {"Version": "0.1"}}
-    ]
-
+def test_extract_metrics_from_deployment_configs(config_name, configs, expected):
     data = utils.extract_metrics_from_deployment_configs(configs, config_name)
 
     assert data == expected

--- a/tests/unit/sagemaker/jumpstart/test_utils.py
+++ b/tests/unit/sagemaker/jumpstart/test_utils.py
@@ -1725,6 +1725,7 @@ class TestBenchmarkStats:
                 ],
                 "Instance Type": ["ml.p2.xlarge", "ml.p2.xlarge", "ml.p2.xlarge", "ml.p2.xlarge"],
                 "Selected": ["No", "No", "No", "No"],
+                "Accelerated": ["Yes", "No", "No", "No"],
                 "Instance Rate (USD/Hrs)": [
                     "0.0083000000",
                     "0.0083000000",
@@ -1744,6 +1745,7 @@ class TestBenchmarkStats:
                 ],
                 "Instance Type": ["ml.p2.xlarge", "ml.p2.xlarge", "ml.p2.xlarge", "ml.p2.xlarge"],
                 "Selected": ["Yes", "No", "No", "No"],
+                "Accelerated": ["Yes", "No", "No", "No"],
                 "Instance Rate (USD/Hrs)": [
                     "0.0083000000",
                     "0.0083000000",
@@ -1755,6 +1757,11 @@ class TestBenchmarkStats:
     ],
 )
 def test_extract_metrics_from_deployment_configs(config_name, expected):
-    data = utils.extract_metrics_from_deployment_configs(get_base_deployment_configs(), config_name)
+    configs = get_base_deployment_configs()
+    configs[0]["AccelerationConfigs"] = [
+        {"Type": "Speculative-Decoding", "Enabled": True, "Spec": {"Version": "0.1"}}
+    ]
+
+    data = utils.extract_metrics_from_deployment_configs(configs, config_name)
 
     assert data == expected

--- a/tests/unit/sagemaker/jumpstart/utils.py
+++ b/tests/unit/sagemaker/jumpstart/utils.py
@@ -307,6 +307,14 @@ def get_base_deployment_configs() -> List[Dict[str, Any]]:
     return DEPLOYMENT_CONFIGS
 
 
+def get_base_deployment_configs_with_acceleration_configs() -> List[Dict[str, Any]]:
+    configs = copy.deepcopy(DEPLOYMENT_CONFIGS)
+    configs[0]["AccelerationConfigs"] = [
+        {"Type": "Speculative-Decoding", "Enabled": True, "Spec": {"Version": "0.1"}}
+    ]
+    return configs
+
+
 def get_mock_init_kwargs(model_id) -> JumpStartModelInitKwargs:
     return JumpStartModelInitKwargs(
         model_id=model_id,

--- a/tests/unit/sagemaker/serve/builder/test_js_builder.py
+++ b/tests/unit/sagemaker/serve/builder/test_js_builder.py
@@ -676,12 +676,95 @@ class TestJumpStartBuilder(unittest.TestCase):
             lambda: DEPLOYMENT_CONFIGS
         )
 
-        model = builder.build()
+        builder.build()
         builder.serve_settings.telemetry_opt_out = True
 
-        configs = model.list_deployment_configs()
+        configs = builder.list_deployment_configs()
 
         self.assertEqual(configs, DEPLOYMENT_CONFIGS)
+
+    @patch("sagemaker.serve.builder.jumpstart_builder._capture_telemetry", side_effect=None)
+    @patch(
+        "sagemaker.serve.builder.jumpstart_builder.JumpStart._is_jumpstart_model_id",
+        return_value=True,
+    )
+    @patch(
+        "sagemaker.serve.builder.jumpstart_builder.JumpStart._create_pre_trained_js_model",
+        return_value=MagicMock(),
+    )
+    @patch(
+        "sagemaker.serve.builder.jumpstart_builder.prepare_tgi_js_resources",
+        return_value=({"model_type": "t5", "n_head": 71}, True),
+    )
+    @patch("sagemaker.serve.builder.jumpstart_builder._get_ram_usage_mb", return_value=1024)
+    @patch(
+        "sagemaker.serve.builder.jumpstart_builder._get_nb_instance", return_value="ml.g5.24xlarge"
+    )
+    def test_get_deployment_config(
+        self,
+        mock_get_nb_instance,
+        mock_get_ram_usage_mb,
+        mock_prepare_for_tgi,
+        mock_pre_trained_model,
+        mock_is_jumpstart_model,
+        mock_telemetry,
+    ):
+        builder = ModelBuilder(
+            model="facebook/galactica-mock-model-id",
+            schema_builder=mock_schema_builder,
+        )
+
+        mock_pre_trained_model.return_value.image_uri = mock_tgi_image_uri
+
+        expected = DEPLOYMENT_CONFIGS[0]
+        mock_pre_trained_model.return_value.deployment_config = expected
+
+        builder.build()
+        builder.serve_settings.telemetry_opt_out = True
+
+        self.assertEqual(builder.get_deployment_config(), expected)
+
+    @patch("sagemaker.serve.builder.jumpstart_builder._capture_telemetry", side_effect=None)
+    @patch(
+        "sagemaker.serve.builder.jumpstart_builder.JumpStart._is_jumpstart_model_id",
+        return_value=True,
+    )
+    @patch(
+        "sagemaker.serve.builder.jumpstart_builder.JumpStart._create_pre_trained_js_model",
+        return_value=MagicMock(),
+    )
+    @patch(
+        "sagemaker.serve.builder.jumpstart_builder.prepare_tgi_js_resources",
+        return_value=({"model_type": "t5", "n_head": 71}, True),
+    )
+    @patch("sagemaker.serve.builder.jumpstart_builder._get_ram_usage_mb", return_value=1024)
+    @patch(
+        "sagemaker.serve.builder.jumpstart_builder._get_nb_instance", return_value="ml.g5.24xlarge"
+    )
+    def test_set_deployment_config(
+        self,
+        mock_get_nb_instance,
+        mock_get_ram_usage_mb,
+        mock_prepare_for_tgi,
+        mock_pre_trained_model,
+        mock_is_jumpstart_model,
+        mock_telemetry,
+    ):
+        builder = ModelBuilder(
+            model="facebook/galactica-mock-model-id",
+            schema_builder=mock_schema_builder,
+        )
+
+        mock_pre_trained_model.return_value.image_uri = mock_tgi_image_uri
+
+        builder.build()
+        builder.serve_settings.telemetry_opt_out = True
+
+        builder.set_deployment_config("config_name")
+
+        mock_pre_trained_model.return_value.set_deployment_config.assert_called_once_with(
+            "config_name"
+        )
 
     @patch("sagemaker.serve.builder.jumpstart_builder._capture_telemetry", side_effect=None)
     @patch(
@@ -719,7 +802,7 @@ class TestJumpStartBuilder(unittest.TestCase):
             lambda *args, **kwargs: "metric data"
         )
 
-        model = builder.build()
+        builder.build()
         builder.serve_settings.telemetry_opt_out = True
 
-        model.display_benchmark_metrics()
+        builder.display_benchmark_metrics()

--- a/tests/unit/sagemaker/serve/builder/test_js_builder.py
+++ b/tests/unit/sagemaker/serve/builder/test_js_builder.py
@@ -735,6 +735,80 @@ class TestJumpStartBuilder(unittest.TestCase):
     @patch(
         "sagemaker.serve.builder.jumpstart_builder._get_nb_instance", return_value="ml.g5.24xlarge"
     )
+    def test_set_deployment_config(
+        self,
+        mock_get_nb_instance,
+        mock_get_ram_usage_mb,
+        mock_prepare_for_tgi,
+        mock_pre_trained_model,
+        mock_is_jumpstart_model,
+        mock_telemetry,
+    ):
+        builder = ModelBuilder(
+            model="facebook/galactica-mock-model-id",
+            schema_builder=mock_schema_builder,
+        )
+
+        mock_pre_trained_model.return_value.image_uri = mock_tgi_image_uri
+
+        builder.build()
+        builder.set_deployment_config("config-1")
+
+        mock_pre_trained_model.return_value.set_deployment_config.assert_called_with("config-1")
+
+    @patch("sagemaker.serve.builder.jumpstart_builder._capture_telemetry", side_effect=None)
+    @patch(
+        "sagemaker.serve.builder.jumpstart_builder.JumpStart._is_jumpstart_model_id",
+        return_value=True,
+    )
+    @patch(
+        "sagemaker.serve.builder.jumpstart_builder.JumpStart._create_pre_trained_js_model",
+        return_value=MagicMock(),
+    )
+    @patch(
+        "sagemaker.serve.builder.jumpstart_builder.prepare_tgi_js_resources",
+        return_value=({"model_type": "t5", "n_head": 71}, True),
+    )
+    @patch("sagemaker.serve.builder.jumpstart_builder._get_ram_usage_mb", return_value=1024)
+    @patch(
+        "sagemaker.serve.builder.jumpstart_builder._get_nb_instance", return_value="ml.g5.24xlarge"
+    )
+    def test_set_deployment_config_ex(
+        self,
+        mock_get_nb_instance,
+        mock_get_ram_usage_mb,
+        mock_prepare_for_tgi,
+        mock_pre_trained_model,
+        mock_is_jumpstart_model,
+        mock_telemetry,
+    ):
+        mock_pre_trained_model.return_value.image_uri = mock_tgi_image_uri
+
+        self.assertRaisesRegex(
+            Exception,
+            "Cannot set deployment config to an uninitialized model.",
+            lambda: ModelBuilder(
+                model="facebook/galactica-mock-model-id", schema_builder=mock_schema_builder
+            ).set_deployment_config("config-2"),
+        )
+
+    @patch("sagemaker.serve.builder.jumpstart_builder._capture_telemetry", side_effect=None)
+    @patch(
+        "sagemaker.serve.builder.jumpstart_builder.JumpStart._is_jumpstart_model_id",
+        return_value=True,
+    )
+    @patch(
+        "sagemaker.serve.builder.jumpstart_builder.JumpStart._create_pre_trained_js_model",
+        return_value=MagicMock(),
+    )
+    @patch(
+        "sagemaker.serve.builder.jumpstart_builder.prepare_tgi_js_resources",
+        return_value=({"model_type": "t5", "n_head": 71}, True),
+    )
+    @patch("sagemaker.serve.builder.jumpstart_builder._get_ram_usage_mb", return_value=1024)
+    @patch(
+        "sagemaker.serve.builder.jumpstart_builder._get_nb_instance", return_value="ml.g5.24xlarge"
+    )
     def test_display_benchmark_metrics(
         self,
         mock_get_nb_instance,
@@ -759,11 +833,3 @@ class TestJumpStartBuilder(unittest.TestCase):
         builder.display_benchmark_metrics()
 
         mock_pre_trained_model.return_value.display_benchmark_metrics.assert_called_once()
-
-    def test_display_benchmark_metrics_ex(self):
-        self.assertRaises(
-            Exception,
-            lambda: ModelBuilder(
-                model="facebook/galactica-mock-model-id", schema_builder=mock_schema_builder
-            ).display_benchmark_metrics(),
-        )

--- a/tests/unit/sagemaker/serve/builder/test_js_builder.py
+++ b/tests/unit/sagemaker/serve/builder/test_js_builder.py
@@ -676,9 +676,6 @@ class TestJumpStartBuilder(unittest.TestCase):
             lambda: DEPLOYMENT_CONFIGS
         )
 
-        builder.build()
-        builder.serve_settings.telemetry_opt_out = True
-
         configs = builder.list_deployment_configs()
 
         self.assertEqual(configs, DEPLOYMENT_CONFIGS)
@@ -718,9 +715,6 @@ class TestJumpStartBuilder(unittest.TestCase):
 
         expected = DEPLOYMENT_CONFIGS[0]
         mock_pre_trained_model.return_value.deployment_config = expected
-
-        builder.build()
-        builder.serve_settings.telemetry_opt_out = True
 
         self.assertEqual(builder.get_deployment_config(), expected)
 
@@ -771,10 +765,7 @@ class TestJumpStartBuilder(unittest.TestCase):
         "sagemaker.serve.builder.jumpstart_builder.JumpStart._is_jumpstart_model_id",
         return_value=True,
     )
-    @patch(
-        "sagemaker.serve.builder.jumpstart_builder.JumpStart._create_pre_trained_js_model",
-        return_value=MagicMock(),
-    )
+    @patch("sagemaker.serve.builder.jumpstart_builder.JumpStart._create_pre_trained_js_model")
     @patch(
         "sagemaker.serve.builder.jumpstart_builder.prepare_tgi_js_resources",
         return_value=({"model_type": "t5", "n_head": 71}, True),
@@ -796,13 +787,6 @@ class TestJumpStartBuilder(unittest.TestCase):
             model="facebook/galactica-mock-model-id",
             schema_builder=mock_schema_builder,
         )
-
-        mock_pre_trained_model.return_value.image_uri = mock_tgi_image_uri
-        mock_pre_trained_model.return_value.display_benchmark_metrics.side_effect = (
-            lambda *args, **kwargs: "metric data"
-        )
-
-        builder.build()
-        builder.serve_settings.telemetry_opt_out = True
-
         builder.display_benchmark_metrics()
+
+        mock_pre_trained_model.return_value.display_benchmark_metrics.assert_called_once()

--- a/tests/unit/sagemaker/serve/builder/test_js_builder.py
+++ b/tests/unit/sagemaker/serve/builder/test_js_builder.py
@@ -833,3 +833,37 @@ class TestJumpStartBuilder(unittest.TestCase):
         builder.display_benchmark_metrics()
 
         mock_pre_trained_model.return_value.display_benchmark_metrics.assert_called_once()
+
+    @patch("sagemaker.serve.builder.jumpstart_builder._capture_telemetry", side_effect=None)
+    @patch(
+        "sagemaker.serve.builder.jumpstart_builder.JumpStart._is_jumpstart_model_id",
+        return_value=True,
+    )
+    @patch(
+        "sagemaker.serve.builder.jumpstart_builder.JumpStart._create_pre_trained_js_model",
+        return_value=MagicMock(),
+    )
+    @patch(
+        "sagemaker.serve.builder.jumpstart_builder.prepare_tgi_js_resources",
+        return_value=({"model_type": "t5", "n_head": 71}, True),
+    )
+    @patch("sagemaker.serve.builder.jumpstart_builder._get_ram_usage_mb", return_value=1024)
+    @patch(
+        "sagemaker.serve.builder.jumpstart_builder._get_nb_instance", return_value="ml.g5.24xlarge"
+    )
+    def test_display_benchmark_metrics_initial(
+        self,
+        mock_get_nb_instance,
+        mock_get_ram_usage_mb,
+        mock_prepare_for_tgi,
+        mock_pre_trained_model,
+        mock_is_jumpstart_model,
+        mock_telemetry,
+    ):
+        builder = ModelBuilder(
+            model="facebook/galactica-mock-model-id",
+            schema_builder=mock_schema_builder,
+        )
+        builder.display_benchmark_metrics()
+
+        mock_pre_trained_model.return_value.display_benchmark_metrics.assert_called_once()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
CX with PySDK: Modelbuilder

* Init 
```
model_builder = ModelBuilder(
    model="meta-textgeneration-llama-2-7b-f",
    schema_builder=SchemaBuilder(sample_input, sample_output),
)
```

* list api

```
model_builder.list_deployment_configs()
```

* output

```
[{'DeploymentConfigName': 'deepspeed',
  'DeploymentArgs': {'ImageUri': '763104351884.dkr.ecr.us-west-2.amazonaws.com/djl-inference:0.27.0-deepspeed0.12.6-cu121',
   'ModelData': {'S3DataSource': {'S3Uri': 's3://jumpstart-private-cache-prod-us-west-2/meta-textgeneration/meta-textgeneration-llama-2-7b-f/artifacts/inference-prepack/v1.1.0/',
     'S3DataType': 'S3Prefix',
     'CompressionType': 'None'}},
   'Environment': {'SAGEMAKER_PROGRAM': 'inference.py',
    'ENDPOINT_SERVER_TIMEOUT': '3600',
    'MODEL_CACHE_ROOT': '/opt/ml/model',
    'SAGEMAKER_ENV': '1',
    'HF_MODEL_ID': '/opt/ml/model',
    'MAX_INPUT_LENGTH': '4095',
    'MAX_TOTAL_TOKENS': '4096',
    'SAGEMAKER_MODEL_SERVER_WORKERS': '1'},
   'InstanceType': 'ml.g5.2xlarge',
   'ComputeResourceRequirements': {'MinMemoryRequiredInMb': 16384,
    'NumberOfAcceleratorDevicesRequired': 1},
   'ModelDataDownloadTimeout': 1200,
   'ContainerStartupHealthCheckTimeout': 1200},
  'AccelerationConfigs': None,
  'BenchmarkMetrics': [{'name': 'AVG Output Sequence Tokens',
    'value': '83.8',
    'unit': 'Count'},
   {'name': 'AVG Latency Per Word', 'value': '50.4', 'unit': 'MS'},
   {'name': 'Instance Rate', 'value': '1.5150000000', 'unit': 'USD/Hrs'}]},
 {'DeploymentConfigName': 'tgi',
  'DeploymentArgs': {'ImageUri': '763104351884.dkr.ecr.us-west-2.amazonaws.com/djl-inference:0.27.0-deepspeed0.12.6-cu121',
   'ModelData': {'S3DataSource': {'S3Uri': 's3://jumpstart-private-cache-prod-us-west-2/meta-textgeneration/meta-textgeneration-llama-2-7b-f/artifacts/inference-prepack/v1.1.0/',
     'S3DataType': 'S3Prefix',
     'CompressionType': 'None'}},
   'Environment': {'SAGEMAKER_PROGRAM': 'inference.py',
    'ENDPOINT_SERVER_TIMEOUT': '3600',
    'MODEL_CACHE_ROOT': '/opt/ml/model',
    'SAGEMAKER_ENV': '1',
    'HF_MODEL_ID': '/opt/ml/model',
    'MAX_INPUT_LENGTH': '4095',
    'MAX_TOTAL_TOKENS': '4096',
    'SAGEMAKER_MODEL_SERVER_WORKERS': '1'},
   'InstanceType': 'ml.g5.2xlarge',
   'ComputeResourceRequirements': {'MinMemoryRequiredInMb': 16384,
    'NumberOfAcceleratorDevicesRequired': 1},
   'ModelDataDownloadTimeout': 1200,
   'ContainerStartupHealthCheckTimeout': 1200},
  'AccelerationConfigs': None,
  'BenchmarkMetrics': [{'name': 'AVG Output Sequence Tokens',
    'value': '85.9',
    'unit': 'Count'},
   {'name': 'AVG Latency Per Word', 'value': '50.0', 'unit': 'MS'},
   {'name': 'Instance Rate', 'value': '1.5150000000', 'unit': 'USD/Hrs'}]}]
```

* Display

```
model_builder.display_benchmark_metrics()
```

* Output
```
|    | Config Name   | Instance Type   | Selected   | Accelerated   |   AVG Output Sequence Tokens (Count) |   AVG Latency Per Word (MS) |   Instance Rate (USD/Hrs) |
|---:|:--------------|:----------------|:-----------|:--------------|-------------------------------------:|----------------------------:|--------------------------:|
|  0 | deepspeed     | ml.g5.2xlarge   | No         | No            |                                 83.8 |                        50.4 |                     1.515 |
|  1 | tgi           | ml.g5.2xlarge   | No         | No            |                                 85.9 |                        50   |                     1.515 |

```

* Set
```
model_builder.set_deployment_config("deepspeed")
model_builder.display_benchmark_metrics()
```

*Output
```
|    | Config Name   | Instance Type   | Selected   | Accelerated   |   AVG Output Sequence Tokens (Count) |   AVG Latency Per Word (MS) |   Instance Rate (USD/Hrs) |
|---:|:--------------|:----------------|:-----------|:--------------|-------------------------------------:|----------------------------:|--------------------------:|
|  0 | deepspeed     | ml.g5.2xlarge   | Yes        | No            |                                 83.8 |                        50.4 |                     1.515 |
|  1 | tgi           | ml.g5.2xlarge   | No         | No            |                                 85.9 |                        50   |                     1.515 |
```

* unset
```
model_builder.set_deployment_config(None)
model_builder.display_benchmark_metrics()
```

* Output
```
|    | Config Name   | Instance Type   | Selected   | Accelerated   |   AVG Output Sequence Tokens (Count) |   AVG Latency Per Word (MS) |   Instance Rate (USD/Hrs) |
|---:|:--------------|:----------------|:-----------|:--------------|-------------------------------------:|----------------------------:|--------------------------:|
|  0 | deepspeed     | ml.g5.2xlarge   | No         | No            |                                 83.8 |                        50.4 |                     1.515 |
|  1 | tgi           | ml.g5.2xlarge   | No         | No            |                                 85.9 |                        50   |                     1.515 |

```


*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
