### PR TITLE
fix: populate default config name to model

### DIFF
--- a/src/sagemaker/jumpstart/estimator.py
+++ b/src/sagemaker/jumpstart/estimator.py
@@ -742,8 +742,8 @@ class JumpStartEstimator(Estimator):
         additional_kwargs = {
             "model_id": model_id,
             "model_version": model_version,
-            "tolerate_vulnerable_model": True,  # model is already trained, so tolerate if deprecated
-            "tolerate_deprecated_model": True,  # model is already trained, so tolerate if deprecated
+            "tolerate_vulnerable_model": True,  # model is already trained
+            "tolerate_deprecated_model": True,  # model is already trained
         }
 
         model_specs = verify_model_region_and_return_specs(

--- a/src/sagemaker/jumpstart/estimator.py
+++ b/src/sagemaker/jumpstart/estimator.py
@@ -739,7 +739,12 @@ class JumpStartEstimator(Estimator):
 
         model_version = model_version or "*"
 
-        additional_kwargs = {"model_id": model_id, "model_version": model_version}
+        additional_kwargs = {
+            "model_id": model_id,
+            "model_version": model_version,
+            "tolerate_vulnerable_model": True,  # model is already trained, so tolerate if deprecated
+            "tolerate_deprecated_model": True,  # model is already trained, so tolerate if deprecated
+        }
 
         model_specs = verify_model_region_and_return_specs(
             model_id=model_id,

--- a/src/sagemaker/jumpstart/factory/model.py
+++ b/src/sagemaker/jumpstart/factory/model.py
@@ -561,7 +561,9 @@ def _add_config_name_to_kwargs(kwargs: JumpStartModelInitKwargs) -> JumpStartMod
         specs.inference_configs
         and specs.inference_configs.get_top_config_from_ranking().config_name
     ):
-        kwargs.config_name = specs.inference_configs.get_top_config_from_ranking().config_name
+        kwargs.config_name = (
+            kwargs.config_name or specs.inference_configs.get_top_config_from_ranking().config_name
+        )
 
     return kwargs
 

--- a/src/sagemaker/jumpstart/factory/model.py
+++ b/src/sagemaker/jumpstart/factory/model.py
@@ -543,6 +543,29 @@ def _add_resources_to_kwargs(kwargs: JumpStartModelInitKwargs) -> JumpStartModel
     return kwargs
 
 
+def _add_config_name_to_kwargs(kwargs: JumpStartModelInitKwargs) -> JumpStartModelInitKwargs:
+    """Sets default config name to the kwargs. Returns full kwargs."""
+
+    specs = verify_model_region_and_return_specs(
+        model_id=kwargs.model_id,
+        version=kwargs.model_version,
+        scope=JumpStartScriptScope.INFERENCE,
+        region=kwargs.region,
+        tolerate_vulnerable_model=kwargs.tolerate_vulnerable_model,
+        tolerate_deprecated_model=kwargs.tolerate_deprecated_model,
+        sagemaker_session=kwargs.sagemaker_session,
+        model_type=kwargs.model_type,
+        config_name=kwargs.config_name,
+    )
+    if (
+        specs.inference_configs
+        and specs.inference_configs.get_top_config_from_ranking().resolved_config
+    ):
+        kwargs.config_name = specs.inference_configs.get_top_config_from_ranking().config_name
+
+    return kwargs
+
+
 def get_deploy_kwargs(
     model_id: str,
     model_version: Optional[str] = None,
@@ -808,5 +831,6 @@ def get_init_kwargs(
     model_init_kwargs = _add_model_package_arn_to_kwargs(kwargs=model_init_kwargs)
 
     model_init_kwargs = _add_resources_to_kwargs(kwargs=model_init_kwargs)
+    model_init_kwargs = _add_config_name_to_kwargs(kwargs=model_init_kwargs)
 
     return model_init_kwargs

--- a/src/sagemaker/jumpstart/factory/model.py
+++ b/src/sagemaker/jumpstart/factory/model.py
@@ -559,7 +559,7 @@ def _add_config_name_to_kwargs(kwargs: JumpStartModelInitKwargs) -> JumpStartMod
     )
     if (
         specs.inference_configs
-        and specs.inference_configs.get_top_config_from_ranking().resolved_config
+        and specs.inference_configs.get_top_config_from_ranking().config_name
     ):
         kwargs.config_name = specs.inference_configs.get_top_config_from_ranking().config_name
 

--- a/src/sagemaker/jumpstart/model.py
+++ b/src/sagemaker/jumpstart/model.py
@@ -351,7 +351,7 @@ class JumpStartModel(Model):
         self.tolerate_deprecated_model = model_init_kwargs.tolerate_deprecated_model
         self.region = model_init_kwargs.region
         self.sagemaker_session = model_init_kwargs.sagemaker_session
-        self.config_name = config_name
+        self.config_name = model_init_kwargs.config_name
 
         if self.model_type == JumpStartModelType.PROPRIETARY:
             self.log_subscription_warning()

--- a/src/sagemaker/jumpstart/types.py
+++ b/src/sagemaker/jumpstart/types.py
@@ -1076,10 +1076,12 @@ class JumpStartMetadataConfig(JumpStartDataHolderType):
         "benchmark_metrics",
         "config_components",
         "resolved_metadata_config",
+        "config_name",
     ]
 
     def __init__(
         self,
+        config_name: str,
         base_fields: Dict[str, Any],
         config_components: Dict[str, JumpStartConfigComponent],
         benchmark_metrics: Dict[str, List[JumpStartBenchmarkStat]],
@@ -1098,6 +1100,7 @@ class JumpStartMetadataConfig(JumpStartDataHolderType):
         self.config_components: Dict[str, JumpStartConfigComponent] = config_components
         self.benchmark_metrics: Dict[str, List[JumpStartBenchmarkStat]] = benchmark_metrics
         self.resolved_metadata_config: Optional[Dict[str, Any]] = None
+        self.config_name: Optional[str] = config_name
 
     def to_json(self) -> Dict[str, Any]:
         """Returns json representation of JumpStartMetadataConfig object."""
@@ -1251,6 +1254,7 @@ class JumpStartModelSpecs(JumpStartMetadataBaseFields):
         inference_configs_dict: Optional[Dict[str, JumpStartMetadataConfig]] = (
             {
                 alias: JumpStartMetadataConfig(
+                    alias,
                     json_obj,
                     (
                         {
@@ -1303,6 +1307,7 @@ class JumpStartModelSpecs(JumpStartMetadataBaseFields):
             training_configs_dict: Optional[Dict[str, JumpStartMetadataConfig]] = (
                 {
                     alias: JumpStartMetadataConfig(
+                        alias,
                         json_obj,
                         (
                             {

--- a/src/sagemaker/predictor.py
+++ b/src/sagemaker/predictor.py
@@ -43,6 +43,7 @@ def retrieve_default(
     tolerate_vulnerable_model: bool = False,
     tolerate_deprecated_model: bool = False,
     model_type: JumpStartModelType = JumpStartModelType.OPEN_WEIGHTS,
+    config_name: Optional[str] = None,
 ) -> Predictor:
     """Retrieves the default predictor for the model matching the given arguments.
 
@@ -65,6 +66,8 @@ def retrieve_default(
         tolerate_deprecated_model (bool): True if deprecated models should be tolerated
             (exception not raised). False if these models should raise an exception.
             (Default: False).
+        config_name (Optional[str]): The name of the configuration to use for the
+            predictor. (Default: None)
     Returns:
         Predictor: The default predictor to use for the model.
 
@@ -91,10 +94,9 @@ def retrieve_default(
         model_id = inferred_model_id
         model_version = model_version or inferred_model_version or "*"
         inference_component_name = inference_component_name or inferred_inference_component_name
-        config_name = inferred_config_name or None
+        config_name = config_name or inferred_config_name or None
     else:
         model_version = model_version or "*"
-        config_name = None
 
     predictor = Predictor(
         endpoint_name=endpoint_name,

--- a/tests/integ/sagemaker/jumpstart/estimator/test_jumpstart_estimator.py
+++ b/tests/integ/sagemaker/jumpstart/estimator/test_jumpstart_estimator.py
@@ -150,6 +150,7 @@ def test_gated_model_training_v2(setup):
         tags=[{"Key": JUMPSTART_TAG, "Value": os.environ[ENV_VAR_JUMPSTART_SDK_TEST_SUITE_ID]}],
         environment={"accept_eula": "true"},
         max_run=259200,  # avoid exceeding resource limits
+        tolerate_vulnerable_model=True,  # TODO: remove once vulnerbility is patched
     )
 
     # uses ml.g5.12xlarge instance

--- a/tests/unit/sagemaker/jumpstart/estimator/test_estimator.py
+++ b/tests/unit/sagemaker/jumpstart/estimator/test_estimator.py
@@ -1011,6 +1011,8 @@ class EstimatorTest(unittest.TestCase):
             additional_kwargs={
                 "model_id": "gemma-model",
                 "model_version": "*",
+                'tolerate_vulnerable_model': True,
+                'tolerate_deprecated_model': True,
                 "environment": {"accept_eula": "true"},
             },
         )
@@ -1056,6 +1058,8 @@ class EstimatorTest(unittest.TestCase):
             additional_kwargs={
                 "model_id": "js-trainable-model-prepacked",
                 "model_version": "1.0.0",
+                'tolerate_vulnerable_model': True,
+                'tolerate_deprecated_model': True,
             },
         )
 

--- a/tests/unit/sagemaker/jumpstart/estimator/test_estimator.py
+++ b/tests/unit/sagemaker/jumpstart/estimator/test_estimator.py
@@ -1011,8 +1011,8 @@ class EstimatorTest(unittest.TestCase):
             additional_kwargs={
                 "model_id": "gemma-model",
                 "model_version": "*",
-                'tolerate_vulnerable_model': True,
-                'tolerate_deprecated_model': True,
+                "tolerate_vulnerable_model": True,
+                "tolerate_deprecated_model": True,
                 "environment": {"accept_eula": "true"},
             },
         )
@@ -1058,8 +1058,8 @@ class EstimatorTest(unittest.TestCase):
             additional_kwargs={
                 "model_id": "js-trainable-model-prepacked",
                 "model_version": "1.0.0",
-                'tolerate_vulnerable_model': True,
-                'tolerate_deprecated_model': True,
+                "tolerate_vulnerable_model": True,
+                "tolerate_deprecated_model": True,
             },
         )
 

--- a/tests/unit/sagemaker/jumpstart/model/test_model.py
+++ b/tests/unit/sagemaker/jumpstart/model/test_model.py
@@ -1595,7 +1595,7 @@ class ModelTest(unittest.TestCase):
 
         model = JumpStartModel(model_id=model_id)
 
-        assert model.config_name == None
+        assert model.config_name is None
 
         model.deploy()
 

--- a/tests/unit/sagemaker/jumpstart/model/test_model.py
+++ b/tests/unit/sagemaker/jumpstart/model/test_model.py
@@ -1550,7 +1550,7 @@ class ModelTest(unittest.TestCase):
         mock_session.return_value = sagemaker_session
 
         model = JumpStartModel(model_id=model_id, config_name="neuron-inference")
-        
+
         assert model.config_name == "neuron-inference"
 
         model.deploy()
@@ -1594,7 +1594,7 @@ class ModelTest(unittest.TestCase):
         mock_session.return_value = sagemaker_session
 
         model = JumpStartModel(model_id=model_id)
-        
+
         assert model.config_name == None
 
         model.deploy()
@@ -1614,7 +1614,7 @@ class ModelTest(unittest.TestCase):
         mock_model_deploy.reset_mock()
         mock_get_model_specs.side_effect = get_prototype_spec_with_configs
         model.set_deployment_config("neuron-inference")
-        
+
         assert model.config_name == "neuron-inference"
 
         model.deploy()
@@ -1658,7 +1658,7 @@ class ModelTest(unittest.TestCase):
         mock_session.return_value = sagemaker_session
 
         model = JumpStartModel(model_id=model_id, config_name="neuron-inference")
-        
+
         assert model.config_name == "neuron-inference"
 
         model.deploy()

--- a/tests/unit/sagemaker/jumpstart/model/test_model.py
+++ b/tests/unit/sagemaker/jumpstart/model/test_model.py
@@ -1550,6 +1550,8 @@ class ModelTest(unittest.TestCase):
         mock_session.return_value = sagemaker_session
 
         model = JumpStartModel(model_id=model_id, config_name="neuron-inference")
+        
+        assert model.config_name == "neuron-inference"
 
         model.deploy()
 
@@ -1592,6 +1594,8 @@ class ModelTest(unittest.TestCase):
         mock_session.return_value = sagemaker_session
 
         model = JumpStartModel(model_id=model_id)
+        
+        assert model.config_name == None
 
         model.deploy()
 
@@ -1610,6 +1614,8 @@ class ModelTest(unittest.TestCase):
         mock_model_deploy.reset_mock()
         mock_get_model_specs.side_effect = get_prototype_spec_with_configs
         model.set_deployment_config("neuron-inference")
+        
+        assert model.config_name == "neuron-inference"
 
         model.deploy()
 
@@ -1652,6 +1658,8 @@ class ModelTest(unittest.TestCase):
         mock_session.return_value = sagemaker_session
 
         model = JumpStartModel(model_id=model_id, config_name="neuron-inference")
+        
+        assert model.config_name == "neuron-inference"
 
         model.deploy()
 

--- a/tests/unit/sagemaker/jumpstart/utils.py
+++ b/tests/unit/sagemaker/jumpstart/utils.py
@@ -237,7 +237,7 @@ def get_base_spec_with_prototype_configs_with_missing_benchmarks(
     copy_inference_configs = copy.deepcopy(INFERENCE_CONFIGS)
     copy_inference_configs["inference_configs"]["neuron-inference"]["benchmark_metrics"] = None
 
-    inference_configs = {**INFERENCE_CONFIGS, **INFERENCE_CONFIG_RANKINGS}
+    inference_configs = {**copy_inference_configs, **INFERENCE_CONFIG_RANKINGS}
     training_configs = {**TRAINING_CONFIGS, **TRAINING_CONFIG_RANKINGS}
 
     spec.update(inference_configs)

--- a/tests/unit/sagemaker/jumpstart/utils.py
+++ b/tests/unit/sagemaker/jumpstart/utils.py
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 from __future__ import absolute_import
 import copy
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Optional
 import boto3
 
 from sagemaker.compute_resource_requirements import ResourceRequirements
@@ -315,7 +315,9 @@ def get_base_deployment_configs_with_acceleration_configs() -> List[Dict[str, An
     return configs
 
 
-def get_mock_init_kwargs(model_id) -> JumpStartModelInitKwargs:
+def get_mock_init_kwargs(
+    model_id: str, config_name: Optional[str] = None
+) -> JumpStartModelInitKwargs:
     return JumpStartModelInitKwargs(
         model_id=model_id,
         model_type=JumpStartModelType.OPEN_WEIGHTS,
@@ -324,4 +326,5 @@ def get_mock_init_kwargs(model_id) -> JumpStartModelInitKwargs:
         instance_type=INIT_KWARGS.get("instance_type"),
         env=INIT_KWARGS.get("env"),
         resources=ResourceRequirements(),
+        config_name=config_name,
     )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This change fixes the default config name population in jumpStart model class.
Expected usage:
```
model_id = "meta-textgeneration-llama-2-7b-f"

model = JumpStartModel(
    model_id=model_id,
    model_version="*",
    role=sagemaker_session.get_caller_identity_arn(),
    sagemaker_session=sagemaker_session,
)

assert model.config_name == "deepspeed"
```


*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
