### PR TITLE
Fix fetch instance rate bug

### DIFF
--- a/src/sagemaker/jumpstart/model.py
+++ b/src/sagemaker/jumpstart/model.py
@@ -922,12 +922,13 @@ class JumpStartModel(Model):
             instance_rate = get_instance_rate_per_hour(
                 instance_type=default_inference_instance_type, region=self.region
             )
-            instance_rate_metric = JumpStartBenchmarkStat(instance_rate)
+            if instance_rate is not None:
+                instance_rate_metric = JumpStartBenchmarkStat(instance_rate)
 
-            if benchmark_metrics is None:
-                benchmark_metrics = [instance_rate_metric]
-            else:
-                benchmark_metrics.append(instance_rate_metric)
+                if benchmark_metrics is None:
+                    benchmark_metrics = [instance_rate_metric]
+                else:
+                    benchmark_metrics.append(instance_rate_metric)
 
         init_kwargs = get_init_kwargs(
             model_id=self.model_id,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fixing bug related to `get_instance_rate_per_hour` api.

As per https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/using-price-list-query-api.html
This policy is needed for `get_instance_rate_per_hour` to work.
```
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Effect": "Allow",
            "Action": [
                "pricing:DescribeServices",
                "pricing:GetAttributeValues",
                "pricing:GetProducts"
            ],
            "Resource": [
                "*"
            ]
        }
    ]
}
```

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
