### PR TITLE
chore: require config name and instance type in set_deployment_config

### DIFF
--- a/src/sagemaker/jumpstart/factory/model.py
+++ b/src/sagemaker/jumpstart/factory/model.py
@@ -569,13 +569,18 @@ def _add_config_name_to_kwargs(kwargs: JumpStartModelInitKwargs) -> JumpStartMod
             kwargs.config_name or specs.inference_configs.get_top_config_from_ranking().config_name
         )
 
-        if kwargs.config_name:
-            resolved_config = specs.inference_configs.configs[kwargs.config_name].resolved_config
-            supported_instance_types = resolved_config.get("supported_inference_instance_types", [])
-            if kwargs.instance_type not in supported_instance_types:
-                raise ValueError(
-                    f"Instance type {kwargs.instance_type} is not supported for config {kwargs.config_name}."
-                )
+        if not kwargs.config_name:
+            return kwargs
+
+        if kwargs.config_name not in set(specs.inference_configs.configs.keys()):
+            raise ValueError(f"Config {kwargs.config_name} is not supported for model {kwargs.model_id}.")
+        
+        resolved_config = specs.inference_configs.configs[kwargs.config_name].resolved_config
+        supported_instance_types = resolved_config.get("supported_inference_instance_types", [])
+        if kwargs.instance_type not in supported_instance_types:
+            raise ValueError(
+                f"Instance type {kwargs.instance_type} is not supported for config {kwargs.config_name}."
+            )
 
     return kwargs
 

--- a/src/sagemaker/jumpstart/factory/model.py
+++ b/src/sagemaker/jumpstart/factory/model.py
@@ -582,7 +582,7 @@ def _add_config_name_to_kwargs(kwargs: JumpStartModelInitKwargs) -> JumpStartMod
         if kwargs.instance_type not in supported_instance_types:
             raise ValueError(
                 f"Instance type {kwargs.instance_type} "
-                "is not supported for config {kwargs.config_name}."
+                f"is not supported for config {kwargs.config_name}."
             )
 
     return kwargs

--- a/src/sagemaker/jumpstart/factory/model.py
+++ b/src/sagemaker/jumpstart/factory/model.py
@@ -544,7 +544,11 @@ def _add_resources_to_kwargs(kwargs: JumpStartModelInitKwargs) -> JumpStartModel
 
 
 def _add_config_name_to_kwargs(kwargs: JumpStartModelInitKwargs) -> JumpStartModelInitKwargs:
-    """Sets default config name to the kwargs. Returns full kwargs."""
+    """Sets default config name to the kwargs. Returns full kwargs.
+
+    Raises:
+        ValueError: If the instance_type is not supported with the current config.
+    """
 
     specs = verify_model_region_and_return_specs(
         model_id=kwargs.model_id,
@@ -564,6 +568,14 @@ def _add_config_name_to_kwargs(kwargs: JumpStartModelInitKwargs) -> JumpStartMod
         kwargs.config_name = (
             kwargs.config_name or specs.inference_configs.get_top_config_from_ranking().config_name
         )
+
+        if kwargs.config_name:
+            resolved_config = specs.inference_configs.configs[kwargs.config_name].resolved_config
+            supported_instance_types = resolved_config.get("supported_inference_instance_types", [])
+            if kwargs.instance_type not in supported_instance_types:
+                raise ValueError(
+                    f"Instance type {kwargs.instance_type} is not supported for config {kwargs.config_name}."
+                )
 
     return kwargs
 

--- a/src/sagemaker/jumpstart/factory/model.py
+++ b/src/sagemaker/jumpstart/factory/model.py
@@ -573,13 +573,16 @@ def _add_config_name_to_kwargs(kwargs: JumpStartModelInitKwargs) -> JumpStartMod
             return kwargs
 
         if kwargs.config_name not in set(specs.inference_configs.configs.keys()):
-            raise ValueError(f"Config {kwargs.config_name} is not supported for model {kwargs.model_id}.")
-        
+            raise ValueError(
+                f"Config {kwargs.config_name} is not supported for model {kwargs.model_id}."
+            )
+
         resolved_config = specs.inference_configs.configs[kwargs.config_name].resolved_config
         supported_instance_types = resolved_config.get("supported_inference_instance_types", [])
         if kwargs.instance_type not in supported_instance_types:
             raise ValueError(
-                f"Instance type {kwargs.instance_type} is not supported for config {kwargs.config_name}."
+                f"Instance type {kwargs.instance_type} "
+                "is not supported for config {kwargs.config_name}."
             )
 
     return kwargs

--- a/src/sagemaker/jumpstart/model.py
+++ b/src/sagemaker/jumpstart/model.py
@@ -429,16 +429,22 @@ class JumpStartModel(Model):
             sagemaker_session=self.sagemaker_session,
         )
 
-    def set_deployment_config(self, config_name: Optional[str]) -> None:
+    def set_deployment_config(self, config_name: str, instance_type: str) -> None:
         """Sets the deployment config to apply to the model.
 
         Args:
-            config_name (Optional[str]):
+            config_name (str):
                 The name of the deployment config. Set to None to unset
                 any existing config that is applied to the model.
+            instance_type (str):
+                The instance_type that the model will use after setting
+                the config.
         """
         self.__init__(
-            model_id=self.model_id, model_version=self.model_version, config_name=config_name
+            model_id=self.model_id,
+            model_version=self.model_version,
+            instance_type=instance_type,
+            config_name=config_name,
         )
 
     @property

--- a/src/sagemaker/jumpstart/model.py
+++ b/src/sagemaker/jumpstart/model.py
@@ -434,8 +434,8 @@ class JumpStartModel(Model):
 
         Args:
             config_name (str):
-                The name of the deployment config. Set to None to unset
-                any existing config that is applied to the model.
+                The name of the deployment config to apply to the model.
+                Call list_deployment_configs to see the list of config names.
             instance_type (str):
                 The instance_type that the model will use after setting
                 the config.

--- a/tests/unit/sagemaker/jumpstart/model/test_model.py
+++ b/tests/unit/sagemaker/jumpstart/model/test_model.py
@@ -1658,7 +1658,7 @@ class ModelTest(unittest.TestCase):
     @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
     @mock.patch("sagemaker.jumpstart.model.Model.deploy")
     @mock.patch("sagemaker.jumpstart.factory.model.JUMPSTART_DEFAULT_REGION_NAME", region)
-    def test_model_set_deployment_config_incompatible_instance_type(
+    def test_model_set_deployment_config_incompatible_instance_type_or_name(
         self,
         mock_model_deploy: mock.Mock,
         mock_get_model_specs: mock.Mock,
@@ -1700,6 +1700,15 @@ class ModelTest(unittest.TestCase):
             model.set_deployment_config("neuron-inference", "ml.inf2.32xlarge")
         assert (
             "Instance type ml.inf2.32xlarge is not supported for config neuron-inference."
+            in str(error)
+        )
+
+        with pytest.raises(ValueError) as error:
+            model.set_deployment_config("neuron-inference-unknown-name", "ml.inf2.32xlarge")
+        assert (
+            "Cannot find Jumpstart config name neuron-inference-unknown-name. "
+            "List of config names that is supported by the model: "
+            "['neuron-inference', 'neuron-inference-budget', 'gpu-inference-budget', 'gpu-inference']"
             in str(error)
         )
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This change made the `set_deployment_config` interface to require two mandatory input: config_name and instance_type, since these two combination will be deterministic for a config. This change also removes the possibility to unset a config, since now both config name and instance_type is required field.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
