### PR TITLE
Deployment Configs - Follow-ups

### DIFF
--- a/src/sagemaker/jumpstart/model.py
+++ b/src/sagemaker/jumpstart/model.py
@@ -905,8 +905,13 @@ class JumpStartModel(Model):
         for config_name, metadata_config in self._metadata_configs.items():
             benchmark_metrics = {}
             for instance_type, benchmark_metric in metadata_config.benchmark_metrics.items():
-                if len(instance_type.split(".")) < 3:
+                if not instance_type.startswith("ml."):
                     instance_type = f"ml.{instance_type}"
+
+                    for metric in benchmark_metric:
+                        if metric.name.lower() == "instance rate":
+                            should_fetch_instance_rate_metric = False
+                            break
 
                 if should_fetch_instance_rate_metric:
                     instance_type_rate = get_instance_rate_per_hour(

--- a/src/sagemaker/jumpstart/model.py
+++ b/src/sagemaker/jumpstart/model.py
@@ -905,6 +905,9 @@ class JumpStartModel(Model):
         for config_name, metadata_config in self._metadata_configs.items():
             benchmark_metrics = {}
             for instance_type, benchmark_metric in metadata_config.benchmark_metrics.items():
+                if len(instance_type.split(".")) < 3:
+                    instance_type = f"ml.{instance_type}"
+
                 if should_fetch_instance_rate_metric:
                     instance_type_rate = get_instance_rate_per_hour(
                         instance_type=instance_type, region=self.region

--- a/src/sagemaker/jumpstart/model.py
+++ b/src/sagemaker/jumpstart/model.py
@@ -922,7 +922,8 @@ class JumpStartModel(Model):
                             benchmark_metric.append(JumpStartBenchmarkStat(instance_type_rate))
                             benchmark_metrics[instance_type] = benchmark_metric
 
-                default_inference_instance_type = metadata_config.resolved_config.get(
+                resolved_config = metadata_config.resolved_config
+                default_inference_instance_type = resolved_config.get(
                     "default_inference_instance_type"
                 )
                 init_kwargs = get_init_kwargs(
@@ -937,7 +938,10 @@ class JumpStartModel(Model):
                 )
 
                 deployment_config_metadata = DeploymentConfigMetadata(
-                    config_name, benchmark_metrics, init_kwargs, deploy_kwargs
+                    config_name,
+                    benchmark_metrics,
+                    resolved_config.get("supported_inference_instance_types"),
+                    init_kwargs, deploy_kwargs
                 )
                 deployment_configs.append(deployment_config_metadata.to_json())
 

--- a/src/sagemaker/jumpstart/model.py
+++ b/src/sagemaker/jumpstart/model.py
@@ -908,10 +908,10 @@ class JumpStartModel(Model):
                 if not instance_type.startswith("ml."):
                     instance_type = f"ml.{instance_type}"
 
-                    for metric in benchmark_metric:
-                        if metric.name.lower() == "instance rate":
-                            should_fetch_instance_rate_metric = False
-                            break
+                for metric in benchmark_metric:
+                    if metric.name.lower() == "instance rate":
+                        should_fetch_instance_rate_metric = False
+                        break
 
                 if should_fetch_instance_rate_metric:
                     instance_type_rate = get_instance_rate_per_hour(

--- a/src/sagemaker/jumpstart/model.py
+++ b/src/sagemaker/jumpstart/model.py
@@ -907,6 +907,8 @@ class JumpStartModel(Model):
                     else:
                         benchmark_metric.append(JumpStartBenchmarkStat(instance_type_rate))
                         benchmark_metrics[instance_type] = benchmark_metric
+                else:
+                    benchmark_metrics[instance_type] = benchmark_metric
 
             init_kwargs = get_init_kwargs(
                 model_id=self.model_id,

--- a/src/sagemaker/jumpstart/types.py
+++ b/src/sagemaker/jumpstart/types.py
@@ -2239,7 +2239,13 @@ class BaseDeploymentConfigDataHolder(JumpStartDataHolderType):
         return json_obj
 
     def _val_to_json(self, val: Any) -> Any:
-        """Converts ``Any`` to JSON."""
+        """Converts the given value to JSON.
+
+        Args:
+            val (Any): The value to convert.
+        Returns:
+            Any: The converted json value.
+        """
         if issubclass(type(val), JumpStartDataHolderType):
             return val.to_json()
         if isinstance(val, list):
@@ -2259,7 +2265,7 @@ class BaseDeploymentConfigDataHolder(JumpStartDataHolderType):
 
 
 class DeploymentArgs(BaseDeploymentConfigDataHolder):
-    """Dataclass representing a Deployment Config."""
+    """Dataclass representing a Deployment Args."""
 
     __slots__ = [
         "image_uri",
@@ -2273,19 +2279,15 @@ class DeploymentArgs(BaseDeploymentConfigDataHolder):
 
     def __init__(
         self,
-        init_kwargs: JumpStartModelInitKwargs,
-        deploy_kwargs: JumpStartModelDeployKwargs,
-        resolved_config: Dict[str, Any],
+        init_kwargs: Optional[JumpStartModelInitKwargs] = None,
+        deploy_kwargs: Optional[JumpStartModelDeployKwargs] = None,
+        resolved_config: Optional[Dict[str, Any]] = None,
     ):
-        """Instantiates DeploymentConfig object."""
+        """Instantiates DeploymentArgs object."""
         if init_kwargs is not None:
             self.image_uri = init_kwargs.image_uri
             self.model_data = init_kwargs.model_data
             self.instance_type = init_kwargs.instance_type
-            self.default_instance_type = resolved_config.get("default_inference_instance_type")
-            self.supported_instance_types = resolved_config.get(
-                "supported_inference_instance_types"
-            )
             self.environment = init_kwargs.env
             if init_kwargs.resources is not None:
                 self.compute_resource_requirements = (
@@ -2295,6 +2297,11 @@ class DeploymentArgs(BaseDeploymentConfigDataHolder):
             self.model_data_download_timeout = deploy_kwargs.model_data_download_timeout
             self.container_startup_health_check_timeout = (
                 deploy_kwargs.container_startup_health_check_timeout
+            )
+        if resolved_config is not None:
+            self.default_instance_type = resolved_config.get("default_inference_instance_type")
+            self.supported_instance_types = resolved_config.get(
+                "supported_inference_instance_types"
             )
 
 
@@ -2310,14 +2317,15 @@ class DeploymentConfigMetadata(BaseDeploymentConfigDataHolder):
 
     def __init__(
         self,
-        config_name: str,
-        benchmark_metrics: Dict[str, List[JumpStartBenchmarkStat]],
-        resolved_config: Dict[str, Any],
-        init_kwargs: JumpStartModelInitKwargs,
-        deploy_kwargs: JumpStartModelDeployKwargs,
+        config_name: Optional[str] = None,
+        benchmark_metrics: Optional[Dict[str, List[JumpStartBenchmarkStat]]] = None,
+        resolved_config: Optional[Dict[str, Any]] = None,
+        init_kwargs: Optional[JumpStartModelInitKwargs] = None,
+        deploy_kwargs: Optional[JumpStartModelDeployKwargs] = None,
     ):
         """Instantiates DeploymentConfigMetadata object."""
         self.deployment_config_name = config_name
         self.deployment_args = DeploymentArgs(init_kwargs, deploy_kwargs, resolved_config)
-        self.acceleration_configs = resolved_config.get("acceleration_configs")
         self.benchmark_metrics = benchmark_metrics
+        if resolved_config is not None:
+            self.acceleration_configs = resolved_config.get("acceleration_configs")

--- a/src/sagemaker/jumpstart/types.py
+++ b/src/sagemaker/jumpstart/types.py
@@ -2264,19 +2264,24 @@ class DeploymentArgs(BaseDeploymentConfigDataHolder):
         "model_data",
         "environment",
         "instance_type",
+        "supported_instance_types",
         "compute_resource_requirements",
         "model_data_download_timeout",
         "container_startup_health_check_timeout",
     ]
 
     def __init__(
-        self, init_kwargs: JumpStartModelInitKwargs, deploy_kwargs: JumpStartModelDeployKwargs
+        self,
+        init_kwargs: JumpStartModelInitKwargs,
+        deploy_kwargs: JumpStartModelDeployKwargs,
+        supported_instance_types: List[str],
     ):
         """Instantiates DeploymentConfig object."""
         if init_kwargs is not None:
             self.image_uri = init_kwargs.image_uri
             self.model_data = init_kwargs.model_data
             self.instance_type = init_kwargs.instance_type
+            self.supported_instance_types = supported_instance_types
             self.environment = init_kwargs.env
             if init_kwargs.resources is not None:
                 self.compute_resource_requirements = (
@@ -2302,12 +2307,16 @@ class DeploymentConfigMetadata(BaseDeploymentConfigDataHolder):
     def __init__(
         self,
         config_name: str,
-        benchmark_metrics: List[JumpStartBenchmarkStat],
+        benchmark_metrics: Dict[str, List[JumpStartBenchmarkStat]],
         init_kwargs: JumpStartModelInitKwargs,
         deploy_kwargs: JumpStartModelDeployKwargs,
     ):
         """Instantiates DeploymentConfigMetadata object."""
         self.deployment_config_name = config_name
-        self.deployment_args = DeploymentArgs(init_kwargs, deploy_kwargs)
+        self.deployment_args = DeploymentArgs(
+            init_kwargs,
+            deploy_kwargs,
+            [instance_type for instance_type in benchmark_metrics],
+        )
         self.acceleration_configs = None
         self.benchmark_metrics = benchmark_metrics

--- a/src/sagemaker/jumpstart/types.py
+++ b/src/sagemaker/jumpstart/types.py
@@ -2308,6 +2308,7 @@ class DeploymentConfigMetadata(BaseDeploymentConfigDataHolder):
         self,
         config_name: str,
         benchmark_metrics: Dict[str, List[JumpStartBenchmarkStat]],
+        supported_instance_types: List[str],
         init_kwargs: JumpStartModelInitKwargs,
         deploy_kwargs: JumpStartModelDeployKwargs,
     ):
@@ -2316,7 +2317,7 @@ class DeploymentConfigMetadata(BaseDeploymentConfigDataHolder):
         self.deployment_args = DeploymentArgs(
             init_kwargs,
             deploy_kwargs,
-            [instance_type for instance_type in benchmark_metrics],
+            supported_instance_types
         )
         self.acceleration_configs = None
         self.benchmark_metrics = benchmark_metrics

--- a/src/sagemaker/jumpstart/types.py
+++ b/src/sagemaker/jumpstart/types.py
@@ -2265,9 +2265,7 @@ class DeploymentArgs(BaseDeploymentConfigDataHolder):
         "image_uri",
         "model_data",
         "environment",
-        "selected_instance_type",
-        "default_instance_type",
-        "supported_instance_types",
+        "instance_type",
         "compute_resource_requirements",
         "model_data_download_timeout",
         "container_startup_health_check_timeout",
@@ -2283,7 +2281,7 @@ class DeploymentArgs(BaseDeploymentConfigDataHolder):
         if init_kwargs is not None:
             self.image_uri = init_kwargs.image_uri
             self.model_data = init_kwargs.model_data
-            self.selected_instance_type = init_kwargs.instance_type
+            self.instance_type = init_kwargs.instance_type
             self.default_instance_type = resolved_config.get("default_inference_instance_type")
             self.supported_instance_types = resolved_config.get(
                 "supported_inference_instance_types"

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -1070,7 +1070,7 @@ def get_metrics_from_deployment_configs(
             for metric in current_instance_type_metrics:
                 column_name = f"{metric.name} ({metric.unit})"
                 if column_name in data:
-                    for _ in range(index):
+                    for i in range(len(data[column_name]), index):
                         data[column_name].append(" - ")
                     data[column_name].append(metric.value)
 

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -1060,16 +1060,16 @@ def get_metrics_from_deployment_configs(
             if index == 0:
                 temp_data = {}
                 for metric in current_instance_type_metrics:
-                    column_name = f"{metric.name} ({metric.unit})"
-                    if metric.name.lower() == "instance rate":
+                    column_name = f"{metric.get('name')} ({metric.get('unit')})"
+                    if metric.get("name").lower() == "instance rate":
                         data[column_name] = []
                     else:
                         temp_data[column_name] = []
                 data = {**data, **temp_data}
 
             for metric in current_instance_type_metrics:
-                column_name = f"{metric.name} ({metric.unit})"
+                column_name = f"{metric.get('name')} ({metric.get('unit')})"
                 if column_name in data:
-                    data[column_name].append(metric.value)
+                    data[column_name].append(metric.get('value'))
 
     return data

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -45,7 +45,7 @@ from sagemaker.jumpstart.types import (
 )
 from sagemaker.session import Session
 from sagemaker.config import load_sagemaker_config
-from sagemaker.utils import resolve_value_from_config, TagsDict
+from sagemaker.utils import resolve_value_from_config, TagsDict, get_instance_rate_per_hour
 from sagemaker.workflow import is_pipeline_variable
 
 

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -1052,7 +1052,7 @@ def get_metrics_from_deployment_configs(
             instance_type_to_display = (
                 f"{current_instance_type} (Default)"
                 if current_instance_type
-                == deployment_config.get("DeploymentArgs").get("InstanceType")
+                == deployment_config.get("DeploymentArgs").get("DefaultInstanceType")
                 else current_instance_type
             )
             data["Instance Type"].append(instance_type_to_display)

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -1051,13 +1051,14 @@ def add_instance_rate_stats_to_benchmark_metrics(
 
     err_message = None
     for instance_type, benchmark_metric_stats in benchmark_metrics.items():
-        if not instance_type.startswith("ml."):
-            instance_type = f"ml.{instance_type}"
+        ml_instance_type = (
+            instance_type if instance_type.startswith("ml.") else f"ml.{instance_type}"
+        )
 
         if not has_instance_rate_stat(benchmark_metric_stats):
             try:
                 instance_type_rate = get_instance_rate_per_hour(
-                    instance_type=instance_type, region=region
+                    instance_type=ml_instance_type, region=region
                 )
 
                 benchmark_metric_stats.append(JumpStartBenchmarkStat(instance_type_rate))

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -1034,20 +1034,23 @@ def get_jumpstart_configs(
 def get_metrics_from_deployment_configs(
     deployment_configs: List[DeploymentConfigMetadata],
 ) -> Dict[str, List[str]]:
-    """Extracts metrics from deployment configs.
+    """Extracts benchmark metrics from deployment configs metadata.
 
     Args:
-        deployment_configs (list[dict[str, Any]]): List of deployment configs.
+        deployment_configs (List[DeploymentConfigMetadata]): List of deployment configs metadata.
     """
-
     data = {"Config Name": [], "Instance Type": []}
 
-    for index, deployment_config in enumerate(deployment_configs):
+    for outer_index, deployment_config in enumerate(deployment_configs):
         if deployment_config.deployment_args is None:
             continue
 
         benchmark_metrics = deployment_config.benchmark_metrics
-        for current_instance_type, current_instance_type_metrics in benchmark_metrics.items():
+        if benchmark_metrics is None:
+            continue
+
+        for inner_index, current_instance_type in enumerate(benchmark_metrics):
+            current_instance_type_metrics = benchmark_metrics[current_instance_type]
 
             data["Config Name"].append(deployment_config.deployment_config_name)
             instance_type_to_display = (
@@ -1057,7 +1060,7 @@ def get_metrics_from_deployment_configs(
             )
             data["Instance Type"].append(instance_type_to_display)
 
-            if index == 0:
+            if outer_index == 0 and inner_index == 0:
                 temp_data = {}
                 for metric in current_instance_type_metrics:
                     column_name = f"{metric.name} ({metric.unit})"
@@ -1070,16 +1073,5 @@ def get_metrics_from_deployment_configs(
             for metric in current_instance_type_metrics:
                 column_name = f"{metric.name} ({metric.unit})"
                 if column_name in data:
-                    for _ in range(len(data[column_name]), index):
-                        data[column_name].append(" - ")
                     data[column_name].append(metric.value)
-
-    # Todo: Temp
-    _len = len(data['Config Name'])
-    for key in data:
-        if len(data[key]) < _len:
-            for _ in range(len(data[key]), _len):
-                data[key].append(" - ")
-    print("*********Testing*************")
-    print(data)
     return data

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -1080,6 +1080,6 @@ def get_metrics_from_deployment_configs(
         if len(data[key]) < _len:
             for _ in range(len(data[key]), _len):
                 data[key].append(" - ")
-    print("**********************")
+    print("*********Testing*************")
     print(data)
     return data

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -1070,8 +1070,10 @@ def get_metrics_from_deployment_configs(
             for metric in current_instance_type_metrics:
                 column_name = f"{metric.name} ({metric.unit})"
                 if column_name in data:
-                    for i in range(len(data[column_name]), index):
+                    for _ in range(len(data[column_name]), index):
                         data[column_name].append(" - ")
                     data[column_name].append(metric.value)
 
+    print("**********************")
+    print(data)
     return data

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -1074,6 +1074,12 @@ def get_metrics_from_deployment_configs(
                         data[column_name].append(" - ")
                     data[column_name].append(metric.value)
 
+    # Todo: Temp
+    _len = len(data['Config Name'])
+    for key in data:
+        if len(data[key]) < _len:
+            for _ in range(len(data[key]), _len):
+                data[key].append(" - ")
     print("**********************")
     print(data)
     return data

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -1060,16 +1060,16 @@ def get_metrics_from_deployment_configs(
             if index == 0:
                 temp_data = {}
                 for metric in current_instance_type_metrics:
-                    column_name = f"{metric.get('name')} ({metric.get('unit')})"
-                    if metric.get("name").lower() == "instance rate":
+                    column_name = f"{metric.name} ({metric.unit})"
+                    if metric.name.lower() == "instance rate":
                         data[column_name] = []
                     else:
                         temp_data[column_name] = []
                 data = {**data, **temp_data}
 
             for metric in current_instance_type_metrics:
-                column_name = f"{metric.get('name')} ({metric.get('unit')})"
+                column_name = f"{metric.name} ({metric.unit})"
                 if column_name in data:
-                    data[column_name].append(metric.get("value"))
+                    data[column_name].append(metric.value)
 
     return data

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -1063,7 +1063,7 @@ def get_metrics_from_deployment_configs(
             if outer_index == 0 and inner_index == 0:
                 temp_data = {}
                 for metric in current_instance_type_metrics:
-                    column_name = f"{metric.name} ({metric.unit})"
+                    column_name = f"{metric.name.replace('_', ' ').title()} ({metric.unit})"
                     if metric.name.lower() == "instance rate":
                         data[column_name] = []
                     else:
@@ -1071,7 +1071,7 @@ def get_metrics_from_deployment_configs(
                 data = {**data, **temp_data}
 
             for metric in current_instance_type_metrics:
-                column_name = f"{metric.name} ({metric.unit})"
+                column_name = f"{metric.name.replace('_', ' ').title()} ({metric.unit})"
                 if column_name in data:
                     data[column_name].append(metric.value)
     return data

--- a/src/sagemaker/serve/builder/jumpstart_builder.py
+++ b/src/sagemaker/serve/builder/jumpstart_builder.py
@@ -431,18 +431,21 @@ class JumpStart(ABC):
             sharded_supported=sharded_supported, max_tuning_duration=max_tuning_duration
         )
 
-    def set_deployment_config(self, config_name: Optional[str]) -> None:
+    def set_deployment_config(self, config_name: str, instance_type: str) -> None:
         """Sets the deployment config to apply to the model.
 
         Args:
-            config_name (Optional[str]):
-                The name of the deployment config. Set to None to unset
-                any existing config that is applied to the model.
+            config_name (str):
+                The name of the deployment config to apply to the model.
+                Call list_deployment_configs to see the list of config names.
+            instance_type (str):
+                The instance_type that the model will use after setting
+                the config.
         """
         if not hasattr(self, "pysdk_model") or self.pysdk_model is None:
             raise Exception("Cannot set deployment config to an uninitialized model.")
 
-        self.pysdk_model.set_deployment_config(config_name)
+        self.pysdk_model.set_deployment_config(config_name, instance_type)
 
     def get_deployment_config(self) -> Optional[Dict[str, Any]]:
         """Gets the deployment config to apply to the model.

--- a/src/sagemaker/utils.py
+++ b/src/sagemaker/utils.py
@@ -1673,6 +1673,7 @@ def get_instance_rate_per_hour(
     Returns:
         Optional[Dict[str, str]]: Instance rate per hour.
         Example: {'name': 'Instance Rate', 'unit': 'USD/Hrs', 'value': '1.125'}.
+
     Raises:
         Exception: An exception is raised if
             the IAM role is not authorized to perform pricing:GetProducts.
@@ -1699,8 +1700,10 @@ def get_instance_rate_per_hour(
         price_data = price_list[0]
         if isinstance(price_data, str):
             price_data = json.loads(price_data)
-        return extract_instance_rate_per_hour(price_data)
 
+        instance_rate_per_hour = extract_instance_rate_per_hour(price_data)
+        if instance_rate_per_hour is not None:
+            return instance_rate_per_hour
     raise Exception(f"Unable to get instance rate per hour for instance type: {instance_type}.")
 
 

--- a/tests/unit/sagemaker/jumpstart/model/test_model.py
+++ b/tests/unit/sagemaker/jumpstart/model/test_model.py
@@ -15,7 +15,6 @@ from inspect import signature
 from typing import Optional, Set
 from unittest import mock
 import unittest
-import pandas as pd
 from mock import MagicMock, Mock
 import pytest
 from sagemaker.async_inference.async_inference_config import AsyncInferenceConfig
@@ -66,7 +65,6 @@ default_predictor_with_presets = Predictor(
 
 
 class ModelTest(unittest.TestCase):
-
     mock_session_empty_config = MagicMock(sagemaker_config={})
 
     @mock.patch(
@@ -1718,11 +1716,9 @@ class ModelTest(unittest.TestCase):
     @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor._get_manifest")
     @mock.patch("sagemaker.jumpstart.factory.model.Session")
     @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
-    @mock.patch("sagemaker.jumpstart.model.Model.deploy")
     @mock.patch("sagemaker.jumpstart.factory.model.JUMPSTART_DEFAULT_REGION_NAME", region)
     def test_model_list_deployment_configs(
         self,
-        mock_model_deploy: mock.Mock,
         mock_get_model_specs: mock.Mock,
         mock_session: mock.Mock,
         mock_get_manifest: mock.Mock,
@@ -1739,13 +1735,12 @@ class ModelTest(unittest.TestCase):
         mock_get_instance_rate_per_hour.side_effect = lambda *args, **kwargs: {
             "name": "Instance Rate",
             "unit": "USD/Hrs",
-            "value": "0.0083000000",
+            "value": "3.76",
         }
         mock_get_model_specs.side_effect = get_prototype_spec_with_configs
         mock_get_manifest.side_effect = (
             lambda region, model_type, *args, **kwargs: get_prototype_manifest(region, model_type)
         )
-        mock_model_deploy.return_value = default_predictor
 
         mock_session.return_value = sagemaker_session
 
@@ -1756,19 +1751,15 @@ class ModelTest(unittest.TestCase):
         self.assertEqual(configs, get_base_deployment_configs())
 
     @mock.patch("sagemaker.jumpstart.utils.verify_model_region_and_return_specs")
-    @mock.patch("sagemaker.jumpstart.model.get_instance_rate_per_hour")
     @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor._get_manifest")
     @mock.patch("sagemaker.jumpstart.factory.model.Session")
     @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
-    @mock.patch("sagemaker.jumpstart.model.Model.deploy")
     @mock.patch("sagemaker.jumpstart.factory.model.JUMPSTART_DEFAULT_REGION_NAME", region)
     def test_model_list_deployment_configs_empty(
         self,
-        mock_model_deploy: mock.Mock,
         mock_get_model_specs: mock.Mock,
         mock_session: mock.Mock,
         mock_get_manifest: mock.Mock,
-        mock_get_instance_rate_per_hour: mock.Mock,
         mock_verify_model_region_and_return_specs: mock.Mock,
     ):
         model_id, _ = "pytorch-eqa-bert-base-cased", "*"
@@ -1776,16 +1767,10 @@ class ModelTest(unittest.TestCase):
         mock_verify_model_region_and_return_specs.side_effect = (
             lambda *args, **kwargs: get_special_model_spec(model_id="gemma-model")
         )
-        mock_get_instance_rate_per_hour.side_effect = lambda *args, **kwargs: {
-            "name": "Instance Rate",
-            "unit": "USD/Hrs",
-            "value": "0.0083000000",
-        }
         mock_get_model_specs.side_effect = get_prototype_spec_with_configs
         mock_get_manifest.side_effect = (
             lambda region, model_type, *args, **kwargs: get_prototype_manifest(region, model_type)
         )
-        mock_model_deploy.return_value = default_predictor
 
         mock_session.return_value = sagemaker_session
 
@@ -1821,7 +1806,7 @@ class ModelTest(unittest.TestCase):
         mock_get_instance_rate_per_hour.side_effect = lambda *args, **kwargs: {
             "name": "Instance Rate",
             "unit": "USD/Hrs",
-            "value": "0.0083000000",
+            "value": "0.0083",
         }
         mock_get_model_specs.side_effect = get_prototype_spec_with_configs
         mock_get_manifest.side_effect = (
@@ -1829,7 +1814,7 @@ class ModelTest(unittest.TestCase):
         )
         mock_model_deploy.return_value = default_predictor
 
-        expected = get_base_deployment_configs()[0]
+        expected = get_base_deployment_configs(True)[0]
         config_name = expected.get("DeploymentConfigName")
         instance_type = expected.get("InstanceType")
         mock_get_init_kwargs.side_effect = lambda *args, **kwargs: get_mock_init_kwargs(
@@ -1853,11 +1838,9 @@ class ModelTest(unittest.TestCase):
     @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor._get_manifest")
     @mock.patch("sagemaker.jumpstart.factory.model.Session")
     @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
-    @mock.patch("sagemaker.jumpstart.model.Model.deploy")
     @mock.patch("sagemaker.jumpstart.factory.model.JUMPSTART_DEFAULT_REGION_NAME", region)
     def test_model_display_benchmark_metrics(
         self,
-        mock_model_deploy: mock.Mock,
         mock_get_model_specs: mock.Mock,
         mock_session: mock.Mock,
         mock_get_manifest: mock.Mock,
@@ -1874,13 +1857,12 @@ class ModelTest(unittest.TestCase):
         mock_get_instance_rate_per_hour.side_effect = lambda *args, **kwargs: {
             "name": "Instance Rate",
             "unit": "USD/Hrs",
-            "value": "0.0083000000",
+            "value": "0.0083",
         }
         mock_get_model_specs.side_effect = get_prototype_spec_with_configs
         mock_get_manifest.side_effect = (
             lambda region, model_type, *args, **kwargs: get_prototype_manifest(region, model_type)
         )
-        mock_model_deploy.return_value = default_predictor
 
         mock_session.return_value = sagemaker_session
 
@@ -1888,48 +1870,48 @@ class ModelTest(unittest.TestCase):
 
         model.display_benchmark_metrics()
 
-    @mock.patch("sagemaker.jumpstart.model.get_init_kwargs")
-    @mock.patch("sagemaker.jumpstart.utils.verify_model_region_and_return_specs")
-    @mock.patch("sagemaker.jumpstart.model.get_instance_rate_per_hour")
-    @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor._get_manifest")
-    @mock.patch("sagemaker.jumpstart.factory.model.Session")
-    @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
-    @mock.patch("sagemaker.jumpstart.model.Model.deploy")
-    @mock.patch("sagemaker.jumpstart.factory.model.JUMPSTART_DEFAULT_REGION_NAME", region)
-    def test_model_benchmark_metrics(
-        self,
-        mock_model_deploy: mock.Mock,
-        mock_get_model_specs: mock.Mock,
-        mock_session: mock.Mock,
-        mock_get_manifest: mock.Mock,
-        mock_get_instance_rate_per_hour: mock.Mock,
-        mock_verify_model_region_and_return_specs: mock.Mock,
-        mock_get_init_kwargs: mock.Mock,
-    ):
-        model_id, _ = "pytorch-eqa-bert-base-cased", "*"
-
-        mock_get_init_kwargs.side_effect = lambda *args, **kwargs: get_mock_init_kwargs(model_id)
-        mock_verify_model_region_and_return_specs.side_effect = (
-            lambda *args, **kwargs: get_base_spec_with_prototype_configs()
-        )
-        mock_get_instance_rate_per_hour.side_effect = lambda *args, **kwargs: {
-            "name": "Instance Rate",
-            "unit": "USD/Hrs",
-            "value": "0.0083000000",
-        }
-        mock_get_model_specs.side_effect = get_prototype_spec_with_configs
-        mock_get_manifest.side_effect = (
-            lambda region, model_type, *args, **kwargs: get_prototype_manifest(region, model_type)
-        )
-        mock_model_deploy.return_value = default_predictor
-
-        mock_session.return_value = sagemaker_session
-
-        model = JumpStartModel(model_id=model_id)
-
-        df = model.benchmark_metrics
-
-        self.assertTrue(isinstance(df, pd.DataFrame))
+    # @mock.patch("sagemaker.jumpstart.model.get_init_kwargs")
+    # @mock.patch("sagemaker.jumpstart.utils.verify_model_region_and_return_specs")
+    # @mock.patch("sagemaker.jumpstart.model.get_instance_rate_per_hour")
+    # @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor._get_manifest")
+    # @mock.patch("sagemaker.jumpstart.factory.model.Session")
+    # @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
+    # @mock.patch("sagemaker.jumpstart.model.Model.deploy")
+    # @mock.patch("sagemaker.jumpstart.factory.model.JUMPSTART_DEFAULT_REGION_NAME", region)
+    # def test_model_benchmark_metrics(
+    #     self,
+    #     mock_model_deploy: mock.Mock,
+    #     mock_get_model_specs: mock.Mock,
+    #     mock_session: mock.Mock,
+    #     mock_get_manifest: mock.Mock,
+    #     mock_get_instance_rate_per_hour: mock.Mock,
+    #     mock_verify_model_region_and_return_specs: mock.Mock,
+    #     mock_get_init_kwargs: mock.Mock,
+    # ):
+    #     model_id, _ = "pytorch-eqa-bert-base-cased", "*"
+    #
+    #     mock_get_init_kwargs.side_effect = lambda *args, **kwargs: get_mock_init_kwargs(model_id)
+    #     mock_verify_model_region_and_return_specs.side_effect = (
+    #         lambda *args, **kwargs: get_base_spec_with_prototype_configs()
+    #     )
+    #     mock_get_instance_rate_per_hour.side_effect = lambda *args, **kwargs: {
+    #         "name": "Instance Rate",
+    #         "unit": "USD/Hrs",
+    #         "value": "0.0083000000",
+    #     }
+    #     mock_get_model_specs.side_effect = get_prototype_spec_with_configs
+    #     mock_get_manifest.side_effect = (
+    #         lambda region, model_type, *args, **kwargs: get_prototype_manifest(region, model_type)
+    #     )
+    #     mock_model_deploy.return_value = default_predictor
+    #
+    #     mock_session.return_value = sagemaker_session
+    #
+    #     model = JumpStartModel(model_id=model_id)
+    #
+    #     df = model.benchmark_metrics
+    #
+    #     self.assertTrue(isinstance(df, pd.DataFrame))
 
 
 def test_jumpstart_model_requires_model_id():

--- a/tests/unit/sagemaker/jumpstart/model/test_model.py
+++ b/tests/unit/sagemaker/jumpstart/model/test_model.py
@@ -15,6 +15,8 @@ from inspect import signature
 from typing import Optional, Set
 from unittest import mock
 import unittest
+
+import pandas as pd
 from mock import MagicMock, Mock
 import pytest
 from sagemaker.async_inference.async_inference_config import AsyncInferenceConfig
@@ -51,6 +53,7 @@ from tests.unit.sagemaker.jumpstart.utils import (
     get_mock_init_kwargs,
     get_base_deployment_configs,
     get_base_spec_with_prototype_configs_with_missing_benchmarks,
+    append_instance_stat_metrics,
 )
 import boto3
 
@@ -1712,7 +1715,7 @@ class ModelTest(unittest.TestCase):
 
     @mock.patch("sagemaker.jumpstart.model.get_init_kwargs")
     @mock.patch("sagemaker.jumpstart.utils.verify_model_region_and_return_specs")
-    @mock.patch("sagemaker.jumpstart.model.get_instance_rate_per_hour")
+    @mock.patch("sagemaker.jumpstart.model.add_instance_rate_stats_to_benchmark_metrics")
     @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor._get_manifest")
     @mock.patch("sagemaker.jumpstart.factory.model.Session")
     @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
@@ -1722,7 +1725,7 @@ class ModelTest(unittest.TestCase):
         mock_get_model_specs: mock.Mock,
         mock_session: mock.Mock,
         mock_get_manifest: mock.Mock,
-        mock_get_instance_rate_per_hour: mock.Mock,
+        mock_add_instance_rate_stats_to_benchmark_metrics: mock.Mock,
         mock_verify_model_region_and_return_specs: mock.Mock,
         mock_get_init_kwargs: mock.Mock,
     ):
@@ -1732,11 +1735,10 @@ class ModelTest(unittest.TestCase):
         mock_verify_model_region_and_return_specs.side_effect = (
             lambda *args, **kwargs: get_base_spec_with_prototype_configs()
         )
-        mock_get_instance_rate_per_hour.side_effect = lambda *args, **kwargs: {
-            "name": "Instance Rate",
-            "unit": "USD/Hrs",
-            "value": "3.76",
-        }
+        mock_add_instance_rate_stats_to_benchmark_metrics.side_effect = lambda region, metrics: (
+            None,
+            append_instance_stat_metrics(metrics),
+        )
         mock_get_model_specs.side_effect = get_prototype_spec_with_configs
         mock_get_manifest.side_effect = (
             lambda region, model_type, *args, **kwargs: get_prototype_manifest(region, model_type)
@@ -1782,7 +1784,7 @@ class ModelTest(unittest.TestCase):
 
     @mock.patch("sagemaker.jumpstart.model.get_init_kwargs")
     @mock.patch("sagemaker.jumpstart.utils.verify_model_region_and_return_specs")
-    @mock.patch("sagemaker.jumpstart.model.get_instance_rate_per_hour")
+    @mock.patch("sagemaker.jumpstart.model.add_instance_rate_stats_to_benchmark_metrics")
     @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor._get_manifest")
     @mock.patch("sagemaker.jumpstart.factory.model.Session")
     @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
@@ -1794,7 +1796,7 @@ class ModelTest(unittest.TestCase):
         mock_get_model_specs: mock.Mock,
         mock_session: mock.Mock,
         mock_get_manifest: mock.Mock,
-        mock_get_instance_rate_per_hour: mock.Mock,
+        mock_add_instance_rate_stats_to_benchmark_metrics: mock.Mock,
         mock_verify_model_region_and_return_specs: mock.Mock,
         mock_get_init_kwargs: mock.Mock,
     ):
@@ -1803,11 +1805,10 @@ class ModelTest(unittest.TestCase):
         mock_verify_model_region_and_return_specs.side_effect = (
             lambda *args, **kwargs: get_base_spec_with_prototype_configs_with_missing_benchmarks()
         )
-        mock_get_instance_rate_per_hour.side_effect = lambda *args, **kwargs: {
-            "name": "Instance Rate",
-            "unit": "USD/Hrs",
-            "value": "0.0083",
-        }
+        mock_add_instance_rate_stats_to_benchmark_metrics.side_effect = lambda region, metrics: (
+            None,
+            append_instance_stat_metrics(metrics),
+        )
         mock_get_model_specs.side_effect = get_prototype_spec_with_configs
         mock_get_manifest.side_effect = (
             lambda region, model_type, *args, **kwargs: get_prototype_manifest(region, model_type)
@@ -1834,7 +1835,7 @@ class ModelTest(unittest.TestCase):
 
     @mock.patch("sagemaker.jumpstart.model.get_init_kwargs")
     @mock.patch("sagemaker.jumpstart.utils.verify_model_region_and_return_specs")
-    @mock.patch("sagemaker.jumpstart.model.get_instance_rate_per_hour")
+    @mock.patch("sagemaker.jumpstart.model.add_instance_rate_stats_to_benchmark_metrics")
     @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor._get_manifest")
     @mock.patch("sagemaker.jumpstart.factory.model.Session")
     @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
@@ -1844,7 +1845,7 @@ class ModelTest(unittest.TestCase):
         mock_get_model_specs: mock.Mock,
         mock_session: mock.Mock,
         mock_get_manifest: mock.Mock,
-        mock_get_instance_rate_per_hour: mock.Mock,
+        mock_add_instance_rate_stats_to_benchmark_metrics: mock.Mock,
         mock_verify_model_region_and_return_specs: mock.Mock,
         mock_get_init_kwargs: mock.Mock,
     ):
@@ -1854,11 +1855,10 @@ class ModelTest(unittest.TestCase):
         mock_verify_model_region_and_return_specs.side_effect = (
             lambda *args, **kwargs: get_base_spec_with_prototype_configs_with_missing_benchmarks()
         )
-        mock_get_instance_rate_per_hour.side_effect = lambda *args, **kwargs: {
-            "name": "Instance Rate",
-            "unit": "USD/Hrs",
-            "value": "0.0083",
-        }
+        mock_add_instance_rate_stats_to_benchmark_metrics.side_effect = lambda region, metrics: (
+            None,
+            append_instance_stat_metrics(metrics),
+        )
         mock_get_model_specs.side_effect = get_prototype_spec_with_configs
         mock_get_manifest.side_effect = (
             lambda region, model_type, *args, **kwargs: get_prototype_manifest(region, model_type)
@@ -1870,48 +1870,44 @@ class ModelTest(unittest.TestCase):
 
         model.display_benchmark_metrics()
 
-    # @mock.patch("sagemaker.jumpstart.model.get_init_kwargs")
-    # @mock.patch("sagemaker.jumpstart.utils.verify_model_region_and_return_specs")
-    # @mock.patch("sagemaker.jumpstart.model.get_instance_rate_per_hour")
-    # @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor._get_manifest")
-    # @mock.patch("sagemaker.jumpstart.factory.model.Session")
-    # @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
-    # @mock.patch("sagemaker.jumpstart.model.Model.deploy")
-    # @mock.patch("sagemaker.jumpstart.factory.model.JUMPSTART_DEFAULT_REGION_NAME", region)
-    # def test_model_benchmark_metrics(
-    #     self,
-    #     mock_model_deploy: mock.Mock,
-    #     mock_get_model_specs: mock.Mock,
-    #     mock_session: mock.Mock,
-    #     mock_get_manifest: mock.Mock,
-    #     mock_get_instance_rate_per_hour: mock.Mock,
-    #     mock_verify_model_region_and_return_specs: mock.Mock,
-    #     mock_get_init_kwargs: mock.Mock,
-    # ):
-    #     model_id, _ = "pytorch-eqa-bert-base-cased", "*"
-    #
-    #     mock_get_init_kwargs.side_effect = lambda *args, **kwargs: get_mock_init_kwargs(model_id)
-    #     mock_verify_model_region_and_return_specs.side_effect = (
-    #         lambda *args, **kwargs: get_base_spec_with_prototype_configs()
-    #     )
-    #     mock_get_instance_rate_per_hour.side_effect = lambda *args, **kwargs: {
-    #         "name": "Instance Rate",
-    #         "unit": "USD/Hrs",
-    #         "value": "0.0083000000",
-    #     }
-    #     mock_get_model_specs.side_effect = get_prototype_spec_with_configs
-    #     mock_get_manifest.side_effect = (
-    #         lambda region, model_type, *args, **kwargs: get_prototype_manifest(region, model_type)
-    #     )
-    #     mock_model_deploy.return_value = default_predictor
-    #
-    #     mock_session.return_value = sagemaker_session
-    #
-    #     model = JumpStartModel(model_id=model_id)
-    #
-    #     df = model.benchmark_metrics
-    #
-    #     self.assertTrue(isinstance(df, pd.DataFrame))
+    @mock.patch("sagemaker.jumpstart.model.get_init_kwargs")
+    @mock.patch("sagemaker.jumpstart.utils.verify_model_region_and_return_specs")
+    @mock.patch("sagemaker.jumpstart.model.add_instance_rate_stats_to_benchmark_metrics")
+    @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor._get_manifest")
+    @mock.patch("sagemaker.jumpstart.factory.model.Session")
+    @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
+    @mock.patch("sagemaker.jumpstart.factory.model.JUMPSTART_DEFAULT_REGION_NAME", region)
+    def test_model_benchmark_metrics(
+        self,
+        mock_get_model_specs: mock.Mock,
+        mock_session: mock.Mock,
+        mock_get_manifest: mock.Mock,
+        mock_add_instance_rate_stats_to_benchmark_metrics: mock.Mock,
+        mock_verify_model_region_and_return_specs: mock.Mock,
+        mock_get_init_kwargs: mock.Mock,
+    ):
+        model_id, _ = "pytorch-eqa-bert-base-cased", "*"
+
+        mock_get_init_kwargs.side_effect = lambda *args, **kwargs: get_mock_init_kwargs(model_id)
+        mock_verify_model_region_and_return_specs.side_effect = (
+            lambda *args, **kwargs: get_base_spec_with_prototype_configs()
+        )
+        mock_add_instance_rate_stats_to_benchmark_metrics.side_effect = lambda region, metrics: (
+            None,
+            append_instance_stat_metrics(metrics),
+        )
+        mock_get_model_specs.side_effect = get_prototype_spec_with_configs
+        mock_get_manifest.side_effect = (
+            lambda region, model_type, *args, **kwargs: get_prototype_manifest(region, model_type)
+        )
+
+        mock_session.return_value = sagemaker_session
+
+        model = JumpStartModel(model_id=model_id)
+
+        df = model.benchmark_metrics
+
+        self.assertTrue(isinstance(df, pd.DataFrame))
 
 
 def test_jumpstart_model_requires_model_id():

--- a/tests/unit/sagemaker/jumpstart/test_types.py
+++ b/tests/unit/sagemaker/jumpstart/test_types.py
@@ -22,6 +22,8 @@ from sagemaker.jumpstart.types import (
     JumpStartModelSpecs,
     JumpStartModelHeader,
     JumpStartConfigComponent,
+    DeploymentConfigMetadata,
+    JumpStartModelInitKwargs,
 )
 from tests.unit.sagemaker.jumpstart.constants import (
     BASE_SPEC,
@@ -29,6 +31,7 @@ from tests.unit.sagemaker.jumpstart.constants import (
     INFERENCE_CONFIGS,
     TRAINING_CONFIG_RANKINGS,
     TRAINING_CONFIGS,
+    INIT_KWARGS,
 )
 
 INSTANCE_TYPE_VARIANT = JumpStartInstanceTypeVariants(
@@ -1248,3 +1251,39 @@ def test_set_training_config():
 
     with pytest.raises(ValueError) as error:
         specs1.set_config("invalid_name", scope="unknown scope")
+
+
+def test_deployment_config_metadata():
+    spec = {**BASE_SPEC, **INFERENCE_CONFIGS, **INFERENCE_CONFIG_RANKINGS}
+    specs = JumpStartModelSpecs(spec)
+    jumpstart_config = specs.inference_configs.get_top_config_from_ranking()
+
+    deployment_config_metadata = DeploymentConfigMetadata(
+        jumpstart_config.config_name,
+        jumpstart_config.benchmark_metrics,
+        jumpstart_config.resolved_config,
+        JumpStartModelInitKwargs(
+            model_id=specs.model_id,
+            model_data=INIT_KWARGS.get("model_data"),
+            image_uri=INIT_KWARGS.get("image_uri"),
+            instance_type=INIT_KWARGS.get("instance_type"),
+            env=INIT_KWARGS.get("env"),
+            config_name=jumpstart_config.config_name,
+        ),
+    )
+
+    json_obj = deployment_config_metadata.to_json()
+
+    assert isinstance(json_obj, dict)
+    assert json_obj["DeploymentConfigName"] == jumpstart_config.config_name
+    for key in json_obj["BenchmarkMetrics"]:
+        assert len(json_obj["BenchmarkMetrics"][key]) == len(
+            jumpstart_config.benchmark_metrics.get(key)
+        )
+    assert json_obj["AccelerationConfigs"] == jumpstart_config.resolved_config.get(
+        "acceleration_configs"
+    )
+    assert json_obj["DeploymentArgs"]["ImageUri"] == INIT_KWARGS.get("image_uri")
+    assert json_obj["DeploymentArgs"]["ModelData"] == INIT_KWARGS.get("model_data")
+    assert json_obj["DeploymentArgs"]["Environment"] == INIT_KWARGS.get("env")
+    assert json_obj["DeploymentArgs"]["InstanceType"] == INIT_KWARGS.get("instance_type")

--- a/tests/unit/sagemaker/jumpstart/test_utils.py
+++ b/tests/unit/sagemaker/jumpstart/test_utils.py
@@ -49,8 +49,7 @@ from tests.unit.sagemaker.jumpstart.utils import (
     get_spec_from_base_spec,
     get_special_model_spec,
     get_prototype_manifest,
-    get_base_deployment_configs,
-    get_base_deployment_configs_with_acceleration_configs,
+    get_base_deployment_configs_metadata,
 )
 from mock import MagicMock
 
@@ -1763,53 +1762,12 @@ class TestBenchmarkStats:
         }
 
 
-@pytest.mark.parametrize(
-    "config_name, configs, expected",
-    [
-        (
-            None,
-            get_base_deployment_configs(),
-            {
-                "Config Name": [
-                    "neuron-inference",
-                    "neuron-inference-budget",
-                    "gpu-inference-budget",
-                    "gpu-inference",
-                ],
-                "Instance Type": ["ml.p2.xlarge", "ml.p2.xlarge", "ml.p2.xlarge", "ml.p2.xlarge"],
-                "Selected": ["No", "No", "No", "No"],
-                "Instance Rate (USD/Hrs)": [
-                    "0.0083000000",
-                    "0.0083000000",
-                    "0.0083000000",
-                    "0.0083000000",
-                ],
-            },
-        ),
-        (
-            "neuron-inference",
-            get_base_deployment_configs_with_acceleration_configs(),
-            {
-                "Config Name": [
-                    "neuron-inference",
-                    "neuron-inference-budget",
-                    "gpu-inference-budget",
-                    "gpu-inference",
-                ],
-                "Instance Type": ["ml.p2.xlarge", "ml.p2.xlarge", "ml.p2.xlarge", "ml.p2.xlarge"],
-                "Selected": ["Yes", "No", "No", "No"],
-                "Accelerated": ["Yes", "No", "No", "No"],
-                "Instance Rate (USD/Hrs)": [
-                    "0.0083000000",
-                    "0.0083000000",
-                    "0.0083000000",
-                    "0.0083000000",
-                ],
-            },
-        ),
-    ],
-)
-def test_extract_metrics_from_deployment_configs(config_name, configs, expected):
-    data = utils.get_metrics_from_deployment_configs(configs, config_name)
+def test_extract_metrics_from_deployment_configs():
+    configs = get_base_deployment_configs_metadata()
+    configs[0].benchmark_metrics = None
+    configs[2].deployment_args = None
 
-    assert data == expected
+    data = utils.get_metrics_from_deployment_configs(configs)
+
+    for key in data:
+        assert len(data[key]) == (len(configs) - 2)

--- a/tests/unit/sagemaker/jumpstart/utils.py
+++ b/tests/unit/sagemaker/jumpstart/utils.py
@@ -391,3 +391,16 @@ def get_base_deployment_configs(
     return [
         config.to_json() for config in get_base_deployment_configs_metadata(omit_benchmark_metrics)
     ]
+
+
+def append_instance_stat_metrics(
+    metrics: Dict[str, List[JumpStartBenchmarkStat]]
+) -> Dict[str, List[JumpStartBenchmarkStat]]:
+    if metrics is not None:
+        for key in metrics:
+            metrics[key].append(
+                JumpStartBenchmarkStat(
+                    {"name": "Instance Rate", "value": "3.76", "unit": "USD/Hrs"}
+                )
+            )
+    return metrics

--- a/tests/unit/sagemaker/serve/builder/test_js_builder.py
+++ b/tests/unit/sagemaker/serve/builder/test_js_builder.py
@@ -752,9 +752,11 @@ class TestJumpStartBuilder(unittest.TestCase):
         mock_pre_trained_model.return_value.image_uri = mock_tgi_image_uri
 
         builder.build()
-        builder.set_deployment_config("config-1")
+        builder.set_deployment_config("config-1", "ml.g5.24xlarge")
 
-        mock_pre_trained_model.return_value.set_deployment_config.assert_called_with("config-1")
+        mock_pre_trained_model.return_value.set_deployment_config.assert_called_with(
+            "config-1", "ml.g5.24xlarge"
+        )
 
     @patch("sagemaker.serve.builder.jumpstart_builder._capture_telemetry", side_effect=None)
     @patch(
@@ -789,7 +791,7 @@ class TestJumpStartBuilder(unittest.TestCase):
             "Cannot set deployment config to an uninitialized model.",
             lambda: ModelBuilder(
                 model="facebook/galactica-mock-model-id", schema_builder=mock_schema_builder
-            ).set_deployment_config("config-2"),
+            ).set_deployment_config("config-2", "ml.g5.24xlarge"),
         )
 
     @patch("sagemaker.serve.builder.jumpstart_builder._capture_telemetry", side_effect=None)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1970,14 +1970,6 @@ def test_get_instance_rate_per_hour(
     assert instance_rate == expected
 
 
-@patch("boto3.client")
-def test_get_instance_rate_per_hour_ex(mock_client):
-    mock_client.return_value.get_products.side_effect = lambda *args, **kwargs: {"PriceList": []}
-
-    with pytest.raises(Exception):
-        get_instance_rate_per_hour(instance_type="ml.t4g.nano", region="us-west-2")
-
-
 @pytest.mark.parametrize(
     "price_data, expected_result",
     [

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -27,7 +27,6 @@ from unittest import TestCase
 from boto3 import exceptions
 import botocore
 import pytest
-from botocore.exceptions import ClientError
 from mock import call, patch, Mock, MagicMock, PropertyMock
 
 import sagemaker
@@ -1956,12 +1955,6 @@ class TestDeepMergeDict(TestCase):
             },
             {"name": "Instance Rate", "unit": "USD/Hrs", "value": "0.008"},
         ),
-        (
-            "ml.t4g.nano",
-            "cn-north-1",
-            {"PriceList": []},
-            None,
-        ),
     ],
 )
 @patch("boto3.client")
@@ -1977,28 +1970,10 @@ def test_get_instance_rate_per_hour(
     assert instance_rate == expected
 
 
-# @patch("sagemaker.utils.logger")
-# @patch("boto3.client")
-# def test_get_instance_rate_per_hour_client_ex(mock_client, mock_logger):
-#     err_msg = (
-#         "User: arn:aws:sts::123456789123:assumed-role/AmazonSageMaker-ExecutionRole-20230707T131628/SageMaker "
-#         "is not authorized to perform: pricing:GetProducts because no identity-based policy allows the "
-#         "pricing:GetProducts action"
-#     )
-#     mock_client.return_value.get_products.side_effect = ClientError(
-#         {"Error": {"Message": err_msg, "Code": "AccessDeniedException"}},
-#         "GetProducts",
-#     )
-#
-#     instance_rate = get_instance_rate_per_hour(instance_type="ml.t4g.nano", region="us-west-2")
-#
-#     mock_logger.warning.assert_called_with(
-#         "Instance rate metrics will be omitted. Reason: %s", err_msg
-#     )
-#     assert instance_rate is None
+@patch("boto3.client")
+def test_get_instance_rate_per_hour_ex(mock_client):
+    mock_client.return_value.get_products.side_effect = lambda *args, **kwargs: {"PriceList": []}
 
-
-def test_get_instance_rate_per_hour_ex():
     with pytest.raises(Exception):
         get_instance_rate_per_hour(instance_type="ml.t4g.nano", region="us-west-2")
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1977,39 +1977,30 @@ def test_get_instance_rate_per_hour(
     assert instance_rate == expected
 
 
-@patch("sagemaker.utils.logger")
-@patch("boto3.client")
-def test_get_instance_rate_per_hour_client_ex(mock_client, mock_logger):
-    err_msg = (
-        "User: arn:aws:sts::123456789123:assumed-role/AmazonSageMaker-ExecutionRole-20230707T131628/SageMaker "
-        "is not authorized to perform: pricing:GetProducts because no identity-based policy allows the "
-        "pricing:GetProducts action"
-    )
-    mock_client.return_value.get_products.side_effect = ClientError(
-        {"Error": {"Message": err_msg, "Code": "AccessDeniedException"}},
-        "GetProducts",
-    )
+# @patch("sagemaker.utils.logger")
+# @patch("boto3.client")
+# def test_get_instance_rate_per_hour_client_ex(mock_client, mock_logger):
+#     err_msg = (
+#         "User: arn:aws:sts::123456789123:assumed-role/AmazonSageMaker-ExecutionRole-20230707T131628/SageMaker "
+#         "is not authorized to perform: pricing:GetProducts because no identity-based policy allows the "
+#         "pricing:GetProducts action"
+#     )
+#     mock_client.return_value.get_products.side_effect = ClientError(
+#         {"Error": {"Message": err_msg, "Code": "AccessDeniedException"}},
+#         "GetProducts",
+#     )
+#
+#     instance_rate = get_instance_rate_per_hour(instance_type="ml.t4g.nano", region="us-west-2")
+#
+#     mock_logger.warning.assert_called_with(
+#         "Instance rate metrics will be omitted. Reason: %s", err_msg
+#     )
+#     assert instance_rate is None
 
-    instance_rate = get_instance_rate_per_hour(instance_type="ml.t4g.nano", region="us-west-2")
 
-    mock_logger.warning.assert_called_with(
-        "Instance rate metrics will be omitted. Reason: %s", err_msg
-    )
-    assert instance_rate is None
-
-
-@patch("sagemaker.utils.logger")
-@patch("boto3.client")
-def test_get_instance_rate_per_hour_ex(mock_client, mock_logger):
-    mock_client.return_value.get_products.side_effect = Exception()
-
-    instance_rate = get_instance_rate_per_hour(instance_type="ml.t4g.nano", region="us-west-2")
-
-    mock_logger.warning.assert_called_with(
-        "Instance rate metrics will be omitted. Reason: %s",
-        "Something went wrong while getting instance rates.",
-    )
-    assert instance_rate is None
+def test_get_instance_rate_per_hour_ex():
+    with pytest.raises(Exception):
+        get_instance_rate_per_hour(instance_type="ml.t4g.nano", region="us-west-2")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Init Deployment config outside Model init
* ModelBuilder set deployment to accept both deployment config name and instance type
* Display deployment config benchmark metrics to display multiple raw.

*Testing done:*
Unit tests and Notebooks E2E

```
jumpstart_model = JumpStartModel(model_id="meta-textgeneration-llama-2-7b-f")

jumpstart_model.list_deployment_configs()
```

Output

```
[{'DeploymentConfigName': 'lmi',
  'DeploymentArgs': {'ImageUri': '763104351884.dkr.ecr.us-west-2.amazonaws.com/djl-inference:0.27.0-deepspeed0.12.6-cu121',
   'ModelData': {'S3DataSource': {'S3Uri': 's3://jumpstart-private-cache-prod-us-west-2/meta-textgeneration/meta-textgeneration-llama-2-7b-f/artifacts/inference-prepack/v2.0.0/',
     'S3DataType': 'S3Prefix',
     'CompressionType': 'None'}},
   'Environment': {'SAGEMAKER_PROGRAM': 'inference.py',
    'ENDPOINT_SERVER_TIMEOUT': '3600',
    'MODEL_CACHE_ROOT': '/opt/ml/model',
    'SAGEMAKER_ENV': '1',
    'HF_MODEL_ID': '/opt/ml/model',
    'MAX_INPUT_LENGTH': '4095',
    'MAX_TOTAL_TOKENS': '4096',
    'SAGEMAKER_MODEL_SERVER_WORKERS': '1'},
   'InstanceType': 'ml.g5.12xlarge',
   'ComputeResourceRequirements': {'MinMemoryRequiredInMb': 98304,
    'NumberOfAcceleratorDevicesRequired': 4},
   'ModelDataDownloadTimeout': 1200,
   'ContainerStartupHealthCheckTimeout': 1200},
  'AccelerationConfigs': None,
  'BenchmarkMetrics': {'ml.g5.2xlarge': [{'name': 'min_latency',
     'value': '34',
     'unit': 'ms'},
    {'name': 'max_throughput', 'value': '173', 'unit': 'ms'},
    {'name': 'max_concurrency', 'value': '64', 'unit': 'count'},
    {'name': 'Instance Rate', 'value': '1.515', 'unit': 'USD/Hrs'}],
   'ml.g5.12xlarge': [{'name': 'min_latency', 'value': '12', 'unit': 'ms'},
    {'name': 'max_throughput', 'value': '294', 'unit': 'ms'},
    {'name': 'max_concurrency', 'value': '64', 'unit': 'count'},
    {'name': 'Instance Rate', 'value': '7.09', 'unit': 'USD/Hrs'}],
   'ml.p4d.24xlarge': [{'name': 'min_latency', 'value': '7', 'unit': 'ms'},
    {'name': 'max_throughput', 'value': '1414', 'unit': 'ms'},
    {'name': 'max_concurrency', 'value': '256', 'unit': 'count'},
    {'name': 'Instance Rate', 'value': '38.67', 'unit': 'USD/Hrs'}]}},
 {'DeploymentConfigName': 'lmi-trtllm',
  'DeploymentArgs': {'ImageUri': '763104351884.dkr.ecr.us-west-2.amazonaws.com/djl-inference:0.27.0-deepspeed0.12.6-cu121',
   'ModelData': {'S3DataSource': {'S3Uri': 's3://jumpstart-private-cache-prod-us-west-2/meta-textgeneration/meta-textgeneration-llama-2-7b-f/artifacts/inference-prepack/v2.0.0/',
     'S3DataType': 'S3Prefix',
     'CompressionType': 'None'}},
   'Environment': {'SAGEMAKER_PROGRAM': 'inference.py',
    'ENDPOINT_SERVER_TIMEOUT': '3600',
    'MODEL_CACHE_ROOT': '/opt/ml/model',
    'SAGEMAKER_ENV': '1',
    'HF_MODEL_ID': '/opt/ml/model',
    'MAX_INPUT_LENGTH': '4095',
    'MAX_TOTAL_TOKENS': '4096',
    'SAGEMAKER_MODEL_SERVER_WORKERS': '1'},
   'InstanceType': 'ml.g5.12xlarge',
   'ComputeResourceRequirements': {'MinMemoryRequiredInMb': 98304,
    'NumberOfAcceleratorDevicesRequired': 4},
   'ModelDataDownloadTimeout': 1200,
   'ContainerStartupHealthCheckTimeout': 1200},
  'AccelerationConfigs': None,
  'BenchmarkMetrics': {'ml.g5.2xlarge': [{'name': 'min_latency',
     'value': '34',
     'unit': 'ms'},
    {'name': 'max_throughput', 'value': '173', 'unit': 'ms'},
    {'name': 'max_concurrency', 'value': '64', 'unit': 'count'},
    {'name': 'Instance Rate', 'value': '1.515', 'unit': 'USD/Hrs'}],
   'ml.g5.12xlarge': [{'name': 'min_latency', 'value': '12', 'unit': 'ms'},
    {'name': 'max_throughput', 'value': '294', 'unit': 'ms'},
    {'name': 'max_concurrency', 'value': '64', 'unit': 'count'},
    {'name': 'Instance Rate', 'value': '7.09', 'unit': 'USD/Hrs'}],
   'ml.p4d.24xlarge': [{'name': 'min_latency', 'value': '7', 'unit': 'ms'},
    {'name': 'max_throughput', 'value': '1414', 'unit': 'ms'},
    {'name': 'max_concurrency', 'value': '256', 'unit': 'count'},
    {'name': 'Instance Rate', 'value': '38.67', 'unit': 'USD/Hrs'}]}},
 {'DeploymentConfigName': 'tgi',
  'DeploymentArgs': {'ImageUri': '763104351884.dkr.ecr.us-west-2.amazonaws.com/djl-inference:0.27.0-deepspeed0.12.6-cu121',
   'ModelData': {'S3DataSource': {'S3Uri': 's3://jumpstart-private-cache-prod-us-west-2/meta-textgeneration/meta-textgeneration-llama-2-7b-f/artifacts/inference-prepack/v2.0.0/',
     'S3DataType': 'S3Prefix',
     'CompressionType': 'None'}},
   'Environment': {'SAGEMAKER_PROGRAM': 'inference.py',
    'ENDPOINT_SERVER_TIMEOUT': '3600',
    'MODEL_CACHE_ROOT': '/opt/ml/model',
    'SAGEMAKER_ENV': '1',
    'HF_MODEL_ID': '/opt/ml/model',
    'MAX_INPUT_LENGTH': '4095',
    'MAX_TOTAL_TOKENS': '4096',
    'SAGEMAKER_MODEL_SERVER_WORKERS': '1'},
   'InstanceType': 'ml.g5.12xlarge',
   'ComputeResourceRequirements': {'MinMemoryRequiredInMb': 98304,
    'NumberOfAcceleratorDevicesRequired': 4},
   'ModelDataDownloadTimeout': 1200,
   'ContainerStartupHealthCheckTimeout': 1200},
  'AccelerationConfigs': None,
  'BenchmarkMetrics': {'ml.g5.2xlarge': [{'name': 'min_latency',
     'value': '33',
     'unit': 'ms'},
    {'name': 'max_throughput', 'value': '121', 'unit': 'ms'},
    {'name': 'max_concurrency', 'value': '8', 'unit': 'count'},
    {'name': 'Instance Rate', 'value': '1.515', 'unit': 'USD/Hrs'}],
   'ml.g5.12xlarge': [{'name': 'min_latency', 'value': '13', 'unit': 'ms'},
    {'name': 'max_throughput', 'value': '306', 'unit': 'ms'},
    {'name': 'max_concurrency', 'value': '64', 'unit': 'count'},
    {'name': 'Instance Rate', 'value': '7.09', 'unit': 'USD/Hrs'}],
   'ml.p4d.24xlarge': [{'name': 'min_latency', 'value': '8', 'unit': 'ms'},
    {'name': 'max_throughput', 'value': '1714', 'unit': 'ms'},
    {'name': 'max_concurrency', 'value': '512', 'unit': 'count'},
    {'name': 'Instance Rate', 'value': '38.67', 'unit': 'USD/Hrs'}]}}]
```

```
jumpstart_model.display_benchmark_metrics()
```

Output

```
| Config Name   | Instance Type            |   Instance Rate (USD/Hrs) |   Min Latency (ms) |   Max Throughput (ms) |   Max Concurrency (count) |
|:--------------|:-------------------------|--------------------------:|-------------------:|----------------------:|--------------------------:|
| lmi           | ml.g5.12xlarge (Default) |                     7.09  |                 12 |                   294 |                        64 |
| lmi           | ml.g5.2xlarge            |                     1.515 |                 34 |                   173 |                        64 |
| lmi           | ml.p4d.24xlarge          |                    38.67  |                  7 |                  1414 |                       256 |
| lmi-trtllm    | ml.g5.12xlarge (Default) |                     7.09  |                 12 |                   294 |                        64 |
| lmi-trtllm    | ml.g5.2xlarge            |                     1.515 |                 34 |                   173 |                        64 |
| lmi-trtllm    | ml.p4d.24xlarge          |                    38.67  |                  7 |                  1414 |                       256 |
| tgi           | ml.g5.12xlarge (Default) |                     7.09  |                 13 |                   306 |                        64 |
| tgi           | ml.g5.2xlarge            |                     1.515 |                 33 |                   121 |                         8 |
| tgi           | ml.p4d.24xlarge          |                    38.67  |                  8 |                  1714 |                       512 |

```

```
model_builder = ModelBuilder(
    model="meta-textgeneration-llama-2-7b-f",
    schema_builder=SchemaBuilder(sample_input, sample_output),
)

model_builder.list_deployment_configs()

model_builder.display_benchmark_metrics()

model_builder.set_deployment_config("lmi", "ml.g5.12xlarge")
```

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
