### PR TITLE
Use separate tags for inference and training configs

### DIFF
--- a/src/sagemaker/jumpstart/enums.py
+++ b/src/sagemaker/jumpstart/enums.py
@@ -92,7 +92,9 @@ class JumpStartTag(str, Enum):
     MODEL_ID = "sagemaker-sdk:jumpstart-model-id"
     MODEL_VERSION = "sagemaker-sdk:jumpstart-model-version"
     MODEL_TYPE = "sagemaker-sdk:jumpstart-model-type"
-    MODEL_CONFIG_NAME = "sagemaker-sdk:jumpstart-model-config-name"
+
+    INFERENCE_CONFIG_NAME = "sagemaker-sdk:jumpstart-inference-config-name"
+    TRAINING_CONFIG_NAME = "sagemaker-sdk:jumpstart-training-config-name"
 
 
 class SerializerType(str, Enum):

--- a/src/sagemaker/jumpstart/estimator.py
+++ b/src/sagemaker/jumpstart/estimator.py
@@ -733,7 +733,7 @@ class JumpStartEstimator(Estimator):
         config_name = None
         if model_id is None:
 
-            model_id, model_version, config_name = get_model_info_from_training_job(
+            model_id, model_version, _, config_name = get_model_info_from_training_job(
                 training_job_name=training_job_name, sagemaker_session=sagemaker_session
             )
 
@@ -1139,7 +1139,9 @@ class JumpStartEstimator(Estimator):
         Args:
             config_name (str): The name of the config.
         """
-        self.__init__(**self.init_kwargs, config_name=config_name)
+        self.__init__(
+            model_id=self.model_id, model_version=self.model_version, config_name=config_name
+        )
 
     def __str__(self) -> str:
         """Overriding str(*) method to make more human-readable."""

--- a/src/sagemaker/jumpstart/factory/estimator.py
+++ b/src/sagemaker/jumpstart/factory/estimator.py
@@ -61,7 +61,7 @@ from sagemaker.jumpstart.types import (
     JumpStartModelInitKwargs,
 )
 from sagemaker.jumpstart.utils import (
-    add_jumpstart_model_id_version_tags,
+    add_jumpstart_model_info_tags,
     get_eula_message,
     update_dict_if_key_not_present,
     resolve_estimator_sagemaker_config_field,
@@ -477,11 +477,12 @@ def _add_tags_to_kwargs(kwargs: JumpStartEstimatorInitKwargs) -> JumpStartEstima
     ).version
 
     if kwargs.sagemaker_session.settings.include_jumpstart_tags:
-        kwargs.tags = add_jumpstart_model_id_version_tags(
+        kwargs.tags = add_jumpstart_model_info_tags(
             kwargs.tags,
             kwargs.model_id,
             full_model_version,
             config_name=kwargs.config_name,
+            scope=JumpStartScriptScope.TRAINING,
         )
     return kwargs
 

--- a/src/sagemaker/jumpstart/factory/model.py
+++ b/src/sagemaker/jumpstart/factory/model.py
@@ -44,7 +44,7 @@ from sagemaker.jumpstart.types import (
     JumpStartModelRegisterKwargs,
 )
 from sagemaker.jumpstart.utils import (
-    add_jumpstart_model_id_version_tags,
+    add_jumpstart_model_info_tags,
     update_dict_if_key_not_present,
     resolve_model_sagemaker_config_field,
     verify_model_region_and_return_specs,
@@ -495,8 +495,13 @@ def _add_tags_to_kwargs(kwargs: JumpStartModelDeployKwargs) -> Dict[str, Any]:
     ).version
 
     if kwargs.sagemaker_session.settings.include_jumpstart_tags:
-        kwargs.tags = add_jumpstart_model_id_version_tags(
-            kwargs.tags, kwargs.model_id, full_model_version, kwargs.model_type, kwargs.config_name
+        kwargs.tags = add_jumpstart_model_info_tags(
+            kwargs.tags,
+            kwargs.model_id,
+            full_model_version,
+            kwargs.model_type,
+            config_name=kwargs.config_name,
+            scope=JumpStartScriptScope.INFERENCE,
         )
 
     return kwargs

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -80,9 +80,9 @@ def get_jumpstart_gated_content_bucket(
             unavailable in that region.
     """
 
-    old_gated_content_bucket: Optional[
-        str
-    ] = accessors.JumpStartModelsAccessor.get_jumpstart_gated_content_bucket()
+    old_gated_content_bucket: Optional[str] = (
+        accessors.JumpStartModelsAccessor.get_jumpstart_gated_content_bucket()
+    )
 
     info_logs: List[str] = []
 
@@ -131,9 +131,9 @@ def get_jumpstart_content_bucket(
         ValueError: If JumpStart is not launched in ``region``.
     """
 
-    old_content_bucket: Optional[
-        str
-    ] = accessors.JumpStartModelsAccessor.get_jumpstart_content_bucket()
+    old_content_bucket: Optional[str] = (
+        accessors.JumpStartModelsAccessor.get_jumpstart_content_bucket()
+    )
 
     info_logs: List[str] = []
 
@@ -177,9 +177,9 @@ def get_formatted_manifest(
     manifest_dict = {}
     for header in manifest:
         header_obj = JumpStartModelHeader(header)
-        manifest_dict[
-            JumpStartVersionedModelId(header_obj.model_id, header_obj.version)
-        ] = header_obj
+        manifest_dict[JumpStartVersionedModelId(header_obj.model_id, header_obj.version)] = (
+            header_obj
+        )
     return manifest_dict
 
 

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -80,9 +80,9 @@ def get_jumpstart_gated_content_bucket(
             unavailable in that region.
     """
 
-    old_gated_content_bucket: Optional[str] = (
-        accessors.JumpStartModelsAccessor.get_jumpstart_gated_content_bucket()
-    )
+    old_gated_content_bucket: Optional[
+        str
+    ] = accessors.JumpStartModelsAccessor.get_jumpstart_gated_content_bucket()
 
     info_logs: List[str] = []
 
@@ -131,9 +131,9 @@ def get_jumpstart_content_bucket(
         ValueError: If JumpStart is not launched in ``region``.
     """
 
-    old_content_bucket: Optional[str] = (
-        accessors.JumpStartModelsAccessor.get_jumpstart_content_bucket()
-    )
+    old_content_bucket: Optional[
+        str
+    ] = accessors.JumpStartModelsAccessor.get_jumpstart_content_bucket()
 
     info_logs: List[str] = []
 
@@ -177,9 +177,9 @@ def get_formatted_manifest(
     manifest_dict = {}
     for header in manifest:
         header_obj = JumpStartModelHeader(header)
-        manifest_dict[JumpStartVersionedModelId(header_obj.model_id, header_obj.version)] = (
-            header_obj
-        )
+        manifest_dict[
+            JumpStartVersionedModelId(header_obj.model_id, header_obj.version)
+        ] = header_obj
     return manifest_dict
 
 
@@ -320,7 +320,8 @@ def add_single_jumpstart_tag(
                     tag_key_in_array(enums.JumpStartTag.MODEL_ID, curr_tags)
                     or tag_key_in_array(enums.JumpStartTag.MODEL_VERSION, curr_tags)
                     or tag_key_in_array(enums.JumpStartTag.MODEL_TYPE, curr_tags)
-                    or tag_key_in_array(enums.JumpStartTag.MODEL_CONFIG_NAME, curr_tags)
+                    or tag_key_in_array(enums.JumpStartTag.INFERENCE_CONFIG_NAME, curr_tags)
+                    or tag_key_in_array(enums.JumpStartTag.TRAINING_CONFIG_NAME, curr_tags)
                 )
                 if is_uri
                 else False
@@ -351,12 +352,13 @@ def get_jumpstart_base_name_if_jumpstart_model(
     return None
 
 
-def add_jumpstart_model_id_version_tags(
+def add_jumpstart_model_info_tags(
     tags: Optional[List[TagsDict]],
     model_id: str,
     model_version: str,
     model_type: Optional[enums.JumpStartModelType] = None,
     config_name: Optional[str] = None,
+    scope: enums.JumpStartScriptScope = None,
 ) -> List[TagsDict]:
     """Add custom model ID and version tags to JumpStart related resources."""
     if model_id is None or model_version is None:
@@ -380,10 +382,17 @@ def add_jumpstart_model_id_version_tags(
             tags,
             is_uri=False,
         )
-    if config_name:
+    if config_name and scope == enums.JumpStartScriptScope.INFERENCE:
         tags = add_single_jumpstart_tag(
             config_name,
-            enums.JumpStartTag.MODEL_CONFIG_NAME,
+            enums.JumpStartTag.INFERENCE_CONFIG_NAME,
+            tags,
+            is_uri=False,
+        )
+    if config_name and scope == enums.JumpStartScriptScope.TRAINING:
+        tags = add_single_jumpstart_tag(
+            config_name,
+            enums.JumpStartTag.TRAINING_CONFIG_NAME,
             tags,
             is_uri=False,
         )
@@ -840,10 +849,10 @@ def _extract_value_from_list_of_tags(
     return resolved_value
 
 
-def get_jumpstart_model_id_version_from_resource_arn(
+def get_jumpstart_model_info_from_resource_arn(
     resource_arn: str,
     sagemaker_session: Session = constants.DEFAULT_JUMPSTART_SAGEMAKER_SESSION,
-) -> Tuple[Optional[str], Optional[str], Optional[str]]:
+) -> Tuple[Optional[str], Optional[str], Optional[str], Optional[str]]:
     """Returns the JumpStart model ID, version and config name if in resource tags.
 
     Returns 'None' if model ID or version or config name cannot be inferred from tags.
@@ -853,7 +862,8 @@ def get_jumpstart_model_id_version_from_resource_arn(
 
     model_id_keys = [enums.JumpStartTag.MODEL_ID, *constants.EXTRA_MODEL_ID_TAGS]
     model_version_keys = [enums.JumpStartTag.MODEL_VERSION, *constants.EXTRA_MODEL_VERSION_TAGS]
-    model_config_name_keys = [enums.JumpStartTag.MODEL_CONFIG_NAME]
+    inference_config_name_keys = [enums.JumpStartTag.INFERENCE_CONFIG_NAME]
+    training_config_name_keys = [enums.JumpStartTag.TRAINING_CONFIG_NAME]
 
     model_id: Optional[str] = _extract_value_from_list_of_tags(
         tag_keys=model_id_keys,
@@ -869,14 +879,21 @@ def get_jumpstart_model_id_version_from_resource_arn(
         resource_arn=resource_arn,
     )
 
-    config_name: Optional[str] = _extract_value_from_list_of_tags(
-        tag_keys=model_config_name_keys,
+    inference_config_name: Optional[str] = _extract_value_from_list_of_tags(
+        tag_keys=inference_config_name_keys,
         list_tags_result=list_tags_result,
-        resource_name="model config name",
+        resource_name="inference config name",
         resource_arn=resource_arn,
     )
 
-    return model_id, model_version, config_name
+    training_config_name: Optional[str] = _extract_value_from_list_of_tags(
+        tag_keys=training_config_name_keys,
+        list_tags_result=list_tags_result,
+        resource_name="training config name",
+        resource_arn=resource_arn,
+    )
+
+    return model_id, model_version, inference_config_name, training_config_name
 
 
 def get_region_fallback(

--- a/src/sagemaker/predictor.py
+++ b/src/sagemaker/predictor.py
@@ -82,6 +82,7 @@ def retrieve_default(
             inferred_model_version,
             inferred_inference_component_name,
             inferred_config_name,
+            _,
         ) = get_model_info_from_endpoint(endpoint_name, inference_component_name, sagemaker_session)
 
         if not inferred_model_id:

--- a/src/sagemaker/utils.py
+++ b/src/sagemaker/utils.py
@@ -40,7 +40,6 @@ import botocore
 from botocore.utils import merge_dicts
 from six.moves.urllib import parse
 from six import viewitems
-import pandas as pd
 
 from sagemaker import deprecations
 from sagemaker.config import validate_sagemaker_config
@@ -1621,10 +1620,7 @@ def flatten_dict(
     def tuple_reducer(k1, k2):
         if k1 is None:
             return (k2,)
-        else:
-            return k1 + (k2,)
-
-    flattenable_types = (Mapping,)
+        return k1 + (k2,)
 
     # check max_flatten_depth
     if max_flatten_depth is not None and max_flatten_depth < 1:
@@ -1640,7 +1636,7 @@ def flatten_dict(
         for key, value in key_value_iterable:
             has_item = True
             flat_key = reducer(parent, key)
-            if isinstance(value, flattenable_types) and (
+            if isinstance(value, Mapping) and (
                 max_flatten_depth is None or depth < max_flatten_depth
             ):
                 # recursively build the result

--- a/src/sagemaker/utils.py
+++ b/src/sagemaker/utils.py
@@ -1636,14 +1636,9 @@ def flatten_dict(
         for key, value in key_value_iterable:
             has_item = True
             flat_key = reducer(parent, key)
-            if isinstance(value, dict) and (
-                max_flatten_depth is None or depth < max_flatten_depth
-            ):
-                # recursively build the result
+            if isinstance(value, dict) and (max_flatten_depth is None or depth < max_flatten_depth):
                 has_child = _flatten(value, depth=depth + 1, parent=flat_key)
                 if has_child:
-                    # ignore the key in this level because it already has child key
-                    # or its value is empty
                     continue
 
             if flat_key in flat_dict:

--- a/src/sagemaker/utils.py
+++ b/src/sagemaker/utils.py
@@ -26,7 +26,7 @@ import tarfile
 import tempfile
 import time
 from functools import lru_cache
-from typing import Union, Any, List, Optional, Dict
+from typing import Mapping, Union, Any, List, Optional, Dict
 import json
 import abc
 import uuid
@@ -39,6 +39,7 @@ import boto3
 import botocore
 from botocore.utils import merge_dicts
 from six.moves.urllib import parse
+from six import viewitems
 import pandas as pd
 
 from sagemaker import deprecations
@@ -1605,44 +1606,88 @@ def can_model_package_source_uri_autopopulate(source_uri: str):
     )
 
 
-def flatten_dict(source_dict: Dict[str, Any], sep: str = ".") -> Dict[str, Any]:
-    """Flatten a nested dictionary.
+def flatten_dict(
+    d: Dict[str, Any],
+    max_flatten_depth=None,
+) -> Dict[str, Any]:
+    """Flatten a dictionary object.
 
-    Args:
-        source_dict (dict): The dictionary to be flattened.
-        sep (str): The separator to be used in the flattened dictionary.
-    Returns:
-        transformed_dict: The flattened dictionary.
+    d : dict-like object
+        The dict that will be flattened.
+    max_flatten_depth : Optional[int]
+        Maximum depth to merge.
     """
-    flat_dict_list = pd.json_normalize(source_dict, sep=sep).to_dict(orient="records")
-    if flat_dict_list:
-        return flat_dict_list[0]
-    return {}
+
+    def tuple_reducer(k1, k2):
+        if k1 is None:
+            return (k2,)
+        else:
+            return k1 + (k2,)
+
+    flattenable_types = (Mapping,)
+
+    # check max_flatten_depth
+    if max_flatten_depth is not None and max_flatten_depth < 1:
+        raise ValueError("max_flatten_depth should not be less than 1.")
+
+    reducer = tuple_reducer
+
+    flat_dict = {}
+
+    def _flatten(_d, depth, parent=None):
+        key_value_iterable = viewitems(_d)
+        has_item = False
+        for key, value in key_value_iterable:
+            has_item = True
+            flat_key = reducer(parent, key)
+            if isinstance(value, flattenable_types) and (
+                max_flatten_depth is None or depth < max_flatten_depth
+            ):
+                # recursively build the result
+                has_child = _flatten(value, depth=depth + 1, parent=flat_key)
+                if has_child:
+                    # ignore the key in this level because it already has child key
+                    # or its value is empty
+                    continue
+
+            if flat_key in flat_dict:
+                raise ValueError("duplicated key '{}'".format(flat_key))
+            flat_dict[flat_key] = value
+
+        return has_item
+
+    _flatten(d, depth=1)
+    return flat_dict
 
 
-def unflatten_dict(source_dict: Dict[str, Any], sep: str = ".") -> Dict[str, Any]:
-    """Unflatten a flattened dictionary back into a nested dictionary.
+def nested_set_dict(d: Dict[str, Any], keys: List[str], value: Any) -> None:
+    """Set a value to a sequence of nested keys."""
 
-    Args:
-        source_dict (dict): The input flattened dictionary.
-        sep (str): The separator used in the flattened keys.
+    key = keys[0]
 
-    Returns:
-        transformed_dict: The reconstructed nested dictionary.
+    if len(keys) == 1:
+        d[key] = value
+        return
+    if not d:
+        return
+
+    d = d.setdefault(key, {})
+    nested_set_dict(d, keys[1:], value)
+
+
+def unflatten_dict(d: Dict[str, Any]) -> Dict[str, Any]:
+    """Unflatten dict-like object.
+
+    d : dict-like object
+        The dict that will be unflattened.
     """
-    if not source_dict:
-        return {}
 
-    result = {}
-    for key, value in source_dict.items():
-        keys = key.split(sep)
-        current = result
-        for k in keys[:-1]:
-            if k not in current:
-                current[k] = {}
-            current = current[k] if current[k] is not None else current
-        current[keys[-1]] = value
-    return result
+    unflattened_dict = {}
+    for flat_key, value in viewitems(d):
+        key_tuple = flat_key
+        nested_set_dict(unflattened_dict, key_tuple, value)
+
+    return unflattened_dict
 
 
 def deep_override_dict(

--- a/src/sagemaker/utils.py
+++ b/src/sagemaker/utils.py
@@ -1611,9 +1611,9 @@ def flatten_dict(
 ) -> Dict[str, Any]:
     """Flatten a dictionary object.
 
-    d : dict-like object
+    d (Dict[str, Any]):
         The dict that will be flattened.
-    max_flatten_depth : Optional[int]
+    max_flatten_depth (Optional[int]):
         Maximum depth to merge.
     """
 
@@ -1669,7 +1669,7 @@ def nested_set_dict(d: Dict[str, Any], keys: List[str], value: Any) -> None:
 def unflatten_dict(d: Dict[str, Any]) -> Dict[str, Any]:
     """Unflatten dict-like object.
 
-    d : dict-like object
+    d (Dict[str, Any]) :
         The dict that will be unflattened.
     """
 

--- a/src/sagemaker/utils.py
+++ b/src/sagemaker/utils.py
@@ -26,7 +26,7 @@ import tarfile
 import tempfile
 import time
 from functools import lru_cache
-from typing import Mapping, Union, Any, List, Optional, Dict
+from typing import Union, Any, List, Optional, Dict
 import json
 import abc
 import uuid
@@ -1636,7 +1636,7 @@ def flatten_dict(
         for key, value in key_value_iterable:
             has_item = True
             flat_key = reducer(parent, key)
-            if isinstance(value, Mapping) and (
+            if isinstance(value, dict) and (
                 max_flatten_depth is None or depth < max_flatten_depth
             ):
                 # recursively build the result

--- a/tests/unit/sagemaker/jumpstart/model/test_model.py
+++ b/tests/unit/sagemaker/jumpstart/model/test_model.py
@@ -1563,7 +1563,7 @@ class ModelTest(unittest.TestCase):
             tags=[
                 {"Key": JumpStartTag.MODEL_ID, "Value": "pytorch-eqa-bert-base-cased"},
                 {"Key": JumpStartTag.MODEL_VERSION, "Value": "1.0.0"},
-                {"Key": JumpStartTag.MODEL_CONFIG_NAME, "Value": "neuron-inference"},
+                {"Key": JumpStartTag.INFERENCE_CONFIG_NAME, "Value": "neuron-inference"},
             ],
             wait=True,
             endpoint_logging=False,
@@ -1627,7 +1627,7 @@ class ModelTest(unittest.TestCase):
             tags=[
                 {"Key": JumpStartTag.MODEL_ID, "Value": "pytorch-eqa-bert-base-cased"},
                 {"Key": JumpStartTag.MODEL_VERSION, "Value": "1.0.0"},
-                {"Key": JumpStartTag.MODEL_CONFIG_NAME, "Value": "neuron-inference"},
+                {"Key": JumpStartTag.INFERENCE_CONFIG_NAME, "Value": "neuron-inference"},
             ],
             wait=True,
             endpoint_logging=False,
@@ -1645,7 +1645,7 @@ class ModelTest(unittest.TestCase):
             tags=[
                 {"Key": JumpStartTag.MODEL_ID, "Value": "pytorch-eqa-bert-base-cased"},
                 {"Key": JumpStartTag.MODEL_VERSION, "Value": "1.0.0"},
-                {"Key": JumpStartTag.MODEL_CONFIG_NAME, "Value": "neuron-inference"},
+                {"Key": JumpStartTag.INFERENCE_CONFIG_NAME, "Value": "neuron-inference"},
             ],
             wait=True,
             endpoint_logging=False,

--- a/tests/unit/sagemaker/jumpstart/test_predictor.py
+++ b/tests/unit/sagemaker/jumpstart/test_predictor.py
@@ -97,7 +97,7 @@ def test_proprietary_predictor_support(
 def test_jumpstart_predictor_support_no_model_id_supplied_happy_case(
     patched_get_model_specs,
     patched_verify_model_region_and_return_specs,
-    patched_get_jumpstart_model_id_version_from_endpoint,
+    patched_get_model_info_from_endpoint,
     patched_get_default_predictor,
     patched_predictor,
 ):
@@ -105,9 +105,10 @@ def test_jumpstart_predictor_support_no_model_id_supplied_happy_case(
     patched_verify_model_region_and_return_specs.side_effect = verify_model_region_and_return_specs
     patched_get_model_specs.side_effect = get_special_model_spec
 
-    patched_get_jumpstart_model_id_version_from_endpoint.return_value = (
+    patched_get_model_info_from_endpoint.return_value = (
         "predictor-specs-model",
         "1.2.3",
+        None,
         None,
         None,
     )
@@ -116,9 +117,7 @@ def test_jumpstart_predictor_support_no_model_id_supplied_happy_case(
 
     predictor.retrieve_default(endpoint_name="blah", sagemaker_session=mock_session)
 
-    patched_get_jumpstart_model_id_version_from_endpoint.assert_called_once_with(
-        "blah", None, mock_session
-    )
+    patched_get_model_info_from_endpoint.assert_called_once_with("blah", None, mock_session)
 
     patched_get_default_predictor.assert_called_once_with(
         predictor=patched_predictor.return_value,

--- a/tests/unit/sagemaker/jumpstart/test_session_utils.py
+++ b/tests/unit/sagemaker/jumpstart/test_session_utils.py
@@ -12,61 +12,63 @@ from sagemaker.jumpstart.session_utils import (
 )
 
 
-@patch("sagemaker.jumpstart.session_utils.get_jumpstart_model_id_version_from_resource_arn")
+@patch("sagemaker.jumpstart.session_utils.get_jumpstart_model_info_from_resource_arn")
 def test_get_model_info_from_training_job_happy_case(
-    mock_get_jumpstart_model_id_version_from_resource_arn,
+    mock_get_jumpstart_model_info_from_resource_arn,
 ):
     mock_sm_session = Mock()
     mock_sm_session.boto_region_name = "us-west-2"
     mock_sm_session.account_id = Mock(return_value="123456789012")
 
-    mock_get_jumpstart_model_id_version_from_resource_arn.return_value = (
+    mock_get_jumpstart_model_info_from_resource_arn.return_value = (
         "model_id",
         "model_version",
+        None,
         None,
     )
 
     retval = get_model_info_from_training_job("bLaH", sagemaker_session=mock_sm_session)
 
-    assert retval == ("model_id", "model_version", None)
+    assert retval == ("model_id", "model_version", None, None)
 
-    mock_get_jumpstart_model_id_version_from_resource_arn.assert_called_once_with(
+    mock_get_jumpstart_model_info_from_resource_arn.assert_called_once_with(
         "arn:aws:sagemaker:us-west-2:123456789012:training-job/bLaH", mock_sm_session
     )
 
 
-@patch("sagemaker.jumpstart.session_utils.get_jumpstart_model_id_version_from_resource_arn")
+@patch("sagemaker.jumpstart.session_utils.get_jumpstart_model_info_from_resource_arn")
 def test_get_model_info_from_training_job_config_name(
-    mock_get_jumpstart_model_id_version_from_resource_arn,
+    mock_get_jumpstart_model_info_from_resource_arn,
 ):
     mock_sm_session = Mock()
     mock_sm_session.boto_region_name = "us-west-2"
     mock_sm_session.account_id = Mock(return_value="123456789012")
 
-    mock_get_jumpstart_model_id_version_from_resource_arn.return_value = (
+    mock_get_jumpstart_model_info_from_resource_arn.return_value = (
         "model_id",
         "model_version",
-        "config_name",
+        None,
+        "training_config_name"
     )
 
     retval = get_model_info_from_training_job("bLaH", sagemaker_session=mock_sm_session)
 
-    assert retval == ("model_id", "model_version", "config_name")
+    assert retval == ("model_id", "model_version", None, "training_config_name")
 
-    mock_get_jumpstart_model_id_version_from_resource_arn.assert_called_once_with(
+    mock_get_jumpstart_model_info_from_resource_arn.assert_called_once_with(
         "arn:aws:sagemaker:us-west-2:123456789012:training-job/bLaH", mock_sm_session
     )
 
 
-@patch("sagemaker.jumpstart.session_utils.get_jumpstart_model_id_version_from_resource_arn")
+@patch("sagemaker.jumpstart.session_utils.get_jumpstart_model_info_from_resource_arn")
 def test_get_model_info_from_training_job_no_model_id_inferred(
-    mock_get_jumpstart_model_id_version_from_resource_arn,
+    mock_get_jumpstart_model_info_from_resource_arn,
 ):
     mock_sm_session = Mock()
     mock_sm_session.boto_region_name = "us-west-2"
     mock_sm_session.account_id = Mock(return_value="123456789012")
 
-    mock_get_jumpstart_model_id_version_from_resource_arn.return_value = (
+    mock_get_jumpstart_model_info_from_resource_arn.return_value = (
         None,
         None,
     )
@@ -75,17 +77,18 @@ def test_get_model_info_from_training_job_no_model_id_inferred(
         get_model_info_from_training_job("blah", sagemaker_session=mock_sm_session)
 
 
-@patch("sagemaker.jumpstart.session_utils.get_jumpstart_model_id_version_from_resource_arn")
+@patch("sagemaker.jumpstart.session_utils.get_jumpstart_model_info_from_resource_arn")
 def test_get_model_info_from_model_based_endpoint_happy_case(
-    mock_get_jumpstart_model_id_version_from_resource_arn,
+    mock_get_jumpstart_model_info_from_resource_arn,
 ):
     mock_sm_session = Mock()
     mock_sm_session.boto_region_name = "us-west-2"
     mock_sm_session.account_id = Mock(return_value="123456789012")
 
-    mock_get_jumpstart_model_id_version_from_resource_arn.return_value = (
+    mock_get_jumpstart_model_info_from_resource_arn.return_value = (
         "model_id",
         "model_version",
+        None,
         None,
     )
 
@@ -93,24 +96,25 @@ def test_get_model_info_from_model_based_endpoint_happy_case(
         "bLaH", inference_component_name=None, sagemaker_session=mock_sm_session
     )
 
-    assert retval == ("model_id", "model_version", None)
+    assert retval == ("model_id", "model_version", None, None)
 
-    mock_get_jumpstart_model_id_version_from_resource_arn.assert_called_once_with(
+    mock_get_jumpstart_model_info_from_resource_arn.assert_called_once_with(
         "arn:aws:sagemaker:us-west-2:123456789012:endpoint/blah", mock_sm_session
     )
 
 
-@patch("sagemaker.jumpstart.session_utils.get_jumpstart_model_id_version_from_resource_arn")
+@patch("sagemaker.jumpstart.session_utils.get_jumpstart_model_info_from_resource_arn")
 def test_get_model_info_from_model_based_endpoint_inference_component_supplied(
-    mock_get_jumpstart_model_id_version_from_resource_arn,
+    mock_get_jumpstart_model_info_from_resource_arn,
 ):
     mock_sm_session = Mock()
     mock_sm_session.boto_region_name = "us-west-2"
     mock_sm_session.account_id = Mock(return_value="123456789012")
 
-    mock_get_jumpstart_model_id_version_from_resource_arn.return_value = (
+    mock_get_jumpstart_model_info_from_resource_arn.return_value = (
         "model_id",
         "model_version",
+        None,
         None,
     )
 
@@ -120,15 +124,16 @@ def test_get_model_info_from_model_based_endpoint_inference_component_supplied(
         )
 
 
-@patch("sagemaker.jumpstart.session_utils.get_jumpstart_model_id_version_from_resource_arn")
+@patch("sagemaker.jumpstart.session_utils.get_jumpstart_model_info_from_resource_arn")
 def test_get_model_info_from_model_based_endpoint_no_model_id_inferred(
-    mock_get_jumpstart_model_id_version_from_resource_arn,
+    mock_get_jumpstart_model_info_from_resource_arn,
 ):
     mock_sm_session = Mock()
     mock_sm_session.boto_region_name = "us-west-2"
     mock_sm_session.account_id = Mock(return_value="123456789012")
 
-    mock_get_jumpstart_model_id_version_from_resource_arn.return_value = (
+    mock_get_jumpstart_model_info_from_resource_arn.return_value = (
+        None,
         None,
         None,
     )
@@ -139,17 +144,18 @@ def test_get_model_info_from_model_based_endpoint_no_model_id_inferred(
         )
 
 
-@patch("sagemaker.jumpstart.session_utils.get_jumpstart_model_id_version_from_resource_arn")
+@patch("sagemaker.jumpstart.session_utils.get_jumpstart_model_info_from_resource_arn")
 def test_get_model_info_from_inference_component_endpoint_with_inference_component_name_happy_case(
-    mock_get_jumpstart_model_id_version_from_resource_arn,
+    mock_get_jumpstart_model_info_from_resource_arn,
 ):
     mock_sm_session = Mock()
     mock_sm_session.boto_region_name = "us-west-2"
     mock_sm_session.account_id = Mock(return_value="123456789012")
 
-    mock_get_jumpstart_model_id_version_from_resource_arn.return_value = (
+    mock_get_jumpstart_model_info_from_resource_arn.return_value = (
         "model_id",
         "model_version",
+        None,
         None,
     )
 
@@ -157,22 +163,23 @@ def test_get_model_info_from_inference_component_endpoint_with_inference_compone
         "bLaH", sagemaker_session=mock_sm_session
     )
 
-    assert retval == ("model_id", "model_version", None)
+    assert retval == ("model_id", "model_version", None, None)
 
-    mock_get_jumpstart_model_id_version_from_resource_arn.assert_called_once_with(
+    mock_get_jumpstart_model_info_from_resource_arn.assert_called_once_with(
         "arn:aws:sagemaker:us-west-2:123456789012:inference-component/bLaH", mock_sm_session
     )
 
 
-@patch("sagemaker.jumpstart.session_utils.get_jumpstart_model_id_version_from_resource_arn")
+@patch("sagemaker.jumpstart.session_utils.get_jumpstart_model_info_from_resource_arn")
 def test_get_model_info_from_inference_component_endpoint_with_inference_component_name_no_model_id_inferred(
-    mock_get_jumpstart_model_id_version_from_resource_arn,
+    mock_get_jumpstart_model_info_from_resource_arn,
 ):
     mock_sm_session = Mock()
     mock_sm_session.boto_region_name = "us-west-2"
     mock_sm_session.account_id = Mock(return_value="123456789012")
 
-    mock_get_jumpstart_model_id_version_from_resource_arn.return_value = (
+    mock_get_jumpstart_model_info_from_resource_arn.return_value = (
+        None,
         None,
         None,
         None,
@@ -272,11 +279,12 @@ def test_get_model_info_from_endpoint_non_inference_component_endpoint(
         "model_id",
         "model_version",
         None,
+        None,
     )
 
     retval = get_model_info_from_endpoint("blah", sagemaker_session=mock_sm_session)
 
-    assert retval == ("model_id", "model_version", None, None)
+    assert retval == ("model_id", "model_version", None, None, None)
     mock_get_model_info_from_model_based_endpoint.assert_called_once_with(
         "blah", None, mock_sm_session
     )
@@ -296,13 +304,14 @@ def test_get_model_info_from_endpoint_inference_component_endpoint_with_inferenc
         "model_id",
         "model_version",
         None,
+        None,
     )
 
     retval = get_model_info_from_endpoint(
         "blah", inference_component_name="icname", sagemaker_session=mock_sm_session
     )
 
-    assert retval == ("model_id", "model_version", "icname", None)
+    assert retval == ("model_id", "model_version", "icname", None, None)
     mock_get_model_info_from_inference_component_endpoint_with_inference_component_name.assert_called_once_with(
         "icname", mock_sm_session
     )
@@ -322,12 +331,13 @@ def test_get_model_info_from_endpoint_inference_component_endpoint_without_infer
         "model_id",
         "model_version",
         None,
+        None,
         "inferred-icname",
     )
 
     retval = get_model_info_from_endpoint("blah", sagemaker_session=mock_sm_session)
 
-    assert retval == ("model_id", "model_version", "inferred-icname", None)
+    assert retval == ("model_id", "model_version", "inferred-icname", None, None)
     mock_get_model_info_from_inference_component_endpoint_without_inference_component_name.assert_called_once()
 
 
@@ -335,7 +345,7 @@ def test_get_model_info_from_endpoint_inference_component_endpoint_without_infer
     "sagemaker.jumpstart.session_utils._get_model_info_from_inference_component_"
     "endpoint_without_inference_component_name"
 )
-def test_get_model_info_from_endpoint_inference_component_endpoint_with_config_name(
+def test_get_model_info_from_endpoint_inference_component_endpoint_with_inference_config_name(
     mock_get_model_info_from_inference_component_endpoint_without_inference_component_name,
 ):
     mock_sm_session = Mock()
@@ -343,11 +353,35 @@ def test_get_model_info_from_endpoint_inference_component_endpoint_with_config_n
     mock_get_model_info_from_inference_component_endpoint_without_inference_component_name.return_value = (
         "model_id",
         "model_version",
-        "config_name",
+        "inference_config_name",
+        None,
         "inferred-icname",
     )
 
     retval = get_model_info_from_endpoint("blah", sagemaker_session=mock_sm_session)
 
-    assert retval == ("model_id", "model_version", "inferred-icname", "config_name")
+    assert retval == ("model_id", "model_version", "inferred-icname", "inference_config_name", None)
+    mock_get_model_info_from_inference_component_endpoint_without_inference_component_name.assert_called_once()
+
+
+@patch(
+    "sagemaker.jumpstart.session_utils._get_model_info_from_inference_component_"
+    "endpoint_without_inference_component_name"
+)
+def test_get_model_info_from_endpoint_inference_component_endpoint_with_training_config_name(
+    mock_get_model_info_from_inference_component_endpoint_without_inference_component_name,
+):
+    mock_sm_session = Mock()
+    mock_sm_session.is_inference_component_based_endpoint.return_value = True
+    mock_get_model_info_from_inference_component_endpoint_without_inference_component_name.return_value = (
+        "model_id",
+        "model_version",
+        None,
+        "training_config_name",
+        "inferred-icname",
+    )
+
+    retval = get_model_info_from_endpoint("blah", sagemaker_session=mock_sm_session)
+
+    assert retval == ("model_id", "model_version", "inferred-icname", None, "training_config_name")
     mock_get_model_info_from_inference_component_endpoint_without_inference_component_name.assert_called_once()

--- a/tests/unit/sagemaker/jumpstart/test_session_utils.py
+++ b/tests/unit/sagemaker/jumpstart/test_session_utils.py
@@ -48,7 +48,7 @@ def test_get_model_info_from_training_job_config_name(
         "model_id",
         "model_version",
         None,
-        "training_config_name"
+        "training_config_name",
     )
 
     retval = get_model_info_from_training_job("bLaH", sagemaker_session=mock_sm_session)

--- a/tests/unit/sagemaker/jumpstart/test_utils.py
+++ b/tests/unit/sagemaker/jumpstart/test_utils.py
@@ -210,16 +210,16 @@ def test_is_jumpstart_model_uri():
     assert utils.is_jumpstart_model_uri(random_jumpstart_s3_uri("random_key"))
 
 
-def test_add_jumpstart_model_id_version_tags():
+def test_add_jumpstart_model_info_tags():
     tags = None
     model_id = "model_id"
     version = "version"
+    inference_config_name = "inference_config_name"
+    training_config_name = "training_config_name"
     assert [
         {"Key": "sagemaker-sdk:jumpstart-model-id", "Value": "model_id"},
         {"Key": "sagemaker-sdk:jumpstart-model-version", "Value": "version"},
-    ] == utils.add_jumpstart_model_id_version_tags(
-        tags=tags, model_id=model_id, model_version=version
-    )
+    ] == utils.add_jumpstart_model_info_tags(tags=tags, model_id=model_id, model_version=version)
 
     tags = [
         {"Key": "sagemaker-sdk:jumpstart-model-id", "Value": "model_id_2"},
@@ -231,9 +231,7 @@ def test_add_jumpstart_model_id_version_tags():
     assert [
         {"Key": "sagemaker-sdk:jumpstart-model-id", "Value": "model_id_2"},
         {"Key": "sagemaker-sdk:jumpstart-model-version", "Value": "version_2"},
-    ] == utils.add_jumpstart_model_id_version_tags(
-        tags=tags, model_id=model_id, model_version=version
-    )
+    ] == utils.add_jumpstart_model_info_tags(tags=tags, model_id=model_id, model_version=version)
 
     tags = [
         {"Key": "random key", "Value": "random_value"},
@@ -244,9 +242,7 @@ def test_add_jumpstart_model_id_version_tags():
         {"Key": "random key", "Value": "random_value"},
         {"Key": "sagemaker-sdk:jumpstart-model-id", "Value": "model_id"},
         {"Key": "sagemaker-sdk:jumpstart-model-version", "Value": "version"},
-    ] == utils.add_jumpstart_model_id_version_tags(
-        tags=tags, model_id=model_id, model_version=version
-    )
+    ] == utils.add_jumpstart_model_info_tags(tags=tags, model_id=model_id, model_version=version)
 
     tags = [
         {"Key": "sagemaker-sdk:jumpstart-model-id", "Value": "model_id_2"},
@@ -257,9 +253,7 @@ def test_add_jumpstart_model_id_version_tags():
     assert [
         {"Key": "sagemaker-sdk:jumpstart-model-id", "Value": "model_id_2"},
         {"Key": "sagemaker-sdk:jumpstart-model-version", "Value": "version"},
-    ] == utils.add_jumpstart_model_id_version_tags(
-        tags=tags, model_id=model_id, model_version=version
-    )
+    ] == utils.add_jumpstart_model_info_tags(tags=tags, model_id=model_id, model_version=version)
 
     tags = [
         {"Key": "random key", "Value": "random_value"},
@@ -268,8 +262,58 @@ def test_add_jumpstart_model_id_version_tags():
     version = None
     assert [
         {"Key": "random key", "Value": "random_value"},
-    ] == utils.add_jumpstart_model_id_version_tags(
-        tags=tags, model_id=model_id, model_version=version
+    ] == utils.add_jumpstart_model_info_tags(tags=tags, model_id=model_id, model_version=version)
+
+    tags = [
+        {"Key": "random key", "Value": "random_value"},
+    ]
+    model_id = "model_id"
+    version = "version"
+    assert [
+        {"Key": "random key", "Value": "random_value"},
+        {"Key": "sagemaker-sdk:jumpstart-model-id", "Value": "model_id"},
+        {"Key": "sagemaker-sdk:jumpstart-model-version", "Value": "version"},
+        {"Key": "sagemaker-sdk:jumpstart-inference-config-name", "Value": "inference_config_name"},
+    ] == utils.add_jumpstart_model_info_tags(
+        tags=tags,
+        model_id=model_id,
+        model_version=version,
+        config_name=inference_config_name,
+        scope=JumpStartScriptScope.INFERENCE,
+    )
+
+    tags = [
+        {"Key": "random key", "Value": "random_value"},
+    ]
+    model_id = "model_id"
+    version = "version"
+    assert [
+        {"Key": "random key", "Value": "random_value"},
+        {"Key": "sagemaker-sdk:jumpstart-model-id", "Value": "model_id"},
+        {"Key": "sagemaker-sdk:jumpstart-model-version", "Value": "version"},
+        {"Key": "sagemaker-sdk:jumpstart-training-config-name", "Value": "training_config_name"},
+    ] == utils.add_jumpstart_model_info_tags(
+        tags=tags,
+        model_id=model_id,
+        model_version=version,
+        config_name=training_config_name,
+        scope=JumpStartScriptScope.TRAINING,
+    )
+
+    tags = [
+        {"Key": "random key", "Value": "random_value"},
+    ]
+    model_id = "model_id"
+    version = "version"
+    assert [
+        {"Key": "random key", "Value": "random_value"},
+        {"Key": "sagemaker-sdk:jumpstart-model-id", "Value": "model_id"},
+        {"Key": "sagemaker-sdk:jumpstart-model-version", "Value": "version"},
+    ] == utils.add_jumpstart_model_info_tags(
+        tags=tags,
+        model_id=model_id,
+        model_version=version,
+        config_name=training_config_name,
     )
 
 
@@ -1322,10 +1366,8 @@ class TestGetModelIdVersionFromResourceArn(TestCase):
         mock_list_tags.return_value = [{"Key": "blah", "Value": "blah1"}]
 
         self.assertEquals(
-            utils.get_jumpstart_model_id_version_from_resource_arn(
-                "some-arn", mock_sagemaker_session
-            ),
-            (None, None, None),
+            utils.get_jumpstart_model_info_from_resource_arn("some-arn", mock_sagemaker_session),
+            (None, None, None, None),
         )
         mock_list_tags.assert_called_once_with("some-arn")
 
@@ -1339,10 +1381,8 @@ class TestGetModelIdVersionFromResourceArn(TestCase):
         ]
 
         self.assertEquals(
-            utils.get_jumpstart_model_id_version_from_resource_arn(
-                "some-arn", mock_sagemaker_session
-            ),
-            ("model_id", None, None),
+            utils.get_jumpstart_model_info_from_resource_arn("some-arn", mock_sagemaker_session),
+            ("model_id", None, None, None),
         )
         mock_list_tags.assert_called_once_with("some-arn")
 
@@ -1356,10 +1396,8 @@ class TestGetModelIdVersionFromResourceArn(TestCase):
         ]
 
         self.assertEquals(
-            utils.get_jumpstart_model_id_version_from_resource_arn(
-                "some-arn", mock_sagemaker_session
-            ),
-            (None, "model_version", None),
+            utils.get_jumpstart_model_info_from_resource_arn("some-arn", mock_sagemaker_session),
+            (None, "model_version", None, None),
         )
         mock_list_tags.assert_called_once_with("some-arn")
 
@@ -1370,27 +1408,54 @@ class TestGetModelIdVersionFromResourceArn(TestCase):
         mock_list_tags.return_value = [{"Key": "blah", "Value": "blah1"}]
 
         self.assertEquals(
-            utils.get_jumpstart_model_id_version_from_resource_arn(
-                "some-arn", mock_sagemaker_session
-            ),
-            (None, None, None),
+            utils.get_jumpstart_model_info_from_resource_arn("some-arn", mock_sagemaker_session),
+            (None, None, None, None),
         )
         mock_list_tags.assert_called_once_with("some-arn")
 
-    def test_config_name_found(self):
+    def test_inference_config_name_found(self):
         mock_list_tags = Mock()
         mock_sagemaker_session = Mock()
         mock_sagemaker_session.list_tags = mock_list_tags
         mock_list_tags.return_value = [
             {"Key": "blah", "Value": "blah1"},
-            {"Key": JumpStartTag.MODEL_CONFIG_NAME, "Value": "config_name"},
+            {"Key": JumpStartTag.INFERENCE_CONFIG_NAME, "Value": "config_name"},
         ]
 
         self.assertEquals(
-            utils.get_jumpstart_model_id_version_from_resource_arn(
-                "some-arn", mock_sagemaker_session
-            ),
-            (None, None, "config_name"),
+            utils.get_jumpstart_model_info_from_resource_arn("some-arn", mock_sagemaker_session),
+            (None, None, "config_name", None),
+        )
+        mock_list_tags.assert_called_once_with("some-arn")
+
+    def test_training_config_name_found(self):
+        mock_list_tags = Mock()
+        mock_sagemaker_session = Mock()
+        mock_sagemaker_session.list_tags = mock_list_tags
+        mock_list_tags.return_value = [
+            {"Key": "blah", "Value": "blah1"},
+            {"Key": JumpStartTag.TRAINING_CONFIG_NAME, "Value": "config_name"},
+        ]
+
+        self.assertEquals(
+            utils.get_jumpstart_model_info_from_resource_arn("some-arn", mock_sagemaker_session),
+            (None, None, None, "config_name"),
+        )
+        mock_list_tags.assert_called_once_with("some-arn")
+
+    def test_both_config_name_found(self):
+        mock_list_tags = Mock()
+        mock_sagemaker_session = Mock()
+        mock_sagemaker_session.list_tags = mock_list_tags
+        mock_list_tags.return_value = [
+            {"Key": "blah", "Value": "blah1"},
+            {"Key": JumpStartTag.INFERENCE_CONFIG_NAME, "Value": "inference_config_name"},
+            {"Key": JumpStartTag.TRAINING_CONFIG_NAME, "Value": "training_config_name"},
+        ]
+
+        self.assertEquals(
+            utils.get_jumpstart_model_info_from_resource_arn("some-arn", mock_sagemaker_session),
+            (None, None, "inference_config_name", "training_config_name"),
         )
         mock_list_tags.assert_called_once_with("some-arn")
 
@@ -1405,10 +1470,8 @@ class TestGetModelIdVersionFromResourceArn(TestCase):
         ]
 
         self.assertEquals(
-            utils.get_jumpstart_model_id_version_from_resource_arn(
-                "some-arn", mock_sagemaker_session
-            ),
-            ("model_id", "model_version", None),
+            utils.get_jumpstart_model_info_from_resource_arn("some-arn", mock_sagemaker_session),
+            ("model_id", "model_version", None, None),
         )
         mock_list_tags.assert_called_once_with("some-arn")
 
@@ -1425,10 +1488,8 @@ class TestGetModelIdVersionFromResourceArn(TestCase):
         ]
 
         self.assertEquals(
-            utils.get_jumpstart_model_id_version_from_resource_arn(
-                "some-arn", mock_sagemaker_session
-            ),
-            (None, None, None),
+            utils.get_jumpstart_model_info_from_resource_arn("some-arn", mock_sagemaker_session),
+            (None, None, None, None),
         )
         mock_list_tags.assert_called_once_with("some-arn")
 
@@ -1445,10 +1506,8 @@ class TestGetModelIdVersionFromResourceArn(TestCase):
         ]
 
         self.assertEquals(
-            utils.get_jumpstart_model_id_version_from_resource_arn(
-                "some-arn", mock_sagemaker_session
-            ),
-            ("model_id_1", "model_version_1", None),
+            utils.get_jumpstart_model_info_from_resource_arn("some-arn", mock_sagemaker_session),
+            ("model_id_1", "model_version_1", None, None),
         )
         mock_list_tags.assert_called_once_with("some-arn")
 
@@ -1465,10 +1524,8 @@ class TestGetModelIdVersionFromResourceArn(TestCase):
         ]
 
         self.assertEquals(
-            utils.get_jumpstart_model_id_version_from_resource_arn(
-                "some-arn", mock_sagemaker_session
-            ),
-            (None, None, None),
+            utils.get_jumpstart_model_info_from_resource_arn("some-arn", mock_sagemaker_session),
+            (None, None, None, None),
         )
         mock_list_tags.assert_called_once_with("some-arn")
 
@@ -1480,15 +1537,13 @@ class TestGetModelIdVersionFromResourceArn(TestCase):
             {"Key": "blah", "Value": "blah1"},
             {"Key": JumpStartTag.MODEL_ID, "Value": "model_id_1"},
             {"Key": JumpStartTag.MODEL_VERSION, "Value": "model_version_1"},
-            {"Key": JumpStartTag.MODEL_CONFIG_NAME, "Value": "config_name_1"},
-            {"Key": JumpStartTag.MODEL_CONFIG_NAME, "Value": "config_name_2"},
+            {"Key": JumpStartTag.INFERENCE_CONFIG_NAME, "Value": "config_name_1"},
+            {"Key": JumpStartTag.INFERENCE_CONFIG_NAME, "Value": "config_name_2"},
         ]
 
         self.assertEquals(
-            utils.get_jumpstart_model_id_version_from_resource_arn(
-                "some-arn", mock_sagemaker_session
-            ),
-            ("model_id_1", "model_version_1", None),
+            utils.get_jumpstart_model_info_from_resource_arn("some-arn", mock_sagemaker_session),
+            ("model_id_1", "model_version_1", None, None),
         )
         mock_list_tags.assert_called_once_with("some-arn")
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1819,7 +1819,13 @@ def test_can_model_package_source_uri_autopopulate():
 class TestDeepMergeDict(TestCase):
     def test_flatten_dict_basic(self):
         nested_dict = {"a": 1, "b": {"x": 2, "y": {"p": 3, "q": 4}}, "c": 5}
-        flattened_dict = {"a": 1, "b.x": 2, "b.y.p": 3, "b.y.q": 4, "c": 5}
+        flattened_dict = {
+            ("a",): 1,
+            ("b", "x"): 2,
+            ("b", "y", "p"): 3,
+            ("b", "y", "q"): 4,
+            ("c",): 5,
+        }
         self.assertDictEqual(flatten_dict(nested_dict), flattened_dict)
         self.assertDictEqual(unflatten_dict(flattened_dict), nested_dict)
 
@@ -1831,13 +1837,19 @@ class TestDeepMergeDict(TestCase):
 
     def test_flatten_dict_no_nested(self):
         nested_dict = {"a": 1, "b": 2, "c": 3}
-        flattened_dict = {"a": 1, "b": 2, "c": 3}
+        flattened_dict = {("a",): 1, ("b",): 2, ("c",): 3}
         self.assertDictEqual(flatten_dict(nested_dict), flattened_dict)
         self.assertDictEqual(unflatten_dict(flattened_dict), nested_dict)
 
     def test_flatten_dict_with_various_types(self):
         nested_dict = {"a": [1, 2, 3], "b": {"x": None, "y": {"p": [], "q": ""}}, "c": 9}
-        flattened_dict = {"a": [1, 2, 3], "b.x": None, "b.y.p": [], "b.y.q": "", "c": 9}
+        flattened_dict = {
+            ("a",): [1, 2, 3],
+            ("b", "x"): None,
+            ("b", "y", "p"): [],
+            ("b", "y", "q"): "",
+            ("c",): 9,
+        }
         self.assertDictEqual(flatten_dict(nested_dict), flattened_dict)
         self.assertDictEqual(unflatten_dict(flattened_dict), nested_dict)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR is a follow-up of the tagging mechanism for configs. We will tag separately for inference_config and training_config, so that the resources are identified clearly with their configs.

Together in this change, addressed a comment to improve on the deep_override_merge dict method, so that we don't rely on any string separator which could conflict with metadata fields.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
