### PR TITLE
feature: add asset manager

### DIFF
--- a/src/sagemaker/asset/__init__.py
+++ b/src/sagemaker/asset/__init__.py
@@ -1,0 +1,16 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+"""Classes for using DatasetDefinition in Processing job with Amazon SageMaker."""
+from sagemaker.asset.asset import Asset, Listing, ChangeSetAction, AssetTypeIdentifier  # noqa: F401
+from sagemaker.asset.asset_manager import AssetManager  # noqa: F401

--- a/src/sagemaker/asset/asset.py
+++ b/src/sagemaker/asset/asset.py
@@ -1,0 +1,87 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+"""This module contains code related to the DataZone SageMaker Asset."""
+from __future__ import print_function, absolute_import
+
+from typing import Optional, Dict, List
+from enum import Enum
+import attr
+
+
+class AssetTypeIdentifier(Enum):
+    """AssetTypeIdentifier class.
+
+    Enumeration for various ML and data asset types.
+
+    """
+
+    SageMakerFeatureGroupAssetType = "amazon.datazone.SageMakerFeatureGroupAssetType"
+    SageMakerModelPackageGroupAssetType = "amazon.datazone.SageMakerModelPackageGroupAssetType"
+    DataZoneGlueAssetType = "amazon.datazone.GlueTableAssetType"
+
+    @staticmethod
+    def value_of(s):
+        """Converts a string to a value of the enumeration.
+
+        Args:
+            s: An enumeration value as string.
+
+        Raises:
+            ValueError: If the combination of arguments specified is not supported.
+        """
+        for e in AssetTypeIdentifier:
+            if e.value == s:
+                return e
+
+        raise ValueError("Argument does not match any AssetTypeIdentifiers")
+
+
+@attr.s
+class Asset(object):
+    """An asset class representing a DataZone SageMaker ML asset.
+
+    Attributes:
+        name (str): The name of the asset.
+        type_id (AssetTypeIdentifier): The DataZone type identifier for the asset.
+        external_id (str): The external id of the asset, which equals to resource ARN.
+        id (str): The id of the asset. We wil update the asset id once asset is created.
+        forms_input (Optional[List[Dict]]): The metadata forms of the asset.
+    """
+
+    name: str = attr.ib()
+    type_id: AssetTypeIdentifier = attr.ib()
+    external_id: str = attr.ib()
+    id: str = attr.ib(default=None)
+    forms_input: Optional[List[Dict]] = attr.ib(default=None)
+
+
+class ChangeSetAction(Enum):
+    """A change set action class."""
+
+    PUBLISH = "PUBLISH"
+    UNPUBLISH = "UNPUBLISH"
+
+
+@attr.s
+class Listing(object):
+    """A listing class representing a published DataZone SageMaker ML asset.
+
+    Attributes:
+        id (str): The id of the listing.
+        revision (str): The revision of the listing.
+        status (str): The status of the listing
+    """
+
+    id: str = attr.ib()
+    revision: str = attr.ib()
+    status: str = attr.ib(default=None)

--- a/src/sagemaker/asset/asset_builder.py
+++ b/src/sagemaker/asset/asset_builder.py
@@ -1,0 +1,528 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+"""This module contains code related to the DataZone SageMaker AssetBuilder abstract class."""
+from __future__ import print_function, absolute_import
+
+import time
+import json
+import logging
+from typing import Dict, Any
+from abc import ABC, abstractmethod  # pylint: disable=E0611
+from boto3 import Session, client
+import sagemaker
+from sagemaker.asset import Asset, AssetTypeIdentifier
+from sagemaker.feature_store.feature_group import FeatureGroup
+from sagemaker.model import ModelPackageGroup
+
+logger = logging.getLogger(__name__)
+
+
+class AssetBuilder(ABC):
+    """Base class for asset builders."""
+
+    def __init__(self, sagemaker_session: Session):
+        """Initializes AssetBuilder
+
+        Args:
+            session: the SageMaker Session
+
+        Returns:
+            domain id, project id, environment id.
+        """
+        self.sagemaker_client = sagemaker_session.sagemaker_client
+        self.manage_access_role = self.__get_manage_access_role()
+        self.asset_common_details_form_name: str = "AssetCommonDetailsForm"
+        self.asset_common_details_form_type_id: str = "amazon.datazone.AssetCommonDetailsFormType"
+
+    @abstractmethod
+    def build_asset(self, resource):
+        """Builds an asset
+
+        Args:
+            resource: the resource used to build the asset
+        """
+
+    @classmethod
+    def convert_date_time(cls, dt):
+        """Converts date time
+
+        Args:
+            dt: The date time to convert
+        """
+        return dt.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+    @staticmethod
+    def __get_manage_access_role():
+        """Gets manage access role
+
+        Returns:
+            The arn of the manage access role
+        """
+        execution_role = sagemaker.get_execution_role()
+        account = execution_role.split(":")[4]
+        return f"arn:aws:iam::{account}:role/AmazonDataZoneSageMakerManageAccessRole"
+
+
+class FeatureGroupAssetBuilder(AssetBuilder):
+    """Builds a DataZone asset from a feature group."""
+
+    LATEST_FORM_TYPE_REVISION = 3
+
+    def __init__(
+        self,
+        sagemaker_session: Session,
+        domain_id: str,
+        project_id: str,
+        environment_id: str,
+        datazone_client: object
+    ):
+        """Initializes a SageMaker `FeatureGroupAssetBuilder` instance.
+
+        Args:
+            sagemaker_session (sagemaker.session.Session): A SageMaker Session
+                object, used for SageMaker interactions (default: None). If not
+                specified, one is created using the default AWS configuration
+                chain.
+            domain_id (str): The id of the DataZone domain
+            project_id (str): The id of the DataZone project
+            environment_id (str): The id of the DataZone environment
+            datazone_client (obj): The datazone client
+        """
+        AssetBuilder.__init__(self, sagemaker_session)
+        self.__asset_type_id = AssetTypeIdentifier.SageMakerFeatureGroupAssetType
+        self.__form_type_id = "amazon.datazone.SageMakerFeatureGroupFormType"
+        self.__form_name = "SageMakerFeatureGroupForm"
+
+        self.__domain_id = domain_id
+        self.__project_id = project_id
+        self.__environment_id = environment_id
+        self.__datazone_client = datazone_client
+
+    def build_asset(self, resource) -> tuple[Asset, Asset]:
+        """Builds an asset for a resource.
+
+        Args:
+            resource: The resource to build an asset for.
+
+        Returns:
+            Online asset, Offline asset
+        """
+
+        if isinstance(resource, FeatureGroup):
+            resource_name = resource.name
+        else:
+            resource_name = resource
+
+        describe_resp = self.sagemaker_client.describe_feature_group(FeatureGroupName=resource_name)
+        fg_status = describe_resp["FeatureGroupStatus"]
+        if fg_status == "Creating":
+            raise ValueError(f"Feature group {resource_name} is in {fg_status} state. Please wait.")
+        if fg_status in ("CreateFailed", "Deleting", "DeleteFailed"):
+            raise ValueError(f"Feature group {resource_name} is in invalid {fg_status} state.")
+
+        # There will be three scenarios, The feature group has
+        # 1. only online store enabled
+        # 2. only offline store enabled
+        # 3. both online and offline stores enabled
+        offline_asset = None
+        if "OfflineStoreConfig" in describe_resp:
+            offline_store_config = describe_resp["OfflineStoreConfig"]
+            if (
+                "DataCatalogConfig" in offline_store_config
+                and offline_store_config["DataCatalogConfig"]
+            ):
+                # 1. validate the offline store s3 location for lake formation registration
+                if self.__validate_for_lake_formation(offline_store_config):
+                    # 2. create a datazone glue data source to import the table as data asset
+                    data_source_id = self.__create_glue_data_source(
+                        feature_group_name=describe_resp["FeatureGroupName"],
+                        data_catalog_config=offline_store_config["DataCatalogConfig"],
+                    )
+                    # 3. start the data source run
+                    data_source_run_id = self.__start_data_source_run(data_source_id)
+                    # 4. retrieve the glue asset created
+                    offline_asset = self.__retrieve_offline_asset(data_source_run_id)
+
+        last_modified_time = describe_resp.get("LastModifiedTime", describe_resp["CreationTime"])
+        feature_group_forms = {
+            "featureGroupName": describe_resp["FeatureGroupName"],
+            "featureGroupArn": describe_resp["FeatureGroupArn"],
+            "recordIdentifierFeatureName": describe_resp["RecordIdentifierFeatureName"],
+            "eventTimeFeatureName": describe_resp["EventTimeFeatureName"],
+            "creationTime": AssetBuilder.convert_date_time(describe_resp["CreationTime"]),
+            "lastModifiedTime": AssetBuilder.convert_date_time(last_modified_time),
+        }
+
+        if "OfflineStoreStatus" in describe_resp:
+            feature_group_forms.update(
+                {"offlineStoreStatus": describe_resp["OfflineStoreStatus"]["Status"].upper()}
+            )
+
+        # we need to retrieve all the feature definitions
+        feature_definitions = describe_resp["FeatureDefinitions"]
+        next_token = describe_resp.get("NextToken", None)
+        while next_token:
+            describe_resp.get("LastModifiedTime", describe_resp["CreationTime"])
+            describe_resp = self.sagemaker_client.describe_feature_group(
+                FeatureGroupName=resource_name,
+                NextToken=next_token,
+            )
+            feature_definitions += describe_resp["FeatureDefinitions"]
+            next_token = describe_resp.get("NextToken", None)
+
+        feature_group_forms.update(
+            {"featureDefinitions": [self.__convert_feature_def(f) for f in feature_definitions]}
+        )
+
+        form_inputs = [
+            {
+                "formName": self.__form_name,
+                "typeIdentifier": self.__form_type_id,
+                "content": json.dumps(feature_group_forms),
+            }
+        ]
+
+        if offline_asset:
+            form_inputs.append(
+                {
+                    "formName": self.asset_common_details_form_name,
+                    "typeIdentifier": self.asset_common_details_form_type_id,
+                    "content": json.dumps(
+                        {"customProperties": {"FeatureGroupOfflineStoreAssetId": offline_asset.id}}
+                    ),
+                }
+            )
+
+        online_asset = Asset(
+            name=describe_resp["FeatureGroupName"],
+            type_id=self.__asset_type_id,
+            external_id=describe_resp["FeatureGroupArn"],
+            forms_input=form_inputs,
+        )
+
+        return (online_asset, offline_asset)
+
+    def __validate_for_lake_formation(self, offline_store_config: Dict):
+        """Validates lake formation
+
+        Args:
+            offline_store_config: The offline store config.
+
+        Returns:
+            True if config is valid.
+        """
+        s3_location = offline_store_config["S3StorageConfig"]["ResolvedOutputS3Uri"]
+        # We need to verify if the ResolvedOutputS3Uri bucket is the same as the
+        # default DZ bucket. If not, we will reject to publish offline store. The reason
+        # is that in order to make the auto-granting work, the offline store s3 location
+        # needs to be registered with LF. ML builder (assuming the execution role) will not
+        # have the permission to register. They will need to ask their Admin to do it.
+        default_bucket = self.__get_environment_default_bucket()
+        if not s3_location.startswith(default_bucket):
+            logger.warning(
+                "Offline store s3 uri %s is not in the same bucket as the default "
+                "DataZone environment bucket. We wont be able to fulfill the access granting"
+                "for any subscription. Skip the creation of offline store glue asset.",
+                s3_location,
+            )
+            return False
+        return True
+
+    def __get_environment_default_bucket(self) -> str:
+        """Get environment default bucket.
+
+        Returns:
+            The bucket uri of the glue producer.
+        """
+        get_environment_resp = self.__datazone_client.get_environment(
+            domainIdentifier=self.__domain_id,
+            identifier=self.__environment_id,
+        )
+        if "provisionedResources" in get_environment_resp:
+            for resource in get_environment_resp["provisionedResources"]:
+                if resource["name"] == "glueProducerOutputUri":
+                    return resource["value"]
+        return ""
+
+    def __create_glue_data_source(self, feature_group_name: str, data_catalog_config) -> str:
+        """Creates a glue data source.
+
+        Returns:
+            The id of the created data source.
+        """
+        offline_store_data_source_name = f"{feature_group_name}-offline-store-data-source"
+        # if we already have a corresponding data source exists, we simply trigger its run
+        list_data_sources_resp = self.__datazone_client.list_data_sources(
+            domainIdentifier=self.__domain_id,
+            projectIdentifier=self.__project_id,
+            environmentIdentifier=self.__environment_id,
+            name=offline_store_data_source_name,
+        )
+
+        if len(list_data_sources_resp["items"]) > 0:
+            assert (
+                len(list_data_sources_resp["items"]) == 1
+            ), f"More than offline store data source for {feature_group_name} found"
+            return list_data_sources_resp["items"][0]["dataSourceId"]
+
+        # otherwise, we create a new data source
+        create_data_source_resp = self.__datazone_client.create_data_source(
+            domainIdentifier=self.__domain_id,
+            projectIdentifier=self.__project_id,
+            environmentIdentifier=self.__environment_id,
+            type="GLUE",
+            configuration={
+                "glueRunConfiguration": {
+                    "dataAccessRole": self.manage_access_role,
+                    "relationalFilterConfigurations": [
+                        {
+                            "databaseName": data_catalog_config["Database"],
+                            "filterExpressions": [
+                                {
+                                    "type": "INCLUDE",
+                                    "expression": data_catalog_config["TableName"],
+                                }
+                            ],
+                        }
+                    ],
+                }
+            },
+            enableSetting="ENABLED",
+            publishOnImport=False,
+            name=offline_store_data_source_name,
+        )
+        return create_data_source_resp["id"]
+
+    def __start_data_source_run(self, data_source_id: str) -> str:
+        """Start data source run.
+
+        Returns:
+            The id of the data source run.
+        """
+        data_source_status = None
+        while not data_source_status or data_source_status == "CREATING":
+            get_data_source_resp = self.__datazone_client.get_data_source(
+                domainIdentifier=self.__domain_id,
+                identifier=data_source_id,
+            )
+            data_source_status = get_data_source_resp["status"]
+            time.sleep(10)
+
+        if data_source_status != "READY":
+            raise ValueError(f"Data source {data_source_id} is in {data_source_status} state")
+
+        start_data_source_run_resp = self.__datazone_client.start_data_source_run(
+            domainIdentifier=self.__domain_id,
+            dataSourceIdentifier=data_source_id,
+        )
+        return start_data_source_run_resp["id"]
+
+    def __retrieve_offline_asset(self, data_source_run_id: str) -> Asset:
+        """Retrieves offline asset.
+
+        Returns:
+            The asset.
+        """
+        status = None
+        while not status or status == "RUNNING" or status == "REQUESTED":
+            get_data_source_run_resp = self.__datazone_client.get_data_source_run(
+                domainIdentifier=self.__domain_id,
+                identifier=data_source_run_id,
+            )
+            status = get_data_source_run_resp["status"]
+
+        if status != "SUCCESS":
+            raise ValueError(f"Data source run {data_source_run_id} is in {status} state")
+
+        list_data_source_run_activities_resp = (
+            self.__datazone_client.list_data_source_run_activities(
+                domainIdentifier=self.__domain_id,
+                identifier=data_source_run_id,
+            )
+        )
+
+        if not list_data_source_run_activities_resp["items"]:
+            return None
+
+        assert (
+            len(list_data_source_run_activities_resp["items"]) == 1
+        ), f"More than one data source run activity found for {data_source_run_id}"
+
+        item = list_data_source_run_activities_resp["items"][0]
+
+        if item["dataAssetStatus"] == "FAILED":
+            raise ValueError(
+                f"Data source run activity {item['id']} "
+                f"failed with error message: {item['errorMessage']}"
+            )
+
+        asset_id = item["dataAssetId"]
+        get_asset_resp = self.__datazone_client.get_asset(
+            domainIdentifier=self.__domain_id,
+            identifier=asset_id,
+        )
+
+        return Asset(
+            id=asset_id,
+            name=get_asset_resp["name"],
+            type_id=AssetTypeIdentifier.value_of(
+                get_asset_resp["typeIdentifier"]
+            ),  # glue table asset type
+            external_id=get_asset_resp["externalIdentifier"],
+            forms_input=[
+                self.__convert_form_output_to_form_input(form_output)
+                for form_output in get_asset_resp["formsOutput"]
+            ],
+        )
+
+    @staticmethod
+    def __convert_feature_def(feature_definition) -> Dict[str, Any]:
+        """Converts feature definition for asset creation.
+
+        Args:
+            feature_definition: the feature definition object
+
+        Returns:
+            The feature definition dictionary.
+        """
+
+        def convert_feature_type(feature_type: str) -> str:
+            if feature_type == "Integral":
+                return feature_type.upper()
+            if feature_type == "Fractional":
+                return feature_type.upper()
+            if feature_type == "String":
+                return feature_type.upper()
+            raise ValueError("Unsupported feature type: {}".format(feature_type))
+
+        feature_def = {
+            "featureName": feature_definition["FeatureName"],
+            "featureType": convert_feature_type(feature_definition["FeatureType"]),
+        }
+
+        if "CollectionType" in feature_definition:
+            feature_def.update({"collectionType": feature_definition["CollectionType"].upper()})
+
+        if "CollectionConfig" in feature_definition:
+            feature_def.update({"collectionConfig": feature_definition["CollectionConfig"]})
+
+        return feature_def
+
+    @staticmethod
+    def __convert_form_output_to_form_input(form_output: Dict[str, Any]) -> Dict[str, Any]:
+        """Converts form output to form input.
+
+        Args:
+            form_output: the form output
+
+        Returns:
+            The form input.
+        """
+        form_input = {
+            "formName": form_output["formName"],
+            "content": form_output["content"],
+            "typeIdentifier": form_output["typeName"],
+        }
+
+        if "typeRevision" in form_output:
+            form_input["typeRevision"] = form_output["typeRevision"]
+
+        return form_input
+
+    def append_offline_store_online_store_property(
+        self, offline_asset: Asset, online_store_asset_id: str
+    ):
+        """Appends offline store to the online store property.
+
+        Args:
+            offline_asset: the offline store asset
+            online_store_asset_id: the online store asset id
+        """
+        offline_asset.forms_input.append(
+            {
+                "formName": self.asset_common_details_form_name,
+                "typeIdentifier": self.asset_common_details_form_type_id,
+                "content": json.dumps(
+                    {
+                        "customProperties": {
+                            "FeatureGroupOnlineStoreAssetId": online_store_asset_id,
+                        }
+                    }
+                ),
+            }
+        )
+
+
+class ModelPackageGroupAssetBuilder(AssetBuilder):
+    """Builds asset for model package groups."""
+
+    def __init__(self, sagemaker_session: Session):
+        """Initializes as SageMaker 'ModelPackageGroupAssetBuilder' instance.
+
+    Args:
+        sagemaker_session (sagemaker.session.Session): A SageMaker Session
+            object, used for SageMaker interactions (default: None). If not
+            specified, one is created using the default AWS configuration
+            chain.
+
+        """
+        super().__init__(sagemaker_session)
+        self.__asset_type_id = AssetTypeIdentifier.SageMakerModelPackageGroupAssetType
+        self.__form_type_id = "amazon.datazone.SageMakerModelPackageGroupFormType"
+        self.__form_name = "SageMakerModelPackageGroupForm"
+
+    def build_asset(self, resource) -> Asset:
+        """Builds an asset from a model package group.
+
+        Args:
+            resource: The Model Package Group to build an asset.
+        """
+
+        if isinstance(resource, ModelPackageGroup):
+            resource_name = resource.name
+        else:
+            resource_name = resource
+
+        describe_resp = self.sagemaker_client.describe_model_package_group(
+            ModelPackageGroupName=resource_name
+        )
+        mpg_forms = {
+            "modelPackageGroupName": describe_resp["ModelPackageGroupName"],
+            "modelPackageGroupArn": describe_resp["ModelPackageGroupArn"],
+            "creationTime": AssetBuilder.convert_date_time(describe_resp["CreationTime"]),
+        }
+
+        if "ModelPackageGroupStatus" in describe_resp:
+            mpg_forms.update(
+                {"modelPackageGroupStatus": describe_resp["ModelPackageGroupStatus"].upper()}
+            )
+
+        if "ModelPackageGroupDescription" in describe_resp:
+            mpg_forms.update(
+                {"modelPackageGroupDescription": describe_resp["ModelPackageGroupDescription"]}
+            )
+
+        form_inputs = [
+            {
+                "formName": self.__form_name,
+                "typeIdentifier": self.__form_type_id,
+                "content": json.dumps(mpg_forms),
+            }
+        ]
+
+        return Asset(
+            name=describe_resp["ModelPackageGroupName"],
+            type_id=self.__asset_type_id,
+            external_id=describe_resp["ModelPackageGroupArn"],
+            forms_input=form_inputs,
+        )

--- a/src/sagemaker/asset/asset_manager.py
+++ b/src/sagemaker/asset/asset_manager.py
@@ -1,0 +1,643 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+"""This module contains code related to the DataZone SageMaker Asset."""
+from __future__ import print_function, absolute_import
+
+import os
+import logging
+import json
+from typing import Optional, Union, List
+from sagemaker.session import Session
+from sagemaker.workflow.pipeline import Pipeline
+from sagemaker.feature_store.feature_group import FeatureGroup
+from sagemaker.model import ModelPackageGroup
+from sagemaker.asset import Asset, Listing, ChangeSetAction, AssetTypeIdentifier
+from sagemaker.asset.asset_builder import (
+    FeatureGroupAssetBuilder,
+    ModelPackageGroupAssetBuilder,
+)
+import random
+logger = logging.getLogger(__name__)
+
+
+class AssetManager(object):
+    """Manages the publishing of ML and data assets to the DataZone inventory and catalog."""
+
+    def __init__(
+        self,
+        sagemaker_session: Session = None,
+        domain_id: Optional[str] = None,
+        project_id: Optional[str] = None,
+        environment_id: Optional[str] = None,
+        override_datazone_endpoint: Optional[str] = None,
+    ):
+        """Initializes a SageMaker `AssetManager` instance.
+
+        Args:
+            sagemaker_session (sagemaker.session.Session): A SageMaker Session
+                object, used for SageMaker interactions (default: None). If not
+                specified, one is created using the default AWS configuration
+                chain.
+            domain_id (str): The id of the DataZone domain
+            project_id (str): The id of the DataZone project
+            environment_id (str): The id of the DataZone environment
+            override_datazone_endpoint (str): The DataZone endpoint to use
+        """
+        self.__sm_session = sagemaker_session if sagemaker_session else Session()
+        self.__boto_session = sagemaker_session.boto_session if sagemaker_session else Session().boto_session
+
+        self.__datazone_client = (
+            self.__boto_session.client("datazone")
+            if not override_datazone_endpoint
+            else self.__boto_session.client("datazone", endpoint_url=override_datazone_endpoint)
+        )
+        self.__sagemaker_client = self.__sm_session.sagemaker_client
+
+        d_id, p_id, e_id = self.__get_datazone_context()
+
+        self.domain_id = domain_id if domain_id is not None else d_id
+        self.project_id = project_id if project_id is not None else p_id
+        self.environment_id = environment_id if environment_id is not None else e_id
+
+        if not self.domain_id or not self.project_id or not self.environment_id:
+            raise ValueError(
+                "Both DataZone domainId, owningProjectId, and environmentId should be given."
+            )
+
+        self.__data_source_manager = _DataSourceManager(
+            self.__sm_session,
+            self.__datazone_client,
+            self.domain_id,
+            self.project_id,
+            self.environment_id)
+
+    def export_to_inventory(
+        self,
+        resource: Optional[Union[Pipeline, FeatureGroup, ModelPackageGroup]] = None,
+        resource_arn: Optional[str] = None,
+        description: Optional[str] = None,
+        glossary_terms: Optional[List[str]] = None,
+    ):
+        """Export a SageMaker resource to DataZone project inventory.
+
+        Export a SageMaker resource to DataZone project inventory as ML asset. If
+        the resource has already been exported to inventory, then an asset revision will
+        be created. Note that for feature group, if both online and offline are enabled,
+        an asset will be returned for each one of them.
+
+        Args:
+            resource:
+                The resource instance
+            resource_arn:
+                The ARN of the resource
+            description:
+                The description of the asset
+            glossary_terms:
+                The glossary terms of the asset
+
+        Returns:
+            One or more asset instance.
+        """
+        if (not resource and not resource_arn) or (resource and resource_arn):
+            raise ValueError("Either resource instance or resource_arn str needs to be given.")
+
+        if resource_arn:
+            resource_type = resource_arn.split("/")[0].split(":")[-1]
+            if resource_type == "feature-group":
+                return self.__export_feature_group_asset(resource_arn, description, glossary_terms)
+            if resource_type == "model-package-group":
+                return self.__export_model_package_group_asset(
+                    resource_arn, description, glossary_terms
+                )
+            raise ValueError(f"Unsupported resource type: {resource_type}")
+
+        if isinstance(resource, FeatureGroup):
+            return self.__export_feature_group_asset(resource, description, glossary_terms)
+        if isinstance(resource, ModelPackageGroup):
+            return self.__export_model_package_group_asset(resource, description, glossary_terms)
+        raise ValueError(f"Unsupported resource type: {type(resource)}")
+
+    def publish_to_catalog(
+        self, asset: Optional[Asset] = None, asset_id: Optional[str] = None
+    ) -> Listing:
+        """Publish/List the asset to DataZone enterprise data catalog (EDC)
+
+        Once the asset is in the project inventory, you can publish the asset
+        to EDC, so members from your enterprise and search and discovery it.
+
+        Args:
+            asset: The asset instance
+            asset_id: The id of the asset.
+
+        Returns:
+            Listing: the listing instance
+        """
+        if not asset and not asset_id:
+            raise ValueError("Asset instance or asset Id must be given.")
+
+        if asset:
+            assert asset.id is not None, "Asset id must be given."
+
+        listing_resp = self.__datazone_client.create_listing_change_set(
+            action=ChangeSetAction.PUBLISH.value,
+            domainIdentifier=self.domain_id,
+            entityIdentifier=asset.id,
+            entityType="ASSET",
+        )
+
+        return Listing(
+            id=listing_resp["listingId"],
+            revision=listing_resp["listingRevision"],
+            status=listing_resp["status"] if "status" in listing_resp else None,
+        )
+
+    def remove_from_catalog(
+        self, asset: Optional[Asset] = None, asset_id: Optional[str] = None
+    ) -> Listing:
+        """Unpublish the listing from DataZone enterprise data catalog (EDC).
+
+        Args:
+            asset: The asset instance.
+            asset_id: The id of the asset.
+        Returns:
+            Listing: the listing instance
+        """
+        if not asset and not asset_id:
+            raise ValueError("Asset instance or asset Id must be given.")
+
+        if asset:
+            assert asset.id is not None, "Asset id must be given."
+
+        un_listing_resp = self.__datazone_client.create_listing_change_set(
+            action=ChangeSetAction.UNPUBLISH.value,
+            domainIdentifier=self.domain_id,
+            entityIdentifier=asset.id if asset else asset_id,
+            entityType="ASSET",
+        )
+        return Listing(
+            id=un_listing_resp["listingId"],
+            revision=un_listing_resp["listingRevision"],
+            status=un_listing_resp["status"] if "status" in un_listing_resp else None,
+        )
+
+    def delete_asset(self, asset: Optional[Asset] = None, asset_id: Optional[str] = None):
+        """Delete the asset
+
+        Delete the asset from inventory, not that you need to unpublish before delete.
+
+        Args:
+            asset: The asset instance.
+            asset_id: The id of the asset.
+        Returns:
+            Listing: the listing instance
+        """
+        if not asset and not asset_id:
+            raise ValueError("Asset instance or asset Id must be given.")
+
+        if asset:
+            assert asset.id is not None, "Asset id must be given."
+
+        self.__datazone_client.delete_asset(
+            domainIdentifier=self.domain_id,
+            identifier=asset.id if asset else asset_id,
+        )
+
+    def get_environment_default_data_lake_config(self) -> (Optional[str], Optional[str]):
+        """Get default data lake config.
+
+        Args:
+
+        Returns:
+            Glue producer output URI, Glue producer DB name.
+        """
+
+        get_environment_resp = self.__datazone_client.get_environment(
+            domainIdentifier=self.domain_id,
+            identifier=self.environment_id,
+        )
+        glue_producer_output_uri = None
+        glue_producer_db_name = None
+        for resource in get_environment_resp["provisionedResources"]:
+            if resource["name"] == "glueProducerOutputUri":
+                glue_producer_output_uri = resource["value"]
+            if resource["name"] == "glueProducerDBName":
+                glue_producer_db_name = resource["value"]
+        return glue_producer_output_uri, glue_producer_db_name
+
+    def __export_feature_group_asset(
+        self,
+        resource,
+        description,
+        glossary_terms
+    ) -> (Asset, Optional[Asset]):
+        """Exports a feature group.
+
+        Args:
+            resource: the feature group
+            description: the feature group description
+            glossary_terms: glossary terms for the feature group
+
+        Returns:
+            Asset for the feature group.
+        """
+
+        feature_group_asset_builder = FeatureGroupAssetBuilder(
+            sagemaker_session=self.__sm_session,
+            domain_id=self.domain_id,
+            project_id=self.project_id,
+            environment_id=self.environment_id,
+            datazone_client=self.__datazone_client,
+        )
+        fg_online_asset, fg_offline_asset = feature_group_asset_builder.build_asset(resource)
+        self.__create_asset(fg_online_asset, description, glossary_terms)
+        if fg_offline_asset:
+            # This is temporarily for beta 2
+            feature_group_asset_builder.append_offline_store_online_store_property(
+                fg_offline_asset, fg_online_asset.id
+            )
+            self.__create_asset_revision(fg_offline_asset, description, glossary_terms)
+            return fg_online_asset, fg_offline_asset
+        return fg_online_asset, None
+
+    def __export_model_package_group_asset(self, resource, description, glossary_terms) -> Asset:
+        """Exports a model package group.
+
+        Args:
+            resource: the model package group
+            glossary_terms: glossary terms for the feature group
+            description: the model package group description
+
+        Returns:
+            Asset for the model package.
+        """
+        mpg_builder = ModelPackageGroupAssetBuilder(sagemaker_session=self.__sm_session)
+        mpg_asset = mpg_builder.build_asset(resource)
+        data_source = self.__data_source_manager.get_mpg_data_source(mpg_asset.external_id)
+        self.__data_source_manager.add_ds_reference_form_to_asset(mpg_asset, data_source)
+        self.__create_asset(mpg_asset, description, glossary_terms)
+        return mpg_asset
+
+    def __get_datazone_context(self) -> (str, str, str):
+        """Gets DataZone context information: domain id, project id, and environment id.
+
+        Args:
+
+        Returns:
+            domain id, project id, environment id.
+        """
+        if os.path.exists("/opt/ml/metadata/resource-metadata.json"):  # pylint: disable=E1101
+            with open("/opt/ml/metadata/resource-metadata.json") as f:
+                metadata = json.load(f)
+                resource_arn = metadata["ResourceArn"]
+                arn_prefix = resource_arn.split(":")[:5]
+                sm_domain_arn = ":".join(arn_prefix) + ":domain/" + metadata["DomainId"]
+                list_tags_resp = self.__sagemaker_client.list_tags(
+                    ResourceArn=sm_domain_arn, MaxResults=50
+                )
+                tags = list_tags_resp["Tags"]
+                for tag in tags:
+                    if tag["Key"] == "AmazonDataZoneDomain":
+                        domain_id = tag["Value"]
+                    elif tag["Key"] == "AmazonDataZoneProject":
+                        project_id = tag["Value"]
+                    elif tag["Key"] == "AmazonDataZoneEnvironment":
+                        environment_id = tag["Value"]
+                logger.info("Reading DataZone domainId: %s", domain_id)
+                logger.info("owningProjectId: %s", project_id)
+                logger.info("environmentId: %s from context.", environment_id)
+                return domain_id, project_id, environment_id
+        else:
+            return None, None, None
+
+    def __create_asset(
+        self,
+        asset: Asset,
+        description: Optional[str] = None,
+        glossary_terms: Optional[List[str]] = None,
+    ):
+        """Creates an asset.
+
+        Args:
+            asset: asset information
+            description: asset description
+            glossary_terms: glossary terms for the asset
+        """
+        request = {
+            "domainIdentifier": self.domain_id,
+            "name": asset.name,
+            "owningProjectIdentifier": self.project_id,
+            "typeIdentifier": asset.type_id.value,
+            "externalIdentifier": asset.external_id,
+            "formsInput": asset.forms_input,
+        }
+
+        if description:
+            request["description"] = description
+        if glossary_terms:
+            request["glossaryTerms"] = glossary_terms
+
+        try:
+            create_asset_resp = self.__datazone_client.create_asset(**request)
+            asset.id = create_asset_resp["id"]
+        except Exception as e:
+            if "ConflictException" in str(e):
+                logger.warning("Asset already exists, creating an asset revision.")
+                asset.id = self.__get_asset_id_by_external_id(asset)
+                self.__create_asset_revision(asset, description, glossary_terms)
+                return
+            raise e
+
+    def __create_asset_revision(
+        self,
+        asset: Asset,
+        description: Optional[str] = None,
+        glossary_terms: Optional[List[str]] = None,
+    ):
+        """Creates an asset revision.
+
+        Args:
+            asset: asset information
+            description: asset description
+            glossary_terms: glossary terms for the asset
+        """
+
+        request = {
+            "domainIdentifier": self.domain_id,
+            "identifier": asset.id,
+            "name": asset.name,
+            "formsInput": asset.forms_input,
+        }
+
+        if description:
+            request["description"] = description
+
+        if glossary_terms:
+            request["glossaryTerms"] = glossary_terms
+
+        self.__datazone_client.create_asset_revision(**request)
+
+    def __get_asset_id_by_external_id(self, asset: Asset) -> str:
+        """Retrieve an asset by external id.
+
+        Args:
+            asset: the asset
+        """
+
+        def __get_arn_attribute_from_asset_type_id(asset_type_id: AssetTypeIdentifier) -> str:
+            if asset_type_id == AssetTypeIdentifier.SageMakerFeatureGroupAssetType:
+                return "SageMakerFeatureGroupForm.featureGroupArn"
+            if asset_type_id == AssetTypeIdentifier.SageMakerModelPackageGroupAssetType:
+                return "SagemakerModelPackageGroupForm.modelPackageGroupArn"
+            raise ValueError(f"Unsupported asset type id: {asset_type_id}")
+
+        search_resp = self.__datazone_client.search(
+            domainIdentifier=self.domain_id,
+            owningProjectIdentifier=self.project_id,
+            searchScope="ASSET",
+            filters={
+                "filter": {
+                    "attribute": __get_arn_attribute_from_asset_type_id(asset.type_id),
+                    "value": asset.external_id,
+                }
+            },
+        )
+        if not search_resp["items"]:
+            raise ValueError(f"Asset with external id {asset.external_id} not found.")
+        assert (
+            len(search_resp["items"]) == 1
+        ), "More than one asset found with the same external id."
+        return search_resp["items"][0]["assetItem"]["identifier"]
+
+
+class _DataSourceManager(object):
+    """Manages DataZone data sources."""
+
+    DATA_SOURCE_NAME_FORMAT = '{0}-default-sagemaker-{1}-datasource'
+    SAGEMAKER_TYPE = 'SAGEMAKER'
+    MPG_ASSET_TYPE = 'ModelPackageGroup'
+    FG_ASSET_TYPE = 'FeatureGroup'
+    MODEL_REGISTRY_ASSET_TYPE = 'SageMakerModelPackageGroupAssetType'
+    FEATURE_GROUP_ASSET_TYPE = 'SageMakerFeatureGroupAssetType'
+    MANAGE_ACCESS_ROLE_NAME = 'AmazonDataZoneSageMakerManageAccessRole'
+    MAX_TRACKED_ASSETS = 500
+    DATA_SOURCE_REFERENCE_FORM_NAME = 'DataSourceReferenceForm'
+    DATA_SOURCE_REFERENCE_FORM_TYPE = 'amazon.datazone.DataSourceReferenceFormType'
+
+    def __init__(
+            self,
+            sagemaker_session: Session = None,
+            datazone_client: Optional[str] = None,
+            domain_id: Optional[str] = None,
+            project_id: Optional[str] = None,
+            environment_id: Optional[str] = None,
+    ):
+        """Initializes a SageMaker `AssetManager` instance.
+
+        Args:
+            sagemaker_session (sagemaker.session.Session): A SageMaker Session
+                object, used for SageMaker interactions (default: None). If not
+                specified, one is created using the default AWS configuration
+                chain.
+            domain_id (str): The id of the DataZone domain
+            project_id (str): The id of the DataZone project
+            environment_id (str): The id of the DataZone environment
+            datazone_client (obj): The datazone client
+        """
+        self.sagemaker_session = sagemaker_session
+        self.datazone_client = datazone_client
+        self.domain_id = domain_id
+        self.project_id = project_id
+        self.environment_id = environment_id
+
+    def get_mpg_data_source(self, resource_arn):
+        environment = self.datazone_client.get_environment(
+            domainIdentifier=self.domain_id,
+            identifier=self.environment_id,
+        )
+        tracking_list_name = self.DATA_SOURCE_NAME_FORMAT.format(
+            environment["name"],
+            self.MPG_ASSET_TYPE.lower())
+
+        return self.__get_data_source(resource_arn, self.MPG_ASSET_TYPE, tracking_list_name)
+
+    def add_ds_reference_form_to_asset(self, asset, data_source):
+        reference_form_content = {
+            "dataSourceIdentifier": {
+             "id": data_source["id"]
+            },
+            "dataSourceType": self.SAGEMAKER_TYPE,
+            "filterableDataSourceId": data_source["id"],
+        }
+        reference_form = {
+            "formName": self.DATA_SOURCE_REFERENCE_FORM_NAME,
+            "content": json.dumps(reference_form_content),
+            "typeIdentifier": self.DATA_SOURCE_REFERENCE_FORM_TYPE
+        }
+        for form_input in asset.forms_input:
+            if "formName" not in form_input:
+                raise ValueError("Invalid form")
+            # if there is already a datasource form in the asset bail
+            if form_input["formName"] == self.DATA_SOURCE_REFERENCE_FORM_NAME:
+                return
+        asset.forms_input.append(reference_form)
+
+
+    def __get_data_source(self, resource_arn, asset_type, tracking_list_name):
+        #self.datazone_client.delete_data_source(domainIdentifier=self.domain_id, identifier="41gsdxsbz9ifc9")
+        #raise ValueError(tracking_list_name)
+        data_sources = self.__list_all_data_sources(tracking_list_name)
+        data_source = self.__get_existing_data_source(data_sources, resource_arn, asset_type)
+        if data_source is None:
+            latest_data_source = data_sources[0] if data_sources else None
+            data_source = self.__create_data_source(
+                latest_data_source,
+                resource_arn,
+                asset_type,
+                tracking_list_name)
+        else:
+            self.__add_to_tracking_list(data_source, resource_arn, asset_type)
+
+        return data_source
+
+
+    def __list_all_data_sources(self, tracking_list_name):
+        next_token = None
+        data_sources = []
+        while True:
+            list_resp = self.datazone_client.list_data_sources(
+                domainIdentifier=self.domain_id,
+                projectIdentifier=self.project_id,
+                environmentIdentifier=self.environment_id,
+                type=self.SAGEMAKER_TYPE)
+            data_sources_response = list_resp["items"]
+            for data_source in data_sources_response:
+                if tracking_list_name in data_source["name"]:
+                    data_sources.append(data_source)
+            next_token = list_resp["nextToken"] if "nextToken" in list_resp else None
+            if next_token is None:
+                break
+
+        return sorted(data_sources, key=lambda x: x["createdAt"], reverse=True)
+
+    def __get_existing_data_source(self, data_sources, resource_arn, asset_type):
+        non_full_ds = []
+        dz_asset_type = self.__get_asset_type_for_resource_type(asset_type)
+        for data_source in data_sources:
+            id = data_source["dataSourceId"]
+            ds = self.datazone_client.get_data_source(
+                domainIdentifier=self.domain_id,
+                identifier=id)
+            if "configuration" in ds and "sageMakerRunConfiguration" in ds["configuration"]:
+                sm_config = ds["configuration"]["sageMakerRunConfiguration"]
+                if "trackingAssets" in sm_config:
+                    assets = sm_config["trackingAssets"][dz_asset_type]
+                    if resource_arn in assets:
+                        return ds
+            else:
+                assets = []
+
+            if len(assets) < self.MAX_TRACKED_ASSETS:
+                non_full_ds.append(ds)
+
+        # no existing, non-full data sources
+        if not non_full_ds:
+            return None
+        return_val = sorted(non_full_ds, key=lambda x: x["createdAt"], reverse=True)[0]
+        return return_val
+
+    def __get_asset_type_for_resource_type(self, resource_type):
+        if resource_type.lower() == 'ModelPackageGroup'.lower():
+            return self.MODEL_REGISTRY_ASSET_TYPE
+        if resource_type.lower() == 'FeatureGroup'.lower():
+            return self.FEATURE_GROUP_ASSET_TYPE
+        raise ValueError(f'Unrecognized resource type {resource_type}')
+
+    def __add_to_tracking_list(self, data_source, resource_arn, asset_type):
+        dz_asset_type = self.__get_asset_type_for_resource_type(asset_type)
+        id = data_source["id"]
+        assets = []
+
+        if "configuration" in data_source and "sageMakerRunConfiguration" in data_source["configuration"]:
+            sm_config = data_source["configuration"]["sageMakerRunConfiguration"]
+            assets = sm_config["trackingAssets"][dz_asset_type]
+            role = sm_config["dataAccessRole"]
+        else:
+            role = self.__get_data_access_role(data_source)
+
+        # resource already tracked
+        if resource_arn not in assets:
+            self.datazone_client.update_data_source(
+                domainIdentifier=self.domain_id,
+                identifier=id,
+                configuration={
+                    "sageMakerRunConfiguration": {
+                        "trackingAssets": {
+                            dz_asset_type: assets + [resource_arn]
+                        },
+                        "dataAccessRole": role
+                    }
+                })
+
+    def __create_data_source(self, latest_data_source, resource_arn, asset_type, tracking_list_name):
+        dz_asset_type = self.__get_asset_type_for_resource_type(asset_type)
+        next_version = 0
+        if latest_data_source:
+            name = latest_data_source["name"]
+            latest_version_text = name.split('-')[-1]
+            if latest_version_text.isnumeric():
+                # <envid>-default-sagemaker-<asset type>-datasource-<##>
+                next_version = int(latest_version_text) + 1
+            else:
+                # latest_data_source is the default like <envid>-default-sagemaker-<asset type>-datasource
+                next_version = 1
+
+        # the latest data source is full, increment version. otherwise default data source doesn't exist yet
+        if next_version > 0:
+            tracking_list_name += f'-{next_version}'
+
+        random_cron = f'cron({random.randint(0, 59)} {random.randint(0, 23)} * * ? *)'
+        data_access_role = self.__get_data_access_role(latest_data_source)
+        create_resp = self.datazone_client.create_data_source(
+            domainIdentifier=self.domain_id,
+            projectIdentifier=self.project_id,
+            environmentIdentifier=self.environment_id,
+            name=tracking_list_name,
+            type=self.SAGEMAKER_TYPE,
+            schedule={
+                "schedule": random_cron
+            },
+            publishOnImport=False,
+            enableSetting="ENABLED",
+            recommendation={
+                "enableBusinessNameGeneration": False
+            },
+            configuration = {
+                "sageMakerRunConfiguration": {
+                    "dataAccessRole": data_access_role,
+                    "trackingAssets": {
+                        dz_asset_type: [resource_arn]
+                    }
+                }
+            })
+        return create_resp
+
+    def __get_data_access_role(self, latest_data_source):
+        if (latest_data_source and
+                "configuration" in latest_data_source and
+                "sageMakerRunConfiguration" in latest_data_source["configuration"]):
+            return latest_data_source["configuration"]["sageMakerRunConfiguration"]["dataAccessRole"]
+
+        sts_client = self.sagemaker_session.boto_session.client('sts')
+        identity = sts_client.get_caller_identity()
+        account_id = identity['Account']
+        return f'arn:aws:iam::{account_id}:role/{self.MANAGE_ACCESS_ROLE_NAME}'

--- a/src/sagemaker/model.py
+++ b/src/sagemaker/model.py
@@ -14,13 +14,14 @@
 # pylint: skip-file
 from __future__ import absolute_import
 
+import attr
 import abc
 import json
 import logging
 import os
 import re
 import copy
-from typing import List, Dict, Optional, Union
+from typing import List, Dict, Optional, Union, Any
 
 import sagemaker
 from sagemaker import (
@@ -2370,3 +2371,41 @@ class ModelPackage(Model):
         )
 
         sagemaker_session.sagemaker_client.update_model_package(**model_package_update_args)
+
+
+@attr.s
+class ModelPackageGroup:
+    """ModelPackageGroup definition.
+
+    This class instantiates a ModelPackageGroup object.
+
+    Attributes:
+        name (str): name of the ModelPackageGroup instance.
+        description (str): name of the ModelPackageGroup instance.
+        sagemaker_session (Session): session instance to perform boto calls.
+            If None, a new Session will be created.
+    """
+
+    name: str = attr.ib()
+    sagemaker_session: Session = attr.ib(factory=Session)
+    description: Optional[str] = attr.ib(default=None)
+
+    def create(self, tags: Optional[List[Dict[str, str]]] = None) -> Dict[str, Any]:
+        """Create a ModelPackageGroup"""
+        kwargs = {"ModelPackageGroupName": self.name}
+        if self.description:
+            kwargs["ModelPackageGroupDescription"] = self.description
+        if tags:
+            kwargs["Tags"] = tags
+
+        return self.sagemaker_session.sagemaker_client.create_model_package_group(**kwargs)
+
+    def describe(self) -> Dict[str, Any]:
+        """Describe a ModelPackageGroup."""
+        return self.sagemaker_session.sagemaker_client.describe_model_package_group(
+            model_package_group_name=self.name,
+        )
+
+    def delete(self):
+        """Delete a ModelPackageGroup."""
+        self.sagemaker_session.sagemaker_client.delete_model_package_group(ModelPackageGroupName=self.name)

--- a/tests/integ/sagemaker/asset/conftest.py
+++ b/tests/integ/sagemaker/asset/conftest.py
@@ -1,0 +1,466 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from __future__ import absolute_import
+
+import pytest
+
+import time
+import json
+from boto3 import Session as BotoSession
+from sagemaker import get_execution_role
+from sagemaker.session import Session
+from botocore.exceptions import ClientError
+from unittest import SkipTest
+
+@pytest.fixture(scope="module")
+def sagemaker_session():
+    return Session(boto_session=BotoSession(region_name="us-east-2"))
+
+
+@pytest.fixture(scope="module")
+def sagemaker_client(sagemaker_session):
+    return sagemaker_session.sagemaker_client
+
+
+@pytest.fixture(scope="module")
+def role(sagemaker_session):
+    return get_execution_role(sagemaker_session)
+
+
+@pytest.fixture(scope="module")
+def domain_exec_role_arn(sagemaker_session):
+    iam_client = sagemaker_session.boto_session.client("iam")
+    role_name='AmazonDataZoneDomainExecution'
+    try:
+        exec_role = iam_client.get_role(RoleName=role_name)
+        return exec_role["Role"]["Arn"]
+    except ClientError as e:
+        if e.response['Error']['Code'] == 'NoSuchEntity':
+            print('Domain execution role not found, creating.')
+
+    test_role_name='AmazonDataZoneDomainExecutionIntegTest'
+    try:
+        exec_role = iam_client.get_role(RoleName=test_role_name)
+        return exec_role["Role"]["Arn"]
+    except ClientError as e:
+        if e.response['Error']['Code'] == 'NoSuchEntity':
+            print('Domain execution role not found, creating.')
+
+        assume_role_policy = json.dumps(
+            {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Principal": {
+                        "Service": [
+                            "datazone.amazonaws.com",
+                            "datazone.aws.internal"
+                        ]},
+                    "Action": [
+                        "sts:AssumeRole",
+                        "sts:TagSession"]
+                    }
+                ],
+            })
+        test_role_name='AmazonDataZoneDomainExecutionIntegTest'
+        iam_client.create_role(RoleName=test_role_name, AssumeRolePolicyDocument=assume_role_policy)
+        iam_client.attach_role_policy(
+            PolicyArn="arn:aws:iam::aws:policy/service-role/AmazonDataZoneDomainExecutionRolePolicy",
+            RoleName=test_role_name,
+        )
+        return iam_client.get_role(RoleName=test_role_name)["Role"]["Arn"]
+
+@pytest.fixture(scope="module")
+def domain_id(sagemaker_session, domain_exec_role_arn):
+    dz_client = sagemaker_session.boto_session.client("datazone")
+    iam_client = sagemaker_session.boto_session.client("sts")
+    account_id = iam_client.get_caller_identity()["Account"]
+    domains = dz_client.list_domains()["items"]
+    domain_name = 'SDKIntegTestDomain'
+    domain_id = None
+    for domain in domains:
+        if domain["name"] == domain_name:
+            domain_id = domain["id"]
+    if domain_id is None:
+        create_resp = dz_client.create_domain(name=domain_name, domainExecutionRole=domain_exec_role_arn)
+        domain_id = create_resp["id"]
+    blueprints = dz_client.list_environment_blueprints(domainIdentifier=domain_id, managed=True)["items"]
+    sm_blueprint = None
+    for bp in blueprints:
+        if bp["name"] == "DefaultSageMaker":
+            sm_blueprint = bp
+    if sm_blueprint is None:
+        raise SkipTest('SageMaker blueprint not available')
+    blueprint_id = sm_blueprint["id"]
+    sm_bp_config = None
+    configs = dz_client.list_environment_blueprint_configurations(domainIdentifier=domain_id)["items"]
+    for config in configs:
+        if config["environmentBlueprintId"] == blueprint_id:
+            sm_bp_config = config
+    if sm_bp_config is None:
+        manageAccessRoleArn = create_role_if_not_exists(
+            sagemaker_session,
+            'AmazonDataZoneSageMakerManageAccessRole')
+        provisioningRoleArn = create_role_if_not_exists(
+            sagemaker_session,
+            'AmazonDataZoneSageMakerProvisioningRole',
+            get_provisioning_policy())
+        dz_client.put_environment_blueprint_configuration(
+            domainIdentifier=domain_id,
+            environmentBlueprintIdentifier=blueprint_id,
+            manageAccessRoleArn=manageAccessRoleArn,
+            provisioningRoleArn=provisioningRoleArn,
+            enabledRegions=[sagemaker_session.boto_session.region_name]
+        )
+    return domain_id
+
+
+@pytest.fixture(scope="module")
+def project_id(sagemaker_session, domain_id):
+    dz_client = sagemaker_session.boto_session.client("datazone")
+    projects = dz_client.list_projects(domainIdentifier=domain_id)["items"]
+    if len(projects) == 0:
+        project_name = 'SDKIntegTestProject'
+        dz_client.create_project(name=project_name, domainIdentifier=domain_id)
+        time.sleep(1)
+        projects = dz_client.list_projects(domainIdentifier=domain_id)["items"]
+        if len(projects) == 0:
+            time.sleep(5)
+        projects = dz_client.list_projects(domainIdentifier=domain_id)["items"]
+    project = projects[0]
+    return project["id"]
+
+
+@pytest.fixture(scope="module")
+def environment_id(sagemaker_session, domain_id, project_id):
+    dz_client = sagemaker_session.boto_session.client("datazone")
+    environments = dz_client.list_environments(domainIdentifier=domain_id, projectIdentifier=project_id)["items"]
+    env_profile_id = create_environment_profile(sagemaker_session, domain_id, project_id)
+    if len(environments) == 0:
+        environment_name = 'SDKIntegTestDummyEnv'
+        create_resp = dz_client.create_environment(
+            name=environment_name,
+            domainIdentifier=domain_id,
+            projectIdentifier=project_id,
+            environmentProfileIdentifier=env_profile_id)
+        environment_id = create_resp["id"]
+    else:
+        environment_id = environments[0]["id"]
+
+    environment = dz_client.get_environment(
+        domainIdentifier=domain_id,
+        identifier=environment_id)
+
+    while True:
+        environment = dz_client.get_environment(
+            domainIdentifier=domain_id,
+            identifier=environment_id)
+        status = environment["status"]
+        if status == "CREATING":
+            print(f'Waiting for DataZone environment {environment["name"]} creation completion.')
+            time.sleep(30)
+        else:
+            break
+
+    if status != "ACTIVE":
+        raise SkipTest(f"DataZone integration tests will fail due to environment not in ACTIVE status: {status}")
+
+    return environment_id
+
+
+def create_role_if_not_exists(sagemaker_session, role_name, inline_policy=None):
+    iam_client = sagemaker_session.boto_session.client("iam")
+    assume_role_policy = json.dumps(
+        {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Principal": {
+                        "Service": [
+                            "datazone.amazonaws.com",
+                            "datazone.aws.internal"
+                        ]},
+                    "Action": [
+                        "sts:AssumeRole",
+                        "sts:TagSession"]
+                }
+            ],
+        })
+    try:
+        exec_role = iam_client.get_role(RoleName=role_name)
+        return exec_role["Role"]["Arn"]
+    except ClientError as e:
+        if e.response['Error']['Code'] == 'NoSuchEntity':
+            print('Role not found, creating.')
+    create_reps = iam_client.create_role(RoleName=role_name, AssumeRolePolicyDocument=assume_role_policy)
+    arn = create_reps["Role"]["Arn"]
+    if inline_policy:
+        iam_client.put_role_policy(
+            RoleName=role_name,
+            PolicyName=role_name + '-Policy',
+            PolicyDocument=inline_policy)
+    return arn
+
+
+def create_environment_profile(sagemaker_session, domain_id, project_id):
+    dz_client = sagemaker_session.boto_session.client("datazone")
+    sts_client = sagemaker_session.boto_session.client("sts")
+    blueprints = dz_client.list_environment_blueprints(domainIdentifier=domain_id, managed=True)["items"]
+    sm_blueprint = None
+    for bp in blueprints:
+        if bp["name"] == "DefaultSageMaker":
+            sm_blueprint = bp
+    identity = sts_client.get_caller_identity()
+    account_id=identity["Account"]
+
+    sm_profile_name = 'SDKTestSMEnvProfile'
+    profiles = dz_client.list_environment_profiles(
+        domainIdentifier=domain_id,
+        environmentBlueprintIdentifier=sm_blueprint["id"],
+        awsAccountId=account_id,
+        awsAccountRegion=sagemaker_session.boto_session.region_name,
+    )
+
+    for profile in profiles["items"]:
+        if profile["name"] == sm_profile_name:
+            print(f'Profile {sm_profile_name} already exists.')
+            return profile["id"]
+
+    ec2_client = sagemaker_session.boto_session.client("ec2")
+    vpcs = ec2_client.describe_vpcs()["Vpcs"]
+    vpc = vpcs[0]
+    subnets = ec2_client.describe_subnets(Filters=[{"Name": "vpc-id", "Values": [vpc["VpcId"]]}])["Subnets"]
+    subnetIds = ','.join([subnets[0]["SubnetId"],subnets[1]["SubnetId"],subnets[2]["SubnetId"]])
+    create_resp = dz_client.create_environment_profile(
+        domainIdentifier=domain_id,
+        projectIdentifier=project_id,
+        name=sm_profile_name,
+        environmentBlueprintIdentifier=sm_blueprint["id"],
+        awsAccountId=account_id,
+        awsAccountRegion=sagemaker_session.boto_session.region_name,
+        userParameters=[
+            {"name": "vpcId", "value": vpc["VpcId"]},
+            {"name": "subnetIds", "value": subnetIds},
+            {"name": "sagemakerDomainAuthMode", "value": "IAM"},
+            {"name": "sagemakerDomainNetworkType", "value": "PublicInternetOnly"},
+            {"name": "kmsKeyId", "value": "dummy-key-id"},
+        ]
+    )
+    return create_resp["id"]
+
+def get_provisioning_policy():
+    return json.dumps({
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "CreateSagemakerStudio",
+                "Effect": "Allow",
+                "Action": [
+                    "sagemaker:CreateDomain",
+                    "sagemaker:AddTags"
+                ],
+                "Resource": [
+                    "*"
+                ],
+                "Condition": {
+                    "StringEquals": {
+                        "aws:CalledViaFirst": [
+                            "cloudformation.amazonaws.com"
+                        ]
+                    },
+                    "ForAnyValue:StringLike": {
+                        "aws:TagKeys": [
+                            "AmazonDataZoneEnvironment"
+                        ]
+                    },
+                    "Null": {
+                        "aws:TagKeys": "false",
+                        "aws:ResourceTag/AmazonDataZoneEnvironment": "false",
+                        "aws:RequestTag/AmazonDataZoneEnvironment": "false"
+                    }
+                }
+            },
+            {
+                "Sid": "DeleteSagemakerStudio",
+                "Effect": "Allow",
+                "Action": [
+                    "sagemaker:DeleteDomain"
+                ],
+                "Resource": [
+                    "*"
+                ],
+                "Condition": {
+                    "StringEquals": {
+                        "aws:CalledViaFirst": [
+                            "cloudformation.amazonaws.com"
+                        ]
+                    },
+                    "ForAnyValue:StringLike": {
+                        "aws:TagKeys": [
+                            "AmazonDataZoneEnvironment"
+                        ]
+                    },
+                    "Null": {
+                        "aws:TagKeys": "false",
+                        "aws:ResourceTag/AmazonDataZoneEnvironment": "false"
+                    }
+                }
+            },
+            {
+                "Sid": "AmazonDataZoneEnvironmentSageMakerDescribePermissions",
+                "Effect": "Allow",
+                "Action": [
+                    "sagemaker:DescribeDomain"
+                ],
+                "Resource": "*",
+                "Condition": {
+                    "StringEquals": {
+                        "aws:CalledViaFirst": [
+                            "cloudformation.amazonaws.com"
+                        ]
+                    }
+                }
+            },
+            {
+                "Sid": "IamPassRolePermissions",
+                "Effect": "Allow",
+                "Action": [
+                    "iam:PassRole"
+                ],
+                "Resource": [
+                    "arn:aws:iam::*:role/sm-provisioning/datazone_usr*"
+                ],
+                "Condition": {
+                    "StringEquals": {
+                        "iam:PassedToService": [
+                            "glue.amazonaws.com",
+                            "lakeformation.amazonaws.com",
+                            "sagemaker.amazonaws.com"
+                        ],
+                        "aws:CalledViaFirst": [
+                            "cloudformation.amazonaws.com"
+                        ]
+                    }
+                }
+            },
+            {
+                "Sid": "AmazonDataZonePermissionsToCreateEnvironmentRole",
+                "Effect": "Allow",
+                "Action": [
+                    "iam:CreateRole",
+                    "iam:DetachRolePolicy",
+                    "iam:DeleteRolePolicy",
+                    "iam:AttachRolePolicy",
+                    "iam:PutRolePolicy"
+                ],
+                "Resource": [
+                    "arn:aws:iam::*:role/sm-provisioning/datazone_usr*"
+                ],
+                "Condition": {
+                    "StringEquals": {
+                        "aws:CalledViaFirst": [
+                            "cloudformation.amazonaws.com"
+                        ],
+                        "iam:PermissionsBoundary": "arn:aws:iam::aws:policy/AmazonDataZoneSageMakerEnvironmentRolePermissionsBoundary"
+                    }
+                }
+            },
+            {
+                "Sid": "AmazonDataZonePermissionsToManageEnvironmentRole",
+                "Effect": "Allow",
+                "Action": [
+                    "iam:GetRole",
+                    "iam:GetRolePolicy",
+                    "iam:DeleteRole"
+                ],
+                "Resource": [
+                    "arn:aws:iam::*:role/sm-provisioning/datazone_usr*"
+                ],
+                "Condition": {
+                    "StringEquals": {
+                        "aws:CalledViaFirst": [
+                            "cloudformation.amazonaws.com"
+                        ]
+                    }
+                }
+            },
+            {
+                "Sid": "AmazonDataZonePermissionsToCreateSageMakerServiceRole",
+                "Effect": "Allow",
+                "Action": [
+                    "iam:CreateServiceLinkedRole"
+                ],
+                "Resource": [
+                    "arn:aws:iam::*:role/aws-service-role/sagemaker.amazonaws.com/AWSServiceRoleForAmazonSageMakerNotebooks"
+                ],
+                "Condition": {
+                    "StringEquals": {
+                        "aws:CalledViaFirst": [
+                            "cloudformation.amazonaws.com"
+                        ]
+                    }
+                }
+            },
+            {
+                "Sid": "AmazonDataZoneEnvironmentParameterValidation",
+                "Effect": "Allow",
+                "Action": [
+                    "ec2:DescribeVpcs",
+                    "ec2:DescribeSubnets",
+                    "sagemaker:ListDomains"
+                ],
+                "Resource": "*"
+            },
+            {
+                "Sid": "AmazonDataZoneEnvironmentKMSKeyValidation",
+                "Effect": "Allow",
+                "Action": [
+                    "kms:DescribeKey"
+                ],
+                "Resource": "*",
+                "Condition": {
+                    "Null":
+                        {
+                            "aws:ResourceTag/AmazonDataZoneEnvironment": "false"
+                        }
+                }
+            },
+            {
+                "Sid": "AmazonDataZoneEnvironmentGluePermissions",
+                "Effect": "Allow",
+                "Action":
+                    [
+                        "glue:CreateConnection",
+                        "glue:DeleteConnection"
+                    ],
+                "Resource": [
+                    "arn:aws:glue:*:*:connection/dz-sm-athena-glue-connection-*",
+                    "arn:aws:glue:*:*:connection/dz-sm-redshift-cluster-connection-*",
+                    "arn:aws:glue:*:*:connection/dz-sm-redshift-serverless-connection-*",
+                    "arn:aws:glue:*:*:catalog"
+                ],
+                "Condition":
+                    {
+                        "StringEquals":
+                            {
+                                "aws:CalledViaFirst":
+                                    [
+                                        "cloudformation.amazonaws.com"
+                                    ]
+                            }
+                    }
+            }
+        ]
+    })

--- a/tests/integ/sagemaker/asset/test_asset_manager.py
+++ b/tests/integ/sagemaker/asset/test_asset_manager.py
@@ -1,0 +1,155 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from __future__ import absolute_import
+
+import pytest
+
+import time
+from boto3 import Session as BotoSession
+from sagemaker import get_execution_role
+from sagemaker.session import Session
+from sagemaker.asset import AssetManager
+from sagemaker.model import ModelPackageGroup
+from sagemaker.feature_store.feature_group import FeatureGroup
+from botocore.exceptions import ClientError
+from sagemaker.feature_store.feature_definition import (
+    FeatureDefinition,
+    FeatureTypeEnum,
+)
+from unittest import SkipTest
+
+
+@pytest.fixture
+def asset_manager(
+        sagemaker_session,
+        domain_id,
+        project_id,
+        environment_id,
+):
+    return AssetManager(
+        sagemaker_session=sagemaker_session,
+        domain_id=domain_id,
+        project_id=project_id,
+        environment_id=environment_id,
+    )
+
+
+def test_export_to_inventory_model_package_group(
+    asset_manager, 
+    sagemaker_session,
+    sagemaker_client,
+    domain_exec_role_arn,
+):
+    mpg = ModelPackageGroup(
+        name="test-asset-manager-model-package-group",
+        description="my test mpg",
+        sagemaker_session=sagemaker_session,
+    )
+    try:
+        mpg.create()
+    except ClientError as e:
+        if e.response['Error']['Code'] == 'EntityAlreadyExists':
+            print(f'ModelPackage {mpg.name} already exists')
+
+    asset = asset_manager.export_to_inventory(mpg)
+    asset_manager.publish_to_catalog(asset)
+
+    # clean up
+    asset_manager.remove_from_catalog(asset)
+    asset_manager.delete_asset(asset)
+    mpg.delete()
+
+
+def test_export_to_inventory_feature_group_with_online_offline(
+    asset_manager, sagemaker_session, sagemaker_client, role
+):
+    fg_name = "test-asset-manager-feature-group"
+    feature_group = FeatureGroup(
+        name=fg_name,
+        feature_definitions=[
+            FeatureDefinition(feature_name="feature1", feature_type=FeatureTypeEnum.INTEGRAL),
+            FeatureDefinition(feature_name="feature2", feature_type=FeatureTypeEnum.STRING),
+            FeatureDefinition(feature_name="feature3", feature_type=FeatureTypeEnum.FRACTIONAL),
+        ],
+        sagemaker_session=sagemaker_session,
+    )
+    try:
+        feature_group.create(
+            s3_uri="s3://" + sagemaker_session.default_bucket() + f"/{fg_name}/offline-store",
+            record_identifier_name="feature1",
+            event_time_feature_name="feature2",
+            role_arn=role,
+            enable_online_store=True,
+        )
+    except Exception as e:
+        if "Resource Already Exists" in str(e):
+            pass
+        else:
+            raise e
+
+    feature_group_resp = feature_group.describe()
+    while feature_group_resp["FeatureGroupStatus"] == "Creating":
+        time.sleep(15)
+        feature_group_resp = feature_group.describe()
+    if feature_group_resp["FeatureGroupStatus"] != "Created":
+        raise ValueError(
+            f"FeatureGroupStatus {feature_group_resp['FeatureGroupStatus'] } is invalid."
+        )
+    asset = asset_manager.export_to_inventory(
+        resource_arn=feature_group_resp["FeatureGroupArn"]
+    )
+    print(asset)
+
+
+def test_export_to_inventory_feature_group_with_online_only(
+    asset_manager, sagemaker_session, sagemaker_client, role
+):
+    fg_name = "test-asset-manager-feature-group-online-only"
+    feature_group = FeatureGroup(
+        name=fg_name,
+        feature_definitions=[
+            FeatureDefinition(feature_name="feature1", feature_type=FeatureTypeEnum.INTEGRAL),
+            FeatureDefinition(feature_name="feature2", feature_type=FeatureTypeEnum.STRING),
+            FeatureDefinition(feature_name="feature3", feature_type=FeatureTypeEnum.FRACTIONAL),
+        ],
+        sagemaker_session=sagemaker_session,
+    )
+
+    try:
+        feature_group.create(
+            s3_uri=False,
+            record_identifier_name="feature1",
+            event_time_feature_name="feature2",
+            role_arn=role,
+            enable_online_store=True,
+        )
+    except Exception as e:
+        if "Resource Already Exists" in str(e):
+            pass
+        else:
+            raise e
+
+    feature_group_resp = feature_group.describe()
+    while feature_group_resp["FeatureGroupStatus"] == "Creating":
+        time.sleep(15)
+        feature_group_resp = feature_group.describe()
+
+    if feature_group_resp["FeatureGroupStatus"] != "Created":
+        raise ValueError(
+            f"FeatureGroupStatus {feature_group_resp['FeatureGroupStatus']} is invalid."
+        )
+
+    asset = asset_manager.export_to_inventory(
+        resource=feature_group,
+    )
+    print(asset)

--- a/tests/unit/sagemaker/asset/__init__.py
+++ b/tests/unit/sagemaker/asset/__init__.py
@@ -1,0 +1,15 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from __future__ import absolute_import
+import sys
+sys.path.append('.')

--- a/tests/unit/sagemaker/asset/conftest.py
+++ b/tests/unit/sagemaker/asset/conftest.py
@@ -1,0 +1,61 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from __future__ import absolute_import
+
+import pytest
+
+import time
+import json
+from boto3 import Session as BotoSession
+from sagemaker import get_execution_role
+from sagemaker.session import Session
+from sagemaker.asset import AssetManager
+from sagemaker.model import ModelPackageGroup
+from sagemaker.feature_store.feature_group import FeatureGroup
+from botocore.exceptions import ClientError
+from sagemaker.feature_store.feature_definition import (
+    FeatureDefinition,
+    FeatureTypeEnum,
+)
+from unittest import SkipTest
+import pytest
+from mock import MagicMock, Mock
+
+@pytest.fixture(scope="module")
+def domain_id():
+    return "dzd_123"
+
+
+@pytest.fixture(scope="module")
+def project_id():
+    return "pj_123"
+
+
+@pytest.fixture(scope="module")
+def environment_id():
+    return "env_123"
+
+
+@pytest.fixture(scope="module")
+def sagemaker_client():
+    return Mock(name="sagemaker_client")
+
+
+@pytest.fixture(scope="module")
+def datazone_client():
+    return Mock(name="datazone_client")
+
+
+@pytest.fixture(scope="module")
+def lf_client():
+    return Mock(name="lakeformation_client")

--- a/tests/unit/sagemaker/asset/test_asset_builder.py
+++ b/tests/unit/sagemaker/asset/test_asset_builder.py
@@ -1,0 +1,257 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from __future__ import absolute_import
+
+import datetime
+import json
+
+import pytest
+from mock import MagicMock, Mock
+from sagemaker.asset import Asset, AssetTypeIdentifier
+from sagemaker.asset.asset_builder import (
+    AssetBuilder,
+    ModelPackageGroupAssetBuilder,
+    FeatureGroupAssetBuilder,
+)
+from sagemaker.feature_store.feature_definition import FeatureTypeEnum, CollectionTypeEnum
+
+
+
+
+@pytest.fixture
+def boto_session(sagemaker_client, datazone_client, lf_client):
+    boto_mock = Mock(name="boto_session", region_name="us-west-2")
+
+    def get_clients(*args, **kwargs):
+        if args[0] == "datazone":
+            return datazone_client
+        elif args[0] == "sagemaker":
+            return sagemaker_client
+        elif args[0] == "lakeformation":
+            return lf_client
+        else:
+            raise ValueError(f"Unexpected client type: {args[0]}")
+
+    boto_mock.client = MagicMock(name="boto_client", side_effect=get_clients)
+    return boto_mock
+
+@pytest.fixture
+def sagemaker_session(boto_session, sagemaker_client):
+    sm_session_mock = Mock(name="session", boto_session=boto_session, sagemaker_client=sagemaker_client)
+    return sm_session_mock
+
+
+def test_build_model_package_group_asset(sagemaker_session):
+    mpg_arn = "arn:aws:sagemaker:us-east-2:1234567890:model-package-group/my-mpg"
+    mpg_name = "my-mpg"
+    mpg_asset_builder = ModelPackageGroupAssetBuilder(sagemaker_session)
+    now = datetime.datetime.now()
+
+    describe_resp = {
+        "ModelPackageGroupName": mpg_name,
+        "ModelPackageGroupArn": mpg_arn,
+        "ModelPackageGroupStatus": "COMPLETED",
+        "ModelPackageGroupDescription": "my good model package group",
+        "CreationTime": now,
+    }
+
+    sagemaker_session.sagemaker_client.describe_model_package_group.return_value = dict(describe_resp)
+
+    mpg_form = {
+        "modelPackageGroupName": describe_resp["ModelPackageGroupName"],
+        "modelPackageGroupArn": describe_resp["ModelPackageGroupArn"],
+        "creationTime": AssetBuilder.convert_date_time(describe_resp["CreationTime"]),
+        "modelPackageGroupStatus": describe_resp["ModelPackageGroupStatus"],
+        "modelPackageGroupDescription": describe_resp["ModelPackageGroupDescription"],
+    }
+
+    mpg_asset = Asset(
+        name=mpg_name,
+        type_id=AssetTypeIdentifier.SageMakerModelPackageGroupAssetType,
+        external_id=mpg_arn,
+        forms_input=[
+            {
+                "formName": "SageMakerModelPackageGroupForm",
+                "typeIdentifier": "amazon.datazone.SageMakerModelPackageGroupFormType",
+                "content": json.dumps(mpg_form),
+            }
+        ],
+    )
+    asset = mpg_asset_builder.build_asset(mpg_arn)
+    assert asset == mpg_asset
+
+
+def test_build_feature_group_asset(
+    domain_id,
+    project_id,
+    environment_id,
+    sagemaker_session,
+    datazone_client,
+    boto_session,
+    sagemaker_client,
+):
+    fg_arn = "arn:aws:sagemaker:us-east-2:1234567890:feature-group/my-fg"
+    offline_store_s3_location = "s3://my-bucket/my-offline-store"
+    offline_store_asset_id = "offline_store_asset_id"
+    fg_name = "my-fg"
+    fg_asset_builder = FeatureGroupAssetBuilder(
+        sagemaker_session,
+        domain_id,
+        project_id,
+        environment_id,
+        datazone_client,
+    )
+    now = datetime.datetime.now()
+
+    describe_resp = {
+        "FeatureGroupName": fg_name,
+        "FeatureGroupArn": fg_arn,
+        "FeatureGroupStatus": "Created",
+        "RecordIdentifierFeatureName": "record_id",
+        "EventTimeFeatureName": "event_time",
+        "CreationTime": now,
+        "LastModifiedTime": now,
+        "FeatureDefinitions": [
+            {
+                "FeatureName": "feature_1",
+                "FeatureType": FeatureTypeEnum.INTEGRAL.value,
+            },
+            {
+                "FeatureName": "feature_2",
+                "FeatureType": FeatureTypeEnum.FRACTIONAL.value,
+            },
+            {
+                "FeatureName": "feature_3",
+                "FeatureType": FeatureTypeEnum.STRING.value,
+            },
+            {
+                "FeatureName": "feature_4",
+                "FeatureType": FeatureTypeEnum.STRING.value,
+                "CollectionType": CollectionTypeEnum.LIST.value,
+            },
+        ],
+        "OfflineStoreConfig": {
+            "DataCatalogConfig": {
+                "Catalog": "catalog",
+                "Database": "database",
+                "TableName": "table",
+            },
+            "S3StorageConfig": {
+                "ResolvedOutputS3Uri": offline_store_s3_location,
+            },
+        },
+        "OfflineStoreStatus": {
+            "BlockedReason": "",
+            "Status": "Active"
+        }
+    }
+
+    fg_forms = {
+        "featureGroupName": describe_resp["FeatureGroupName"],
+        "featureGroupArn": describe_resp["FeatureGroupArn"],
+        "recordIdentifierFeatureName": describe_resp["RecordIdentifierFeatureName"],
+        "eventTimeFeatureName": describe_resp["EventTimeFeatureName"],
+        "creationTime": AssetBuilder.convert_date_time(describe_resp["CreationTime"]),
+        "lastModifiedTime": AssetBuilder.convert_date_time(describe_resp["LastModifiedTime"]),
+        "offlineStoreStatus": "ACTIVE",
+        "featureDefinitions": [
+            {
+                "featureName": "feature_1",
+                "featureType": "INTEGRAL",
+            },
+            {
+                "featureName": "feature_2",
+                "featureType": "FRACTIONAL",
+            },
+            {"featureName": "feature_3", "featureType": "STRING"},
+            {
+                "featureName": "feature_4",
+                "featureType": "STRING",
+                "collectionType": "LIST",
+            },
+        ],
+    }
+
+    fg_online_asset = Asset(
+        name=fg_name,
+        type_id=AssetTypeIdentifier.SageMakerFeatureGroupAssetType,
+        external_id=fg_arn,
+        forms_input=[
+            {
+                "formName": "SageMakerFeatureGroupForm",
+                "typeIdentifier": "amazon.datazone.SageMakerFeatureGroupFormType",
+                "content": json.dumps(fg_forms),
+            },
+            {
+                "formName": "AssetCommonDetailsForm",
+                "typeIdentifier": "amazon.datazone.AssetCommonDetailsFormType",
+                "content": json.dumps({
+                        "customProperties": {
+                            "FeatureGroupOfflineStoreAssetId": offline_store_asset_id,
+                        }
+                    }
+                ),
+            },
+        ],
+    )
+
+    sagemaker_client.describe_feature_group.return_value = describe_resp
+    datazone_client.list_data_sources.return_value = {"items": []}
+    datazone_client.create_data_source.return_value = {"id": "data-source-id"}
+    datazone_client.get_data_source.return_value = {"status": "READY"}
+    datazone_client.start_data_source_run.return_value = {"id": "data-source-run-id"}
+    datazone_client.get_data_source_run.return_value = {"status": "SUCCESS"}
+    datazone_client.list_data_source_run_activities.return_value = {
+        "items": [
+            {
+                "dataAssetId": offline_store_asset_id,
+                "dataAssetStatus": "SUCCEEDED_CREATED",
+            }
+        ]
+    }
+    glue_form_outputs = [
+        {
+            "content": json.dumps({"k1": "v1"}),
+            "formName": "GlueTableAssetForm",
+            "typeName": "amazon.datazone.GlueTableAssetFormType",
+        }
+    ]
+    datazone_client.get_asset.return_value = {
+        "id": offline_store_asset_id,
+        "name": describe_resp["FeatureGroupName"],
+        "typeIdentifier": "amazon.datazone.GlueTableAssetType",
+        "externalId": "glue-table-arn",
+        "formsOutput": glue_form_outputs,
+        "externalIdentifier": "glue-table-arn",
+    }
+    datazone_client.get_environment.return_value = {
+        "provisionedResources": [],
+    }
+
+    glue_form_inputs = [
+        {
+            "content": json.dumps({"k1": "v1"}),
+            "formName": "GlueTableAssetForm",
+            "typeIdentifier": "amazon.datazone.GlueTableAssetFormType",
+        }
+    ]
+
+    online_asset, offline_asset = fg_asset_builder.build_asset(fg_arn)
+    assert online_asset == fg_online_asset
+    assert offline_asset == Asset(
+        id=offline_store_asset_id,
+        name=describe_resp["FeatureGroupName"],
+        type_id=AssetTypeIdentifier.DataZoneGlueAssetType,
+        external_id="glue-table-arn",
+        forms_input=glue_form_inputs,
+    )

--- a/tests/unit/sagemaker/asset/test_asset_manager.py
+++ b/tests/unit/sagemaker/asset/test_asset_manager.py
@@ -1,0 +1,523 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from __future__ import absolute_import
+
+import pytest
+import json
+import datetime
+from mock import MagicMock, Mock, patch
+from sagemaker.asset import AssetManager, Asset, AssetTypeIdentifier, ChangeSetAction, Listing
+from sagemaker.asset.asset_builder import (
+    ModelPackageGroupAssetBuilder,
+    FeatureGroupAssetBuilder,
+)
+from sagemaker.model import ModelPackageGroup
+from sagemaker.feature_store.feature_group import FeatureGroup
+
+
+@pytest.fixture
+def domain_id():
+    return "dzd_123"
+
+
+@pytest.fixture
+def project_id():
+    return "pj_123"
+
+
+@pytest.fixture
+def environment_id():
+    return "env_123"
+
+
+@pytest.fixture
+def sagemaker_client():
+    return Mock(name="sagemaker_client")
+
+
+@pytest.fixture
+def datazone_client():
+    return Mock(name="datazone_client")
+
+
+@pytest.fixture
+def lf_client():
+    return Mock(name="lakeformation_client")
+
+
+@pytest.fixture
+def sts_client():
+    return Mock(name="sts_client")
+
+
+@pytest.fixture
+def sagemaker_session(sagemaker_client, datazone_client, lf_client, sts_client):
+    boto_mock = Mock(name="boto_session", region_name="us-west-2")
+
+    def get_clients(*args, **kwargs):
+        if args[0] == "datazone":
+            return datazone_client
+        elif args[0] == "sagemaker":
+            return sagemaker_client
+        elif args[0] == "lakeformation":
+            return lf_client
+        elif args[0] == "sts":
+            return sts_client
+        else:
+            raise ValueError(f"Unexpected client type: {args[0]}")
+
+    boto_mock.client = MagicMock(name="boto_client", side_effect=get_clients)
+
+    session_mock = MagicMock(
+        name="sagemaker_session",
+        boto_session=boto_mock,
+        boto_region_name="us-west-2",
+        config=None,
+        local_mode=False,
+        default_bucket_prefix=None,
+    )
+    session_mock.boto_session.return_value = boto_mock
+
+    return session_mock
+
+
+@pytest.fixture
+def asset_manager(sagemaker_session, domain_id, project_id, environment_id):
+    return AssetManager(
+        sagemaker_session=sagemaker_session,
+        domain_id=domain_id,
+        project_id=project_id,
+        environment_id=environment_id,
+    )
+
+def test_asset_manager_export_mpg_asset_to_inventory(
+    asset_manager: AssetManager,
+    datazone_client: Mock,
+    sagemaker_session: MagicMock,
+    sts_client: Mock,
+    environment_id: str
+):
+    mpg_arn = "arn:aws:sagemaker:us-east-2:1234567890:model-package-group/my-mpg"
+    form_content = {
+        "modelPackageGroupName": "my-mpg",
+        "modelPackageGroupArn": mpg_arn,
+        "modelPackageGroupDescription": "my good mpg",
+        "modelPackageGroupStatus": "Completed",
+        "creationTime": "2022-01-01T00:00:00Z",
+    }
+    mpg_asset = Asset(
+        name="asset-name",
+        type_id=AssetTypeIdentifier.SageMakerModelPackageGroupAssetType,
+        external_id=mpg_arn,
+        forms_input=[
+            {
+                "formName": "SageMakerModelPackageGroupForm",
+                "typeIdentifier": "amazon.datazone.SageMakerModelPackageGroupFormType",
+                "typeRevision": "1",
+                "content": json.dumps(form_content)
+            }
+        ],
+    )
+
+    # setup create asset response
+    datazone_client.create_asset.return_value = {"id": "asset-id"}
+
+    # setup list data sources response
+    list_ds_response = {
+        "items": [
+            {
+                "dataSourceId": "ds-id",
+                "name": f"{environment_id}-default-sagemaker-modelpackagegroup-datasource",
+                "createdAt": str(datetime.datetime.now())
+            }
+        ]
+    }
+    datazone_client.list_data_sources.return_value = list_ds_response
+
+    get_environment_response = {
+        "id": "envId",
+        "name": "fooEnvName"
+    }
+    datazone_client.get_environment.return_value = get_environment_response
+
+    # setup get data source response
+    get_ds_response = {
+        "id": "ds-id",
+        "createdAt": str(datetime.datetime.now()),
+        "configuration": {
+            "sageMakerRunConfiguration": {
+                "dataAccessRole": "ManageAccessRole",
+                "trackingAssets": {
+                    "SageMakerModelPackageGroupAssetType": []
+                }
+            }
+        }
+    }
+    datazone_client.get_data_source.return_value = get_ds_response
+
+    get_caller_identity_resp = {
+        "Account": "123456789100"
+    }
+    sts_client.get_caller_identity.return_value = get_caller_identity_resp
+
+    create_data_source_resp = {
+        "id": "ds-id"
+    }
+    datazone_client.create_data_source.return_value = create_data_source_resp
+
+    with patch.object(
+        ModelPackageGroupAssetBuilder, "build_asset", return_value=mpg_asset
+    ) as mock_method:
+        asset_manager.export_to_inventory(
+            resource_arn=mpg_arn, description="my description", glossary_terms=["term1", "term2"]
+        )
+        mock_method.assert_called_once_with(mpg_arn)
+        datazone_client.create_asset.assert_called_with(
+            domainIdentifier=asset_manager.domain_id,
+            name=mpg_asset.name,
+            owningProjectIdentifier=asset_manager.project_id,
+            typeIdentifier=mpg_asset.type_id.value,
+            externalIdentifier=mpg_asset.external_id,
+            formsInput=mpg_asset.forms_input,
+            description="my description",
+            glossaryTerms=["term1", "term2"],
+        )
+        assert mpg_asset.id == "asset-id"
+
+    mpg_asset_2_form_content = {
+        "modelPackageGroupName": "my-mpg-2",
+        "modelPackageGroupArn": mpg_arn + "-2",
+        "modelPackageGroupStatus": "Completed",
+        "modelPackageGroupDescription": "my good mpg",
+        "creationTime": "2022-01-01T00:00:00Z",
+    }
+    mpg_asset_2 = Asset(
+        name="asset-name-2",
+        type_id=AssetTypeIdentifier.SageMakerModelPackageGroupAssetType,
+        external_id=mpg_arn + "-2",
+        forms_input=[
+            {
+                "formName": "SageMakerModelPackageGroupForm",
+                "typeIdentifier": "amazon.datazone.SageMakerModelPackageGroupFormType",
+                "typeRevision": "1",
+                "content": json.dumps(mpg_asset_2_form_content)
+            }
+        ],
+    )
+    mpg = ModelPackageGroup(
+        name="my-mpg-2", description="my good mpg", sagemaker_session=sagemaker_session
+    )
+
+    with patch.object(
+        ModelPackageGroupAssetBuilder, "build_asset", return_value=mpg_asset_2
+    ) as mock_method:
+        asset_manager.export_to_inventory(
+            resource=mpg, description="my description 2", glossary_terms=["term1", "term2"]
+        )
+        mock_method.assert_called_once_with(mpg)
+        datazone_client.create_asset.assert_called_with(
+            domainIdentifier=asset_manager.domain_id,
+            name=mpg_asset_2.name,
+            owningProjectIdentifier=asset_manager.project_id,
+            typeIdentifier=mpg_asset_2.type_id.value,
+            externalIdentifier=mpg_asset_2.external_id,
+            formsInput=mpg_asset_2.forms_input,
+            description="my description 2",
+            glossaryTerms=["term1", "term2"],
+        )
+        assert mpg_asset_2.id == "asset-id"
+
+
+def test_asset_manager_export_fg_asset_to_inventory(
+    asset_manager: AssetManager,
+    datazone_client: Mock,
+    sagemaker_session: MagicMock,
+):
+    fg_arn = "arn:aws:sagemaker:us-east-2:1234567890:feature-group/my-fg"
+    fg_form_content = {
+            "featureGroupName": "my-fg",
+            "featureGroupArn": fg_arn,
+            "featureGroupDescription": "my good mpg",
+            "recordIdentifierFeatureName": "f1",
+            "eventTimeFeatureName": "f2",
+            "creationTime": "2022-01-01T00:00:00Z",
+            "lastModifiedTime": "2022-01-01T00:00:00Z",
+        }
+    fg_online_asset = Asset(
+        name="asset-name",
+        type_id=AssetTypeIdentifier.SageMakerFeatureGroupAssetType,
+        external_id=fg_arn,
+        forms_input=[
+            {
+                "formName": "SageMakerFeatureGroupForm",
+                "typeIdentifier": "amazon.datazone.SageMakerFeatureGroupFormType",
+                "typeRevision": "2",
+                "content": json.dumps(fg_form_content)
+            }
+        ],
+    )
+    fg_offline_form_content = {
+        "glueTableName": "my-glue-table"
+    }
+    fg_offline_asset = Asset(
+        id="offline-asset-id",
+        name="asset-name",
+        type_id=AssetTypeIdentifier.SageMakerFeatureGroupAssetType,
+        external_id=fg_arn,
+        forms_input=[
+            {
+                "formName": "SageMakerFeatureGroupForm",
+                "typeIdentifier": "amazon.datazone.SageMakerFeatureGroupFormType",
+                "typeRevision": "2",
+                "content": json.dumps(fg_offline_form_content)
+            }],
+    )
+
+    datazone_client.create_asset.return_value = {"id": "asset-id"}
+
+    with patch.object(
+        FeatureGroupAssetBuilder, "build_asset", return_value=(fg_online_asset, fg_offline_asset)
+    ) as mock_method:
+
+        with patch.object(
+            FeatureGroupAssetBuilder, "append_offline_store_online_store_property"
+        ) as mock_append_method:
+
+            asset_manager.export_to_inventory(
+                resource_arn=fg_arn, description="my description", glossary_terms=["term1", "term2"]
+            )
+            mock_method.assert_called_once_with(fg_arn)
+            datazone_client.create_asset.assert_called_with(
+                domainIdentifier=asset_manager.domain_id,
+                name=fg_online_asset.name,
+                owningProjectIdentifier=asset_manager.project_id,
+                typeIdentifier=fg_online_asset.type_id.value,
+                externalIdentifier=fg_online_asset.external_id,
+                formsInput=fg_online_asset.forms_input,
+                description="my description",
+                glossaryTerms=["term1", "term2"],
+            )
+            mock_append_method.assert_called_once_with(fg_offline_asset, fg_online_asset.id)
+            datazone_client.create_asset_revision.assert_called_with(
+                domainIdentifier=asset_manager.domain_id,
+                identifier=fg_offline_asset.id,
+                name=fg_offline_asset.name,
+                formsInput=fg_offline_asset.forms_input,
+                description="my description",
+                glossaryTerms=["term1", "term2"],
+            )
+
+    fg_asset_2_content = {
+        "featureGroupName": "my-fg-2",
+        "featureGroupArn": fg_arn + "-2",
+        "featureGroupDescription": "my good mpg",
+        "recordIdentifierFeatureName": "f1",
+        "eventTimeFeatureName": "f2",
+        "creationTime": "2022-01-01T00:00:00Z",
+        "lastModifiedTime": "2022-01-01T00:00:00Z",
+    }
+    fg_asset_2 = Asset(
+        name="asset-name-2",
+        type_id=AssetTypeIdentifier.SageMakerFeatureGroupAssetType,
+        external_id=fg_arn + "-2",
+        forms_input=[
+            {
+                "formName": "SageMakerFeatureGroupForm",
+                "typeIdentifier": "amazon.datazone.SageMakerFeatureGroupFormType",
+                "typeRevision": "2",
+                "content": json.dumps(fg_asset_2_content)
+            }
+        ],
+    )
+
+    fg = FeatureGroup(name="my-fg-2", sagemaker_session=sagemaker_session)
+    with patch.object(
+        FeatureGroupAssetBuilder, "build_asset", return_value=(fg_asset_2, None)
+    ) as mock_method:
+        with patch.object(
+            FeatureGroupAssetBuilder, "append_offline_store_online_store_property"
+        ) as mock_append_method:
+            asset_manager.export_to_inventory(
+                resource=fg, description="my description", glossary_terms=["term1", "term2"]
+            )
+            mock_method.assert_called_once_with(fg)
+            datazone_client.create_asset.assert_called_with(
+                domainIdentifier=asset_manager.domain_id,
+                name=fg_asset_2.name,
+                owningProjectIdentifier=asset_manager.project_id,
+                typeIdentifier=fg_asset_2.type_id.value,
+                externalIdentifier=fg_asset_2.external_id,
+                formsInput=fg_asset_2.forms_input,
+                description="my description",
+                glossaryTerms=["term1", "term2"],
+            )
+            mock_append_method.assert_not_called()
+
+
+def test_export_inventory_existing_asset_create_revision(
+        asset_manager: AssetManager,
+        datazone_client: Mock,
+    ):
+    fg_arn = "arn:aws:sagemaker:us-east-2:1234567890:feature-group/my-fg"
+    fg_online_asset_form_content =  {
+        "featureGroupName": "my-fg",
+        "featureGroupArn": fg_arn,
+        "featureGroupDescription": "my good mpg",
+        "recordIdentifierFeatureName": "f1",
+        "eventTimeFeatureName": "f2",
+        "creationTime": "2022-01-01T00:00:00Z",
+        "lastModifiedTime": "2022-01-01T00:00:00Z",
+    }
+    fg_online_asset = Asset(
+        name="asset-name",
+        type_id=AssetTypeIdentifier.SageMakerFeatureGroupAssetType,
+        external_id=fg_arn,
+        forms_input=[
+            {
+                "formName": "SageMakerFeatureGroupForm",
+                "typeIdentifier": "amazon.datazone.SageMakerFeatureGroupFormType",
+                "typeRevision": "2",
+                "content": json.dumps(fg_online_asset_form_content)
+            }
+        ],
+    )
+    asset_id = "asset-id"
+    datazone_client.create_asset = MagicMock(name='create-asset', side_effect=ValueError("ConflictException"))
+    datazone_client.search.return_value = {
+        'items': [{
+            "assetItem": {"identifier": asset_id}
+        }]
+    }
+
+
+    with patch.object(
+        FeatureGroupAssetBuilder, "build_asset", return_value=(fg_online_asset, None)
+    ) as mock_method:
+        asset_manager.export_to_inventory(resource_arn=fg_arn)
+        mock_method.assert_called_once_with(fg_arn)
+        datazone_client.create_asset.assert_called_with(
+            domainIdentifier=asset_manager.domain_id,
+            name=fg_online_asset.name,
+            owningProjectIdentifier=asset_manager.project_id,
+            typeIdentifier=fg_online_asset.type_id.value,
+            externalIdentifier=fg_online_asset.external_id,
+            formsInput=fg_online_asset.forms_input,
+        )
+        datazone_client.search.assert_called_once_with(
+            domainIdentifier=asset_manager.domain_id,
+            owningProjectIdentifier=asset_manager.project_id,
+            searchScope="ASSET",
+            filters={
+                "filter": {
+                    "attribute": "SageMakerFeatureGroupForm.featureGroupArn",
+                    "value": fg_online_asset.external_id,
+                }
+            },
+        )
+        datazone_client.create_asset_revision.assert_called_once_with(
+            domainIdentifier=asset_manager.domain_id,
+            identifier=asset_id,
+            name=fg_online_asset.name,
+            formsInput=fg_online_asset.forms_input,
+        )
+
+
+def test_publish_to_catalog(asset_manager, datazone_client):
+    fg_arn = "arn:aws:sagemaker:us-east-2:1234567890:feature-group/my-fg"
+    fg_online_asset_content = {
+        "featureGroupName": "my-fg",
+        "featureGroupArn": fg_arn,
+        "featureGroupDescription": "my good mpg",
+        "recordIdentifierFeatureName": "f1",
+        "eventTimeFeatureName": "f2",
+        "creationTime": "2022-01-01T00:00:00Z",
+        "lastModifiedTime": "2022-01-01T00:00:00Z",
+    }
+    fg_online_asset = Asset(
+        name="asset-name",
+        id="asset-id",
+        type_id=AssetTypeIdentifier.SageMakerFeatureGroupAssetType,
+        external_id=fg_arn,
+        forms_input=[
+            {
+                "formName": "SageMakerFeatureGroupForm",
+                "typeIdentifier": "amazon.datazone.SageMakerFeatureGroupFormType",
+                "typeRevision": "2",
+                "content": json.dumps(fg_online_asset_content)
+            }
+        ],
+    )
+
+    listing_resp = {"listingId": "123", "listingRevision": "1", "status": "ACTIVE"}
+    datazone_client.create_listing_change_set.return_value = listing_resp
+
+    listing: Listing = asset_manager.publish_to_catalog(fg_online_asset)
+
+    datazone_client.create_listing_change_set.assert_called_once_with(
+        action="PUBLISH",
+        domainIdentifier=asset_manager.domain_id,
+        entityIdentifier=fg_online_asset.id,
+        entityType="ASSET",
+    )
+    assert listing.id == listing_resp["listingId"]
+    assert listing.revision == listing_resp["listingRevision"]
+    assert listing.status == listing_resp["status"]
+
+
+def test_un_publish_to_catalog(asset_manager, datazone_client):
+    fg_arn = "arn:aws:sagemaker:us-east-2:1234567890:feature-group/my-fg"
+    fg_online_asset_content = {
+        "featureGroupName": "my-fg",
+        "featureGroupArn": fg_arn,
+        "featureGroupDescription": "my good mpg",
+        "recordIdentifierFeatureName": "f1",
+        "eventTimeFeatureName": "f2",
+        "creationTime": "2022-01-01T00:00:00Z",
+        "lastModifiedTime": "2022-01-01T00:00:00Z",
+    }
+    fg_online_asset = Asset(
+        name="asset-name",
+        id="asset-id",
+        type_id=AssetTypeIdentifier.SageMakerFeatureGroupAssetType,
+        external_id=fg_arn,
+        forms_input=[
+            {
+                "formName": "SageMakerFeatureGroupForm",
+                "typeIdentifier": "amazon.datazone.SageMakerFeatureGroupFormType",
+                "typeRevision": "2",
+                "content": json.dumps(fg_online_asset_content)
+            }
+        ],
+    )
+
+    listing_resp = {"listingId": "123", "listingRevision": "1", "status": "INACTIVE"}
+    datazone_client.create_listing_change_set.return_value = listing_resp
+
+    listing: Listing = asset_manager.remove_from_catalog(fg_online_asset)
+
+    datazone_client.create_listing_change_set.assert_called_once_with(
+        action="UNPUBLISH",
+        domainIdentifier=asset_manager.domain_id,
+        entityIdentifier=fg_online_asset.id,
+        entityType="ASSET",
+    )
+    assert listing.id == listing_resp["listingId"]
+    assert listing.revision == listing_resp["listingRevision"]
+    assert listing.status == listing_resp["status"]
+
+
+def test_delete_asset(asset_manager, datazone_client):
+    asset_manager.delete_asset(asset_id="asset-id")
+    datazone_client.delete_asset.assert_called_once_with(
+        domainIdentifier=asset_manager.domain_id, identifier="asset-id"
+    )


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Add DataZone asset management behavior

*Testing done:* unit, integration, and manual tests

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
