### PR TITLE
fix: Use sagemaker session's s3 resource for downloading folders

### DIFF
--- a/src/sagemaker/utils.py
+++ b/src/sagemaker/utils.py
@@ -384,8 +384,7 @@ def download_folder(bucket_name, prefix, target, sagemaker_session):
         sagemaker_session (sagemaker.session.Session): a sagemaker session to
             interact with S3.
     """
-    boto_session = sagemaker_session.boto_session
-    s3 = boto_session.resource("s3", region_name=boto_session.region_name)
+    s3 = sagemaker_session.s3_resource
 
     prefix = prefix.lstrip("/")
 
@@ -657,9 +656,8 @@ def download_file(bucket_name, path, target, sagemaker_session):
             interact with S3.
     """
     path = path.lstrip("/")
-    boto_session = sagemaker_session.boto_session
 
-    s3 = boto_session.resource("s3", region_name=sagemaker_session.boto_region_name)
+    s3 = sagemaker_session.s3_resource
     bucket = s3.Bucket(bucket_name)
     bucket.download_file(path, target)
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1032,10 +1032,10 @@ class FakeS3(object):
         self.current_bucket = None
         self.object_mock = MagicMock()
 
-        self.sagemaker_session.boto_session.resource().Bucket().download_file.side_effect = (
+        self.sagemaker_session.s3_resource.Bucket().download_file.side_effect = (
             self.download_file
         )
-        self.sagemaker_session.boto_session.resource().Bucket.side_effect = self.bucket
+        self.sagemaker_session.s3_resource.Bucket.side_effect = self.bucket
         self.fake_upload_path = self.mock_s3_upload()
 
     def bucket(self, name):


### PR DESCRIPTION
*Issue #, if available:*
#4663 

*Description of changes:*
Uses the s3 resource that is created as part of the sagemaker session instead of making a new one.
*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
