### PR TITLE
Fix race condition

### DIFF
--- a/tests/integ/sagemaker/serve/test_schema_builder.py
+++ b/tests/integ/sagemaker/serve/test_schema_builder.py
@@ -12,6 +12,8 @@
 # language governing permissions and limitations under the License.
 from __future__ import absolute_import
 
+import copy
+
 from sagemaker.serve.builder.model_builder import ModelBuilder
 from sagemaker.serve.utils import task
 
@@ -82,6 +84,8 @@ def test_model_builder_negative_path(sagemaker_session):
 def test_model_builder_happy_path_with_task_provided_local_schema_mode(
     model_id, task_provided, sagemaker_session, instance_type_provided, container_startup_timeout
 ):
+    local_download_dir = copy.deepcopy(sagemaker_session.settings._local_download_dir)
+
     model_builder = ModelBuilder(
         model=model_id,
         model_metadata={"HF_TASK": task_provided},
@@ -89,6 +93,7 @@ def test_model_builder_happy_path_with_task_provided_local_schema_mode(
     )
 
     model = model_builder.build(sagemaker_session=sagemaker_session)
+    sagemaker_session.settings._local_download_dir = local_download_dir
 
     assert model is not None
     assert model_builder.schema_builder is not None
@@ -158,12 +163,15 @@ def test_model_builder_happy_path_with_task_provided_local_schema_mode(
 def test_model_builder_happy_path_with_task_provided_remote_schema_mode(
     model_id, task_provided, sagemaker_session, instance_type_provided
 ):
+    local_download_dir = copy.deepcopy(sagemaker_session.settings._local_download_dir)
+
     model_builder = ModelBuilder(
         model=model_id,
         model_metadata={"HF_TASK": task_provided},
         instance_type=instance_type_provided,
     )
     model = model_builder.build(sagemaker_session=sagemaker_session)
+    sagemaker_session.settings._local_download_dir = local_download_dir
 
     assert model is not None
     assert model_builder.schema_builder is not None
@@ -213,12 +221,15 @@ def test_model_builder_happy_path_with_task_provided_remote_schema_mode(
 def test_model_builder_with_task_provided_remote_schema_mode_asr(
     model_id, task_provided, sagemaker_session, instance_type_provided
 ):
+    local_download_dir = copy.deepcopy(sagemaker_session.settings._local_download_dir)
+
     model_builder = ModelBuilder(
         model=model_id,
         model_metadata={"HF_TASK": task_provided},
         instance_type=instance_type_provided,
     )
     model = model_builder.build(sagemaker_session=sagemaker_session)
+    sagemaker_session.settings._local_download_dir = local_download_dir
 
     assert model is not None
     assert model_builder.schema_builder is not None

--- a/tests/integ/sagemaker/serve/test_serve_js_happy.py
+++ b/tests/integ/sagemaker/serve/test_serve_js_happy.py
@@ -12,6 +12,8 @@
 # language governing permissions and limitations under the License.
 from __future__ import absolute_import
 
+import copy
+
 import pytest
 
 from sagemaker.serve.builder.model_builder import ModelBuilder
@@ -52,9 +54,14 @@ def happy_model_builder(sagemaker_session):
 )
 @pytest.mark.slow_test
 def test_happy_tgi_sagemaker_endpoint(happy_model_builder, gpu_instance_type):
+    local_download_dir = copy.deepcopy(
+        happy_model_builder.sagemaker_session.settings._local_download_dir
+    )
     logger.info("Running in SAGEMAKER_ENDPOINT mode...")
     caught_ex = None
+
     model = happy_model_builder.build()
+    happy_model_builder.sagemaker_session.settings._local_download_dir = local_download_dir
 
     with timeout(minutes=SERVE_SAGEMAKER_ENDPOINT_TIMEOUT):
         try:

--- a/tests/integ/sagemaker/serve/test_serve_mlflow_pytorch_flavor_happy.py
+++ b/tests/integ/sagemaker/serve/test_serve_mlflow_pytorch_flavor_happy.py
@@ -12,6 +12,8 @@
 # language governing permissions and limitations under the License.
 from __future__ import absolute_import
 
+import copy
+
 import pytest
 import torch
 from PIL import Image
@@ -179,6 +181,7 @@ def test_happy_pytorch_sagemaker_endpoint_with_torch_serve(
     logger.info("Running in SAGEMAKER_ENDPOINT mode...")
     caught_ex = None
 
+    local_download_dir = copy.deepcopy(sagemaker_session.settings._local_download_dir)
     iam_client = sagemaker_session.boto_session.client("iam")
     role_arn = iam_client.get_role(RoleName=ROLE_NAME)["Role"]["Arn"]
 
@@ -204,6 +207,7 @@ def test_happy_pytorch_sagemaker_endpoint_with_torch_serve(
     )
 
     model = model_builder.build(sagemaker_session=sagemaker_session)
+    sagemaker_session.settings._local_download_dir = local_download_dir
 
     with timeout(minutes=SERVE_SAGEMAKER_ENDPOINT_TIMEOUT):
         try:

--- a/tests/integ/sagemaker/serve/test_serve_mlflow_xgboost_flavor_happy.py
+++ b/tests/integ/sagemaker/serve/test_serve_mlflow_xgboost_flavor_happy.py
@@ -12,6 +12,8 @@
 # language governing permissions and limitations under the License.
 from __future__ import absolute_import
 
+import copy
+
 import pytest
 import io
 import numpy as np
@@ -160,6 +162,7 @@ def test_happy_xgboost_sagemaker_endpoint_with_torch_serve(
     logger.info("Running in SAGEMAKER_ENDPOINT mode...")
     caught_ex = None
 
+    local_download_dir = copy.deepcopy(sagemaker_session.settings._local_download_dir)
     iam_client = sagemaker_session.boto_session.client("iam")
     role_arn = iam_client.get_role(RoleName=ROLE_NAME)["Role"]["Arn"]
     test_x, _ = test_data
@@ -186,6 +189,7 @@ def test_happy_xgboost_sagemaker_endpoint_with_torch_serve(
     )
 
     model = model_builder.build(sagemaker_session=sagemaker_session)
+    sagemaker_session.settings._local_download_dir = local_download_dir
 
     with timeout(minutes=SERVE_SAGEMAKER_ENDPOINT_TIMEOUT):
         try:

--- a/tests/integ/sagemaker/serve/test_serve_model_builder_gpu.py
+++ b/tests/integ/sagemaker/serve/test_serve_model_builder_gpu.py
@@ -12,6 +12,8 @@
 # language governing permissions and limitations under the License.
 from __future__ import absolute_import
 
+import copy
+
 import pytest
 from sagemaker.serve.builder.schema_builder import SchemaBuilder
 from sagemaker.serve.builder.model_builder import ModelBuilder, Mode
@@ -93,9 +95,12 @@ def model_builder(request):
 def test_non_text_generation_model_single_GPU(
     sagemaker_session, model_builder, model_input, **kwargs
 ):
+    local_download_dir = copy.deepcopy(sagemaker_session.settings._local_download_dir)
     iam_client = sagemaker_session.boto_session.client("iam")
     role_arn = iam_client.get_role(RoleName="SageMakerRole")["Role"]["Arn"]
     model = model_builder.build(role_arn=role_arn, sagemaker_session=sagemaker_session)
+    sagemaker_session.settings._local_download_dir = local_download_dir
+
     caught_ex = None
     with timeout(minutes=SERVE_SAGEMAKER_ENDPOINT_TIMEOUT):
         try:
@@ -144,10 +149,13 @@ def test_non_text_generation_model_single_GPU(
 def test_non_text_generation_model_multi_GPU(
     sagemaker_session, model_builder, model_input, **kwargs
 ):
+    local_download_dir = copy.deepcopy(sagemaker_session.settings._local_download_dir)
     iam_client = sagemaker_session.boto_session.client("iam")
     role_arn = iam_client.get_role(RoleName="SageMakerRole")["Role"]["Arn"]
     caught_ex = None
     model = model_builder.build(role_arn=role_arn, sagemaker_session=sagemaker_session)
+    sagemaker_session.settings._local_download_dir = local_download_dir
+
     with timeout(minutes=SERVE_SAGEMAKER_ENDPOINT_TIMEOUT):
         try:
             logger.info("Running in SAGEMAKER_ENDPOINT mode")

--- a/tests/integ/sagemaker/serve/test_serve_pt_happy.py
+++ b/tests/integ/sagemaker/serve/test_serve_pt_happy.py
@@ -13,6 +13,8 @@
 # flake8: noqa: F631
 from __future__ import absolute_import
 
+import copy
+
 import pytest
 import torch
 from PIL import Image
@@ -196,6 +198,8 @@ def test_happy_pytorch_sagemaker_endpoint(
     cpu_instance_type,
     test_image,
 ):
+    local_download_dir = copy.deepcopy(sagemaker_session.settings._local_download_dir)
+
     logger.info("Running in SAGEMAKER_ENDPOINT mode...")
     caught_ex = None
 
@@ -205,6 +209,7 @@ def test_happy_pytorch_sagemaker_endpoint(
     model = model_builder.build(
         mode=Mode.SAGEMAKER_ENDPOINT, role_arn=role_arn, sagemaker_session=sagemaker_session
     )
+    sagemaker_session.settings._local_download_dir = local_download_dir
 
     with timeout(minutes=SERVE_SAGEMAKER_ENDPOINT_TIMEOUT):
         try:

--- a/tests/integ/sagemaker/serve/test_serve_transformers.py
+++ b/tests/integ/sagemaker/serve/test_serve_transformers.py
@@ -12,6 +12,8 @@
 # language governing permissions and limitations under the License.
 from __future__ import absolute_import
 
+import copy
+
 import pytest
 from sagemaker.serve.builder.schema_builder import SchemaBuilder
 from sagemaker.serve.builder.model_builder import ModelBuilder, Mode
@@ -96,6 +98,8 @@ def model_builder(request):
 def test_pytorch_transformers_sagemaker_endpoint(
     sagemaker_session, model_builder, model_input, **kwargs
 ):
+    local_download_dir = copy.deepcopy(sagemaker_session.settings._local_download_dir)
+
     logger.info("Running in SAGEMAKER_ENDPOINT mode...")
     caught_ex = None
 
@@ -105,6 +109,7 @@ def test_pytorch_transformers_sagemaker_endpoint(
     model = model_builder.build(
         mode=Mode.SAGEMAKER_ENDPOINT, role_arn=role_arn, sagemaker_session=sagemaker_session
     )
+    sagemaker_session.settings._local_download_dir = local_download_dir
 
     with timeout(minutes=SERVE_SAGEMAKER_ENDPOINT_TIMEOUT):
         try:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix Flaky tests

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
