### PR TITLE
fix: model builder race condition on sagemaker session

### DIFF
--- a/src/sagemaker/serve/builder/model_builder.py
+++ b/src/sagemaker/serve/builder/model_builder.py
@@ -708,8 +708,6 @@ class ModelBuilder(Triton, DJL, JumpStart, TGI, Transformers):
             self.role_arn = role_arn
         self.sagemaker_session = sagemaker_session or Session()
 
-        self.sagemaker_session.settings._local_download_dir = self.model_path
-
         # https://github.com/boto/botocore/blob/develop/botocore/useragent.py#L258
         # decorate to_string() due to
         # https://github.com/boto/botocore/blob/develop/botocore/client.py#L1014-L1015


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Other integration tests are failing du to race condition. This is caused by use of single `sagemaker_session` object for all integration tests and ModelBuilder mutate the object.

Note: There is no need to mutate the session as it's not needed. `model_path` is passed directly to `s3_downloader`.
https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/serve/model_server/djl_serving/prepare.py#L228

See: https://github.com/aws/sagemaker-python-sdk/actions/runs/9010187570/job/24755797329

*Testing done:*
Notebook

```
model_builder = ModelBuilder(
    model="bigscience/bloom-7b1",
    schema_builder=SchemaBuilder(sample_input, sample_output),
    model_path="/home/ec2-user/SageMaker/LoadTestResources/bloom-7b1",
    mode=Mode.LOCAL_CONTAINER
)

%%time
builder = model_builder.build()

%%time
local_djl_predictor = builder.deploy()

updated_sample_input = model_builder.schema_builder.sample_input
updated_sample_input

%%time
print(local_djl_predictor.predict(updated_sample_input)[0]["generated_text"])
```

```
southeastern United States. It is the only species of turtle native to the southeastern United States. It is a medium-sized turtle, with a carapace length of about 30 cm (12 in) and a weight of about 1 kg (2.2 lb). The carapace is smooth, with a dark brown coloration. The head is large, with a prominent snout and a small eye. The tail is short, with a single dorsal fin. The legs are long and slender, with a webbed foot. The dorsal fin is long and narrow, with a single spine. The ventral fin is short and broad, with
CPU times: user 2.69 ms, sys: 1.46 ms, total: 4.15 ms
Wall time: 2.47 s
```

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
