### PR TITLE
fix benchmark feature read-only apis

### DIFF
--- a/src/sagemaker/jumpstart/model.py
+++ b/src/sagemaker/jumpstart/model.py
@@ -465,7 +465,7 @@ class JumpStartModel(Model):
             Benchmark Metrics: Pandas DataFrame object.
         """
         df = pd.DataFrame(self._get_deployment_configs_benchmarks_data())
-        df = df.sort_values(by=['Instance Type', 'Concurrent users'], ascending=False)
+        df = df.sort_values(by=['Instance Type', 'Concurrent Users'], ascending=False)
         return df
 
     def display_benchmark_metrics(self, *args, **kwargs) -> None:

--- a/src/sagemaker/jumpstart/model.py
+++ b/src/sagemaker/jumpstart/model.py
@@ -908,16 +908,34 @@ class JumpStartModel(Model):
                     )
                 )
 
+            config_components = metadata_config.config_components.get(config_name)
+            image_uri = (
+                (
+                    config_components.hosting_instance_type_variants.get("regional_aliases", {})
+                    .get(self.region, {})
+                    .get("alias_ecr_uri_1")
+                )
+                if config_components
+                else self.image_uri
+            )
+
             init_kwargs = get_init_kwargs(
+                config_name=config_name,
                 model_id=self.model_id,
                 instance_type=instance_type_to_use,
                 sagemaker_session=self.sagemaker_session,
+                image_uri=image_uri,
+                region=self.region,
+                model_version=self.model_version,
             )
             deploy_kwargs = get_deploy_kwargs(
                 model_id=self.model_id,
                 instance_type=instance_type_to_use,
                 sagemaker_session=self.sagemaker_session,
+                region=self.region,
+                model_version=self.model_version,
             )
+
             deployment_config_metadata = DeploymentConfigMetadata(
                 config_name,
                 metadata_config.benchmark_metrics,

--- a/src/sagemaker/jumpstart/model.py
+++ b/src/sagemaker/jumpstart/model.py
@@ -904,6 +904,9 @@ class JumpStartModel(Model):
                 instance_type_to_use = resolved_config.get("default_inference_instance_type")
 
             if metadata_config.benchmark_metrics:
+                print("********************")
+                print("Benchmark Metrics")
+                print("********************")
                 err, metadata_config.benchmark_metrics = (
                     add_instance_rate_stats_to_benchmark_metrics(
                         self.region, metadata_config.benchmark_metrics

--- a/src/sagemaker/jumpstart/model.py
+++ b/src/sagemaker/jumpstart/model.py
@@ -465,7 +465,7 @@ class JumpStartModel(Model):
             Benchmark Metrics: Pandas DataFrame object.
         """
         df = pd.DataFrame(self._get_deployment_configs_benchmarks_data())
-        df = df.sort_values(by=['Instance Type', 'Concurrent Users'], ascending=False)
+        df = df.sort_values(by=['Concurrent Users'])
         return df
 
     def display_benchmark_metrics(self, *args, **kwargs) -> None:

--- a/src/sagemaker/jumpstart/model.py
+++ b/src/sagemaker/jumpstart/model.py
@@ -904,9 +904,6 @@ class JumpStartModel(Model):
                 instance_type_to_use = resolved_config.get("default_inference_instance_type")
 
             if metadata_config.benchmark_metrics:
-                print("********************")
-                print("Benchmark Metrics")
-                print("********************")
                 err, metadata_config.benchmark_metrics = (
                     add_instance_rate_stats_to_benchmark_metrics(
                         self.region, metadata_config.benchmark_metrics

--- a/src/sagemaker/jumpstart/model.py
+++ b/src/sagemaker/jumpstart/model.py
@@ -464,11 +464,14 @@ class JumpStartModel(Model):
         Returns:
             Benchmark Metrics: Pandas DataFrame object.
         """
-        return pd.DataFrame(self._get_deployment_configs_benchmarks_data())
+        df = pd.DataFrame(self._get_deployment_configs_benchmarks_data())
+        blank_index = [""] * len(df)
+        df.index = blank_index
+        return df
 
     def display_benchmark_metrics(self, *args, **kwargs) -> None:
         """Display deployment configs benchmark metrics."""
-        print(self.benchmark_metrics.to_markdown(index=False), *args, **kwargs)
+        print(self.benchmark_metrics.to_markdown(index=False, floatfmt=".2f"), *args, **kwargs)
 
     def list_deployment_configs(self) -> List[Dict[str, Any]]:
         """List deployment configs for ``This`` model.

--- a/src/sagemaker/jumpstart/model.py
+++ b/src/sagemaker/jumpstart/model.py
@@ -464,11 +464,7 @@ class JumpStartModel(Model):
         Returns:
             Benchmark Metrics: Pandas DataFrame object.
         """
-        df = pd.DataFrame(self._get_deployment_configs_benchmarks_data())
-        df = df.sort_values(by=['Instance Type'])
-        default_mask = df.apply(lambda raw: any('Default' in str(val) for val in raw), axis=1)
-        sorted_df = pd.concat([df[default_mask], df[~default_mask]])
-        return sorted_df
+        return pd.DataFrame(self._get_deployment_configs_benchmarks_data())
 
     def display_benchmark_metrics(self, *args, **kwargs) -> None:
         """Display deployment configs benchmark metrics."""

--- a/src/sagemaker/jumpstart/model.py
+++ b/src/sagemaker/jumpstart/model.py
@@ -465,9 +465,8 @@ class JumpStartModel(Model):
             Benchmark Metrics: Pandas DataFrame object.
         """
         df = pd.DataFrame(self._get_deployment_configs_benchmarks_data())
-        default_mask = df.apply(lambda row: any("Default" in str(val) for val in row), axis=1)
-        sorted_df = pd.concat([df[default_mask], df[~default_mask]])
-        return sorted_df
+        df = df.sort_values(by=['Instance Type', 'Concurrent users'], ascending=False)
+        return df
 
     def display_benchmark_metrics(self, *args, **kwargs) -> None:
         """Display deployment configs benchmark metrics."""

--- a/src/sagemaker/jumpstart/model.py
+++ b/src/sagemaker/jumpstart/model.py
@@ -465,8 +465,10 @@ class JumpStartModel(Model):
             Benchmark Metrics: Pandas DataFrame object.
         """
         df = pd.DataFrame(self._get_deployment_configs_benchmarks_data())
-        df = df.sort_values(by=['Concurrent Users'])
-        return df
+        df = df.sort_values(by=['Instance Type'])
+        default_mask = df.apply(lambda raw: any('Default' in str(val) for val in raw), axis=1)
+        sorted_df = pd.concat([df[default_mask], df[~default_mask]])
+        return sorted_df
 
     def display_benchmark_metrics(self, *args, **kwargs) -> None:
         """Display deployment configs benchmark metrics."""

--- a/src/sagemaker/jumpstart/types.py
+++ b/src/sagemaker/jumpstart/types.py
@@ -762,6 +762,9 @@ class JumpStartBenchmarkStat(JumpStartDataHolderType):
         Args:
             json_obj (Dict[str, Any]): Dictionary representation of benchmark stats.
         """
+        print("***********JumpStartBenchmarkStat***************")
+        print(json_obj)
+        print("*****************************************")
         self.name: str = json_obj["name"]
         self.value: str = json_obj["value"]
         self.unit: Union[int, str] = json_obj["unit"]

--- a/src/sagemaker/jumpstart/types.py
+++ b/src/sagemaker/jumpstart/types.py
@@ -762,9 +762,6 @@ class JumpStartBenchmarkStat(JumpStartDataHolderType):
         Args:
             json_obj (Dict[str, Any]): Dictionary representation of benchmark stats.
         """
-        print("***********JumpStartBenchmarkStat***************")
-        print(json_obj)
-        print("*****************************************")
         self.name: str = json_obj["name"]
         self.value: str = json_obj["value"]
         self.unit: Union[int, str] = json_obj["unit"]

--- a/src/sagemaker/jumpstart/types.py
+++ b/src/sagemaker/jumpstart/types.py
@@ -746,7 +746,7 @@ class JumpStartInstanceTypeVariants(JumpStartDataHolderType):
 class JumpStartBenchmarkStat(JumpStartDataHolderType):
     """Data class JumpStart benchmark stat."""
 
-    __slots__ = ["name", "value", "unit"]
+    __slots__ = ["name", "value", "unit", "concurrency"]
 
     def __init__(self, spec: Dict[str, Any]):
         """Initializes a JumpStartBenchmarkStat object.
@@ -765,6 +765,7 @@ class JumpStartBenchmarkStat(JumpStartDataHolderType):
         self.name: str = json_obj["name"]
         self.value: str = json_obj["value"]
         self.unit: Union[int, str] = json_obj["unit"]
+        self.concurrency: Union[int, str] = json_obj["concurrency"]
 
     def to_json(self) -> Dict[str, Any]:
         """Returns json representation of JumpStartBenchmarkStat object."""

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -1075,7 +1075,6 @@ def add_instance_rate_stats_to_benchmark_metrics(
         instance_type = instance_type if instance_type.startswith("ml.") else f"ml.{instance_type}"
 
         if not has_instance_rate_stat(benchmark_metric_stats) and not err_message:
-            print("Here")
             try:
                 print(instance_type)
                 instance_type_rate = get_instance_rate_per_hour(
@@ -1157,31 +1156,38 @@ def get_metrics_from_deployment_configs(
 
                 instance_type_to_display = (
                     f"{current_instance_type} (Default)"
-                    if index == 0 and current_instance_type == deployment_config.deployment_args.default_instance_type
+                    if index == 0 and concurrent_user == 1 and current_instance_type == deployment_config.deployment_args.default_instance_type
                     else current_instance_type
                 )
 
                 instance_rate_column_name = f"{instance_type_rate.name} ({instance_type_rate.unit})"
                 data[instance_rate_column_name] = data.get(instance_rate_column_name, [])
-                if current_instance_type == default_instance_type:
-                    data["Config Name"].insert(default_index, deployment_config.deployment_config_name)
-                    data["Instance Type"].insert(default_index, instance_type_to_display)
-                    data["Concurrent Users"].insert(default_index, concurrent_user)
-                    data[instance_rate_column_name].insert(default_index, instance_type_rate.value)
-                else:
-                    data["Config Name"].append(deployment_config.deployment_config_name)
-                    data["Instance Type"].append(instance_type_to_display)
-                    data["Concurrent Users"].append(concurrent_user)
-                    data[instance_rate_column_name].append(instance_type_rate.value)
+
+                data["Config Name"].append(deployment_config.deployment_config_name)
+                data["Instance Type"].append(instance_type_to_display)
+                data["Concurrent Users"].append(concurrent_user)
+                data[instance_rate_column_name].append(instance_type_rate.value)
+
+                # if current_instance_type == default_instance_type:
+                #     data["Config Name"].insert(default_index, deployment_config.deployment_config_name)
+                #     data["Instance Type"].insert(default_index, instance_type_to_display)
+                #     data["Concurrent Users"].insert(default_index, concurrent_user)
+                #     data[instance_rate_column_name].insert(default_index, instance_type_rate.value)
+                # else:
+                #     data["Config Name"].append(deployment_config.deployment_config_name)
+                #     data["Instance Type"].append(instance_type_to_display)
+                #     data["Concurrent Users"].append(concurrent_user)
+                #     data[instance_rate_column_name].append(instance_type_rate.value)
 
                 for metric in metrics:
                     column_name = f"{metric.name} ({metric.unit})"
                     data[column_name] = data.get(column_name, [])
+                    data[column_name].append(metric.value)
 
-                    if current_instance_type == default_instance_type:
-                        data[column_name].insert(default_index, metric.value)
-                    else:
-                        data[column_name].append(metric.value)
+                    # if current_instance_type == default_instance_type:
+                    #     data[column_name].insert(default_index, metric.value)
+                    # else:
+                    #     data[column_name].append(metric.value)
 
                 if current_instance_type == default_instance_type:
                     default_index += 1

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -1105,6 +1105,7 @@ def has_instance_rate_stat(benchmark_metric_stats: Optional[List[JumpStartBenchm
     Returns:
         bool: Whether the benchmark metric stats contains instance rate metric stat.
     """
+    print(benchmark_metric_stats)
     if benchmark_metric_stats is None:
         return True
     for benchmark_metric_stat in benchmark_metric_stats:

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -1202,9 +1202,6 @@ def deployment_config_response_data(
 
     for deployment_config in deployment_configs:
         deployment_config_json = deployment_config.to_json()
-        print("************deployment_config_response_data*****************")
-        print(deployment_config_json)
-        print("************deployment_config_response_data***************")
         benchmark_metrics = deployment_config_json.get("BenchmarkMetrics")
         if benchmark_metrics and deployment_config.deployment_args:
             deployment_config_json["BenchmarkMetrics"] = {

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -1129,8 +1129,6 @@ def get_metrics_from_deployment_configs(
 
     data = {"Instance Type": [], "Concurrent Users": [], "Config Name": []}
     instance_rate_data = {}
-    default_instance_type = None
-    default_index = 0
     for index, deployment_config in enumerate(deployment_configs):
         benchmark_metrics = deployment_config.benchmark_metrics
         if not deployment_config.deployment_args or not benchmark_metrics:
@@ -1150,9 +1148,6 @@ def get_metrics_from_deployment_configs(
                     concurrent_users[current_instance_type_metric.concurrency].append(current_instance_type_metric)
 
             for concurrent_user, metrics in concurrent_users.items():
-                if index == 0 and current_instance_type == deployment_config.deployment_args.default_instance_type:
-                    default_instance_type = current_instance_type
-
                 instance_type_to_display = (
                     f"{current_instance_type} (Default)"
                     if index == 0 and int(concurrent_user) == 1 and current_instance_type == deployment_config.deployment_args.default_instance_type
@@ -1167,29 +1162,10 @@ def get_metrics_from_deployment_configs(
                 data["Concurrent Users"].append(concurrent_user)
                 instance_rate_data[instance_rate_column_name].append(instance_type_rate.value)
 
-                # if current_instance_type == default_instance_type:
-                #     data["Config Name"].insert(default_index, deployment_config.deployment_config_name)
-                #     data["Instance Type"].insert(default_index, instance_type_to_display)
-                #     data["Concurrent Users"].insert(default_index, concurrent_user)
-                #     data[instance_rate_column_name].insert(default_index, instance_type_rate.value)
-                # else:
-                #     data["Config Name"].append(deployment_config.deployment_config_name)
-                #     data["Instance Type"].append(instance_type_to_display)
-                #     data["Concurrent Users"].append(concurrent_user)
-                #     data[instance_rate_column_name].append(instance_type_rate.value)
-
                 for metric in metrics:
                     column_name = f"{metric.name} ({metric.unit})"
                     data[column_name] = data.get(column_name, [])
                     data[column_name].append(metric.value)
-
-                    # if current_instance_type == default_instance_type:
-                    #     data[column_name].insert(default_index, metric.value)
-                    # else:
-                    #     data[column_name].append(metric.value)
-
-                if current_instance_type == default_instance_type:
-                    default_index += 1
 
     data = {**data, **instance_rate_data}
 
@@ -1197,80 +1173,6 @@ def get_metrics_from_deployment_configs(
     print(data)
     print("****************")
     return data
-
-
-# def get_metrics_from_deployment_configs(
-#     deployment_configs: Optional[List[DeploymentConfigMetadata]],
-# ) -> Dict[str, List[str]]:
-#     """Extracts benchmark metrics from deployment configs metadata.
-#
-#     Args:
-#         deployment_configs (Optional[List[DeploymentConfigMetadata]]):
-#         List of deployment configs metadata.
-#     Returns:
-#         Dict[str, List[str]]: Deployment configs bench metrics dict.
-#     """
-#     if not deployment_configs:
-#         return {}
-#
-#     data = {"Instance Type": [], "Concurrent Users": [], "Config Name": []}
-#     instance_rate_data = {}
-#     default_instance_type = None
-#     default_index = 0
-#     for index, deployment_config in enumerate(deployment_configs):
-#         benchmark_metrics = deployment_config.benchmark_metrics
-#         if not deployment_config.deployment_args or not benchmark_metrics:
-#             continue
-#
-#         for inner_index, current_instance_type in enumerate(benchmark_metrics):
-#             current_instance_type_metrics = benchmark_metrics[current_instance_type]
-#             if index == 0 and current_instance_type == deployment_config.deployment_args.default_instance_type:
-#                 default_instance_type = current_instance_type
-#
-#             instance_type_to_display = (
-#                 f"{current_instance_type} (Default)"
-#                 if index == 0 and current_instance_type == deployment_config.deployment_args.default_instance_type
-#                 else current_instance_type
-#             )
-#
-#             if current_instance_type == default_instance_type:
-#                 data["Config Name"].insert(default_index, deployment_config.deployment_config_name)
-#                 data["Instance Type"].insert(default_index, instance_type_to_display)
-#             else:
-#                 data["Config Name"].append(deployment_config.deployment_config_name)
-#                 data["Instance Type"].append(instance_type_to_display)
-#
-#             for metric in current_instance_type_metrics:
-#                 column_name = f"{metric.name} ({metric.unit})"
-#
-#                 if metric.name.lower() == "instance rate":
-#                     instance_rate_data[column_name] = instance_rate_data.get(column_name, [])
-#
-#                     if current_instance_type == default_instance_type:
-#                         instance_rate_data[column_name].insert(default_index, metric.value)
-#                     else:
-#                         instance_rate_data[column_name].append(metric.value)
-#                 else:
-#                     data[column_name] = data.get(column_name, [])
-#                     for _ in range(len(data[column_name]), inner_index):
-#                         data[column_name].append(" - ")
-#
-#                     if current_instance_type == default_instance_type:
-#                         data[column_name].insert(default_index, metric.value)
-#                         data["Concurrent Users"].insert(default_index, metric.concurrency)
-#                     else:
-#                         data[column_name].append(metric.value)
-#                         data["Concurrent Users"].append(metric.concurrency)
-#
-#             if current_instance_type == default_instance_type:
-#                 default_index += 1
-#
-#     data = {**data, **instance_rate_data}
-#
-#     print("*****************")
-#     print(data)
-#     print("****************")
-#     return data
 
 
 def deployment_config_response_data(

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -1129,7 +1129,7 @@ def get_metrics_from_deployment_configs(
     if not deployment_configs:
         return {}
 
-    data = {"Instance Type": [], "Concurrent Users": [], "Config Name": []}
+    data = {"Instance Type": [], "Config Name": [], "Concurrent Users": []}
     instance_rate_data = {}
     for index, deployment_config in enumerate(deployment_configs):
         benchmark_metrics = deployment_config.benchmark_metrics

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -1143,7 +1143,7 @@ def get_metrics_from_deployment_configs(
 
             instance_type_to_display = (
                 f"{current_instance_type} (Default)"
-                if default_instance_type
+                if index == 0 and current_instance_type == deployment_config.deployment_args.default_instance_type
                 else current_instance_type
             )
 

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -1136,17 +1136,6 @@ def get_metrics_from_deployment_configs(
 
         for inner_index, current_instance_type in enumerate(benchmark_metrics):
             current_instance_type_metrics = benchmark_metrics[current_instance_type]
-
-            # instance_type_rate = None
-            # concurrent_users = dict()
-            # for current_instance_type_metric in current_instance_type_metrics:
-            #     if current_instance_type_metric.name.lower() == "instance rate":
-            #         instance_type_rate = current_instance_type_metric
-            #     elif current_instance_type_metric.concurrency not in concurrent_users:
-            #         concurrent_users[current_instance_type_metric.concurrency] = [current_instance_type_metric]
-            #     else:
-            #         concurrent_users[current_instance_type_metric.concurrency].append(current_instance_type_metric)
-
             instance_type_rate, concurrent_users = _normalize_benchmark_metrics(current_instance_type_metrics)
 
             for concurrent_user, metrics in concurrent_users.items():
@@ -1165,7 +1154,7 @@ def get_metrics_from_deployment_configs(
                 instance_rate_data[instance_rate_column_name].append(instance_type_rate.value)
 
                 for metric in metrics:
-                    column_name = f"{metric.name} ({metric.unit})"
+                    column_name = _normalize_benchmark_metric_column_name(metric.name)
                     data[column_name] = data.get(column_name, [])
                     data[column_name].append(metric.value)
 
@@ -1175,6 +1164,14 @@ def get_metrics_from_deployment_configs(
     print(data)
     print("****************")
     return data
+
+
+def _normalize_benchmark_metric_column_name(name: str) -> str:
+    if "latency" in name.lower():
+        return "Latency for each user (TTFT in ms)"
+    elif "throughput" in name.lower():
+        return "Throughput per user (token/seconds)"
+    return name
 
 
 def _normalize_benchmark_metrics(

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -1160,7 +1160,7 @@ def get_metrics_from_deployment_configs(
                 )
 
                 instance_rate_column_name = f"{instance_type_rate.name} ({instance_type_rate.unit})"
-                instance_rate_data[instance_rate_column_name] = data.get(instance_rate_column_name, [])
+                instance_rate_data[instance_rate_column_name] = instance_rate_data.get(instance_rate_column_name, [])
 
                 data["Config Name"].append(deployment_config.deployment_config_name)
                 data["Instance Type"].append(instance_type_to_display)

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -1075,6 +1075,7 @@ def add_instance_rate_stats_to_benchmark_metrics(
         instance_type = instance_type if instance_type.startswith("ml.") else f"ml.{instance_type}"
 
         if not has_instance_rate_stat(benchmark_metric_stats) and not err_message:
+            print("Here")
             try:
                 instance_type_rate = get_instance_rate_per_hour(
                     instance_type=instance_type, region=region
@@ -1105,12 +1106,14 @@ def has_instance_rate_stat(benchmark_metric_stats: Optional[List[JumpStartBenchm
     Returns:
         bool: Whether the benchmark metric stats contains instance rate metric stat.
     """
-    print(benchmark_metric_stats)
     if benchmark_metric_stats is None:
+        print("True")
         return True
     for benchmark_metric_stat in benchmark_metric_stats:
         if benchmark_metric_stat.name.lower() == "instance rate":
+            print("True")
             return True
+    print("False")
     return False
 
 

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -1077,6 +1077,7 @@ def add_instance_rate_stats_to_benchmark_metrics(
         if not has_instance_rate_stat(benchmark_metric_stats) and not err_message:
             print("Here")
             try:
+                print(instance_type)
                 instance_type_rate = get_instance_rate_per_hour(
                     instance_type=instance_type, region=region
                 )
@@ -1092,7 +1093,9 @@ def add_instance_rate_stats_to_benchmark_metrics(
             except ClientError as e:
                 final_benchmark_metrics[instance_type] = benchmark_metric_stats
                 err_message = e.response["Error"]
-            except Exception:  # pylint: disable=W0703
+            except Exception as e:  # pylint: disable=W0703
+                print("Error")
+                print(e)
                 final_benchmark_metrics[instance_type] = benchmark_metric_stats
         else:
             final_benchmark_metrics[instance_type] = benchmark_metric_stats

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -1171,10 +1171,10 @@ def get_metrics_from_deployment_configs(
 
                     if current_instance_type == default_instance_type:
                         data[column_name].insert(default_index, metric.value)
-                        instance_rate_data["Concurrent Users"].insert(default_index, metric.concurrency)
+                        data["Concurrent Users"].insert(default_index, metric.concurrency)
                     else:
                         data[column_name].append(metric.value)
-                        instance_rate_data["Concurrent Users"].append(metric.concurrency)
+                        data["Concurrent Users"].append(metric.concurrency)
 
             if current_instance_type == default_instance_type:
                 default_index += 1

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -1151,15 +1151,18 @@ def get_metrics_from_deployment_configs(
                     else current_instance_type
                 )
 
-                instance_rate_column_name = f"{instance_type_rate.name} ({instance_type_rate.unit})"
-                instance_rate_data[instance_rate_column_name] = instance_rate_data.get(
-                    instance_rate_column_name, []
-                )
-
                 data["Config Name"].append(deployment_config.deployment_config_name)
                 data["Instance Type"].append(instance_type_to_display)
                 data["Concurrent Users"].append(concurrent_user)
-                instance_rate_data[instance_rate_column_name].append(instance_type_rate.value)
+
+                if instance_type_rate:
+                    instance_rate_column_name = (
+                        f"{instance_type_rate.name} ({instance_type_rate.unit})"
+                    )
+                    instance_rate_data[instance_rate_column_name] = instance_rate_data.get(
+                        instance_rate_column_name, []
+                    )
+                    instance_rate_data[instance_rate_column_name].append(instance_type_rate.value)
 
                 for metric in metrics:
                     column_name = _normalize_benchmark_metric_column_name(metric.name)

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -1084,19 +1084,14 @@ def add_instance_rate_stats_to_benchmark_metrics(
 
                 if not benchmark_metric_stats:
                     benchmark_metric_stats = []
-                benchmark_metric_stats.append(JumpStartBenchmarkStat(instance_type_rate))
+                benchmark_metric_stats.append(JumpStartBenchmarkStat({'concurrency': None, **instance_type_rate}))
 
                 final_benchmark_metrics[instance_type] = benchmark_metric_stats
-
-                print("Instance type rate")
-                print(instance_type_rate)
             except ClientError as e:
                 final_benchmark_metrics[instance_type] = benchmark_metric_stats
                 err_message = e.response["Error"]
-            except Exception as e:  # pylint: disable=W0703
-                print("Error")
+            except Exception:  # pylint: disable=W0703
                 final_benchmark_metrics[instance_type] = benchmark_metric_stats
-                raise e
         else:
             final_benchmark_metrics[instance_type] = benchmark_metric_stats
 

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -1160,12 +1160,12 @@ def get_metrics_from_deployment_configs(
                 )
 
                 instance_rate_column_name = f"{instance_type_rate.name} ({instance_type_rate.unit})"
-                data[instance_rate_column_name] = data.get(instance_rate_column_name, [])
+                instance_rate_data[instance_rate_column_name] = data.get(instance_rate_column_name, [])
 
                 data["Config Name"].append(deployment_config.deployment_config_name)
                 data["Instance Type"].append(instance_type_to_display)
                 data["Concurrent Users"].append(concurrent_user)
-                data[instance_rate_column_name].append(instance_type_rate.value)
+                instance_rate_data[instance_rate_column_name].append(instance_type_rate.value)
 
                 # if current_instance_type == default_instance_type:
                 #     data["Config Name"].insert(default_index, deployment_config.deployment_config_name)

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -1095,8 +1095,8 @@ def add_instance_rate_stats_to_benchmark_metrics(
                 err_message = e.response["Error"]
             except Exception as e:  # pylint: disable=W0703
                 print("Error")
-                print(e)
                 final_benchmark_metrics[instance_type] = benchmark_metric_stats
+                raise e
         else:
             final_benchmark_metrics[instance_type] = benchmark_metric_stats
 

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -1076,7 +1076,6 @@ def add_instance_rate_stats_to_benchmark_metrics(
 
         if not has_instance_rate_stat(benchmark_metric_stats) and not err_message:
             try:
-                print(instance_type)
                 instance_type_rate = get_instance_rate_per_hour(
                     instance_type=instance_type, region=region
                 )
@@ -1156,7 +1155,7 @@ def get_metrics_from_deployment_configs(
 
                 instance_type_to_display = (
                     f"{current_instance_type} (Default)"
-                    if index == 0 and concurrent_user == 1 and current_instance_type == deployment_config.deployment_args.default_instance_type
+                    if index == 0 and int(concurrent_user) == 1 and current_instance_type == deployment_config.deployment_args.default_instance_type
                     else current_instance_type
                 )
 

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -1137,15 +1137,17 @@ def get_metrics_from_deployment_configs(
         for inner_index, current_instance_type in enumerate(benchmark_metrics):
             current_instance_type_metrics = benchmark_metrics[current_instance_type]
 
-            instance_type_rate = None
-            concurrent_users = dict()
-            for current_instance_type_metric in current_instance_type_metrics:
-                if current_instance_type_metric.name.lower() == "instance rate":
-                    instance_type_rate = current_instance_type_metric
-                elif current_instance_type_metric.concurrency not in concurrent_users:
-                    concurrent_users[current_instance_type_metric.concurrency] = [current_instance_type_metric]
-                else:
-                    concurrent_users[current_instance_type_metric.concurrency].append(current_instance_type_metric)
+            # instance_type_rate = None
+            # concurrent_users = dict()
+            # for current_instance_type_metric in current_instance_type_metrics:
+            #     if current_instance_type_metric.name.lower() == "instance rate":
+            #         instance_type_rate = current_instance_type_metric
+            #     elif current_instance_type_metric.concurrency not in concurrent_users:
+            #         concurrent_users[current_instance_type_metric.concurrency] = [current_instance_type_metric]
+            #     else:
+            #         concurrent_users[current_instance_type_metric.concurrency].append(current_instance_type_metric)
+
+            instance_type_rate, concurrent_users = _normalize_benchmark_metrics(current_instance_type_metrics)
 
             for concurrent_user, metrics in concurrent_users.items():
                 instance_type_to_display = (
@@ -1173,6 +1175,23 @@ def get_metrics_from_deployment_configs(
     print(data)
     print("****************")
     return data
+
+
+def _normalize_benchmark_metrics(
+        benchmark_metric_stats: List[JumpStartBenchmarkStat]
+) -> Tuple[JumpStartBenchmarkStat, Dict[str, List[JumpStartBenchmarkStat]]]:
+
+    instance_type_rate = None
+    concurrent_users = {}
+    for current_instance_type_metric in benchmark_metric_stats:
+        if current_instance_type_metric.name.lower() == "instance rate":
+            instance_type_rate = current_instance_type_metric
+        elif current_instance_type_metric.concurrency not in concurrent_users:
+            concurrent_users[current_instance_type_metric.concurrency] = [current_instance_type_metric]
+        else:
+            concurrent_users[current_instance_type_metric.concurrency].append(current_instance_type_metric)
+
+    return instance_type_rate, concurrent_users
 
 
 def deployment_config_response_data(

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -1162,10 +1162,8 @@ def get_metrics_from_deployment_configs(
 
                     if current_instance_type == default_instance_type:
                         instance_rate_data[column_name].insert(default_index, metric.value)
-                        instance_rate_data["Concurrent Users"].insert(default_index, metric.concurrency)
                     else:
                         instance_rate_data[column_name].append(metric.value)
-                        instance_rate_data["Concurrent Users"].append(metric.concurrency)
                 else:
                     data[column_name] = data.get(column_name, [])
                     for _ in range(len(data[column_name]), inner_index):

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -1182,6 +1182,10 @@ def get_metrics_from_deployment_configs(
                 default_index += 1
 
     data = {**data, **instance_rate_data}
+
+    print("*****************")
+    print(data)
+    print("****************")
     return data
 
 

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -1086,6 +1086,9 @@ def add_instance_rate_stats_to_benchmark_metrics(
                 benchmark_metric_stats.append(JumpStartBenchmarkStat(instance_type_rate))
 
                 final_benchmark_metrics[instance_type] = benchmark_metric_stats
+
+                print("Instance type rate")
+                print(instance_type_rate)
             except ClientError as e:
                 final_benchmark_metrics[instance_type] = benchmark_metric_stats
                 err_message = e.response["Error"]

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -1202,6 +1202,9 @@ def deployment_config_response_data(
 
     for deployment_config in deployment_configs:
         deployment_config_json = deployment_config.to_json()
+        print("************deployment_config_response_data*****************")
+        print(deployment_config_json)
+        print("************deployment_config_response_data***************")
         benchmark_metrics = deployment_config_json.get("BenchmarkMetrics")
         if benchmark_metrics and deployment_config.deployment_args:
             deployment_config_json["BenchmarkMetrics"] = {

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -1155,26 +1155,28 @@ def get_metrics_from_deployment_configs(
                 data["Instance Type"].append(instance_type_to_display)
 
             for metric in current_instance_type_metrics:
-                column_name = "Concurrent Users" if "concurrency" in metric.name.lower() else f"{metric.name} ({metric.unit})"
+                column_name = f"{metric.name} ({metric.unit})"
 
                 if metric.name.lower() == "instance rate":
-                    if column_name not in instance_rate_data:
-                        instance_rate_data[column_name] = []
+                    instance_rate_data[column_name] = instance_rate_data.get(column_name, [])
 
                     if current_instance_type == default_instance_type:
                         instance_rate_data[column_name].insert(default_index, metric.value)
+                        instance_rate_data["Concurrent Users"].insert(default_index, metric.concurrency)
                     else:
                         instance_rate_data[column_name].append(metric.value)
+                        instance_rate_data["Concurrent Users"].append(metric.concurrency)
                 else:
-                    if column_name not in data:
-                        data[column_name] = []
+                    data[column_name] = data.get(column_name, [])
                     for _ in range(len(data[column_name]), inner_index):
                         data[column_name].append(" - ")
 
                     if current_instance_type == default_instance_type:
                         data[column_name].insert(default_index, metric.value)
+                        instance_rate_data["Concurrent Users"].insert(default_index, metric.concurrency)
                     else:
                         data[column_name].append(metric.value)
+                        instance_rate_data["Concurrent Users"].append(metric.concurrency)
 
             if current_instance_type == default_instance_type:
                 default_index += 1

--- a/src/sagemaker/utils.py
+++ b/src/sagemaker/utils.py
@@ -1731,6 +1731,9 @@ def get_instance_rate_per_hour(
         ],
     )
 
+    print("*****************")
+    print(res)
+
     price_list = res.get("PriceList", [])
     if len(price_list) > 0:
         price_data = price_list[0]

--- a/src/sagemaker/utils.py
+++ b/src/sagemaker/utils.py
@@ -1731,9 +1731,6 @@ def get_instance_rate_per_hour(
         ],
     )
 
-    print("*****************")
-    print(res)
-
     price_list = res.get("PriceList", [])
     if len(price_list) > 0:
         price_data = price_list[0]

--- a/tests/unit/sagemaker/jumpstart/constants.py
+++ b/tests/unit/sagemaker/jumpstart/constants.py
@@ -7662,25 +7662,33 @@ INFERENCE_CONFIGS = {
     "inference_configs": {
         "neuron-inference": {
             "benchmark_metrics": {
-                "ml.inf2.2xlarge": [{"name": "Latency", "value": "100", "unit": "Tokens/S"}]
+                "ml.inf2.2xlarge": [
+                    {"name": "Latency", "value": "100", "unit": "Tokens/S", "concurrency": 1}
+                ]
             },
             "component_names": ["neuron-inference"],
         },
         "neuron-inference-budget": {
             "benchmark_metrics": {
-                "ml.inf2.2xlarge": [{"name": "Latency", "value": "100", "unit": "Tokens/S"}]
+                "ml.inf2.2xlarge": [
+                    {"name": "Latency", "value": "100", "unit": "Tokens/S", "concurrency": 1}
+                ]
             },
             "component_names": ["neuron-base"],
         },
         "gpu-inference-budget": {
             "benchmark_metrics": {
-                "ml.p3.2xlarge": [{"name": "Latency", "value": "100", "unit": "Tokens/S"}]
+                "ml.p3.2xlarge": [
+                    {"name": "Latency", "value": "100", "unit": "Tokens/S", "concurrency": 1}
+                ]
             },
             "component_names": ["gpu-inference-budget"],
         },
         "gpu-inference": {
             "benchmark_metrics": {
-                "ml.p3.2xlarge": [{"name": "Latency", "value": "100", "unit": "Tokens/S"}]
+                "ml.p3.2xlarge": [
+                    {"name": "Latency", "value": "100", "unit": "Tokens/S", "concurrency": 1}
+                ]
             },
             "component_names": ["gpu-inference"],
         },
@@ -7748,8 +7756,12 @@ TRAINING_CONFIGS = {
     "training_configs": {
         "neuron-training": {
             "benchmark_metrics": {
-                "ml.tr1n1.2xlarge": [{"name": "Latency", "value": "100", "unit": "Tokens/S"}],
-                "ml.tr1n1.4xlarge": [{"name": "Latency", "value": "50", "unit": "Tokens/S"}],
+                "ml.tr1n1.2xlarge": [
+                    {"name": "Latency", "value": "100", "unit": "Tokens/S", "concurrency": 1}
+                ],
+                "ml.tr1n1.4xlarge": [
+                    {"name": "Latency", "value": "50", "unit": "Tokens/S", "concurrency": 1}
+                ],
             },
             "component_names": ["neuron-training"],
             "default_inference_config": "neuron-inference",
@@ -7759,8 +7771,12 @@ TRAINING_CONFIGS = {
         },
         "neuron-training-budget": {
             "benchmark_metrics": {
-                "ml.tr1n1.2xlarge": [{"name": "Latency", "value": "100", "unit": "Tokens/S"}],
-                "ml.tr1n1.4xlarge": [{"name": "Latency", "value": "50", "unit": "Tokens/S"}],
+                "ml.tr1n1.2xlarge": [
+                    {"name": "Latency", "value": "100", "unit": "Tokens/S", "concurrency": 1}
+                ],
+                "ml.tr1n1.4xlarge": [
+                    {"name": "Latency", "value": "50", "unit": "Tokens/S", "concurrency": 1}
+                ],
             },
             "component_names": ["neuron-training-budget"],
             "default_inference_config": "neuron-inference-budget",
@@ -7770,7 +7786,9 @@ TRAINING_CONFIGS = {
         },
         "gpu-training": {
             "benchmark_metrics": {
-                "ml.p3.2xlarge": [{"name": "Latency", "value": "200", "unit": "Tokens/S"}],
+                "ml.p3.2xlarge": [
+                    {"name": "Latency", "value": "200", "unit": "Tokens/S", "concurrency": "1"}
+                ],
             },
             "component_names": ["gpu-training"],
             "default_inference_config": "gpu-inference",
@@ -7780,7 +7798,9 @@ TRAINING_CONFIGS = {
         },
         "gpu-training-budget": {
             "benchmark_metrics": {
-                "ml.p3.2xlarge": [{"name": "Latency", "value": "100", "unit": "Tokens/S"}]
+                "ml.p3.2xlarge": [
+                    {"name": "Latency", "value": "100", "unit": "Tokens/S", "concurrency": "1"}
+                ]
             },
             "component_names": ["gpu-training-budget"],
             "default_inference_config": "gpu-inference-budget",
@@ -7966,7 +7986,9 @@ DEPLOYMENT_CONFIGS = [
             "ContainerStartupHealthCheckTimeout": None,
         },
         "AccelerationConfigs": None,
-        "BenchmarkMetrics": [{"name": "Instance Rate", "value": "0.0083000000", "unit": "USD/Hrs"}],
+        "BenchmarkMetrics": [
+            {"name": "Instance Rate", "value": "0.0083000000", "unit": "USD/Hrs", "concurrency": 1}
+        ],
     },
     {
         "DeploymentConfigName": "neuron-inference-budget",
@@ -7998,7 +8020,9 @@ DEPLOYMENT_CONFIGS = [
             "ContainerStartupHealthCheckTimeout": None,
         },
         "AccelerationConfigs": None,
-        "BenchmarkMetrics": [{"name": "Instance Rate", "value": "0.0083000000", "unit": "USD/Hrs"}],
+        "BenchmarkMetrics": [
+            {"name": "Instance Rate", "value": "0.0083000000", "unit": "USD/Hrs", "concurrency": 1}
+        ],
     },
     {
         "DeploymentConfigName": "gpu-inference-budget",
@@ -8030,7 +8054,9 @@ DEPLOYMENT_CONFIGS = [
             "ContainerStartupHealthCheckTimeout": None,
         },
         "AccelerationConfigs": None,
-        "BenchmarkMetrics": [{"name": "Instance Rate", "value": "0.0083000000", "unit": "USD/Hrs"}],
+        "BenchmarkMetrics": [
+            {"name": "Instance Rate", "value": "0.0083000000", "unit": "USD/Hrs", "concurrency": 1}
+        ],
     },
     {
         "DeploymentConfigName": "gpu-inference",

--- a/tests/unit/sagemaker/jumpstart/test_types.py
+++ b/tests/unit/sagemaker/jumpstart/test_types.py
@@ -1027,7 +1027,9 @@ def test_inference_configs_parsing():
 
     assert config.benchmark_metrics == {
         "ml.inf2.2xlarge": [
-            JumpStartBenchmarkStat({"name": "Latency", "value": "100", "unit": "Tokens/S"})
+            JumpStartBenchmarkStat(
+                {"name": "Latency", "value": "100", "unit": "Tokens/S", "concurrency": 1}
+            ),
         ]
     }
     assert len(config.config_components) == 1
@@ -1191,10 +1193,14 @@ def test_training_configs_parsing():
 
     assert config.benchmark_metrics == {
         "ml.tr1n1.2xlarge": [
-            JumpStartBenchmarkStat({"name": "Latency", "value": "100", "unit": "Tokens/S"})
+            JumpStartBenchmarkStat(
+                {"name": "Latency", "value": "100", "unit": "Tokens/S", "concurrency": 1}
+            ),
         ],
         "ml.tr1n1.4xlarge": [
-            JumpStartBenchmarkStat({"name": "Latency", "value": "50", "unit": "Tokens/S"})
+            JumpStartBenchmarkStat(
+                {"name": "Latency", "value": "50", "unit": "Tokens/S", "concurrency": 1}
+            ),
         ],
     }
     assert len(config.config_components) == 1

--- a/tests/unit/sagemaker/jumpstart/test_utils.py
+++ b/tests/unit/sagemaker/jumpstart/test_utils.py
@@ -1709,22 +1709,30 @@ class TestBenchmarkStats:
         ) == {
             "neuron-inference": {
                 "ml.inf2.2xlarge": [
-                    JumpStartBenchmarkStat({"name": "Latency", "value": "100", "unit": "Tokens/S"})
+                    JumpStartBenchmarkStat(
+                        {"name": "Latency", "value": "100", "unit": "Tokens/S", "concurrency": 1}
+                    )
                 ]
             },
             "neuron-inference-budget": {
                 "ml.inf2.2xlarge": [
-                    JumpStartBenchmarkStat({"name": "Latency", "value": "100", "unit": "Tokens/S"})
+                    JumpStartBenchmarkStat(
+                        {"name": "Latency", "value": "100", "unit": "Tokens/S", "concurrency": 1}
+                    )
                 ]
             },
             "gpu-inference-budget": {
                 "ml.p3.2xlarge": [
-                    JumpStartBenchmarkStat({"name": "Latency", "value": "100", "unit": "Tokens/S"})
+                    JumpStartBenchmarkStat(
+                        {"name": "Latency", "value": "100", "unit": "Tokens/S", "concurrency": 1}
+                    )
                 ]
             },
             "gpu-inference": {
                 "ml.p3.2xlarge": [
-                    JumpStartBenchmarkStat({"name": "Latency", "value": "100", "unit": "Tokens/S"})
+                    JumpStartBenchmarkStat(
+                        {"name": "Latency", "value": "100", "unit": "Tokens/S", "concurrency": 1}
+                    )
                 ]
             },
         }
@@ -1744,12 +1752,16 @@ class TestBenchmarkStats:
         ) == {
             "neuron-inference-budget": {
                 "ml.inf2.2xlarge": [
-                    JumpStartBenchmarkStat({"name": "Latency", "value": "100", "unit": "Tokens/S"})
+                    JumpStartBenchmarkStat(
+                        {"name": "Latency", "value": "100", "unit": "Tokens/S", "concurrency": 1}
+                    )
                 ]
             },
             "gpu-inference-budget": {
                 "ml.p3.2xlarge": [
-                    JumpStartBenchmarkStat({"name": "Latency", "value": "100", "unit": "Tokens/S"})
+                    JumpStartBenchmarkStat(
+                        {"name": "Latency", "value": "100", "unit": "Tokens/S", "concurrency": 1}
+                    )
                 ]
             },
         }
@@ -1769,7 +1781,9 @@ class TestBenchmarkStats:
         ) == {
             "neuron-inference-budget": {
                 "ml.inf2.2xlarge": [
-                    JumpStartBenchmarkStat({"name": "Latency", "value": "100", "unit": "Tokens/S"})
+                    JumpStartBenchmarkStat(
+                        {"name": "Latency", "value": "100", "unit": "Tokens/S", "concurrency": 1}
+                    )
                 ]
             }
         }
@@ -1797,6 +1811,16 @@ class TestBenchmarkStats:
     ):
         patched_get_model_specs.side_effect = get_base_spec_with_prototype_configs
 
+        print(
+            utils.get_benchmark_stats(
+                "mock-region",
+                "mock-model",
+                "mock-model-version",
+                scope=JumpStartScriptScope.TRAINING,
+                config_names=["neuron-training", "gpu-training-budget"],
+            )
+        )
+
         assert utils.get_benchmark_stats(
             "mock-region",
             "mock-model",
@@ -1806,15 +1830,21 @@ class TestBenchmarkStats:
         ) == {
             "neuron-training": {
                 "ml.tr1n1.2xlarge": [
-                    JumpStartBenchmarkStat({"name": "Latency", "value": "100", "unit": "Tokens/S"})
+                    JumpStartBenchmarkStat(
+                        {"name": "Latency", "value": "100", "unit": "Tokens/S", "concurrency": 1}
+                    )
                 ],
                 "ml.tr1n1.4xlarge": [
-                    JumpStartBenchmarkStat({"name": "Latency", "value": "50", "unit": "Tokens/S"})
+                    JumpStartBenchmarkStat(
+                        {"name": "Latency", "value": "50", "unit": "Tokens/S", "concurrency": 1}
+                    )
                 ],
             },
             "gpu-training-budget": {
                 "ml.p3.2xlarge": [
-                    JumpStartBenchmarkStat({"name": "Latency", "value": "100", "unit": "Tokens/S"})
+                    JumpStartBenchmarkStat(
+                        {"name": "Latency", "value": "100", "unit": "Tokens/S", "concurrency": "1"}
+                    )
                 ]
             },
         }
@@ -1845,10 +1875,14 @@ def test_add_instance_rate_stats_to_benchmark_metrics(
         "us-west-2",
         {
             "ml.p2.xlarge": [
-                JumpStartBenchmarkStat({"name": "Latency", "value": "100", "unit": "Tokens/S"})
+                JumpStartBenchmarkStat(
+                    {"name": "Latency", "value": "100", "unit": "Tokens/S", "concurrency": 1}
+                )
             ],
             "ml.gd4.xlarge": [
-                JumpStartBenchmarkStat({"name": "Latency", "value": "100", "unit": "Tokens/S"})
+                JumpStartBenchmarkStat(
+                    {"name": "Latency", "value": "100", "unit": "Tokens/S", "concurrency": 1}
+                )
             ],
         },
     )
@@ -1862,7 +1896,65 @@ def test_add_instance_rate_stats_to_benchmark_metrics(
                     "name": "Instance Rate",
                     "unit": "USD/Hrs",
                     "value": "3.76",
+                    "concurrency": None,
                 }
+
+
+def test__normalize_benchmark_metrics():
+    rate, metrics = utils._normalize_benchmark_metrics(
+        [
+            JumpStartBenchmarkStat(
+                {"name": "Latency", "value": "100", "unit": "Tokens/S", "concurrency": 1}
+            ),
+            JumpStartBenchmarkStat(
+                {"name": "Throughput", "value": "100", "unit": "Tokens/S", "concurrency": 1}
+            ),
+            JumpStartBenchmarkStat(
+                {"name": "Latency", "value": "100", "unit": "Tokens/S", "concurrency": 2}
+            ),
+            JumpStartBenchmarkStat(
+                {"name": "Throughput", "value": "100", "unit": "Tokens/S", "concurrency": 2}
+            ),
+            JumpStartBenchmarkStat(
+                {"name": "Instance Rate", "unit": "USD/Hrs", "value": "3.76", "concurrency": None}
+            ),
+        ]
+    )
+
+    assert rate == JumpStartBenchmarkStat(
+        {"name": "Instance Rate", "unit": "USD/Hrs", "value": "3.76", "concurrency": None}
+    )
+    assert metrics == {
+        1: [
+            JumpStartBenchmarkStat(
+                {"name": "Latency", "value": "100", "unit": "Tokens/S", "concurrency": 1}
+            ),
+            JumpStartBenchmarkStat(
+                {"name": "Throughput", "value": "100", "unit": "Tokens/S", "concurrency": 1}
+            ),
+        ],
+        2: [
+            JumpStartBenchmarkStat(
+                {"name": "Latency", "value": "100", "unit": "Tokens/S", "concurrency": 2}
+            ),
+            JumpStartBenchmarkStat(
+                {"name": "Throughput", "value": "100", "unit": "Tokens/S", "concurrency": 2}
+            ),
+        ],
+    }
+
+
+@pytest.mark.parametrize(
+    "name, expected",
+    [
+        ("latency", "Latency for each user (TTFT in ms)"),
+        ("throughput", "Throughput per user (token/seconds)"),
+    ],
+)
+def test__normalize_benchmark_metric_column_name(name, expected):
+    out = utils._normalize_benchmark_metric_column_name(name)
+
+    assert out == expected
 
 
 @patch("sagemaker.jumpstart.utils.get_instance_rate_per_hour")
@@ -1883,7 +1975,9 @@ def test_add_instance_rate_stats_to_benchmark_metrics_client_ex(
         "us-west-2",
         {
             "ml.p2.xlarge": [
-                JumpStartBenchmarkStat({"name": "Latency", "value": "100", "unit": "Tokens/S"})
+                JumpStartBenchmarkStat(
+                    {"name": "Latency", "value": "100", "unit": "Tokens/S", "concurrency": 1}
+                )
             ],
         },
     )
@@ -1899,10 +1993,26 @@ def test_add_instance_rate_stats_to_benchmark_metrics_client_ex(
     [
         (None, True),
         (
-            [JumpStartBenchmarkStat({"name": "Instance Rate", "unit": "USD/Hrs", "value": "3.76"})],
+            [
+                JumpStartBenchmarkStat(
+                    {
+                        "name": "Instance Rate",
+                        "unit": "USD/Hrs",
+                        "value": "3.76",
+                        "concurrency": None,
+                    }
+                )
+            ],
             True,
         ),
-        ([JumpStartBenchmarkStat({"name": "Latency", "value": "100", "unit": "Tokens/S"})], False),
+        (
+            [
+                JumpStartBenchmarkStat(
+                    {"name": "Latency", "value": "100", "unit": "Tokens/S", "concurrency": None}
+                )
+            ],
+            False,
+        ),
     ],
 )
 def test_has_instance_rate_stat(stats, expected):

--- a/tests/unit/sagemaker/jumpstart/utils.py
+++ b/tests/unit/sagemaker/jumpstart/utils.py
@@ -366,7 +366,12 @@ def get_base_deployment_configs_metadata(
             for instance_type in benchmark_metrics:
                 benchmark_metrics[instance_type].append(
                     JumpStartBenchmarkStat(
-                        {"name": "Instance Rate", "unit": "USD/Hrs", "value": "3.76"}
+                        {
+                            "name": "Instance Rate",
+                            "unit": "USD/Hrs",
+                            "value": "3.76",
+                            "concurrency": None,
+                        }
                     )
                 )
 
@@ -409,7 +414,12 @@ def append_instance_stat_metrics(
         for key in metrics:
             metrics[key].append(
                 JumpStartBenchmarkStat(
-                    {"name": "Instance Rate", "value": "3.76", "unit": "USD/Hrs"}
+                    {
+                        "name": "Instance Rate",
+                        "value": "3.76",
+                        "unit": "USD/Hrs",
+                        "concurrency": None,
+                    }
                 )
             )
     return metrics


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

```
jumpstart_model = JumpStartModel(model_id="meta-textgeneration-llama-3-8b")
jumpstart_model.list_deployment_configs()

[{'DeploymentConfigName': 'lmi-accelerated',
  'DeploymentArgs': {'ImageUri': '763104351884.dkr.ecr.us-west-2.amazonaws.com/djl-inference:0.27.0-deepspeed0.12.6-cu121',
   'ModelData': {'S3DataSource': {'S3Uri': 's3://jumpstart-private-cache-prod-us-west-2/meta-textgeneration/meta-textgeneration-llama-3-8b/artifacts/inference-prepack/v1.0.0/',
     'S3DataType': 'S3Prefix',
     'CompressionType': 'None'}},
   'Environment': {'SAGEMAKER_PROGRAM': 'inference.py',
    'ENDPOINT_SERVER_TIMEOUT': '3600',
    'MODEL_CACHE_ROOT': '/opt/ml/model',
    'SAGEMAKER_ENV': '1',
    'HF_MODEL_ID': '/opt/ml/model',
    'SERVING_LOAD_MODELS': 'test::MPI=/opt/ml/model',
    'OPTION_MODEL_ID': '/opt/ml/model',
    'OPTION_SPECULATIVE_DRAFT_MODEL': 'sagemaker',
    'OPTION_TENSOR_PARALLEL_DEGREE': 'max',
    'OPTION_MAX_ROLLING_BATCH_SIZE': '64',
    'OPTION_ROLLING_BATCH': 'lmi-dist',
    'OPTION_GPU_MEMORY_UTILIZATION': '0.8',
    'SAGEMAKER_MODEL_SERVER_WORKERS': '1'},
   'InstanceType': 'ml.g5.2xlarge',
   'ComputeResourceRequirements': {'MinMemoryRequiredInMb': 98304,
    'NumberOfAcceleratorDevicesRequired': 4},
   'ModelDataDownloadTimeout': 1200,
   'ContainerStartupHealthCheckTimeout': 1200},
  'AccelerationConfigs': None,
  'BenchmarkMetrics': {'ml.g5.2xlarge': [{'name': 'Latency',
     'value': '12',
     'unit': 'ms/token',
     'concurrency': '1'},
    {'name': 'Throughput',
     'value': '213',
     'unit': 'tokens/sec',
     'concurrency': '1'},
    {'name': 'Latency', 'value': '12', 'unit': 'ms/token', 'concurrency': '2'},
    {'name': 'Throughput',
     'value': '213',
     'unit': 'tokens/sec',
     'concurrency': '2'},
    {'name': 'Instance Rate',
     'value': '1.515',
     'unit': 'USD/Hrs',
     'concurrency': None}]}},
 {'DeploymentConfigName': 'lmi',
  'DeploymentArgs': {'ImageUri': '763104351884.dkr.ecr.us-west-2.amazonaws.com/djl-inference:0.27.0-deepspeed0.12.6-cu121',
   'ModelData': {'S3DataSource': {'S3Uri': 's3://jumpstart-private-cache-prod-us-west-2/meta-textgeneration/meta-textgeneration-llama-3-8b/artifacts/inference-prepack/v1.0.0/',
     'S3DataType': 'S3Prefix',
     'CompressionType': 'None'}},
   'Environment': {'SAGEMAKER_PROGRAM': 'inference.py',
    'ENDPOINT_SERVER_TIMEOUT': '3600',
    'MODEL_CACHE_ROOT': '/opt/ml/model',
    'SAGEMAKER_ENV': '1',
    'HF_MODEL_ID': '/opt/ml/model',
    'SERVING_LOAD_MODELS': 'test::MPI=/opt/ml/model',
    'OPTION_MODEL_ID': '/opt/ml/model',
    'OPTION_SPECULATIVE_DRAFT_MODEL': 'sagemaker',
    'OPTION_TENSOR_PARALLEL_DEGREE': 'max',
    'OPTION_MAX_ROLLING_BATCH_SIZE': '64',
    'OPTION_ROLLING_BATCH': 'lmi-dist',
    'OPTION_GPU_MEMORY_UTILIZATION': '0.8',
    'SAGEMAKER_MODEL_SERVER_WORKERS': '1'},
   'InstanceType': 'ml.g5.2xlarge',
   'ComputeResourceRequirements': {'MinMemoryRequiredInMb': 98304,
    'NumberOfAcceleratorDevicesRequired': 4},
   'ModelDataDownloadTimeout': 1200,
   'ContainerStartupHealthCheckTimeout': 1200},
  'AccelerationConfigs': None,
  'BenchmarkMetrics': {'ml.g5.2xlarge': [{'name': 'Latency',
     'value': '36',
     'unit': 'ms/token',
     'concurrency': '1'},
    {'name': 'Throughput',
     'value': '390',
     'unit': 'tokens/sec',
     'concurrency': '1'},
    {'name': 'Latency', 'value': '36', 'unit': 'ms/token', 'concurrency': '2'},
    {'name': 'Throughput',
     'value': '390',
     'unit': 'tokens/sec',
     'concurrency': '2'},
    {'name': 'Instance Rate',
     'value': '1.515',
     'unit': 'USD/Hrs',
     'concurrency': None}]}},
 {'DeploymentConfigName': 'lmi-trtllm',
  'DeploymentArgs': {'ImageUri': '763104351884.dkr.ecr.us-west-2.amazonaws.com/djl-inference:0.27.0-deepspeed0.12.6-cu121',
   'ModelData': {'S3DataSource': {'S3Uri': 's3://jumpstart-private-cache-prod-us-west-2/meta-textgeneration/meta-textgeneration-llama-3-8b/artifacts/inference-prepack/v1.0.0/',
     'S3DataType': 'S3Prefix',
     'CompressionType': 'None'}},
   'Environment': {'SAGEMAKER_PROGRAM': 'inference.py',
    'ENDPOINT_SERVER_TIMEOUT': '3600',
    'MODEL_CACHE_ROOT': '/opt/ml/model',
    'SAGEMAKER_ENV': '1',
    'HF_MODEL_ID': '/opt/ml/model',
    'SERVING_LOAD_MODELS': 'test::MPI=/opt/ml/model',
    'OPTION_MODEL_ID': '/opt/ml/model',
    'OPTION_SPECULATIVE_DRAFT_MODEL': 'sagemaker',
    'OPTION_TENSOR_PARALLEL_DEGREE': 'max',
    'OPTION_MAX_ROLLING_BATCH_SIZE': '64',
    'OPTION_ROLLING_BATCH': 'lmi-dist',
    'OPTION_GPU_MEMORY_UTILIZATION': '0.8',
    'SAGEMAKER_MODEL_SERVER_WORKERS': '1'},
   'InstanceType': 'ml.g5.2xlarge',
   'ComputeResourceRequirements': {'MinMemoryRequiredInMb': 98304,
    'NumberOfAcceleratorDevicesRequired': 4},
   'ModelDataDownloadTimeout': 1200,
   'ContainerStartupHealthCheckTimeout': 1200},
  'AccelerationConfigs': None,
  'BenchmarkMetrics': None},
 {'DeploymentConfigName': 'tgi',
  'DeploymentArgs': {'ImageUri': '763104351884.dkr.ecr.us-west-2.amazonaws.com/djl-inference:0.27.0-deepspeed0.12.6-cu121',
   'ModelData': {'S3DataSource': {'S3Uri': 's3://jumpstart-private-cache-prod-us-west-2/meta-textgeneration/meta-textgeneration-llama-3-8b/artifacts/inference-prepack/v1.0.0/',
     'S3DataType': 'S3Prefix',
     'CompressionType': 'None'}},
   'Environment': {'SAGEMAKER_PROGRAM': 'inference.py',
    'ENDPOINT_SERVER_TIMEOUT': '3600',
    'MODEL_CACHE_ROOT': '/opt/ml/model',
    'SAGEMAKER_ENV': '1',
    'HF_MODEL_ID': '/opt/ml/model',
    'SERVING_LOAD_MODELS': 'test::MPI=/opt/ml/model',
    'OPTION_MODEL_ID': '/opt/ml/model',
    'OPTION_SPECULATIVE_DRAFT_MODEL': 'sagemaker',
    'OPTION_TENSOR_PARALLEL_DEGREE': 'max',
    'OPTION_MAX_ROLLING_BATCH_SIZE': '64',
    'OPTION_ROLLING_BATCH': 'lmi-dist',
    'OPTION_GPU_MEMORY_UTILIZATION': '0.8',
    'SAGEMAKER_MODEL_SERVER_WORKERS': '1'},
   'InstanceType': 'ml.g5.2xlarge',
   'ComputeResourceRequirements': {'MinMemoryRequiredInMb': 98304,
    'NumberOfAcceleratorDevicesRequired': 4},
   'ModelDataDownloadTimeout': 1200,
   'ContainerStartupHealthCheckTimeout': 1200},
  'AccelerationConfigs': None,
  'BenchmarkMetrics': None}]
```

```
jumpstart_model.deployment_config

{'DeploymentConfigName': 'lmi-accelerated',
 'DeploymentArgs': {'ImageUri': '763104351884.dkr.ecr.us-west-2.amazonaws.com/djl-inference:0.27.0-deepspeed0.12.6-cu121',
  'ModelData': {'S3DataSource': {'S3Uri': 's3://jumpstart-private-cache-prod-us-west-2/meta-textgeneration/meta-textgeneration-llama-3-8b/artifacts/inference-prepack/v1.0.0/',
    'S3DataType': 'S3Prefix',
    'CompressionType': 'None'}},
  'Environment': {'SAGEMAKER_PROGRAM': 'inference.py',
   'ENDPOINT_SERVER_TIMEOUT': '3600',
   'MODEL_CACHE_ROOT': '/opt/ml/model',
   'SAGEMAKER_ENV': '1',
   'HF_MODEL_ID': '/opt/ml/model',
   'SERVING_LOAD_MODELS': 'test::MPI=/opt/ml/model',
   'OPTION_MODEL_ID': '/opt/ml/model',
   'OPTION_SPECULATIVE_DRAFT_MODEL': 'sagemaker',
   'OPTION_TENSOR_PARALLEL_DEGREE': 'max',
   'OPTION_MAX_ROLLING_BATCH_SIZE': '64',
   'OPTION_ROLLING_BATCH': 'lmi-dist',
   'OPTION_GPU_MEMORY_UTILIZATION': '0.8',
   'SAGEMAKER_MODEL_SERVER_WORKERS': '1'},
  'InstanceType': 'ml.g5.2xlarge',
  'ComputeResourceRequirements': {'MinMemoryRequiredInMb': 98304,
   'NumberOfAcceleratorDevicesRequired': 4},
  'ModelDataDownloadTimeout': 1200,
  'ContainerStartupHealthCheckTimeout': 1200},
 'AccelerationConfigs': None,
 'BenchmarkMetrics': {'ml.g5.2xlarge': [{'name': 'Latency',
    'value': '12',
    'unit': 'ms/token',
    'concurrency': '1'},
   {'name': 'Throughput',
    'value': '213',
    'unit': 'tokens/sec',
    'concurrency': '1'},
   {'name': 'Latency', 'value': '12', 'unit': 'ms/token', 'concurrency': '2'},
   {'name': 'Throughput',
    'value': '213',
    'unit': 'tokens/sec',
    'concurrency': '2'},
   {'name': 'Instance Rate',
    'value': '1.515',
    'unit': 'USD/Hrs',
    'concurrency': None}]}}
```

```
jumpstart_model.display_benchmark_metrics()

| Instance Type           |   Concurrent Users | Config Name     |   Latency for each user (TTFT in ms) |   Throughput per user (token/seconds) |   Instance Rate (USD/Hrs) |
|:------------------------|-------------------:|:----------------|-------------------------------------:|--------------------------------------:|--------------------------:|
| ml.g5.2xlarge (Default) |                  1 | lmi-accelerated |                                   12 |                                   213 |                     1.515 |
| ml.g5.2xlarge           |                  2 | lmi-accelerated |                                   12 |                                   213 |                     1.515 |
| ml.g5.2xlarge           |                  1 | lmi             |                                   36 |                                   390 |                     1.515 |
| ml.g5.2xlarge           |                  2 | lmi             |                                   36 |                                   390 |                     1.515 |
| ml.g5.12xlarge          |                  1 | lmi             |                                   14 |                                   651 |                     7.09  |
| ml.g5.12xlarge          |                  2 | lmi             |                                   14 |                                   651 |                     7.09  |
| ml.p4d.24xlarge         |                  1 | lmi             |                                    7 |                                  2274 |                    38.67  |
| ml.p4d.24xlarge         |                  2 | lmi             |                                    7 |                                  2274 |                    38.67  |
```

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
