### PR TITLE
chore: add new images for HF TGI release

### DIFF
--- a/src/sagemaker/image_uri_config/huggingface-llm-neuronx.json
+++ b/src/sagemaker/image_uri_config/huggingface-llm-neuronx.json
@@ -4,7 +4,7 @@
             "inf2"
         ],
         "version_aliases": {
-            "0.0": "0.0.16"
+            "0.0": "0.0.22"
         },
         "versions": {
             "0.0.16": {
@@ -176,6 +176,35 @@
                     "ca-west-1": "204538143572"
                 },
                 "tag_prefix": "1.13.1-optimum0.0.21",
+                "repository": "huggingface-pytorch-tgi-inference",
+                "container_version": {
+                    "inf2": "ubuntu22.04"
+                }
+            },
+            "0.0.22": {
+                "py_versions": [
+                    "py310"
+                ],
+                "registries": {
+                    "ap-northeast-1": "763104351884",
+                    "ap-south-1": "763104351884",
+                    "ap-south-2": "772153158452",
+                    "ap-southeast-1": "763104351884",
+                    "ap-southeast-2": "763104351884",
+                    "ap-southeast-4": "457447274322",
+                    "eu-central-1": "763104351884",
+                    "eu-central-2": "380420809688",
+                    "eu-south-2": "503227376785",
+                    "eu-west-1": "763104351884",
+                    "eu-west-3": "763104351884",
+                    "il-central-1": "780543022126",
+                    "sa-east-1": "763104351884",
+                    "us-east-1": "763104351884",
+                    "us-east-2": "763104351884",
+                    "us-west-2": "763104351884",
+                    "ca-west-1": "204538143572"
+                },
+                "tag_prefix": "2.1.2-optimum0.0.22",
                 "repository": "huggingface-pytorch-tgi-inference",
                 "container_version": {
                     "inf2": "ubuntu22.04"

--- a/src/sagemaker/image_uri_config/huggingface-llm.json
+++ b/src/sagemaker/image_uri_config/huggingface-llm.json
@@ -12,7 +12,7 @@
             "1.2": "1.2.0",
             "1.3": "1.3.3",
             "1.4": "1.4.5",
-            "2.0": "2.0.1"
+            "2.0": "2.0.2"
         },
         "versions": {
             "0.6.0": {
@@ -621,6 +621,53 @@
                     "ca-west-1": "204538143572"
                 },
                 "tag_prefix": "2.1.1-tgi2.0.1",
+                "repository": "huggingface-pytorch-tgi-inference",
+                "container_version": {
+                    "gpu": "cu121-ubuntu22.04"
+                }
+            },
+            "2.0.2": {
+                "py_versions": [
+                    "py310"
+                ],
+                "registries": {
+                    "af-south-1": "626614931356",
+                    "il-central-1": "780543022126",
+                    "ap-east-1": "871362719292",
+                    "ap-northeast-1": "763104351884",
+                    "ap-northeast-2": "763104351884",
+                    "ap-northeast-3": "364406365360",
+                    "ap-south-1": "763104351884",
+                    "ap-south-2": "772153158452",
+                    "ap-southeast-1": "763104351884",
+                    "ap-southeast-2": "763104351884",
+                    "ap-southeast-3": "907027046896",
+                    "ap-southeast-4": "457447274322",
+                    "ca-central-1": "763104351884",
+                    "cn-north-1": "727897471807",
+                    "cn-northwest-1": "727897471807",
+                    "eu-central-1": "763104351884",
+                    "eu-central-2": "380420809688",
+                    "eu-north-1": "763104351884",
+                    "eu-west-1": "763104351884",
+                    "eu-west-2": "763104351884",
+                    "eu-west-3": "763104351884",      
+                    "eu-south-1": "692866216735",
+                    "eu-south-2": "503227376785",
+                    "me-south-1": "217643126080",
+                    "me-central-1": "914824155844",
+                    "sa-east-1": "763104351884",
+                    "us-east-1": "763104351884",
+                    "us-east-2": "763104351884",
+                    "us-gov-east-1": "446045086412",
+                    "us-gov-west-1": "442386744353",
+                    "us-iso-east-1": "886529160074",
+                    "us-isob-east-1": "094389454867",
+                    "us-west-1": "763104351884",
+                    "us-west-2": "763104351884",
+                    "ca-west-1": "204538143572"
+                },
+                "tag_prefix": "2.3.0-tgi2.0.2",
                 "repository": "huggingface-pytorch-tgi-inference",
                 "container_version": {
                     "gpu": "cu121-ubuntu22.04"

--- a/src/sagemaker/image_uri_config/huggingface-neuronx.json
+++ b/src/sagemaker/image_uri_config/huggingface-neuronx.json
@@ -5,7 +5,8 @@
         ],
         "version_aliases": {
             "4.28": "4.28.1",
-            "4.34": "4.34.1"
+            "4.34": "4.34.1",
+            "4.36": "4.36.2"
         },
         "versions": {
             "4.28.1": {
@@ -77,6 +78,42 @@
                     },
                     "sdk_versions": [
                         "sdk2.15.0"
+                    ]
+                }
+            },
+            "4.36.2": {
+                "version_aliases": {
+                    "pytorch1.13": "pytorch1.13.1"
+                },
+                "pytorch1.13.1": {
+                    "py_versions": [
+                        "py310"
+                    ],
+                    "repository": "huggingface-pytorch-inference-neuronx",
+                    "registries": {
+                        "ap-northeast-1": "763104351884",
+                        "ap-south-1": "763104351884",
+                        "ap-south-2": "772153158452",
+                        "ap-southeast-1": "763104351884",
+                        "ap-southeast-2": "763104351884",
+                        "ap-southeast-4": "457447274322",
+                        "eu-central-1": "763104351884",
+                        "eu-central-2": "380420809688",
+                        "eu-south-2": "503227376785",
+                        "eu-west-1": "763104351884",
+                        "eu-west-3": "763104351884",
+                        "il-central-1": "780543022126",
+                        "sa-east-1": "763104351884",
+                        "us-east-1": "763104351884",
+                        "us-east-2": "763104351884",
+                        "us-west-2": "763104351884",
+                        "ca-west-1": "204538143572"
+                    },
+                    "container_version": {
+                        "inf": "ubuntu20.04"
+                    },
+                    "sdk_versions": [
+                        "sdk2.18.0"
                     ]
                 }
             }
@@ -198,7 +235,8 @@
             },
             "4.36.2": {
                 "version_aliases": {
-                    "pytorch1.13": "pytorch1.13.1"
+                    "pytorch1.13": "pytorch1.13.1",
+                    "pytorch2.1": "pytorch2.1.2"
                 },
                 "pytorch1.13.1": {
                     "py_versions": [
@@ -245,6 +283,53 @@
                     },
                     "sdk_versions": [
                         "sdk2.16.1"
+                    ]
+                },
+                "pytorch2.1.2": {
+                    "py_versions": [
+                        "py310"
+                    ],
+                    "repository": "huggingface-pytorch-inference-neuronx",
+                    "registries": {
+                        "af-south-1": "626614931356",
+                        "il-central-1": "780543022126",
+                        "ap-east-1": "871362719292",
+                        "ap-northeast-1": "763104351884",
+                        "ap-northeast-2": "763104351884",
+                        "ap-northeast-3": "364406365360",
+                        "ap-south-1": "763104351884",
+                        "ap-south-2": "772153158452",
+                        "ap-southeast-1": "763104351884",
+                        "ap-southeast-2": "763104351884",
+                        "ap-southeast-4": "457447274322",
+                        "ca-central-1": "763104351884",
+                        "cn-north-1": "727897471807",
+                        "cn-northwest-1": "727897471807",
+                        "eu-central-1": "763104351884",
+                        "eu-central-2": "380420809688",
+                        "eu-north-1": "763104351884",
+                        "eu-west-1": "763104351884",
+                        "eu-west-2": "763104351884",
+                        "eu-west-3": "763104351884",
+                        "eu-south-1": "692866216735",
+                        "eu-south-2": "503227376785",
+                        "me-south-1": "217643126080",
+                        "sa-east-1": "763104351884",
+                        "us-east-1": "763104351884",
+                        "us-east-2": "763104351884",
+                        "us-gov-east-1": "446045086412",
+                        "us-gov-west-1": "442386744353",
+                        "us-iso-east-1": "886529160074",
+                        "us-isob-east-1": "094389454867",
+                        "us-west-1": "763104351884",
+                        "us-west-2": "763104351884",
+                        "ca-west-1": "204538143572"
+                    },
+                    "container_version": {
+                        "inf": "ubuntu20.04"
+                    },
+                    "sdk_versions": [
+                        "sdk2.18.0"
                     ]
                 }
             }

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -123,7 +123,7 @@ def get_jumpstart_gated_content_bucket(
 def get_jumpstart_content_bucket(
     region: str = constants.JUMPSTART_DEFAULT_REGION_NAME,
 ) -> str:
-    """Returns regionalized content bucket name for JumpStart.
+    """Returns the regionalized content bucket name for JumpStart.
 
     Raises:
         ValueError: If JumpStart is not launched in ``region``.

--- a/tests/unit/sagemaker/image_uris/test_huggingface_llm.py
+++ b/tests/unit/sagemaker/image_uris/test_huggingface_llm.py
@@ -33,6 +33,7 @@ HF_VERSIONS_MAPPING = {
         "1.4.5": "2.1.1-tgi1.4.5-gpu-py310-cu121-ubuntu22.04",
         "2.0.0": "2.1.1-tgi2.0.0-gpu-py310-cu121-ubuntu22.04",
         "2.0.1": "2.1.1-tgi2.0.1-gpu-py310-cu121-ubuntu22.04",
+        "2.0.2": "2.3.0-tgi2.0.2-gpu-py310-cu121-ubuntu22.04",
     },
     "inf2": {
         "0.0.16": "1.13.1-optimum0.0.16-neuronx-py310-ubuntu22.04",
@@ -41,6 +42,7 @@ HF_VERSIONS_MAPPING = {
         "0.0.19": "1.13.1-optimum0.0.19-neuronx-py310-ubuntu22.04",
         "0.0.20": "1.13.1-optimum0.0.20-neuronx-py310-ubuntu22.04",
         "0.0.21": "1.13.1-optimum0.0.21-neuronx-py310-ubuntu22.04",
+        "0.0.22": "2.1.2-optimum0.0.22-neuronx-py310-ubuntu22.04",
     },
 }
 


### PR DESCRIPTION
*Issue #, if available:*

1. https://github.com/awslabs/llm-hosting-container/pull/73
2. https://github.com/awslabs/llm-hosting-container/pull/74
3. https://github.com/aws/deep-learning-containers/pull/3823
4. https://github.com/aws/deep-learning-containers/pull/3824

*Description of changes:*

Release the above 4 updates to Huggingface TGI images.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
