### PR TITLE
Fix: Image URI should take precedence for HF models

### DIFF
--- a/tests/unit/sagemaker/serve/builder/test_transformers_builder.py
+++ b/tests/unit/sagemaker/serve/builder/test_transformers_builder.py
@@ -16,7 +16,7 @@ from unittest.mock import MagicMock, patch
 import unittest
 from sagemaker.serve.builder.model_builder import ModelBuilder
 from sagemaker.serve.mode.function_pointers import Mode
-from tests.unit.sagemaker.serve.constants import MOCK_IMAGE_CONFIG, MOCK_VPC_CONFIG
+from tests.unit.sagemaker.serve.constants import MOCK_VPC_CONFIG
 
 from sagemaker.serve.utils.predictors import TransformersLocalModePredictor
 
@@ -58,6 +58,9 @@ mock_sample_output = [
 mock_schema_builder = MagicMock()
 mock_schema_builder.sample_input = mock_sample_input
 mock_schema_builder.sample_output = mock_sample_output
+MOCK_IMAGE_CONFIG = \
+    "763104351884.dkr.ecr.us-west-2.amazonaws.com/" \
+    "huggingface-pytorch-inference:2.0.0-transformers4.28.1-gpu-py310-cu118-ubuntu20.04-v1.0"
 
 
 class TestTransformersBuilder(unittest.TestCase):
@@ -115,8 +118,7 @@ class TestTransformersBuilder(unittest.TestCase):
             model=mock_model_id,
             schema_builder=mock_schema_builder,
             mode=Mode.LOCAL_CONTAINER,
-            vpc_config=MOCK_VPC_CONFIG,
-            image_config=MOCK_IMAGE_CONFIG,
+            image_uri=MOCK_IMAGE_CONFIG,
         )
 
         builder._prepare_for_mode = MagicMock()
@@ -128,17 +130,11 @@ class TestTransformersBuilder(unittest.TestCase):
         builder.modes[str(Mode.LOCAL_CONTAINER)] = MagicMock()
         predictor = model.deploy(model_data_download_timeout=1800)
 
-        assert model.image_config == MOCK_IMAGE_CONFIG
-        assert model.vpc_config == MOCK_VPC_CONFIG
+        assert builder.image_uri == MOCK_IMAGE_CONFIG
         assert builder.env_vars["MODEL_LOADING_TIMEOUT"] == "1800"
         assert isinstance(predictor, TransformersLocalModePredictor)
 
         assert builder.nb_instance_type == "ml.g5.24xlarge"
-
-        builder._original_deploy = MagicMock()
-        builder._prepare_for_mode.return_value = (None, {})
-        predictor = model.deploy(mode=Mode.SAGEMAKER_ENDPOINT, role="mock_role_arn")
-        assert "HF_MODEL_ID" in model.env
 
         with self.assertRaises(ValueError) as _:
             model.deploy(mode=Mode.IN_PROCESS)

--- a/tests/unit/sagemaker/serve/builder/test_transformers_builder.py
+++ b/tests/unit/sagemaker/serve/builder/test_transformers_builder.py
@@ -58,9 +58,10 @@ mock_sample_output = [
 mock_schema_builder = MagicMock()
 mock_schema_builder.sample_input = mock_sample_input
 mock_schema_builder.sample_output = mock_sample_output
-MOCK_IMAGE_CONFIG = \
-    "763104351884.dkr.ecr.us-west-2.amazonaws.com/" \
+MOCK_IMAGE_CONFIG = (
+    "763104351884.dkr.ecr.us-west-2.amazonaws.com/"
     "huggingface-pytorch-inference:2.0.0-transformers4.28.1-gpu-py310-cu118-ubuntu20.04-v1.0"
+)
 
 
 class TestTransformersBuilder(unittest.TestCase):

--- a/tests/unit/sagemaker/serve/builder/test_transformers_builder.py
+++ b/tests/unit/sagemaker/serve/builder/test_transformers_builder.py
@@ -101,16 +101,15 @@ class TestTransformersBuilder(unittest.TestCase):
         with self.assertRaises(ValueError) as _:
             model.deploy(mode=Mode.IN_PROCESS)
 
-
     @patch(
         "sagemaker.serve.builder.transformers_builder._get_nb_instance",
         return_value="ml.g5.24xlarge",
     )
     @patch("sagemaker.serve.builder.transformers_builder._capture_telemetry", side_effect=None)
     def test_image_uri(
-            self,
-            mock_get_nb_instance,
-            mock_telemetry,
+        self,
+        mock_get_nb_instance,
+        mock_telemetry,
     ):
         builder = ModelBuilder(
             model=mock_model_id,

--- a/tests/unit/sagemaker/serve/builder/test_transformers_builder.py
+++ b/tests/unit/sagemaker/serve/builder/test_transformers_builder.py
@@ -137,5 +137,10 @@ class TestTransformersBuilder(unittest.TestCase):
 
         assert builder.nb_instance_type == "ml.g5.24xlarge"
 
+        builder._original_deploy = MagicMock()
+        builder._prepare_for_mode.return_value = (None, {})
+        predictor = model.deploy(mode=Mode.SAGEMAKER_ENDPOINT, role="mock_role_arn")
+        assert "HF_MODEL_ID" in model.env
+
         with self.assertRaises(ValueError) as _:
             model.deploy(mode=Mode.IN_PROCESS)

--- a/tests/unit/sagemaker/serve/builder/test_transformers_builder.py
+++ b/tests/unit/sagemaker/serve/builder/test_transformers_builder.py
@@ -16,7 +16,7 @@ from unittest.mock import MagicMock, patch
 import unittest
 from sagemaker.serve.builder.model_builder import ModelBuilder
 from sagemaker.serve.mode.function_pointers import Mode
-from tests.unit.sagemaker.serve.constants import MOCK_VPC_CONFIG
+from tests.unit.sagemaker.serve.constants import MOCK_IMAGE_CONFIG, MOCK_VPC_CONFIG
 
 from sagemaker.serve.utils.predictors import TransformersLocalModePredictor
 
@@ -87,6 +87,49 @@ class TestTransformersBuilder(unittest.TestCase):
         builder.modes[str(Mode.LOCAL_CONTAINER)] = MagicMock()
         predictor = model.deploy(model_data_download_timeout=1800)
 
+        assert model.vpc_config == MOCK_VPC_CONFIG
+        assert builder.env_vars["MODEL_LOADING_TIMEOUT"] == "1800"
+        assert isinstance(predictor, TransformersLocalModePredictor)
+
+        assert builder.nb_instance_type == "ml.g5.24xlarge"
+
+        builder._original_deploy = MagicMock()
+        builder._prepare_for_mode.return_value = (None, {})
+        predictor = model.deploy(mode=Mode.SAGEMAKER_ENDPOINT, role="mock_role_arn")
+        assert "HF_MODEL_ID" in model.env
+
+        with self.assertRaises(ValueError) as _:
+            model.deploy(mode=Mode.IN_PROCESS)
+
+
+    @patch(
+        "sagemaker.serve.builder.transformers_builder._get_nb_instance",
+        return_value="ml.g5.24xlarge",
+    )
+    @patch("sagemaker.serve.builder.transformers_builder._capture_telemetry", side_effect=None)
+    def test_image_uri(
+            self,
+            mock_get_nb_instance,
+            mock_telemetry,
+    ):
+        builder = ModelBuilder(
+            model=mock_model_id,
+            schema_builder=mock_schema_builder,
+            mode=Mode.LOCAL_CONTAINER,
+            vpc_config=MOCK_VPC_CONFIG,
+            image_config=MOCK_IMAGE_CONFIG,
+        )
+
+        builder._prepare_for_mode = MagicMock()
+        builder._prepare_for_mode.side_effect = None
+
+        model = builder.build()
+        builder.serve_settings.telemetry_opt_out = True
+
+        builder.modes[str(Mode.LOCAL_CONTAINER)] = MagicMock()
+        predictor = model.deploy(model_data_download_timeout=1800)
+
+        assert model.image_config == MOCK_IMAGE_CONFIG
         assert model.vpc_config == MOCK_VPC_CONFIG
         assert builder.env_vars["MODEL_LOADING_TIMEOUT"] == "1800"
         assert isinstance(predictor, TransformersLocalModePredictor)


### PR DESCRIPTION
*Issue #, if available:*

Don't override customer provided image_uri since it blocks customers from testing latest images. 

*Description of changes:*

1. Change check to set uri only if not set.
2. Fix instance type being logged. 

*Testing done:*

1. Added UT

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [X] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [X] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [X] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [X] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [X] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [X] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [X] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [X] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [X] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
