### PR TITLE
Fix: JS Model with non-TGI/non-DJL deployment failure

### DIFF
--- a/src/sagemaker/serve/builder/jumpstart_builder.py
+++ b/src/sagemaker/serve/builder/jumpstart_builder.py
@@ -470,9 +470,10 @@ class JumpStart(ABC):
 
         self.pysdk_model = self._create_pre_trained_js_model()
         self.pysdk_model.tune = lambda *args, **kwargs: self._default_tune()
+        self.image_uri = self.pysdk_model.image_uri
 
         logger.info(
-            "JumpStart ID %s is packaged with Image URI: %s", self.model, self.pysdk_model.image_uri
+            "JumpStart ID %s is packaged with Image URI: %s", self.model, self.image_uri
         )
 
         if self.mode != Mode.SAGEMAKER_ENDPOINT:
@@ -484,7 +485,6 @@ class JumpStart(ABC):
             if "djl-inference" in self.pysdk_model.image_uri:
                 logger.info("Building for DJL JumpStart Model ID...")
                 self.model_server = ModelServer.DJL_SERVING
-                self.image_uri = self.pysdk_model.image_uri
 
                 self._build_for_djl_jumpstart()
 
@@ -492,7 +492,6 @@ class JumpStart(ABC):
             elif "tgi-inference" in self.pysdk_model.image_uri:
                 logger.info("Building for TGI JumpStart Model ID...")
                 self.model_server = ModelServer.TGI
-                self.image_uri = self.pysdk_model.image_uri
 
                 self._build_for_tgi_jumpstart()
 
@@ -500,7 +499,6 @@ class JumpStart(ABC):
             elif "huggingface-pytorch-inference:" in self.pysdk_model.image_uri:
                 logger.info("Building for MMS JumpStart Model ID...")
                 self.model_server = ModelServer.MMS
-                self.image_uri = self.pysdk_model.image_uri
 
                 self._build_for_mms_jumpstart()
             else:

--- a/src/sagemaker/serve/builder/jumpstart_builder.py
+++ b/src/sagemaker/serve/builder/jumpstart_builder.py
@@ -516,17 +516,6 @@ class JumpStart(ABC):
 
         return self.pysdk_model
 
-    def _default_tune(self):
-        """Logs a warning message if tune is invoked on endpoint mode.
-
-        Returns:
-            Jumpstart Model: ``This`` model
-        """
-        logger.warning(
-            "Tuning is only a %s capability. Returning original model.", Mode.LOCAL_CONTAINER
-        )
-        return self.pysdk_model
-
     def _is_gated_model(self, model) -> bool:
         """Determine if ``this`` Model is Gated
 

--- a/src/sagemaker/serve/builder/jumpstart_builder.py
+++ b/src/sagemaker/serve/builder/jumpstart_builder.py
@@ -476,9 +476,7 @@ class JumpStart(ABC):
         pysdk_model = self._create_pre_trained_js_model()
         image_uri = pysdk_model.image_uri
 
-        logger.info(
-            "JumpStart ID %s is packaged with Image URI: %s", self.model, image_uri
-        )
+        logger.info("JumpStart ID %s is packaged with Image URI: %s", self.model, image_uri)
 
         if self._is_gated_model(pysdk_model) and self.mode != Mode.SAGEMAKER_ENDPOINT:
             raise ValueError(

--- a/src/sagemaker/serve/builder/jumpstart_builder.py
+++ b/src/sagemaker/serve/builder/jumpstart_builder.py
@@ -300,6 +300,11 @@ class JumpStart(ABC):
         returns:
             Tuned Model.
         """
+        if self.mode == Mode.SAGEMAKER_ENDPOINT:
+            logger.warning(
+                "Tuning is only a %s capability. Returning original model.", Mode.LOCAL_CONTAINER
+            )
+            return self.pysdk_model
 
         num_shard_env_var_name = "SM_NUM_GPUS"
         if "OPTION_TENSOR_PARALLEL_DEGREE" in self.pysdk_model.env.keys():
@@ -468,44 +473,48 @@ class JumpStart(ABC):
         self.secret_key = None
         self.jumpstart = True
 
-        self.pysdk_model = self._create_pre_trained_js_model()
-        self.pysdk_model.tune = lambda *args, **kwargs: self._default_tune()
-        self.image_uri = self.pysdk_model.image_uri
+        pysdk_model = self._create_pre_trained_js_model()
+        image_uri = pysdk_model.image_uri
 
         logger.info(
-            "JumpStart ID %s is packaged with Image URI: %s", self.model, self.image_uri
+            "JumpStart ID %s is packaged with Image URI: %s", self.model, image_uri
         )
 
-        if self.mode != Mode.SAGEMAKER_ENDPOINT:
-            if self._is_gated_model(self.pysdk_model):
-                raise ValueError(
-                    "JumpStart Gated Models are only supported in SAGEMAKER_ENDPOINT mode."
-                )
+        if self._is_gated_model(pysdk_model) and self.mode != Mode.SAGEMAKER_ENDPOINT:
+            raise ValueError(
+                "JumpStart Gated Models are only supported in SAGEMAKER_ENDPOINT mode."
+            )
 
-            if "djl-inference" in self.pysdk_model.image_uri:
-                logger.info("Building for DJL JumpStart Model ID...")
-                self.model_server = ModelServer.DJL_SERVING
+        if "djl-inference" in image_uri:
+            logger.info("Building for DJL JumpStart Model ID...")
+            self.model_server = ModelServer.DJL_SERVING
+            self.pysdk_model = pysdk_model
+            self.image_uri = self.pysdk_model.image_uri
 
-                self._build_for_djl_jumpstart()
+            self._build_for_djl_jumpstart()
 
-                self.pysdk_model.tune = self.tune_for_djl_jumpstart
-            elif "tgi-inference" in self.pysdk_model.image_uri:
-                logger.info("Building for TGI JumpStart Model ID...")
-                self.model_server = ModelServer.TGI
+            self.pysdk_model.tune = self.tune_for_djl_jumpstart
+        elif "tgi-inference" in image_uri:
+            logger.info("Building for TGI JumpStart Model ID...")
+            self.model_server = ModelServer.TGI
+            self.pysdk_model = pysdk_model
+            self.image_uri = self.pysdk_model.image_uri
 
-                self._build_for_tgi_jumpstart()
+            self._build_for_tgi_jumpstart()
 
-                self.pysdk_model.tune = self.tune_for_tgi_jumpstart
-            elif "huggingface-pytorch-inference:" in self.pysdk_model.image_uri:
-                logger.info("Building for MMS JumpStart Model ID...")
-                self.model_server = ModelServer.MMS
+            self.pysdk_model.tune = self.tune_for_tgi_jumpstart
+        elif "huggingface-pytorch-inference:" in image_uri:
+            logger.info("Building for MMS JumpStart Model ID...")
+            self.model_server = ModelServer.MMS
+            self.pysdk_model = pysdk_model
+            self.image_uri = self.pysdk_model.image_uri
 
-                self._build_for_mms_jumpstart()
-            else:
-                raise ValueError(
-                    "JumpStart Model ID was not packaged "
-                    "with djl-inference, tgi-inference, or mms-inference container."
-                )
+            self._build_for_mms_jumpstart()
+        elif self.mode != Mode.SAGEMAKER_ENDPOINT:
+            raise ValueError(
+                "JumpStart Model ID was not packaged "
+                "with djl-inference, tgi-inference, or mms-inference container."
+            )
 
         return self.pysdk_model
 

--- a/src/sagemaker/serve/mode/local_container_mode.py
+++ b/src/sagemaker/serve/mode/local_container_mode.py
@@ -215,15 +215,6 @@ class LocalContainerMode(
             logger.warning("Unable to login to ecr: %s", e)
 
         self.client = docker.from_env()
-        print("*" * 80)
-        images = self.client.images.list()
-        for img in images:
-            for tag in img.tags:
-                if tag == image:
-                    print(f"Matched {tag}")
-                print(tag)
-            print()
-        print("*" * 80)
         try:
             logger.info("Pulling image %s from repository...", image)
             self.client.images.pull(image)

--- a/src/sagemaker/serve/mode/local_container_mode.py
+++ b/src/sagemaker/serve/mode/local_container_mode.py
@@ -220,8 +220,8 @@ class LocalContainerMode(
         for img in images:
             for tag in img.tags:
                 if tag == image:
-                    print(tag)
-                    break
+                    print(f"Matched {tag}")
+                print(tag)
             print()
         print("*" * 80)
         try:

--- a/src/sagemaker/serve/mode/local_container_mode.py
+++ b/src/sagemaker/serve/mode/local_container_mode.py
@@ -215,6 +215,10 @@ class LocalContainerMode(
             logger.warning("Unable to login to ecr: %s", e)
 
         self.client = docker.from_env()
+        print("*" * 80)
+        images = self.client.images.list()
+        print(images)
+        print("*" * 80)
         try:
             logger.info("Pulling image %s from repository...", image)
             self.client.images.pull(image)

--- a/src/sagemaker/serve/mode/local_container_mode.py
+++ b/src/sagemaker/serve/mode/local_container_mode.py
@@ -217,10 +217,11 @@ class LocalContainerMode(
         self.client = docker.from_env()
         print("*" * 80)
         images = self.client.images.list()
-        for image in images:
-            print(image.id)
-            print(image.tags)
-            print(image.short_id)
+        for img in images:
+            for tag in img.tags:
+                if tag == image:
+                    print(tag)
+                    break
             print()
         print("*" * 80)
         try:

--- a/src/sagemaker/serve/mode/local_container_mode.py
+++ b/src/sagemaker/serve/mode/local_container_mode.py
@@ -217,7 +217,11 @@ class LocalContainerMode(
         self.client = docker.from_env()
         print("*" * 80)
         images = self.client.images.list()
-        print(images)
+        for image in images:
+            print(image.id)
+            print(image.tags)
+            print(image.short_id)
+            print()
         print("*" * 80)
         try:
             logger.info("Pulling image %s from repository...", image)

--- a/tests/integ/sagemaker/serve/test_serve_js_happy.py
+++ b/tests/integ/sagemaker/serve/test_serve_js_happy.py
@@ -34,6 +34,14 @@ SAMPLE_RESPONSE = [
 JS_MODEL_ID = "huggingface-textgeneration1-gpt-neo-125m-fp16"
 ROLE_NAME = "SageMakerRole"
 
+SAMPLE_MMS_PROMPT = [
+    "How cute your dog is!",
+    "Your dog is so cute.",
+    "The mitochondria is the powerhouse of the cell.",
+]
+SAMPLE_MMS_RESPONSE = {"embedding": []}
+JS_MMS_MODEL_ID = "huggingface-sentencesimilarity-bge-m3"
+
 
 @pytest.fixture
 def happy_model_builder(sagemaker_session):
@@ -41,6 +49,17 @@ def happy_model_builder(sagemaker_session):
     return ModelBuilder(
         model=JS_MODEL_ID,
         schema_builder=SchemaBuilder(SAMPLE_PROMPT, SAMPLE_RESPONSE),
+        role_arn=iam_client.get_role(RoleName=ROLE_NAME)["Role"]["Arn"],
+        sagemaker_session=sagemaker_session,
+    )
+
+
+@pytest.fixture
+def happy_mms_model_builder(sagemaker_session):
+    iam_client = sagemaker_session.boto_session.client("iam")
+    return ModelBuilder(
+        model=JS_MMS_MODEL_ID,
+        schema_builder=SchemaBuilder(SAMPLE_MMS_PROMPT, SAMPLE_MMS_RESPONSE),
         role_arn=iam_client.get_role(RoleName=ROLE_NAME)["Role"]["Arn"],
         sagemaker_session=sagemaker_session,
     )
@@ -70,6 +89,37 @@ def test_happy_tgi_sagemaker_endpoint(happy_model_builder, gpu_instance_type):
         finally:
             cleanup_model_resources(
                 sagemaker_session=happy_model_builder.sagemaker_session,
+                model_name=model.name,
+                endpoint_name=model.endpoint_name,
+            )
+            if caught_ex:
+                raise caught_ex
+
+
+@pytest.mark.skipif(
+    PYTHON_VERSION_IS_NOT_310,
+    reason="The goal of these test are to test the serving components of our feature",
+)
+@pytest.mark.slow_test
+def test_happy_mms_sagemaker_endpoint(happy_mms_model_builder, gpu_instance_type):
+    logger.info("Running in SAGEMAKER_ENDPOINT mode...")
+    caught_ex = None
+    model = happy_mms_model_builder.build()
+
+    with timeout(minutes=SERVE_SAGEMAKER_ENDPOINT_TIMEOUT):
+        try:
+            logger.info("Deploying and predicting in SAGEMAKER_ENDPOINT mode...")
+            predictor = model.deploy(instance_type=gpu_instance_type, endpoint_logging=False)
+            logger.info("Endpoint successfully deployed.")
+
+            updated_sample_input = happy_mms_model_builder.schema_builder.sample_input
+
+            predictor.predict(updated_sample_input)
+        except Exception as e:
+            caught_ex = e
+        finally:
+            cleanup_model_resources(
+                sagemaker_session=happy_mms_model_builder.sagemaker_session,
                 model_name=model.name,
                 endpoint_name=model.endpoint_name,
             )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix: JS Model with non-TGI/non-DJL deployment failure

*Testing done:*
Notebook

```
model_builder = ModelBuilder(
    model="huggingface-sentencesimilarity-bge-m3",
    schema_builder=SchemaBuilder(sample_input, sample_output),
)

model = model_builder.build()
predictor = model.deploy()
```

```
INFO:sagemaker:2024-05-16T06:05:27,302 [INFO ] W-9000-model com.amazonaws.ml.mms.wlm.WorkerThread - Backend response time: 9161
INFO:sagemaker:2024-05-16T06:05:27,302 [WARN ] W-9000-model com.amazonaws.ml.mms.wlm.WorkerLifeCycle - attachIOStreams() threadName=W-model-1
INFO:sagemaker:2024-05-16T06:05:29,865 [INFO ] pool-2-thread-3 ACCESS_LOG - /169.254.178.2:46500 "GET /ping HTTP/1.1" 200 0
INFO:sagemaker:2024-05-16T06:05:34,865 [INFO ] pool-2-thread-3 ACCESS_LOG - /169.254.178.2:46500 "GET /ping HTTP/1.1" 200 0
INFO:sagemaker:2024-05-16T06:05:39,865 [INFO ] pool-2-thread-3 ACCESS_LOG - /169.254.178.2:46500 "GET /ping HTTP/1.1" 200 0
INFO:sagemaker:2024-05-16T06:05:44,865 [INFO ] pool-2-thread-3 ACCESS_LOG - /169.254.178.2:46500 "GET /ping HTTP/1.1" 200 0
INFO:sagemaker:Created endpoint with name hf-sentencesimilarity-bge-m3-2024-05-16-06-01-26-451
INFO:sagemaker:2024-05-16T06:05:49,865 [INFO ] pool-2-thread-3 ACCESS_LOG - /169.254.178.2:46500 "GET /ping HTTP/1.1" 200 0
ModelBuilder: DEBUG:     ModelBuilder metrics emitted.
CPU times: user 514 ms, sys: 47 ms, total: 561 ms
Wall time: 4min 36s
```

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
