### PR TITLE
Fix: Add Image URI overrides for transformers models

### DIFF
--- a/tests/integ/sagemaker/serve/test_serve_transformers.py
+++ b/tests/integ/sagemaker/serve/test_serve_transformers.py
@@ -127,4 +127,4 @@ def test_pytorch_transformers_sagemaker_endpoint(
                 logger.exception(caught_ex)
                 assert (
                     False
-                ), f"{caught_ex} was thrown when running pytorch transformers sagemaker endpoint test"
+                ), f"{caught_ex} thrown when running pytorch transformers sagemaker endpoint test"

--- a/tests/unit/sagemaker/serve/builder/test_transformers_builder.py
+++ b/tests/unit/sagemaker/serve/builder/test_transformers_builder.py
@@ -144,3 +144,28 @@ class TestTransformersBuilder(unittest.TestCase):
 
         with self.assertRaises(ValueError) as _:
             model.deploy(mode=Mode.IN_PROCESS)
+
+    @patch("sagemaker.serve.builder.model_builder.ModelBuilder._build_for_transformers")
+    @patch(
+        "sagemaker.serve.builder.transformers_builder._get_nb_instance",
+        return_value="ml.g5.24xlarge",
+    )
+    @patch("sagemaker.serve.builder.transformers_builder._capture_telemetry", side_effect=None)
+    @patch(
+        "sagemaker.huggingface.llm_utils.get_huggingface_model_metadata",
+        return_value=None,
+    )
+    def test_failure_hf_md(self, mock_model_md, mock_get_nb_instance, mock_telemetry,
+                           mock_build_for_transformers):
+        builder = ModelBuilder(
+            model=mock_model_id,
+            schema_builder=mock_schema_builder,
+            mode=Mode.LOCAL_CONTAINER,
+        )
+
+        builder._prepare_for_mode = MagicMock()
+        builder._prepare_for_mode.side_effect = None
+
+        builder.build()
+
+        mock_build_for_transformers.assert_called_once()

--- a/tests/unit/sagemaker/serve/builder/test_transformers_builder.py
+++ b/tests/unit/sagemaker/serve/builder/test_transformers_builder.py
@@ -155,8 +155,9 @@ class TestTransformersBuilder(unittest.TestCase):
         "sagemaker.huggingface.llm_utils.get_huggingface_model_metadata",
         return_value=None,
     )
-    def test_failure_hf_md(self, mock_model_md, mock_get_nb_instance, mock_telemetry,
-                           mock_build_for_transformers):
+    def test_failure_hf_md(
+        self, mock_model_md, mock_get_nb_instance, mock_telemetry, mock_build_for_transformers
+    ):
         builder = ModelBuilder(
             model=mock_model_id,
             schema_builder=mock_schema_builder,


### PR DESCRIPTION
*Issue #, if available:*

In Transformers builder if image_uri is provided, directly initialize the pySDK model.

Else fetch HF framework version etc to create the Model and then fetch latest image. 

If we cannot set the image_uri, throw an error to customer with message to override image if possible. 

*Description of changes:*

*Testing done:*

1. Add UT

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [X] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [X] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [X] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [X] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [X] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [X] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [X] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [X] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [X] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
