### PR TITLE
fix: remove sagemaker-local network before compose

### DIFF
--- a/src/sagemaker/local/image.py
+++ b/src/sagemaker/local/image.py
@@ -227,6 +227,17 @@ class _SageMakerContainer(object):
 
         if _ecr_login_if_needed(self.sagemaker_session.boto_session, self.image):
             _pull_image(self.image)
+        
+        # Remove sagemaker-local network, compose_command will fail if an existing network is still around
+        remove_sagemaker_local = ["docker", "network", "rm", STUDIO_HOST_NAME]
+        remove_process = subprocess.Popen(
+            remove_sagemaker_local, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+        )
+        try:
+            _stream_output(remove_process)
+        except RuntimeError:
+            # Continue even if rm sagemaker-local fails
+            pass
 
         compose_command = self._compose()
         process = subprocess.Popen(


### PR DESCRIPTION
*Issue #, if available:*
Issue #4659

*Description of changes:*

Simple bug fix to the linked issue, run "docker network rm sagemaker-local" before doing the docker compose during setup for a processing job in local mode, stream the output and continue if the network rm fails. The bug I was seeing was from the sagemaker-local network already existing before the job was ran, so this should tear it down before docker-compose and fix it.

*Testing done:*

No new tests added, ran with existing unit tests locally and results remain the same.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
