### PR TITLE
ModelBuilder to support display with filter.

### DIFF
--- a/src/sagemaker/serve/builder/jumpstart_builder.py
+++ b/src/sagemaker/serve/builder/jumpstart_builder.py
@@ -458,12 +458,12 @@ class JumpStart(ABC):
 
         return self.pysdk_model.deployment_config
 
-    def display_benchmark_metrics(self):
+    def display_benchmark_metrics(self, **kwargs):
         """Display Markdown Benchmark Metrics for deployment configs."""
         if not hasattr(self, "pysdk_model") or self.pysdk_model is None:
             self._build_for_jumpstart()
 
-        self.pysdk_model.display_benchmark_metrics()
+        self.pysdk_model.display_benchmark_metrics(**kwargs)
 
     def list_deployment_configs(self) -> List[Dict[str, Any]]:
         """List deployment configs for ``This`` model in the current region.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update: ModelBuilder to support display with filter.

*Testing done:*

```
model_builder = ModelBuilder(
    model="meta-textgeneration-llama-3-8b",
    schema_builder=SchemaBuilder(sample_input, sample_output),
)

model_builder.display_benchmark_metrics()

| Instance Type            | Config Name     |   Concurrent Users |   Latency for each user (TTFT in ms) |   Throughput per user (token/seconds) |   Instance Rate (USD/Hrs) |
|:-------------------------|:----------------|-------------------:|-------------------------------------:|--------------------------------------:|--------------------------:|
| ml.g5.12xlarge (Default) | tgi             |                  1 |                                13.40 |                                    72 |                      7.09 |
| ml.g5.12xlarge           | tgi             |                 64 |                                89.30 |                                   689 |                      7.09 |
| ml.g5.12xlarge           | tgi             |                128 |                               159.70 |                                   681 |                      7.09 |
| ml.g5.2xlarge            | lmi             |                 32 |                                67.50 |                                   337 |                      1.51 |
| ml.g5.2xlarge            | lmi             |                 64 |                               100.10 |                                   390 |                      1.51 |
| ml.g5.12xlarge           | lmi             |                  2 |                                14.60 |                                   125 |                      7.09 |
| ml.g5.12xlarge           | lmi             |                  4 |                                17.60 |                                   215 |                      7.09 |
| ml.p4d.24xlarge          | lmi             |                  1 |                                 6.90 |                                   137 |                     38.67 |
| ml.p4d.24xlarge          | lmi             |                  2 |                                 7.50 |                                   250 |                     38.67 |
| ml.p4d.24xlarge          | lmi             |                  4 |                                 8.40 |                                   436 |                     38.67 |
| ml.p4d.24xlarge          | lmi             |                  8 |                                 9.80 |                                   790 |                     38.67 |
| ml.p4d.24xlarge          | lmi             |                 16 |                                12.20 |                                  1240 |                     38.67 |
| ml.p4d.24xlarge          | lmi             |                 32 |                                17.30 |                                  1725 |                     38.67 |
| ml.g5.12xlarge           | lmi-trtllm      |                  8 |                                21.40 |                                   366 |                      7.09 |
| ml.g5.12xlarge           | lmi-trtllm      |                 16 |                                30.00 |                                   397 |                      7.09 |
| ml.g5.12xlarge           | lmi-trtllm      |                 32 |                                19.50 |                                    66 |                      7.09 |
| ml.g5.12xlarge           | lmi-trtllm      |                256 |                              1508.90 |                                     2 |                      7.09 |
| ml.g5.12xlarge           | lmi-trtllm      |                512 |                              3474.40 |                                     1 |                      7.09 |
| ml.g5.12xlarge           | lmi-trtllm      |               1024 |                              3970.20 |                                     1 |                      7.09 |
| ml.p4d.24xlarge          | lmi-trtllm      |                 64 |                                27.20 |                                  2237 |                     38.67 |
| ml.p4d.24xlarge          | lmi-trtllm      |                128 |                                36.70 |                                  3030 |                     38.67 |
| ml.p4d.24xlarge          | lmi-trtllm      |                256 |                                50.80 |                                  3561 |                     38.67 |
| ml.p4d.24xlarge          | lmi-trtllm      |                512 |                                99.70 |                                  3151 |                     38.67 |
| ml.p4d.24xlarge          | lmi-trtllm      |               1024 |                               187.10 |                                  2858 |                     38.67 |
| ml.g5.2xlarge            | lmi-accelerated |                  1 |                                19.60 |                                    50 |                      1.51 |
| ml.g5.2xlarge            | lmi-accelerated |                  2 |                                12.30 |                                   129 |                      1.51 |
| ml.g5.2xlarge            | lmi-accelerated |                  4 |                                16.20 |                                   187 |                      1.51 |
| ml.g5.2xlarge            | lmi-accelerated |                  8 |                                25.90 |                                   210 |                      1.51 |
| ml.g5.2xlarge            | lmi-accelerated |                 16 |                                45.10 |                                   213 |                      1.51 |
```

```
model_builder.display_benchmark_metrics(instance_type="12xlarge")

| Instance Type            | Config Name   |   Concurrent Users |   Latency for each user (TTFT in ms) |   Throughput per user (token/seconds) |   Instance Rate (USD/Hrs) |
|:-------------------------|:--------------|-------------------:|-------------------------------------:|--------------------------------------:|--------------------------:|
| ml.g5.12xlarge (Default) | tgi           |                  1 |                                13.40 |                                    72 |                      7.09 |
| ml.g5.12xlarge           | tgi           |                 64 |                                89.30 |                                   689 |                      7.09 |
| ml.g5.12xlarge           | tgi           |                128 |                               159.70 |                                   681 |                      7.09 |
| ml.g5.12xlarge           | lmi           |                  2 |                                14.60 |                                   125 |                      7.09 |
| ml.g5.12xlarge           | lmi           |                  4 |                                17.60 |                                   215 |                      7.09 |
| ml.g5.12xlarge           | lmi-trtllm    |                  8 |                                21.40 |                                   366 |                      7.09 |
| ml.g5.12xlarge           | lmi-trtllm    |                 16 |                                30.00 |                                   397 |                      7.09 |
| ml.g5.12xlarge           | lmi-trtllm    |                 32 |                                19.50 |                                    66 |                      7.09 |
| ml.g5.12xlarge           | lmi-trtllm    |                256 |                              1508.90 |                                     2 |                      7.09 |
| ml.g5.12xlarge           | lmi-trtllm    |                512 |                              3474.40 |                                     1 |                      7.09 |
| ml.g5.12xlarge           | lmi-trtllm    |               1024 |                              3970.20 |                                     1 |                      7.09 |
```

```
model_builder.display_benchmark_metrics(instance_type="ml.p4d.24xlarge")

| Instance Type   | Config Name   |   Concurrent Users |   Latency for each user (TTFT in ms) |   Throughput per user (token/seconds) |   Instance Rate (USD/Hrs) |
|:----------------|:--------------|-------------------:|-------------------------------------:|--------------------------------------:|--------------------------:|
| ml.p4d.24xlarge | lmi           |                  1 |                                 6.90 |                                   137 |                     38.67 |
| ml.p4d.24xlarge | lmi           |                  2 |                                 7.50 |                                   250 |                     38.67 |
| ml.p4d.24xlarge | lmi           |                  4 |                                 8.40 |                                   436 |                     38.67 |
| ml.p4d.24xlarge | lmi           |                  8 |                                 9.80 |                                   790 |                     38.67 |
| ml.p4d.24xlarge | lmi           |                 16 |                                12.20 |                                  1240 |                     38.67 |
| ml.p4d.24xlarge | lmi           |                 32 |                                17.30 |                                  1725 |                     38.67 |
| ml.p4d.24xlarge | lmi-trtllm    |                 64 |                                27.20 |                                  2237 |                     38.67 |
| ml.p4d.24xlarge | lmi-trtllm    |                128 |                                36.70 |                                  3030 |                     38.67 |
| ml.p4d.24xlarge | lmi-trtllm    |                256 |                                50.80 |                                  3561 |                     38.67 |
| ml.p4d.24xlarge | lmi-trtllm    |                512 |                                99.70 |                                  3151 |                     38.67 |
| ml.p4d.24xlarge | lmi-trtllm    |               1024 |                               187.10 |                                  2858 |                     38.67 |
```

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
