### PR TITLE
fix: fix instance_type assignment logic

### DIFF
--- a/src/sagemaker/jumpstart/factory/estimator.py
+++ b/src/sagemaker/jumpstart/factory/estimator.py
@@ -322,7 +322,7 @@ def get_deploy_kwargs(
         model_id=model_id,
         model_from_estimator=True,
         model_version=model_version,
-        instance_type=model_deploy_kwargs.instance_type if training_instance_type is None else None,
+        instance_type=model_deploy_kwargs.instance_type or training_instance_type,
         region=region,
         image_uri=image_uri,
         source_dir=source_dir,


### PR DESCRIPTION
*Issue #, if available:*
4666 - https://github.com/aws/amazon-sagemaker-examples/issues/4666

*Description of changes:*
In this code change, the logic for assigning the `instance_type` variable has been improved by using the Python `or` operator instead of a ternary conditional expression.

The original code:

```python
instance_type = model_deploy_kwargs.instance_type if training_instance_type is None else None
```

This line checks if `training_instance_type` is `None`. If it is `None`, it assigns `model_deploy_kwargs.instance_type` to `instance_type`. Otherwise, it assigns `None` to `instance_type`, which seems counterintuitive and results in it ignoring a passed in `instance_type` if a `training_instance_type` also exists.

The new code:

```python
instance_type = model_deploy_kwargs.instance_type or training_instance_type
```

This line uses the `or` operator to assign the value of `model_deploy_kwargs.instance_type` to `instance_type` if it is a "truthy" value (i.e., not `None`, `0`, `False`, or an empty collection). If `model_deploy_kwargs.instance_type` is a "falsy" value (i.e., `None`, `0`, `False`, or an empty collection), it will assign the value of `training_instance_type` to `instance_type`.

This change improves the logic by ensuring that `instance_type` is assigned a non-`None` value if either `model_deploy_kwargs.instance_type` or `training_instance_type` has a valid value. 

*Testing done:*
No new tests added, ran with existing unit tests locally and results remain the same.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
