### PR TITLE
feature: add support for HF_HOME

### DIFF
--- a/src/sagemaker/serve/builder/djl_builder.py
+++ b/src/sagemaker/serve/builder/djl_builder.py
@@ -265,6 +265,7 @@ class DJL(ABC):
             # if has not been built for local container we must use cache
             # that hosting has write access to.
             self.pysdk_model.env["TRANSFORMERS_CACHE"] = "/tmp"
+            self.pysdk_model.env["HF_HOME"] = "/tmp"
             self.pysdk_model.env["HUGGINGFACE_HUB_CACHE"] = "/tmp"
 
         if "endpoint_logging" not in kwargs:

--- a/src/sagemaker/serve/builder/tei_builder.py
+++ b/src/sagemaker/serve/builder/tei_builder.py
@@ -175,6 +175,7 @@ class TEI(ABC):
             # if has not been built for local container we must use cache
             # that hosting has write access to.
             self.pysdk_model.env["TRANSFORMERS_CACHE"] = "/tmp"
+            self.pysdk_model.env["HF_HOME"] = "/tmp"
             self.pysdk_model.env["HUGGINGFACE_HUB_CACHE"] = "/tmp"
 
         if "endpoint_logging" not in kwargs:

--- a/src/sagemaker/serve/builder/tgi_builder.py
+++ b/src/sagemaker/serve/builder/tgi_builder.py
@@ -214,6 +214,7 @@ class TGI(ABC):
             # if has not been built for local container we must use cache
             # that hosting has write access to.
             self.pysdk_model.env["TRANSFORMERS_CACHE"] = "/tmp"
+            self.pysdk_model.env["HF_HOME"] = "/tmp"
             self.pysdk_model.env["HUGGINGFACE_HUB_CACHE"] = "/tmp"
 
         if "endpoint_logging" not in kwargs:

--- a/src/sagemaker/serve/model_server/djl_serving/server.py
+++ b/src/sagemaker/serve/model_server/djl_serving/server.py
@@ -19,6 +19,7 @@ _SHM_SIZE = "2G"
 _DEFAULT_ENV_VARS = {
     "SERVING_OPTS": "-Dai.djl.logging.level=debug",
     "TRANSFORMERS_CACHE": "/opt/ml/model/",
+    "HF_HOME": "/opt/ml/model/",
     "HUGGINGFACE_HUB_CACHE": "/opt/ml/model/",
 }
 

--- a/src/sagemaker/serve/model_server/tei/server.py
+++ b/src/sagemaker/serve/model_server/tei/server.py
@@ -18,6 +18,7 @@ MODE_DIR_BINDING = "/opt/ml/model/"
 _SHM_SIZE = "2G"
 _DEFAULT_ENV_VARS = {
     "TRANSFORMERS_CACHE": "/opt/ml/model/",
+    "HF_HOME": "/opt/ml/model/",
     "HUGGINGFACE_HUB_CACHE": "/opt/ml/model/",
 }
 

--- a/src/sagemaker/serve/model_server/tgi/server.py
+++ b/src/sagemaker/serve/model_server/tgi/server.py
@@ -17,6 +17,7 @@ MODE_DIR_BINDING = "/opt/ml/model/"
 _SHM_SIZE = "2G"
 _DEFAULT_ENV_VARS = {
     "TRANSFORMERS_CACHE": "/opt/ml/model/",
+    "HF_HOME": "/opt/ml/model/",
     "HUGGINGFACE_HUB_CACHE": "/opt/ml/model/",
 }
 

--- a/tests/unit/sagemaker/serve/model_server/tei/test_server.py
+++ b/tests/unit/sagemaker/serve/model_server/tei/test_server.py
@@ -66,6 +66,7 @@ class TeiServerTests(TestCase):
             volumes={PosixPath("model_path/code"): {"bind": "/opt/ml/model/", "mode": "rw"}},
             environment={
                 "TRANSFORMERS_CACHE": "/opt/ml/model/",
+                "HF_HOME": "/opt/ml/model/",
                 "HUGGINGFACE_HUB_CACHE": "/opt/ml/model/",
                 "KEY": "VALUE",
                 "SAGEMAKER_SERVE_SECRET_KEY": "secret_key",


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Added support for customers to use HF_HOME. Address Future warning by Adding HF_HOME to env variables. Older variables will be deprecated once all customers move to v5 version of Transformers. 

```
/opt/conda/lib/python3.10/site-packages/transformers/utils/hub.py:124: FutureWarning: Using `TRANSFORMERS_CACHE` is deprecated and will be removed in v5 of Transformers. Use `HF_HOME` instead.
 warnings.warn(

```
*Testing done:*
Integr tests run locally

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [X] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [X] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [X] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [X] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [X] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [X] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
