### PR TITLE
fix: estimator.deploy not respecting instance type

### DIFF
--- a/src/sagemaker/jumpstart/factory/estimator.py
+++ b/src/sagemaker/jumpstart/factory/estimator.py
@@ -322,7 +322,11 @@ def get_deploy_kwargs(
         model_id=model_id,
         model_from_estimator=True,
         model_version=model_version,
-        instance_type=model_deploy_kwargs.instance_type if training_instance_type is None else None,
+        instance_type=(
+            model_deploy_kwargs.instance_type
+            if training_instance_type is None or instance_type is not None
+            else None
+        ),
         region=region,
         image_uri=image_uri,
         source_dir=source_dir,

--- a/src/sagemaker/jumpstart/factory/estimator.py
+++ b/src/sagemaker/jumpstart/factory/estimator.py
@@ -324,7 +324,8 @@ def get_deploy_kwargs(
         model_version=model_version,
         instance_type=(
             model_deploy_kwargs.instance_type
-            if training_instance_type is None or instance_type is not None
+            if training_instance_type is None
+            or instance_type is not None  # always use supplied inference instance type
             else None
         ),
         region=region,

--- a/tests/unit/sagemaker/jumpstart/estimator/test_estimator.py
+++ b/tests/unit/sagemaker/jumpstart/estimator/test_estimator.py
@@ -1532,6 +1532,9 @@ class EstimatorTest(unittest.TestCase):
         estimator.deploy(image_uri="blah")
         assert mock_estimator_deploy.call_args[1]["instance_type"] == "ml.p4de.24xlarge"
 
+        estimator.deploy(image_uri="blah", instance_type="ml.quantum.large")
+        assert mock_estimator_deploy.call_args[1]["instance_type"] == "ml.quantum.large"
+
     @mock.patch("sagemaker.utils.sagemaker_timestamp")
     @mock.patch("sagemaker.jumpstart.estimator.validate_model_id_and_get_type")
     @mock.patch(


### PR DESCRIPTION
*Issue #, if available:* 
https://github.com/aws/amazon-sagemaker-examples/issues/4666

*Description of changes:*
Fixes issue with not using user-supplied instance type for `Estimator.deploy`

*Testing done:*
Unit test added

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
