### PR TITLE
fix: list_models() for python3.8

### DIFF
--- a/src/sagemaker/jumpstart/hub/hub.py
+++ b/src/sagemaker/jumpstart/hub/hub.py
@@ -184,15 +184,15 @@ class Hub:
                 **{
                     "hub_name": self.hub_name,
                     "hub_content_type": HubContentType.MODEL_REFERENCE.value,
-                    **kwargs
+                    **kwargs,
                 }
             )
 
             hub_model_summaries = self._list_and_paginate_models(
                 **{
-                    "hub_name": self.hub_name, 
+                    "hub_name": self.hub_name,
                     "hub_content_type": HubContentType.MODEL.value,
-                    **kwargs
+                    **kwargs,
                 }
             )
             response["hub_content_summaries"] = hub_model_reference_summaries + hub_model_summaries

--- a/src/sagemaker/jumpstart/hub/hub.py
+++ b/src/sagemaker/jumpstart/hub/hub.py
@@ -184,13 +184,16 @@ class Hub:
                 **{
                     "hub_name": self.hub_name,
                     "hub_content_type": HubContentType.MODEL_REFERENCE.value,
+                    **kwargs
                 }
-                | kwargs
             )
 
             hub_model_summaries = self._list_and_paginate_models(
-                **{"hub_name": self.hub_name, "hub_content_type": HubContentType.MODEL.value}
-                | kwargs
+                **{
+                    "hub_name": self.hub_name, 
+                    "hub_content_type": HubContentType.MODEL.value,
+                    **kwargs
+                }
             )
             response["hub_content_summaries"] = hub_model_reference_summaries + hub_model_summaries
         response["next_token"] = None  # Temporary until pagination is implemented


### PR DESCRIPTION
*Issue #, if available:*
for Python3.8 list_models() function was failing with an error
```
in list_models
    **{
TypeError: unsupported operand type(s) for |: 'dict' and 'dict'
```
this PR is to fix the compatibility issue with Python3.8

*Description of changes:*
Rootcause: 
In Python 3.8 and earlier versions, the bitwise OR operator (|) is not overloaded to work with dictionaries.

fixing it with an alternative compatible code for PySDK

*Testing done:*
End to end test with example notebook using Python3.8

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
