### PR TITLE
Fix: Adding application/octet-stream to content type #4772

### DIFF
--- a/src/sagemaker/model_card/helpers.py
+++ b/src/sagemaker/model_card/helpers.py
@@ -503,12 +503,12 @@ def _read_s3_json(session: Session, bucket: str, key: str):
             raise
 
     result = {}
-    if data["ContentType"] == "application/json" or data["ContentType"] == "binary/octet-stream":
+    content_types = ["application/json", "binary/octet-stream", "application/octet-stream"]
+    if data["ContentType"] in content_types:
         result = json.loads(data["Body"].read().decode("utf-8"))
     else:
         logger.warning(
-            "Invalid file type %s. application/json or binary/octet-stream is expected.",
-            data["ContentType"],
+            "Invalid file type %s. %s is expected.", data["ContentType"], ", ".join(content_types)
         )
 
     return result


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes: Fix for #4772

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
