### PR TITLE
Fix for Estimator Training details on register

### DIFF
--- a/src/sagemaker/estimator.py
+++ b/src/sagemaker/estimator.py
@@ -1807,6 +1807,7 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):  # pylint: disable=too-man
             model_card = ModelCard(
                 name="estimator_card",
                 training_details=training_details,
+                sagemaker_session=self.sagemaker_session,
             )
         return model.register(
             content_types,

--- a/src/sagemaker/model.py
+++ b/src/sagemaker/model.py
@@ -549,7 +549,10 @@ class Model(ModelBase, InferenceRecommenderMixin):
             model_package_group_name = utils.base_name_from_image(
                 self.image_uri, default_base_name=ModelPackage.__name__
             )
-        if model_package_group_name is not None and model_type is not JumpStartModelType.PROPRIETARY:
+        if (
+            model_package_group_name is not None
+            and model_type is not JumpStartModelType.PROPRIETARY
+        ):
             container_def = self.prepare_container_def(accept_eula=accept_eula)
             container_def = update_container_with_inference_params(
                 framework=framework,

--- a/src/sagemaker/model.py
+++ b/src/sagemaker/model.py
@@ -549,7 +549,10 @@ class Model(ModelBase, InferenceRecommenderMixin):
             model_package_group_name = utils.base_name_from_image(
                 self.image_uri, default_base_name=ModelPackage.__name__
             )
-        if model_package_group_name is not None:
+        if (
+            model_package_group_name is not None
+            and self.model_type is not JumpStartModelType.PROPRIETARY
+        ):
             container_def = self.prepare_container_def(accept_eula=accept_eula)
             container_def = update_container_with_inference_params(
                 framework=framework,

--- a/src/sagemaker/model.py
+++ b/src/sagemaker/model.py
@@ -551,6 +551,7 @@ class Model(ModelBase, InferenceRecommenderMixin):
             )
         if (
             model_package_group_name is not None
+            and self.model_type is not None
             and self.model_type is not JumpStartModelType.PROPRIETARY
         ):
             container_def = self.prepare_container_def(accept_eula=accept_eula)

--- a/src/sagemaker/model.py
+++ b/src/sagemaker/model.py
@@ -549,11 +549,7 @@ class Model(ModelBase, InferenceRecommenderMixin):
             model_package_group_name = utils.base_name_from_image(
                 self.image_uri, default_base_name=ModelPackage.__name__
             )
-        if (
-            model_package_group_name is not None
-            and self.model_type is not None
-            and self.model_type is not JumpStartModelType.PROPRIETARY
-        ):
+        if model_package_group_name is not None and model_type is not JumpStartModelType.PROPRIETARY:
             container_def = self.prepare_container_def(accept_eula=accept_eula)
             container_def = update_container_with_inference_params(
                 framework=framework,

--- a/tests/integ/test_byo_estimator.py
+++ b/tests/integ/test_byo_estimator.py
@@ -108,9 +108,7 @@ def test_byo_estimator(sagemaker_session, region, cpu_instance_type, training_se
             assert prediction["score"] is not None
 
 
-def test_estimator_register_publish_training_details(
-    sagemaker_session, region, cpu_instance_type, training_set
-):
+def test_estimator_register_publish_training_details(sagemaker_session, region):
 
     bucket = sagemaker_session.default_bucket()
     prefix = "model-card-sample-notebook"

--- a/tests/integ/test_byo_estimator.py
+++ b/tests/integ/test_byo_estimator.py
@@ -12,14 +12,20 @@
 # language governing permissions and limitations under the License.
 from __future__ import absolute_import
 
+import io
 import json
 import os
 
+import numpy as np
+
 import pytest
+import sagemaker.amazon.common as smac
+
 
 import sagemaker
 from sagemaker import image_uris
 from sagemaker.estimator import Estimator
+from sagemaker.s3 import S3Uploader
 from sagemaker.serializers import SimpleBaseSerializer
 from sagemaker.utils import unique_name_from_base
 from tests.integ import DATA_DIR, TRAINING_DEFAULT_TIMEOUT_MINUTES, datasets
@@ -100,6 +106,61 @@ def test_byo_estimator(sagemaker_session, region, cpu_instance_type, training_se
         assert len(result["predictions"]) == 10
         for prediction in result["predictions"]:
             assert prediction["score"] is not None
+
+
+def test_estimator_register_publish_training_details(
+    sagemaker_session, region, cpu_instance_type, training_set
+):
+
+    bucket = sagemaker_session.default_bucket()
+    prefix = "model-card-sample-notebook"
+
+    raw_data = (
+        (0.5, 0),
+        (0.75, 0),
+        (1.0, 0),
+        (1.25, 0),
+        (1.50, 0),
+        (1.75, 0),
+        (2.0, 0),
+        (2.25, 1),
+        (2.5, 0),
+        (2.75, 1),
+        (3.0, 0),
+        (3.25, 1),
+        (3.5, 0),
+        (4.0, 1),
+        (4.25, 1),
+        (4.5, 1),
+        (4.75, 1),
+        (5.0, 1),
+        (5.5, 1),
+    )
+    training_data = np.array(raw_data).astype("float32")
+    labels = training_data[:, 1]
+
+    # upload data to S3 bucket
+    buf = io.BytesIO()
+    smac.write_numpy_to_dense_tensor(buf, training_data, labels)
+    buf.seek(0)
+    s3_train_data = f"s3://{bucket}/{prefix}/train"
+    S3Uploader.upload_bytes(b=buf, s3_uri=s3_train_data, sagemaker_session=sagemaker_session)
+    output_location = f"s3://{bucket}/{prefix}/output"
+    container = image_uris.retrieve("linear-learner", region)
+    estimator = sagemaker.estimator.Estimator(
+        container,
+        role="SageMakerRole",
+        instance_count=1,
+        instance_type="ml.m4.xlarge",
+        output_path=output_location,
+        sagemaker_session=sagemaker_session,
+    )
+    estimator.set_hyperparameters(
+        feature_dim=2, mini_batch_size=10, predictor_type="binary_classifier"
+    )
+    estimator.fit({"train": s3_train_data})
+    print(f"Training job name: {estimator.latest_training_job.name}")
+    estimator.register()
 
 
 def test_async_byo_estimator(sagemaker_session, region, cpu_instance_type, training_set):

--- a/tests/integ/test_byo_estimator.py
+++ b/tests/integ/test_byo_estimator.py
@@ -108,6 +108,7 @@ def test_byo_estimator(sagemaker_session, region, cpu_instance_type, training_se
             assert prediction["score"] is not None
 
 
+@pytest.mark.release
 def test_estimator_register_publish_training_details(sagemaker_session, region):
 
     bucket = sagemaker_session.default_bucket()
@@ -145,7 +146,7 @@ def test_estimator_register_publish_training_details(sagemaker_session, region):
     S3Uploader.upload_bytes(b=buf, s3_uri=s3_train_data, sagemaker_session=sagemaker_session)
     output_location = f"s3://{bucket}/{prefix}/output"
     container = image_uris.retrieve("linear-learner", region)
-    estimator = sagemaker.estimator.Estimator(
+    estimator = Estimator(
         container,
         role="SageMakerRole",
         instance_count=1,

--- a/tests/unit/test_estimator.py
+++ b/tests/unit/test_estimator.py
@@ -4402,10 +4402,7 @@ def test_register_default_image_without_instance_type_args(sagemaker_session):
     framework = "TENSORFLOW"
     framework_version = "2.9"
     nearest_model_name = "resnet50"
-    model_card = {
-        'ModelCardStatus': ModelCardStatusEnum.DRAFT,
-        'ModelCardContent': '{}'
-    }
+    model_card = {"ModelCardStatus": ModelCardStatusEnum.DRAFT, "ModelCardContent": "{}"}
     estimator.register(
         content_types=content_types,
         response_types=response_types,
@@ -4458,10 +4455,7 @@ def test_register_inference_image(sagemaker_session):
     framework = "TENSORFLOW"
     framework_version = "2.9"
     nearest_model_name = "resnet50"
-    model_card = {
-        'ModelCardStatus': ModelCardStatusEnum.DRAFT,
-        'ModelCardContent': '{}'
-    }
+    model_card = {"ModelCardStatus": ModelCardStatusEnum.DRAFT, "ModelCardContent": "{}"}
 
     estimator.register(
         content_types=content_types,

--- a/tests/unit/test_estimator.py
+++ b/tests/unit/test_estimator.py
@@ -4402,7 +4402,10 @@ def test_register_default_image_without_instance_type_args(sagemaker_session):
     framework = "TENSORFLOW"
     framework_version = "2.9"
     nearest_model_name = "resnet50"
-
+    model_card = {
+        'ModelCardStatus': ModelCardStatusEnum.DRAFT,
+        'ModelCardContent': '{}'
+    }
     estimator.register(
         content_types=content_types,
         response_types=response_types,
@@ -4425,6 +4428,7 @@ def test_register_default_image_without_instance_type_args(sagemaker_session):
         "marketplace_cert": False,
         "sample_payload_url": sample_payload_url,
         "task": task,
+        "model_card": model_card,
     }
     sagemaker_session.create_model_package_from_containers.assert_called_with(
         **expected_create_model_package_request
@@ -4454,6 +4458,10 @@ def test_register_inference_image(sagemaker_session):
     framework = "TENSORFLOW"
     framework_version = "2.9"
     nearest_model_name = "resnet50"
+    model_card = {
+        'ModelCardStatus': ModelCardStatusEnum.DRAFT,
+        'ModelCardContent': '{}'
+    }
 
     estimator.register(
         content_types=content_types,
@@ -4480,6 +4488,7 @@ def test_register_inference_image(sagemaker_session):
         "marketplace_cert": False,
         "sample_payload_url": sample_payload_url,
         "task": task,
+        "model_card": model_card,
     }
     sagemaker_session.create_model_package_from_containers.assert_called_with(
         **expected_create_model_package_request


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes: Fix for Estimator Training details on register

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
