### PR TITLE
fix: explicitly access enum member values to avoid Python version rel…

### DIFF
--- a/src/sagemaker/jumpstart/hub/hub.py
+++ b/src/sagemaker/jumpstart/hub/hub.py
@@ -233,7 +233,7 @@ class Hub:
                     f"arn:{info.partition}:"
                     f"sagemaker:{info.region}:"
                     f"aws:hub-content/{info.hub_name}/"
-                    f"{HubContentType.MODEL}/{model[0]}"
+                    f"{HubContentType.MODEL.value}/{model[0]}"
                 )
                 hub_content_summary = {
                     "hub_content_name": model[0],


### PR DESCRIPTION
*Issue #, if available:*


*Description of changes:*
- In python version Python 3.6 and earlier, the default str method for enum members returns the full string representation, including the class name and member name (e.g., 'HubContentType.MODEL'). Which results in an invalid public model arn format and fails to create a hub model reference for those Python versions.
- To maintain consistency across various Python versions, explicitly accessing the value attribute of the enum object to get the value and construct the correct Hub Model Arn. 

*Testing done:*
- Notebook testing

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
