### PR TITLE
chore: pin framework version in serverless inference tests

### DIFF
--- a/tests/integ/test_sklearn.py
+++ b/tests/integ/test_sklearn.py
@@ -159,8 +159,6 @@ def test_deploy_model(
 def test_deploy_model_with_serverless_inference_config(
     sklearn_training_job,
     sagemaker_session,
-    sklearn_latest_version,
-    sklearn_latest_py_version,
 ):
     endpoint_name = unique_name_from_base("test-sklearn-deploy-model-serverless")
     with timeout_and_delete_endpoint_by_name(endpoint_name, sagemaker_session):
@@ -173,7 +171,7 @@ def test_deploy_model_with_serverless_inference_config(
             model_data,
             ROLE,
             entry_point=script_path,
-            framework_version=sklearn_latest_version,
+            framework_version="1.0-1",
             sagemaker_session=sagemaker_session,
         )
         predictor = model.deploy(

--- a/tests/integ/test_xgboost.py
+++ b/tests/integ/test_xgboost.py
@@ -121,11 +121,9 @@ def test_training_with_network_isolation(
         ]
 
 
-@pytest.mark.skip(reason="re:Invent keynote3 blocker. Revisit after release")
 def test_xgboost_serverless_inference(
     xgboost_training_job,
     sagemaker_session,
-    xgboost_latest_version,
 ):
     endpoint_name = unique_name_from_base("test-xgboost-deploy-model-serverless")
     with timeout_and_delete_endpoint_by_name(endpoint_name, sagemaker_session):
@@ -139,7 +137,7 @@ def test_xgboost_serverless_inference(
             model_data=model_data,
             role=ROLE,
             entry_point=os.path.join(DATA_DIR, "xgboost_abalone", "abalone.py"),
-            framework_version=xgboost_latest_version,
+            framework_version="1.5-1",
         )
 
         xgboost.deploy(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Pinning framework versions in serverless inference tests to last version that supports serverless inference.
* New [xgboost](https://github.com/aws/sagemaker-xgboost-container) and [sklearn](https://github.com/aws/sagemaker-scikit-learn-container) image not compatible for serverless inference




*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
