### PR TITLE
Fixed cpu isntance type for the estimator register test

### DIFF
--- a/tests/integ/test_byo_estimator.py
+++ b/tests/integ/test_byo_estimator.py
@@ -109,7 +109,7 @@ def test_byo_estimator(sagemaker_session, region, cpu_instance_type, training_se
 
 
 @pytest.mark.release
-def test_estimator_register_publish_training_details(sagemaker_session, region):
+def test_estimator_register_publish_training_details(sagemaker_session, region, cpu_instance_type):
 
     bucket = sagemaker_session.default_bucket()
     prefix = "model-card-sample-notebook"
@@ -150,7 +150,7 @@ def test_estimator_register_publish_training_details(sagemaker_session, region):
         container,
         role="SageMakerRole",
         instance_count=1,
-        instance_type="ml.m4.xlarge",
+        instance_type=cpu_instance_type,
         output_path=output_location,
         sagemaker_session=sagemaker_session,
     )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes: Fixed cpu isntance type for the estimator register test

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
