### PR TITLE
fix: avoided printing stack trace and escaped input

### DIFF
--- a/tests/data/marketplace/iris/scoring_logic.py
+++ b/tests/data/marketplace/iris/scoring_logic.py
@@ -3,7 +3,7 @@ import json
 import logging
 import re
 from flask import Flask
-from flask import request
+from flask import request, escape
 from joblib import dump, load
 import numpy as np
 import os
@@ -106,4 +106,4 @@ def endpoint_invocations():
 
         return response
     except Exception as e:
-        return f"Error during model invocation: {str(e)} for input: {request.get_data()}"
+        return f"Error during model invocation: {type(str(e)).__name__} for input: {escape(request.get_data())}"

--- a/tests/data/marketplace/iris/scoring_logic.py
+++ b/tests/data/marketplace/iris/scoring_logic.py
@@ -73,37 +73,34 @@ def endpoint_ping():
 # Create a path for inference
 @app.route("/invocations", methods=["POST"])
 def endpoint_invocations():
-    try:
-        logger.info(f"Processing request: {request.headers}")
-        logger.debug(f"Payload: {request.headers}")
+    logger.info(f"Processing request: {request.headers}")
+    logger.debug(f"Payload: {request.headers}")
 
-        if request.content_type not in SUPPORTED_REQUEST_MIMETYPES:
-            logger.error(f"Unsupported Content-Type specified: {request.content_type}")
-            return f"Invalid Content-Type. Supported Content-Types: {', '.join(SUPPORTED_REQUEST_MIMETYPES)}"
-        elif request.content_type == "text/csv":
-            # Step 1: Decode payload into input format expected by model
-            data = request.get_data().decode("utf8")
-            # Step 2: Perform inference with the loaded model
-            predictions = model.predict_from_csv(data)
-        elif request.content_type == "application/json":
-            data = request.get_data().decode("utf8")
-            predictions = model.predict_from_json(data)
-        elif request.content_type == "application/jsonlines":
-            data = request.get_data().decode("utf8")
-            predictions = model.predict_from_jsonlines(data)
+    if request.content_type not in SUPPORTED_REQUEST_MIMETYPES:
+        logger.error(f"Unsupported Content-Type specified: {request.content_type}")
+        return f"Invalid Content-Type. Supported Content-Types: {', '.join(SUPPORTED_REQUEST_MIMETYPES)}"
+    elif request.content_type == "text/csv":
+        # Step 1: Decode payload into input format expected by model
+        data = request.get_data().decode("utf8")
+        # Step 2: Perform inference with the loaded model
+        predictions = model.predict_from_csv(data)
+    elif request.content_type == "application/json":
+        data = request.get_data().decode("utf8")
+        predictions = model.predict_from_json(data)
+    elif request.content_type == "application/jsonlines":
+        data = request.get_data().decode("utf8")
+        predictions = model.predict_from_jsonlines(data)
 
-        # Step 3: Process predictions into the specified response type (if specified)
-        response_mimetype = request.accept_mimetypes.best_match(
-            SUPPORTED_RESPONSE_MIMETYPES, default="application/json"
-        )
+    # Step 3: Process predictions into the specified response type (if specified)
+    response_mimetype = request.accept_mimetypes.best_match(
+        SUPPORTED_RESPONSE_MIMETYPES, default="application/json"
+    )
 
-        if response_mimetype == "text/csv":
-            response = "\n".join(predictions)
-        elif response_mimetype == "application/jsonlines":
-            response = "\n".join([json.dumps({"class": pred}) for pred in predictions])
-        elif response_mimetype == "application/json":
-            response = json.dumps({"predictions": [{"class": pred} for pred in predictions]})
+    if response_mimetype == "text/csv":
+        response = "\n".join(predictions)
+    elif response_mimetype == "application/jsonlines":
+        response = "\n".join([json.dumps({"class": pred}) for pred in predictions])
+    elif response_mimetype == "application/json":
+        response = json.dumps({"predictions": [{"class": pred} for pred in predictions]})
 
-        return response
-    except Exception as e:
-        return f"Error during model invocation: {type(str(e)).__name__} for input: {escape(request.get_data())}"
+    return response


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The first change was to print only the error type rather than the entire stack trace as it may reveal the application as well as any internal components it relies on. 
The second change escape the user input before returning it to avoid a cross-site scripting vulnerability.

*Testing done:*
Tested changes in my own fork and CodeQL recognizes them as fixes.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
