### PR TITLE
feat: implemented security-monitoring to send metrics to CW #1510

### DIFF
--- a/.github/workflows/security-monitoring.yml
+++ b/.github/workflows/security-monitoring.yml
@@ -102,21 +102,21 @@ jobs:
       - name: Put Code Scanning Alert Metric Data
         run: |
           if [ "${{ needs.check-code-scanning-alerts.outputs.code_scanning_alert_status }}" == "1" ]; then
-            aws cloudwatch put-metric-data --metric-name CodeScanningAlert --namespace CodeScanningMonitoringMetrics --value 1 --unit Count --dimensions ProjectName=sagemaker-python-sdk
+            aws cloudwatch put-metric-data --metric-name CodeScanningAlert --namespace SecurityMonitoringMetrics --value 1 --unit Count --dimensions ProjectName=sagemaker-python-sdk
           else
-            aws cloudwatch put-metric-data --metric-name CodeScanningAlert --namespace CodeScanningMonitoringMetrics --value 0 --unit Count --dimensions ProjectName=sagemaker-python-sdk
+            aws cloudwatch put-metric-data --metric-name CodeScanningAlert --namespace SecurityMonitoringMetrics --value 0 --unit Count --dimensions ProjectName=sagemaker-python-sdk
           fi
       - name: Put Dependabot Alert Metric Data
         run: |
           if [ "${{ needs.check-dependabot-alerts.outputs.dependabot_alert_status }}" == "1" ]; then
-            aws cloudwatch put-metric-data --metric-name DependabotAlert --namespace DependabotMonitoringMetrics --value 1 --unit Count --dimensions ProjectName=sagemaker-python-sdk
+            aws cloudwatch put-metric-data --metric-name DependabotAlert --namespace SecurityMonitoringMetrics --value 1 --unit Count --dimensions ProjectName=sagemaker-python-sdk
           else
-            aws cloudwatch put-metric-data --metric-name DependabotAlert --namespace DependabotMonitoringMetrics --value 0 --unit Count --dimensions ProjectName=sagemaker-python-sdk
+            aws cloudwatch put-metric-data --metric-name DependabotAlert --namespace SecurityMonitoringMetrics --value 0 --unit Count --dimensions ProjectName=sagemaker-python-sdk
           fi
       - name: Put Secret Scanning Alert Metric Data
         run: |
           if [ "${{ needs.check-secret-scanning-alerts.outputs.secret_scanning_alert_status }}" == "1" ]; then
-            aws cloudwatch put-metric-data --metric-name SecretScanningAlert --namespace SecretScanningMonitoringMetrics --value 1 --unit Count --dimensions ProjectName=sagemaker-python-sdk
+            aws cloudwatch put-metric-data --metric-name SecretScanningAlert --namespace SecurityMonitoringMetrics --value 1 --unit Count --dimensions ProjectName=sagemaker-python-sdk
           else
-            aws cloudwatch put-metric-data --metric-name SecretScanningAlert --namespace SecretScanningMonitoringMetrics --value 0 --unit Count --dimensions ProjectName=sagemaker-python-sdk
+            aws cloudwatch put-metric-data --metric-name SecretScanningAlert --namespace SecurityMonitoringMetrics --value 0 --unit Count --dimensions ProjectName=sagemaker-python-sdk
           fi

--- a/.github/workflows/security-monitoring.yml
+++ b/.github/workflows/security-monitoring.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@12e3392609eaaceb7ae6191b3f54bbcb85b5002b
         with:
-          role-to-assume: ${{ secrets.SECURITY_VULNERABILITY_ROLE_ARN }}
+          role-to-assume: ${{ secrets.MONITORING_ROLE_ARN }}
           aws-region: us-west-2
       - name: Put Code Scanning Alert Metric Data
         run: |

--- a/.github/workflows/security-monitoring.yml
+++ b/.github/workflows/security-monitoring.yml
@@ -1,0 +1,122 @@
+name: Security Monitoring
+
+on:
+  schedule:
+    - cron: '0 9 * * *'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  id-token: write
+
+jobs:
+  check-code-scanning-alerts:
+    runs-on: ubuntu-latest
+    outputs:
+      code_scanning_alert_status: ${{ steps.check-code-scanning-alerts.outputs.code_scanning_alert_status }}
+    steps:
+      - name: Check for security alerts
+        id: check-code-scanning-alerts
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
+        with:
+          github-token: ${{ secrets.GH_PAT }}
+          script: |
+            async function checkAlerts() {
+              const owner = '${{ github.repository_owner }}';
+              const repo = '${{ github.event.repository.name }}';
+              const ref = 'refs/heads/master';
+            
+              const codeScanningAlerts = await github.rest.codeScanning.listAlertsForRepo({
+                owner,
+                repo,
+                ref: ref
+              });
+              const activeCodeScanningAlerts = codeScanningAlerts.data.filter(alert => alert.state === 'open');
+              core.setOutput('code_scanning_alert_status', activeCodeScanningAlerts.length > 0 ? '1': '0');
+            }
+            await checkAlerts();
+
+  check-dependabot-alerts:
+    runs-on: ubuntu-latest
+    outputs:
+      dependabot_alert_status: ${{ steps.check-dependabot-alerts.outputs.dependabot_alert_status }}
+    steps:
+      - name: Check for dependabot alerts
+        id: check-dependabot-alerts
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
+        with:
+          github-token: ${{ secrets.GH_PAT }}
+          script: |
+            async function checkAlerts() {
+              const owner = '${{ github.repository_owner }}';
+              const repo = '${{ github.event.repository.name }}';
+            
+              const dependabotAlerts = await github.rest.dependabot.listAlertsForRepo({
+                owner,
+                repo,
+                headers: {
+                  'accept': 'applications/vnd.github+json'
+                }
+              }); 
+              const activeDependabotAlerts = dependabotAlerts.data.filter(alert => alert.state === 'open');
+              core.setOutput('dependabot_alert_status', activeDependabotAlerts.length > 0 ? '1': '0');
+            }
+            await checkAlerts();
+
+  check-secret-scanning-alerts:
+    runs-on: ubuntu-latest
+    outputs:
+      secret_scanning_alert_status: ${{ steps.check-secret-scanning-alerts.outputs.secret_scanning_alert_status }}
+    steps:
+      - name: Check for secret scanning alerts
+        id: check-secret-scanning-alerts
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
+        with:
+          github-token: ${{ secrets.GH_PAT }}
+          script: |
+            async function checkAlerts() {
+              const owner = '${{ github.repository_owner }}';
+              const repo = '${{ github.event.repository.name }}';
+
+              const secretScanningAlerts = await github.rest.secretScanning.listAlertsForRepo({
+                owner,
+                repo,
+              }); 
+              const activeSecretScanningAlerts = secretScanningAlerts.data.filter(alert => alert.state === 'open');
+              core.setOutput('secret_scanning_alert_status', activeSecretScanningAlerts.length > 0 ? '1': '0');
+              console.log("Active Secret Scanning Alerts", activeSecretScanningAlerts);
+            }
+            await checkAlerts();
+
+  put-metric-data:
+    runs-on: ubuntu-latest
+    needs: [check-code-scanning-alerts, check-dependabot-alerts, check-secret-scanning-alerts]
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@12e3392609eaaceb7ae6191b3f54bbcb85b5002b
+        with:
+          role-to-assume: ${{ secrets.SECURITY_VULNERABILITY_ROLE_ARN }}
+          aws-region: us-west-2
+      - name: Put Code Scanning Alert Metric Data
+        run: |
+          if [ "${{ needs.check-code-scanning-alerts.outputs.code_scanning_alert_status }}" == "1" ]; then
+            aws cloudwatch put-metric-data --metric-name CodeScanningAlert --namespace CodeScanningMonitoringMetrics --value 1 --unit Count --dimensions ProjectName=sagemaker-python-sdk
+          else
+            aws cloudwatch put-metric-data --metric-name CodeScanningAlert --namespace CodeScanningMonitoringMetrics --value 0 --unit Count --dimensions ProjectName=sagemaker-python-sdk
+          fi
+      - name: Put Dependabot Alert Metric Data
+        run: |
+          if [ "${{ needs.check-dependabot-alerts.outputs.dependabot_alert_status }}" == "1" ]; then
+            aws cloudwatch put-metric-data --metric-name DependabotAlert --namespace DependabotMonitoringMetrics --value 1 --unit Count --dimensions ProjectName=sagemaker-python-sdk
+          else
+            aws cloudwatch put-metric-data --metric-name DependabotAlert --namespace DependabotMonitoringMetrics --value 0 --unit Count --dimensions ProjectName=sagemaker-python-sdk
+          fi
+      - name: Put Secret Scanning Alert Metric Data
+        run: |
+          if [ "${{ needs.check-secret-scanning-alerts.outputs.secret_scanning_alert_status }}" == "1" ]; then
+            aws cloudwatch put-metric-data --metric-name SecretScanningAlert --namespace SecretScanningMonitoringMetrics --value 1 --unit Count --dimensions ProjectName=sagemaker-python-sdk
+          else
+            aws cloudwatch put-metric-data --metric-name SecretScanningAlert --namespace SecretScanningMonitoringMetrics --value 0 --unit Count --dimensions ProjectName=sagemaker-python-sdk
+          fi


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Created a workflow that calls the GitHub RESTAPI to list out the alerts in the repository, checks if any exist, and sends either a value of 1 or 0 depending on if any are found or not.

*Testing done:*
Tested in my fork and it successfully sends the metrics according to if there are security vuln or not.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
