### PR TITLE
Fix: Remove duplicate `batch_data_capture_config` docstring

### DIFF
--- a/src/sagemaker/transformer.py
+++ b/src/sagemaker/transformer.py
@@ -231,9 +231,6 @@ class Transformer(object):
             batch_data_capture_config (BatchDataCaptureConfig): Configuration object which
                 specifies the configurations related to the batch data capture for the transform job
                 (default: ``None``).
-            batch_data_capture_config (BatchDataCaptureConfig): Configuration object which
-                specifies the configurations related to the batch data capture for the transform job
-                (default: ``None``).
             wait (bool): Whether the call should wait until the job completes
                 (default: ``True``).
             logs (bool): Whether to show the logs produced by the job.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Remove duplicate definition from `Transformer` docstring and fix docs:

![image](https://github.com/user-attachments/assets/fa3ae295-30a5-432e-ab5b-f4be3941dbbf)

*Testing done:*

Documentation only

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
