### PR TITLE
fix: trn1 instance family does not support volume size

### DIFF
--- a/src/sagemaker/utils.py
+++ b/src/sagemaker/utils.py
@@ -1462,6 +1462,7 @@ def volume_size_supported(instance_type: str) -> bool:
             and not family.startswith("g5")
             and not family.startswith("g6")
             and not family.startswith("p5")
+            and not family.startswith("trn1")
         )
     except Exception as e:
         raise ValueError(f"Failed to parse instance type '{instance_type}': {str(e)}")

--- a/src/sagemaker/utils.py
+++ b/src/sagemaker/utils.py
@@ -1457,12 +1457,11 @@ def volume_size_supported(instance_type: str) -> bool:
         # Any instance type with a "d" in the instance family (i.e. c5d, p4d, etc)
         # + g5 or g6 or p5 does not support attaching an EBS volume.
         family = parts[0]
-        return (
-            "d" not in family
-            and not family.startswith("g5")
-            and not family.startswith("g6")
-            and not family.startswith("p5")
-            and not family.startswith("trn1")
+
+        unsupported_families = ["g5", "g6", "p5", "trn1"]
+
+        return "d" not in family and not any(
+            family.startswith(prefix) for prefix in unsupported_families
         )
     except Exception as e:
         raise ValueError(f"Failed to parse instance type '{instance_type}': {str(e)}")

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1815,6 +1815,8 @@ class TestVolumeSizeSupported(TestCase):
             "local",
             "local_gpu",
             ParameterString(name="InstanceType", default_value="ml.m4.xlarge"),
+            "ml.trn1.32xlarge",
+            "ml.trn1n.32xlarge",
         ]
 
         for instance in instances_that_dont_support_volume_size:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When a `trn1` instance family is used, the PySDK would automatically use volume size argument when creating the endpoint config. However, this instance family does not support attaching an ebs volume, hence volume size argument throws a service exception. This PR updates the `volume_size_supported` function to correctly identify `trn1` instance types as not supporting volume size. 

*Testing done:*
Unit tests added. 

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
