### PR TITLE
fix: alt configs model deployment and training issues

### DIFF
--- a/src/sagemaker/jumpstart/artifacts/metric_definitions.py
+++ b/src/sagemaker/jumpstart/artifacts/metric_definitions.py
@@ -96,16 +96,17 @@ def _retrieve_default_training_metric_definitions(
         else []
     )
 
-    instance_specific_metric_name: str
-    for instance_specific_metric_definition in instance_specific_metric_definitions:
-        instance_specific_metric_name = instance_specific_metric_definition["Name"]
-        default_metric_definitions = list(
-            filter(
-                lambda metric_definition: metric_definition["Name"]
-                != instance_specific_metric_name,
-                default_metric_definitions,
+    if instance_specific_metric_definitions:
+        instance_specific_metric_name: str
+        for instance_specific_metric_definition in instance_specific_metric_definitions:
+            instance_specific_metric_name = instance_specific_metric_definition["Name"]
+            default_metric_definitions = list(
+                filter(
+                    lambda metric_definition: metric_definition["Name"]
+                    != instance_specific_metric_name,
+                    default_metric_definitions,
+                )
             )
-        )
-        default_metric_definitions.append(instance_specific_metric_definition)
+            default_metric_definitions.append(instance_specific_metric_definition)
 
     return default_metric_definitions

--- a/src/sagemaker/jumpstart/factory/model.py
+++ b/src/sagemaker/jumpstart/factory/model.py
@@ -259,6 +259,7 @@ def _add_instance_type_to_kwargs(
         sagemaker_session=kwargs.sagemaker_session,
         model_type=kwargs.model_type,
         config_name=kwargs.config_name,
+        hub_arn=kwargs.hub_arn,
     )
 
     if specs.inference_configs and kwargs.config_name not in specs.inference_configs.configs:
@@ -780,6 +781,7 @@ def _add_config_name_to_deploy_kwargs(
             sagemaker_session=temp_session,
             model_type=kwargs.model_type,
             config_name=kwargs.config_name,
+            hub_arn=kwargs.hub_arn,
         )
         default_config_name = _select_inference_config_from_training_config(
             specs=specs, training_config_name=training_config_name

--- a/src/sagemaker/jumpstart/hub/parser_utils.py
+++ b/src/sagemaker/jumpstart/hub/parser_utils.py
@@ -14,12 +14,15 @@
 from __future__ import absolute_import
 
 import re
-from typing import Any, Dict
+from typing import Any, Dict, List, Optional
 
 
 def camel_to_snake(camel_case_string: str) -> str:
     """Converts camelCaseString or UpperCamelCaseString to snake_case_string."""
     snake_case_string = re.sub("(.)([A-Z][a-z]+)", r"\1_\2", camel_case_string)
+    if "-" in snake_case_string:
+        #remove any hyphen from the string for accurate conversion.
+        snake_case_string = snake_case_string.replace("-", "")
     return re.sub("([a-z0-9])([A-Z])", r"\1_\2", snake_case_string).lower()
 
 
@@ -29,20 +32,28 @@ def snake_to_upper_camel(snake_case_string: str) -> str:
     return upper_camel_case_string
 
 
-def walk_and_apply_json(json_obj: Dict[Any, Any], apply) -> Dict[Any, Any]:
-    """Recursively walks a json object and applies a given function to the keys."""
+def walk_and_apply_json(
+    json_obj: Dict[Any, Any], apply, stop_keys: Optional[List[str]] = ["metrics"]
+) -> Dict[Any, Any]:
+    """Recursively walks a json object and applies a given function to the keys.
+    stop_keys (Optional[list[str]]): List of field keys that should stop the application function.
+        Any children of these keys will not have the application function applied to them.
+    """
 
     def _walk_and_apply_json(json_obj, new):
         if isinstance(json_obj, dict) and isinstance(new, dict):
             for key, value in json_obj.items():
-                new_key = apply(key)
-                if isinstance(value, dict):
-                    new[new_key] = {}
-                    _walk_and_apply_json(value, new=new[new_key])
-                elif isinstance(value, list):
-                    new[new_key] = []
-                    for item in value:
-                        _walk_and_apply_json(item, new=new[new_key])
+                new_key = apply(key)           
+                if (stop_keys and new_key not in stop_keys) or stop_keys is None:
+                    if isinstance(value, dict):
+                        new[new_key] = {}
+                        _walk_and_apply_json(value, new=new[new_key])
+                    elif isinstance(value, list):
+                        new[new_key] = []
+                        for item in value:
+                            _walk_and_apply_json(item, new=new[new_key])
+                    else:
+                        new[new_key] = value
                 else:
                     new[new_key] = value
         elif isinstance(json_obj, dict) and isinstance(new, list):
@@ -50,6 +61,8 @@ def walk_and_apply_json(json_obj: Dict[Any, Any], apply) -> Dict[Any, Any]:
         elif isinstance(json_obj, list) and isinstance(new, dict):
             new.update(json_obj)
         elif isinstance(json_obj, list) and isinstance(new, list):
+            new.append(json_obj)
+        elif isinstance(json_obj, str) and isinstance(new, list):
             new.append(json_obj)
         return new
 

--- a/src/sagemaker/jumpstart/hub/parser_utils.py
+++ b/src/sagemaker/jumpstart/hub/parser_utils.py
@@ -36,6 +36,7 @@ def walk_and_apply_json(
     json_obj: Dict[Any, Any], apply, stop_keys: Optional[List[str]] = ["metrics"]
 ) -> Dict[Any, Any]:
     """Recursively walks a json object and applies a given function to the keys.
+
     stop_keys (Optional[list[str]]): List of field keys that should stop the application function.
         Any children of these keys will not have the application function applied to them.
     """

--- a/src/sagemaker/jumpstart/hub/parser_utils.py
+++ b/src/sagemaker/jumpstart/hub/parser_utils.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+# pylint: skip-file
 """This module contains utilities related to SageMaker JumpStart Hub."""
 from __future__ import absolute_import
 

--- a/src/sagemaker/jumpstart/hub/parser_utils.py
+++ b/src/sagemaker/jumpstart/hub/parser_utils.py
@@ -21,7 +21,7 @@ def camel_to_snake(camel_case_string: str) -> str:
     """Converts camelCaseString or UpperCamelCaseString to snake_case_string."""
     snake_case_string = re.sub("(.)([A-Z][a-z]+)", r"\1_\2", camel_case_string)
     if "-" in snake_case_string:
-        #remove any hyphen from the string for accurate conversion.
+        # remove any hyphen from the string for accurate conversion.
         snake_case_string = snake_case_string.replace("-", "")
     return re.sub("([a-z0-9])([A-Z])", r"\1_\2", snake_case_string).lower()
 
@@ -43,7 +43,7 @@ def walk_and_apply_json(
     def _walk_and_apply_json(json_obj, new):
         if isinstance(json_obj, dict) and isinstance(new, dict):
             for key, value in json_obj.items():
-                new_key = apply(key)           
+                new_key = apply(key)
                 if (stop_keys and new_key not in stop_keys) or stop_keys is None:
                     if isinstance(value, dict):
                         new[new_key] = {}

--- a/src/sagemaker/jumpstart/types.py
+++ b/src/sagemaker/jumpstart/types.py
@@ -1278,7 +1278,7 @@ class JumpStartMetadataBaseFields(JumpStartDataHolderType):
             json_obj (Dict[str, Any]): Dictionary representation of spec.
         """
         if self._is_hub_content:
-            json_obj = walk_and_apply_json(json_obj, camel_to_snake, ["metrics"])
+            json_obj = walk_and_apply_json(json_obj, camel_to_snake)
         self.model_id: str = json_obj.get("model_id")
         self.url: str = json_obj.get("url")
         self.version: str = json_obj.get("version")

--- a/src/sagemaker/jumpstart/types.py
+++ b/src/sagemaker/jumpstart/types.py
@@ -1174,7 +1174,7 @@ class JumpStartConfigRanking(JumpStartDataHolderType):
             spec (Dict[str, Any]): Dictionary representation of training config ranking.
         """
         if is_hub_content:
-            spec = {camel_to_snake(key): val for key, val in spec.items()}
+            spec = walk_and_apply_json(spec, camel_to_snake)
         self.from_json(spec)
 
     def from_json(self, json_obj: Dict[str, Any]) -> None:
@@ -1277,6 +1277,8 @@ class JumpStartMetadataBaseFields(JumpStartDataHolderType):
         Args:
             json_obj (Dict[str, Any]): Dictionary representation of spec.
         """
+        if self._is_hub_content:
+            json_obj = walk_and_apply_json(json_obj, camel_to_snake, ["metrics"])
         self.model_id: str = json_obj.get("model_id")
         self.url: str = json_obj.get("url")
         self.version: str = json_obj.get("version")
@@ -1398,7 +1400,7 @@ class JumpStartMetadataBaseFields(JumpStartDataHolderType):
 
         if self.training_supported:
             if self._is_hub_content:
-                self.training_ecr_uri: Optional[str] = json_obj["training_ecr_uri"]
+                self.training_ecr_uri: Optional[str] = json_obj.get("training_ecr_uri")
                 self._non_serializable_slots.append("training_ecr_specs")
             else:
                 self.training_ecr_specs: Optional[JumpStartECRSpecs] = (

--- a/src/sagemaker/jumpstart/types.py
+++ b/src/sagemaker/jumpstart/types.py
@@ -1277,8 +1277,6 @@ class JumpStartMetadataBaseFields(JumpStartDataHolderType):
         Args:
             json_obj (Dict[str, Any]): Dictionary representation of spec.
         """
-        if self._is_hub_content:
-            json_obj = walk_and_apply_json(json_obj, camel_to_snake)
         self.model_id: str = json_obj.get("model_id")
         self.url: str = json_obj.get("url")
         self.version: str = json_obj.get("version")

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -33,6 +33,7 @@ from sagemaker.config.config_schema import (
 
 from sagemaker.jumpstart import constants, enums
 from sagemaker.jumpstart import accessors
+from sagemaker.jumpstart.hub.parser_utils import camel_to_snake, snake_to_upper_camel
 from sagemaker.s3 import parse_s3_url
 from sagemaker.jumpstart.exceptions import (
     DeprecatedJumpStartModelError,
@@ -1103,6 +1104,12 @@ def get_jumpstart_configs(
             metadata_configs.config_rankings.get("overall").rankings if metadata_configs else []
         )
 
+    if hub_arn:
+        return (
+        {config_name: metadata_configs.configs[camel_to_snake(snake_to_upper_camel(config_name))] for config_name in config_names}
+        if metadata_configs
+        else {}
+    )
     return (
         {config_name: metadata_configs.configs[config_name] for config_name in config_names}
         if metadata_configs

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -1106,10 +1106,15 @@ def get_jumpstart_configs(
 
     if hub_arn:
         return (
-        {config_name: metadata_configs.configs[camel_to_snake(snake_to_upper_camel(config_name))] for config_name in config_names}
-        if metadata_configs
-        else {}
-    )
+            {
+                config_name: metadata_configs.configs[
+                    camel_to_snake(snake_to_upper_camel(config_name))
+                ]
+                for config_name in config_names
+            }
+            if metadata_configs
+            else {}
+        )
     return (
         {config_name: metadata_configs.configs[config_name] for config_name in config_names}
         if metadata_configs

--- a/tests/unit/sagemaker/jumpstart/hub/test_utils.py
+++ b/tests/unit/sagemaker/jumpstart/hub/test_utils.py
@@ -15,7 +15,7 @@ from __future__ import absolute_import
 from unittest.mock import patch, Mock
 from sagemaker.jumpstart.types import HubArnExtractedInfo
 from sagemaker.jumpstart.constants import JUMPSTART_DEFAULT_REGION_NAME
-from sagemaker.jumpstart.hub import utils
+from sagemaker.jumpstart.hub import parser_utils, utils
 
 
 def test_get_info_from_hub_resource_arn():
@@ -254,3 +254,52 @@ def test_get_hub_model_version_wildcard_char(mock_session):
     )
 
     assert result == "2.0.0"
+
+
+def test_walk_and_apply_json():
+    test_json = {
+        "CamelCaseKey": "value",
+        "CamelCaseObjectKey": {
+            "CamelCaseObjectChildOne": "value1",
+            "CamelCaseObjectChildTwo": "value2",
+        },
+        "IgnoreMyChildren": {"ShouldNotBeTouchedOne": "const1", "ShouldNotBeTouchedTwo": "const2"},
+        "ShouldNotIgnoreMyChildren": {"NopeNope": "no"},
+    }
+
+    result = parser_utils.walk_and_apply_json(
+        test_json, parser_utils.camel_to_snake, ["ignore_my_children"]
+    )
+    assert result == {
+        "camel_case_key": "value",
+        "camel_case_object_key": {
+            "camel_case_object_child_one": "value1",
+            "camel_case_object_child_two": "value2",
+        },
+        "ignore_my_children": {
+            "ShouldNotBeTouchedOne": "const1",
+            "ShouldNotBeTouchedTwo": "const2",
+        },
+        "should_not_ignore_my_children": {"nope_nope": "no"},
+    }
+
+
+def test_walk_and_apply_json_no_stop():
+    test_json = {
+        "CamelCaseKey": "value",
+        "CamelCaseObjectKey": {
+            "CamelCaseObjectChildOne": "value1",
+            "CamelCaseObjectChildTwo": "value2",
+        },
+        "CamelCaseObjectListKey": {"instance.ml.type.xlarge": [{"ShouldChangeMe": "string"}]},
+    }
+
+    result = parser_utils.walk_and_apply_json(test_json, parser_utils.camel_to_snake)
+    assert result == {
+        "camel_case_key": "value",
+        "camel_case_object_key": {
+            "camel_case_object_child_one": "value1",
+            "camel_case_object_child_two": "value2",
+        },
+        "camel_case_object_list_key": {"instance.ml.type.xlarge": [{"should_change_me": "string"}]},
+    }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Model Deployment and training failed for curatedHub customers last week for models with alt configs. 
- Reverting back on this commit fixed the issue locally so investigated this commit for fixing the issue https://github.com/aws/sagemaker-python-sdk/commit/ba7e6a9b3fa6d3b8f9c104d024acec518605e96d

*Testing done:*
- Notebook testing
- Unit tests

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
