### PR TITLE
support latest container version in image_uris and DJLModel for lmi c…

### DIFF
--- a/src/sagemaker/djl_inference/model.py
+++ b/src/sagemaker/djl_inference/model.py
@@ -43,7 +43,7 @@ class DJLModel(Model):
         self,
         model_id: Optional[str] = None,
         engine: Optional[str] = None,
-        djl_version: str = "0.28.0",
+        djl_version: str = "latest",
         djl_framework: Optional[str] = None,
         task: Optional[str] = None,
         dtype: Optional[str] = None,

--- a/src/sagemaker/image_uri_config/djl-lmi.json
+++ b/src/sagemaker/image_uri_config/djl-lmi.json
@@ -2,6 +2,9 @@
     "scope": [
         "inference"
     ],
+    "version_aliases": {
+        "latest": "0.29.0"
+    },
     "versions": {
         "0.29.0": {
             "registries": {

--- a/src/sagemaker/image_uri_config/djl-neuronx.json
+++ b/src/sagemaker/image_uri_config/djl-neuronx.json
@@ -2,6 +2,9 @@
     "scope": [
         "inference"
     ],
+    "version_aliases": {
+        "latest": "0.29.0"
+    },
     "versions": {
         "0.29.0": {
             "registries": {

--- a/src/sagemaker/image_uri_config/djl-tensorrtllm.json
+++ b/src/sagemaker/image_uri_config/djl-tensorrtllm.json
@@ -2,6 +2,9 @@
     "scope": [
         "inference"
     ],
+    "version_aliases": {
+        "latest": "0.29.0"
+    },
     "versions": {
         "0.29.0": {
             "registries": {

--- a/tests/unit/sagemaker/image_uris/test_djl.py
+++ b/tests/unit/sagemaker/image_uris/test_djl.py
@@ -18,12 +18,7 @@ from tests.unit.sagemaker.image_uris import expected_uris
 
 @pytest.mark.parametrize(
     "load_config_and_file_name",
-    [
-        "djl-neuronx.json",
-        "djl-fastertransformer.json",
-        "djl-deepspeed.json",
-        "djl-tensorrtllm.json",
-    ],
+    ["djl-neuronx.json", "djl-tensorrtllm.json", "djl-lmi.json"],
     indirect=True,
 )
 def test_djl_uris(load_config_and_file_name):

--- a/tests/unit/test_djl_inference.py
+++ b/tests/unit/test_djl_inference.py
@@ -26,7 +26,7 @@ VALID_COMPRESSED_MODEL_DATA = "s3://mybucket/model.tar.gz"
 HF_MODEL_ID = "hf_hub_model_id"
 ROLE = "dummy_role"
 REGION = "us-west-2"
-VERSION = "0.28.0"
+VERSION = "latest"
 
 LMI_IMAGE_URI = image_uris.retrieve(framework="djl-lmi", version=VERSION, region=REGION)
 TRT_IMAGE_URI = image_uris.retrieve(framework="djl-tensorrtllm", version=VERSION, region=REGION)


### PR DESCRIPTION
…ontainers

*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
