### PR TITLE
fix: pin tf version in tests [DO-NOT-MERGE]

### DIFF
--- a/tests/data/tensorflow_mnist/mnist_v2.py
+++ b/tests/data/tensorflow_mnist/mnist_v2.py
@@ -198,7 +198,7 @@ def main(args):
 
         if args.current_host == args.hosts[0]:
             ckpt_manager.save()
-            net.save("/opt/ml/model/1.keras")
+            net.save("/opt/ml/model/1")
 
 
 if __name__ == "__main__":

--- a/tests/integ/test_tf.py
+++ b/tests/integ/test_tf.py
@@ -278,7 +278,7 @@ def _create_and_fit_estimator(sagemaker_session, tf_version, py_version, instanc
         instance_count=2,
         instance_type=instance_type,
         sagemaker_session=sagemaker_session,
-        framework_version=tf_version,
+        framework_version="2.14",
         py_version=py_version,
         distribution=PARAMETER_SERVER_DISTRIBUTION,
         disable_profiler=True,

--- a/tests/integ/test_tuner.py
+++ b/tests/integ/test_tuner.py
@@ -701,7 +701,7 @@ def test_tuning_tf(
         instance_count=1,
         instance_type=cpu_instance_type,
         sagemaker_session=sagemaker_session,
-        framework_version=tensorflow_training_latest_version,
+        framework_version="2.14",
         py_version=tensorflow_training_latest_py_version,
     )
 
@@ -749,7 +749,7 @@ def test_tuning_tf_vpc_multi(
         entry_point=script_path,
         source_dir=resource_path,
         role="SageMakerRole",
-        framework_version=tensorflow_training_latest_version,
+        framework_version="2.14",
         py_version=tensorflow_training_latest_py_version,
         instance_count=instance_count,
         instance_type=instance_type,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
