### PR TITLE
fix: disable failing integration tests

### DIFF
--- a/tests/data/tensorflow_mnist/mnist_v2.py
+++ b/tests/data/tensorflow_mnist/mnist_v2.py
@@ -198,7 +198,7 @@ def main(args):
 
         if args.current_host == args.hosts[0]:
             ckpt_manager.save()
-            net.save("/opt/ml/model/1.keras")
+            net.save("/opt/ml/model/1")
 
 
 if __name__ == "__main__":

--- a/tests/integ/test_tf.py
+++ b/tests/integ/test_tf.py
@@ -86,8 +86,10 @@ def test_mnist_with_checkpoint_config(
     tensorflow_training_latest_py_version,
 ):
     if Version(tensorflow_training_latest_version) >= Version("2.16"):
-        pytest.skip("This test is failing in TensorFlow 2.16 beacuse of an upstream bug: "
-                    "https://github.com/tensorflow/io/issues/2039")
+        pytest.skip(
+            "This test is failing in TensorFlow 2.16 beacuse of an upstream bug: "
+            "https://github.com/tensorflow/io/issues/2039"
+        )
     checkpoint_s3_uri = "s3://{}/checkpoints/tf-{}".format(
         sagemaker_session.default_bucket(), sagemaker_timestamp()
     )
@@ -239,8 +241,10 @@ def test_mnist_distributed_cpu(
     tensorflow_training_latest_py_version,
 ):
     if Version(tensorflow_training_latest_version) >= Version("2.16"):
-        pytest.skip("This test is failing in TensorFlow 2.16 beacuse of an upstream bug: "
-                    "https://github.com/tensorflow/io/issues/2039")
+        pytest.skip(
+            "This test is failing in TensorFlow 2.16 beacuse of an upstream bug: "
+            "https://github.com/tensorflow/io/issues/2039"
+        )
     _create_and_fit_estimator(
         sagemaker_session,
         tensorflow_training_latest_version,

--- a/tests/integ/test_tf.py
+++ b/tests/integ/test_tf.py
@@ -85,6 +85,9 @@ def test_mnist_with_checkpoint_config(
     tensorflow_training_latest_version,
     tensorflow_training_latest_py_version,
 ):
+    if Version(tensorflow_training_latest_version) >= Version("2.16"):
+        pytest.skip("This test is failing in TensorFlow 2.16 beacuse of an upstream bug: "
+                    "https://github.com/tensorflow/io/issues/2039")
     checkpoint_s3_uri = "s3://{}/checkpoints/tf-{}".format(
         sagemaker_session.default_bucket(), sagemaker_timestamp()
     )
@@ -235,6 +238,9 @@ def test_mnist_distributed_cpu(
     tensorflow_training_latest_version,
     tensorflow_training_latest_py_version,
 ):
+    if Version(tensorflow_training_latest_version) >= Version("2.16"):
+        pytest.skip("This test is failing in TensorFlow 2.16 beacuse of an upstream bug: "
+                    "https://github.com/tensorflow/io/issues/2039")
     _create_and_fit_estimator(
         sagemaker_session,
         tensorflow_training_latest_version,

--- a/tests/integ/test_tuner.py
+++ b/tests/integ/test_tuner.py
@@ -693,8 +693,10 @@ def test_tuning_tf(
     tensorflow_training_latest_py_version,
 ):
     if Version(tensorflow_training_latest_version) >= Version("2.16"):
-        pytest.skip("This test is failing in TensorFlow 2.16 beacuse of an upstream bug: "
-                    "https://github.com/tensorflow/io/issues/2039")
+        pytest.skip(
+            "This test is failing in TensorFlow 2.16 beacuse of an upstream bug: "
+            "https://github.com/tensorflow/io/issues/2039"
+        )
     resource_path = os.path.join(DATA_DIR, "tensorflow_mnist")
     script_path = "mnist.py"
 

--- a/tests/integ/test_tuner.py
+++ b/tests/integ/test_tuner.py
@@ -12,7 +12,6 @@
 # language governing permissions and limitations under the License.
 from __future__ import absolute_import
 
-from distutils.version import Version
 import json
 import os
 import time
@@ -20,6 +19,7 @@ import time
 import numpy as np
 import pytest
 from botocore.exceptions import ClientError
+from packaging.version import Version
 
 import tests.integ
 from sagemaker import KMeans, LDA, RandomCutForest, image_uris
@@ -741,6 +741,11 @@ def test_tuning_tf_vpc_multi(
     tensorflow_training_latest_py_version,
 ):
     """Test Tensorflow multi-instance using the same VpcConfig for training and inference"""
+    if Version(tensorflow_training_latest_version) >= Version("2.16"):
+        pytest.skip(
+            "This test is failing in TensorFlow 2.16 beacuse of an upstream bug: "
+            "https://github.com/tensorflow/io/issues/2039"
+        )
     instance_type = cpu_instance_type
     instance_count = 2
 

--- a/tests/integ/test_tuner.py
+++ b/tests/integ/test_tuner.py
@@ -12,6 +12,7 @@
 # language governing permissions and limitations under the License.
 from __future__ import absolute_import
 
+from distutils.version import Version
 import json
 import os
 import time
@@ -691,6 +692,9 @@ def test_tuning_tf(
     tensorflow_training_latest_version,
     tensorflow_training_latest_py_version,
 ):
+    if Version(tensorflow_training_latest_version) >= Version("2.16"):
+        pytest.skip("This test is failing in TensorFlow 2.16 beacuse of an upstream bug: "
+                    "https://github.com/tensorflow/io/issues/2039")
     resource_path = os.path.join(DATA_DIR, "tensorflow_mnist")
     script_path = "mnist.py"
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Some integration tests are failing because of an upstream bug from Tensorflow 2.16: https://github.com/tensorflow/io/issues/2039. Skipping these tests to fix CI.
*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
