### PR TITLE
Allow attrs v24 package dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
 ]
 dependencies = [
-  "attrs>=23.1.0,<24",
+  "attrs>=23.1.0,<25",
   "boto3>=1.34.142,<2.0",
   "cloudpickle==2.2.1",
   "docker",

--- a/requirements/extras/test_requirements.txt
+++ b/requirements/extras/test_requirements.txt
@@ -15,7 +15,7 @@ stopit==1.1.2
 # Update tox.ini to have correct version of airflow constraints file
 apache-airflow==2.9.3
 apache-airflow-providers-amazon==7.2.1
-attrs>=23.1.0,<24
+attrs>=23.1.0,<25
 fabric==2.6.0
 requests==2.32.2
 sagemaker-experiments==0.1.35

--- a/src/sagemaker/serve/utils/conda_in_process.yml
+++ b/src/sagemaker/serve/utils/conda_in_process.yml
@@ -8,7 +8,7 @@ dependencies:
     - fastapi>=0.111.0
     - nest-asyncio
     - pip>=23.0.1
-    - attrs>=23.1.0,<24
+    - attrs>=23.1.0,<25
     - boto3>=1.34.142,<2.0
     - cloudpickle==2.2.1
     - google-pasta

--- a/tests/unit/sagemaker/serve/detector/test_dependency_manager.py
+++ b/tests/unit/sagemaker/serve/detector/test_dependency_manager.py
@@ -26,7 +26,7 @@ DEPENDENCY_LIST = [
     "matplotlib<3.5.0",
     "scikit-learn>0.24.1",
     "Django!=4.0.0",
-    "attrs>=23.1.0,<24",
+    "attrs>=23.1.0,<25",
     "torch@https://download.pytorch.org/whl/cpu/torch-2.0.0%2Bcpu-cp310-cp310-linux_x86_64.whl",
     "# some comment",
     "boto3==1.26.*",
@@ -39,7 +39,7 @@ EXPECTED_DEPENDENCY_MAP = {
     "matplotlib": "<3.5.0",
     "scikit-learn": ">0.24.1",
     "Django": "!=4.0.0",
-    "attrs": ">=23.1.0,<24",
+    "attrs": ">=23.1.0,<25",
     "torch": "@https://download.pytorch.org/whl/cpu/torch-2.0.0%2Bcpu-cp310-cp310-linux_x86_64.whl",
     "boto3": "==1.26.*",
 }


### PR DESCRIPTION
[Airflow 2.10](https://raw.githubusercontent.com/apache/airflow/constraints-2.10.0/constraints-3.10.txt) uses `attrs==24.2.0` but Sagemaker requires `<24`.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
