### PR TITLE
fix: cross account private hub model fine-tuning

### DIFF
--- a/src/sagemaker/jumpstart/cache.py
+++ b/src/sagemaker/jumpstart/cache.py
@@ -462,19 +462,24 @@ class JumpStartModelsCache:
             HubContentType.MODEL_REFERENCE,
         }:
 
-            hub_arn_extracted_info = hub_utils.get_info_from_hub_resource_arn(id_info)
+            hub_resource_arn_extracted_info = hub_utils.get_info_from_hub_resource_arn(id_info)
+            hub_arn = hub_utils.construct_hub_arn_from_name(
+                hub_name=hub_resource_arn_extracted_info.hub_name,
+                region=hub_resource_arn_extracted_info.region,
+                account_id=hub_resource_arn_extracted_info.account_id,
+            )
 
             model_version: str = hub_utils.get_hub_model_version(
-                hub_model_name=hub_arn_extracted_info.hub_content_name,
+                hub_model_name=hub_resource_arn_extracted_info.hub_content_name,
                 hub_model_type=data_type.value,
-                hub_name=hub_arn_extracted_info.hub_name,
+                hub_name=hub_arn,
                 sagemaker_session=self._sagemaker_session,
-                hub_model_version=hub_arn_extracted_info.hub_content_version,
+                hub_model_version=hub_resource_arn_extracted_info.hub_content_version,
             )
 
             hub_model_description: Dict[str, Any] = self._sagemaker_session.describe_hub_content(
-                hub_name=hub_arn_extracted_info.hub_name,
-                hub_content_name=hub_arn_extracted_info.hub_content_name,
+                hub_name=hub_arn,
+                hub_content_name=hub_resource_arn_extracted_info.hub_content_name,
                 hub_content_version=model_version,
                 hub_content_type=data_type.value,
             )

--- a/src/sagemaker/jumpstart/hub/utils.py
+++ b/src/sagemaker/jumpstart/hub/utils.py
@@ -67,10 +67,11 @@ def construct_hub_arn_from_name(
     hub_name: str,
     region: Optional[str] = None,
     session: Optional[Session] = constants.DEFAULT_JUMPSTART_SAGEMAKER_SESSION,
+    account_id: Optional[str] = None,
 ) -> str:
     """Constructs a Hub arn from the Hub name using default Session values."""
 
-    account_id = session.account_id()
+    account_id = account_id or session.account_id()
     region = region or session.boto_region_name
     partition = aws_partition(region)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Fixing Cross Account private hub model fine-tuning 

*Testing done:*
- Current Unit tests/ integ tests
- Notebook tests: PrivateHub Model Deployment and Training, PrivateHub Cross account model deployment and training

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
