### PR TITLE
chore: add HF LLM neuronx 0.0.24 image

### DIFF
--- a/src/sagemaker/image_uri_config/huggingface-llm-neuronx.json
+++ b/src/sagemaker/image_uri_config/huggingface-llm-neuronx.json
@@ -4,7 +4,7 @@
             "inf2"
         ],
         "version_aliases": {
-            "0.0": "0.0.23"
+            "0.0": "0.0.24"
         },
         "versions": {
             "0.0.16": {
@@ -234,6 +234,35 @@
                     "ca-west-1": "204538143572"
                 },
                 "tag_prefix": "2.1.2-optimum0.0.23",
+                "repository": "huggingface-pytorch-tgi-inference",
+                "container_version": {
+                    "inf2": "ubuntu22.04"
+                }
+            },
+            "0.0.24": {
+                "py_versions": [
+                    "py310"
+                ],
+                "registries": {
+                    "ap-northeast-1": "763104351884",
+                    "ap-south-1": "763104351884",
+                    "ap-south-2": "772153158452",
+                    "ap-southeast-1": "763104351884",
+                    "ap-southeast-2": "763104351884",
+                    "ap-southeast-4": "457447274322",
+                    "eu-central-1": "763104351884",
+                    "eu-central-2": "380420809688",
+                    "eu-south-2": "503227376785",
+                    "eu-west-1": "763104351884",
+                    "eu-west-3": "763104351884",
+                    "il-central-1": "780543022126",
+                    "sa-east-1": "763104351884",
+                    "us-east-1": "763104351884",
+                    "us-east-2": "763104351884",
+                    "us-west-2": "763104351884",
+                    "ca-west-1": "204538143572"
+                },
+                "tag_prefix": "2.1.2-optimum0.0.24",
                 "repository": "huggingface-pytorch-tgi-inference",
                 "container_version": {
                     "inf2": "ubuntu22.04"

--- a/tests/unit/sagemaker/image_uris/test_huggingface_llm.py
+++ b/tests/unit/sagemaker/image_uris/test_huggingface_llm.py
@@ -55,6 +55,7 @@ HF_VERSIONS_MAPPING = {
         "0.0.21": "1.13.1-optimum0.0.21-neuronx-py310-ubuntu22.04",
         "0.0.22": "2.1.2-optimum0.0.22-neuronx-py310-ubuntu22.04",
         "0.0.23": "2.1.2-optimum0.0.23-neuronx-py310-ubuntu22.04",
+        "0.0.24": "2.1.2-optimum0.0.24-neuronx-py310-ubuntu22.04",
     },
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add the new HF Neuronx 0.0.24 image to image uri configuration.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
