### PR TITLE
fix: pass name from modelbuilder constructor to created model

### DIFF
--- a/src/sagemaker/serve/builder/djl_builder.py
+++ b/src/sagemaker/serve/builder/djl_builder.py
@@ -92,6 +92,7 @@ class DJL(ABC):
         self.nb_instance_type = None
         self.ram_usage_model_load = None
         self.role_arn = None
+        self.name = None
 
     @abstractmethod
     def _prepare_for_mode(self):
@@ -130,6 +131,7 @@ class DJL(ABC):
             huggingface_hub_token=self.env_vars.get("HF_TOKEN"),
             image_config=self.image_config,
             vpc_config=self.vpc_config,
+            name=self.name,
         )
 
         if not self.image_uri:

--- a/src/sagemaker/serve/builder/jumpstart_builder.py
+++ b/src/sagemaker/serve/builder/jumpstart_builder.py
@@ -121,6 +121,7 @@ class JumpStart(ABC):
         self.is_compiled = False
         self.is_quantized = False
         self.speculative_decoding_draft_model_source = None
+        self.name = None
 
     @abstractmethod
     def _prepare_for_mode(self, **kwargs):
@@ -147,7 +148,10 @@ class JumpStart(ABC):
     def _create_pre_trained_js_model(self) -> Type[Model]:
         """Placeholder docstring"""
         pysdk_model = JumpStartModel(
-            self.model, vpc_config=self.vpc_config, sagemaker_session=self.sagemaker_session
+            self.model,
+            vpc_config=self.vpc_config,
+            sagemaker_session=self.sagemaker_session,
+            name=self.name,
         )
 
         self._original_deploy = pysdk_model.deploy

--- a/src/sagemaker/serve/builder/model_builder.py
+++ b/src/sagemaker/serve/builder/model_builder.py
@@ -492,6 +492,7 @@ class ModelBuilder(Triton, DJL, JumpStart, TGI, Transformers, TensorflowServing,
             env=self.env_vars,
             sagemaker_session=self.sagemaker_session,
             predictor_cls=self._get_predictor,
+            name=self.name,
         )
 
         # store the modes in the model so that we may

--- a/src/sagemaker/serve/builder/tei_builder.py
+++ b/src/sagemaker/serve/builder/tei_builder.py
@@ -65,6 +65,7 @@ class TEI(ABC):
         self.ram_usage_model_load = None
         self.secret_key = None
         self.role_arn = None
+        self.name = None
 
     @abstractmethod
     def _prepare_for_mode(self, *args, **kwargs):
@@ -105,6 +106,7 @@ class TEI(ABC):
             env=self.env_vars,
             role=self.role_arn,
             sagemaker_session=self.sagemaker_session,
+            name=self.name,
         )
 
         logger.info("Detected %s. Proceeding with the the deployment.", self.image_uri)

--- a/src/sagemaker/serve/builder/tf_serving_builder.py
+++ b/src/sagemaker/serve/builder/tf_serving_builder.py
@@ -51,6 +51,7 @@ class TensorflowServing(ABC):
         self.pysdk_model = None
         self.schema_builder = None
         self.env_vars = None
+        self.name = None
 
     @abstractmethod
     def _prepare_for_mode(self):
@@ -97,6 +98,7 @@ class TensorflowServing(ABC):
             env=self.env_vars,
             sagemaker_session=self.sagemaker_session,
             predictor_cls=self._get_tensorflow_predictor,
+            name=self.name,
         )
 
         self.pysdk_model.mode = self.mode

--- a/src/sagemaker/serve/builder/tgi_builder.py
+++ b/src/sagemaker/serve/builder/tgi_builder.py
@@ -92,6 +92,7 @@ class TGI(ABC):
         self.ram_usage_model_load = None
         self.secret_key = None
         self.role_arn = None
+        self.name = None
 
     @abstractmethod
     def _prepare_for_mode(self, *args, **kwargs):
@@ -142,6 +143,7 @@ class TGI(ABC):
             env=self.env_vars,
             role=self.role_arn,
             sagemaker_session=self.sagemaker_session,
+            name=self.name,
         )
 
         self._original_deploy = pysdk_model.deploy

--- a/src/sagemaker/serve/builder/transformers_builder.py
+++ b/src/sagemaker/serve/builder/transformers_builder.py
@@ -89,6 +89,7 @@ class Transformers(ABC):
         self.schema_builder = None
         self.inference_spec = None
         self.shared_libs = None
+        self.name = None
 
     @abstractmethod
     def _prepare_for_mode(self, *args, **kwargs):
@@ -105,6 +106,7 @@ class Transformers(ABC):
                 env=self.env_vars,
                 role=self.role_arn,
                 sagemaker_session=self.sagemaker_session,
+                name=self.name,
             )
 
         logger.info("Detected %s. Proceeding with the the deployment.", self.image_uri)

--- a/tests/unit/sagemaker/serve/builder/test_djl_builder.py
+++ b/tests/unit/sagemaker/serve/builder/test_djl_builder.py
@@ -78,6 +78,7 @@ class TestDjlBuilder(unittest.TestCase):
     ):
         builder = ModelBuilder(
             model=mock_model_id,
+            name="mock_model_name",
             schema_builder=mock_schema_builder,
             mode=Mode.LOCAL_CONTAINER,
             model_server=ModelServer.DJL_SERVING,
@@ -89,6 +90,8 @@ class TestDjlBuilder(unittest.TestCase):
         builder._prepare_for_mode.side_effect = None
 
         model = builder.build()
+        assert model.name == "mock_model_name"
+
         builder.serve_settings.telemetry_opt_out = True
 
         assert isinstance(model, DJLModel)

--- a/tests/unit/sagemaker/serve/builder/test_model_builder.py
+++ b/tests/unit/sagemaker/serve/builder/test_model_builder.py
@@ -317,7 +317,7 @@ class TestModelBuilder(unittest.TestCase):
         )
 
         mock_model_obj = Mock()
-        mock_sdk_model.side_effect = lambda image_uri, image_config, vpc_config, model_data, role, env, sagemaker_session, predictor_cls: (  # noqa E501
+        mock_sdk_model.side_effect = lambda image_uri, image_config, vpc_config, model_data, role, env, sagemaker_session, predictor_cls, name: (  # noqa E501
             mock_model_obj
             if image_uri == mock_image_uri
             and image_config == MOCK_IMAGE_CONFIG
@@ -326,6 +326,7 @@ class TestModelBuilder(unittest.TestCase):
             and role == mock_role_arn
             and env == ENV_VARS
             and sagemaker_session == mock_session
+            and "model-name-" in name
             else None
         )
 
@@ -425,13 +426,14 @@ class TestModelBuilder(unittest.TestCase):
         )
 
         mock_model_obj = Mock()
-        mock_sdk_model.side_effect = lambda image_uri, image_config, vpc_config, model_data, role, env, sagemaker_session, predictor_cls: (  # noqa E501
+        mock_sdk_model.side_effect = lambda image_uri, image_config, vpc_config, model_data, role, env, sagemaker_session, predictor_cls, name: (  # noqa E501
             mock_model_obj
             if image_uri == mock_1p_dlc_image_uri
             and model_data == model_data
             and role == mock_role_arn
             and env == ENV_VARS
             and sagemaker_session == mock_session
+            and "model-name-" in name
             else None
         )
 
@@ -532,13 +534,14 @@ class TestModelBuilder(unittest.TestCase):
         )
 
         mock_model_obj = Mock()
-        mock_sdk_model.side_effect = lambda image_uri, image_config, vpc_config, model_data, role, env, sagemaker_session, predictor_cls: (  # noqa E501
+        mock_sdk_model.side_effect = lambda image_uri, image_config, vpc_config, model_data, role, env, sagemaker_session, predictor_cls, name: (  # noqa E501
             mock_model_obj
             if image_uri == mock_image_uri
             and model_data == model_data
             and role == mock_role_arn
             and env == ENV_VARS_INF_SPEC
             and sagemaker_session == mock_session
+            and "model-name-" in name
             else None
         )
 
@@ -633,13 +636,14 @@ class TestModelBuilder(unittest.TestCase):
         )
 
         mock_model_obj = Mock()
-        mock_sdk_model.side_effect = lambda image_uri, image_config, vpc_config, model_data, role, env, sagemaker_session, predictor_cls: (  # noqa E501
+        mock_sdk_model.side_effect = lambda image_uri, image_config, vpc_config, model_data, role, env, sagemaker_session, predictor_cls, name: (  # noqa E501
             mock_model_obj
             if image_uri == mock_image_uri
             and model_data == model_data
             and role == mock_role_arn
             and env == ENV_VARS
             and sagemaker_session == mock_session
+            and "model-name-" in name
             else None
         )
 
@@ -742,13 +746,14 @@ class TestModelBuilder(unittest.TestCase):
         )
 
         mock_model_obj = Mock()
-        mock_sdk_model.side_effect = lambda image_uri, image_config, vpc_config, model_data, role, env, sagemaker_session, predictor_cls: (  # noqa E501
+        mock_sdk_model.side_effect = lambda image_uri, image_config, vpc_config, model_data, role, env, sagemaker_session, predictor_cls, name: (  # noqa E501
             mock_model_obj
             if image_uri == mock_image_uri
             and model_data == model_data
             and role == mock_role_arn
             and env == ENV_VARS
             and sagemaker_session == mock_session
+            and "model-name-" in name
             else None
         )
 
@@ -847,13 +852,14 @@ class TestModelBuilder(unittest.TestCase):
         mock_mode.prepare.side_effect = lambda: None
 
         mock_model_obj = Mock()
-        mock_sdk_model.side_effect = lambda image_uri, image_config, vpc_config, model_data, role, env, sagemaker_session, predictor_cls: (  # noqa E501
+        mock_sdk_model.side_effect = lambda image_uri, image_config, vpc_config, model_data, role, env, sagemaker_session, predictor_cls, name: (  # noqa E501
             mock_model_obj
             if image_uri == mock_image_uri
             and model_data is None
             and role == mock_role_arn
             and env == {}
             and sagemaker_session == mock_session
+            and "model-name-" in name
             else None
         )
 
@@ -968,13 +974,14 @@ class TestModelBuilder(unittest.TestCase):
         )
 
         mock_model_obj = Mock()
-        mock_sdk_model.side_effect = lambda image_uri, image_config, vpc_config, model_data, role, env, sagemaker_session, predictor_cls: (  # noqa E501
+        mock_sdk_model.side_effect = lambda image_uri, image_config, vpc_config, model_data, role, env, sagemaker_session, predictor_cls, name: (  # noqa E501
             mock_model_obj
             if image_uri == mock_image_uri
             and model_data is None
             and role == mock_role_arn
             and env == {}
             and sagemaker_session == mock_session
+            and "model-name-" in name
             else None
         )
 
@@ -1119,13 +1126,14 @@ class TestModelBuilder(unittest.TestCase):
         )
 
         mock_model_obj = Mock()
-        mock_sdk_model.side_effect = lambda image_uri, image_config, vpc_config, model_data, role, env, sagemaker_session, predictor_cls: (  # noqa E501
+        mock_sdk_model.side_effect = lambda image_uri, image_config, vpc_config, model_data, role, env, sagemaker_session, predictor_cls, name: (  # noqa E501
             mock_model_obj
             if image_uri == mock_image_uri
             and model_data == model_data
             and role == mock_role_arn
             and env == ENV_VARS
             and sagemaker_session == mock_session
+            and "model-name-" in name
             else None
         )
 

--- a/tests/unit/sagemaker/serve/builder/test_tei_builder.py
+++ b/tests/unit/sagemaker/serve/builder/test_tei_builder.py
@@ -79,6 +79,7 @@ class TestTEIBuilder(unittest.TestCase):
         # verify SAGEMAKER_ENDPOINT deploy
         builder = ModelBuilder(
             model=MOCK_MODEL_ID,
+            name="mock_model_name",
             schema_builder=MOCK_SCHEMA_BUILDER,
             mode=Mode.SAGEMAKER_ENDPOINT,
             model_metadata={
@@ -88,7 +89,10 @@ class TestTEIBuilder(unittest.TestCase):
 
         builder._prepare_for_mode = MagicMock()
         builder._prepare_for_mode.return_value = (None, {})
+
         model = builder.build()
+        assert model.name == "mock_model_name"
+
         builder.serve_settings.telemetry_opt_out = True
         builder._original_deploy = MagicMock()
 

--- a/tests/unit/sagemaker/serve/builder/test_tensorflow_serving_builder.py
+++ b/tests/unit/sagemaker/serve/builder/test_tensorflow_serving_builder.py
@@ -33,6 +33,7 @@ class TestTransformersBuilder(unittest.TestCase):
         self.instance.image_config = {}
         self.instance.vpc_config = {}
         self.instance.modes = {}
+        self.instance.name = "model-name-mock-uuid-hex"
 
     @patch("os.makedirs")
     @patch("os.path.exists")
@@ -71,5 +72,6 @@ class TestTransformersBuilder(unittest.TestCase):
             env=self.instance.env_vars,
             sagemaker_session=self.instance.sagemaker_session,
             predictor_cls=self.instance._get_tensorflow_predictor,
+            name="model-name-mock-uuid-hex",
         )
         self.assertEqual(model, mock_model.return_value)

--- a/tests/unit/sagemaker/serve/builder/test_tgi_builder.py
+++ b/tests/unit/sagemaker/serve/builder/test_tgi_builder.py
@@ -61,13 +61,17 @@ class TestTGIBuilder(TestCase):
         # verify SAGEMAKER_ENDPOINT deploy
         builder = ModelBuilder(
             model=MOCK_MODEL_ID,
+            name="mock_model_name",
             schema_builder=MOCK_SCHEMA_BUILDER,
             mode=Mode.SAGEMAKER_ENDPOINT,
         )
 
         builder._prepare_for_mode = MagicMock()
         builder._prepare_for_mode.return_value = (None, {})
+
         model = builder.build()
+        assert model.name == "mock_model_name"
+
         builder.serve_settings.telemetry_opt_out = True
         builder._original_deploy = MagicMock()
 
@@ -187,3 +191,75 @@ class TestTGIBuilder(TestCase):
 
         # verify that if optimized, no s3 upload occurs
         builder._prepare_for_mode.assert_called_with()
+
+    @patch(
+        "sagemaker.serve.builder.tgi_builder._get_nb_instance",
+        return_value="ml.g5.24xlarge",
+    )
+    @patch("sagemaker.serve.builder.tgi_builder._capture_telemetry", side_effect=None)
+    @patch(
+        "sagemaker.serve.builder.model_builder.get_huggingface_model_metadata",
+        return_value={"pipeline_tag": "text-generation"},
+    )
+    @patch(
+        "sagemaker.serve.builder.tgi_builder._get_model_config_properties_from_hf",
+        return_value=({}, None),
+    )
+    @patch(
+        "sagemaker.serve.builder.tgi_builder._get_default_tgi_configurations",
+        return_value=({}, None),
+    )
+    @patch(
+        "sagemaker.serve.builder.tgi_builder._get_admissible_tensor_parallel_degrees",
+        return_value=[4, 8],
+    )
+    @patch("sagemaker.serve.builder.tgi_builder._get_admissible_dtypes", return_value=["fp16"])
+    @patch("sagemaker.serve.builder.tgi_builder.datetime")
+    @patch("sagemaker.serve.builder.tgi_builder.timedelta", return_value=1800)
+    @patch("sagemaker.serve.builder.tgi_builder._serial_benchmark")
+    @patch("sagemaker.serve.builder.tgi_builder._concurrent_benchmark")
+    def test_tgi_builder_tune_success(
+        self,
+        mock_concurrent_benchmark,
+        mock_serial_benchmark,
+        mock_timedelta,
+        mock_datetime,
+        mock_get_admissible_dtypes,
+        mock_get_admissible_tensor_parallel_degrees,
+        mock_default_tgi_configurations,
+        mock_hf_model_config,
+        mock_hf_model_md,
+        mock_get_nb_instance,
+        mock_telemetry,
+    ):
+        # WHERE
+        mock_datetime.now.side_effect = [0, 100, 200]
+        mock_serial_benchmark.side_effect = [(1000, 10000, 10), (500, 5000, 50)]
+        mock_concurrent_benchmark.side_effect = [(10, 10), (50, 5)]
+
+        builder = ModelBuilder(
+            model=MOCK_MODEL_ID,
+            schema_builder=MOCK_SCHEMA_BUILDER,
+            mode=Mode.LOCAL_CONTAINER,
+            model_path=MOCK_MODEL_PATH,
+        )
+        builder._prepare_for_mode = MagicMock()
+        builder._prepare_for_mode.side_effect = None
+
+        model = builder.build()
+
+        builder.serve_settings.telemetry_opt_out = True
+        builder.modes[str(Mode.LOCAL_CONTAINER)] = MagicMock()
+        builder.pysdk_model = MagicMock()
+
+        # WHEN
+        ret_new_model = model.tune(max_tuning_duration=1800)
+
+        # THEN
+        assert ret_new_model != model
+        assert len(mock_datetime.now.call_args_list) == 3
+        assert len(mock_serial_benchmark.call_args_list) == 2
+        assert len(mock_concurrent_benchmark.call_args_list) == 2
+        assert ret_new_model.env["NUM_SHARD"] == "8"
+        assert ret_new_model.env["DTYPE"] == "fp16"
+        assert ret_new_model.env["SHARDED"] == "true"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- When passing name, the name should be propagated from ModelBuilder to the Model created. It currently does not
```
model_builder = ModelBuilder(
    mode=Mode.SAGEMAKER_ENDPOINT,
    schema_builder=sklearn_schema_builder,
    role_arn="arn:aws:iam::337323248444:role/service-role/AmazonSageMaker-ExecutionRole-20230412T172825",
    model_metadata={"MLFLOW_MODEL_PATH": source_path},
    name="testing-name-propagation"
)
```
- Update all builder variants to propagate name to the Model

*Testing done:*
- Updated Unit Testing
- Verified Integration Testing With Fix

<img width="948" alt="image" src="https://github.com/user-attachments/assets/9a07774f-af66-431e-b000-c8cb0b2db706">


## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
