### PR TITLE
feat: add telemetry for deployment config in model builder

### DIFF
--- a/src/sagemaker/serve/builder/jumpstart_builder.py
+++ b/src/sagemaker/serve/builder/jumpstart_builder.py
@@ -121,7 +121,6 @@ class JumpStart(ABC):
         self.is_compiled = False
         self.is_quantized = False
         self.speculative_decoding_draft_model_source = None
-        self.is_set_deployment_config = False
         self.deployment_config_name = None
 
     @abstractmethod
@@ -513,7 +512,6 @@ class JumpStart(ABC):
             raise Exception("Cannot set deployment config to an uninitialized model.")
 
         self.pysdk_model.set_deployment_config(config_name, instance_type)
-        is_set_deployment_config = True
         self.deployment_config_name = config_name
 
         self.instance_type = instance_type

--- a/src/sagemaker/serve/builder/jumpstart_builder.py
+++ b/src/sagemaker/serve/builder/jumpstart_builder.py
@@ -121,6 +121,8 @@ class JumpStart(ABC):
         self.is_compiled = False
         self.is_quantized = False
         self.speculative_decoding_draft_model_source = None
+        self.is_set_deployment_config = False
+        self.deployment_config_name = None
 
     @abstractmethod
     def _prepare_for_mode(self, **kwargs):
@@ -511,6 +513,8 @@ class JumpStart(ABC):
             raise Exception("Cannot set deployment config to an uninitialized model.")
 
         self.pysdk_model.set_deployment_config(config_name, instance_type)
+        is_set_deployment_config = True
+        self.deployment_config_name = config_name
 
         self.instance_type = instance_type
 

--- a/src/sagemaker/serve/utils/telemetry_logger.py
+++ b/src/sagemaker/serve/utils/telemetry_logger.py
@@ -164,7 +164,7 @@ def _capture_telemetry(func_name: str):
                 )
                 model_provider_value = SD_DRAFT_MODEL_SOURCE_TO_CODE[str(model_provider_enum)]
                 extra += f"&x-sdDraftModelSource={model_provider_value}"
-                
+
             if getattr(self, "deployment_config_name", False):
                 config_name_code = self.deployment_config_name.lower()
                 extra += f"&x-configName={config_name_code}"

--- a/src/sagemaker/serve/utils/telemetry_logger.py
+++ b/src/sagemaker/serve/utils/telemetry_logger.py
@@ -164,6 +164,10 @@ def _capture_telemetry(func_name: str):
                 )
                 model_provider_value = SD_DRAFT_MODEL_SOURCE_TO_CODE[str(model_provider_enum)]
                 extra += f"&x-sdDraftModelSource={model_provider_value}"
+                
+            if getattr(self, "deployment_config_name", False):
+                config_name_code = self.deployment_config_name.lower()
+                extra += f"&x-configName={config_name_code}"
 
             extra += f"&x-latency={round(elapsed, 2)}"
 


### PR DESCRIPTION
*Issue #, if available:*

No telemetry was being recorded for deployment configuration information for JumpStart models. This adds recording of deployment configuration information.


*Description of changes:*
- Append deployment-config name to the url
- Helps to distinguish deployments with optimized configs vs non-optimized config

Testing:
Unit tests


## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
