### PR TITLE
feature: add Clarify image URIs for us-isof

### DIFF
--- a/src/sagemaker/image_uri_config/clarify.json
+++ b/src/sagemaker/image_uri_config/clarify.json
@@ -27,7 +27,9 @@
                     "us-east-2": "211330385671",
                     "us-gov-west-1": "598674086554",
                     "us-west-1": "740489534195",
-                    "us-west-2": "306415355426"
+                    "us-west-2": "306415355426",
+                    "us-isof-south-1": "411392592546",
+                    "us-isof-east-1": "579539705040"
                 },
                 "repository": "sagemaker-clarify-processing"
             }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* add Clarify image URIs for us-isof regions (us-isof-south-1, us-isof-east-1)

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
