### PR TITLE
Correct documentation

### DIFF
--- a/src/sagemaker/huggingface/estimator.py
+++ b/src/sagemaker/huggingface/estimator.py
@@ -65,7 +65,7 @@ class HuggingFace(Framework):
 
         Args:
             py_version (str): Python version you want to use for executing your model training
-                code. Defaults to ``None``. Required unless ``image_uri`` is provided.  If
+                code. If ``image_uri`` is provided, it can be set to ``None``.  If
                 using PyTorch, the current supported version is ``py36``. If using TensorFlow,
                 the current supported version is ``py37``.
             entry_point (str or PipelineVariable): Path (absolute or relative) to the Python source


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
The description says that it is not necessary to pass in py_version, but since the parameter has no default parameter, this is not the case.

*Testing done:*
N/A

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests
N/A
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
