### PR TITLE
fix: fixing typo in dependency setup

### DIFF
--- a/src/sagemaker/serve/utils/conda_in_process.yml
+++ b/src/sagemaker/serve/utils/conda_in_process.yml
@@ -37,7 +37,7 @@ dependencies:
             - botocore>=1.29.114
             - cachetools>=5.3.0
             - certifi==2022.12.7
-            - harset-normalizer>=3.1.0
+            - charset-normalizer>=3.1.0
             - click>=8.1.3
             - cloudpickle>=2.2.1
             - colorama>=0.4.4

--- a/src/sagemaker/serve/utils/in_process_requirements.txt
+++ b/src/sagemaker/serve/utils/in_process_requirements.txt
@@ -5,7 +5,7 @@ blinker>=1.6.2
 botocore>=1.29.114
 cachetools>=5.3.0
 certifi==2024.7.4
-harset-normalizer>=3.1.0
+charset-normalizer>=3.1.0
 click>=8.1.3
 cloudpickle>=2.2.1
 colorama>=0.4.4


### PR DESCRIPTION
charset-normalizer is misplet in the
requirements.txt files

*Issue #, if available:*

*Description of changes:*

*Testing done:*

run tox locally for UTs

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
