### PR TITLE
Revert "change: add TGI 2.4.0 image uri (#4922)"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,7 @@ Before sending us a pull request, please ensure that:
 1. Install tox using `pip install tox`
 1. Install coverage using `pip install .[test]`
 1. cd into the sagemaker-python-sdk folder: `cd sagemaker-python-sdk` or `cd /environment/sagemaker-python-sdk`
-1. Run the following tox command and verify that all code checks and unit tests pass: `tox -- tests/unit`
+1. Run the following tox command and verify that all code checks and unit tests pass: `tox tests/unit`
 1. You can also run a single test with the following command: `tox -e py310 -- -s -vv <path_to_file><file_name>::<test_function_name>`
 1. You can run coverage via runcvoerage env : `tox -e runcoverage -- tests/unit` or `tox -e py310 -- tests/unit --cov=sagemaker --cov-append --cov-report xml`
   * Note that the coverage test will fail if you only run a single test, so make sure to surround the command with `export IGNORE_COVERAGE=-` and `unset IGNORE_COVERAGE`

--- a/src/sagemaker/image_uri_config/huggingface-llm.json
+++ b/src/sagemaker/image_uri_config/huggingface-llm.json
@@ -766,53 +766,6 @@
                 "container_version": {
                     "gpu": "cu124-ubuntu22.04"
                 }
-            },
-            "2.4.0": {
-                "py_versions": [
-                    "py311"
-                ],
-                "registries": {
-                    "af-south-1": "626614931356",
-                    "il-central-1": "780543022126",
-                    "ap-east-1": "871362719292",
-                    "ap-northeast-1": "763104351884",
-                    "ap-northeast-2": "763104351884",
-                    "ap-northeast-3": "364406365360",
-                    "ap-south-1": "763104351884",
-                    "ap-south-2": "772153158452",
-                    "ap-southeast-1": "763104351884",
-                    "ap-southeast-2": "763104351884",
-                    "ap-southeast-3": "907027046896",
-                    "ap-southeast-4": "457447274322",
-                    "ca-central-1": "763104351884",
-                    "cn-north-1": "727897471807",
-                    "cn-northwest-1": "727897471807",
-                    "eu-central-1": "763104351884",
-                    "eu-central-2": "380420809688",
-                    "eu-north-1": "763104351884",
-                    "eu-west-1": "763104351884",
-                    "eu-west-2": "763104351884",
-                    "eu-west-3": "763104351884",      
-                    "eu-south-1": "692866216735",
-                    "eu-south-2": "503227376785",
-                    "me-south-1": "217643126080",
-                    "me-central-1": "914824155844",
-                    "sa-east-1": "763104351884",
-                    "us-east-1": "763104351884",
-                    "us-east-2": "763104351884",
-                    "us-gov-east-1": "446045086412",
-                    "us-gov-west-1": "442386744353",
-                    "us-iso-east-1": "886529160074",
-                    "us-isob-east-1": "094389454867",
-                    "us-west-1": "763104351884",
-                    "us-west-2": "763104351884",
-                    "ca-west-1": "204538143572"
-                },
-                "tag_prefix": "2.4.0-tgi2.4.0",
-                "repository": "huggingface-pytorch-tgi-inference",
-                "container_version": {
-                    "gpu": "cu124-ubuntu22.04"
-                }
             }
         }
     }

--- a/tests/unit/sagemaker/image_uris/test_huggingface_llm.py
+++ b/tests/unit/sagemaker/image_uris/test_huggingface_llm.py
@@ -46,7 +46,6 @@ HF_VERSIONS_MAPPING = {
         "2.0.2": "2.3.0-tgi2.0.2-gpu-py310-cu121-ubuntu22.04",
         "2.2.0": "2.3.0-tgi2.2.0-gpu-py310-cu121-ubuntu22.04-v2.0",
         "2.3.1": "2.4.0-tgi2.3.1-gpu-py311-cu124-ubuntu22.04",
-        "2.4.0": "2.4.0-tgi2.4.0-gpu-py311-cu124-ubuntu22.04",
     },
     "inf2": {
         "0.0.16": "1.13.1-optimum0.0.16-neuronx-py310-ubuntu22.04",


### PR DESCRIPTION
This reverts commit 0ea59948daeed1f3b12d4269db637852a17ee6e4.

*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)
- [x] If adding any dependency in requirements.txt files, I have spell checked and ensured they exist in PyPi

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
