### PR TITLE
Sniping fix for S3 bucket

### DIFF
--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -630,13 +630,13 @@ class Session(object):  # pylint: disable=too-many-public-methods
             s3 = self.s3_resource
 
         bucket = s3.Bucket(name=bucket_name)
+        expected_bucket_owner_id = self.account_id()
+
         if bucket.creation_date is None:
             self.general_bucket_check_if_user_has_permission(bucket_name, s3, bucket, region, True)
-
+            self.expected_bucket_owner_id_bucket_check(bucket_name, s3, expected_bucket_owner_id)
         elif self._default_bucket_set_by_sdk:
             self.general_bucket_check_if_user_has_permission(bucket_name, s3, bucket, region, False)
-
-            expected_bucket_owner_id = self.account_id()
             self.expected_bucket_owner_id_bucket_check(bucket_name, s3, expected_bucket_owner_id)
 
     def expected_bucket_owner_id_bucket_check(self, bucket_name, s3, expected_bucket_owner_id):

--- a/tests/unit/test_default_bucket.py
+++ b/tests/unit/test_default_bucket.py
@@ -13,6 +13,7 @@
 from __future__ import absolute_import
 
 import datetime
+import unittest
 from unittest.mock import Mock
 
 import pytest
@@ -173,3 +174,31 @@ def test_bucket_creation_other_error(sagemaker_session):
 
         sagemaker_session.default_bucket()
     assert sagemaker_session._default_bucket is None
+
+
+def test_default_bucket_s3_create_call_creation_date(sagemaker_session):
+    error = ClientError(
+        error_response={"Error": {"Code": "403", "Message": "Forbidden"}},
+        operation_name="foo",
+    )
+    sagemaker_session.boto_session.resource("s3").meta.client.head_bucket.side_effect = Mock(
+        side_effect=error
+    )
+
+    with pytest.raises(ClientError):
+        sagemaker_session.default_bucket()
+
+
+def test_default_bucket_s3_create_call_default_bucket_set_by_sdk(sagemaker_session):
+    sagemaker_session._default_bucket_set_by_sdk = True
+    sagemaker_session.boto_session.resource("s3").Bucket().creation_date = 1733509801
+    error = ClientError(
+        error_response={"Error": {"Code": "403", "Message": "Forbidden"}},
+        operation_name="foo",
+    )
+    sagemaker_session.boto_session.resource("s3").meta.client.head_bucket.side_effect = Mock(
+        side_effect=error
+    )
+
+    with pytest.raises(ClientError):
+        sagemaker_session.default_bucket()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)
- [x] If adding any dependency in requirements.txt files, I have spell checked and ensured they exist in PyPi

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
