### PR TITLE
Added parsing string support for situations where custom code might b…

### DIFF
--- a/src/sagemaker/serve/model_server/multi_model_server/inference.py
+++ b/src/sagemaker/serve/model_server/multi_model_server/inference.py
@@ -45,11 +45,11 @@ def input_fn(input_data, content_type):
     try:
         if hasattr(schema_builder, "custom_input_translator"):
             deserialized_data = schema_builder.custom_input_translator.deserialize(
-                io.BytesIO(input_data), content_type
+                io.BytesIO(input_data) if type(input_data)== bytes else io.BytesIO(input_data.encode('utf-8')), content_type
             )
         else:
             deserialized_data = schema_builder.input_deserializer.deserialize(
-                io.BytesIO(input_data), content_type[0]
+                io.BytesIO(input_data) if type(input_data)== bytes else io.BytesIO(input_data.encode('utf-8')), content_type[0]
             )
 
         # Check if preprocess method is defined and call it

--- a/src/sagemaker/serve/model_server/torchserve/inference.py
+++ b/src/sagemaker/serve/model_server/torchserve/inference.py
@@ -67,11 +67,11 @@ def input_fn(input_data, content_type):
     try:
         if hasattr(schema_builder, "custom_input_translator"):
             deserialized_data = schema_builder.custom_input_translator.deserialize(
-                io.BytesIO(input_data), content_type
+                io.BytesIO(input_data) if type(input_data)== bytes else io.BytesIO(input_data.encode('utf-8')), content_type
             )
         else:
             deserialized_data = schema_builder.input_deserializer.deserialize(
-                io.BytesIO(input_data), content_type[0]
+                io.BytesIO(input_data) if type(input_data)== bytes else io.BytesIO(input_data.encode('utf-8')), content_type[0]
             )
 
         # Check if preprocess method is defined and call it

--- a/src/sagemaker/serve/model_server/torchserve/xgboost_inference.py
+++ b/src/sagemaker/serve/model_server/torchserve/xgboost_inference.py
@@ -70,11 +70,11 @@ def input_fn(input_data, content_type):
     try:
         if hasattr(schema_builder, "custom_input_translator"):
             return schema_builder.custom_input_translator.deserialize(
-                io.BytesIO(input_data), content_type
+                io.BytesIO(input_data) if type(input_data)== bytes else io.BytesIO(input_data.encode('utf-8')), content_type
             )
         else:
             return schema_builder.input_deserializer.deserialize(
-                io.BytesIO(input_data), content_type[0]
+                io.BytesIO(input_data) if type(input_data)== bytes else io.BytesIO(input_data.encode('utf-8')), content_type[0]
             )
     except Exception as e:
         raise Exception("Encountered error in deserialize_request.") from e


### PR DESCRIPTION
…e used (ie. mlflow)

*Issue #, if available:* 4959

*Description of changes:* Added parsing of `string` class to BytesIO when value is string (mainly when input is JSON or CSV)

*Testing done:* Ran in SageMaker endpoint for MLflow.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)
- [ ] If adding any dependency in requirements.txt files, I have spell checked and ensured they exist in PyPi

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
