### PR TITLE
fix: resolve infinite loop in _find_config on Windows systems

### DIFF
--- a/src/sagemaker/_studio.py
+++ b/src/sagemaker/_studio.py
@@ -65,10 +65,9 @@ def _find_config(working_dir=None):
         wd = Path(working_dir) if working_dir else Path.cwd()
 
         path = None
-
-        root = Path(
-            wd.anchor
-        )  # Properly get the root of the current working directory for both Windows and Unix-like systems
+        
+        # Get the root of the current working directory for both Windows and Unix-like systems
+        root = Path(wd.anchor)
         while path is None and wd != root:
             candidate = wd / STUDIO_PROJECT_CONFIG
             if Path.exists(candidate):

--- a/src/sagemaker/_studio.py
+++ b/src/sagemaker/_studio.py
@@ -65,8 +65,10 @@ def _find_config(working_dir=None):
         wd = Path(working_dir) if working_dir else Path.cwd()
 
         path = None
-        
-        root = Path(wd.anchor) # Properly get the root of the current working directory for both Windows and Unix-like systems
+
+        root = Path(
+            wd.anchor
+        )  # Properly get the root of the current working directory for both Windows and Unix-like systems
         while path is None and wd != root:
             candidate = wd / STUDIO_PROJECT_CONFIG
             if Path.exists(candidate):

--- a/src/sagemaker/_studio.py
+++ b/src/sagemaker/_studio.py
@@ -65,7 +65,7 @@ def _find_config(working_dir=None):
         wd = Path(working_dir) if working_dir else Path.cwd()
 
         path = None
-        
+
         # Get the root of the current working directory for both Windows and Unix-like systems
         root = Path(wd.anchor)
         while path is None and wd != root:

--- a/src/sagemaker/_studio.py
+++ b/src/sagemaker/_studio.py
@@ -65,7 +65,9 @@ def _find_config(working_dir=None):
         wd = Path(working_dir) if working_dir else Path.cwd()
 
         path = None
-        while path is None and not wd.match("/"):
+        
+        root = Path(wd.anchor) # Properly get the root of the current working directory for both Windows and Unix-like systems
+        while path is None and wd != root:
             candidate = wd / STUDIO_PROJECT_CONFIG
             if Path.exists(candidate):
                 path = candidate

--- a/tests/unit/sagemaker/test_studio.py
+++ b/tests/unit/sagemaker/test_studio.py
@@ -71,20 +71,17 @@ def test_find_config_path_separators(tmpdir):
     base_path = str(tmpdir)
 
     # Always include the OS native path and forward slashes (which are equivalent on all OS)
-    paths = [os.path.join(base_path, "dir1", "dir2"),
-             "/".join([base_path, "dir1", "dir2"])]
+    paths = [os.path.join(base_path, "dir1", "dir2"), "/".join([base_path, "dir1", "dir2"])]
 
     # Only on Windows add the backslashes and mixed separator test cases.
     if os.name == "nt":
-        paths.extend([
-            "\\".join([base_path, "dir1", "dir2"]),
-            base_path + "/dir1\\dir2",
-        ])
+        paths.extend(["\\".join([base_path, "dir1", "dir2"]), base_path + "/dir1\\dir2"])
 
     for path in paths:
         os.makedirs(path, exist_ok=True)
         found_path = _find_config(path)
         assert found_path == config
+
 
 def test_find_config(tmpdir):
     path = tmpdir.join(".sagemaker-code-config")

--- a/tests/unit/sagemaker/test_studio.py
+++ b/tests/unit/sagemaker/test_studio.py
@@ -12,7 +12,8 @@
 # language governing permissions and limitations under the License.
 # language governing permissions and limitations under the License.
 from __future__ import absolute_import
-
+import os
+from pathlib import Path
 from sagemaker._studio import (
     _append_project_tags,
     _find_config,
@@ -20,6 +21,62 @@ from sagemaker._studio import (
     _parse_tags,
 )
 
+def test_find_config_cross_platform(tmpdir):
+    """Test _find_config works correctly across different platforms."""
+    # Create a completely separate directory for isolated tests
+    import tempfile
+    with tempfile.TemporaryDirectory() as isolated_root:
+        # Setup test directory structure for positive tests
+        config = tmpdir.join(".sagemaker-code-config")
+        config.write('{"sagemakerProjectId": "proj-1234"}')
+        
+        # Test 1: Direct parent directory
+        working_dir = tmpdir.mkdir("sub")
+        found_path = _find_config(working_dir)
+        assert found_path == config
+        
+        # Test 2: Deeply nested directories
+        nested_dir = tmpdir.mkdir("deep").mkdir("nested").mkdir("path")
+        found_path = _find_config(nested_dir)
+        assert found_path == config
+        
+        # Test 3: Start from root directory
+        import os
+        root_dir = os.path.abspath(os.sep)
+        found_path = _find_config(root_dir)
+        assert found_path is None
+        
+        # Test 4: No config file in path - using truly isolated directory
+        isolated_path = Path(isolated_root) / "nested" / "path"
+        isolated_path.mkdir(parents=True)
+        found_path = _find_config(isolated_path)
+        assert found_path is None
+
+def test_find_config_path_separators(tmpdir):
+    """Test _find_config handles different path separator styles.
+    
+    Tests:
+    1. Forward slashes
+    2. Backslashes
+    3. Mixed separators
+    """
+    # Setup
+    config = tmpdir.join(".sagemaker-code-config")
+    config.write('{"sagemakerProjectId": "proj-1234"}')
+    base_path = str(tmpdir)
+    
+    # Test different path separator styles
+    paths = [
+        os.path.join(base_path, "dir1", "dir2"),  # OS native
+        "/".join([base_path, "dir1", "dir2"]),    # Forward slashes
+        "\\".join([base_path, "dir1", "dir2"]),   # Backslashes
+        base_path + "/dir1\\dir2"                 # Mixed
+    ]
+    
+    for path in paths:
+        os.makedirs(path, exist_ok=True)
+        found_path = _find_config(path)
+        assert found_path == config
 
 def test_find_config(tmpdir):
     path = tmpdir.join(".sagemaker-code-config")

--- a/tests/unit/sagemaker/test_studio.py
+++ b/tests/unit/sagemaker/test_studio.py
@@ -21,40 +21,44 @@ from sagemaker._studio import (
     _parse_tags,
 )
 
+
 def test_find_config_cross_platform(tmpdir):
     """Test _find_config works correctly across different platforms."""
     # Create a completely separate directory for isolated tests
     import tempfile
+
     with tempfile.TemporaryDirectory() as isolated_root:
         # Setup test directory structure for positive tests
         config = tmpdir.join(".sagemaker-code-config")
         config.write('{"sagemakerProjectId": "proj-1234"}')
-        
+
         # Test 1: Direct parent directory
         working_dir = tmpdir.mkdir("sub")
         found_path = _find_config(working_dir)
         assert found_path == config
-        
+
         # Test 2: Deeply nested directories
         nested_dir = tmpdir.mkdir("deep").mkdir("nested").mkdir("path")
         found_path = _find_config(nested_dir)
         assert found_path == config
-        
+
         # Test 3: Start from root directory
         import os
+
         root_dir = os.path.abspath(os.sep)
         found_path = _find_config(root_dir)
         assert found_path is None
-        
+
         # Test 4: No config file in path - using truly isolated directory
         isolated_path = Path(isolated_root) / "nested" / "path"
         isolated_path.mkdir(parents=True)
         found_path = _find_config(isolated_path)
         assert found_path is None
 
+
 def test_find_config_path_separators(tmpdir):
     """Test _find_config handles different path separator styles.
-    
+
     Tests:
     1. Forward slashes
     2. Backslashes
@@ -64,19 +68,20 @@ def test_find_config_path_separators(tmpdir):
     config = tmpdir.join(".sagemaker-code-config")
     config.write('{"sagemakerProjectId": "proj-1234"}')
     base_path = str(tmpdir)
-    
+
     # Test different path separator styles
     paths = [
         os.path.join(base_path, "dir1", "dir2"),  # OS native
-        "/".join([base_path, "dir1", "dir2"]),    # Forward slashes
-        "\\".join([base_path, "dir1", "dir2"]),   # Backslashes
-        base_path + "/dir1\\dir2"                 # Mixed
+        "/".join([base_path, "dir1", "dir2"]),  # Forward slashes
+        "\\".join([base_path, "dir1", "dir2"]),  # Backslashes
+        base_path + "/dir1\\dir2",  # Mixed
     ]
-    
+
     for path in paths:
         os.makedirs(path, exist_ok=True)
         found_path = _find_config(path)
         assert found_path == config
+
 
 def test_find_config(tmpdir):
     path = tmpdir.join(".sagemaker-code-config")

--- a/tests/unit/sagemaker/test_studio.py
+++ b/tests/unit/sagemaker/test_studio.py
@@ -13,7 +13,6 @@
 # language governing permissions and limitations under the License.
 from __future__ import absolute_import
 import os
-import platform
 from pathlib import Path
 from sagemaker._studio import (
     _append_project_tags,

--- a/tests/unit/sagemaker/test_studio.py
+++ b/tests/unit/sagemaker/test_studio.py
@@ -13,6 +13,7 @@
 # language governing permissions and limitations under the License.
 from __future__ import absolute_import
 import os
+import platform
 from pathlib import Path
 from sagemaker._studio import (
     _append_project_tags,
@@ -69,19 +70,21 @@ def test_find_config_path_separators(tmpdir):
     config.write('{"sagemakerProjectId": "proj-1234"}')
     base_path = str(tmpdir)
 
-    # Test different path separator styles
-    paths = [
-        os.path.join(base_path, "dir1", "dir2"),  # OS native
-        "/".join([base_path, "dir1", "dir2"]),  # Forward slashes
-        "\\".join([base_path, "dir1", "dir2"]),  # Backslashes
-        base_path + "/dir1\\dir2",  # Mixed
-    ]
+    # Always include the OS native path and forward slashes (which are equivalent on all OS)
+    paths = [os.path.join(base_path, "dir1", "dir2"),
+             "/".join([base_path, "dir1", "dir2"])]
+
+    # Only on Windows add the backslashes and mixed separator test cases.
+    if os.name == "nt":
+        paths.extend([
+            "\\".join([base_path, "dir1", "dir2"]),
+            base_path + "/dir1\\dir2",
+        ])
 
     for path in paths:
         os.makedirs(path, exist_ok=True)
         found_path = _find_config(path)
         assert found_path == config
-
 
 def test_find_config(tmpdir):
     path = tmpdir.join(".sagemaker-code-config")


### PR DESCRIPTION
*Issue #4967*

*Description of changes:*
This PR fixes an infinite loop in _find_config that occurs on Windows systems. The issue was caused by using Path.match("/") to detect root directories, which never matches on Windows due to different path separators.

Changes made:
1. Replace platform-specific Path.match("/") with Path.anchor comparison
2. Implement proper root directory detection for both Windows and Unix systems
3. Add comprehensive cross-platform tests

*Testing done:*
- Verified fix on both Windows and Linux systems
- Added test_find_config_cross_platform to validate:
  - Basic path traversal
  - Nested directory structures
  - Root directory handling
  - Non-existent config scenarios
- Added test_find_config_path_separators to verify handling of:
  - Forward slashes
  - Backslashes
  - Mixed separators
- All existing tests pass without modification

## Merge Checklist
#### General
- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible
- [x] I used the commit message format described in CONTRIBUTING
- [x] I have passed the region in to all S3 and STS clients (N/A for this change)
- [x] I have updated necessary documentation (N/A - internal implementation change)

#### Tests
- [x] I have added tests that prove my fix is effective
- [x] I have added unit tests to ensure backward compatibility
- [x] I have checked that my tests are not configured for a specific region or account
- [x] I have used unique_name_from_base for resource names (N/A - unit tests only)
- [x] No new dependencies added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.