### PR TITLE
Add an option in local model trainer to remove inputs and container artifacts

### DIFF
--- a/src/sagemaker/modules/train/model_trainer.py
+++ b/src/sagemaker/modules/train/model_trainer.py
@@ -203,6 +203,8 @@ class ModelTrainer(BaseModel):
         local_container_root (Optional[str]):
             The local root directory to store artifacts from a training job launched in
             "LOCAL_CONTAINER" mode.
+        remove_inputs_and_container_artifacts (Optional[bool]):
+                Whether to remove inputs and container artifacts after training.
     """
 
     model_config = ConfigDict(arbitrary_types_allowed=True, extra="forbid")
@@ -227,6 +229,7 @@ class ModelTrainer(BaseModel):
     hyperparameters: Optional[Dict[str, Any]] = {}
     tags: Optional[List[Tag]] = None
     local_container_root: Optional[str] = os.getcwd()
+    remove_inputs_and_container_artifacts: Optional[bool] = True
 
     # Created Artifacts
     _latest_training_job: Optional[resources.TrainingJob] = PrivateAttr(default=None)
@@ -646,7 +649,7 @@ class ModelTrainer(BaseModel):
                 hyper_parameters=string_hyper_parameters,
                 environment=self.environment,
             )
-            local_container.train(wait)
+            local_container.train(wait, self.remove_inputs_and_container_artifacts)
 
     def create_input_data_channel(
         self, channel_name: str, data_source: DataSourceType, key_prefix: Optional[str] = None

--- a/tests/integ/sagemaker/modules/train/test_local_model_trainer.py
+++ b/tests/integ/sagemaker/modules/train/test_local_model_trainer.py
@@ -92,10 +92,7 @@ def test_single_container_local_mode_local_data(modules_sagemaker_session):
                 "compressed_artifacts",
                 "artifacts",
                 "model",
-                "shared",
-                "input",
                 "output",
-                "algo-1",
             ]
 
             for directory in directories:
@@ -103,7 +100,7 @@ def test_single_container_local_mode_local_data(modules_sagemaker_session):
                 delete_local_path(path)
 
 
-def test_single_container_local_mode_s3_data(modules_sagemaker_session):
+def test_single_container_local_mode_s3_data_remove_input(modules_sagemaker_session):
     with lock.lock(LOCK_PATH):
         try:
             # upload local data to s3
@@ -143,6 +140,70 @@ def test_single_container_local_mode_s3_data(modules_sagemaker_session):
                 input_data_config=[train_data, test_data],
                 base_job_name="local_mode_single_container_s3_data",
                 training_mode=Mode.LOCAL_CONTAINER,
+            )
+
+            model_trainer.train()
+            assert os.path.exists(os.path.join(CWD, "compressed_artifacts/model.tar.gz"))
+        finally:
+            subprocess.run(["docker", "compose", "down", "-v"])
+
+            assert not os.path.exists(os.path.join(CWD, "shared"))
+            assert not os.path.exists(os.path.join(CWD, "input"))
+            assert not os.path.exists(os.path.join(CWD, "algo-1"))
+
+            directories = [
+                "compressed_artifacts",
+                "artifacts",
+                "model",
+                "output",
+            ]
+
+            for directory in directories:
+                path = os.path.join(CWD, directory)
+                delete_local_path(path)
+
+
+def test_single_container_local_mode_s3_data_not_remove_input(modules_sagemaker_session):
+    with lock.lock(LOCK_PATH):
+        try:
+            # upload local data to s3
+            session = modules_sagemaker_session
+            bucket = session.default_bucket()
+            session.upload_data(
+                path=os.path.join(SOURCE_DIR, "data/train/"),
+                bucket=bucket,
+                key_prefix="data/train",
+            )
+            session.upload_data(
+                path=os.path.join(SOURCE_DIR, "data/test/"),
+                bucket=bucket,
+                key_prefix="data/test",
+            )
+
+            source_code = SourceCode(
+                source_dir=SOURCE_DIR,
+                entry_script="local_training_script.py",
+            )
+
+            compute = Compute(
+                instance_type="local_cpu",
+                instance_count=1,
+            )
+
+            # read input data from s3
+            train_data = InputData(channel_name="train", data_source=f"s3://{bucket}/data/train/")
+
+            test_data = InputData(channel_name="test", data_source=f"s3://{bucket}/data/test/")
+
+            model_trainer = ModelTrainer(
+                training_image=DEFAULT_CPU_IMAGE,
+                sagemaker_session=modules_sagemaker_session,
+                source_code=source_code,
+                compute=compute,
+                input_data_config=[train_data, test_data],
+                base_job_name="local_mode_single_container_s3_data",
+                training_mode=Mode.LOCAL_CONTAINER,
+                remove_inputs_and_container_artifacts=False,
             )
 
             model_trainer.train()
@@ -213,11 +274,7 @@ def test_multi_container_local_mode(modules_sagemaker_session):
                 "compressed_artifacts",
                 "artifacts",
                 "model",
-                "shared",
-                "input",
                 "output",
-                "algo-1",
-                "algo-2",
             ]
 
             for directory in directories:


### PR DESCRIPTION
…using local model trainer

*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)
- [ ] If adding any dependency in requirements.txt files, I have spell checked and ensured they exist in PyPi

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
