### PR TITLE
Fix: Account for requests that have already been decoded by model server

### DIFF
--- a/src/sagemaker/serve/model_server/multi_model_server/inference.py
+++ b/src/sagemaker/serve/model_server/multi_model_server/inference.py
@@ -46,18 +46,28 @@ def input_fn(input_data, content_type, context=None):
         if hasattr(schema_builder, "custom_input_translator"):
             deserialized_data = schema_builder.custom_input_translator.deserialize(
                 (
-                    io.BytesIO(input_data)
-                    if type(input_data) == bytes
-                    else io.BytesIO(input_data.encode("utf-8"))
+                    io.BytesIO(input_data.encode("utf-8"))
+                    if not any(
+                        [
+                            isinstance(input_data, bytes),
+                            isinstance(input_data, bytearray),
+                        ]
+                    )
+                    else io.BytesIO(input_data)
                 ),
                 content_type,
             )
         else:
             deserialized_data = schema_builder.input_deserializer.deserialize(
                 (
-                    io.BytesIO(input_data)
-                    if type(input_data) == bytes
-                    else io.BytesIO(input_data.encode("utf-8"))
+                    io.BytesIO(input_data.encode("utf-8"))
+                    if not any(
+                        [
+                            isinstance(input_data, bytes),
+                            isinstance(input_data, bytearray),
+                        ]
+                    )
+                    else io.BytesIO(input_data)
                 ),
                 content_type[0],
             )

--- a/src/sagemaker/serve/model_server/torchserve/inference.py
+++ b/src/sagemaker/serve/model_server/torchserve/inference.py
@@ -68,18 +68,28 @@ def input_fn(input_data, content_type):
         if hasattr(schema_builder, "custom_input_translator"):
             deserialized_data = schema_builder.custom_input_translator.deserialize(
                 (
-                    io.BytesIO(input_data)
-                    if type(input_data) == bytes
-                    else io.BytesIO(input_data.encode("utf-8"))
+                    io.BytesIO(input_data.encode("utf-8"))
+                    if not any(
+                        [
+                            isinstance(input_data, bytes),
+                            isinstance(input_data, bytearray),
+                        ]
+                    )
+                    else io.BytesIO(input_data)
                 ),
                 content_type,
             )
         else:
             deserialized_data = schema_builder.input_deserializer.deserialize(
                 (
-                    io.BytesIO(input_data)
-                    if type(input_data) == bytes
-                    else io.BytesIO(input_data.encode("utf-8"))
+                    io.BytesIO(input_data.encode("utf-8"))
+                    if not any(
+                        [
+                            isinstance(input_data, bytes),
+                            isinstance(input_data, bytearray),
+                        ]
+                    )
+                    else io.BytesIO(input_data)
                 ),
                 content_type[0],
             )

--- a/src/sagemaker/serve/model_server/torchserve/xgboost_inference.py
+++ b/src/sagemaker/serve/model_server/torchserve/xgboost_inference.py
@@ -71,18 +71,28 @@ def input_fn(input_data, content_type):
         if hasattr(schema_builder, "custom_input_translator"):
             return schema_builder.custom_input_translator.deserialize(
                 (
-                    io.BytesIO(input_data)
-                    if type(input_data) == bytes
-                    else io.BytesIO(input_data.encode("utf-8"))
+                    io.BytesIO(input_data.encode("utf-8"))
+                    if not any(
+                        [
+                            isinstance(input_data, bytes),
+                            isinstance(input_data, bytearray),
+                        ]
+                    )
+                    else io.BytesIO(input_data)
                 ),
                 content_type,
             )
         else:
             return schema_builder.input_deserializer.deserialize(
                 (
-                    io.BytesIO(input_data)
-                    if type(input_data) == bytes
-                    else io.BytesIO(input_data.encode("utf-8"))
+                    io.BytesIO(input_data.encode("utf-8"))
+                    if not any(
+                        [
+                            isinstance(input_data, bytes),
+                            isinstance(input_data, bytearray),
+                        ]
+                    )
+                    else io.BytesIO(input_data)
                 ),
                 content_type[0],
             )


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/sagemaker-python-sdk/issues/4959

*Description of changes:*
Some model servers (MMS in specific) decode the request from bytes ahead of time if the content type of the request is in a known format.

In these scenarios, we should honor that logic. If the request by the time it gets to our decoder is no longer in a bytes / bytestream format then propagate it as is.

We should not get into the business of re-encoding it back into a bytes or bytestream format

In the first iteration: https://github.com/aws/sagemaker-python-sdk/pull/4960 a regression was introduced. Fixed that here

*Testing done:*

```
tests/integ/sagemaker/serve/test_serve_mlflow_pytorch_flavor_happy.py::test_happy_pytorch_sagemaker_endpoint_with_torch_serve PASSED
```

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)
- [x] If adding any dependency in requirements.txt files, I have spell checked and ensured they exist in PyPi

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
