### PR TITLE
fix: pin metadata-version to 2.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ pattern = "(?P<version>.+)"
 [tool.hatch.metadata.hooks.custom]
 
 [tool.hatch.build.targets.wheel]
+core-metadata-version = "2.3"
 packages = ["src/sagemaker"]
 exclude = ["src/sagemaker/serve/model_server/triton/pack_conda_env.sh"]
 
@@ -80,6 +81,7 @@ exclude = ["src/sagemaker/serve/model_server/triton/pack_conda_env.sh"]
 "src/sagemaker/serve/model_server/triton/pack_conda_env.sh" = "pack_conda_env.sh"
 
 [tool.hatch.build.targets.sdist]
+core-metadata-version = "2.3"
 only-include = [
   "/requirements/extras",
   "/src",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* [Twine](https://github.com/pypa/twine/commit/0605ef02a6a5ffa8bddab6816f7ff3e0db9a442f) does not yet support core-metadata-version 2.4 which is new default for [hatchling](https://github.com/pypa/hatch/issues/1856).  Pinning to unblock 

*Testing done:*
```
root@b3e99f464864:/sagemaker-python-sdk# python3 -m twine check --strict dist/*
Checking dist/sagemaker-2.237.4.dev0-py3-none-any.whl: PASSED
Checking dist/sagemaker-2.237.4.dev0.tar.gz: PASSED
root@b3e99f464864:/sagemaker-python-sdk# git diff
diff --git a/pyproject.toml b/pyproject.toml
index 21eb1850..7711249c 100644
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ pattern = "(?P<version>.+)"
 [tool.hatch.metadata.hooks.custom]

 [tool.hatch.build.targets.wheel]
+core-metadata-version = "2.3"
 packages = ["src/sagemaker"]
 exclude = ["src/sagemaker/serve/model_server/triton/pack_conda_env.sh"]

@@ -80,6 +81,7 @@ exclude = ["src/sagemaker/serve/model_server/triton/pack_conda_env.sh"]
 "src/sagemaker/serve/model_server/triton/pack_conda_env.sh" = "pack_conda_env.sh"

 [tool.hatch.build.targets.sdist]
+core-metadata-version = "2.3"
 only-include = [
   "/requirements/extras",
   "/src",
```

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)
- [ ] If adding any dependency in requirements.txt files, I have spell checked and ensured they exist in PyPi

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
