### PR TITLE
fix: Add missing attributes to local resourceconfig

### DIFF
--- a/src/sagemaker/local/image.py
+++ b/src/sagemaker/local/image.py
@@ -519,7 +519,12 @@ class _SageMakerContainer(object):
         """
         config_path = os.path.join(self.container_root, host, "input", "config")
 
-        resource_config = {"current_host": host, "hosts": self.hosts}
+        resource_config = {
+            "current_host": host, 
+            "hosts": self.hosts, 
+            "network_interface_name": "eth0",
+            "current_instance_type": self.instance_type,
+        }
 
         json_input_data_config = {}
         for c in input_data_config:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Recent PR add some bootstrap scripts that run for @remote decorator - https://github.com/aws/sagemaker-python-sdk/pull/4984
* These scripts run both in remote and local mode and reference attributes from resource_config. This change adds the attributes these scripts expect for local simulation. similar to local mode in ModelTrainer - https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/modules/local_core/local_container.py#L302

*Testing done:*
```
tox -e py310 -- -vv -s  tests/integ/test_local_mode.py::test_local_pipeline_with_step_decorator_and_step_dependency
```

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)
- [ ] If adding any dependency in requirements.txt files, I have spell checked and ensured they exist in PyPi

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
