### PR TITLE
fix: skip TF tests for unsupported versions

### DIFF
--- a/tests/integ/sagemaker/workflow/test_model_create_and_registration.py
+++ b/tests/integ/sagemaker/workflow/test_model_create_and_registration.py
@@ -26,7 +26,6 @@ import re
 import pytest
 
 from packaging.version import Version
-from packaging.specifiers import SpecifierSet
 
 from sagemaker.model_card.model_card import ModelCard, ModelOverview, ModelPackageModelCard
 from sagemaker.model_card.schema_constraints import ModelCardStatusEnum

--- a/tests/integ/sagemaker/workflow/test_model_create_and_registration.py
+++ b/tests/integ/sagemaker/workflow/test_model_create_and_registration.py
@@ -1422,7 +1422,7 @@ def test_model_registration_with_tensorflow_model_with_pipeline_model(
     pipeline_name,
     region_name,
 ):
-    if Version(tf_full_version) in SpecifierSet("==2.16.*"):
+    if Version(tf_full_version) >= Version("2.16"):
         pytest.skip(
             "This test is failing in TensorFlow 2.16 beacuse of an upstream bug: "
             "https://github.com/tensorflow/io/issues/2039"

--- a/tests/integ/sagemaker/workflow/test_model_steps.py
+++ b/tests/integ/sagemaker/workflow/test_model_steps.py
@@ -592,7 +592,7 @@ def test_model_registration_with_drift_check_baselines_and_model_metrics(
 def test_model_registration_with_tensorflow_model_with_pipeline_model(
     pipeline_session, role, tf_full_version, tf_full_py_version, pipeline_name
 ):
-    if Version(tf_full_version) in SpecifierSet("==2.16.*"):
+    if Version(tf_full_version) >= Version("2.16"):
         pytest.skip(
             "This test is failing in TensorFlow 2.16 beacuse of an upstream bug: "
             "https://github.com/tensorflow/io/issues/2039"

--- a/tests/integ/sagemaker/workflow/test_model_steps.py
+++ b/tests/integ/sagemaker/workflow/test_model_steps.py
@@ -18,7 +18,6 @@ import os
 import pytest
 
 from packaging.version import Version
-from packaging.specifiers import SpecifierSet
 
 from tests.integ.sagemaker.workflow.helpers import wait_pipeline_execution
 from sagemaker.workflow.fail_step import FailStep

--- a/tests/integ/sagemaker/workflow/test_training_steps.py
+++ b/tests/integ/sagemaker/workflow/test_training_steps.py
@@ -238,7 +238,7 @@ def test_training_step_with_output_path_as_join(
 def test_tensorflow_training_step_with_parameterized_code_input(
     pipeline_session, role, tf_full_version, tf_full_py_version, pipeline_name
 ):
-    if Version(tf_full_version) in SpecifierSet("==2.16.*"):
+    if Version(tf_full_version) >= Version("2.16"):
         pytest.skip(
             "This test is failing in TensorFlow 2.16 beacuse of an upstream bug: "
             "https://github.com/tensorflow/io/issues/2039"

--- a/tests/integ/sagemaker/workflow/test_training_steps.py
+++ b/tests/integ/sagemaker/workflow/test_training_steps.py
@@ -19,7 +19,6 @@ import logging
 import pytest
 
 from packaging.version import Version
-from packaging.specifiers import SpecifierSet
 
 from tests.integ.sagemaker.workflow.helpers import wait_pipeline_execution
 from sagemaker import TrainingInput, get_execution_role, utils, image_uris

--- a/tests/integ/test_transformer.py
+++ b/tests/integ/test_transformer.py
@@ -19,7 +19,6 @@ import time
 import pytest
 
 from packaging.version import Version
-from packaging.specifiers import SpecifierSet
 
 from sagemaker import KMeans, s3, get_execution_role
 from sagemaker.mxnet import MXNet

--- a/tests/integ/test_transformer.py
+++ b/tests/integ/test_transformer.py
@@ -556,7 +556,7 @@ def test_transform_mxnet_logs(
 def test_transform_tf_kms_network_isolation(
     sagemaker_session, cpu_instance_type, tmpdir, tf_full_version, tf_full_py_version
 ):
-    if Version(tf_full_version) in SpecifierSet("==2.16.*"):
+    if Version(tf_full_version) >= Version("2.16"):
         pytest.skip(
             "This test is failing in TensorFlow 2.16 beacuse of an upstream bug: "
             "https://github.com/tensorflow/io/issues/2039"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Skipping tests with TF >= 2.16 due to lack of s3 support - https://github.com/tensorflow/io/issues/2039

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)
- [ ] If adding any dependency in requirements.txt files, I have spell checked and ensured they exist in PyPi

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
