### PR TITLE
fix: keep sagemaker_session from being overridden to None

### DIFF
--- a/src/sagemaker/jumpstart/cache.py
+++ b/src/sagemaker/jumpstart/cache.py
@@ -110,7 +110,8 @@ class JumpStartModelsCache:
             sagemaker_session: sagemaker session object to use.
                 Default: session object from default region us-west-2.
         """
-
+        # if sagemaker_session is None:
+        #     sagemaker_session = DEFAULT_JUMPSTART_SAGEMAKER_SESSION
         self._region = region or utils.get_region_fallback(
             s3_bucket_name=s3_bucket_name, s3_client=s3_client
         )
@@ -150,7 +151,8 @@ class JumpStartModelsCache:
             if s3_client_config
             else boto3.client("s3", region_name=self._region)
         )
-        self._sagemaker_session = sagemaker_session
+        # Fallback in case a caller overrides sagemaker_session to None
+        self._sagemaker_session = sagemaker_session or DEFAULT_JUMPSTART_SAGEMAKER_SESSION
 
     def set_region(self, region: str) -> None:
         """Set region for cache. Clears cache after new region is set."""

--- a/src/sagemaker/jumpstart/cache.py
+++ b/src/sagemaker/jumpstart/cache.py
@@ -110,8 +110,7 @@ class JumpStartModelsCache:
             sagemaker_session: sagemaker session object to use.
                 Default: session object from default region us-west-2.
         """
-        # if sagemaker_session is None:
-        #     sagemaker_session = DEFAULT_JUMPSTART_SAGEMAKER_SESSION
+
         self._region = region or utils.get_region_fallback(
             s3_bucket_name=s3_bucket_name, s3_client=s3_client
         )

--- a/src/sagemaker/jumpstart/hub/utils.py
+++ b/src/sagemaker/jumpstart/hub/utils.py
@@ -78,6 +78,9 @@ def construct_hub_arn_from_name(
     account_id: Optional[str] = None,
 ) -> str:
     """Constructs a Hub arn from the Hub name using default Session values."""
+    if session is None:
+        # session is overridden to none by some callers
+        session = constants.DEFAULT_JUMPSTART_SAGEMAKER_SESSION
 
     account_id = account_id or session.account_id()
     region = region or session.boto_region_name
@@ -211,6 +214,9 @@ def get_hub_model_version(
         ClientError: If the specified model is not found in the hub.
         KeyError: If the specified model version is not found.
     """
+    if sagemaker_session is None:
+        # sagemaker_session is overridden to none by some callers
+        sagemaker_session = constants.DEFAULT_JUMPSTART_SAGEMAKER_SESSION
 
     try:
         hub_content_summaries = sagemaker_session.list_hub_content_versions(

--- a/tests/integ/sagemaker/jumpstart/private_hub/model/test_jumpstart_private_hub_model.py
+++ b/tests/integ/sagemaker/jumpstart/private_hub/model/test_jumpstart_private_hub_model.py
@@ -82,6 +82,23 @@ def test_jumpstart_hub_model(setup, add_model_references):
     assert sagemaker_session.endpoint_in_service_or_not(predictor.endpoint_name)
 
 
+def test_jumpstart_hub_model_with_default_session(setup, add_model_references):
+    model_version = "*"
+    hub_name = os.environ[ENV_VAR_JUMPSTART_SDK_TEST_HUB_NAME]
+
+    model_id = "catboost-classification-model"
+
+    sagemaker_session = get_sm_session()
+
+    model = JumpStartModel(model_id=model_id, model_version=model_version, hub_name=hub_name)
+
+    predictor = model.deploy(
+        tags=[{"Key": JUMPSTART_TAG, "Value": os.environ[ENV_VAR_JUMPSTART_SDK_TEST_SUITE_ID]}],
+    )
+
+    assert sagemaker_session.endpoint_in_service_or_not(predictor.endpoint_name)
+
+
 def test_jumpstart_hub_gated_model(setup, add_model_references):
 
     model_id = "meta-textgeneration-llama-3-2-1b"

--- a/tests/unit/sagemaker/jumpstart/hub/test_utils.py
+++ b/tests/unit/sagemaker/jumpstart/hub/test_utils.py
@@ -15,8 +15,8 @@ from __future__ import absolute_import
 from unittest.mock import patch, Mock
 from sagemaker.jumpstart.types import HubArnExtractedInfo
 from sagemaker.jumpstart.constants import (
-    JUMPSTART_DEFAULT_REGION_NAME, 
-    DEFAULT_JUMPSTART_SAGEMAKER_SESSION
+    JUMPSTART_DEFAULT_REGION_NAME,
+    DEFAULT_JUMPSTART_SAGEMAKER_SESSION,
 )
 from sagemaker.jumpstart.hub import parser_utils, utils
 

--- a/tests/unit/sagemaker/jumpstart/hub/test_utils.py
+++ b/tests/unit/sagemaker/jumpstart/hub/test_utils.py
@@ -14,7 +14,10 @@ from __future__ import absolute_import
 
 from unittest.mock import patch, Mock
 from sagemaker.jumpstart.types import HubArnExtractedInfo
-from sagemaker.jumpstart.constants import JUMPSTART_DEFAULT_REGION_NAME
+from sagemaker.jumpstart.constants import (
+    JUMPSTART_DEFAULT_REGION_NAME, 
+    DEFAULT_JUMPSTART_SAGEMAKER_SESSION
+)
 from sagemaker.jumpstart.hub import parser_utils, utils
 
 
@@ -77,6 +80,17 @@ def test_construct_hub_arn_from_name():
             hub_name=hub_name, region="us-east-1", session=mock_sagemaker_session
         )
         == "arn:aws:sagemaker:us-east-1:123456789123:hub/my-cool-hub"
+    )
+
+
+def test_construct_hub_arn_from_name_with_session_none():
+    hub_name = "my-cool-hub"
+    account_id = DEFAULT_JUMPSTART_SAGEMAKER_SESSION.account_id()
+    boto_region_name = DEFAULT_JUMPSTART_SAGEMAKER_SESSION.boto_region_name
+
+    assert (
+        utils.construct_hub_arn_from_name(hub_name=hub_name, session=None)
+        == f"arn:aws:sagemaker:{boto_region_name}:{account_id}:hub/{hub_name}"
     )
 
 

--- a/tests/unit/sagemaker/jumpstart/test_cache.py
+++ b/tests/unit/sagemaker/jumpstart/test_cache.py
@@ -26,6 +26,7 @@ from mock import patch
 from sagemaker.jumpstart.cache import (
     JUMPSTART_DEFAULT_MANIFEST_FILE_S3_KEY,
     JUMPSTART_DEFAULT_PROPRIETARY_MANIFEST_KEY,
+    DEFAULT_JUMPSTART_SAGEMAKER_SESSION,
     JumpStartModelsCache,
 )
 from sagemaker.jumpstart.constants import (
@@ -51,6 +52,25 @@ from tests.unit.sagemaker.jumpstart.constants import (
     BASE_PROPRIETARY_MANIFEST,
 )
 from sagemaker.jumpstart.utils import get_jumpstart_content_bucket
+
+
+@patch("sagemaker.jumpstart.utils.get_region_fallback", lambda *args, **kwargs: "dummy-region")
+@patch(
+    "sagemaker.jumpstart.utils.get_jumpstart_content_bucket", lambda *args, **kwargs: "dummy-bucket"
+)
+@patch("boto3.client")
+def test_jumpstart_cache_init(mock_boto3_client):
+    cache = JumpStartModelsCache()
+    assert cache._region == "dummy-region"
+    assert cache.s3_bucket_name == "dummy-bucket"
+    assert cache._manifest_file_s3_key == JUMPSTART_DEFAULT_MANIFEST_FILE_S3_KEY
+    assert cache._proprietary_manifest_s3_key == JUMPSTART_DEFAULT_PROPRIETARY_MANIFEST_KEY
+    assert cache._sagemaker_session == DEFAULT_JUMPSTART_SAGEMAKER_SESSION
+    mock_boto3_client.assert_called_once_with("s3", region_name="dummy-region")
+
+    # Some callers override the session to None, should still be set to default
+    cache = JumpStartModelsCache(sagemaker_session=None)
+    assert cache._sagemaker_session == DEFAULT_JUMPSTART_SAGEMAKER_SESSION
 
 
 @patch.object(JumpStartModelsCache, "_retrieval_function", patched_retrieval_function)


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
When instantiating a `JumpStartModel` or `JumpStartEstimator` with a `hub_name` param for private hubs, the `sagemaker_session` gets overridden to None in certain lower level function calls. This code change ensures that whenever the session is overridden to None, it takes on the default session value. Furthermore, unit tests and integ tests were added to cover this case.

*Testing done:*
Added unit tests and integ tests. Also ran sample notebook code (since that is where the issue was discovered)

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)
- [x] If adding any dependency in requirements.txt files, I have spell checked and ensured they exist in PyPi

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
