### PR TITLE
Move RecordSerializer and RecordDeserializer to sagemaker.serializers and sagemaker.deserialzers

### DIFF
--- a/doc/v2.rst
+++ b/doc/v2.rst
@@ -324,9 +324,9 @@ The follow serializer/deserializer classes have been renamed and/or moved:
 +--------------------------------------------------------+-------------------------------------------------------+
 | ``sagemaker.predictor._NPYSerializer``                 | ``sagemaker.serializers.NumpySerializer``             |
 +--------------------------------------------------------+-------------------------------------------------------+
-| ``sagemaker.amazon.common.numpy_to_record_serializer`` | ``sagemaker.amazon.common.RecordSerializer``          |
+| ``sagemaker.amazon.common.numpy_to_record_serializer`` | ``sagemaker.serializers.RecordSerializer``          |
 +--------------------------------------------------------+-------------------------------------------------------+
-| ``sagemaker.amazon.common.record_deserializer``        | ``sagemaker.amazon.common.RecordDeserializer``        |
+| ``sagemaker.amazon.common.record_deserializer``        | ``sagemaker.deserializers.RecordDeserializer``        |
 +--------------------------------------------------------+-------------------------------------------------------+
 | ``sagemaker.predictor._JsonDeserializer``              | ``sagemaker.deserializers.JSONDeserializer``          |
 +--------------------------------------------------------+-------------------------------------------------------+

--- a/doc/v2.rst
+++ b/doc/v2.rst
@@ -324,7 +324,7 @@ The follow serializer/deserializer classes have been renamed and/or moved:
 +--------------------------------------------------------+-------------------------------------------------------+
 | ``sagemaker.predictor._NPYSerializer``                 | ``sagemaker.serializers.NumpySerializer``             |
 +--------------------------------------------------------+-------------------------------------------------------+
-| ``sagemaker.amazon.common.numpy_to_record_serializer`` | ``sagemaker.serializers.RecordSerializer``          |
+| ``sagemaker.amazon.common.numpy_to_record_serializer`` | ``sagemaker.serializers.RecordSerializer``            |
 +--------------------------------------------------------+-------------------------------------------------------+
 | ``sagemaker.amazon.common.record_deserializer``        | ``sagemaker.deserializers.RecordDeserializer``        |
 +--------------------------------------------------------+-------------------------------------------------------+

--- a/src/sagemaker/amazon/factorization_machines.py
+++ b/src/sagemaker/amazon/factorization_machines.py
@@ -17,11 +17,12 @@ from typing import Union, Optional
 
 from sagemaker import image_uris
 from sagemaker.amazon.amazon_estimator import AmazonAlgorithmEstimatorBase
-from sagemaker.amazon.common import RecordSerializer, RecordDeserializer
 from sagemaker.amazon.hyperparameter import Hyperparameter as hp  # noqa
 from sagemaker.amazon.validation import gt, isin, ge
+from sagemaker.deserializers import RecordDeserializer
 from sagemaker.predictor import Predictor
 from sagemaker.model import Model
+from sagemaker.serializers import RecordSerializer
 from sagemaker.session import Session
 from sagemaker.utils import pop_out_unused_kwarg
 from sagemaker.vpc_utils import VPC_CONFIG_DEFAULT

--- a/src/sagemaker/amazon/kmeans.py
+++ b/src/sagemaker/amazon/kmeans.py
@@ -17,11 +17,12 @@ from typing import Union, Optional, List
 
 from sagemaker import image_uris
 from sagemaker.amazon.amazon_estimator import AmazonAlgorithmEstimatorBase
-from sagemaker.amazon.common import RecordSerializer, RecordDeserializer
 from sagemaker.amazon.hyperparameter import Hyperparameter as hp  # noqa
 from sagemaker.amazon.validation import gt, isin, ge, le
+from sagemaker.deserializers import RecordDeserializer
 from sagemaker.predictor import Predictor
 from sagemaker.model import Model
+from sagemaker.serializers import RecordSerializer
 from sagemaker.session import Session
 from sagemaker.utils import pop_out_unused_kwarg
 from sagemaker.vpc_utils import VPC_CONFIG_DEFAULT

--- a/src/sagemaker/amazon/knn.py
+++ b/src/sagemaker/amazon/knn.py
@@ -17,11 +17,12 @@ from typing import Union, Optional
 
 from sagemaker import image_uris
 from sagemaker.amazon.amazon_estimator import AmazonAlgorithmEstimatorBase
-from sagemaker.amazon.common import RecordSerializer, RecordDeserializer
 from sagemaker.amazon.hyperparameter import Hyperparameter as hp  # noqa
 from sagemaker.amazon.validation import ge, isin
+from sagemaker.deserializers import RecordDeserializer
 from sagemaker.predictor import Predictor
 from sagemaker.model import Model
+from sagemaker.serializers import RecordSerializer
 from sagemaker.session import Session
 from sagemaker.utils import pop_out_unused_kwarg
 from sagemaker.vpc_utils import VPC_CONFIG_DEFAULT

--- a/src/sagemaker/amazon/lda.py
+++ b/src/sagemaker/amazon/lda.py
@@ -18,11 +18,12 @@ from typing import Union, Optional
 
 from sagemaker import image_uris
 from sagemaker.amazon.amazon_estimator import AmazonAlgorithmEstimatorBase
-from sagemaker.amazon.common import RecordSerializer, RecordDeserializer
+from sagemaker.deserializers import RecordDeserializer
 from sagemaker.amazon.hyperparameter import Hyperparameter as hp  # noqa
 from sagemaker.amazon.validation import gt
 from sagemaker.predictor import Predictor
 from sagemaker.model import Model
+from sagemaker.serializers import RecordSerializer
 from sagemaker.session import Session
 from sagemaker.utils import pop_out_unused_kwarg
 from sagemaker.vpc_utils import VPC_CONFIG_DEFAULT

--- a/src/sagemaker/amazon/linear_learner.py
+++ b/src/sagemaker/amazon/linear_learner.py
@@ -18,11 +18,12 @@ from typing import Union, Optional
 
 from sagemaker import image_uris
 from sagemaker.amazon.amazon_estimator import AmazonAlgorithmEstimatorBase
-from sagemaker.amazon.common import RecordSerializer, RecordDeserializer
+from sagemaker.deserializers import RecordDeserializer
 from sagemaker.amazon.hyperparameter import Hyperparameter as hp  # noqa
 from sagemaker.amazon.validation import isin, gt, lt, ge, le
 from sagemaker.predictor import Predictor
 from sagemaker.model import Model
+from sagemaker.serializers import RecordSerializer
 from sagemaker.session import Session
 from sagemaker.utils import pop_out_unused_kwarg
 from sagemaker.vpc_utils import VPC_CONFIG_DEFAULT

--- a/src/sagemaker/amazon/ntm.py
+++ b/src/sagemaker/amazon/ntm.py
@@ -17,11 +17,12 @@ from typing import Optional, Union, List
 
 from sagemaker import image_uris
 from sagemaker.amazon.amazon_estimator import AmazonAlgorithmEstimatorBase
-from sagemaker.amazon.common import RecordSerializer, RecordDeserializer
 from sagemaker.amazon.hyperparameter import Hyperparameter as hp  # noqa
 from sagemaker.amazon.validation import ge, le, isin
+from sagemaker.deserializers import RecordDeserializer
 from sagemaker.predictor import Predictor
 from sagemaker.model import Model
+from sagemaker.serializers import RecordSerializer
 from sagemaker.session import Session
 from sagemaker.utils import pop_out_unused_kwarg
 from sagemaker.vpc_utils import VPC_CONFIG_DEFAULT

--- a/src/sagemaker/amazon/pca.py
+++ b/src/sagemaker/amazon/pca.py
@@ -17,11 +17,12 @@ from typing import Union, Optional
 
 from sagemaker import image_uris
 from sagemaker.amazon.amazon_estimator import AmazonAlgorithmEstimatorBase
-from sagemaker.amazon.common import RecordSerializer, RecordDeserializer
 from sagemaker.amazon.hyperparameter import Hyperparameter as hp  # noqa
 from sagemaker.amazon.validation import gt, isin
+from sagemaker.deserializers import RecordDeserializer
 from sagemaker.predictor import Predictor
 from sagemaker.model import Model
+from sagemaker.serializers import RecordSerializer
 from sagemaker.session import Session
 from sagemaker.utils import pop_out_unused_kwarg
 from sagemaker.vpc_utils import VPC_CONFIG_DEFAULT

--- a/src/sagemaker/amazon/randomcutforest.py
+++ b/src/sagemaker/amazon/randomcutforest.py
@@ -17,11 +17,12 @@ from typing import Optional, Union, List
 
 from sagemaker import image_uris
 from sagemaker.amazon.amazon_estimator import AmazonAlgorithmEstimatorBase
-from sagemaker.amazon.common import RecordSerializer, RecordDeserializer
 from sagemaker.amazon.hyperparameter import Hyperparameter as hp  # noqa
 from sagemaker.amazon.validation import ge, le
+from sagemaker.deserializers import RecordDeserializer
 from sagemaker.predictor import Predictor
 from sagemaker.model import Model
+from sagemaker.serializers import RecordSerializer
 from sagemaker.session import Session
 from sagemaker.utils import pop_out_unused_kwarg
 from sagemaker.vpc_utils import VPC_CONFIG_DEFAULT

--- a/src/sagemaker/base_deserializers.py
+++ b/src/sagemaker/base_deserializers.py
@@ -23,6 +23,7 @@ import json
 import numpy as np
 from six import with_metaclass
 
+from sagemaker.amazon.common import read_records
 from sagemaker.utils import DeferredError
 
 try:
@@ -388,3 +389,31 @@ class TorchTensorDeserializer(SimpleBaseDeserializer):
                 "Unable to deserialize your data to torch.Tensor.\
                     Please provide custom deserializer in InferenceSpec."
             )
+
+
+class RecordDeserializer(SimpleBaseDeserializer):
+    """Deserialize RecordIO Protobuf data from an inference endpoint."""
+
+    def __init__(self, accept="application/x-recordio-protobuf"):
+        """Initialize a ``RecordDeserializer`` instance.
+
+        Args:
+            accept (union[str, tuple[str]]): The MIME type (or tuple of allowable MIME types) that
+                is expected from the inference endpoint (default:
+                "application/x-recordio-protobuf").
+        """
+        super(RecordDeserializer, self).__init__(accept=accept)
+
+    def deserialize(self, data, content_type):
+        """Deserialize RecordIO Protobuf data from an inference endpoint.
+
+        Args:
+            data (object): The protobuf message to deserialize.
+            content_type (str): The MIME type of the data.
+        Returns:
+            list: A list of records.
+        """
+        try:
+            return read_records(data)
+        finally:
+            data.close()

--- a/src/sagemaker/base_serializers.py
+++ b/src/sagemaker/base_serializers.py
@@ -22,6 +22,7 @@ import numpy as np
 from pandas import DataFrame
 from six import with_metaclass
 
+from sagemaker.amazon.common import write_numpy_to_dense_tensor
 from sagemaker.utils import DeferredError
 
 try:
@@ -466,3 +467,39 @@ class TorchTensorSerializer(SimpleBaseSerializer):
                 )
 
         raise ValueError("Object of type %s is not a torch.Tensor" % type(data))
+
+
+class RecordSerializer(SimpleBaseSerializer):
+    """Serialize a NumPy array for an inference request."""
+
+    def __init__(self, content_type="application/x-recordio-protobuf"):
+        """Initialize a ``RecordSerializer`` instance.
+
+        Args:
+            content_type (str): The MIME type to signal to the inference endpoint when sending
+                request data (default: "application/x-recordio-protobuf").
+        """
+        super(RecordSerializer, self).__init__(content_type=content_type)
+
+    def serialize(self, data):
+        """Serialize a NumPy array into a buffer containing RecordIO records.
+
+        Args:
+            data (numpy.ndarray): The data to serialize.
+
+        Returns:
+            io.BytesIO: A buffer containing the data serialized as records.
+        """
+        if len(data.shape) == 1:
+            data = data.reshape(1, data.shape[0])
+
+        if len(data.shape) != 2:
+            raise ValueError(
+                "Expected a 1D or 2D array, but got a %dD array instead." % len(data.shape)
+            )
+
+        buffer = io.BytesIO()
+        write_numpy_to_dense_tensor(buffer, data)
+        buffer.seek(0)
+
+        return buffer

--- a/src/sagemaker/cli/compatibility/v2/modifiers/serde.py
+++ b/src/sagemaker/cli/compatibility/v2/modifiers/serde.py
@@ -51,8 +51,8 @@ NEW_CLASS_NAME_TO_NAMESPACES = {
     "StreamDeserializer": ("sagemaker.deserializers",),
     "NumpyDeserializer": ("sagemaker.deserializers",),
     "JSONDeserializer": ("sagemaker.deserializers",),
-    "RecordSerializer ": ("sagemaker.amazon.common",),
-    "RecordDeserializer": ("sagemaker.amazon.common",),
+    "RecordSerializer ": ("sagemaker.serializers",),
+    "RecordDeserializer": ("sagemaker.deserializers",),
 }
 
 OLD_CLASS_NAME_TO_NEW_CLASS_NAME = {
@@ -101,8 +101,8 @@ class SerdeConstructorRenamer(Modifier):
         - ``sagemaker.predictor.StreamDeserializer``
         - ``sagemaker.predictor._NumpyDeserializer``
         - ``sagemaker.predictor._JsonDeserializer``
-        - ``sagemaker.amazon.common.numpy_to_record_serializer``
-        - ``sagemaker.amazon.common.record_deserializer``
+        - ``sagemaker.serializers.numpy_to_record_serializer``
+        - ``sagemaker.deserializers.record_deserializer``
 
         Args:
             node (ast.Call): a node that represents a function call. For more,
@@ -128,8 +128,8 @@ class SerdeConstructorRenamer(Modifier):
         - ``sagemaker.deserializers.StreamDeserializer``
         - ``sagemaker.deserializers.NumpyDeserializer``
         - ``sagemaker.deserializers._JsonDeserializer``
-        - ``sagemaker.amazon.common.RecordSerializer``
-        - ``sagemaker.amazon.common.RecordDeserializer``
+        - ``sagemaker.serializers.RecordSerializer``
+        - ``sagemaker.deserializers.RecordDeserializer``
 
         Args:
             node (ast.Call): a node that represents a SerDe constructor.
@@ -303,8 +303,8 @@ class SerdeImportFromAmazonCommonRenamer(Modifier):
         """Checks if the import statement imports a SerDe from the ``sagemaker.amazon.common``.
 
         This checks for:
-        - ``sagemaker.amazon.common.numpy_to_record_serializer``
-        - ``sagemaker.amazon.common.record_deserializer``
+        - ``sagemaker.serializers.numpy_to_record_serializer``
+        - ``sagemaker.deserializers.record_deserializer``
 
         Args:
             node (ast.ImportFrom): a node that represents a ``from ... import ... `` statement.
@@ -322,8 +322,8 @@ class SerdeImportFromAmazonCommonRenamer(Modifier):
         """Upgrades the ``numpy_to_record_serializer`` and ``record_deserializer`` imports.
 
         This upgrades the classes to (if applicable):
-        - ``sagemaker.amazon.common.RecordSerializer``
-        - ``sagemaker.amazon.common.RecordDeserializer``
+        - ``sagemaker.serializers.RecordSerializer``
+        - ``sagemaker.deserializers.RecordDeserializer``
 
         Args:
             node (ast.ImportFrom): a node that represents a ``from ... import ... `` statement.

--- a/src/sagemaker/deserializers.py
+++ b/src/sagemaker/deserializers.py
@@ -31,8 +31,10 @@ from sagemaker.base_deserializers import (  # noqa: F401 # pylint: disable=W0611
     StreamDeserializer,
     StringDeserializer,
     TorchTensorDeserializer,
+    RecordDeserializer,
 )
 
+from sagemaker.deprecations import deprecated_class
 from sagemaker.jumpstart import artifacts, utils as jumpstart_utils
 from sagemaker.jumpstart.constants import DEFAULT_JUMPSTART_SAGEMAKER_SESSION
 from sagemaker.jumpstart.enums import JumpStartModelType
@@ -150,3 +152,6 @@ def retrieve_default(
         model_type=model_type,
         config_name=config_name,
     )
+
+
+record_deserializer = deprecated_class(RecordDeserializer, "record_deserializer")

--- a/src/sagemaker/serializers.py
+++ b/src/sagemaker/serializers.py
@@ -30,8 +30,10 @@ from sagemaker.base_serializers import (  # noqa: F401 # pylint: disable=W0611
     SparseMatrixSerializer,
     TorchTensorSerializer,
     StringSerializer,
+    RecordSerializer,
 )
 
+from sagemaker.deprecations import deprecated_class
 from sagemaker.jumpstart import artifacts, utils as jumpstart_utils
 from sagemaker.jumpstart.constants import DEFAULT_JUMPSTART_SAGEMAKER_SESSION
 from sagemaker.jumpstart.enums import JumpStartModelType
@@ -152,3 +154,6 @@ def retrieve_default(
         model_type=model_type,
         config_name=config_name,
     )
+
+
+numpy_to_record_serializer = deprecated_class(RecordSerializer, "numpy_to_record_serializer")

--- a/tests/unit/sagemaker/cli/compatibility/v2/modifiers/test_serde.py
+++ b/tests/unit/sagemaker/cli/compatibility/v2/modifiers/test_serde.py
@@ -34,8 +34,8 @@ from tests.unit.sagemaker.cli.compatibility.v2.modifiers.ast_converter import as
         ("sagemaker.predictor._NumpyDeserializer()", True),
         ("sagemaker.predictor._JsonDeserializer()", True),
         ("sagemaker.predictor.OtherClass()", False),
-        ("sagemaker.serializers.numpy_to_record_serializer()", True),
-        ("sagemaker.deserializers.record_deserializer()", True),
+        ("sagemaker.amazon.common.numpy_to_record_serializer()", True),
+        ("sagemaker.amazon.common.record_deserializer()", True),
         ("_CsvSerializer()", True),
         ("_JsonSerializer()", True),
         ("_NpySerializer()", True),
@@ -250,8 +250,8 @@ def test_import_from_predictor_modify_node(src, expected):
 @pytest.mark.parametrize(
     "import_statement, expected",
     [
-        ("from sagemaker.serializers import numpy_to_record_serializer", True),
-        ("from sagemaker.deserializers import record_deserializer", True),
+        ("from sagemaker.amazon.common import numpy_to_record_serializer", True),
+        ("from sagemaker.amazon.common import record_deserializer", True),
         ("from sagemaker.amazon.common import write_spmatrix_to_sparse_tensor", False),
     ],
 )

--- a/tests/unit/sagemaker/cli/compatibility/v2/modifiers/test_serde.py
+++ b/tests/unit/sagemaker/cli/compatibility/v2/modifiers/test_serde.py
@@ -34,8 +34,8 @@ from tests.unit.sagemaker.cli.compatibility.v2.modifiers.ast_converter import as
         ("sagemaker.predictor._NumpyDeserializer()", True),
         ("sagemaker.predictor._JsonDeserializer()", True),
         ("sagemaker.predictor.OtherClass()", False),
-        ("sagemaker.amazon.common.numpy_to_record_serializer()", True),
-        ("sagemaker.amazon.common.record_deserializer()", True),
+        ("sagemaker.serializers.numpy_to_record_serializer()", True),
+        ("sagemaker.deserializers.record_deserializer()", True),
         ("_CsvSerializer()", True),
         ("_JsonSerializer()", True),
         ("_NpySerializer()", True),
@@ -75,12 +75,12 @@ def test_constructor_node_should_be_modified(src, expected):
         ("sagemaker.predictor._NumpyDeserializer()", "deserializers.NumpyDeserializer()"),
         ("sagemaker.predictor._JsonDeserializer()", "deserializers.JSONDeserializer()"),
         (
-            "sagemaker.amazon.common.numpy_to_record_serializer()",
-            "sagemaker.amazon.common.RecordSerializer()",
+            "sagemaker.serializers.numpy_to_record_serializer()",
+            "sagemaker.serializers.RecordSerializer()",
         ),
         (
-            "sagemaker.amazon.common.record_deserializer()",
-            "sagemaker.amazon.common.RecordDeserializer()",
+            "sagemaker.deserializers.record_deserializer()",
+            "sagemaker.deserializers.RecordDeserializer()",
         ),
         ("_CsvSerializer()", "serializers.CSVSerializer()"),
         ("_JsonSerializer()", "serializers.JSONSerializer()"),
@@ -250,8 +250,8 @@ def test_import_from_predictor_modify_node(src, expected):
 @pytest.mark.parametrize(
     "import_statement, expected",
     [
-        ("from sagemaker.amazon.common import numpy_to_record_serializer", True),
-        ("from sagemaker.amazon.common import record_deserializer", True),
+        ("from sagemaker.serializers import numpy_to_record_serializer", True),
+        ("from sagemaker.deserializers import record_deserializer", True),
         ("from sagemaker.amazon.common import write_spmatrix_to_sparse_tensor", False),
     ],
 )
@@ -265,20 +265,12 @@ def test_import_from_amazon_common_node_should_be_modified(import_statement, exp
     "import_statement, expected",
     [
         (
-            "from sagemaker.amazon.common import numpy_to_record_serializer",
-            "from sagemaker.amazon.common import RecordSerializer",
+            "from sagemaker.serializers import numpy_to_record_serializer",
+            "from sagemaker.serializers import RecordSerializer",
         ),
         (
-            "from sagemaker.amazon.common import record_deserializer",
-            "from sagemaker.amazon.common import RecordDeserializer",
-        ),
-        (
-            "from sagemaker.amazon.common import numpy_to_record_serializer, record_deserializer",
-            "from sagemaker.amazon.common import RecordSerializer, RecordDeserializer",
-        ),
-        (
-            "from sagemaker.amazon.common import write_spmatrix_to_sparse_tensor, numpy_to_record_serializer",
-            "from sagemaker.amazon.common import write_spmatrix_to_sparse_tensor, RecordSerializer",
+            "from sagemaker.deserializers import record_deserializer",
+            "from sagemaker.deserializers import RecordDeserializer",
         ),
     ],
 )

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -16,12 +16,12 @@ import numpy as np
 import tempfile
 import pytest
 import itertools
+from sagemaker.deserializers import RecordDeserializer
+from sagemaker.serializers import RecordSerializer
 from scipy.sparse import coo_matrix
 from sagemaker.amazon.common import (
-    RecordDeserializer,
     write_numpy_to_dense_tensor,
     read_recordio,
-    RecordSerializer,
     write_spmatrix_to_sparse_tensor,
 )
 from sagemaker.amazon.record_pb2 import Record


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/sagemaker-python-sdk/issues/1994
*Description of changes:*
Move RecordSerializer and RecordDeserializer from sagemaker.amazon.common to sagemaker.serializers and sagemaker.deserialzers
*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)
- [ ] If adding any dependency in requirements.txt files, I have spell checked and ensured they exist in PyPi

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
