### PR TITLE
Add framework_version to all TensorFlowModel examples

### DIFF
--- a/doc/frameworks/tensorflow/deploying_tensorflow_serving.rst
+++ b/doc/frameworks/tensorflow/deploying_tensorflow_serving.rst
@@ -64,7 +64,7 @@ If you already have existing model artifacts in S3, you can skip training and de
 
   from sagemaker.tensorflow import TensorFlowModel
 
-  model = TensorFlowModel(model_data='s3://mybucket/model.tar.gz', role='MySageMakerRole', framework_version='MyFrameworkVersion')
+  model = TensorFlowModel(model_data='s3://mybucket/model.tar.gz', role='MySageMakerRole', framework_version='x.x.x')
 
   predictor = model.deploy(initial_instance_count=1, instance_type='ml.c5.xlarge')
 
@@ -74,7 +74,7 @@ Python-based TensorFlow serving on SageMaker has support for `Elastic Inference 
 
     from sagemaker.tensorflow import TensorFlowModel
 
-    model = TensorFlowModel(model_data='s3://mybucket/model.tar.gz', role='MySageMakerRole', framework_version='MyFrameworkVersion')
+    model = TensorFlowModel(model_data='s3://mybucket/model.tar.gz', role='MySageMakerRole', framework_version='x.x.x')
 
     predictor = model.deploy(initial_instance_count=1, instance_type='ml.c5.xlarge', accelerator_type='ml.eia1.medium')
 

--- a/doc/frameworks/tensorflow/deploying_tensorflow_serving.rst
+++ b/doc/frameworks/tensorflow/deploying_tensorflow_serving.rst
@@ -64,7 +64,7 @@ If you already have existing model artifacts in S3, you can skip training and de
 
   from sagemaker.tensorflow import TensorFlowModel
 
-  model = TensorFlowModel(model_data='s3://mybucket/model.tar.gz', role='MySageMakerRole')
+  model = TensorFlowModel(model_data='s3://mybucket/model.tar.gz', role='MySageMakerRole', framework_version='MyFrameworkVersion')
 
   predictor = model.deploy(initial_instance_count=1, instance_type='ml.c5.xlarge')
 
@@ -74,7 +74,7 @@ Python-based TensorFlow serving on SageMaker has support for `Elastic Inference 
 
     from sagemaker.tensorflow import TensorFlowModel
 
-    model = TensorFlowModel(model_data='s3://mybucket/model.tar.gz', role='MySageMakerRole')
+    model = TensorFlowModel(model_data='s3://mybucket/model.tar.gz', role='MySageMakerRole', framework_version='MyFrameworkVersion')
 
     predictor = model.deploy(initial_instance_count=1, instance_type='ml.c5.xlarge', accelerator_type='ml.eia1.medium')
 

--- a/doc/frameworks/tensorflow/using_tf.rst
+++ b/doc/frameworks/tensorflow/using_tf.rst
@@ -468,7 +468,7 @@ If you already have existing model artifacts in S3, you can skip training and de
 
   from sagemaker.tensorflow import TensorFlowModel
 
-  model = TensorFlowModel(model_data='s3://mybucket/model.tar.gz', role='MySageMakerRole')
+  model = TensorFlowModel(model_data='s3://mybucket/model.tar.gz', role='MySageMakerRole', framework_version='MyFrameworkVersion')
 
   predictor = model.deploy(initial_instance_count=1, instance_type='ml.c5.xlarge')
 
@@ -478,7 +478,7 @@ Python-based TensorFlow serving on SageMaker has support for `Elastic Inference 
 
     from sagemaker.tensorflow import TensorFlowModel
 
-    model = TensorFlowModel(model_data='s3://mybucket/model.tar.gz', role='MySageMakerRole')
+    model = TensorFlowModel(model_data='s3://mybucket/model.tar.gz', role='MySageMakerRole', framework_version='MyFrameworkVersion')
 
     predictor = model.deploy(initial_instance_count=1, instance_type='ml.c5.xlarge', accelerator_type='ml.eia1.medium')
 
@@ -767,7 +767,8 @@ This customized Python code must be named ``inference.py`` and is specified thro
 
     model = TensorFlowModel(entry_point='inference.py',
                             model_data='s3://mybucket/model.tar.gz',
-                            role='MySageMakerRole')
+                            role='MySageMakerRole',
+                            framework_version='MyFrameworkVersion')
 
 In the example above, ``inference.py`` is assumed to be a file inside ``model.tar.gz``. If you want to use a local file instead, you must add the ``source_dir`` argument. See the documentation on `TensorFlowModel <https://sagemaker.readthedocs.io/en/stable/frameworks/tensorflow/sagemaker.tensorflow.html#sagemaker.tensorflow.model.TensorFlowModel>`_.
 
@@ -923,7 +924,8 @@ processing. There are 2 ways to do this:
     model = TensorFlowModel(entry_point='inference.py',
                             dependencies=['requirements.txt'],
                             model_data='s3://mybucket/model.tar.gz',
-                            role='MySageMakerRole')
+                            role='MySageMakerRole',
+                            framework_version='MyFrameworkVersion')
 
 
 2. If you are working in a network-isolation situation or if you don't
@@ -941,7 +943,8 @@ processing. There are 2 ways to do this:
     model = TensorFlowModel(entry_point='inference.py',
                            dependencies=['/path/to/folder/named/lib'],
                            model_data='s3://mybucket/model.tar.gz',
-                           role='MySageMakerRole')
+                           role='MySageMakerRole',
+                           framework_version='MyFrameworkVersion')
 
 For more information, see: https://github.com/aws/sagemaker-tensorflow-serving-container#prepost-processing
 

--- a/doc/frameworks/tensorflow/using_tf.rst
+++ b/doc/frameworks/tensorflow/using_tf.rst
@@ -468,7 +468,7 @@ If you already have existing model artifacts in S3, you can skip training and de
 
   from sagemaker.tensorflow import TensorFlowModel
 
-  model = TensorFlowModel(model_data='s3://mybucket/model.tar.gz', role='MySageMakerRole', framework_version='MyFrameworkVersion')
+  model = TensorFlowModel(model_data='s3://mybucket/model.tar.gz', role='MySageMakerRole', framework_version='x.x.x')
 
   predictor = model.deploy(initial_instance_count=1, instance_type='ml.c5.xlarge')
 
@@ -478,7 +478,7 @@ Python-based TensorFlow serving on SageMaker has support for `Elastic Inference 
 
     from sagemaker.tensorflow import TensorFlowModel
 
-    model = TensorFlowModel(model_data='s3://mybucket/model.tar.gz', role='MySageMakerRole', framework_version='MyFrameworkVersion')
+    model = TensorFlowModel(model_data='s3://mybucket/model.tar.gz', role='MySageMakerRole', framework_version='x.x.x')
 
     predictor = model.deploy(initial_instance_count=1, instance_type='ml.c5.xlarge', accelerator_type='ml.eia1.medium')
 
@@ -768,7 +768,7 @@ This customized Python code must be named ``inference.py`` and is specified thro
     model = TensorFlowModel(entry_point='inference.py',
                             model_data='s3://mybucket/model.tar.gz',
                             role='MySageMakerRole',
-                            framework_version='MyFrameworkVersion')
+                            framework_version='x.x.x')
 
 In the example above, ``inference.py`` is assumed to be a file inside ``model.tar.gz``. If you want to use a local file instead, you must add the ``source_dir`` argument. See the documentation on `TensorFlowModel <https://sagemaker.readthedocs.io/en/stable/frameworks/tensorflow/sagemaker.tensorflow.html#sagemaker.tensorflow.model.TensorFlowModel>`_.
 
@@ -925,7 +925,7 @@ processing. There are 2 ways to do this:
                             dependencies=['requirements.txt'],
                             model_data='s3://mybucket/model.tar.gz',
                             role='MySageMakerRole',
-                            framework_version='MyFrameworkVersion')
+                            framework_version='x.x.x')
 
 
 2. If you are working in a network-isolation situation or if you don't
@@ -944,7 +944,7 @@ processing. There are 2 ways to do this:
                            dependencies=['/path/to/folder/named/lib'],
                            model_data='s3://mybucket/model.tar.gz',
                            role='MySageMakerRole',
-                           framework_version='MyFrameworkVersion')
+                           framework_version='x.x.x')
 
 For more information, see: https://github.com/aws/sagemaker-tensorflow-serving-container#prepost-processing
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/sagemaker-python-sdk/issues/2630
*Description of changes:*
Add framework_version to all TensorFlowModel examples
*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)
- [ ] If adding any dependency in requirements.txt files, I have spell checked and ensured they exist in PyPi

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
