### PR TITLE
Fixing Pytorch training python version in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -254,6 +254,8 @@ def mxnet_eia_latest_py_version():
 
 @pytest.fixture(scope="module", params=["py2", "py3"])
 def pytorch_training_py_version(pytorch_training_version, request):
+    if Version(pytorch_training_version) >= Version("2.6"):
+        return "py312"
     if Version(pytorch_training_version) >= Version("2.3"):
         return "py311"
     elif Version(pytorch_training_version) >= Version("2.0"):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -272,7 +272,9 @@ def pytorch_training_py_version(pytorch_training_version, request):
 
 @pytest.fixture(scope="module", params=["py2", "py3"])
 def pytorch_inference_py_version(pytorch_inference_version, request):
-    if Version(pytorch_inference_version) >= Version("2.3"):
+    if Version(pytorch_inference_version) >= Version("2.6"):
+        return "py312"
+    elif Version(pytorch_inference_version) >= Version("2.3"):
         return "py311"
     elif Version(pytorch_inference_version) >= Version("2.0"):
         return "py310"


### PR DESCRIPTION
*Issue #, if available:*
New Python Version support for Pytorch added in automated Commit yesterday . 
https://github.com/aws/sagemaker-python-sdk/commit/30fe0ee0a04ebab3df09d6bf62290852b4e42c9f


*Description of changes:*

*Testing done:*
Unit Test Build

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)
- [x] If adding any dependency in requirements.txt files, I have spell checked and ensured they exist in PyPi

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
