### PR TITLE
fix: fix flaky clarify model monitor test

### DIFF
--- a/tests/unit/sagemaker/monitor/test_clarify_model_monitor.py
+++ b/tests/unit/sagemaker/monitor/test_clarify_model_monitor.py
@@ -568,11 +568,12 @@ def test_clarify_model_monitor():
 
     # The subclass should has monitoring_type() defined
     # noinspection PyAbstractClass
-    class DummyClarifyModelMonitoir(ClarifyModelMonitor):
+    class DummyClarifyModelMonitor(ClarifyModelMonitor):
+        _TEST_CLASS = True
         pass
 
     with pytest.raises(TypeError):
-        DummyClarifyModelMonitoir.monitoring_type()
+        DummyClarifyModelMonitor.monitoring_type()
 
 
 def test_clarify_model_monitor_invalid_update(clarify_model_monitors):
@@ -593,6 +594,8 @@ def test_clarify_model_monitor_invalid_attach(sagemaker_session):
     )
     # attach, invalid monitoring type
     for clarify_model_monitor_cls in ClarifyModelMonitor.__subclasses__():
+        if hasattr(clarify_model_monitor_cls, "_TEST_CLASS"):
+            continue
         with pytest.raises(TypeError):
             clarify_model_monitor_cls.attach(SCHEDULE_NAME, sagemaker_session)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* https://github.com/aws/sagemaker-python-sdk/actions/runs/14079305493/job/39428419047
* Fix flaky clarify model monitor test
* From fail test run can see that it the test fails when incorrectly invoking test class, which is not expected in the test
```
cls = <class 'tests.unit.sagemaker.monitor.test_clarify_model_monitor.test_clarify_model_monitor.<locals>.DummyClarifyModelMonitoir'>
``` 


*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)
- [ ] If adding any dependency in requirements.txt files, I have spell checked and ensured they exist in PyPi

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
