### PR TITLE
fix: fix flaky spark processor integ

### DIFF
--- a/tests/integ/test_spark_processing.py
+++ b/tests/integ/test_spark_processing.py
@@ -210,9 +210,7 @@ def test_sagemaker_pyspark_v3(
     spark_v3_py_processor, spark_v3_jar_processor, sagemaker_session, configuration
 ):
     test_sagemaker_pyspark_multinode(spark_v3_py_processor, sagemaker_session, configuration)
-    test_sagemaker_java_jar_multinode(
-        spark_v3_jar_processor, sagemaker_session, configuration
-    )
+    test_sagemaker_java_jar_multinode(spark_v3_jar_processor, sagemaker_session, configuration)
 
 
 def test_sagemaker_pyspark_multinode(spark_py_processor, sagemaker_session, configuration):
@@ -280,9 +278,7 @@ def test_sagemaker_pyspark_multinode(spark_py_processor, sagemaker_session, conf
     assert len(output_contents) != 0
 
 
-def test_sagemaker_java_jar_multinode(
-    spark_jar_processor, sagemaker_session, configuration
-):
+def test_sagemaker_java_jar_multinode(spark_jar_processor, sagemaker_session, configuration):
     """Test SparkJarProcessor using Java application jar"""
     bucket = spark_jar_processor.sagemaker_session.default_bucket()
     with open(os.path.join(SPARK_PATH, "files", "data.jsonl")) as data:

--- a/tests/integ/test_spark_processing.py
+++ b/tests/integ/test_spark_processing.py
@@ -35,7 +35,7 @@ SPARK_APPLICATION_URL_SUFFIX = "/history/application_1594922484246_0001/1/jobs/"
 SPARK_PATH = os.path.join(DATA_DIR, "spark")
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="module", autouse=True)
 def build_jar():
     jar_file_path = os.path.join(SPARK_PATH, "code", "java", "hello-java-spark")
     # compile java file
@@ -207,11 +207,11 @@ def configuration() -> list:
 
 
 def test_sagemaker_pyspark_v3(
-    spark_v3_py_processor, spark_v3_jar_processor, sagemaker_session, configuration, build_jar
+    spark_v3_py_processor, spark_v3_jar_processor, sagemaker_session, configuration
 ):
     test_sagemaker_pyspark_multinode(spark_v3_py_processor, sagemaker_session, configuration)
     test_sagemaker_java_jar_multinode(
-        spark_v3_jar_processor, sagemaker_session, configuration, build_jar
+        spark_v3_jar_processor, sagemaker_session, configuration
     )
 
 
@@ -281,7 +281,7 @@ def test_sagemaker_pyspark_multinode(spark_py_processor, sagemaker_session, conf
 
 
 def test_sagemaker_java_jar_multinode(
-    spark_jar_processor, sagemaker_session, configuration, build_jar
+    spark_jar_processor, sagemaker_session, configuration
 ):
     """Test SparkJarProcessor using Java application jar"""
     bucket = spark_jar_processor.sagemaker_session.default_bucket()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* https://github.com/aws/sagemaker-python-sdk/actions/runs/14095833798/job/39482861839
* Fails because of flaky condition where shared test resource is deleted 
```
E               ValueError: code /codebuild/output/src4051418682/src/github.com/aws/sagemaker-python-sdk/tests/integ/../data/spark/code/java/hello-java-spark/hello-spark-java.jar wasn't found. Please make sure that the file exists.
```
* Modify tests and fixture so setup and teardown only happen once for whole module test run

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)
- [ ] If adding any dependency in requirements.txt files, I have spell checked and ensured they exist in PyPi

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
