### PR TITLE
Update instance gpu info

### DIFF
--- a/src/sagemaker/image_uri_config/instance_gpu_info.json
+++ b/src/sagemaker/image_uri_config/instance_gpu_info.json
@@ -23,7 +23,7 @@
         "ml.g5.16xlarge": {"Count": 1, "TotalGpuMemoryInMiB": 24576},
         "ml.g5.12xlarge": {"Count": 4, "TotalGpuMemoryInMiB": 98304},
         "ml.g5.24xlarge": {"Count": 4, "TotalGpuMemoryInMiB": 98304},
-        "ml.g5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 196608}
+        "ml.g5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 183104}
     },
     "ap-east-1": {
         "ml.p5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 655360},
@@ -49,7 +49,7 @@
         "ml.g5.16xlarge": {"Count": 1, "TotalGpuMemoryInMiB": 24576},
         "ml.g5.12xlarge": {"Count": 4, "TotalGpuMemoryInMiB": 98304},
         "ml.g5.24xlarge": {"Count": 4, "TotalGpuMemoryInMiB": 98304},
-        "ml.g5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 196608}
+        "ml.g5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 183104}
     },
     "ap-northeast-1": {
         "ml.p5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 655360},
@@ -75,7 +75,7 @@
         "ml.g5.16xlarge": {"Count": 1, "TotalGpuMemoryInMiB": 24576},
         "ml.g5.12xlarge": {"Count": 4, "TotalGpuMemoryInMiB": 98304},
         "ml.g5.24xlarge": {"Count": 4, "TotalGpuMemoryInMiB": 98304},
-        "ml.g5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 196608}
+        "ml.g5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 183104}
     },
     "ap-northeast-2": {
         "ml.p5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 655360},
@@ -101,7 +101,7 @@
         "ml.g5.16xlarge": {"Count": 1, "TotalGpuMemoryInMiB": 24576},
         "ml.g5.12xlarge": {"Count": 4, "TotalGpuMemoryInMiB": 98304},
         "ml.g5.24xlarge": {"Count": 4, "TotalGpuMemoryInMiB": 98304},
-        "ml.g5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 196608}
+        "ml.g5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 183104}
     },
     "ap-northeast-3": {
         "ml.p5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 655360},
@@ -127,7 +127,7 @@
         "ml.g5.16xlarge": {"Count": 1, "TotalGpuMemoryInMiB": 24576},
         "ml.g5.12xlarge": {"Count": 4, "TotalGpuMemoryInMiB": 98304},
         "ml.g5.24xlarge": {"Count": 4, "TotalGpuMemoryInMiB": 98304},
-        "ml.g5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 196608}
+        "ml.g5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 183104}
     },
     "ap-south-1": {
         "ml.p5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 655360},
@@ -153,7 +153,7 @@
         "ml.g5.16xlarge": {"Count": 1, "TotalGpuMemoryInMiB": 24576},
         "ml.g5.12xlarge": {"Count": 4, "TotalGpuMemoryInMiB": 98304},
         "ml.g5.24xlarge": {"Count": 4, "TotalGpuMemoryInMiB": 98304},
-        "ml.g5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 196608}
+        "ml.g5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 183104}
     },
     "ap-southeast-1": {
         "ml.p5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 655360},
@@ -179,7 +179,7 @@
         "ml.g5.16xlarge": {"Count": 1, "TotalGpuMemoryInMiB": 24576},
         "ml.g5.12xlarge": {"Count": 4, "TotalGpuMemoryInMiB": 98304},
         "ml.g5.24xlarge": {"Count": 4, "TotalGpuMemoryInMiB": 98304},
-        "ml.g5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 196608}
+        "ml.g5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 183104}
     },
     "ap-southeast-2": {
         "ml.p5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 655360},
@@ -205,7 +205,7 @@
         "ml.g5.16xlarge": {"Count": 1, "TotalGpuMemoryInMiB": 24576},
         "ml.g5.12xlarge": {"Count": 4, "TotalGpuMemoryInMiB": 98304},
         "ml.g5.24xlarge": {"Count": 4, "TotalGpuMemoryInMiB": 98304},
-        "ml.g5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 196608}
+        "ml.g5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 183104}
     },
     "ap-southeast-3": {
         "ml.p5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 655360},
@@ -231,7 +231,7 @@
         "ml.g5.16xlarge": {"Count": 1, "TotalGpuMemoryInMiB": 24576},
         "ml.g5.12xlarge": {"Count": 4, "TotalGpuMemoryInMiB": 98304},
         "ml.g5.24xlarge": {"Count": 4, "TotalGpuMemoryInMiB": 98304},
-        "ml.g5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 196608}
+        "ml.g5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 183104}
     },
     "ca-central-1": {
         "ml.p5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 655360},
@@ -257,7 +257,7 @@
         "ml.g5.16xlarge": {"Count": 1, "TotalGpuMemoryInMiB": 24576},
         "ml.g5.12xlarge": {"Count": 4, "TotalGpuMemoryInMiB": 98304},
         "ml.g5.24xlarge": {"Count": 4, "TotalGpuMemoryInMiB": 98304},
-        "ml.g5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 196608}
+        "ml.g5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 183104}
     },
     "cn-north-1": {
         "ml.p5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 655360},
@@ -283,7 +283,7 @@
         "ml.g5.16xlarge": {"Count": 1, "TotalGpuMemoryInMiB": 24576},
         "ml.g5.12xlarge": {"Count": 4, "TotalGpuMemoryInMiB": 98304},
         "ml.g5.24xlarge": {"Count": 4, "TotalGpuMemoryInMiB": 98304},
-        "ml.g5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 196608}
+        "ml.g5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 183104}
     },
     "cn-northwest-1": {
         "ml.p5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 655360},
@@ -309,7 +309,7 @@
         "ml.g5.16xlarge": {"Count": 1, "TotalGpuMemoryInMiB": 24576},
         "ml.g5.12xlarge": {"Count": 4, "TotalGpuMemoryInMiB": 98304},
         "ml.g5.24xlarge": {"Count": 4, "TotalGpuMemoryInMiB": 98304},
-        "ml.g5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 196608}
+        "ml.g5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 183104}
     },
     "eu-central-1": {
         "ml.p5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 655360},
@@ -335,7 +335,7 @@
         "ml.g5.16xlarge": {"Count": 1, "TotalGpuMemoryInMiB": 24576},
         "ml.g5.12xlarge": {"Count": 4, "TotalGpuMemoryInMiB": 98304},
         "ml.g5.24xlarge": {"Count": 4, "TotalGpuMemoryInMiB": 98304},
-        "ml.g5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 196608}
+        "ml.g5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 183104}
     },
     "eu-central-2": {
         "ml.p5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 655360},
@@ -361,7 +361,7 @@
         "ml.g5.16xlarge": {"Count": 1, "TotalGpuMemoryInMiB": 24576},
         "ml.g5.12xlarge": {"Count": 4, "TotalGpuMemoryInMiB": 98304},
         "ml.g5.24xlarge": {"Count": 4, "TotalGpuMemoryInMiB": 98304},
-        "ml.g5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 196608}
+        "ml.g5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 183104}
     },
     "eu-north-1": {
         "ml.p5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 655360},
@@ -387,7 +387,7 @@
         "ml.g5.16xlarge": {"Count": 1, "TotalGpuMemoryInMiB": 24576},
         "ml.g5.12xlarge": {"Count": 4, "TotalGpuMemoryInMiB": 98304},
         "ml.g5.24xlarge": {"Count": 4, "TotalGpuMemoryInMiB": 98304},
-        "ml.g5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 196608}
+        "ml.g5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 183104}
     },
     "eu-south-1": {
         "ml.p5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 655360},
@@ -413,7 +413,7 @@
         "ml.g5.16xlarge": {"Count": 1, "TotalGpuMemoryInMiB": 24576},
         "ml.g5.12xlarge": {"Count": 4, "TotalGpuMemoryInMiB": 98304},
         "ml.g5.24xlarge": {"Count": 4, "TotalGpuMemoryInMiB": 98304},
-        "ml.g5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 196608}
+        "ml.g5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 183104}
     },
     "eu-south-2": {
         "ml.p5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 655360},
@@ -439,7 +439,7 @@
         "ml.g5.16xlarge": {"Count": 1, "TotalGpuMemoryInMiB": 24576},
         "ml.g5.12xlarge": {"Count": 4, "TotalGpuMemoryInMiB": 98304},
         "ml.g5.24xlarge": {"Count": 4, "TotalGpuMemoryInMiB": 98304},
-        "ml.g5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 196608}
+        "ml.g5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 183104}
     },
     "eu-west-1": {
         "ml.p5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 655360},
@@ -465,7 +465,7 @@
         "ml.g5.16xlarge": {"Count": 1, "TotalGpuMemoryInMiB": 24576},
         "ml.g5.12xlarge": {"Count": 4, "TotalGpuMemoryInMiB": 98304},
         "ml.g5.24xlarge": {"Count": 4, "TotalGpuMemoryInMiB": 98304},
-        "ml.g5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 196608}
+        "ml.g5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 183104}
     },
     "eu-west-2": {
         "ml.p5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 655360},
@@ -491,7 +491,7 @@
         "ml.g5.16xlarge": {"Count": 1, "TotalGpuMemoryInMiB": 24576},
         "ml.g5.12xlarge": {"Count": 4, "TotalGpuMemoryInMiB": 98304},
         "ml.g5.24xlarge": {"Count": 4, "TotalGpuMemoryInMiB": 98304},
-        "ml.g5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 196608}
+        "ml.g5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 183104}
     },
     "eu-west-3": {
         "ml.p5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 655360},
@@ -517,7 +517,7 @@
         "ml.g5.16xlarge": {"Count": 1, "TotalGpuMemoryInMiB": 24576},
         "ml.g5.12xlarge": {"Count": 4, "TotalGpuMemoryInMiB": 98304},
         "ml.g5.24xlarge": {"Count": 4, "TotalGpuMemoryInMiB": 98304},
-        "ml.g5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 196608}
+        "ml.g5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 183104}
     },
     "il-central-1": {
         "ml.p5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 655360},
@@ -543,7 +543,7 @@
         "ml.g5.16xlarge": {"Count": 1, "TotalGpuMemoryInMiB": 24576},
         "ml.g5.12xlarge": {"Count": 4, "TotalGpuMemoryInMiB": 98304},
         "ml.g5.24xlarge": {"Count": 4, "TotalGpuMemoryInMiB": 98304},
-        "ml.g5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 196608}
+        "ml.g5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 183104}
     },
     "me-central-1": {
         "ml.p5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 655360},
@@ -569,7 +569,7 @@
         "ml.g5.16xlarge": {"Count": 1, "TotalGpuMemoryInMiB": 24576},
         "ml.g5.12xlarge": {"Count": 4, "TotalGpuMemoryInMiB": 98304},
         "ml.g5.24xlarge": {"Count": 4, "TotalGpuMemoryInMiB": 98304},
-        "ml.g5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 196608}
+        "ml.g5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 183104}
     },
     "me-south-1": {
         "ml.p5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 655360},
@@ -595,7 +595,7 @@
         "ml.g5.16xlarge": {"Count": 1, "TotalGpuMemoryInMiB": 24576},
         "ml.g5.12xlarge": {"Count": 4, "TotalGpuMemoryInMiB": 98304},
         "ml.g5.24xlarge": {"Count": 4, "TotalGpuMemoryInMiB": 98304},
-        "ml.g5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 196608}
+        "ml.g5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 183104}
     },
     "sa-east-1": {
         "ml.p5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 655360},
@@ -621,7 +621,7 @@
         "ml.g5.16xlarge": {"Count": 1, "TotalGpuMemoryInMiB": 24576},
         "ml.g5.12xlarge": {"Count": 4, "TotalGpuMemoryInMiB": 98304},
         "ml.g5.24xlarge": {"Count": 4, "TotalGpuMemoryInMiB": 98304},
-        "ml.g5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 196608}
+        "ml.g5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 183104}
     },
     "us-east-1": {
         "ml.p5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 655360},
@@ -647,7 +647,7 @@
         "ml.g5.16xlarge": {"Count": 1, "TotalGpuMemoryInMiB": 24576},
         "ml.g5.12xlarge": {"Count": 4, "TotalGpuMemoryInMiB": 98304},
         "ml.g5.24xlarge": {"Count": 4, "TotalGpuMemoryInMiB": 98304},
-        "ml.g5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 196608}
+        "ml.g5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 183104}
     },
     "us-east-2": {
         "ml.p5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 655360},
@@ -673,7 +673,7 @@
         "ml.g5.16xlarge": {"Count": 1, "TotalGpuMemoryInMiB": 24576},
         "ml.g5.12xlarge": {"Count": 4, "TotalGpuMemoryInMiB": 98304},
         "ml.g5.24xlarge": {"Count": 4, "TotalGpuMemoryInMiB": 98304},
-        "ml.g5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 196608}
+        "ml.g5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 183104}
     },
     "us-gov-east-1": {
         "ml.p5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 655360},
@@ -699,7 +699,7 @@
         "ml.g5.16xlarge": {"Count": 1, "TotalGpuMemoryInMiB": 24576},
         "ml.g5.12xlarge": {"Count": 4, "TotalGpuMemoryInMiB": 98304},
         "ml.g5.24xlarge": {"Count": 4, "TotalGpuMemoryInMiB": 98304},
-        "ml.g5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 196608}
+        "ml.g5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 183104}
     },
     "us-gov-west-1": {
         "ml.p5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 655360},
@@ -725,7 +725,7 @@
         "ml.g5.16xlarge": {"Count": 1, "TotalGpuMemoryInMiB": 24576},
         "ml.g5.12xlarge": {"Count": 4, "TotalGpuMemoryInMiB": 98304},
         "ml.g5.24xlarge": {"Count": 4, "TotalGpuMemoryInMiB": 98304},
-        "ml.g5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 196608}
+        "ml.g5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 183104}
     },
     "us-west-1": {
         "ml.p5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 655360},
@@ -751,7 +751,7 @@
         "ml.g5.16xlarge": {"Count": 1, "TotalGpuMemoryInMiB": 24576},
         "ml.g5.12xlarge": {"Count": 4, "TotalGpuMemoryInMiB": 98304},
         "ml.g5.24xlarge": {"Count": 4, "TotalGpuMemoryInMiB": 98304},
-        "ml.g5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 196608}
+        "ml.g5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 183104}
     },
     "us-west-2": {
         "ml.p5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 655360},
@@ -777,6 +777,6 @@
         "ml.g5.16xlarge": {"Count": 1, "TotalGpuMemoryInMiB": 24576},
         "ml.g5.12xlarge": {"Count": 4, "TotalGpuMemoryInMiB": 98304},
         "ml.g5.24xlarge": {"Count": 4, "TotalGpuMemoryInMiB": 98304},
-        "ml.g5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 196608}
+        "ml.g5.48xlarge": {"Count": 8, "TotalGpuMemoryInMiB": 183104}
     }
 }

--- a/tests/integ/sagemaker/serve/utils/test_hardware_detector.py
+++ b/tests/integ/sagemaker/serve/utils/test_hardware_detector.py
@@ -19,7 +19,7 @@ from sagemaker.serve.utils import hardware_detector
 REGION = "us-west-2"
 VALID_INSTANCE_TYPE = "ml.g5.48xlarge"
 INVALID_INSTANCE_TYPE = "fl.c5.57xxlarge"
-EXPECTED_INSTANCE_GPU_INFO = (8, 196608)
+EXPECTED_INSTANCE_GPU_INFO = (8, 183104)
 
 
 def test_get_gpu_info_success(sagemaker_session):

--- a/tests/unit/sagemaker/serve/utils/test_hardware_detector.py
+++ b/tests/unit/sagemaker/serve/utils/test_hardware_detector.py
@@ -21,7 +21,7 @@ from sagemaker.serve.utils import hardware_detector
 REGION = "us-west-2"
 VALID_INSTANCE_TYPE = "ml.g5.48xlarge"
 INVALID_INSTANCE_TYPE = "fl.c5.57xxlarge"
-EXPECTED_INSTANCE_GPU_INFO = (8, 196608)
+EXPECTED_INSTANCE_GPU_INFO = (8, 183104)
 MIB_CONVERSION_FACTOR = 0.00000095367431640625
 MEMORY_BUFFER_MULTIPLIER = 1.2  # 20% buffer
 
@@ -39,7 +39,7 @@ def test_get_gpu_info_success(sagemaker_session, boto_session):
                             "MemoryInfo": {"SizeInMiB": 24576},
                         }
                     ],
-                    "TotalGpuMemoryInMiB": 196608,
+                    "TotalGpuMemoryInMiB": 183104,
                 },
             }
         ]


### PR DESCRIPTION
*Issue #, if available:*
Tests failed due to ec2 update instance gpu info.
```
__________________________ test_get_gpu_info_success ___________________________
[gw42] linux -- Python 3.10.13 /codebuild/output/src4177795889/src/github.com/aws/sagemaker-python-sdk/.tox/py310/bin/python

sagemaker_session = <sagemaker.session.Session object at 0x7f0e61a990f0>

    def test_get_gpu_info_success(sagemaker_session):
        gpu_info = hardware_detector._get_gpu_info(VALID_INSTANCE_TYPE, sagemaker_session)

>       assert gpu_info == EXPECTED_INSTANCE_GPU_INFO
E       assert (8, 183104) == (8, 196608)
E         At index 1 diff: 183104 != 196608
E         Full diff:
E         - (8, 196608)
E         + (8, 183104)

tests/integ/sagemaker/serve/utils/test_hardware_detector.py:28: AssertionError
----------------------------- Captured stderr call -----------------------------
ModelBuilder: INFO:     GPU Info [g5.48xlarge]: (8, 183104)
----------------------------- Captured stderr call -----------------------------
ModelBuilder: INFO:     GPU Info [g5.48xlarge]: (8, 183104)
----------------------------- Captured stderr call -----------------------------
ModelBuilder: INFO:     GPU Info [g5.48xlarge]: (8, 183104)
----------------------------- Captured stderr call -----------------------------
ModelBuilder: INFO:     GPU Info [g5.48xlarge]: (8, 183104)
```

*Description of changes:*

Update the hardcoded value.

Verified by running:

```
➜ aws ec2 describe-instance-types \
  --instance-types g5.48xlarge \
  --region us-east-1 \
  --query "InstanceTypes[].{
    InstanceType: InstanceType,
    TotalGpuMemoryInMiB: GpuInfo.TotalGpuMemoryInMiB,
    GpuCount: GpuInfo.Gpus[].Count | [0]
  }"
```

Response:
```
[
    {
        "InstanceType": "g5.48xlarge",
        "TotalGpuMemoryInMiB": 183104,
        "GpuCount": 8
    }
]
```


*Testing done:*

Local ran unit and integ tests.

```
../../../../../home/ruiliann/MorpheusMaster/sagemaker-python-sdk/tests/integ/sagemaker/serve/utils/test_hardware_detector.py::test_get_gpu_info_success [04/04/25 17:25:30] INFO     Found credentials in shared credentials file: ~/.aws/credentials                                                        credentials.py:1352
ModelBuilder: INFO:     GPU Info [g5.48xlarge]: (8, 183104)
PASSED
../../../../../home/ruiliann/MorpheusMaster/sagemaker-python-sdk/tests/integ/sagemaker/serve/utils/test_hardware_detector.py::test_get_gpu_info_throws PASSED
../../../../../home/ruiliann/MorpheusMaster/sagemaker-python-sdk/tests/integ/sagemaker/serve/utils/test_hardware_detector.py::test_get_gpu_info_fallback_success ModelBuilder: INFO:     GPU Info [g5.48xlarge]: (8, 183104)
PASSED
../../../../../home/ruiliann/MorpheusMaster/sagemaker-python-sdk/tests/integ/sagemaker/serve/utils/test_hardware_detector.py::test_get_gpu_info_fallback_throws PASSED
```

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)
- [x] If adding any dependency in requirements.txt files, I have spell checked and ensured they exist in PyPi

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
