### PR TITLE
fix: tgi image uri unit tests

### DIFF
--- a/tests/unit/sagemaker/image_uris/test_huggingface_llm.py
+++ b/tests/unit/sagemaker/image_uris/test_huggingface_llm.py
@@ -91,10 +91,10 @@ def test_huggingface_uris(load_config):
             # that doesn't involve a human raising a PR.
             if parse(version) > parse(highest_version):
                 print(
-                    f"Skipping test for version {version} as it is higher than "
-                    "the highest known version {highest_version}. There is "
+                    f"Skipping version check for {version} as there is "
                     "automation that now updates the image_uri_config "
-                    "without a human raising a PR."
+                    "without a human raising a PR. Tests will pass for "
+                    f"versions higher than {highest_version} that are not in HF_VERSIONS_MAPPING."
                 )
                 continue
 

--- a/tests/unit/sagemaker/image_uris/test_huggingface_llm.py
+++ b/tests/unit/sagemaker/image_uris/test_huggingface_llm.py
@@ -79,7 +79,7 @@ def test_huggingface_uris(load_config):
         raise ValueError(f"Device {device} not found in HF_VERSIONS_MAPPING")
 
     # Get highest version for the device
-    highest_version = max(HF_VERSIONS_MAPPING[device].keys(), key=lambda x: version.parse(x))
+    highest_version = max(HF_VERSIONS_MAPPING[device].keys(), key=lambda x: parse(x))
 
     for version in VERSIONS:
         ACCOUNTS = load_config["inference"]["versions"][version]["registries"]

--- a/tests/unit/sagemaker/image_uris/test_huggingface_llm.py
+++ b/tests/unit/sagemaker/image_uris/test_huggingface_llm.py
@@ -13,7 +13,7 @@
 from __future__ import absolute_import
 
 import pytest
-from packaging import version
+from packaging.version import parse
 
 from sagemaker.huggingface import get_huggingface_llm_image_uri
 from tests.unit.sagemaker.image_uris import expected_uris, conftest
@@ -89,10 +89,12 @@ def test_huggingface_uris(load_config):
             # Skip only if test version is higher than highest known version.
             # There's now automation to add new TGI releases to image_uri_config directory
             # that doesn't involve a human raising a PR.
-            if version.parse(version) > version.parse(highest_version):
+            if parse(version) > parse(highest_version):
                 print(
-                    f"Skipping test for version {test_version} as it is higher than the highest known version {highest_version}. "
-                    "There is automation that now updates the image_uri_config without a human raising a PR."
+                    f"Skipping test for version {version} as it is higher than "
+                    "the highest known version {highest_version}. There is "
+                    "automation that now updates the image_uri_config "
+                    "without a human raising a PR."
                 )
                 continue
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The image uri configs for tgi images are now updated via an automated process. To achieve this automation, we have to relax the unit test for this container to not require hardcoding the mappings between versions and full repository tag name. 

*Testing done:*
Unit tests pass. 

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)
- [ ] If adding any dependency in requirements.txt files, I have spell checked and ensured they exist in PyPi

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
