### PR TITLE
fix: parameter mismatch in update_endpoint

### DIFF
--- a/src/sagemaker/model.py
+++ b/src/sagemaker/model.py
@@ -1805,7 +1805,7 @@ api/latest/reference/services/sagemaker.html#SageMaker.Client.add_tags>`_
                     container_startup_health_check_timeout=container_startup_health_check_timeout,
                     explainer_config_dict=explainer_config_dict,
                     async_inference_config_dict=async_inference_config_dict,
-                    serverless_inference_config=serverless_inference_config_dict,
+                    serverless_inference_config_dict=serverless_inference_config_dict,
                     routing_config=routing_config,
                     inference_ami_version=inference_ami_version,
                 )


### PR DESCRIPTION
*Issue #, if available:*
Closes: #5130

*Description of changes:*
There is a parameter name mismatch that causes updating endpoints to fail as `serverless_inference_config` should be `serverless_inference_config_dict`. 

*Testing done:*
I've made these changes locally and ensured the update_endpoint flag works: 
```
/Users/dtaivpp/.pyenv/versions/issues_semantic/lib/python3.13/site-packages/pydantic/_internal/_fields.py:198: UserWarning: Field name "json" in "MonitoringDatasetFormat" shadows an attribute in parent "Base"
  warnings.warn(
[04/17/25 23:24:16] INFO     Found credentials in  credentials.py:1352
                             shared credentials                       
                             file:                                    
                             ~/.aws/credentials                       
sagemaker.config INFO - Not applying SDK defaults from location: /Library/Application Support/sagemaker/config.yaml
sagemaker.config INFO - Not applying SDK defaults from location: /Users/dtaivpp/Library/Application Support/sagemaker/config.yaml
[04/17/25 23:24:17] INFO     Found credentials in  credentials.py:1352
                             shared credentials                       
                             file:                                                          
[04/17/25 23:24:18] INFO     Repacking model artifact     model.py:820
                             (s3:/bucket/file.tar.gz),                
                             script artifact (.), and                 
                             dependencies ([]) into                   
                             single tar.gz file located               
                             at                                       
                             s3://model.tar.gz. This               
                             may take some time depending             
                             on model size...                         
[04/17/25 23:37:16] INFO     Creating model with name: session.py:4094
                             huggingface-pytorch-infer                
                             ence-2025-04-18-03-37-16-                
                             326                                      
[04/17/25 23:37:17] INFO     Creating endpoint-config  session.py:4610
                             with name                                
                             huggingface-pytorch-infer                
                             ence-2025-04-18-03-37-16-                
                             326                                      
-------!Model deployed successfully to endpoint: medembed-endpoint
Allow a few minutes for the endpoint to fully update if this was an update operation.
```
## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)
- [ ] If adding any dependency in requirements.txt files, I have spell checked and ensured they exist in PyPi

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
