### PR TITLE
chore: add huggingface images

### DIFF
--- a/src/sagemaker/image_uri_config/huggingface.json
+++ b/src/sagemaker/image_uri_config/huggingface.json
@@ -14,7 +14,9 @@
             "4.26": "4.26.0",
             "4.28": "4.28.1",
             "4.36": "4.36.0",
-            "4.46": "4.46.1"
+            "4.46": "4.46.1",
+            "4.48": "4.48.0",
+            "4.49": "4.49.0"
         },
         "versions": {
             "4.4.2": {
@@ -1066,6 +1068,100 @@
                         "gpu": "cu121-ubuntu20.04"
                     }
                 }
+            },
+            "4.48.0": {
+                "version_aliases": {
+                    "pytorch2.3": "pytorch2.3.0"
+                },
+                "pytorch2.3.0": {
+                    "py_versions": [
+                        "py311"
+                    ],
+                    "registries": {
+                        "af-south-1": "626614931356",
+                        "il-central-1": "780543022126",
+                        "ap-east-1": "871362719292",
+                        "ap-northeast-1": "763104351884",
+                        "ap-northeast-2": "763104351884",
+                        "ap-northeast-3": "364406365360",
+                        "ap-south-1": "763104351884",
+                        "ap-southeast-1": "763104351884",
+                        "ap-southeast-2": "763104351884",
+                        "ap-southeast-3": "907027046896",
+                        "ca-central-1": "763104351884",
+                        "cn-north-1": "727897471807",
+                        "cn-northwest-1": "727897471807",
+                        "eu-central-1": "763104351884",
+                        "eu-north-1": "763104351884",
+                        "eu-west-1": "763104351884",
+                        "eu-west-2": "763104351884",
+                        "eu-west-3": "763104351884",
+                        "eu-south-1": "692866216735",
+                        "me-south-1": "217643126080",
+                        "me-central-1": "914824155844",
+                        "sa-east-1": "763104351884",
+                        "us-east-1": "763104351884",
+                        "us-east-2": "763104351884",
+                        "us-gov-east-1": "446045086412",
+                        "us-gov-west-1": "442386744353",
+                        "us-iso-east-1": "886529160074",
+                        "us-isob-east-1": "094389454867",
+                        "us-west-1": "763104351884",
+                        "us-west-2": "763104351884",
+                        "ca-west-1": "204538143572"
+                    },
+                    "repository": "huggingface-pytorch-training",
+                    "container_version": {
+                        "gpu": "cu121-ubuntu20.04"
+                    }
+                }
+            },
+            "4.49.0": {
+                "version_aliases": {
+                    "pytorch2.5": "pytorch2.5.1"
+                },
+                "pytorch2.5.1": {
+                    "py_versions": [
+                        "py311"
+                    ],
+                    "registries": {
+                        "af-south-1": "626614931356",
+                        "il-central-1": "780543022126",
+                        "ap-east-1": "871362719292",
+                        "ap-northeast-1": "763104351884",
+                        "ap-northeast-2": "763104351884",
+                        "ap-northeast-3": "364406365360",
+                        "ap-south-1": "763104351884",
+                        "ap-southeast-1": "763104351884",
+                        "ap-southeast-2": "763104351884",
+                        "ap-southeast-3": "907027046896",
+                        "ca-central-1": "763104351884",
+                        "cn-north-1": "727897471807",
+                        "cn-northwest-1": "727897471807",
+                        "eu-central-1": "763104351884",
+                        "eu-north-1": "763104351884",
+                        "eu-west-1": "763104351884",
+                        "eu-west-2": "763104351884",
+                        "eu-west-3": "763104351884",
+                        "eu-south-1": "692866216735",
+                        "me-south-1": "217643126080",
+                        "me-central-1": "914824155844",
+                        "sa-east-1": "763104351884",
+                        "us-east-1": "763104351884",
+                        "us-east-2": "763104351884",
+                        "us-gov-east-1": "446045086412",
+                        "us-gov-west-1": "442386744353",
+                        "us-iso-east-1": "886529160074",
+                        "us-isob-east-1": "094389454867",
+                        "us-west-1": "763104351884",
+                        "us-west-2": "763104351884",
+                        "ca-west-1": "204538143572"
+                    },
+                    "repository": "huggingface-pytorch-training",
+                    "container_version": {
+                        "gpu": "cu124-ubuntu22.04"
+                    }
+                }
             }
         }
     },
@@ -1082,7 +1178,8 @@
             "4.17": "4.17.0",
             "4.26": "4.26.0",
             "4.28": "4.28.1",
-            "4.37": "4.37.0"
+            "4.37": "4.37.0",
+            "4.49": "4.49.0"
         },
         "versions": {
             "4.6.1": {
@@ -1980,6 +2077,58 @@
                     "repository": "huggingface-pytorch-inference",
                     "container_version": {
                         "gpu": "cu121-ubuntu22.04",
+                        "cpu": "ubuntu22.04"
+                    }
+                }
+            },
+            "4.49.0": {
+                "version_aliases": {
+                    "pytorch2.6": "pytorch2.6.0"
+                },
+                "pytorch2.6.0": {
+                    "py_versions": [
+                        "py312"
+                    ],
+                    "registries": {
+                        "af-south-1": "626614931356",
+                        "il-central-1": "780543022126",
+                        "ap-east-1": "871362719292",
+                        "ap-northeast-1": "763104351884",
+                        "ap-northeast-2": "763104351884",
+                        "ap-northeast-3": "364406365360",
+                        "ap-south-1": "763104351884",
+                        "ap-south-2": "772153158452",
+                        "ap-southeast-1": "763104351884",
+                        "ap-southeast-2": "763104351884",
+                        "ap-southeast-3": "907027046896",
+                        "ap-southeast-4": "457447274322",
+                        "ca-central-1": "763104351884",
+                        "cn-north-1": "727897471807",
+                        "cn-northwest-1": "727897471807",
+                        "eu-central-1": "763104351884",
+                        "eu-central-2": "380420809688",
+                        "eu-north-1": "763104351884",
+                        "eu-west-1": "763104351884",
+                        "eu-west-2": "763104351884",
+                        "eu-west-3": "763104351884",
+                        "eu-south-1": "692866216735",
+                        "eu-south-2": "503227376785",
+                        "me-south-1": "217643126080",
+                        "me-central-1": "914824155844",
+                        "sa-east-1": "763104351884",
+                        "us-east-1": "763104351884",
+                        "us-east-2": "763104351884",
+                        "us-gov-east-1": "446045086412",
+                        "us-gov-west-1": "442386744353",
+                        "us-iso-east-1": "886529160074",
+                        "us-isob-east-1": "094389454867",
+                        "us-west-1": "763104351884",
+                        "us-west-2": "763104351884",
+                        "ca-west-1": "204538143572"
+                    },
+                    "repository": "huggingface-pytorch-inference",
+                    "container_version": {
+                        "gpu": "cu124-ubuntu22.04",
                         "cpu": "ubuntu22.04"
                     }
                 }


### PR DESCRIPTION
add latest huggingface images:

huggingface-pytorch-training:2.3.0-transformers4.48.0-gpu-py311-cu121-ubuntu20.04 https://github.com/aws/deep-learning-containers/releases/tag/v2.1-hf-4.48.0-pt-2.3.0-tr-gpu-py311

huggingface-pytorch-training:2.5.1-transformers4.49.0-gpu-py311-cu124-ubuntu22.04 https://github.com/aws/deep-learning-containers/releases/tag/v2.0-hf-4.49.0-pt-2.5.1-tr-gpu-py311

huggingface-pytorch-inference:2.6.0-transformers4.49.0-gpu-py312-cu124-ubuntu22.04

huggingface-pytorch-inference:2.6.0-transformers4.49.0-cpu-py312-ubuntu22.04 https://github.com/aws/deep-learning-containers/releases/tag/v2.1-hf-4.49.0-pt-2.6.0-inf-py312


*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)
- [ ] If adding any dependency in requirements.txt files, I have spell checked and ensured they exist in PyPi

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
