### PR TITLE
fix: fix bad initialization script error message

### DIFF
--- a/src/sagemaker/workflow/notebook_job_step.py
+++ b/src/sagemaker/workflow/notebook_job_step.py
@@ -243,25 +243,27 @@ class NotebookJobStep(ConfigurableRetryStep):
         # input notebook is required
         if not self.input_notebook or not os.path.isfile(self.input_notebook):
             errors.append(
-                f"The required input notebook({self.input_notebook}) is not a valid " f"file."
+                f"The required input notebook ({self.input_notebook}) is not a valid file."
             )
 
         # init script is optional
         if self.initialization_script and not os.path.isfile(self.initialization_script):
-            errors.append(f"The initialization script({self.input_notebook}) is not a valid file.")
+            errors.append(
+                f"The initialization script ({self.initialization_script}) is not a valid file."
+            )
 
         if self.additional_dependencies:
             for path in self.additional_dependencies:
                 if not os.path.exists(path):
                     errors.append(
-                        f"The path({path}) specified in additional dependencies does not exist."
+                        f"The path ({path}) specified in additional dependencies does not exist."
                     )
         # image uri is required
         if not self.image_uri or self._region_from_session not in self.image_uri:
             errors.append(
-                f"The image uri(specified as {self.image_uri}) is required and "
+                f"The image uri (specified as {self.image_uri}) is required and "
                 f"should be hosted in same region of the session"
-                f"({self._region_from_session})."
+                f" ({self._region_from_session})."
             )
 
         if not self.kernel_name:

--- a/tests/unit/sagemaker/workflow/test_notebook_job_step.py
+++ b/tests/unit/sagemaker/workflow/test_notebook_job_step.py
@@ -199,11 +199,11 @@ class TestNotebookJobStep(unittest.TestCase):
             in str(context.exception)
         )
         self.assertTrue(
-            "The required input notebook(None) is not a valid file." in str(context.exception)
+            "The required input notebook (None) is not a valid file." in str(context.exception)
         )
         self.assertTrue(
-            "The image uri(specified as None) is required and should be hosted in "
-            "same region of the session(us-west-2)." in str(context.exception)
+            "The image uri (specified as None) is required and should be hosted in "
+            "same region of the session (us-west-2)." in str(context.exception)
         )
         self.assertTrue("The kernel name is required." in str(context.exception))
 
@@ -222,19 +222,19 @@ class TestNotebookJobStep(unittest.TestCase):
             ).arguments
 
         self.assertTrue(
-            "The required input notebook(path/non-existing-file) is not a valid file."
+            "The required input notebook (path/non-existing-file) is not a valid file."
             in str(context.exception)
         )
         self.assertTrue(
-            "The initialization script(path/non-existing-file) is not a valid file."
+            "The initialization script (non-existing-script) is not a valid file."
             in str(context.exception)
         )
         self.assertTrue(
-            "The path(/tmp/non-existing-folder) specified in additional dependencies "
+            "The path (/tmp/non-existing-folder) specified in additional dependencies "
             "does not exist." in str(context.exception)
         )
         self.assertTrue(
-            "The path(path2/non-existing-file) specified in additional dependencies "
+            "The path (path2/non-existing-file) specified in additional dependencies "
             "does not exist." in str(context.exception)
         )
 
@@ -251,9 +251,9 @@ class TestNotebookJobStep(unittest.TestCase):
             ).arguments
 
         self.assertTrue(
-            "The image uri(specified as 236514542706.dkr.ecr.us-east-9.amazonaws.com/"
+            "The image uri (specified as 236514542706.dkr.ecr.us-east-9.amazonaws.com/"
             "sagemaker-data-science) is required and should be hosted in "
-            "same region of the session(us-west-2)." in str(context.exception)
+            "same region of the session (us-west-2)." in str(context.exception)
         )
 
     def test_invalid_notebook_job_name(self):


### PR DESCRIPTION
*Issue #, if available:* #4855

*Description of changes:*
Fixed initialization script name in error message 

*Testing done:*
tested bad init script input manually

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)
- [ ] If adding any dependency in requirements.txt files, I have spell checked and ensured they exist in PyPi

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
