### PR TITLE
fix: Map llama models to correct script

### DIFF
--- a/src/sagemaker/modules/train/sm_recipes/utils.py
+++ b/src/sagemaker/modules/train/sm_recipes/utils.py
@@ -129,7 +129,7 @@ def _get_trainining_recipe_gpu_model_name_and_script(model_type: str):
     """Get the model base name and script for the training recipe."""
 
     model_type_to_script = {
-        "llama_v3": ("llama", "llama_pretrain.py"),
+        "llama": ("llama", "llama_pretrain.py"),
         "mistral": ("mistral", "mistral_pretrain.py"),
         "mixtral": ("mixtral", "mixtral_pretrain.py"),
         "deepseek": ("deepseek", "deepseek_pretrain.py"),

--- a/tests/unit/sagemaker/modules/train/sm_recipes/test_utils.py
+++ b/tests/unit/sagemaker/modules/train/sm_recipes/test_utils.py
@@ -180,14 +180,11 @@ def test_get_args_from_recipe_compute(
             assert mock_trainium_args.call_count == 0
             assert args is None
 
+
 @pytest.mark.parametrize(
     "test_case",
     [
-        {
-            "model_type": "llama_v4",
-            "script": "llama_pretrain.py",
-            "model_base_name": "llama"
-        },
+        {"model_type": "llama_v4", "script": "llama_pretrain.py", "model_base_name": "llama"},
         {
             "model_type": "llama_v3",
             "script": "llama_pretrain.py",
@@ -213,8 +210,6 @@ def test_get_args_from_recipe_compute(
 def test_get_trainining_recipe_gpu_model_name_and_script(test_case):
     model_type = test_case["model_type"]
     script = test_case["script"]
-    model_base_name, script = _get_trainining_recipe_gpu_model_name_and_script(
-        model_type
-    )
+    model_base_name, script = _get_trainining_recipe_gpu_model_name_and_script(model_type)
     assert model_base_name == test_case["model_base_name"]
     assert script == test_case["script"]

--- a/tests/unit/sagemaker/modules/train/sm_recipes/test_utils.py
+++ b/tests/unit/sagemaker/modules/train/sm_recipes/test_utils.py
@@ -180,36 +180,41 @@ def test_get_args_from_recipe_compute(
             assert mock_trainium_args.call_count == 0
             assert args is None
 
-    @pytest.mark.parametrize(
-        "test_case",
-        [
-            {
-                "model_type": "llama_v3",
-                "script": "llama_pretrain.py",
-                "model_base_name": "llama_v3",
-            },
-            {
-                "model_type": "mistral",
-                "script": "mistral_pretrain.py",
-                "model_base_name": "mistral",
-            },
-            {
-                "model_type": "deepseek_llamav3",
-                "script": "deepseek_pretrain.py",
-                "model_base_name": "deepseek",
-            },
-            {
-                "model_type": "deepseek_qwenv2",
-                "script": "deepseek_pretrain.py",
-                "model_base_name": "deepseek",
-            },
-        ],
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        {
+            "model_type": "llama_v4",
+            "script": "llama_pretrain.py",
+            "model_base_name": "llama"
+        },
+        {
+            "model_type": "llama_v3",
+            "script": "llama_pretrain.py",
+            "model_base_name": "llama",
+        },
+        {
+            "model_type": "mistral",
+            "script": "mistral_pretrain.py",
+            "model_base_name": "mistral",
+        },
+        {
+            "model_type": "deepseek_llamav3",
+            "script": "deepseek_pretrain.py",
+            "model_base_name": "deepseek",
+        },
+        {
+            "model_type": "deepseek_qwenv2",
+            "script": "deepseek_pretrain.py",
+            "model_base_name": "deepseek",
+        },
+    ],
+)
+def test_get_trainining_recipe_gpu_model_name_and_script(test_case):
+    model_type = test_case["model_type"]
+    script = test_case["script"]
+    model_base_name, script = _get_trainining_recipe_gpu_model_name_and_script(
+        model_type
     )
-    def test_get_trainining_recipe_gpu_model_name_and_script(test_case):
-        model_type = test_case["model_type"]
-        script = test_case["script"]
-        model_base_name, script = _get_trainining_recipe_gpu_model_name_and_script(
-            model_type, script
-        )
-        assert model_base_name == test_case["model_base_name"]
-        assert script == test_case["script"]
+    assert model_base_name == test_case["model_base_name"]
+    assert script == test_case["script"]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Correctly map llama models to corresponding training script for HyperPod Recipes. 
   * Ie, both `llama_v3` and `llama_v4` should map to `llama_pretrain.py`

*Testing done:*
* Updated unit tests

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)
- [ ] If adding any dependency in requirements.txt files, I have spell checked and ensured they exist in PyPi

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
