### PR TITLE
fix: honor json serialization of HPs

### DIFF
--- a/src/sagemaker/modules/train/container_drivers/common/utils.py
+++ b/src/sagemaker/modules/train/container_drivers/common/utils.py
@@ -124,8 +124,6 @@ def safe_deserialize(data: Any) -> Any:
 
     This function handles the following cases:
     1. If `data` is not a string, it returns the input as-is.
-    2. If `data` is a string and matches common boolean values ("true" or "false"),
-    it returns the corresponding boolean value (True or False).
     3. If `data` is a JSON-encoded string, it attempts to deserialize it using `json.loads()`.
     4. If `data` is a string but cannot be decoded as JSON, it returns the original string.
 
@@ -134,13 +132,6 @@ def safe_deserialize(data: Any) -> Any:
     """
     if not isinstance(data, str):
         return data
-
-    lower_data = data.lower()
-    if lower_data in ["true"]:
-        return True
-    if lower_data in ["false"]:
-        return False
-
     try:
         return json.loads(data)
     except json.JSONDecodeError:

--- a/tests/unit/sagemaker/modules/train/container_drivers/test_utils.py
+++ b/tests/unit/sagemaker/modules/train/container_drivers/test_utils.py
@@ -61,12 +61,12 @@ def test_safe_deserialize_boolean_strings():
     assert safe_deserialize("false") is False
 
     # The below are not valid JSON booleans
-    assert safe_deserialize("True") is "True"
-    assert safe_deserialize("False") is "False"
-    assert safe_deserialize("TRUE") is "TRUE"
-    assert safe_deserialize("FALSE") is "FALSE"
-    assert safe_deserialize("tRuE") is "tRuE"
-    assert safe_deserialize("fAlSe") is "fAlSe"
+    assert safe_deserialize("True") == "True"
+    assert safe_deserialize("False") == "False"
+    assert safe_deserialize("TRUE") == "TRUE"
+    assert safe_deserialize("FALSE") == "FALSE"
+    assert safe_deserialize("tRuE") == "tRuE"
+    assert safe_deserialize("fAlSe") == "fAlSe"
 
 
 def test_safe_deserialize_valid_json_string():

--- a/tests/unit/sagemaker/modules/train/container_drivers/test_utils.py
+++ b/tests/unit/sagemaker/modules/train/container_drivers/test_utils.py
@@ -59,8 +59,14 @@ def test_safe_deserialize_not_a_string():
 def test_safe_deserialize_boolean_strings():
     assert safe_deserialize("true") is True
     assert safe_deserialize("false") is False
-    assert safe_deserialize("True") is True
-    assert safe_deserialize("False") is False
+
+    # The below are not valid JSON booleans
+    assert safe_deserialize("True") is "True"
+    assert safe_deserialize("False") is "False"
+    assert safe_deserialize("TRUE") is "TRUE"
+    assert safe_deserialize("FALSE") is "FALSE"
+    assert safe_deserialize("tRuE") is "tRuE"
+    assert safe_deserialize("fAlSe") is "fAlSe"
 
 
 def test_safe_deserialize_valid_json_string():


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Honor JSON serialization of HPs. The `safe_deserialize()` method breaks contract for JSON serialization by forcibly changing non JSON boolean strings to lower case. This change corrects this by honoring the serialization.

*Testing done:*
* Fix unit tests

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)
- [ ] If adding any dependency in requirements.txt files, I have spell checked and ensured they exist in PyPi

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
