### PR TITLE
fix: clarify model monitor one time schedule bug

### DIFF
--- a/src/sagemaker/model_monitor/clarify_model_monitoring.py
+++ b/src/sagemaker/model_monitor/clarify_model_monitoring.py
@@ -1103,6 +1103,8 @@ class ModelExplainabilityMonitor(ClarifyModelMonitor):
                 monitor_schedule_name=monitor_schedule_name,
                 job_definition_name=new_job_definition_name,
                 schedule_cron_expression=schedule_cron_expression,
+                data_analysis_start_time=data_analysis_start_time,
+                data_analysis_end_time=data_analysis_end_time,
             )
             self.job_definition_name = new_job_definition_name
             self.monitoring_schedule_name = monitor_schedule_name

--- a/tests/unit/sagemaker/monitor/test_clarify_model_monitor.py
+++ b/tests/unit/sagemaker/monitor/test_clarify_model_monitor.py
@@ -89,6 +89,7 @@ NETWORK_CONFIG = NetworkConfig(
     subnets=SUBNETS,
 )
 CRON_HOURLY = CronExpressionGenerator.hourly()
+CRON_NOW = CronExpressionGenerator.now()
 ENDPOINT_NAME = "endpoint"
 GROUND_TRUTH_S3_URI = "s3://bucket/monitoring_captured/actuals"
 ANALYSIS_CONFIG_S3_URI = "s3://bucket/analysis_config.json"
@@ -1303,6 +1304,66 @@ def test_model_explainability_monitor(model_explainability_monitor, sagemaker_se
         model_explainability_monitor=model_explainability_monitor,
         sagemaker_session=sagemaker_session,
     )
+
+
+def test_model_explainability_create_one_time_schedule(
+    model_explainability_monitor, sagemaker_session
+):
+    endpoint_input = EndpointInput(
+        endpoint_name=ENDPOINT_NAME,
+        destination=ENDPOINT_INPUT_LOCAL_PATH,
+        features_attribute=FEATURES_ATTRIBUTE,
+        inference_attribute=str(INFERENCE_ATTRIBUTE),
+    )
+
+    # Create one-time schedule
+    with patch(
+        "sagemaker.s3.S3Uploader.upload_string_as_file_body", return_value=ANALYSIS_CONFIG_S3_URI
+    ) as _:
+        model_explainability_monitor.create_monitoring_schedule(
+            endpoint_input=endpoint_input,
+            analysis_config=ANALYSIS_CONFIG_S3_URI,
+            output_s3_uri=OUTPUT_S3_URI,
+            monitor_schedule_name=SCHEDULE_NAME,
+            schedule_cron_expression=CRON_NOW,
+            data_analysis_start_time=START_TIME_OFFSET,
+            data_analysis_end_time=END_TIME_OFFSET,
+        )
+
+    # Validate job definition creation
+    sagemaker_session.sagemaker_client.create_model_explainability_job_definition.assert_called_once()
+    job_definition_args = (
+        sagemaker_session.sagemaker_client.create_model_explainability_job_definition.call_args[1]
+    )
+    assert (
+        job_definition_args["JobDefinitionName"] == model_explainability_monitor.job_definition_name
+    )
+    assert job_definition_args == {
+        "JobDefinitionName": model_explainability_monitor.job_definition_name,
+        **EXPLAINABILITY_JOB_DEFINITION,
+        "Tags": TAGS,
+    }
+
+    # Validate monitoring schedule creation
+    sagemaker_session.sagemaker_client.create_monitoring_schedule.assert_called_once()
+    schedule_args = sagemaker_session.sagemaker_client.create_monitoring_schedule.call_args[1]
+    assert schedule_args == {
+        "MonitoringScheduleName": SCHEDULE_NAME,
+        "MonitoringScheduleConfig": {
+            "MonitoringJobDefinitionName": model_explainability_monitor.job_definition_name,
+            "MonitoringType": "ModelExplainability",
+            "ScheduleConfig": {
+                "ScheduleExpression": CRON_NOW,
+                "DataAnalysisStartTime": START_TIME_OFFSET,
+                "DataAnalysisEndTime": END_TIME_OFFSET,
+            },
+        },
+        "Tags": TAGS,
+    }
+
+    # Check if the monitoring schedule is stored in the monitor object
+    assert model_explainability_monitor.monitoring_schedule_name == SCHEDULE_NAME
+    assert model_explainability_monitor.job_definition_name is not None
 
 
 def test_model_explainability_batch_transform_monitor(


### PR DESCRIPTION
*Issue #, if available:
* error reported: https://github.com/aws/sagemaker-python-sdk/issues/4431

*Description of changes:
* add missing parameters `data_analysis_end_time` and `data_analysis_start_time` for Model Explainability Monitor

*Testing done:
* tox -e py310 -- -s -vv tests/unit/sagemaker/monitor/test_clarify_model_monitor.py

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)
- [x] If adding any dependency in requirements.txt files, I have spell checked and ensured they exist in PyPi

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
