### PR TITLE
fix: include model channel for gated uncompressed models

### DIFF
--- a/src/sagemaker/jumpstart/cache.py
+++ b/src/sagemaker/jumpstart/cache.py
@@ -372,10 +372,18 @@ class JumpStartModelsCache:
         object and None when reading from the local file system.
         """
         if self._is_local_metadata_mode():
-            file_content, etag = self._get_json_file_from_local_override(key, filetype), None
-        else:
-            file_content, etag = self._get_json_file_and_etag_from_s3(key)
-        return file_content, etag
+            if filetype in {
+                JumpStartS3FileType.OPEN_WEIGHT_MANIFEST,
+                JumpStartS3FileType.OPEN_WEIGHT_SPECS,
+            }:
+                return self._get_json_file_from_local_override(key, filetype), None
+            else:
+                JUMPSTART_LOGGER.warning(
+                    "Local metadata mode is enabled, but the file type %s is not supported "
+                    "for local override. Falling back to s3.",
+                    filetype,
+                )
+        return self._get_json_file_and_etag_from_s3(key)
 
     def _get_json_md5_hash(self, key: str):
         """Retrieves md5 object hash for s3 objects, using `s3.head_object`.

--- a/src/sagemaker/jumpstart/factory/estimator.py
+++ b/src/sagemaker/jumpstart/factory/estimator.py
@@ -56,7 +56,6 @@ from sagemaker.jumpstart.constants import (
     JUMPSTART_LOGGER,
     TRAINING_ENTRY_POINT_SCRIPT_NAME,
     SAGEMAKER_GATED_MODEL_S3_URI_TRAINING_ENV_VAR_KEY,
-    JUMPSTART_MODEL_HUB_NAME,
 )
 from sagemaker.jumpstart.enums import JumpStartScriptScope, JumpStartModelType
 from sagemaker.jumpstart.factory import model

--- a/src/sagemaker/jumpstart/factory/estimator.py
+++ b/src/sagemaker/jumpstart/factory/estimator.py
@@ -632,13 +632,7 @@ def _add_model_reference_arn_to_kwargs(
 
 def _add_model_uri_to_kwargs(kwargs: JumpStartEstimatorInitKwargs) -> JumpStartEstimatorInitKwargs:
     """Sets model uri in kwargs based on default or override, returns full kwargs."""
-    # hub_arn is by default None unless the user specifies the hub_name
-    # If no hub_name is specified, it is assumed the public hub
-    is_private_hub = JUMPSTART_MODEL_HUB_NAME not in kwargs.hub_arn if kwargs.hub_arn else False
-    if (
-        _model_supports_training_model_uri(**get_model_info_default_kwargs(kwargs))
-        or is_private_hub
-    ):
+    if _model_supports_training_model_uri(**get_model_info_default_kwargs(kwargs)):
         default_model_uri = model_uris.retrieve(
             model_scope=JumpStartScriptScope.TRAINING,
             instance_type=kwargs.instance_type,

--- a/src/sagemaker/jumpstart/types.py
+++ b/src/sagemaker/jumpstart/types.py
@@ -1940,12 +1940,20 @@ class JumpStartModelSpecs(JumpStartMetadataBaseFields):
 
     def use_training_model_artifact(self) -> bool:
         """Returns True if the model should use a model uri when kicking off training job."""
-        # gated model never use training model artifact
-        if self.gated_bucket:
+        # old models with this environment variable present don't use model channel
+        if any(
+            self.training_instance_type_variants.get_instance_specific_gated_model_key_env_var_value(
+                instance_type
+            )
+            for instance_type in self.supported_training_instance_types
+        ):
             return False
 
-        # otherwise, return true is a training model package is not set
-        return len(self.training_model_package_artifact_uris or {}) == 0
+        # even older models with training model package artifact uris present also don't use model channel
+        if len(self.training_model_package_artifact_uris or {}) > 0:
+            return False
+
+        return getattr(self, "training_artifact_key", None) is not None
 
     def is_gated_model(self) -> bool:
         """Returns True if the model has a EULA key or the model bucket is gated."""

--- a/tests/unit/sagemaker/jumpstart/factory/test_estimator.py
+++ b/tests/unit/sagemaker/jumpstart/factory/test_estimator.py
@@ -1,0 +1,108 @@
+import pytest
+from unittest.mock import patch, Mock
+from sagemaker.jumpstart.factory.estimator import (
+    _add_model_uri_to_kwargs,
+    get_model_info_default_kwargs,
+)
+from sagemaker.jumpstart.types import JumpStartEstimatorInitKwargs
+from sagemaker.jumpstart.enums import JumpStartScriptScope
+
+
+class TestAddModelUriToKwargs:
+    @pytest.fixture
+    def mock_kwargs(self):
+        return JumpStartEstimatorInitKwargs(
+            model_id="test-model",
+            model_version="1.0.0",
+            instance_type="ml.m5.large",
+            model_uri=None,
+        )
+
+    @patch(
+        "sagemaker.jumpstart.factory.estimator._model_supports_training_model_uri",
+        return_value=True,
+    )
+    @patch("sagemaker.jumpstart.factory.estimator.model_uris.retrieve")
+    def test_add_model_uri_to_kwargs_default_uri(
+        self, mock_retrieve, mock_supports_training, mock_kwargs
+    ):
+        """Test adding default model URI when none is provided."""
+        default_uri = "s3://jumpstart-models/training/test-model/1.0.0"
+        mock_retrieve.return_value = default_uri
+
+        result = _add_model_uri_to_kwargs(mock_kwargs)
+
+        mock_supports_training.assert_called_once()
+        mock_retrieve.assert_called_once_with(
+            model_scope=JumpStartScriptScope.TRAINING,
+            instance_type=mock_kwargs.instance_type,
+            **get_model_info_default_kwargs(mock_kwargs),
+        )
+        assert result.model_uri == default_uri
+
+    @patch(
+        "sagemaker.jumpstart.factory.estimator._model_supports_training_model_uri",
+        return_value=True,
+    )
+    @patch(
+        "sagemaker.jumpstart.factory.estimator._model_supports_incremental_training",
+        return_value=True,
+    )
+    @patch("sagemaker.jumpstart.factory.estimator.model_uris.retrieve")
+    def test_add_model_uri_to_kwargs_custom_uri_with_incremental(
+        self, mock_retrieve, mock_supports_incremental, mock_supports_training, mock_kwargs
+    ):
+        """Test using custom model URI with incremental training support."""
+        default_uri = "s3://jumpstart-models/training/test-model/1.0.0"
+        custom_uri = "s3://custom-bucket/my-model"
+        mock_retrieve.return_value = default_uri
+        mock_kwargs.model_uri = custom_uri
+
+        result = _add_model_uri_to_kwargs(mock_kwargs)
+
+        mock_supports_training.assert_called_once()
+        mock_supports_incremental.assert_called_once()
+        assert result.model_uri == custom_uri
+
+    @patch(
+        "sagemaker.jumpstart.factory.estimator._model_supports_training_model_uri",
+        return_value=True,
+    )
+    @patch(
+        "sagemaker.jumpstart.factory.estimator._model_supports_incremental_training",
+        return_value=False,
+    )
+    @patch("sagemaker.jumpstart.factory.estimator.model_uris.retrieve")
+    @patch("sagemaker.jumpstart.factory.estimator.JUMPSTART_LOGGER.warning")
+    def test_add_model_uri_to_kwargs_custom_uri_without_incremental(
+        self,
+        mock_warning,
+        mock_retrieve,
+        mock_supports_incremental,
+        mock_supports_training,
+        mock_kwargs,
+    ):
+        """Test using custom model URI without incremental training support logs warning."""
+        default_uri = "s3://jumpstart-models/training/test-model/1.0.0"
+        custom_uri = "s3://custom-bucket/my-model"
+        mock_retrieve.return_value = default_uri
+        mock_kwargs.model_uri = custom_uri
+
+        result = _add_model_uri_to_kwargs(mock_kwargs)
+
+        mock_supports_training.assert_called_once()
+        mock_supports_incremental.assert_called_once()
+        mock_warning.assert_called_once()
+        assert "does not support incremental training" in mock_warning.call_args[0][0]
+        assert result.model_uri == custom_uri
+
+    @patch(
+        "sagemaker.jumpstart.factory.estimator._model_supports_training_model_uri",
+        return_value=False,
+    )
+    def test_add_model_uri_to_kwargs_no_training_support(self, mock_supports_training, mock_kwargs):
+        """Test when model doesn't support training model URI."""
+        result = _add_model_uri_to_kwargs(mock_kwargs)
+
+        mock_supports_training.assert_called_once()
+        assert result.model_uri is None

--- a/tests/unit/sagemaker/jumpstart/factory/test_estimator.py
+++ b/tests/unit/sagemaker/jumpstart/factory/test_estimator.py
@@ -1,5 +1,18 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from __future__ import absolute_import
 import pytest
-from unittest.mock import patch, Mock
+from unittest.mock import patch
 from sagemaker.jumpstart.factory.estimator import (
     _add_model_uri_to_kwargs,
     get_model_info_default_kwargs,

--- a/tests/unit/sagemaker/jumpstart/test_types.py
+++ b/tests/unit/sagemaker/jumpstart/test_types.py
@@ -39,6 +39,8 @@ from tests.unit.sagemaker.jumpstart.constants import (
     INIT_KWARGS,
 )
 
+from unittest.mock import Mock
+
 INSTANCE_TYPE_VARIANT = JumpStartInstanceTypeVariants(
     {
         "regional_aliases": {
@@ -329,14 +331,66 @@ def test_jumpstart_model_header():
     assert header1 == header3
 
 
-def test_use_training_model_artifact():
-    specs1 = JumpStartModelSpecs(BASE_SPEC)
-    assert specs1.use_training_model_artifact()
-    specs1.gated_bucket = True
-    assert not specs1.use_training_model_artifact()
-    specs1.gated_bucket = False
-    specs1.training_model_package_artifact_uris = {"region1": "blah", "region2": "blah2"}
-    assert not specs1.use_training_model_artifact()
+class TestUseTrainingModelArtifact:
+    @pytest.fixture
+    def mock_specs(self):
+        specs = Mock(spec=JumpStartModelSpecs)
+        specs.training_instance_type_variants = Mock()
+        specs.supported_training_instance_types = ["ml.p3.2xlarge", "ml.g4dn.xlarge"]
+        specs.training_model_package_artifact_uris = {}
+        specs.training_artifact_key = None
+        return specs
+
+    def test_use_training_model_artifact_with_env_var(self, mock_specs):
+        """Test when instance type variants have env var values."""
+        mock_specs.training_instance_type_variants.get_instance_specific_gated_model_key_env_var_value.side_effect = [
+            "some-value",
+            None,
+        ]
+
+        result = JumpStartModelSpecs.use_training_model_artifact(mock_specs)
+
+        assert result is False
+        mock_specs.training_instance_type_variants.get_instance_specific_gated_model_key_env_var_value.assert_any_call(
+            "ml.p3.2xlarge"
+        )
+
+    def test_use_training_model_artifact_with_package_uris(self, mock_specs):
+        """Test when model has training package artifact URIs."""
+        mock_specs.training_instance_type_variants.get_instance_specific_gated_model_key_env_var_value.return_value = (
+            None
+        )
+        mock_specs.training_model_package_artifact_uris = {
+            "ml.p3.2xlarge": "arn:aws:sagemaker:ap-southeast-1:192199979996:model-package/llama2-13b-e155a2e0347b323fb882f1875851c5d3"
+        }
+
+        result = JumpStartModelSpecs.use_training_model_artifact(mock_specs)
+
+        assert result is False
+
+    def test_use_training_model_artifact_with_artifact_key(self, mock_specs):
+        """Test when model has training artifact key."""
+        mock_specs.training_instance_type_variants.get_instance_specific_gated_model_key_env_var_value.return_value = (
+            None
+        )
+        mock_specs.training_model_package_artifact_uris = {}
+        mock_specs.training_artifact_key = "some-key"
+
+        result = JumpStartModelSpecs.use_training_model_artifact(mock_specs)
+
+        assert result is True
+
+    def test_use_training_model_artifact_without_artifact_key(self, mock_specs):
+        """Test when model has no training artifact key."""
+        mock_specs.training_instance_type_variants.get_instance_specific_gated_model_key_env_var_value.return_value = (
+            None
+        )
+        mock_specs.training_model_package_artifact_uris = {}
+        mock_specs.training_artifact_key = None
+
+        result = JumpStartModelSpecs.use_training_model_artifact(mock_specs)
+
+        assert result is False
 
 
 def test_jumpstart_model_specs():

--- a/tests/unit/sagemaker/jumpstart/test_types.py
+++ b/tests/unit/sagemaker/jumpstart/test_types.py
@@ -361,7 +361,8 @@ class TestUseTrainingModelArtifact:
             None
         )
         mock_specs.training_model_package_artifact_uris = {
-            "ml.p3.2xlarge": "arn:aws:sagemaker:ap-southeast-1:192199979996:model-package/llama2-13b-e155a2e0347b323fb882f1875851c5d3"
+            "ml.p3.2xlarge": "arn:aws:sagemaker:ap-southeast-1:192199979996:model-package/"
+            "llama2-13b-e155a2e0347b323fb882f1875851c5d3"
         }
 
         result = JumpStartModelSpecs.use_training_model_artifact(mock_specs)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- This PR fixes an issue with `JumpStartEstimator` not including the model channel when invoking `CreateTrainingJob`


*Testing done:*
- Unit tests added
- Integration tests pass
- Tested workflow locally 
- TO-DO: Add integration test for gated uncompressed training once artifacts and metadata are in production

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)
- [ ] If adding any dependency in requirements.txt files, I have spell checked and ensured they exist in PyPi

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
