### PR TITLE
change: merge method inputs with class inputs

### DIFF
--- a/src/sagemaker/modules/train/model_trainer.py
+++ b/src/sagemaker/modules/train/model_trainer.py
@@ -580,7 +580,7 @@ class ModelTrainer(BaseModel):
         """Train a model using AWS SageMaker.
 
         Args:
-            input_data_config (Optional[Union[List[Channel], Dict[str, DataSourceType]]]):
+            input_data_config (Optional[List[Union[Channel, InputData]]]):
                 The input data config for the training job.
                 Takes a list of Channel objects or a dictionary of channel names to DataSourceType.
                 DataSourceType can be an S3 URI string, local file path string,

--- a/src/sagemaker/modules/train/model_trainer.py
+++ b/src/sagemaker/modules/train/model_trainer.py
@@ -596,11 +596,23 @@ class ModelTrainer(BaseModel):
         current_training_job_name = _get_unique_name(self.base_job_name)
         input_data_key_prefix = f"{self.base_job_name}/{current_training_job_name}/input"
 
-        self.input_data_config = input_data_config or self.input_data_config or []
+        final_input_data_config = self.input_data_config.copy() if self.input_data_config else []
 
-        if self.input_data_config:
-            self.input_data_config = self._get_input_data_config(
-                self.input_data_config, input_data_key_prefix
+        if input_data_config:
+            # merge the inputs with method parameter taking precedence
+            existing_channels = {input.channel_name: input for input in final_input_data_config}
+            new_channels = []
+            for new_input in input_data_config:
+                if new_input.channel_name in existing_channels:
+                    existing_channels[new_input.channel_name] = new_input
+                else:
+                    new_channels.append(new_input)
+
+            final_input_data_config = list(existing_channels.values()) + new_channels
+
+        if final_input_data_config:
+            final_input_data_config = self._get_input_data_config(
+                final_input_data_config, input_data_key_prefix
             )
 
         if self.checkpoint_config and not self.checkpoint_config.s3_uri:
@@ -643,7 +655,7 @@ class ModelTrainer(BaseModel):
                     data_source=self.source_code.source_dir,
                     key_prefix=input_data_key_prefix,
                 )
-                self.input_data_config.append(source_code_channel)
+                final_input_data_config.append(source_code_channel)
 
             self._prepare_train_script(
                 tmp_dir=tmp_dir,
@@ -664,7 +676,7 @@ class ModelTrainer(BaseModel):
                 data_source=tmp_dir.name,
                 key_prefix=input_data_key_prefix,
             )
-            self.input_data_config.append(sm_drivers_channel)
+            final_input_data_config.append(sm_drivers_channel)
 
             # If source_code is provided, we will always use
             # the default container entrypoint and arguments
@@ -691,7 +703,7 @@ class ModelTrainer(BaseModel):
                 training_job_name=current_training_job_name,
                 algorithm_specification=algorithm_specification,
                 hyper_parameters=string_hyper_parameters,
-                input_data_config=self.input_data_config,
+                input_data_config=final_input_data_config,
                 resource_config=resource_config,
                 vpc_config=vpc_config,
                 # Public Instance Attributes
@@ -736,7 +748,7 @@ class ModelTrainer(BaseModel):
                 sagemaker_session=self.sagemaker_session,
                 container_entrypoint=algorithm_specification.container_entrypoint,
                 container_arguments=algorithm_specification.container_arguments,
-                input_data_config=self.input_data_config,
+                input_data_config=final_input_data_config,
                 hyper_parameters=string_hyper_parameters,
                 environment=self.environment,
             )

--- a/tests/unit/sagemaker/modules/train/test_model_trainer.py
+++ b/tests/unit/sagemaker/modules/train/test_model_trainer.py
@@ -1258,3 +1258,44 @@ def test_model_trainer_default_paths(mock_training_job, mock_unique_name, module
 
     assert kwargs["tensor_board_output_config"].s3_output_path == default_base_path
     assert kwargs["tensor_board_output_config"].local_path == "/opt/ml/output/tensorboard"
+
+
+@patch("sagemaker.modules.train.model_trainer.TrainingJob")
+def test_input_merge(mock_training_job, modules_session):
+    model_input = InputData(channel_name="model", data_source="s3://bucket/model/model.tar.gz")
+    model_trainer = ModelTrainer(
+        training_image=DEFAULT_IMAGE,
+        role=DEFAULT_ROLE,
+        sagemaker_session=modules_session,
+        compute=DEFAULT_COMPUTE_CONFIG,
+        input_data_config=[model_input],
+    )
+
+    train_input = InputData(channel_name="train", data_source="s3://bucket/data/train")
+    model_trainer.train(input_data_config=[train_input])
+
+    mock_training_job.create.assert_called_once()
+    assert mock_training_job.create.call_args.kwargs["input_data_config"] == [
+        Channel(
+            channel_name="model",
+            data_source=DataSource(
+                s3_data_source=S3DataSource(
+                    s3_data_type="S3Prefix",
+                    s3_uri="s3://bucket/model/model.tar.gz",
+                    s3_data_distribution_type="FullyReplicated",
+                )
+            ),
+            input_mode="File",
+        ),
+        Channel(
+            channel_name="train",
+            data_source=DataSource(
+                s3_data_source=S3DataSource(
+                    s3_data_type="S3Prefix",
+                    s3_uri="s3://bucket/data/train",
+                    s3_data_distribution_type="FullyReplicated",
+                )
+            ),
+            input_mode="File",
+        ),
+    ]

--- a/tox.ini
+++ b/tox.ini
@@ -83,8 +83,8 @@ passenv =
 commands =
     python -c "import os; os.system('install-custom-pkgs --install-boto-wheels')"
     pip install 'apache-airflow==2.10.4' --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.10.4/constraints-3.9.txt"
-    pip install 'torch==2.3.1' -f 'https://download.pytorch.org/whl/torch_stable.html'
-    pip install 'torchvision==0.18.1' -f 'https://download.pytorch.org/whl/torch_stable.html'
+    pip install 'torch==2.3.1+cpu' -f 'https://download.pytorch.org/whl/torch_stable.html'
+    pip install 'torchvision==0.18.1+cpu' -f 'https://download.pytorch.org/whl/torch_stable.html'
     pip install 'dill>=0.3.9'
 
     pytest {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -83,8 +83,8 @@ passenv =
 commands =
     python -c "import os; os.system('install-custom-pkgs --install-boto-wheels')"
     pip install 'apache-airflow==2.10.4' --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.10.4/constraints-3.9.txt"
-    pip install 'torch==2.3.1+cpu' -f 'https://download.pytorch.org/whl/torch_stable.html'
-    pip install 'torchvision==0.18.1+cpu' -f 'https://download.pytorch.org/whl/torch_stable.html'
+    pip install 'torch==2.3.1' -f 'https://download.pytorch.org/whl/torch_stable.html'
+    pip install 'torchvision==0.18.1' -f 'https://download.pytorch.org/whl/torch_stable.html'
     pip install 'dill>=0.3.9'
 
     pytest {posargs}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Small change in behavior for managing inputs in ModelTrainer. 
* merge method inputs with class inputs instead of override

Previous Behavior:
```
model_trainer = ModelTrainer(input_data_config=[model_input]) # user provides model channel 

model_trainer.train(input_data_config[train_input]) # User provides train input, and would override the model input when calling train
```

New Behavior:
```
model_trainer = ModelTrainer(input_data_config=[model_input]) # user provides model channel 

model_trainer.train(input_data_config[train_input]) # method and class inputs merged when calling API
```

*Testing done:*
* Unit test

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)
- [ ] If adding any dependency in requirements.txt files, I have spell checked and ensured they exist in PyPi

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
