### PR TITLE
fix: sanitize git clone repo input url

### DIFF
--- a/tests/unit/test_git_utils.py
+++ b/tests/unit/test_git_utils.py
@@ -12,11 +12,12 @@
 # language governing permissions and limitations under the License.
 from __future__ import absolute_import
 
-import pytest
 import os
-from pathlib import Path
 import subprocess
-from mock import patch, ANY
+from pathlib import Path
+
+import pytest
+from mock import ANY, patch
 
 from sagemaker import git_utils
 
@@ -494,3 +495,212 @@ def test_git_clone_repo_codecommit_https_creds_not_stored_locally(tempdir, mkdte
     with pytest.raises(subprocess.CalledProcessError) as error:
         git_utils.git_clone_repo(git_config, entry_point)
     assert "returned non-zero exit status" in str(error.value)
+
+
+# ============================================================================
+# URL Sanitization Tests - Security vulnerability prevention
+# ============================================================================
+
+class TestGitUrlSanitization:
+    """Test cases for Git URL sanitization to prevent injection attacks."""
+
+    def test_sanitize_git_url_valid_https_urls(self):
+        """Test that valid HTTPS URLs pass sanitization."""
+        valid_urls = [
+            "https://github.com/user/repo.git",
+            "https://gitlab.com/user/repo.git",
+            "https://token@github.com/user/repo.git",
+            "https://user:pass@github.com/user/repo.git",
+            "http://internal-git.company.com/repo.git",
+        ]
+        
+        for url in valid_urls:
+            # Should not raise any exception
+            result = git_utils._sanitize_git_url(url)
+            assert result == url
+
+    def test_sanitize_git_url_valid_ssh_urls(self):
+        """Test that valid SSH URLs pass sanitization."""
+        valid_urls = [
+            "git@github.com:user/repo.git",
+            "git@gitlab.com:user/repo.git",
+            "ssh://git@github.com/user/repo.git",
+            "ssh://git-codecommit.us-west-2.amazonaws.com/v1/repos/test-repo/",  # 0 @ symbols - valid for ssh://
+            "git@internal-git.company.com:repo.git",
+        ]
+        
+        for url in valid_urls:
+            # Should not raise any exception
+            result = git_utils._sanitize_git_url(url)
+            assert result == url
+
+    def test_sanitize_git_url_blocks_multiple_at_https(self):
+        """Test that HTTPS URLs with multiple @ symbols are blocked."""
+        malicious_urls = [
+            "https://user@attacker.com@github.com/repo.git",
+            "https://token@evil.com@gitlab.com/user/repo.git",
+            "https://a@b@c@github.com/repo.git",
+            "https://user@malicious-host@github.com/legit/repo.git",
+        ]
+        
+        for url in malicious_urls:
+            with pytest.raises(ValueError) as error:
+                git_utils._sanitize_git_url(url)
+            assert "multiple @ symbols detected" in str(error.value)
+
+    def test_sanitize_git_url_blocks_multiple_at_ssh(self):
+        """Test that SSH URLs with multiple @ symbols are blocked."""
+        malicious_urls = [
+            "git@attacker.com@github.com:repo.git",
+            "git@evil@gitlab.com:user/repo.git",
+            "ssh://git@malicious@github.com/repo.git",
+            "git@a@b@c:repo.git",
+        ]
+        
+        for url in malicious_urls:
+            with pytest.raises(ValueError) as error:
+                git_utils._sanitize_git_url(url)
+            # git@ URLs should give "exactly one @ symbol" error
+            # ssh:// URLs should give "multiple @ symbols detected" error
+            assert any(phrase in str(error.value) for phrase in [
+                "multiple @ symbols detected",
+                "exactly one @ symbol"
+            ])
+
+    def test_sanitize_git_url_blocks_invalid_schemes_and_git_at_format(self):
+        """Test that invalid schemes and git@ format violations are blocked."""
+        # Test unsupported schemes
+        unsupported_scheme_urls = [
+            "git-github.com:user/repo.git",  # Doesn't start with git@, ssh://, http://, https://
+        ]
+        
+        for url in unsupported_scheme_urls:
+            with pytest.raises(ValueError) as error:
+                git_utils._sanitize_git_url(url)
+            assert "Unsupported URL scheme" in str(error.value)
+        
+        # Test git@ URLs with wrong @ count
+        invalid_git_at_urls = [
+            "git@github.com@evil.com:repo.git",  # 2 @ symbols
+        ]
+        
+        for url in invalid_git_at_urls:
+            with pytest.raises(ValueError) as error:
+                git_utils._sanitize_git_url(url)
+            assert "exactly one @ symbol" in str(error.value)
+
+    def test_sanitize_git_url_blocks_url_encoding_obfuscation(self):
+        """Test that URL-encoded obfuscation attempts are blocked."""
+        obfuscated_urls = [
+            "https://github.com%25evil.com/repo.git",
+            "https://user@github.com%40attacker.com/repo.git",
+            "https://github.com%2Fevil.com/repo.git",
+            "https://github.com%3Aevil.com/repo.git",
+        ]
+        
+        for url in obfuscated_urls:
+            with pytest.raises(ValueError) as error:
+                git_utils._sanitize_git_url(url)
+            # The error could be either suspicious encoding or invalid characters
+            assert any(phrase in str(error.value) for phrase in [
+                "Suspicious URL encoding detected",
+                "Invalid characters in hostname"
+            ])
+
+    def test_sanitize_git_url_blocks_invalid_hostname_chars(self):
+        """Test that hostnames with invalid characters are blocked."""
+        invalid_urls = [
+            "https://github<script>.com/repo.git",
+            "https://github>.com/repo.git",
+            "https://github[].com/repo.git",
+            "https://github{}.com/repo.git",
+        ]
+        
+        for url in invalid_urls:
+            with pytest.raises(ValueError) as error:
+                git_utils._sanitize_git_url(url)
+            # The error could be various types due to URL parsing edge cases
+            assert any(phrase in str(error.value) for phrase in [
+                "Invalid characters in hostname",
+                "Failed to parse URL",
+                "does not appear to be an IPv4 or IPv6 address"
+            ])
+
+    def test_sanitize_git_url_blocks_unsupported_schemes(self):
+        """Test that unsupported URL schemes are blocked."""
+        unsupported_urls = [
+            "ftp://github.com/repo.git",
+            "file:///local/repo.git",
+            "javascript:alert('xss')",
+            "data:text/html,<script>alert('xss')</script>",
+        ]
+        
+        for url in unsupported_urls:
+            with pytest.raises(ValueError) as error:
+                git_utils._sanitize_git_url(url)
+            assert "Unsupported URL scheme" in str(error.value)
+
+    def test_git_clone_repo_blocks_malicious_https_url(self):
+        """Test that git_clone_repo blocks malicious HTTPS URLs."""
+        malicious_git_config = {
+            "repo": "https://user@attacker.com@github.com/legit/repo.git",
+            "branch": "main"
+        }
+        entry_point = "train.py"
+        
+        with pytest.raises(ValueError) as error:
+            git_utils.git_clone_repo(malicious_git_config, entry_point)
+        assert "multiple @ symbols detected" in str(error.value)
+
+    def test_git_clone_repo_blocks_malicious_ssh_url(self):
+        """Test that git_clone_repo blocks malicious SSH URLs."""
+        malicious_git_config = {
+            "repo": "git@OBVIOUS@github.com:sage-maker/temp-sev2.git",
+            "branch": "main"
+        }
+        entry_point = "train.py"
+        
+        with pytest.raises(ValueError) as error:
+            git_utils.git_clone_repo(malicious_git_config, entry_point)
+        assert "exactly one @ symbol" in str(error.value)
+
+    def test_git_clone_repo_blocks_url_encoded_attack(self):
+        """Test that git_clone_repo blocks URL-encoded attacks."""
+        malicious_git_config = {
+            "repo": "https://github.com%40attacker.com/repo.git",
+            "branch": "main"
+        }
+        entry_point = "train.py"
+        
+        with pytest.raises(ValueError) as error:
+            git_utils.git_clone_repo(malicious_git_config, entry_point)
+        assert "Suspicious URL encoding detected" in str(error.value)
+
+    def test_sanitize_git_url_comprehensive_attack_scenarios(self):
+        """Test comprehensive attack scenarios from the vulnerability report."""
+        # These are the exact attack patterns from the security report
+        attack_scenarios = [
+            # Original PoC attack
+            "https://USER@YOUR_NGROK_OR_LOCALHOST/malicious.git@github.com%25legit%25repo.git",
+            # Variations of the attack
+            "https://user@malicious-host@github.com/legit/repo.git",
+            "git@attacker.com@github.com:user/repo.git",
+            "ssh://git@evil.com@github.com/repo.git",
+            # URL encoding variations
+            "https://github.com%40evil.com/repo.git",
+            "https://user@github.com%2Fevil.com/repo.git",
+        ]
+        
+        entry_point = "train.py"
+        
+        for malicious_url in attack_scenarios:
+            git_config = {"repo": malicious_url}
+            with pytest.raises(ValueError) as error:
+                git_utils.git_clone_repo(git_config, entry_point)
+            # Should be blocked by sanitization
+            assert any(phrase in str(error.value) for phrase in [
+                "multiple @ symbols detected",
+                "exactly one @ symbol",
+                "Suspicious URL encoding detected",
+                "Invalid characters in hostname"
+            ])


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)
- [ ] If adding any dependency in requirements.txt files, I have spell checked and ensured they exist in PyPi

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
