### PR TITLE
change: When rootlessDocker is enabled, return a fixed SageMaker IP

### DIFF
--- a/src/sagemaker/local/utils.py
+++ b/src/sagemaker/local/utils.py
@@ -153,7 +153,8 @@ def get_child_process_ids(pid):
 def get_docker_host():
     """Discover remote docker host address (if applicable) or use "localhost"
 
-    Use "docker context inspect" to read current docker host endpoint url,
+    When rootlessDocker is enabled (Cgroup Driver: none), use fixed SageMaker IP.
+    Otherwise, Use "docker context inspect" to read current docker host endpoint url,
     url must start with "tcp://"
 
     Args:
@@ -161,6 +162,27 @@ def get_docker_host():
     Returns:
         docker_host (str): Docker host DNS or IP address
     """
+    # Check if using SageMaker rootless Docker by examining storage driver
+    try:
+        cmd = ["docker", "info"]
+        process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        output, err = process.communicate()
+        if process.returncode == 0:  # Check return code instead of stderr
+            output_text = output.decode("utf-8")
+            # Check for rootless Docker by looking at Cgroup Driver
+            if "Cgroup Driver: none" in output_text:
+                # log the result of check
+                logger.warning("RootlessDocker detected (Cgroup Driver: none), returning fixed IP.")
+                # SageMaker rootless Docker detected - return fixed IP
+                return "172.17.0.1"
+            else:
+                logger.warning(
+                    "RootlessDocker not detected, falling back to remote host IP or localhost."
+                )
+    except subprocess.SubprocessError:
+        pass
+
+    # Fallback to existing logic for remote Docker hosts
     cmd = "docker context inspect".split()
     process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     output, err = process.communicate()

--- a/tests/unit/sagemaker/local/test_local_utils.py
+++ b/tests/unit/sagemaker/local/test_local_utils.py
@@ -135,6 +135,68 @@ def test_get_docker_host(m_subprocess):
         assert host == endpoint["result"]
 
 
+@patch("sagemaker.local.utils.subprocess")
+def test_get_docker_host_rootless_docker(m_subprocess):
+    """Test that rootless Docker is detected and returns fixed IP"""
+    # Mock docker info process for rootless Docker
+    info_process_mock = Mock()
+    info_attrs = {"communicate.return_value": (b"Cgroup Driver: none", b""), "returncode": 0}
+    info_process_mock.configure_mock(**info_attrs)
+    m_subprocess.Popen.return_value = info_process_mock
+
+    host = sagemaker.local.utils.get_docker_host()
+    assert host == "172.17.0.1"
+
+    # Verify docker info was called
+    m_subprocess.Popen.assert_called_with(
+        ["docker", "info"], stdout=m_subprocess.PIPE, stderr=m_subprocess.PIPE
+    )
+
+
+@patch("sagemaker.local.utils.subprocess")
+def test_get_docker_host_traditional_docker(m_subprocess):
+    """Test that traditional Docker falls back to existing logic"""
+    scenarios = [
+        {
+            "docker_info": b"Cgroup Driver: cgroupfs",
+            "context_host": "tcp://host:port",
+            "result": "host",
+        },
+        {
+            "docker_info": b"Cgroup Driver: cgroupfs",
+            "context_host": "unix:///var/run/docker.sock",
+            "result": "localhost",
+        },
+        {
+            "docker_info": b"Cgroup Driver: cgroupfs",
+            "context_host": "fd://something",
+            "result": "localhost",
+        },
+    ]
+
+    for scenario in scenarios:
+        # Mock docker info process for traditional Docker
+        info_process_mock = Mock()
+        info_attrs = {"communicate.return_value": (scenario["docker_info"], b""), "returncode": 0}
+        info_process_mock.configure_mock(**info_attrs)
+
+        # Mock docker context inspect process
+        context_return_value = (
+            '[\n{\n"Endpoints":{\n"docker":{\n"Host": "%s"}\n}\n}\n]\n' % scenario["context_host"]
+        )
+        context_process_mock = Mock()
+        context_attrs = {
+            "communicate.return_value": (context_return_value.encode("utf-8"), None),
+            "returncode": 0,
+        }
+        context_process_mock.configure_mock(**context_attrs)
+
+        m_subprocess.Popen.side_effect = [info_process_mock, context_process_mock]
+
+        host = sagemaker.local.utils.get_docker_host()
+        assert host == scenario["result"]
+
+
 @pytest.mark.parametrize(
     "json_path, expected",
     [


### PR DESCRIPTION
*Issue #, if available:*
N/A - Internal requirement for SageMaker Studio rootless Docker support

*Description of changes:*
Enhanced `get_docker_host()` function in `src/sagemaker/local/utils.py` to support rootless Docker environments:

- Detect rootless Docker by checking for `Cgroup Driver: none` in `docker info` output
- Return fixed IP `172.17.0.1` for rootless Docker instead of `localhost`
- Maintain backward compatibility with traditional Docker setups
- Enable SageMaker local mode to work correctly in Studio's rootless Docker environment

*Testing done:*
- Added unit tests for rootless Docker detection (`test_get_docker_host_rootless_docker`)
- Added unit tests for traditional Docker fallback scenarios (`test_get_docker_host_traditional_docker`)
- Tested in traditional Docker environment (returns `localhost` as expected)
- Built and tested custom wheel in SageMaker Studio environment
- Confirmed backward compatibility with existing remote Docker functionality

Ref: https://quip-amazon.com/EvbfAyrac6Nh/SageMaker-Studio-V2-Docker-access-in-VPCOnly-mode#temp:C:bDf835bbc571f5245dfb5e32037b

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)
- [x] If adding any dependency in requirements.txt files, I have spell checked and ensured they exist in PyPi

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
