### PR TITLE
Directly use customer-provided endpoint name for ModelBuilder deployment.

### DIFF
--- a/src/sagemaker/serve/builder/model_builder.py
+++ b/src/sagemaker/serve/builder/model_builder.py
@@ -116,7 +116,7 @@ from sagemaker.serve.validations.check_image_and_hardware_type import (
     validate_image_uri_and_hardware,
 )
 from sagemaker.serverless import ServerlessInferenceConfig
-from sagemaker.utils import Tags, unique_name_from_base
+from sagemaker.utils import Tags
 from sagemaker.workflow.entities import PipelineVariable
 from sagemaker.huggingface.llm_utils import (
     get_huggingface_model_metadata,
@@ -1983,8 +1983,6 @@ class ModelBuilder(Triton, DJL, JumpStart, TGI, Transformers, TensorflowServing,
         """
         if not hasattr(self, "built_model") and not hasattr(self, "_deployables"):
             raise ValueError("Model needs to be built before deploying")
-        if not update_endpoint:
-            endpoint_name = unique_name_from_base(endpoint_name)
 
         if not hasattr(self, "_deployables"):
             if not inference_config:  # Real-time Deployment

--- a/tests/integ/sagemaker/serve/test_base_model_builder_deploy.py
+++ b/tests/integ/sagemaker/serve/test_base_model_builder_deploy.py
@@ -185,7 +185,7 @@ def xgboost_model_builder(mb_sagemaker_session):
 
 def test_real_time_deployment(xgboost_model_builder):
     real_time_predictor = xgboost_model_builder.deploy(
-        endpoint_name="test", initial_instance_count=1
+        endpoint_name=f"test-{uuid.uuid1().hex}", initial_instance_count=1
     )
 
     assert real_time_predictor is not None
@@ -198,7 +198,7 @@ def test_real_time_deployment(xgboost_model_builder):
 
 def test_serverless_deployment(xgboost_model_builder):
     serverless_predictor = xgboost_model_builder.deploy(
-        endpoint_name="test1", inference_config=ServerlessInferenceConfig()
+        endpoint_name=f"test1-{uuid.uuid1().hex}", inference_config=ServerlessInferenceConfig()
     )
 
     assert serverless_predictor is not None

--- a/tests/integ/sagemaker/serve/test_serve_model_builder_inference_component_happy.py
+++ b/tests/integ/sagemaker/serve/test_serve_model_builder_inference_component_happy.py
@@ -14,6 +14,7 @@ from __future__ import absolute_import
 
 import pytest
 import tests.integ
+import uuid
 
 from botocore.exceptions import ClientError
 from sagemaker.predictor import Predictor
@@ -88,7 +89,7 @@ def test_model_builder_ic_sagemaker_endpoint(
     with timeout(minutes=SERVE_SAGEMAKER_ENDPOINT_TIMEOUT):
         try:
             logger.info("Deploying and predicting in SAGEMAKER_ENDPOINT mode...")
-            endpoint_name = "llama-ic-endpoint-name"
+            endpoint_name = f"llama-ic-endpoint-name-{uuid.uuid1().hex}"
             predictors = chain.deploy(
                 instance_type=INSTANCE_TYPE,
                 initial_instance_count=1,

--- a/tests/unit/sagemaker/serve/builder/test_model_builder.py
+++ b/tests/unit/sagemaker/serve/builder/test_model_builder.py
@@ -4241,9 +4241,7 @@ class TestModelBuilderOptimizeValidations(unittest.TestCase):
         "Batch",
     ],
 )
-@patch("sagemaker.serve.builder.model_builder.unique_name_from_base")
-def test_deploy(mock_unique_name_from_base, test_case):
-    mock_unique_name_from_base.return_value = "test"
+def test_deploy(test_case):
     model: Model = MagicMock()
     model_builder = ModelBuilder(
         model="meta-llama/Meta-Llama-3-8B-Instruct",


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* ModelBuilder is generating a unique name from the customer-provided endpoint name as base. Leads to confusion and inconsistencies in the user experience, especially when customers already set a UUID string for uniqueness in their base name.

*Testing done:* UTs and integ tests succeed locally

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)
- [ ] If adding any dependency in requirements.txt files, I have spell checked and ensured they exist in PyPi

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
