### PR TITLE
fix: add sleep for model deployment to fix flaky test

### DIFF
--- a/tests/integ/test_multidatamodel.py
+++ b/tests/integ/test_multidatamodel.py
@@ -14,6 +14,7 @@ from __future__ import absolute_import
 
 import base64
 import os
+import time
 import requests
 
 import docker
@@ -138,6 +139,7 @@ def test_multi_data_model_deploy_pretrained_models(
         multi_data_model.add_model(pretrained_model_data_local_path, PRETRAINED_MODEL_PATH_1)
         # Deploy model to an endpoint
         multi_data_model.deploy(1, cpu_instance_type, endpoint_name=endpoint_name)
+        time.sleep(30)
         # Add models after deploy
         multi_data_model.add_model(pretrained_model_data_local_path, PRETRAINED_MODEL_PATH_2)
 
@@ -266,6 +268,7 @@ def test_multi_data_model_deploy_trained_model_from_framework_estimator(
         multi_data_model.add_model(mxnet_model_1.model_data, PRETRAINED_MODEL_PATH_1)
         # Deploy model to an endpoint
         multi_data_model.deploy(1, cpu_instance_type, endpoint_name=endpoint_name)
+        time.sleep(30)
 
         # Train another model
         mxnet_model_2 = _mxnet_training_job(
@@ -373,6 +376,7 @@ def test_multi_data_model_deploy_train_model_from_amazon_first_party_estimator(
         multi_data_model.add_model(rcf_model_v1.model_data, PRETRAINED_MODEL_PATH_1)
         # Deploy model to an endpoint
         multi_data_model.deploy(1, cpu_instance_type, endpoint_name=endpoint_name)
+        time.sleep(30)
         # Train another model
         rcf_model_v2 = __rcf_training_job(
             sagemaker_session, container_image, cpu_instance_type, 70, 20
@@ -470,6 +474,7 @@ def test_multi_data_model_deploy_pretrained_models_update_endpoint(
         multi_data_model.add_model(pretrained_model_data_local_path, PRETRAINED_MODEL_PATH_1)
         # Deploy model to an endpoint
         multi_data_model.deploy(1, cpu_instance_type, endpoint_name=endpoint_name)
+        time.sleep(30)
         # Add model after deploy
         multi_data_model.add_model(pretrained_model_data_local_path, PRETRAINED_MODEL_PATH_2)
 


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/sagemaker-python-sdk/blob/e65b0d75e41d38cc33a1706b5ad25c09c60a587d/tests/integ/test_multidatamodel.py#L350

*Description of changes:*

Fixes intermittently flaky tests by allowing time for the model to deploy after endpoint is created

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)
- [ ] If adding any dependency in requirements.txt files, I have spell checked and ensured they exist in PyPi

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
