### PR TITLE
Feature: add eval custom lambda arn to hyperparameters

### DIFF
--- a/src/sagemaker/modules/train/sm_recipes/utils.py
+++ b/src/sagemaker/modules/train/sm_recipes/utils.py
@@ -305,6 +305,13 @@ def _get_args_from_nova_recipe(
             )
         args["hyperparameters"]["kms_key"] = kms_key
 
+    # Handle eval custom lambda configuration
+    if recipe.get("evaluation", {}):
+        processor = recipe.get("processor", {})
+        lambda_arn = processor.get("lambda_arn", "")
+        if lambda_arn:
+            args["hyperparameters"]["lambda_arn"] = lambda_arn
+
     _register_custom_resolvers()
 
     # Resolve Final Recipe

--- a/tests/unit/sagemaker/modules/train/sm_recipes/test_utils.py
+++ b/tests/unit/sagemaker/modules/train/sm_recipes/test_utils.py
@@ -446,3 +446,35 @@ def test_get_args_from_nova_recipe_with_distillation_errors(test_case):
         _get_args_from_nova_recipe(
             recipe=recipe, compute=test_case["compute"], role=test_case.get("role")
         )
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        {
+            "recipe": {
+                "evaluation": {"task:": "gen_qa", "strategy": "gen_qa", "metric": "all"},
+                "processor": {
+                    "lambda_arn": "arn:aws:lambda:us-east-1:123456789012:function:MyLambdaFunction"
+                },
+            },
+            "compute": Compute(instance_type="ml.m5.xlarge", instance_count=2),
+            "role": "arn:aws:iam::123456789012:role/SageMakerRole",
+            "expected_args": {
+                "compute": Compute(instance_type="ml.m5.xlarge", instance_count=2),
+                "hyperparameters": {
+                    "lambda_arn": "arn:aws:lambda:us-east-1:123456789012:function:MyLambdaFunction",
+                },
+                "training_image": None,
+                "source_code": None,
+                "distributed": None,
+            },
+        },
+    ],
+)
+def test_get_args_from_nova_recipe_with_evaluation(test_case):
+    recipe = OmegaConf.create(test_case["recipe"])
+    args, _ = _get_args_from_nova_recipe(
+        recipe=recipe, compute=test_case["compute"], role=test_case["role"]
+    )
+    assert args == test_case["expected_args"]


### PR DESCRIPTION
*Issue #, if available:*
Support nova custom evaluation SMTJ job to have a eval specific hyperparameter

*Description of changes:*
This change is to support nova custom evaluation SMTJ job to have a eval specific hyperparameter.

We modify the `src/sagemaker/modules/train/sm_recipes/utils.py` so the hyperparameters will contains the value for a lambda_arn which nova evaluation job need. 

*Testing done:*
Add and pass unit test
## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)
- [ ] If adding any dependency in requirements.txt files, I have spell checked and ensured they exist in PyPi

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
