### PR TITLE
fix: handle trial component status message longer than API supports

### DIFF
--- a/src/sagemaker/experiments/run.py
+++ b/src/sagemaker/experiments/run.py
@@ -68,6 +68,7 @@ RUN_NAME_BASE = "Sagemaker-Run".lower()
 TRIAL_NAME_TEMPLATE = "Default-Run-Group-{}"
 MAX_RUN_TC_ARTIFACTS_LEN = 30
 MAX_NAME_LEN_IN_BACKEND = 120
+MAX_STATUS_MESSAGE_LEN = 1024
 EXPERIMENT_NAME = "ExperimentName"
 TRIAL_NAME = "TrialName"
 RUN_NAME = "RunName"
@@ -759,7 +760,7 @@ class Run(object):
         if exc_value:
             self._trial_component.status = _api_types.TrialComponentStatus(
                 primary_status=_TrialComponentStatusType.Failed.value,
-                message=str(exc_value),
+                message=(str(exc_value) or "")[:MAX_STATUS_MESSAGE_LEN],
             )
         else:
             self._trial_component.status = _api_types.TrialComponentStatus(


### PR DESCRIPTION
*Issue #, if available:* no issue

*Description of changes:* fixes 3 CI integ test failures due to an API request parameter validation failure (UpdateTrialComponent.status.message longer than 1024 character).

*Testing done:*  `tox`

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)
- [x] If adding any dependency in requirements.txt files, I have spell checked and ensured they exist in PyPi

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


```
        if http.status_code >= 300:
            error_info = parsed_response.get("Error", {})
            error_code = request_context.get(
                'error_code_override'
            ) or error_info.get("Code")
            error_class = self.exceptions.from_code(error_code)
>           raise error_class(parsed_response, operation_name)
E           botocore.exceptions.ClientError: An error occurred (ValidationException) when calling the UpdateTrialComponent operation: 2 validation errors detected: Value 'Error for Training job train-job-experiments-integ-1757366487-a8d6: Failed. Reason: AlgorithmError: framework error:
E           Traceback (most recent call last):
E             File "/usr/local/lib/python3.8/dist-packages/sagemaker_containers/_trainer.py", line 84, in train
E               entrypoint()
E             File "/usr/local/lib/python3.8/dist-packages/sagemaker_sklearn_container/training.py", line 39, in main
E               train(environment.Environment())
E             File "/usr/local/lib/python3.8/dist-packages/sagemaker_sklearn_container/training.py", line 31, in train
E               entry_point.run(uri=training_environment.module_dir,
E             File "/usr/local/lib/python3.8/dist-packages/sagemaker_training/entry_point.py", line 108, in run
E               return runner.get(runner_type, user_entry_point, args, env_vars, extra_opts).run(
E             File "/usr/local/lib/python3.8/dist-packages/sagemaker_training/process.py", line 424, in run
E               process = check_error(
E             File "/usr/local/lib/python3.8/dist-packages/sagemaker_training/process.py", line 335, in check_error
E               raise error_class(
E           sagemaker_training.errors.ExecuteUserScriptError: ExecuteUserScriptError:
E           ExitCode 1
E           ErrorMessa. Check troubleshooting guide for common errors: https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-python-sdk-troubleshooting.html' at 'status.message' failed to satisfy constraint: Member must have length less than or equal to 1024; Value 'Error for Training job train-job-experiments-integ-1757366487-a8d6: Failed. Reason: AlgorithmError: framework error:
E           Traceback (most recent call last):
E             File "/usr/local/lib/python3.8/dist-packages/sagemaker_containers/_trainer.py", line 84, in train
E               entrypoint()
E             File "/usr/local/lib/python3.8/dist-packages/sagemaker_sklearn_container/training.py", line 39, in main
E               train(environment.Environment())
E             File "/usr/local/lib/python3.8/dist-packages/sagemaker_sklearn_container/training.py", line 31, in train
E               entry_point.run(uri=training_environment.module_dir,
E             File "/usr/local/lib/python3.8/dist-packages/sagemaker_training/entry_point.py", line 108, in run
E               return runner.get(runner_type, user_entry_point, args, env_vars, extra_opts).run(
E             File "/usr/local/lib/python3.8/dist-packages/sagemaker_training/process.py", line 424, in run
E               process = check_error(
E             File "/usr/local/lib/python3.8/dist-packages/sagemaker_training/process.py", line 335, in check_error
E               raise error_class(
E           sagemaker_training.errors.ExecuteUserScriptError: ExecuteUserScriptError:
E           ExitCode 1
E           ErrorMessa. Check troubleshooting guide for common errors: https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-python-sdk-troubleshooting.html' at 'status.message' failed to satisfy constraint: Member must satisfy regular expression pattern: .*


```