### PR TITLE
Add nova custom lambda in hyperparameter from estimator

### DIFF
--- a/src/sagemaker/modules/train/sm_recipes/utils.py
+++ b/src/sagemaker/modules/train/sm_recipes/utils.py
@@ -310,7 +310,7 @@ def _get_args_from_nova_recipe(
         processor = recipe.get("processor", {})
         lambda_arn = processor.get("lambda_arn", "")
         if lambda_arn:
-            args["hyperparameters"]["lambda_arn"] = lambda_arn
+            args["hyperparameters"]["eval_lambda_arn"] = lambda_arn
 
     _register_custom_resolvers()
 

--- a/src/sagemaker/pytorch/estimator.py
+++ b/src/sagemaker/pytorch/estimator.py
@@ -1229,9 +1229,7 @@ class PyTorch(Framework):
             processor = recipe.get("processor", {})
             lambda_arn = processor.get("lambda_arn", "")
             if lambda_arn:
-                args["hyperparameters"]["lambda_arn"] = lambda_arn
-            # Resolve and save the final recipe
-            self._recipe_resolve_and_save(recipe, recipe_name, args["source_dir"])
+                args["hyperparameters"]["eval_lambda_arn"] = lambda_arn
 
         # Resolve and save the final recipe
         self._recipe_resolve_and_save(recipe, recipe_name, args["source_dir"])

--- a/src/sagemaker/pytorch/estimator.py
+++ b/src/sagemaker/pytorch/estimator.py
@@ -1224,6 +1224,15 @@ class PyTorch(Framework):
                 )
             args["hyperparameters"]["kms_key"] = kms_key
 
+        # Handle eval custom lambda configuration
+        if recipe.get("evaluation", {}):
+            processor = recipe.get("processor", {})
+            lambda_arn = processor.get("lambda_arn", "")
+            if lambda_arn:
+                args["hyperparameters"]["lambda_arn"] = lambda_arn
+            # Resolve and save the final recipe
+            self._recipe_resolve_and_save(recipe, recipe_name, args["source_dir"])
+
         # Resolve and save the final recipe
         self._recipe_resolve_and_save(recipe, recipe_name, args["source_dir"])
 

--- a/tests/unit/sagemaker/modules/train/sm_recipes/test_utils.py
+++ b/tests/unit/sagemaker/modules/train/sm_recipes/test_utils.py
@@ -463,7 +463,7 @@ def test_get_args_from_nova_recipe_with_distillation_errors(test_case):
             "expected_args": {
                 "compute": Compute(instance_type="ml.m5.xlarge", instance_count=2),
                 "hyperparameters": {
-                    "lambda_arn": "arn:aws:lambda:us-east-1:123456789012:function:MyLambdaFunction",
+                    "eval_lambda_arn": "arn:aws:lambda:us-east-1:123456789012:function:MyLambdaFunction",
                 },
                 "training_image": None,
                 "source_code": None,


### PR DESCRIPTION
*Issue #, if available:*
Support nova custom evaluation SMTJ job to have a eval specific hyperparameter, I have previously created a PR: https://github.com/aws/sagemaker-python-sdk/pull/5272 which is to set the hyperparameter from model trainer. This PR set the hyperparameter from estimator.

*Description of changes:*
This change is to support nova custom evaluation SMTJ job to have a eval specific hyperparameter.


*Testing done:*
Tested on Sagemaker training job locally, verify the hyperparameter field is set correctly

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)
- [ ] If adding any dependency in requirements.txt files, I have spell checked and ensured they exist in PyPi

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
