### PR TITLE
update sklearn from 1.2-1 to 1.2-1-1

### DIFF
--- a/src/sagemaker/image_uri_config/sklearn.json
+++ b/src/sagemaker/image_uri_config/sklearn.json
@@ -192,6 +192,54 @@
                     "us-west-2": "246618743249"
                 },
                 "repository": "sagemaker-scikit-learn"
+            },
+            "1.2-1-1": {
+                "processors": [
+                    "cpu"
+                ],
+                "py_versions": [
+                    "py3"
+                ],
+                "registries": {
+                    "af-south-1": "510948584623",
+                    "ap-east-1": "651117190479",
+                    "ap-northeast-1": "354813040037",
+                    "ap-northeast-2": "366743142698",
+                    "ap-northeast-3": "867004704886",
+                    "ap-south-1": "720646828776",
+                    "ap-south-2": "628508329040",
+                    "ap-southeast-1": "121021644041",
+                    "ap-southeast-2": "783357654285",
+                    "ap-southeast-3": "951798379941",
+                    "ap-southeast-4": "106583098589",
+                    "ca-central-1": "341280168497",
+                    "ca-west-1": "190319476487",
+                    "cn-north-1": "450853457545",
+                    "cn-northwest-1": "451049120500",
+                    "eu-central-1": "492215442770",
+                    "eu-central-2": "680994064768",
+                    "eu-north-1": "662702820516",
+                    "eu-south-1": "978288397137",
+                    "eu-south-2": "104374241257",
+                    "eu-west-1": "141502667606",
+                    "eu-west-2": "764974769150",
+                    "eu-west-3": "659782779980",
+                    "il-central-1": "898809789911",
+                    "me-central-1": "272398656194",
+                    "me-south-1": "801668240914",
+                    "sa-east-1": "737474898029",
+                    "us-east-1": "683313688378",
+                    "us-east-2": "257758044811",
+                    "us-gov-east-1": "237065988967",
+                    "us-gov-west-1": "414596584902",
+                    "us-iso-east-1": "833128469047",
+                    "us-isob-east-1": "281123927165",
+                    "us-isof-east-1": "108575199400",
+                    "us-isof-south-1": "124985052026",
+                    "us-west-1": "746614075791",
+                    "us-west-2": "246618743249"
+                },
+                "repository": "sagemaker-scikit-learn"
             }
         }
     },
@@ -342,6 +390,54 @@
                 "repository": "sagemaker-scikit-learn"
             },
             "1.2-1": {
+                "processors": [
+                    "cpu"
+                ],
+                "py_versions": [
+                    "py3"
+                ],
+                "registries": {
+                    "af-south-1": "510948584623",
+                    "ap-east-1": "651117190479",
+                    "ap-northeast-1": "354813040037",
+                    "ap-northeast-2": "366743142698",
+                    "ap-northeast-3": "867004704886",
+                    "ap-south-1": "720646828776",
+                    "ap-south-2": "628508329040",
+                    "ap-southeast-1": "121021644041",
+                    "ap-southeast-2": "783357654285",
+                    "ap-southeast-3": "951798379941",
+                    "ap-southeast-4": "106583098589",
+                    "ca-central-1": "341280168497",
+                    "ca-west-1": "190319476487",
+                    "cn-north-1": "450853457545",
+                    "cn-northwest-1": "451049120500",
+                    "eu-central-1": "492215442770",
+                    "eu-central-2": "680994064768",
+                    "eu-north-1": "662702820516",
+                    "eu-south-1": "978288397137",
+                    "eu-south-2": "104374241257",
+                    "eu-west-1": "141502667606",
+                    "eu-west-2": "764974769150",
+                    "eu-west-3": "659782779980",
+                    "il-central-1": "898809789911",
+                    "me-central-1": "272398656194",
+                    "me-south-1": "801668240914",
+                    "sa-east-1": "737474898029",
+                    "us-east-1": "683313688378",
+                    "us-east-2": "257758044811",
+                    "us-gov-east-1": "237065988967",
+                    "us-gov-west-1": "414596584902",
+                    "us-iso-east-1": "833128469047",
+                    "us-isob-east-1": "281123927165",
+                    "us-isof-east-1": "108575199400",
+                    "us-isof-south-1": "124985052026",
+                    "us-west-1": "746614075791",
+                    "us-west-2": "246618743249"
+                },
+                "repository": "sagemaker-scikit-learn"
+            },
+            "1.2-1-1": {
                 "processors": [
                     "cpu"
                 ],

--- a/src/sagemaker/workflow/_utils.py
+++ b/src/sagemaker/workflow/_utils.py
@@ -46,7 +46,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-FRAMEWORK_VERSION = "1.2-1"
+FRAMEWORK_VERSION = "1.2-1-1"
 INSTANCE_TYPE = "ml.m5.large"
 REPACK_SCRIPT = "_repack_model.py"
 REPACK_SCRIPT_LAUNCHER = "_repack_script_launcher.sh"

--- a/tests/integ/sagemaker/experiments/test_run.py
+++ b/tests/integ/sagemaker/experiments/test_run.py
@@ -693,7 +693,7 @@ def _generate_estimator(
         sagemaker_client_config=sagemaker_client_config,
     )
     return SKLearn(
-        framework_version="1.2-1",
+        framework_version="1.2-1-1",
         entry_point=_ENTRY_POINT_PATH,
         dependencies=[sdk_tar],
         role=execution_role,

--- a/tests/unit/sagemaker/image_uris/jumpstart/test_sklearn.py
+++ b/tests/unit/sagemaker/image_uris/jumpstart/test_sklearn.py
@@ -56,13 +56,12 @@ def test_jumpstart_sklearn_image_uri(patched_get_model_specs, session):
     # framework classes dont use digest.
     assert (
         framework_class_uri
-        == "246618743249.dkr.ecr.us-west-2.amazonaws.com/sagemaker-scikit-learn:1.2-1"
+        == "246618743249.dkr.ecr.us-west-2.amazonaws.com/sagemaker-scikit-learn:1.2-1-1"
         "-cpu-py3"
     )
     assert (
         uri == "246618743249.dkr.ecr.us-west-2.amazonaws.com/sagemaker-scikit-learn@"
-        "sha256:e09bbb7686077a1db23d316b699020a786a6e1636b2b89384be9651368c40f95"
-    )
+        "sha256:a7a5a9097f078d3d0ccb7248ec076ad63e10c82e39a798408f5066450afe82bd"
 
     # training
     uri = image_uris.retrieve(
@@ -88,11 +87,11 @@ def test_jumpstart_sklearn_image_uri(patched_get_model_specs, session):
     # framework classes dont use digest.
     assert (
         framework_class_uri
-        == "246618743249.dkr.ecr.us-west-2.amazonaws.com/sagemaker-scikit-learn:1.2-1-cpu-py3"
+        == "246618743249.dkr.ecr.us-west-2.amazonaws.com/sagemaker-scikit-learn:1.2-1-1-cpu-py3"
     )
     assert (
         uri == "246618743249.dkr.ecr.us-west-2.amazonaws.com/sagemaker-scikit-learn"
-        "@sha256:e09bbb7686077a1db23d316b699020a786a6e1636b2b89384be9651368c40f95"
+        "@sha256:a7a5a9097f078d3d0ccb7248ec076ad63e10c82e39a798408f5066450afe82bd"
     )
 
     with pytest.raises(ValueError):

--- a/tests/unit/sagemaker/jumpstart/constants.py
+++ b/tests/unit/sagemaker/jumpstart/constants.py
@@ -14854,7 +14854,7 @@ PROTOTYPICAL_MODEL_SPECS_DICT = {
         "incremental_training_supported": False,
         "hosting_ecr_specs": {
             "framework": "sklearn",
-            "framework_version": "1.2-1",
+            "framework_version": "1.2-1-1",
             "py_version": "py3",
         },
         "hosting_artifact_key": "sklearn-infer/infer-sklearn-classification-linear.tar.gz",
@@ -14974,7 +14974,7 @@ PROTOTYPICAL_MODEL_SPECS_DICT = {
         "training_script_key": "source-directory-tarballs/training/sklearn-classification/v2.0.1/sourcedir.tar.gz",
         "training_ecr_specs": {
             "framework": "sklearn",
-            "framework_version": "1.2-1",
+            "framework_version": "1.2-1-1",
             "py_version": "py3",
         },
         "training_artifact_key": "sklearn-training/train-sklearn-classification-linear.tar.gz",

--- a/tests/unit/sagemaker/workflow/test_step_collections.py
+++ b/tests/unit/sagemaker/workflow/test_step_collections.py
@@ -55,7 +55,7 @@ from tests.unit.sagemaker.workflow.conftest import IMAGE_URI, ROLE, BUCKET, REGI
 
 MODEL_NAME = "gisele"
 MODEL_REPACKING_IMAGE_URI = (
-    "246618743249.dkr.ecr.us-west-2.amazonaws.com/sagemaker-scikit-learn:1.2-1-cpu-py3"
+    "246618743249.dkr.ecr.us-west-2.amazonaws.com/sagemaker-scikit-learn:1.2-1-1-cpu-py3"
 )
 
 


### PR DESCRIPTION
*Issue #, if available:*
update sklearn from 1.2-1 to 1.2-1-1

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)
- [ ] If adding any dependency in requirements.txt files, I have spell checked and ensured they exist in PyPi

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
