### PR TITLE
fix: update get_execution_role to directly return the ExecutionRoleArn if it presents in the resource metadata file

### DIFF
--- a/src/sagemaker/session.py
+++ b/src/sagemaker/session.py
@@ -6285,15 +6285,15 @@ class Session(object):  # pylint: disable=too-many-public-methods
                 user_profile_name = metadata.get("UserProfileName")
                 execution_role_arn = metadata.get("ExecutionRoleArn")
             try:
+                # find execution role from the metadata file if present
+                if execution_role_arn is not None:
+                    return execution_role_arn
+
                 if domain_id is None:
                     instance_desc = self.sagemaker_client.describe_notebook_instance(
                         NotebookInstanceName=instance_name
                     )
                     return instance_desc["RoleArn"]
-
-                # find execution role from the metadata file if present
-                if execution_role_arn is not None:
-                    return execution_role_arn
 
                 user_profile_desc = self.sagemaker_client.describe_user_profile(
                     DomainId=domain_id, UserProfileName=user_profile_name


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Previously the code first check if DomainId exists in the resource metadata, then acts accordingly. However, if the ExecutionRoleArn is already in the resource metadata file, the code should just return it.
- This changes the code to directly return the ExecutionRoleArn if it presents in the resource metadata file

*Testing done:*
New unit test added

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)
- [ ] If adding any dependency in requirements.txt files, I have spell checked and ensured they exist in PyPi

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
