### PR TITLE
fix: fixing test requirements

### DIFF
--- a/requirements/extras/test_requirements.txt
+++ b/requirements/extras/test_requirements.txt
@@ -61,4 +61,5 @@ mypy-boto3-redshift-data==1.35.51
 mypy-boto3-s3==1.35.76
 mypy-extensions==1.0.0
 mypy==1.9.0
-google-re2<1.1.20250805
+# apache-airflow transitive dependancy
+google-re2<1.1.20250805; python_version < "3.10"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix Python 3.9 tox failure due to google-re2 missing prebuilt wheels. The `google-re2` package is transitive dependancy.

- Latest google-re2 versions lack Python 3.9 wheels
- Forces source compilation requiring Bazel (not available in CI)
- Added constraint: `google-re2<1.1.20250805; python_version<"3.10"`
- Only affects Python 3.9, allows latest versions on 3.10+


*Testing done:*
- Reproduced failure locally with `tox -e py39`
- Verified fix resolves build error
- Confirmed constraint only applies to Python 3.9
- Tox command completes successfully


## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)
- [x] If adding any dependency in requirements.txt files, I have spell checked and ensured they exist in PyPi

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
