### PR TITLE
Fix tox.ini for using right core version

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -90,7 +90,7 @@ commands =
     pip install 'torchvision==0.18.1+cpu' -f 'https://download.pytorch.org/whl/torch_stable.html'
     pip install 'dill>=0.3.9'
     pip install 'altair>=5.3' # needed for amtviz
-    pip install -U "sagemaker-core" # needed to keep sagemaker-core up to date
+    pip install -U "sagemaker-core<2.0.0" # needed to keep sagemaker-core up to date
 
     pytest {posargs}
 deps =


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Pin sagemaker-core version to be less than 2.0 so it is compatible with SageMaker V2


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
