### PR TITLE
skip resource unit test

### DIFF
--- a/sagemaker-core/tests/unit/generated/test_resources.py
+++ b/sagemaker-core/tests/unit/generated/test_resources.py
@@ -66,7 +66,7 @@ class ResourcesTest(unittest.TestCase):
                         self._get_required_parameters_for_function(cls.get)
                     )
 
-    @pytest.mark.skip(reason="Skipped by user request")
+    @pytest.mark.skip(reason="Pending fixes in auto-generation script")
     @patch("sagemaker.core.resources.transform")
     @patch("boto3.session.Session")
     def test_resources(self, session, mock_transform):


### PR DESCRIPTION
Skip a unit test for sagemaker core resource.py

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
