### PR TITLE
fix: Address Hyperparameter issue , validate s3 output path, additional unit tests

### DIFF
--- a/sagemaker-train/src/sagemaker/train/dpo_trainer.py
+++ b/sagemaker-train/src/sagemaker/train/dpo_trainer.py
@@ -17,7 +17,8 @@ from sagemaker.train.common_utils.finetune_utils import (
     _create_serverless_config,
     _create_mlflow_config,
     _create_model_package_config,
-    _validate_eula_for_gated_model
+    _validate_eula_for_gated_model,
+    _validate_hyperparameter_values
 )
 from sagemaker.core.telemetry.telemetry_logging import _telemetry_emitter
 from sagemaker.core.telemetry.constants import Feature
@@ -137,8 +138,38 @@ class DPOTrainer(BaseTrainer):
        
                                                                                     ))
         
+        # Process hyperparameters
+        self._process_hyperparameters()
+        
         # Validate and set EULA acceptance
         self.accept_eula = _validate_eula_for_gated_model(model, accept_eula, is_gated_model)
+
+    def _process_hyperparameters(self):
+        """Remove hyperparameter keys that are handled by constructor inputs."""
+        if self.hyperparameters:
+            # Remove keys that are handled by constructor inputs
+            if hasattr(self.hyperparameters, 'data_path'):
+                delattr(self.hyperparameters, 'data_path')
+                self.hyperparameters._specs.pop('data_path', None)
+            if hasattr(self.hyperparameters, 'output_path'):
+                delattr(self.hyperparameters, 'output_path')
+                self.hyperparameters._specs.pop('output_path', None)
+            if hasattr(self.hyperparameters, 'data_s3_path'):
+                delattr(self.hyperparameters, 'data_s3_path')
+                self.hyperparameters._specs.pop('data_s3_path', None)
+            if hasattr(self.hyperparameters, 'output_s3_path'):
+                delattr(self.hyperparameters, 'output_s3_path')
+                self.hyperparameters._specs.pop('output_s3_path', None)
+            if hasattr(self.hyperparameters, 'training_data_name'):
+                delattr(self.hyperparameters, 'training_data_name')
+                self.hyperparameters._specs.pop('training_data_name', None)
+            if hasattr(self.hyperparameters, 'validation_data_name'):
+                delattr(self.hyperparameters, 'validation_data_name')
+                self.hyperparameters._specs.pop('validation_data_name', None)
+            if hasattr(self.hyperparameters, 'validation_data_path'):
+                delattr(self.hyperparameters, 'validation_data_path')
+                self.hyperparameters._specs.pop('validation_data_path', None)
+
     @_telemetry_emitter(feature=Feature.MODEL_CUSTOMIZATION, func_name="DPOTrainer.train")
     def train(self,
               training_dataset: Optional[Union[str, DataSet]] = None,
@@ -198,6 +229,7 @@ class DPOTrainer(BaseTrainer):
         )
 
         final_hyperparameters = self.hyperparameters.to_dict()
+        _validate_hyperparameter_values(final_hyperparameters)
 
         model_package_config = _create_model_package_config(
             model_package_group_name=self.model_package_group_name,

--- a/sagemaker-train/tests/integ/train/test_dpo_trainer_integration.py
+++ b/sagemaker-train/tests/integ/train/test_dpo_trainer_integration.py
@@ -30,10 +30,8 @@ def test_dpo_trainer_lora_complete_workflow(sagemaker_session):
         model="meta-textgeneration-llama-3-2-1b-instruct",
         training_type=TrainingType.LORA,
         model_package_group_name="sdk-test-finetuned-models",
-        training_dataset="s3://mc-flows-sdk-testing/input_data/dpo/preference_dataset_train_256.jsonl",
+        training_dataset="arn:aws:sagemaker:us-west-2:729646638167:hub-content/sdktest/DataSet/dpo-oss-test-data/0.0.1",
         s3_output_path="s3://mc-flows-sdk-testing/output/",
-        # Unique job name
-        base_job_name=f"dpo-llama-{random.randint(1, 1000)}",
         accept_eula=True
     )
     
@@ -71,11 +69,9 @@ def test_dpo_trainer_with_validation_dataset(sagemaker_session):
         model="meta-textgeneration-llama-3-2-1b-instruct",
         training_type=TrainingType.LORA,
         model_package_group_name="sdk-test-finetuned-models",
-        training_dataset="s3://mc-flows-sdk-testing/input_data/dpo/preference_dataset_train_256.jsonl",
-        validation_dataset="s3://mc-flows-sdk-testing/input_data/dpo/preference_dataset_train_256.jsonl",
+        training_dataset="arn:aws:sagemaker:us-west-2:729646638167:hub-content/sdktest/DataSet/dpo-oss-test-data/0.0.1",
+        validation_dataset="arn:aws:sagemaker:us-west-2:729646638167:hub-content/sdktest/DataSet/dpo-oss-test-data/0.0.1",
         s3_output_path="s3://mc-flows-sdk-testing/output/",
-        # Unique job name
-        base_job_name=f"dpo-llama-{random.randint(1, 1000)}",
         accept_eula=True
     )
     

--- a/sagemaker-train/tests/integ/train/test_rlaif_trainer_integration.py
+++ b/sagemaker-train/tests/integ/train/test_rlaif_trainer_integration.py
@@ -29,15 +29,15 @@ def test_rlaif_trainer_lora_complete_workflow(sagemaker_session):
         model="meta-textgeneration-llama-3-2-1b-instruct",
         training_type=TrainingType.LORA,
         model_package_group_name="sdk-test-finetuned-models",
-        reward_model_id='anthropic.claude-3-5-sonnet-20240620-v1:0',
-        reward_prompt='Builtin.Correctness',
+        reward_model_id='openai.gpt-oss-120b-1:0',
+        reward_prompt='Builtin.Summarize',
         mlflow_experiment_name="test-rlaif-finetuned-models-exp",
         mlflow_run_name="test-rlaif-finetuned-models-run",
-        training_dataset="s3://mc-flows-sdk-testing/input_data/rlvr-rlaif-test-data/train_285.jsonl",
+        training_dataset="arn:aws:sagemaker:us-west-2:729646638167:hub-content/sdktest/DataSet/rlvr-rlaif-oss-test-data/0.0.1",
         s3_output_path="s3://mc-flows-sdk-testing/output/",
         accept_eula=True
     )
-    
+
     # Create training job
     training_job = rlaif_trainer.train(wait=False)
     
@@ -64,16 +64,16 @@ def test_rlaif_trainer_lora_complete_workflow(sagemaker_session):
 @pytest.mark.skip(reason="Skipping GPU resource intensive test")
 def test_rlaif_trainer_with_custom_reward_settings(sagemaker_session):
     """Test RLAIF trainer with different reward model and prompt."""
-    
+
     rlaif_trainer = RLAIFTrainer(
         model="meta-textgeneration-llama-3-2-1b-instruct",
         training_type=TrainingType.LORA,
         model_package_group_name="sdk-test-finetuned-models",
-        reward_model_id='anthropic.claude-3-5-sonnet-20240620-v1:0',
+        reward_model_id='openai.gpt-oss-120b-1:0',
         reward_prompt="arn:aws:sagemaker:us-west-2:729646638167:hub-content/sdktest/JsonDoc/rlaif-test-prompt/0.0.1",
         mlflow_experiment_name="test-rlaif-finetuned-models-exp",
         mlflow_run_name="test-rlaif-finetuned-models-run",
-        training_dataset="s3://mc-flows-sdk-testing/input_data/rlvr-rlaif-test-data/train_285.jsonl",
+        training_dataset="arn:aws:sagemaker:us-west-2:729646638167:hub-content/sdktest/DataSet/rlvr-rlaif-oss-test-data/0.0.1",
         s3_output_path="s3://mc-flows-sdk-testing/output/",
         accept_eula=True
     )
@@ -108,11 +108,11 @@ def test_rlaif_trainer_continued_finetuning(sagemaker_session):
         model="arn:aws:sagemaker:us-west-2:729646638167:model-package/sdk-test-finetuned-models/1",
         training_type=TrainingType.LORA,
         model_package_group_name="sdk-test-finetuned-models",
-        reward_model_id='anthropic.claude-3-5-sonnet-20240620-v1:0',
-        reward_prompt='Builtin.Correctness',
+        reward_model_id='openai.gpt-oss-120b-1:0',
+        reward_prompt='Builtin.Summarize',
         mlflow_experiment_name="test-rlaif-finetuned-models-exp",
         mlflow_run_name="test-rlaif-finetuned-models-run",
-        training_dataset="s3://mc-flows-sdk-testing/input_data/rlvr-rlaif-test-data/train_285.jsonl",
+        training_dataset="arn:aws:sagemaker:us-west-2:729646638167:hub-content/sdktest/DataSet/rlvr-rlaif-oss-test-data/0.0.1",
         s3_output_path="s3://mc-flows-sdk-testing/output/",
         accept_eula=True
     )

--- a/sagemaker-train/tests/integ/train/test_rlvr_trainer_integration.py
+++ b/sagemaker-train/tests/integ/train/test_rlvr_trainer_integration.py
@@ -32,7 +32,7 @@ def test_rlvr_trainer_lora_complete_workflow(sagemaker_session):
         model_package_group_name="sdk-test-finetuned-models",
         mlflow_experiment_name="test-rlvr-finetuned-models-exp",
         mlflow_run_name="test-rlvr-finetuned-models-run",
-        training_dataset="s3://mc-flows-sdk-testing/input_data/rlvr-rlaif-test-data/train_285.jsonl",
+        training_dataset="arn:aws:sagemaker:us-west-2:729646638167:hub-content/sdktest/DataSet/rlvr-rlaif-oss-test-data/0.0.1",
         s3_output_path="s3://mc-flows-sdk-testing/output/",
         accept_eula=True
     )
@@ -70,7 +70,7 @@ def test_rlvr_trainer_with_custom_reward_function(sagemaker_session):
         model_package_group_name="sdk-test-finetuned-models",
         mlflow_experiment_name="test-rlvr-finetuned-models-exp",
         mlflow_run_name="test-rlvr-finetuned-models-run",
-        training_dataset="s3://mc-flows-sdk-testing/input_data/rlvr-rlaif-test-data/train_285.jsonl",
+        training_dataset="arn:aws:sagemaker:us-west-2:729646638167:hub-content/sdktest/DataSet/rlvr-rlaif-oss-test-data/0.0.1",
         s3_output_path="s3://mc-flows-sdk-testing/output/",
         custom_reward_function="arn:aws:sagemaker:us-west-2:729646638167:hub-content/sdktest/JsonDoc/rlvr-test-rf/0.0.1",
         accept_eula=True

--- a/sagemaker-train/tests/integ/train/test_sft_trainer_integration.py
+++ b/sagemaker-train/tests/integ/train/test_sft_trainer_integration.py
@@ -30,7 +30,7 @@ def test_sft_trainer_lora_complete_workflow(sagemaker_session):
         model="meta-textgeneration-llama-3-2-1b-instruct",
         training_type=TrainingType.LORA,
         model_package_group_name="arn:aws:sagemaker:us-west-2:729646638167:model-package-group/sdk-test-finetuned-models",
-        training_dataset="s3://mc-flows-sdk-testing/input_data/sft/",
+        training_dataset="arn:aws:sagemaker:us-west-2:729646638167:hub-content/sdktest/DataSet/sft-oss-test-data/0.0.1",
         s3_output_path="s3://mc-flows-sdk-testing/output/",
         accept_eula=True
     )
@@ -66,8 +66,8 @@ def test_sft_trainer_with_validation_dataset(sagemaker_session):
         model="meta-textgeneration-llama-3-2-1b-instruct",
         training_type=TrainingType.LORA,
         model_package_group_name="arn:aws:sagemaker:us-west-2:729646638167:model-package-group/sdk-test-finetuned-models",
-        training_dataset="s3://mc-flows-sdk-testing/input_data/sft/",
-        validation_dataset="s3://mc-flows-sdk-testing/input_data/sft/",
+        training_dataset="arn:aws:sagemaker:us-west-2:729646638167:hub-content/sdktest/DataSet/sft-oss-test-data/0.0.1",
+        validation_dataset="arn:aws:sagemaker:us-west-2:729646638167:hub-content/sdktest/DataSet/sft-oss-test-data/0.0.1",
         accept_eula=True
     )
     

--- a/sagemaker-train/tests/unit/train/test_dpo_trainer.py
+++ b/sagemaker-train/tests/unit/train/test_dpo_trainer.py
@@ -17,7 +17,9 @@ class TestDPOTrainer:
     @patch('sagemaker.train.dpo_trainer._get_fine_tuning_options_and_model_arn')
     def test_init_with_defaults(self, mock_finetuning_options, mock_validate_group, mock_session):
         mock_validate_group.return_value = "test-group"
-        mock_finetuning_options.return_value = (Mock(), "model-arn", False)
+        mock_hyperparams = Mock()
+        mock_hyperparams.to_dict.return_value = {}
+        mock_finetuning_options.return_value = (mock_hyperparams, "model-arn", False)
         trainer = DPOTrainer(model="test-model", model_package_group_name="test-group")
         assert trainer.training_type == TrainingType.LORA
         assert trainer.model == "test-model"
@@ -26,7 +28,9 @@ class TestDPOTrainer:
     @patch('sagemaker.train.dpo_trainer._get_fine_tuning_options_and_model_arn')
     def test_init_with_full_training_type(self, mock_finetuning_options, mock_validate_group, mock_session):
         mock_validate_group.return_value = "test-group"
-        mock_finetuning_options.return_value = (Mock(), "model-arn", False)
+        mock_hyperparams = Mock()
+        mock_hyperparams.to_dict.return_value = {}
+        mock_finetuning_options.return_value = (mock_hyperparams, "model-arn", False)
         trainer = DPOTrainer(model="test-model", training_type=TrainingType.FULL, model_package_group_name="test-group")
         assert trainer.training_type == TrainingType.FULL
 
@@ -79,7 +83,9 @@ class TestDPOTrainer:
     @patch('sagemaker.train.dpo_trainer._get_fine_tuning_options_and_model_arn')
     def test_training_type_string_value(self, mock_finetuning_options, mock_validate_group, mock_session):
         mock_validate_group.return_value = "test-group"
-        mock_finetuning_options.return_value = (Mock(), "model-arn", False)
+        mock_hyperparams = Mock()
+        mock_hyperparams.to_dict.return_value = {}
+        mock_finetuning_options.return_value = (mock_hyperparams, "model-arn", False)
         trainer = DPOTrainer(model="test-model", training_type="CUSTOM", model_package_group_name="test-group")
         assert trainer.training_type == "CUSTOM"
 
@@ -88,7 +94,9 @@ class TestDPOTrainer:
     @patch('sagemaker.train.dpo_trainer._get_fine_tuning_options_and_model_arn')
     def test_model_package_input(self, mock_finetuning_options, mock_validate_group, mock_resolve_model):
         mock_validate_group.return_value = "test-group"
-        mock_finetuning_options.return_value = (Mock(), "model-arn", False)
+        mock_hyperparams = Mock()
+        mock_hyperparams.to_dict.return_value = {}
+        mock_finetuning_options.return_value = (mock_hyperparams, "model-arn", False)
         
         model_package = Mock(spec=ModelPackage)
         model_package.inference_specification = Mock()
@@ -102,7 +110,9 @@ class TestDPOTrainer:
     @patch('sagemaker.train.dpo_trainer._get_fine_tuning_options_and_model_arn')
     def test_init_with_datasets(self, mock_finetuning_options, mock_validate_group, mock_session):
         mock_validate_group.return_value = "test-group"
-        mock_finetuning_options.return_value = (Mock(), "model-arn", False)
+        mock_hyperparams = Mock()
+        mock_hyperparams.to_dict.return_value = {}
+        mock_finetuning_options.return_value = (mock_hyperparams, "model-arn", False)
         trainer = DPOTrainer(
             model="test-model",
             model_package_group_name="test-group",
@@ -116,7 +126,9 @@ class TestDPOTrainer:
     @patch('sagemaker.train.dpo_trainer._get_fine_tuning_options_and_model_arn')
     def test_init_with_mlflow_config(self, mock_finetuning_options, mock_validate_group, mock_session):
         mock_validate_group.return_value = "test-group"
-        mock_finetuning_options.return_value = (Mock(), "model-arn", False)
+        mock_hyperparams = Mock()
+        mock_hyperparams.to_dict.return_value = {}
+        mock_finetuning_options.return_value = (mock_hyperparams, "model-arn", False)
         trainer = DPOTrainer(
             model="test-model",
             model_package_group_name="test-group",
@@ -177,7 +189,9 @@ class TestDPOTrainer:
     @patch('sagemaker.train.dpo_trainer._get_fine_tuning_options_and_model_arn')
     def test_fit_without_datasets_raises_error(self, mock_finetuning_options, mock_validate_group):
         mock_validate_group.return_value = "test-group"
-        mock_finetuning_options.return_value = (Mock(), "model-arn", False)
+        mock_hyperparams = Mock()
+        mock_hyperparams.to_dict.return_value = {}
+        mock_finetuning_options.return_value = (mock_hyperparams, "model-arn", False)
         trainer = DPOTrainer(model="test-model", model_package_group_name="test-group")
         
         with pytest.raises(Exception):
@@ -189,7 +203,9 @@ class TestDPOTrainer:
     def test_model_package_group_handling(self, mock_validate_group, mock_get_options, mock_resolve_model):
         mock_validate_group.return_value = "test-group"
         mock_resolve_model.return_value = "resolved-model"
-        mock_get_options.return_value = (Mock(), "model-arn", False)
+        mock_hyperparams = Mock()
+        mock_hyperparams.to_dict.return_value = {}
+        mock_get_options.return_value = (mock_hyperparams, "model-arn", False)
         
         trainer = DPOTrainer(
             model="test-model",
@@ -201,7 +217,9 @@ class TestDPOTrainer:
     @patch('sagemaker.train.dpo_trainer._get_fine_tuning_options_and_model_arn')
     def test_s3_output_path_configuration(self, mock_finetuning_options, mock_validate_group, mock_session):
         mock_validate_group.return_value = "test-group"
-        mock_finetuning_options.return_value = (Mock(), "model-arn", False)
+        mock_hyperparams = Mock()
+        mock_hyperparams.to_dict.return_value = {}
+        mock_finetuning_options.return_value = (mock_hyperparams, "model-arn", False)
         trainer = DPOTrainer(
             model="test-model",
             model_package_group_name="test-group",
@@ -260,7 +278,9 @@ class TestDPOTrainer:
     def test_gated_model_eula_validation(self, mock_finetuning_options, mock_validate_group, mock_session):
         """Test EULA validation for gated models"""
         mock_validate_group.return_value = "test-group"
-        mock_finetuning_options.return_value = (Mock(), "model-arn", True)  # is_gated_model=True
+        mock_hyperparams = Mock()
+        mock_hyperparams.to_dict.return_value = {}
+        mock_finetuning_options.return_value = (mock_hyperparams, "model-arn", True)  # is_gated_model=True
         
         # Should raise error when accept_eula=False for gated model
         with pytest.raises(ValueError, match="gated model and requires EULA acceptance"):
@@ -269,3 +289,71 @@ class TestDPOTrainer:
         # Should work when accept_eula=True for gated model
         trainer = DPOTrainer(model="gated-model", model_package_group_name="test-group", accept_eula=True)
         assert trainer.accept_eula == True
+
+    def test_process_hyperparameters_removes_constructor_handled_keys(self):
+        """Test that _process_hyperparameters removes keys handled by constructor inputs."""
+        # Create mock hyperparameters with all possible keys
+        mock_hyperparams = Mock()
+        mock_hyperparams._specs = {
+            'data_path': 'test_data_path',
+            'output_path': 'test_output_path', 
+            'training_data_name': 'test_training_data_name',
+            'validation_data_name': 'test_validation_data_name',
+            'other_param': 'should_remain'
+        }
+        
+        # Add attributes to mock
+        mock_hyperparams.data_path = 'test_data_path'
+        mock_hyperparams.output_path = 'test_output_path'
+        mock_hyperparams.training_data_name = 'test_training_data_name'
+        mock_hyperparams.validation_data_name = 'test_validation_data_name'
+        
+        # Create trainer instance with mock hyperparameters
+        trainer = DPOTrainer.__new__(DPOTrainer)
+        trainer.hyperparameters = mock_hyperparams
+        
+        # Call the method
+        trainer._process_hyperparameters()
+        
+        # Verify attributes were removed
+        assert not hasattr(mock_hyperparams, 'data_path')
+        assert not hasattr(mock_hyperparams, 'output_path')
+        assert not hasattr(mock_hyperparams, 'training_data_name')
+        assert not hasattr(mock_hyperparams, 'validation_data_name')
+        
+        # Verify _specs were updated
+        assert 'data_path' not in mock_hyperparams._specs
+        assert 'output_path' not in mock_hyperparams._specs
+        assert 'training_data_name' not in mock_hyperparams._specs
+        assert 'validation_data_name' not in mock_hyperparams._specs
+        assert 'other_param' in mock_hyperparams._specs
+
+    def test_process_hyperparameters_handles_missing_attributes(self):
+        """Test that _process_hyperparameters handles missing attributes gracefully."""
+        # Create mock hyperparameters with only some keys
+        mock_hyperparams = Mock()
+        mock_hyperparams._specs = {
+            'data_path': 'test_data_path',
+            'other_param': 'should_remain'
+        }
+        mock_hyperparams.data_path = 'test_data_path'
+        
+        # Create trainer instance
+        trainer = DPOTrainer.__new__(DPOTrainer)
+        trainer.hyperparameters = mock_hyperparams
+        
+        # Call the method
+        trainer._process_hyperparameters()
+        
+        # Verify only existing attributes were processed
+        assert not hasattr(mock_hyperparams, 'data_path')
+        assert 'data_path' not in mock_hyperparams._specs
+        assert 'other_param' in mock_hyperparams._specs
+
+    def test_process_hyperparameters_with_none_hyperparameters(self):
+        """Test that _process_hyperparameters handles None hyperparameters."""
+        trainer = DPOTrainer.__new__(DPOTrainer)
+        trainer.hyperparameters = None
+        
+        # Should not raise an exception
+        trainer._process_hyperparameters()

--- a/sagemaker-train/tests/unit/train/test_rlaif_trainer.py
+++ b/sagemaker-train/tests/unit/train/test_rlaif_trainer.py
@@ -17,7 +17,9 @@ class TestRLAIFTrainer:
     @patch('sagemaker.train.rlaif_trainer._get_fine_tuning_options_and_model_arn')
     def test_init_with_defaults(self, mock_finetuning_options, mock_validate_group, mock_session):
         mock_validate_group.return_value = "test-group"
-        mock_finetuning_options.return_value = (Mock(), "model-arn", False)
+        mock_hyperparams = Mock()
+        mock_hyperparams.to_dict.return_value = {}
+        mock_finetuning_options.return_value = (mock_hyperparams, "model-arn", False)
         trainer = RLAIFTrainer(model="test-model", model_package_group_name="test-group")
         assert trainer.training_type == TrainingType.LORA
         assert trainer.model == "test-model"
@@ -26,7 +28,9 @@ class TestRLAIFTrainer:
     @patch('sagemaker.train.rlaif_trainer._get_fine_tuning_options_and_model_arn')
     def test_init_with_full_training_type(self, mock_finetuning_options, mock_validate_group, mock_session):
         mock_validate_group.return_value = "test-group"
-        mock_finetuning_options.return_value = (Mock(), "model-arn", False)
+        mock_hyperparams = Mock()
+        mock_hyperparams.to_dict.return_value = {}
+        mock_finetuning_options.return_value = (mock_hyperparams, "model-arn", False)
         trainer = RLAIFTrainer(model="test-model", training_type=TrainingType.FULL, model_package_group_name="test-group")
         assert trainer.training_type == TrainingType.FULL
 
@@ -122,7 +126,9 @@ class TestRLAIFTrainer:
     @patch('sagemaker.train.rlaif_trainer._get_fine_tuning_options_and_model_arn')
     def test_training_type_string_value(self, mock_finetuning_options, mock_validate_group, mock_session):
         mock_validate_group.return_value = "test-group"
-        mock_finetuning_options.return_value = (Mock(), "model-arn", False)
+        mock_hyperparams = Mock()
+        mock_hyperparams.to_dict.return_value = {}
+        mock_finetuning_options.return_value = (mock_hyperparams, "model-arn", False)
         trainer = RLAIFTrainer(model="test-model", training_type="CUSTOM", model_package_group_name="test-group")
         assert trainer.training_type == "CUSTOM"
 
@@ -133,7 +139,9 @@ class TestRLAIFTrainer:
     def test_model_package_input(self, mock_finetuning_options, mock_validate_group, mock_resolve_model, mock_get_session):
         mock_validate_group.return_value = "test-group"
         mock_get_session.return_value = Mock()
-        mock_finetuning_options.return_value = (Mock(), "model-arn", False)
+        mock_hyperparams = Mock()
+        mock_hyperparams.to_dict.return_value = {}
+        mock_finetuning_options.return_value = (mock_hyperparams, "model-arn", False)
         
         model_package = Mock(spec=ModelPackage)
         model_package.inference_specification = Mock()
@@ -148,7 +156,9 @@ class TestRLAIFTrainer:
     @patch('sagemaker.train.rlaif_trainer._get_fine_tuning_options_and_model_arn')
     def test_init_with_datasets(self, mock_finetuning_options, mock_validate_group, mock_session):
         mock_validate_group.return_value = "test-group"
-        mock_finetuning_options.return_value = (Mock(), "model-arn", False)
+        mock_hyperparams = Mock()
+        mock_hyperparams.to_dict.return_value = {}
+        mock_finetuning_options.return_value = (mock_hyperparams, "model-arn", False)
         trainer = RLAIFTrainer(
             model="test-model",
             model_package_group_name="test-group",
@@ -162,7 +172,9 @@ class TestRLAIFTrainer:
     @patch('sagemaker.train.rlaif_trainer._get_fine_tuning_options_and_model_arn')
     def test_init_with_mlflow_config(self, mock_finetuning_options, mock_validate_group, mock_session):
         mock_validate_group.return_value = "test-group"
-        mock_finetuning_options.return_value = (Mock(), "model-arn", False)
+        mock_hyperparams = Mock()
+        mock_hyperparams.to_dict.return_value = {}
+        mock_finetuning_options.return_value = (mock_hyperparams, "model-arn", False)
         trainer = RLAIFTrainer(
             model="test-model",
             model_package_group_name="test-group",
@@ -179,7 +191,9 @@ class TestRLAIFTrainer:
     @patch('sagemaker.train.rlaif_trainer._get_fine_tuning_options_and_model_arn')
     def test_train_without_datasets_raises_error(self, mock_finetuning_options, mock_validate_group, mock_get_session):
         mock_validate_group.return_value = "test-group"
-        mock_finetuning_options.return_value = (Mock(), "model-arn", False)
+        mock_hyperparams = Mock()
+        mock_hyperparams.to_dict.return_value = {}
+        mock_finetuning_options.return_value = (mock_hyperparams, "model-arn", False)
         mock_get_session.return_value = Mock()
         trainer = RLAIFTrainer(model="test-model", model_package_group_name="test-group")
         
@@ -194,7 +208,9 @@ class TestRLAIFTrainer:
         mock_validate_group.return_value = "test-group"
         mock_get_session.return_value = Mock()
         mock_resolve_model.return_value = "resolved-model"
-        mock_get_options.return_value = (Mock(), "model-arn", False)
+        mock_hyperparams = Mock()
+        mock_hyperparams.to_dict.return_value = {}
+        mock_get_options.return_value = (mock_hyperparams, "model-arn", False)
         
         trainer = RLAIFTrainer(
             model="test-model",
@@ -206,7 +222,9 @@ class TestRLAIFTrainer:
     @patch('sagemaker.train.rlaif_trainer._get_fine_tuning_options_and_model_arn')
     def test_s3_output_path_configuration(self, mock_finetuning_options, mock_validate_group, mock_session):
         mock_validate_group.return_value = "test-group"
-        mock_finetuning_options.return_value = (Mock(), "model-arn", False)
+        mock_hyperparams = Mock()
+        mock_hyperparams.to_dict.return_value = {}
+        mock_finetuning_options.return_value = (mock_hyperparams, "model-arn", False)
         trainer = RLAIFTrainer(
             model="test-model",
             model_package_group_name="test-group",
@@ -265,7 +283,9 @@ class TestRLAIFTrainer:
     def test_gated_model_eula_validation(self, mock_finetuning_options, mock_validate_group, mock_session):
         """Test EULA validation for gated models"""
         mock_validate_group.return_value = "test-group"
-        mock_finetuning_options.return_value = (Mock(), "model-arn", True)  # is_gated_model=True
+        mock_hyperparams = Mock()
+        mock_hyperparams.to_dict.return_value = {}
+        mock_finetuning_options.return_value = (mock_hyperparams, "model-arn", True)  # is_gated_model=True
         
         # Should raise error when accept_eula=False for gated model
         with pytest.raises(ValueError, match="gated model and requires EULA acceptance"):
@@ -274,3 +294,212 @@ class TestRLAIFTrainer:
         # Should work when accept_eula=True for gated model
         trainer = RLAIFTrainer(model="gated-model", model_package_group_name="test-group", accept_eula=True)
         assert trainer.accept_eula == True
+
+    def test_process_hyperparameters_removes_constructor_handled_keys(self):
+        """Test that _process_hyperparameters removes keys handled by constructor inputs."""
+        # Create mock hyperparameters with all possible keys
+        mock_hyperparams = Mock()
+        mock_hyperparams._specs = {
+            'output_path': 'test_output_path',
+            'data_path': 'test_data_path',
+            'validation_data_path': 'test_validation_data_path',
+            'other_param': 'should_remain'
+        }
+        
+        # Add attributes to mock
+        mock_hyperparams.output_path = 'test_output_path'
+        mock_hyperparams.data_path = 'test_data_path'
+        mock_hyperparams.validation_data_path = 'test_validation_data_path'
+        
+        # Create trainer instance with mock hyperparameters
+        trainer = RLAIFTrainer.__new__(RLAIFTrainer)
+        trainer.hyperparameters = mock_hyperparams
+        trainer.reward_model_id = "test-reward-model"
+        
+        # Call the method
+        trainer._process_hyperparameters()
+        
+        # Verify attributes were removed
+        assert not hasattr(mock_hyperparams, 'output_path')
+        assert not hasattr(mock_hyperparams, 'data_path')
+        assert not hasattr(mock_hyperparams, 'validation_data_path')
+        
+        # Verify _specs were updated
+        assert 'output_path' not in mock_hyperparams._specs
+        assert 'data_path' not in mock_hyperparams._specs
+        assert 'validation_data_path' not in mock_hyperparams._specs
+        assert 'other_param' in mock_hyperparams._specs
+        
+        # Verify judge_model_id was set
+        assert mock_hyperparams.judge_model_id == "bedrock/test-reward-model"
+
+    def test_process_hyperparameters_updates_judge_model_id(self):
+        """Test that _process_hyperparameters updates judge_model_id when reward_model_id is provided."""
+        # Use a simple object instead of Mock to allow proper attribute assignment
+        class MockHyperparams:
+            def __init__(self):
+                self._specs = {'some_param': 'value'}  # Non-empty specs
+        
+        mock_hyperparams = MockHyperparams()
+        
+        trainer = RLAIFTrainer.__new__(RLAIFTrainer)
+        trainer.hyperparameters = mock_hyperparams
+        trainer.reward_model_id = "my-reward-model"
+        
+        trainer._process_hyperparameters()
+        
+        assert hasattr(mock_hyperparams, 'judge_model_id')
+        assert mock_hyperparams.judge_model_id == "bedrock/my-reward-model"
+
+    def test_process_hyperparameters_handles_missing_attributes(self):
+        """Test that _process_hyperparameters handles missing attributes gracefully."""
+        # Create mock hyperparameters with only some keys
+        mock_hyperparams = Mock()
+        mock_hyperparams._specs = {
+            'data_path': 'test_data_path',
+            'other_param': 'should_remain'
+        }
+        mock_hyperparams.data_path = 'test_data_path'
+        
+        # Create trainer instance
+        trainer = RLAIFTrainer.__new__(RLAIFTrainer)
+        trainer.hyperparameters = mock_hyperparams
+        trainer.reward_model_id = None
+        
+        # Call the method
+        trainer._process_hyperparameters()
+        
+        # Verify only existing attributes were processed
+        assert not hasattr(mock_hyperparams, 'data_path')
+        assert 'data_path' not in mock_hyperparams._specs
+        assert 'other_param' in mock_hyperparams._specs
+
+    def test_process_hyperparameters_with_none_hyperparameters(self):
+        """Test that _process_hyperparameters handles None hyperparameters."""
+        trainer = RLAIFTrainer.__new__(RLAIFTrainer)
+        trainer.hyperparameters = None
+        
+        # Should not raise an exception
+        trainer._process_hyperparameters()
+
+    def test_process_hyperparameters_early_return_on_none(self):
+        """Test that _process_hyperparameters returns early when hyperparameters is None."""
+        trainer = RLAIFTrainer.__new__(RLAIFTrainer)
+        trainer.hyperparameters = None
+        trainer.reward_model_id = "test-model"
+        
+        # Should return early and not attempt to set judge_model_id
+        trainer._process_hyperparameters()
+        
+        # No exception should be raised
+
+    def test_update_judge_prompt_template_direct_with_matching_template(self):
+        """Test _update_judge_prompt_template_direct with matching template."""
+        mock_hyperparams = Mock()
+        mock_hyperparams._specs = {
+            'judge_prompt_template': {
+                'enum': ['templates/summarize.jinja', 'templates/helpfulness.jinja']
+            }
+        }
+        
+        trainer = RLAIFTrainer.__new__(RLAIFTrainer)
+        trainer.hyperparameters = mock_hyperparams
+        
+        trainer._update_judge_prompt_template_direct("Builtin.summarize")
+        
+        assert mock_hyperparams.judge_prompt_template == 'templates/summarize.jinja'
+
+    def test_update_judge_prompt_template_direct_with_no_enum(self):
+        """Test _update_judge_prompt_template_direct when no enum is available."""
+        mock_hyperparams = Mock()
+        mock_hyperparams._specs = {'judge_prompt_template': {}}
+        mock_hyperparams.judge_prompt_template = 'current_template.jinja'
+        
+        trainer = RLAIFTrainer.__new__(RLAIFTrainer)
+        trainer.hyperparameters = mock_hyperparams
+        
+        trainer._update_judge_prompt_template_direct("Builtin.current_template")
+        
+        assert mock_hyperparams.judge_prompt_template == 'current_template.jinja'
+
+    def test_update_judge_prompt_template_direct_no_matching_template(self):
+        """Test _update_judge_prompt_template_direct raises error for non-matching template."""
+        mock_hyperparams = Mock()
+        mock_hyperparams._specs = {
+            'judge_prompt_template': {
+                'enum': ['templates/summarize.jinja', 'templates/helpfulness.jinja']
+            }
+        }
+        
+        trainer = RLAIFTrainer.__new__(RLAIFTrainer)
+        trainer.hyperparameters = mock_hyperparams
+        
+        with pytest.raises(ValueError, match="Selected reward function option 'Builtin.nonexistent' is not available"):
+            trainer._update_judge_prompt_template_direct("Builtin.nonexistent")
+
+    def test_update_judge_prompt_template_direct_early_return(self):
+        """Test _update_judge_prompt_template_direct returns early when no templates available."""
+        mock_hyperparams = Mock()
+        mock_hyperparams._specs = {'judge_prompt_template': {}}
+        mock_hyperparams.judge_prompt_template = None
+        
+        trainer = RLAIFTrainer.__new__(RLAIFTrainer)
+        trainer.hyperparameters = mock_hyperparams
+        
+        # Should return early without error
+        trainer._update_judge_prompt_template_direct("Builtin.anything")
+
+    def test_process_non_builtin_reward_prompt_removes_judge_template(self):
+        """Test _process_non_builtin_reward_prompt removes judge_prompt_template."""
+        mock_hyperparams = Mock()
+        mock_hyperparams._specs = {'judge_prompt_template': 'template.jinja'}
+        mock_hyperparams.judge_prompt_template = 'template.jinja'
+        
+        trainer = RLAIFTrainer.__new__(RLAIFTrainer)
+        trainer.hyperparameters = mock_hyperparams
+        trainer.reward_prompt = "arn:aws:sagemaker:us-east-1:123456789012:evaluator/test"
+        
+        with patch('sagemaker.train.rlaif_trainer._extract_evaluator_arn') as mock_extract:
+            mock_extract.return_value = "test-arn"
+            trainer._process_non_builtin_reward_prompt()
+        
+        assert not hasattr(mock_hyperparams, 'judge_prompt_template')
+        assert 'judge_prompt_template' not in mock_hyperparams._specs
+        assert trainer._evaluator_arn == "test-arn"
+
+    def test_process_non_builtin_reward_prompt_with_hub_content(self):
+        """Test _process_non_builtin_reward_prompt with hub content name."""
+        mock_hyperparams = Mock()
+        mock_hyperparams._specs = {}
+        
+        trainer = RLAIFTrainer.__new__(RLAIFTrainer)
+        trainer.hyperparameters = mock_hyperparams
+        trainer.reward_prompt = "custom-prompt-name"
+        trainer.sagemaker_session = None
+        
+        with patch('sagemaker.train.rlaif_trainer.TrainDefaults.get_sagemaker_session') as mock_session, \
+             patch('sagemaker.train.rlaif_trainer._get_hub_content_metadata') as mock_hub:
+            mock_session.return_value = Mock(boto_session=Mock(region_name="us-west-2"))
+            mock_hub.return_value = Mock(hub_content_arn="hub-content-arn")
+            
+            trainer._process_non_builtin_reward_prompt()
+        
+        assert trainer._evaluator_arn == "hub-content-arn"
+
+    def test_process_non_builtin_reward_prompt_hub_content_error(self):
+        """Test _process_non_builtin_reward_prompt raises error for invalid hub content."""
+        mock_hyperparams = Mock()
+        mock_hyperparams._specs = {}
+        
+        trainer = RLAIFTrainer.__new__(RLAIFTrainer)
+        trainer.hyperparameters = mock_hyperparams
+        trainer.reward_prompt = "invalid-prompt"
+        trainer.sagemaker_session = None
+        
+        with patch('sagemaker.train.rlaif_trainer.TrainDefaults.get_sagemaker_session') as mock_session, \
+             patch('sagemaker.train.rlaif_trainer._get_hub_content_metadata') as mock_hub:
+            mock_session.return_value = Mock(boto_session=Mock(region_name="us-west-2"))
+            mock_hub.side_effect = Exception("Not found")
+            
+            with pytest.raises(ValueError, match="Custom prompt 'invalid-prompt' not found in HubContent"):
+                trainer._process_non_builtin_reward_prompt()

--- a/sagemaker-train/tests/unit/train/test_rlvr_trainer.py
+++ b/sagemaker-train/tests/unit/train/test_rlvr_trainer.py
@@ -17,7 +17,9 @@ class TestRLVRTrainer:
     @patch('sagemaker.train.rlvr_trainer._get_fine_tuning_options_and_model_arn')
     def test_init_with_defaults(self, mock_finetuning_options, mock_validate_group, mock_session):
         mock_validate_group.return_value = "test-group"
-        mock_finetuning_options.return_value = (Mock(), "model-arn", False)
+        mock_hyperparams = Mock()
+        mock_hyperparams.to_dict.return_value = {}
+        mock_finetuning_options.return_value = (mock_hyperparams, "model-arn", False)
         trainer = RLVRTrainer(model="test-model", model_package_group_name="test-group")
         assert trainer.training_type == TrainingType.LORA
         assert trainer.model == "test-model"
@@ -26,7 +28,9 @@ class TestRLVRTrainer:
     @patch('sagemaker.train.rlvr_trainer._get_fine_tuning_options_and_model_arn')
     def test_init_with_full_training_type(self, mock_finetuning_options, mock_validate_group, mock_session):
         mock_validate_group.return_value = "test-group"
-        mock_finetuning_options.return_value = (Mock(), "model-arn", False)
+        mock_hyperparams = Mock()
+        mock_hyperparams.to_dict.return_value = {}
+        mock_finetuning_options.return_value = (mock_hyperparams, "model-arn", False)
         trainer = RLVRTrainer(model="test-model", training_type=TrainingType.FULL, model_package_group_name="test-group")
         assert trainer.training_type == TrainingType.FULL
 
@@ -122,7 +126,9 @@ class TestRLVRTrainer:
     @patch('sagemaker.train.rlvr_trainer._get_fine_tuning_options_and_model_arn')
     def test_training_type_string_value(self, mock_finetuning_options, mock_validate_group, mock_session):
         mock_validate_group.return_value = "test-group"
-        mock_finetuning_options.return_value = (Mock(), "model-arn", False)
+        mock_hyperparams = Mock()
+        mock_hyperparams.to_dict.return_value = {}
+        mock_finetuning_options.return_value = (mock_hyperparams, "model-arn", False)
         trainer = RLVRTrainer(model="test-model", training_type="CUSTOM", model_package_group_name="test-group")
         assert trainer.training_type == "CUSTOM"
 
@@ -133,7 +139,9 @@ class TestRLVRTrainer:
     def test_model_package_input(self, mock_finetuning_options, mock_validate_group, mock_resolve_model, mock_get_session):
         mock_validate_group.return_value = "test-group"
         mock_get_session.return_value = Mock()
-        mock_finetuning_options.return_value = (Mock(), "model-arn", False)
+        mock_hyperparams = Mock()
+        mock_hyperparams.to_dict.return_value = {}
+        mock_finetuning_options.return_value = (mock_hyperparams, "model-arn", False)
         
         model_package = Mock(spec=ModelPackage)
         model_package.inference_specification = Mock()
@@ -148,7 +156,9 @@ class TestRLVRTrainer:
     @patch('sagemaker.train.rlvr_trainer._get_fine_tuning_options_and_model_arn')
     def test_init_with_datasets(self, mock_finetuning_options, mock_validate_group, mock_session):
         mock_validate_group.return_value = "test-group"
-        mock_finetuning_options.return_value = (Mock(), "model-arn", False)
+        mock_hyperparams = Mock()
+        mock_hyperparams.to_dict.return_value = {}
+        mock_finetuning_options.return_value = (mock_hyperparams, "model-arn", False)
         trainer = RLVRTrainer(
             model="test-model",
             model_package_group_name="test-group",
@@ -162,7 +172,9 @@ class TestRLVRTrainer:
     @patch('sagemaker.train.rlvr_trainer._get_fine_tuning_options_and_model_arn')
     def test_init_with_mlflow_config(self, mock_finetuning_options, mock_validate_group, mock_session):
         mock_validate_group.return_value = "test-group"
-        mock_finetuning_options.return_value = (Mock(), "model-arn", False)
+        mock_hyperparams = Mock()
+        mock_hyperparams.to_dict.return_value = {}
+        mock_finetuning_options.return_value = (mock_hyperparams, "model-arn", False)
         trainer = RLVRTrainer(
             model="test-model",
             model_package_group_name="test-group",
@@ -179,7 +191,9 @@ class TestRLVRTrainer:
     @patch('sagemaker.train.rlvr_trainer._get_fine_tuning_options_and_model_arn')
     def test_train_without_datasets_raises_error(self, mock_finetuning_options, mock_validate_group, mock_get_session):
         mock_validate_group.return_value = "test-group"
-        mock_finetuning_options.return_value = (Mock(), "model-arn", False)
+        mock_hyperparams = Mock()
+        mock_hyperparams.to_dict.return_value = {}
+        mock_finetuning_options.return_value = (mock_hyperparams, "model-arn", False)
         mock_get_session.return_value = Mock()
         trainer = RLVRTrainer(model="test-model", model_package_group_name="test-group")
         
@@ -194,7 +208,9 @@ class TestRLVRTrainer:
         mock_validate_group.return_value = "test-group"
         mock_get_session.return_value = Mock()
         mock_resolve_model.return_value = "resolved-model"
-        mock_get_options.return_value = (Mock(), "model-arn", False)
+        mock_hyperparams = Mock()
+        mock_hyperparams.to_dict.return_value = {}
+        mock_get_options.return_value = (mock_hyperparams, "model-arn", False)
         
         trainer = RLVRTrainer(
             model="test-model",
@@ -206,7 +222,9 @@ class TestRLVRTrainer:
     @patch('sagemaker.train.rlvr_trainer._get_fine_tuning_options_and_model_arn')
     def test_s3_output_path_configuration(self, mock_finetuning_options, mock_validate_group, mock_session):
         mock_validate_group.return_value = "test-group"
-        mock_finetuning_options.return_value = (Mock(), "model-arn", False)
+        mock_hyperparams = Mock()
+        mock_hyperparams.to_dict.return_value = {}
+        mock_finetuning_options.return_value = (mock_hyperparams, "model-arn", False)
         trainer = RLVRTrainer(
             model="test-model",
             model_package_group_name="test-group",
@@ -263,7 +281,9 @@ class TestRLVRTrainer:
     def test_gated_model_eula_validation(self, mock_finetuning_options, mock_validate_group, mock_session):
         """Test EULA validation for gated models"""
         mock_validate_group.return_value = "test-group"
-        mock_finetuning_options.return_value = (Mock(), "model-arn", True)  # is_gated_model=True
+        mock_hyperparams = Mock()
+        mock_hyperparams.to_dict.return_value = {}
+        mock_finetuning_options.return_value = (mock_hyperparams, "model-arn", True)  # is_gated_model=True
         
         # Should raise error when accept_eula=False for gated model
         with pytest.raises(ValueError, match="gated model and requires EULA acceptance"):
@@ -272,3 +292,71 @@ class TestRLVRTrainer:
         # Should work when accept_eula=True for gated model
         trainer = RLVRTrainer(model="gated-model", model_package_group_name="test-group", accept_eula=True)
         assert trainer.accept_eula == True
+
+    def test_process_hyperparameters_removes_constructor_handled_keys(self):
+        """Test that _process_hyperparameters removes keys handled by constructor inputs."""
+        # Create mock hyperparameters with all possible keys
+        mock_hyperparams = Mock()
+        mock_hyperparams._specs = {
+            'data_s3_path': 'test_data_s3_path',
+            'reward_lambda_arn': 'test_reward_lambda_arn',
+            'data_path': 'test_data_path',
+            'validation_data_path': 'test_validation_data_path',
+            'other_param': 'should_remain'
+        }
+        
+        # Add attributes to mock
+        mock_hyperparams.data_s3_path = 'test_data_s3_path'
+        mock_hyperparams.reward_lambda_arn = 'test_reward_lambda_arn'
+        mock_hyperparams.data_path = 'test_data_path'
+        mock_hyperparams.validation_data_path = 'test_validation_data_path'
+        
+        # Create trainer instance with mock hyperparameters
+        trainer = RLVRTrainer.__new__(RLVRTrainer)
+        trainer.hyperparameters = mock_hyperparams
+        
+        # Call the method
+        trainer._process_hyperparameters()
+        
+        # Verify attributes were removed
+        assert not hasattr(mock_hyperparams, 'data_s3_path')
+        assert not hasattr(mock_hyperparams, 'reward_lambda_arn')
+        assert not hasattr(mock_hyperparams, 'data_path')
+        assert not hasattr(mock_hyperparams, 'validation_data_path')
+        
+        # Verify _specs were updated
+        assert 'data_s3_path' not in mock_hyperparams._specs
+        assert 'reward_lambda_arn' not in mock_hyperparams._specs
+        assert 'data_path' not in mock_hyperparams._specs
+        assert 'validation_data_path' not in mock_hyperparams._specs
+        assert 'other_param' in mock_hyperparams._specs
+
+    def test_process_hyperparameters_handles_missing_attributes(self):
+        """Test that _process_hyperparameters handles missing attributes gracefully."""
+        # Create mock hyperparameters with only some keys
+        mock_hyperparams = Mock()
+        mock_hyperparams._specs = {
+            'data_s3_path': 'test_data_s3_path',
+            'other_param': 'should_remain'
+        }
+        mock_hyperparams.data_s3_path = 'test_data_s3_path'
+        
+        # Create trainer instance
+        trainer = RLVRTrainer.__new__(RLVRTrainer)
+        trainer.hyperparameters = mock_hyperparams
+        
+        # Call the method
+        trainer._process_hyperparameters()
+        
+        # Verify only existing attributes were processed
+        assert not hasattr(mock_hyperparams, 'data_s3_path')
+        assert 'data_s3_path' not in mock_hyperparams._specs
+        assert 'other_param' in mock_hyperparams._specs
+
+    def test_process_hyperparameters_with_none_hyperparameters(self):
+        """Test that _process_hyperparameters handles None hyperparameters."""
+        trainer = RLVRTrainer.__new__(RLVRTrainer)
+        trainer.hyperparameters = None
+        
+        # Should not raise an exception
+        trainer._process_hyperparameters()

--- a/sagemaker-train/tests/unit/train/test_sft_trainer.py
+++ b/sagemaker-train/tests/unit/train/test_sft_trainer.py
@@ -17,7 +17,9 @@ class TestSFTTrainer:
     @patch('sagemaker.train.sft_trainer._get_fine_tuning_options_and_model_arn')
     def test_init_with_defaults(self, mock_finetuning_options, mock_validate_group, mock_session):
         mock_validate_group.return_value = "test-group"
-        mock_finetuning_options.return_value = (Mock(), "model-arn", False)
+        mock_hyperparams = Mock()
+        mock_hyperparams.to_dict.return_value = {}
+        mock_finetuning_options.return_value = (mock_hyperparams, "model-arn", False)
         trainer = SFTTrainer(model="test-model", model_package_group_name="test-group")
         assert trainer.training_type == TrainingType.LORA
         assert trainer.model == "test-model"
@@ -26,7 +28,9 @@ class TestSFTTrainer:
     @patch('sagemaker.train.sft_trainer._get_fine_tuning_options_and_model_arn')
     def test_init_with_full_training_type(self, mock_finetuning_options, mock_validate_group, mock_session):
         mock_validate_group.return_value = "test-group"
-        mock_finetuning_options.return_value = (Mock(), "model-arn", False)
+        mock_hyperparams = Mock()
+        mock_hyperparams.to_dict.return_value = {}
+        mock_finetuning_options.return_value = (mock_hyperparams, "model-arn", False)
         trainer = SFTTrainer(model="test-model", training_type=TrainingType.FULL, model_package_group_name="test-group")
         assert trainer.training_type == TrainingType.FULL
 
@@ -122,7 +126,9 @@ class TestSFTTrainer:
     @patch('sagemaker.train.sft_trainer._get_fine_tuning_options_and_model_arn')
     def test_training_type_string_value(self, mock_finetuning_options, mock_validate_group, mock_session):
         mock_validate_group.return_value = "test-group"
-        mock_finetuning_options.return_value = (Mock(), "model-arn", False)
+        mock_hyperparams = Mock()
+        mock_hyperparams.to_dict.return_value = {}
+        mock_finetuning_options.return_value = (mock_hyperparams, "model-arn", False)
         trainer = SFTTrainer(model="test-model", training_type="CUSTOM", model_package_group_name="test-group")
         assert trainer.training_type == "CUSTOM"
 
@@ -131,7 +137,9 @@ class TestSFTTrainer:
     @patch('sagemaker.train.sft_trainer._get_fine_tuning_options_and_model_arn')
     def test_model_package_input(self, mock_finetuning_options, mock_validate_group, mock_resolve_model):
         mock_validate_group.return_value = "test-group"
-        mock_finetuning_options.return_value = (Mock(), "model-arn", False)
+        mock_hyperparams = Mock()
+        mock_hyperparams.to_dict.return_value = {}
+        mock_finetuning_options.return_value = (mock_hyperparams, "model-arn", False)
         
         model_package = Mock(spec=ModelPackage)
         model_package.inference_specification = Mock()
@@ -146,7 +154,9 @@ class TestSFTTrainer:
     @patch('sagemaker.train.sft_trainer._get_fine_tuning_options_and_model_arn')
     def test_init_with_datasets(self, mock_finetuning_options, mock_validate_group, mock_session):
         mock_validate_group.return_value = "test-group"
-        mock_finetuning_options.return_value = (Mock(), "model-arn", False)
+        mock_hyperparams = Mock()
+        mock_hyperparams.to_dict.return_value = {}
+        mock_finetuning_options.return_value = (mock_hyperparams, "model-arn", False)
         trainer = SFTTrainer(
             model="test-model",
             model_package_group_name="test-group",
@@ -160,7 +170,9 @@ class TestSFTTrainer:
     @patch('sagemaker.train.sft_trainer._get_fine_tuning_options_and_model_arn')
     def test_init_with_mlflow_config(self, mock_finetuning_options, mock_validate_group, mock_session):
         mock_validate_group.return_value = "test-group"
-        mock_finetuning_options.return_value = (Mock(), "model-arn", False)
+        mock_hyperparams = Mock()
+        mock_hyperparams.to_dict.return_value = {}
+        mock_finetuning_options.return_value = (mock_hyperparams, "model-arn", False)
         trainer = SFTTrainer(
             model="test-model",
             model_package_group_name="test-group",
@@ -177,7 +189,9 @@ class TestSFTTrainer:
     @patch('sagemaker.train.sft_trainer._get_fine_tuning_options_and_model_arn')
     def test_fit_without_datasets_raises_error(self, mock_finetuning_options, mock_validate_group, mock_get_session):
         mock_validate_group.return_value = "test-group"
-        mock_finetuning_options.return_value = (Mock(), "model-arn", False)
+        mock_hyperparams = Mock()
+        mock_hyperparams.to_dict.return_value = {}
+        mock_finetuning_options.return_value = (mock_hyperparams, "model-arn", False)
         mock_get_session.return_value = Mock()
         trainer = SFTTrainer(model="test-model", model_package_group_name="test-group")
         
@@ -188,7 +202,9 @@ class TestSFTTrainer:
     @patch('sagemaker.train.sft_trainer._validate_and_resolve_model_package_group')
     def test_model_package_group_handling(self, mock_validate_group, mock_get_options):
         mock_validate_group.return_value = "test-group"
-        mock_get_options.return_value = (Mock(), "model-arn", False)
+        mock_hyperparams = Mock()
+        mock_hyperparams.to_dict.return_value = {}
+        mock_get_options.return_value = (mock_hyperparams, "model-arn", False)
         
         trainer = SFTTrainer(
             model="test-model",
@@ -200,7 +216,9 @@ class TestSFTTrainer:
     @patch('sagemaker.train.sft_trainer._get_fine_tuning_options_and_model_arn')
     def test_s3_output_path_configuration(self, mock_finetuning_options, mock_validate_group, mock_session):
         mock_validate_group.return_value = "test-group"
-        mock_finetuning_options.return_value = (Mock(), "model-arn", False)
+        mock_hyperparams = Mock()
+        mock_hyperparams.to_dict.return_value = {}
+        mock_finetuning_options.return_value = (mock_hyperparams, "model-arn", False)
         trainer = SFTTrainer(
             model="test-model",
             model_package_group_name="test-group",
@@ -213,7 +231,9 @@ class TestSFTTrainer:
     def test_gated_model_eula_validation(self, mock_finetuning_options, mock_validate_group, mock_session):
         """Test EULA validation for gated models"""
         mock_validate_group.return_value = "test-group"
-        mock_finetuning_options.return_value = (Mock(), "model-arn", True)  # is_gated_model=True
+        mock_hyperparams = Mock()
+        mock_hyperparams.to_dict.return_value = {}
+        mock_finetuning_options.return_value = (mock_hyperparams, "model-arn", True)  # is_gated_model=True
         
         # Should raise error when accept_eula=False for gated model
         with pytest.raises(ValueError, match="gated model and requires EULA acceptance"):
@@ -267,3 +287,75 @@ class TestSFTTrainer:
             {"key": "sagemaker-studio:jumpstart-model-id", "value": "test-model"},
             {"key": "sagemaker-studio:jumpstart-hub-name", "value": "SageMakerPublicHub"}
         ]
+
+    def test_process_hyperparameters_removes_constructor_handled_keys(self):
+        """Test that _process_hyperparameters removes keys handled by constructor inputs."""
+        # Create mock hyperparameters with all possible keys
+        mock_hyperparams = Mock()
+        mock_hyperparams._specs = {
+            'data_path': 'test_data_path',
+            'output_path': 'test_output_path', 
+            'training_data_name': 'test_training_data_name',
+            'validation_data_name': 'test_validation_data_name',
+            'validation_data_path': 'test_validation_data_path',
+            'other_param': 'should_remain'
+        }
+        
+        # Add attributes to mock
+        mock_hyperparams.data_path = 'test_data_path'
+        mock_hyperparams.output_path = 'test_output_path'
+        mock_hyperparams.training_data_name = 'test_training_data_name'
+        mock_hyperparams.validation_data_name = 'test_validation_data_name'
+        mock_hyperparams.validation_data_path = 'test_validation_data_path'
+        
+        # Create trainer instance with mock hyperparameters
+        trainer = SFTTrainer.__new__(SFTTrainer)
+        trainer.hyperparameters = mock_hyperparams
+        
+        # Call the method
+        trainer._process_hyperparameters()
+        
+        # Verify attributes were removed
+        assert not hasattr(mock_hyperparams, 'data_path')
+        assert not hasattr(mock_hyperparams, 'output_path')
+        assert not hasattr(mock_hyperparams, 'training_data_name')
+        assert not hasattr(mock_hyperparams, 'validation_data_name')
+        assert not hasattr(mock_hyperparams, 'validation_data_path')
+        
+        # Verify _specs were updated
+        assert 'data_path' not in mock_hyperparams._specs
+        assert 'output_path' not in mock_hyperparams._specs
+        assert 'training_data_name' not in mock_hyperparams._specs
+        assert 'validation_data_name' not in mock_hyperparams._specs
+        assert 'validation_data_path' not in mock_hyperparams._specs
+        assert 'other_param' in mock_hyperparams._specs
+
+    def test_process_hyperparameters_handles_missing_attributes(self):
+        """Test that _process_hyperparameters handles missing attributes gracefully."""
+        # Create mock hyperparameters with only some keys
+        mock_hyperparams = Mock()
+        mock_hyperparams._specs = {
+            'data_path': 'test_data_path',
+            'other_param': 'should_remain'
+        }
+        mock_hyperparams.data_path = 'test_data_path'
+        
+        # Create trainer instance
+        trainer = SFTTrainer.__new__(SFTTrainer)
+        trainer.hyperparameters = mock_hyperparams
+        
+        # Call the method
+        trainer._process_hyperparameters()
+        
+        # Verify only existing attributes were processed
+        assert not hasattr(mock_hyperparams, 'data_path')
+        assert 'data_path' not in mock_hyperparams._specs
+        assert 'other_param' in mock_hyperparams._specs
+
+    def test_process_hyperparameters_with_none_hyperparameters(self):
+        """Test that _process_hyperparameters handles None hyperparameters."""
+        trainer = SFTTrainer.__new__(SFTTrainer)
+        trainer.hyperparameters = None
+        
+        # Should not raise an exception
+        trainer._process_hyperparameters()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Add a method _process_hyperparameters in all trainers to remove redundant, update any parameters if required(example judge_prompt_template in rlaif_trainer)
* Add validation to s3_output_path, raise error to user before submitting training job.
* Update integ tests with dataset arn instead of s3 paths(as this is not in scope for support)
* Update/add any additional unit tests for the current changes

Testing:
pytest tests/unit/train/
`-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================ 1027 passed, 13 skipped, 45 warnings in 33.89s ============================================`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
