### PR TITLE
feat: Adding DataSets format validation

### DIFF
--- a/sagemaker-train/src/sagemaker/ai_registry/dataset_format_detector.py
+++ b/sagemaker-train/src/sagemaker/ai_registry/dataset_format_detector.py
@@ -1,0 +1,97 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+import json
+from typing import Dict, Any, Optional
+from pathlib import Path
+
+
+class DatasetFormatDetector:
+    """Utility class for detecting dataset formats."""
+    
+    # Schema directory
+    SCHEMA_DIR = Path(__file__).parent / "schemas"
+    
+    @staticmethod
+    def _load_schema(format_name: str) -> Dict[str, Any]:
+        """Load JSON schema for a format."""
+        schema_path = DatasetFormatDetector.SCHEMA_DIR / f"{format_name}.json"
+        if schema_path.exists():
+            with open(schema_path) as f:
+                return json.load(f)
+        return {}
+    
+    @staticmethod
+    def validate_dataset(file_path: str) -> bool:
+        """
+        Validate if the dataset adheres to any known format.
+        
+        Args:
+            file_path: Path to the JSONL file
+            
+        Returns:
+            True if dataset is valid according to any known format, False otherwise
+        """
+        import jsonschema
+        
+        # Schema-based formats
+        schema_formats = [
+            "dpo", "converse", "hf_preference", "hf_prompt_completion",
+            "verl", "openai_chat", "genqa"
+        ]
+        
+        try:
+            with open(file_path, 'r') as f:
+                for line in f:
+                    line = line.strip()
+                    if line:
+                        data = json.loads(line)
+                        
+                        # Try schema validation first
+                        for format_name in schema_formats:
+                            schema = DatasetFormatDetector._load_schema(format_name)
+                            if schema:
+                                try:
+                                    jsonschema.validate(instance=data, schema=schema)
+                                    return True
+                                except jsonschema.exceptions.ValidationError:
+                                    continue
+                        
+                        # Check for RFT-style format (messages + additional fields)
+                        if DatasetFormatDetector._is_rft_format(data):
+                            return True
+                        break
+            return False
+        except (json.JSONDecodeError, FileNotFoundError, IOError):
+            return False
+    
+    @staticmethod
+    def _is_rft_format(data: Dict[str, Any]) -> bool:
+        """Check if data matches RFT format pattern."""
+        if not isinstance(data, dict) or "messages" not in data:
+            return False
+        
+        messages = data["messages"]
+        if not isinstance(messages, list) or not messages:
+            return False
+        
+        # Check message structure
+        for msg in messages:
+            if not isinstance(msg, dict):
+                return False
+            if "role" not in msg or "content" not in msg:
+                return False
+            if not isinstance(msg["role"], str) or not isinstance(msg["content"], str):
+                return False
+        
+        return True

--- a/sagemaker-train/src/sagemaker/ai_registry/schemas/converse.json
+++ b/sagemaker-train/src/sagemaker/ai_registry/schemas/converse.json
@@ -1,0 +1,234 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "AWS Converse Format",
+  "description": "AWS Bedrock Converse API format for training data",
+  "type": "object",
+  "required": ["messages"],
+  "properties": {
+    "schemaVersion": {
+      "type": "string"
+    },
+    "system": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["text"],
+        "properties": {
+          "text": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "messages": {
+      "type": "array",
+      "minItems": 2,
+      "items": {
+        "type": "object",
+        "required": ["role", "content"],
+        "properties": {
+          "role": {
+            "type": "string",
+            "enum": ["user", "assistant"]
+          },
+          "content": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "object",
+              "properties": {
+                "text": {
+                  "type": "string"
+                },
+                "image": {
+                  "type": "object",
+                  "required": ["format", "source"],
+                  "properties": {
+                    "format": {
+                      "type": "string",
+                      "enum": ["jpeg", "png", "gif", "webp"]
+                    },
+                    "source": {
+                      "type": "object",
+                      "required": ["s3Location"],
+                      "properties": {
+                        "s3Location": {
+                          "type": "object",
+                          "required": ["localPath"],
+                          "properties": {
+                            "localPath": {
+                              "type": "string"
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "video": {
+                  "type": "object",
+                  "required": ["format", "source"],
+                  "properties": {
+                    "format": {
+                      "type": "string",
+                      "enum": ["mov", "mkv", "mp4", "webm"]
+                    },
+                    "source": {
+                      "type": "object",
+                      "required": ["s3Location"],
+                      "properties": {
+                        "s3Location": {
+                          "type": "object",
+                          "required": ["localPath"],
+                          "properties": {
+                            "localPath": {
+                              "type": "string"
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "document": {
+                  "type": "object",
+                  "required": ["format", "source"],
+                  "properties": {
+                    "format": {
+                      "type": "string",
+                      "enum": ["pdf"]
+                    },
+                    "source": {
+                      "type": "object",
+                      "required": ["s3Location"],
+                      "properties": {
+                        "s3Location": {
+                          "type": "object",
+                          "required": ["localPath"],
+                          "properties": {
+                            "localPath": {
+                              "type": "string"
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "toolUse": {
+                  "type": "object",
+                  "required": ["toolUseId", "name", "input"],
+                  "properties": {
+                    "toolUseId": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "input": {
+                      "type": "object"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "toolResult": {
+                  "type": "object",
+                  "required": ["toolUseId", "content"],
+                  "properties": {
+                    "toolUseId": {
+                      "type": "string"
+                    },
+                    "content": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "json": {
+                            "type": "object"
+                          },
+                          "text": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": true
+                      }
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "reasoningContent": {
+                  "type": "object",
+                  "required": ["reasoningText"],
+                  "properties": {
+                    "reasoningText": {
+                      "type": "object",
+                      "required": ["text"],
+                      "properties": {
+                        "text": {
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": true
+            }
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "toolConfig": {
+      "type": "object",
+      "required": ["tools"],
+      "properties": {
+        "tools": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "toolSpec": {
+                "type": "object",
+                "required": ["name"],
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                      "json": {
+                        "type": "object"
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/sagemaker-train/src/sagemaker/ai_registry/schemas/dpo.json
+++ b/sagemaker-train/src/sagemaker/ai_registry/schemas/dpo.json
@@ -1,0 +1,97 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "DPO (Direct Preference Optimization) Format",
+  "description": "DPO format with preference candidates based on ConverseDatasetSampleWithCandidates",
+  "type": "object",
+  "required": ["messages"],
+  "properties": {
+    "schemaVersion": {
+      "type": "string"
+    },
+    "system": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["text"],
+        "properties": {
+          "text": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "messages": {
+      "type": "array",
+      "minItems": 2,
+      "items": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": ["role", "content"],
+            "properties": {
+              "role": {
+                "type": "string",
+                "enum": ["user", "assistant"]
+              },
+              "content": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "text": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": ["role", "candidates"],
+            "properties": {
+              "role": {
+                "type": "string",
+                "enum": ["assistant"]
+              },
+              "candidates": {
+                "type": "array",
+                "minItems": 2,
+                "items": {
+                  "type": "object",
+                  "required": ["content", "preferenceLabel"],
+                  "properties": {
+                    "content": {
+                      "type": "array",
+                      "minItems": 1,
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "text": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": true
+                      }
+                    },
+                    "preferenceLabel": {
+                      "type": "string",
+                      "enum": ["preferred", "non-preferred"]
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/sagemaker-train/src/sagemaker/ai_registry/schemas/genqa.json
+++ b/sagemaker-train/src/sagemaker/ai_registry/schemas/genqa.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "description": "GenQA format for evaluation",
+  "properties": {
+    "query": {
+      "type": "string",
+      "description": "Required query to the model"
+    },
+    "response": {
+      "type": "string",
+      "description": "Optional target response (required for evaluation, optional for inference-only)"
+    },
+    "system": {
+      "type": "string",
+      "description": "Optional system prompt for the model"
+    },
+    "metadata": {
+      "type": "object",
+      "description": "Optional metadata for labeling purposes"
+    },
+    "images": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "string"
+          }
+        },
+        "required": ["data"]
+      }
+    }
+  },
+  "required": ["query"],
+  "additionalProperties": true
+}

--- a/sagemaker-train/src/sagemaker/ai_registry/schemas/hf_preference.json
+++ b/sagemaker-train/src/sagemaker/ai_registry/schemas/hf_preference.json
@@ -1,0 +1,117 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "description": "HuggingFace Preference format for DPO/RLHF training",
+  "properties": {
+    "input": {
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "The input prompt or query as a string"
+        },
+        {
+          "type": "array",
+          "description": "Array of conversation messages",
+          "items": {
+            "type": "object",
+            "properties": {
+              "role": {
+                "type": "string"
+              },
+              "content": {
+                "type": "string"
+              }
+            },
+            "required": ["role", "content"]
+          }
+        }
+      ]
+    },
+    "prompt": {
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "Alternative field for the input prompt as a string"
+        },
+        {
+          "type": "array",
+          "description": "Array of conversation messages",
+          "items": {
+            "type": "object",
+            "properties": {
+              "role": {
+                "type": "string"
+              },
+              "content": {
+                "type": "string"
+              }
+            },
+            "required": ["role", "content"]
+          }
+        }
+      ]
+    },
+    "chosen": {
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "The preferred/chosen response as a string"
+        },
+        {
+          "type": "array",
+          "description": "Array of assistant message(s) for chosen response",
+          "items": {
+            "type": "object",
+            "properties": {
+              "role": {
+                "type": "string"
+              },
+              "content": {
+                "type": "string"
+              }
+            },
+            "required": ["role", "content"]
+          }
+        }
+      ]
+    },
+    "rejected": {
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "The rejected/non-preferred response as a string"
+        },
+        {
+          "type": "array",
+          "description": "Array of assistant message(s) for rejected response",
+          "items": {
+            "type": "object",
+            "properties": {
+              "role": {
+                "type": "string"
+              },
+              "content": {
+                "type": "string"
+              }
+            },
+            "required": ["role", "content"]
+          }
+        }
+      ]
+    },
+    "id": {
+      "type": "string",
+      "description": "Optional unique identifier"
+    },
+    "attributes": {
+      "type": "object",
+      "description": "Optional metadata attributes"
+    },
+    "difficulty": {
+      "type": "string",
+      "description": "Optional difficulty level"
+    }
+  },
+  "required": ["chosen", "rejected"],
+  "additionalProperties": true
+}

--- a/sagemaker-train/src/sagemaker/ai_registry/schemas/hf_prompt_completion.json
+++ b/sagemaker-train/src/sagemaker/ai_registry/schemas/hf_prompt_completion.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "description": "HuggingFace Prompt-Completion format for supervised fine-tuning",
+  "properties": {
+    "prompt": {
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "The input prompt as a string"
+        },
+        {
+          "type": "array",
+          "description": "Array of conversation messages",
+          "items": {
+            "type": "object",
+            "properties": {
+              "role": {
+                "type": "string"
+              },
+              "content": {
+                "type": "string"
+              }
+            },
+            "required": ["role", "content"]
+          }
+        }
+      ]
+    },
+    "completion": {
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "The target completion as a string"
+        },
+        {
+          "type": "array",
+          "description": "Array of assistant message(s)",
+          "items": {
+            "type": "object",
+            "properties": {
+              "role": {
+                "type": "string"
+              },
+              "content": {
+                "type": "string"
+              }
+            },
+            "required": ["role", "content"]
+          }
+        }
+      ]
+    },
+    "id": {
+      "type": "string",
+      "description": "Optional unique identifier"
+    },
+    "attributes": {
+      "type": "object",
+      "description": "Optional metadata attributes"
+    },
+    "difficulty": {
+      "type": "string",
+      "description": "Optional difficulty level"
+    }
+  },
+  "required": ["prompt", "completion"],
+  "additionalProperties": true
+}

--- a/sagemaker-train/src/sagemaker/ai_registry/schemas/openai_chat.json
+++ b/sagemaker-train/src/sagemaker/ai_registry/schemas/openai_chat.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "OpenAI Chat Format",
+  "description": "OpenAI chat completion format with messages array",
+  "type": "object",
+  "required": ["messages"],
+  "properties": {
+    "messages": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["role", "content"],
+        "properties": {
+          "role": {
+            "type": "string",
+            "enum": ["system", "user", "assistant"]
+          },
+          "content": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/sagemaker-train/src/sagemaker/ai_registry/schemas/verl.json
+++ b/sagemaker-train/src/sagemaker/ai_registry/schemas/verl.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "description": "VERL format for reinforcement learning training",
+  "properties": {
+    "prompt": {
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "The prompt/query as a string (legacy format)"
+        },
+        {
+          "type": "array",
+          "description": "Array of conversation messages",
+          "items": {
+            "type": "object",
+            "properties": {
+              "role": {
+                "type": "string"
+              },
+              "content": {
+                "type": "string"
+              }
+            },
+            "required": ["role", "content"]
+          }
+        }
+      ]
+    },
+    "id": {
+      "type": "string",
+      "description": "Optional unique identifier"
+    },
+    "attributes": {
+      "oneOf": [
+        {"type": "object"},
+        {"type": "string"}
+      ],
+      "description": "Optional metadata attributes"
+    },
+    "difficulty": {
+      "type": "string",
+      "description": "Optional difficulty level"
+    },
+    "data_source": {
+      "type": "string",
+      "description": "Optional source of the data"
+    },
+    "ability": {
+      "type": "string",
+      "description": "Optional ability category"
+    },
+    "reward_model": {
+      "type": "object",
+      "description": "Optional reward model configuration"
+    },
+    "extra_info": {
+      "type": "object",
+      "description": "Optional additional information"
+    }
+  },
+  "required": ["prompt"],
+  "additionalProperties": true
+}

--- a/sagemaker-train/tests/integ/ai_registry/test_dataset.py
+++ b/sagemaker-train/tests/integ/ai_registry/test_dataset.py
@@ -19,6 +19,7 @@ import pytest
 from sagemaker.ai_registry.dataset import DataSet
 from sagemaker.ai_registry.dataset_utils import CustomizationTechnique
 from sagemaker.ai_registry.air_constants import HubContentStatus
+from unittest.mock import patch
 
 
 @pytest.mark.serial
@@ -39,9 +40,9 @@ class TestDataSetIntegration:
         assert dataset.version is not None
         assert dataset.customization_technique == CustomizationTechnique.SFT
 
-    def test_create_dataset_from_s3_uri_sft(self, unique_name, test_bucket, cleanup_list):
+    def test_create_dataset_from_s3_oss_sft(self, unique_name, test_bucket, cleanup_list):
         """Test creating SFT dataset from S3 URI."""
-        s3_uri = f"s3://{test_bucket}/test-sft-ds1.jsonl"
+        s3_uri = f"s3://{test_bucket}/test_datasets/OSS/oss_sft_train.jsonl"
         dataset = DataSet.create(
             name=unique_name,
             source=s3_uri,
@@ -52,9 +53,22 @@ class TestDataSetIntegration:
         assert dataset.name == unique_name
         assert dataset.customization_technique == CustomizationTechnique.SFT
 
-    def test_create_dataset_from_s3_uri_dpo(self, unique_name, test_bucket, cleanup_list):
-        """Test creating DPO dataset from S3 URI."""
-        s3_uri = f"s3://{test_bucket}/preference_dataset_train_256.jsonl"
+    def test_create_dataset_from_s3_oss_rlvr(self, unique_name, test_bucket, cleanup_list):
+        """Test creating RLVR dataset from S3 URI."""
+        s3_uri = f"s3://{test_bucket}/test_datasets/OSS/oss_rlvr_train.jsonl"
+        dataset = DataSet.create(
+            name=unique_name,
+            source=s3_uri,
+            customization_technique=CustomizationTechnique.RLVR,
+            wait=False
+        )
+        cleanup_list.append(dataset)
+        assert dataset.name == unique_name
+        assert dataset.customization_technique == CustomizationTechnique.RLVR
+
+    def test_create_dataset_from_s3_oss_dpo(self, unique_name, test_bucket, cleanup_list):
+        """Test creating RLVR dataset from S3 URI."""
+        s3_uri = f"s3://{test_bucket}/test_datasets/OSS/oss_dpo_train.jsonl"
         dataset = DataSet.create(
             name=unique_name,
             source=s3_uri,
@@ -64,6 +78,56 @@ class TestDataSetIntegration:
         cleanup_list.append(dataset)
         assert dataset.name == unique_name
         assert dataset.customization_technique == CustomizationTechnique.DPO
+
+    def test_create_dataset_from_s3_nova_sft(self, unique_name, test_bucket, cleanup_list):
+        """Test creating RLVR dataset from S3 URI."""
+        s3_uri = f"s3://{test_bucket}/test_datasets/Nova/nova_sft_train.jsonl"
+        dataset = DataSet.create(
+            name=unique_name,
+            source=s3_uri,
+            customization_technique=CustomizationTechnique.SFT,
+            wait=False
+        )
+        cleanup_list.append(dataset)
+        assert dataset.name == unique_name
+        assert dataset.customization_technique == CustomizationTechnique.SFT
+
+    def test_create_dataset_from_s3_nova_dpo(self, unique_name, test_bucket, cleanup_list):
+        """Test creating RLVR dataset from S3 URI."""
+        s3_uri = f"s3://{test_bucket}/test_datasets/Nova/nova_dpo_train.jsonl"
+        dataset = DataSet.create(
+            name=unique_name,
+            source=s3_uri,
+            customization_technique=CustomizationTechnique.DPO,
+            wait=False
+        )
+        cleanup_list.append(dataset)
+        assert dataset.name == unique_name
+        assert dataset.customization_technique == CustomizationTechnique.DPO
+
+    def test_create_dataset_from_s3_nova_rft(self, unique_name, test_bucket, cleanup_list):
+        """Test creating RLVR dataset from S3 URI."""
+        s3_uri = f"s3://{test_bucket}/test_datasets/Nova/nova_rft_train.jsonl"
+        dataset = DataSet.create(
+            name=unique_name,
+            source=s3_uri,
+            customization_technique=CustomizationTechnique.RLVR,
+            wait=False
+        )
+        cleanup_list.append(dataset)
+        assert dataset.name == unique_name
+        assert dataset.customization_technique == CustomizationTechnique.RLVR
+
+    def test_create_dataset_from_s3_nova_eval(self, unique_name, test_bucket, cleanup_list):
+        """Test creating RLVR dataset from S3 URI."""
+        s3_uri = f"s3://{test_bucket}/test_datasets/Nova/nova_eval.jsonl"
+        dataset = DataSet.create(
+            name=unique_name,
+            source=s3_uri,
+            wait=False
+        )
+        cleanup_list.append(dataset)
+        assert dataset.name == unique_name
 
     def test_get_dataset(self, unique_name, sample_jsonl_file):
         """Test retrieving dataset by name."""
@@ -122,6 +186,34 @@ class TestDataSetIntegration:
         with pytest.raises(ValueError, match="Unsupported file extension"):
             DataSet._validate_dataset_file("test.txt")
 
+    def test_create_dataset_with_invalid_format_s3(self, unique_name, test_bucket):
+        """Test creating dataset from S3 with invalid format fails."""
+        # This would require an actual invalid file in S3, so we'll mock it
+        with patch('sagemaker.ai_registry.dataset.AIRHub.download_from_s3'), \
+             patch('sagemaker.ai_registry.dataset.DataSet._validate_dataset_format', side_effect=ValueError("Invalid format")):
+            with pytest.raises(ValueError, match="Invalid format"):
+                DataSet.create(
+                    name=unique_name,
+                    source=f"s3://{test_bucket}/invalid_file.jsonl",
+                    wait=False
+                )
+
+    def test_create_dataset_with_invalid_format_local(self, unique_name):
+        """Test creating dataset from local file with invalid format fails."""
+        import tempfile
+        with tempfile.NamedTemporaryFile(suffix='.jsonl', mode='w', delete=False) as f:
+            f.write("invalid content")
+            f.flush()
+            try:
+                with pytest.raises(ValueError, match="Unable to detect format"):
+                    DataSet.create(
+                        name=unique_name,
+                        source=f.name,
+                        wait=False
+                    )
+            finally:
+                os.unlink(f.name)
+
     def test_dataset_validation_large_file(self, unique_name):
         """Test dataset validation with oversized file."""
         import tempfile
@@ -155,4 +247,28 @@ class TestDataSetIntegration:
         )
         cleanup_list.append(dataset)
         assert dataset.name == unique_name
+
+    def test_dataset_format_validation_success(self, unique_name, sample_jsonl_file):
+        """Test dataset format validation succeeds for valid files."""
+        # Should not raise any exception for valid JSONL file
+        DataSet._validate_dataset_format(sample_jsonl_file)
+
+    def test_dataset_format_validation_failure_invalid_format(self, unique_name):
+        """Test dataset format validation fails for invalid format."""
+        import tempfile
+        with tempfile.NamedTemporaryFile(suffix='.jsonl', mode='w', delete=False) as f:
+            f.write("invalid json content")
+            f.flush()
+            with pytest.raises(ValueError, match="Unable to detect format"):
+                DataSet._validate_dataset_format(f.name)
+            os.unlink(f.name)
+
+    def test_dataset_format_validation_failure_empty_file(self, unique_name):
+        """Test dataset format validation fails for empty files."""
+        import tempfile
+        with tempfile.NamedTemporaryFile(suffix='.jsonl', delete=False) as f:
+            f.flush()  # Create empty file
+            with pytest.raises(ValueError, match="Unable to detect format"):
+                DataSet._validate_dataset_format(f.name)
+            os.unlink(f.name)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Added Datasets format validation during DataSet create.
- Added Json Schemas for format detection.
- Added test cases for following cases
1. OSS SFT DataSet
2. OSS DPO DataSet
3. OSS RLVR DataSet
4. Nova SFT DataSet
5. Nova DPO DataSet
6. Nova RFT DataSet
7. Nova Eval DataSet

- Verified integs tests are passing before raising PR:
- 
<img width="1678" height="788" alt="Screenshot 2025-12-15 at 2 03 32 PM" src="https://github.com/user-attachments/assets/9ceefb28-fe16-4756-a900-fe6591e92f93" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
