### PR TITLE
Temporarily pin numpy version to <2.0 for hf tests

### DIFF
--- a/tests/data/huggingface/requirements.txt
+++ b/tests/data/huggingface/requirements.txt
@@ -1,1 +1,2 @@
 datasets==2.16.1
+numpy<2


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Tests tests/integ/test_huggingface.py::test_huggingface_training[4.56.2-2.8.0] and tests/integ/test_huggingface_torch_distributed.py::test_huggingface_torch_distributed_g5_glue[4.56.2-2.8.0] were failing due to incompatibilities between the transformers package and numpy package (due to numpy being >=2.0.0). Temporarily pinning numpy version to be less than 2.0.0 until container is updated as recommended by member of deep learning container team.

These two tests stopped working due to this PR merged a couple of weeks ago: https://github.com/aws/deep-learning-containers/pull/5555/files


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
