### PR TITLE
fix: fix evaluate_base_model flag

### DIFF
--- a/sagemaker-train/src/sagemaker/train/evaluate/benchmark_evaluator.py
+++ b/sagemaker-train/src/sagemaker/train/evaluate/benchmark_evaluator.py
@@ -301,7 +301,7 @@ class BenchMarkEvaluator(BaseEvaluator):
     
     benchmark: _Benchmark
     subtasks: Optional[Union[str, List[str]]] = None
-    evaluate_base_model: bool = False
+    evaluate_base_model: bool = True
     _hyperparameters: Optional[Any] = None
 
     

--- a/sagemaker-train/src/sagemaker/train/evaluate/custom_scorer_evaluator.py
+++ b/sagemaker-train/src/sagemaker/train/evaluate/custom_scorer_evaluator.py
@@ -137,7 +137,7 @@ class CustomScorerEvaluator(BaseEvaluator):
     _hyperparameters: Optional[Any] = None
     
     # Template-required fields
-    evaluate_base_model: bool = False
+    evaluate_base_model: bool = True
     
     @validator('dataset', pre=True)
     def _resolve_dataset(cls, v):

--- a/sagemaker-train/src/sagemaker/train/evaluate/llm_as_judge_evaluator.py
+++ b/sagemaker-train/src/sagemaker/train/evaluate/llm_as_judge_evaluator.py
@@ -123,7 +123,7 @@ class LLMAsJudgeEvaluator(BaseEvaluator):
     custom_metrics: Optional[str] = None
     
     # Template-required fields
-    evaluate_base_model: bool = False
+    evaluate_base_model: bool = True
     
     @validator('dataset', pre=True)
     def _resolve_dataset(cls, v):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Small bug in the repository. Pydocs and example notebook say that this `evaluate_base_model` defaults to true but it actually defaults false.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
