### PR TITLE
Removing pinned version of numpy

### DIFF
--- a/tests/data/huggingface/requirements.txt
+++ b/tests/data/huggingface/requirements.txt
@@ -1,2 +1,1 @@
 datasets==2.16.1
-numpy<2


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Deep learning container has unpinned numpy version in this PR (https://github.com/aws/deep-learning-containers/pull/5571) and has now been released. Removing pinning of numpy since the container has now been fixed


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
