### PR TITLE
fix: Add ml.p5e.48xlarge and ml.p5.48xlarge to EFA instance lists

### DIFF
--- a/sagemaker-core/src/sagemaker/core/modules/train/container_drivers/common/utils.py
+++ b/sagemaker-core/src/sagemaker/core/modules/train/container_drivers/common/utils.py
@@ -50,12 +50,15 @@ SM_EFA_NCCL_INSTANCES = [
     "ml.p4d.24xlarge",
     "ml.p4de.24xlarge",
     "ml.p5.48xlarge",
+    "ml.p5e.48xlarge",
     "ml.trn1.32xlarge",
 ]
 
 SM_EFA_RDMA_INSTANCES = [
     "ml.p4d.24xlarge",
     "ml.p4de.24xlarge",
+    "ml.p5.48xlarge",
+    "ml.p5e.48xlarge",
     "ml.trn1.32xlarge",
 ]
 

--- a/sagemaker-core/src/sagemaker/core/remote_function/runtime_environment/bootstrap_runtime_environment.py
+++ b/sagemaker-core/src/sagemaker/core/remote_function/runtime_environment/bootstrap_runtime_environment.py
@@ -75,12 +75,15 @@ SM_EFA_NCCL_INSTANCES = [
     "ml.p4d.24xlarge",
     "ml.p4de.24xlarge",
     "ml.p5.48xlarge",
+    "ml.p5e.48xlarge",
     "ml.trn1.32xlarge",
 ]
 
 SM_EFA_RDMA_INSTANCES = [
     "ml.p4d.24xlarge",
     "ml.p4de.24xlarge",
+    "ml.p5.48xlarge",
+    "ml.p5e.48xlarge",
     "ml.trn1.32xlarge",
 ]
 

--- a/sagemaker-train/src/sagemaker/train/container_drivers/common/utils.py
+++ b/sagemaker-train/src/sagemaker/train/container_drivers/common/utils.py
@@ -50,12 +50,15 @@ SM_EFA_NCCL_INSTANCES = [
     "ml.p4d.24xlarge",
     "ml.p4de.24xlarge",
     "ml.p5.48xlarge",
+    "ml.p5e.48xlarge",
     "ml.trn1.32xlarge",
 ]
 
 SM_EFA_RDMA_INSTANCES = [
     "ml.p4d.24xlarge",
     "ml.p4de.24xlarge",
+    "ml.p5.48xlarge",
+    "ml.p5e.48xlarge",
     "ml.trn1.32xlarge",
 ]
 

--- a/sagemaker-train/src/sagemaker/train/remote_function/runtime_environment/bootstrap_runtime_environment.py
+++ b/sagemaker-train/src/sagemaker/train/remote_function/runtime_environment/bootstrap_runtime_environment.py
@@ -75,12 +75,15 @@ SM_EFA_NCCL_INSTANCES = [
     "ml.p4d.24xlarge",
     "ml.p4de.24xlarge",
     "ml.p5.48xlarge",
+    "ml.p5e.48xlarge",
     "ml.trn1.32xlarge",
 ]
 
 SM_EFA_RDMA_INSTANCES = [
     "ml.p4d.24xlarge",
     "ml.p4de.24xlarge",
+    "ml.p5.48xlarge",
+    "ml.p5e.48xlarge",
     "ml.trn1.32xlarge",
 ]
 


### PR DESCRIPTION
## Description

Add ml.p5e.48xlarge to `SM_EFA_NCCL_INSTANCES` and `SM_EFA_RDMA_INSTANCES`.
Add ml.p5.48xlarge to `SM_EFA_RDMA_INSTANCES` (was missing).

Without these entries, NCCL hangs during distributed training initialization on P5e instances due to missing EFA environment variables (`FI_PROVIDER`, `FI_EFA_USE_DEVICE_RDMA`, `RDMAV_FORK_SAFE`).

## Related

- Fixes #5491
- sagemaker-training-toolkit issue: https://github.com/aws/sagemaker-training-toolkit/issues/240
- sagemaker-training-toolkit PR: https://github.com/aws/sagemaker-training-toolkit/pull/241

## Testing

- Added unit test for P5/P5e EFA instance list membership