### PR TITLE
Fix sagemaker-core unit test and sagemaker-serve integ test

### DIFF
--- a/sagemaker-core/pyproject.toml
+++ b/sagemaker-core/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "packaging>=20.0",
     "protobuf>=3.12,<5.0",
     "pandas>=1.0.0",
-    "numpy>=1.23.0",
+    "numpy>=1.9.0",
     # Dependencies migrated from sagemaker_utils
     "smdebug_rulesconfig>=1.0.1",
     "schema>=0.7.5",

--- a/sagemaker-core/tests/unit/image_uris/test_djl.py
+++ b/sagemaker-core/tests/unit/image_uris/test_djl.py
@@ -86,7 +86,12 @@ EXPECTED_DJL_LMI_REGIONS = {
 # Known missing framework:version:region combinations that don't exist in ECR
 KNOWN_MISSING_COMBINATIONS = {
     "djl-lmi": {
-        "0.36.0": {"ap-east-2"},
+        "0.36.0-lmi18.0.0-cu128": {"ap-east-2"},
+        "0.35.0-lmi17.0.0-cu128": {"ap-east-2"},
+        "0.34.0-lmi16.0.0-cu128": {"ap-east-2"},
+        "0.33.0-lmi15.0.0-cu128": {"ap-east-2"},
+        "0.32.0-lmi14.0.0-cu126": {"ap-east-2"},
+        "0.31.0-lmi13.0.0-cu124": {"ap-east-2"},
         "0.30.0-lmi12.0.0-cu124": {"ap-east-2"},
         "0.29.0-lmi11.0.0-cu124": {"ap-east-2"},
         "0.28.0-lmi10.0.0-cu124": {"ap-east-2"},
@@ -206,7 +211,8 @@ KNOWN_MISSING_COMBINATIONS = {
         },
     },
     "djl-tensorrtllm": {
-        "0.33.0": {"ap-east-2"},
+        "0.33.0-tensorrtllm0.21.0-cu128": {"ap-east-2"},
+        "0.32.0-tensorrtllm0.12.0-cu125": {"ap-east-2"},
         "0.30.0-tensorrtllm0.12.0-cu125": {"ap-east-2"},
         "0.29.0-tensorrtllm0.11.0-cu124": {"ap-east-2"},
         "0.28.0-tensorrtllm0.9.0-cu122": {"ap-east-2"},

--- a/sagemaker-core/tests/unit/test_analytics.py
+++ b/sagemaker-core/tests/unit/test_analytics.py
@@ -17,11 +17,7 @@ import datetime
 import pytest
 from unittest.mock import Mock, patch, MagicMock, mock_open
 from collections import OrderedDict
-
-# Mock pandas before importing analytics
 import sys
-
-sys.modules["pandas"] = MagicMock()
 
 from sagemaker.core.analytics import (
     AnalyticsMetricsBase,
@@ -31,6 +27,19 @@ from sagemaker.core.analytics import (
     ExperimentAnalytics,
     METRICS_PERIOD_DEFAULT,
 )
+
+
+@pytest.fixture(autouse=True)
+def mock_pandas_for_analytics():
+    """Mock pandas for analytics tests only, with proper cleanup."""
+    original_pandas = sys.modules.get("pandas")
+    sys.modules["pandas"] = MagicMock()
+    yield
+    # Restore original pandas after each test
+    if original_pandas is not None:
+        sys.modules["pandas"] = original_pandas
+    elif "pandas" in sys.modules:
+        del sys.modules["pandas"]
 
 
 class TestAnalyticsMetricsBase:


### PR DESCRIPTION
*Issue #, if available:*
There are test failures in https://github.com/aws/sagemaker-python-sdk/pull/5499 and https://github.com/aws/sagemaker-python-sdk/pull/5489. The failures do not come from the code changes of these PR, but rather require fixes due to the recent commit of DJL 0.36.0 release: https://github.com/aws/sagemaker-python-sdk/pull/5486

*Description of changes:*
#### For unit test in sagemaker-core
```
FAILED tests/unit/deserializers/test_base_deserializers.py::test_pandas_deserializer_json
FAILED tests/unit/deserializers/test_base_deserializers.py::test_pandas_deserializer_csv
FAILED tests/unit/image_uris/test_djl.py::test_djl_lmi_config_for_framework_has_all_regions[djl-lmi]
FAILED tests/unit/image_uris/test_djl.py::test_djl_lmi_config_for_framework_has_all_regions[djl-tensorrtllm]
```
- Add known missing combinations of DJL images
- Add pytest autouse fixture to prevent pandas mock leak from polluting other tests in Python 3.11/3.12

#### For integ test failure in sagemaker-serve
```
FAILED tests/integ/test_huggingface_integration.py::test_huggingface_build_deploy_invoke_cleanup - botocore.errorfactory.ValidationError: An error occurred (ValidationError) when calling the InvokeEndpoint operation: Endpoint hf-test-endpoint-d33a5c59 of account 729646638167 not found.
```
- Update hugging face model id that is compatible with DJL 0.36.0 vLLM

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
