### PR TITLE
Fix: Catch case where no `requirements` argument is sent to create S…

### DIFF
--- a/sagemaker-core/src/sagemaker/core/workflow/utilities.py
+++ b/sagemaker-core/src/sagemaker/core/workflow/utilities.py
@@ -172,7 +172,7 @@ def get_code_hash(step: Entity) -> str:
         source_code = model_trainer.source_code
         if source_code:
             source_dir = source_code.source_dir
-            requirements = source_code.requirements
+            requirements = [source_code.requirements] if source_code.requirements else []
             entry_point = source_code.entry_script
             return get_training_code_hash(entry_point, source_dir, requirements)
     return None


### PR DESCRIPTION

Noticed SourceCode.requirements is an optional argument and causes an error when left to default `None` value in a TrainingStep  as part of a Pipeline.

Catches case where no `requirements` argument is sent to create SourceCode object and `get_code_hash` fails to provide a `List` to the `get_training_code_hash` function.

*Issue #, if available:* 
* [5443](https://github.com/aws/sagemaker-python-sdk/issues/5443)
* [5518](https://github.com/aws/sagemaker-python-sdk/issues/5518)

*Description of changes:*
From the `get_code_hash` function created a conditional statement to get the right DataType to pass to `get_training_code_hash` and supply a default value.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
