### PR TITLE
docs: fix typo in shapes.py docstring

### DIFF
--- a/sagemaker-core/src/sagemaker/core/shapes/shapes.py
+++ b/sagemaker-core/src/sagemaker/core/shapes/shapes.py
@@ -11401,7 +11401,7 @@ class OidcMemberDefinition(Base):
 
     Attributes
     ----------------------
-    groups: A list of comma seperated strings that identifies user groups in your OIDC IdP. Each user group is made up of a group of private workers.
+    groups: A list of comma-separated strings that identifies user groups in your OIDC IdP. Each user group is made up of a group of private workers.
     group
     member_definition_id
     """


### PR DESCRIPTION
Fix minor typo in docstring: 'seperated' → 'separated'