### PR TITLE
fix(train): Skip default instance_type/instance_count when instance_groups is set

### DIFF
--- a/sagemaker-train/src/sagemaker/train/defaults.py
+++ b/sagemaker-train/src/sagemaker/train/defaults.py
@@ -100,12 +100,15 @@ class TrainDefaults:
                 volume_size_in_gb=DEFAULT_VOLUME_SIZE,
             )
             logger.info(f"Compute not provided. Using default:\n{compute}")
-        if compute.instance_type is None:
-            compute.instance_type = DEFAULT_INSTANCE_TYPE
-            logger.info(f"Instance type not provided. Using default:\n{DEFAULT_INSTANCE_TYPE}")
-        if compute.instance_count is None:
-            compute.instance_count = DEFAULT_INSTANCE_COUNT
-            logger.info(f"Instance count not provided. Using default:\n{compute.instance_count}")
+        if not compute.instance_groups:
+            if compute.instance_type is None:
+                compute.instance_type = DEFAULT_INSTANCE_TYPE
+                logger.info(f"Instance type not provided. Using default:\n{DEFAULT_INSTANCE_TYPE}")
+            if compute.instance_count is None:
+                compute.instance_count = DEFAULT_INSTANCE_COUNT
+                logger.info(
+                    f"Instance count not provided. Using default:\n{compute.instance_count}"
+                )
         if compute.volume_size_in_gb is None:
             compute.volume_size_in_gb = DEFAULT_VOLUME_SIZE
             logger.info(f"Volume size not provided. Using default:\n{compute.volume_size_in_gb}")
@@ -225,11 +228,21 @@ class JumpStartTrainDefaults:
                 ),
             )
             logger.info(f"Compute not provided. Using default compute:\n{compute}")
-        if compute.instance_type is None and training_components_model.DefaultTrainingInstanceType:
-            compute.instance_type = training_components_model.DefaultTrainingInstanceType
-            logger.info(
-                f"Instance type not provided. Using default instance type:\n{compute.instance_type}"
-            )
+        if not compute.instance_groups:
+            if (
+                compute.instance_type is None
+                and training_components_model.DefaultTrainingInstanceType
+            ):
+                compute.instance_type = training_components_model.DefaultTrainingInstanceType
+                logger.info(
+                    f"Instance type not provided. Using default instance type:"
+                    f"\n{compute.instance_type}"
+                )
+            if compute.instance_count is None:
+                compute.instance_count = DEFAULT_INSTANCE_COUNT
+                logger.info(
+                    f"Instance count not provided. Using default instance count:\n{compute}"
+                )
         if compute.volume_size_in_gb is None:
             compute.volume_size_in_gb = (
                 training_components_model.TrainingVolumeSize or DEFAULT_VOLUME_SIZE
@@ -237,9 +250,6 @@ class JumpStartTrainDefaults:
             logger.info(
                 f"Volume size not provided. Using default volume size:\n{compute.volume_size_in_gb}"
             )
-        if compute.instance_count is None:
-            compute.instance_count = DEFAULT_INSTANCE_COUNT
-            logger.info(f"Instance count not provided. Using default instance count:\n{compute}")
         return compute
 
     def get_networking(


### PR DESCRIPTION
## Issue

Fixes #5555

## Description

When creating a `ModelTrainer` with a `Compute` config that uses `instance_groups` (heterogeneous cluster), `TrainDefaults.get_compute()` and `JumpStartTrainDefaults.get_compute()` unconditionally inject default `instance_type` (`ml.m5.xlarge`) and `instance_count` (1) when those fields are `None`.

With heterogeneous clusters, `instance_type` and `instance_count` are intentionally `None` because they are **mutually exclusive** with `instance_groups` in the SageMaker `CreateTrainingJob` API. This causes the API call to include both `InstanceType`/`InstanceCount` and `InstanceGroups` in the `ResourceConfig`, which SageMaker rejects with:

```
ValidationException: InstanceType or InstanceCount cannot be specified with InstanceGroups
```

## Changes

Wrapped the default `instance_type` and `instance_count` injection in both methods with a `if not compute.instance_groups:` guard so defaults are only applied for homogeneous cluster configurations.

**`TrainDefaults.get_compute()`** — skips setting `instance_type` and `instance_count` defaults when `instance_groups` is present.

**`JumpStartTrainDefaults.get_compute()`** — same guard applied. `volume_size_in_gb` default is still set regardless since it applies to both cluster types.

## Testing

This change is a minimal guard condition. When `instance_groups` is not set, behavior is identical to before. When `instance_groups` is set, `instance_type` and `instance_count` remain `None` as intended by the caller.