### PR TITLE
fix(deps): Relax protobuf upper bound to <7.0 for CVE-2026-0994

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
   "pandas>=2.3.0",
   "pathos",
   "platformdirs",
-  "protobuf>=3.12,<6.32",
+  "protobuf>=3.12,<7.0",
   "psutil",
   "PyYAML>=6.0.1",
   "requests",


### PR DESCRIPTION
## Description

Raises the protobuf upper bound from `<6.32` to `<7.0` so users on the 6.x line can upgrade to 6.33.5+ which contains the fix for CVE-2026-0994.

The minimum remains `>=3.12` to avoid breaking existing environments on protobuf 4.x/5.x.

## Motivation

Protobuf 6.31.1 (currently allowed by the `<6.32` ceiling) has an open CVE (CVE-2026-0994). The fix is available in protobuf 6.33.5, but the current upper bound prevents users from upgrading.

Fixes #5548

## Changes

- `pyproject.toml`: Changed `protobuf>=3.12,<6.32` to `protobuf>=3.12,<7.0`

## Testing

This is a dependency constraint change only — no code changes. Existing tests should pass as-is since protobuf maintains backward compatibility within major versions.