### PR TITLE
Relax protobuf version to <7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
   "pandas>=2.3.0",
   "pathos",
   "platformdirs",
-  "protobuf>=3.12,<6.32",
+  "protobuf>=3.12,<7.0",
   "psutil",
   "PyYAML>=6.0.1",
   "requests",


### PR DESCRIPTION
*Issue #, if available:*

Bump protobuf version to <7.0 to pick up latest version which includes security fixes:

*Description of changes:*

This also resolves the issue: https://github.com/aws/sagemaker-python-sdk/issues/5548

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
