### PR TITLE
feat: add stop condition to model customization trainers

### DIFF
--- a/sagemaker-train/src/sagemaker/train/rlaif_trainer.py
+++ b/sagemaker-train/src/sagemaker/train/rlaif_trainer.py
@@ -9,6 +9,7 @@ from sagemaker.train.utils import _get_unique_name, _get_studio_tags
 from sagemaker.train.common_utils.recipe_utils import _get_hub_content_metadata
 from sagemaker.ai_registry.dataset import DataSet
 from sagemaker.ai_registry.evaluator import Evaluator
+from sagemaker.train.configs import StoppingCondition
 from sagemaker.train.common_utils.finetune_utils import (
     _get_beta_session,
     _get_fine_tuning_options_and_model_arn,
@@ -110,6 +111,9 @@ class RLAIFTrainer(BaseTrainer):
             The KMS key ID for encrypting training job outputs.
         networking (Optional[VpcConfig]):
             The VPC configuration for the training job.
+        stopping_condition (Optional[StoppingCondition]):
+            The stopping condition to override training runtime limit.
+            If not specified, defaults to 1 hour max runtime.
     """
 
     def __init__(
@@ -130,6 +134,7 @@ class RLAIFTrainer(BaseTrainer):
         # vpc config
         networking: Optional[VpcConfig] = None,
         accept_eula: bool = False,
+        stopping_condition: Optional[StoppingCondition] = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -150,6 +155,7 @@ class RLAIFTrainer(BaseTrainer):
         self.s3_output_path = s3_output_path
         self.kms_key_id = kms_key_id
         self.networking = networking
+        self.stopping_condition = stopping_condition
 
         # Initialize fine-tuning options with beta session fallback
         self.hyperparameters, self._model_arn, is_gated_model = _get_fine_tuning_options_and_model_arn(self._model_name,
@@ -215,6 +221,10 @@ class RLAIFTrainer(BaseTrainer):
         current_training_job_name = _get_unique_name(
             self.base_job_name or f"{self._model_name}-rlaif"
         )
+        
+        stopping_condition = TrainDefaults.get_stopping_condition(
+            stopping_condition=self.stopping_condition
+        )
 
         logger.info(f"Training Job Name: {current_training_job_name}")
 
@@ -270,6 +280,7 @@ class RLAIFTrainer(BaseTrainer):
                 hyper_parameters=final_hyperparameters,
                 model_package_config=model_package_config,
                 vpc_config=vpc_config,
+                stopping_condition=stopping_condition,
                 session=sagemaker_session.boto_session,
                 region=sagemaker_session.boto_session.region_name,
                 tags=tags,

--- a/sagemaker-train/src/sagemaker/train/rlvr_trainer.py
+++ b/sagemaker-train/src/sagemaker/train/rlvr_trainer.py
@@ -8,6 +8,7 @@ from sagemaker.train.defaults import TrainDefaults
 from sagemaker.train.utils import _get_unique_name, _get_studio_tags
 from sagemaker.ai_registry.dataset import DataSet
 from sagemaker.ai_registry.evaluator import Evaluator
+from sagemaker.train.configs import StoppingCondition
 from sagemaker.train.common_utils.finetune_utils import (
     _get_fine_tuning_options_and_model_arn,
     _validate_and_resolve_model_package_group,
@@ -102,6 +103,9 @@ class RLVRTrainer(BaseTrainer):
             The KMS key ID for encrypting training job outputs.
         networking (Optional[VpcConfig]):
             The VPC configuration for the training job.
+        stopping_condition (Optional[StoppingCondition]):
+            The stopping condition to override training runtime limit.
+            If not specified, defaults to 1 hour max runtime.
     """
 
     def __init__(
@@ -121,6 +125,7 @@ class RLVRTrainer(BaseTrainer):
         # vpc config
         networking: Optional[VpcConfig] = None,
         accept_eula: bool = False,
+        stopping_condition: Optional[StoppingCondition] = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -140,6 +145,7 @@ class RLVRTrainer(BaseTrainer):
         self.s3_output_path = s3_output_path
         self.kms_key_id = kms_key_id
         self.networking = networking
+        self.stopping_condition = stopping_condition
 
         # Initialize fine-tuning options with beta session fallback
         self.hyperparameters, self._model_arn, is_gated_model = _get_fine_tuning_options_and_model_arn(self._model_name,
@@ -202,6 +208,10 @@ class RLVRTrainer(BaseTrainer):
         current_training_job_name = _get_unique_name(
             self.base_job_name or f"{self._model_name}-rlvr"
         )
+        
+        stopping_condition = TrainDefaults.get_stopping_condition(
+            stopping_condition=self.stopping_condition
+        )
 
         logger.info(f"Training Job Name: {current_training_job_name}")
 
@@ -258,6 +268,7 @@ class RLVRTrainer(BaseTrainer):
                 hyper_parameters=final_hyperparameters,
                 model_package_config=model_package_config,
                 vpc_config=vpc_config,
+                stopping_condition=stopping_condition,
                 session=sagemaker_session.boto_session,
                 region=sagemaker_session.boto_session.region_name,
                 tags=tags,

--- a/sagemaker-train/tests/unit/train/test_dpo_trainer.py
+++ b/sagemaker-train/tests/unit/train/test_dpo_trainer.py
@@ -357,3 +357,24 @@ class TestDPOTrainer:
         
         # Should not raise an exception
         trainer._process_hyperparameters()
+
+    @patch('sagemaker.train.dpo_trainer._validate_and_resolve_model_package_group')
+    @patch('sagemaker.train.dpo_trainer._get_fine_tuning_options_and_model_arn')
+    def test_accepts_stopping_condition(self, mock_finetuning, mock_validate):
+        """Test DPOTrainer accepts stopping_condition parameter."""
+        from sagemaker.train.configs import StoppingCondition
+        
+        mock_validate.return_value = "test-group"
+        mock_hyperparams = Mock()
+        mock_hyperparams.to_dict.return_value = {}
+        mock_finetuning.return_value = (mock_hyperparams, "model-arn", False)
+        
+        stopping_condition = StoppingCondition(max_runtime_in_seconds=14400)
+        trainer = DPOTrainer(
+            model="test-model",
+            model_package_group="test-group",
+            stopping_condition=stopping_condition
+        )
+        
+        assert trainer.stopping_condition == stopping_condition
+        assert trainer.stopping_condition.max_runtime_in_seconds == 14400

--- a/sagemaker-train/tests/unit/train/test_rlaif_trainer.py
+++ b/sagemaker-train/tests/unit/train/test_rlaif_trainer.py
@@ -532,3 +532,25 @@ class TestRLAIFTrainer:
         
         result = trainer._validate_reward_model_id(None)
         assert result is None
+
+    @patch('sagemaker.train.rlaif_trainer._validate_and_resolve_model_package_group')
+    @patch('sagemaker.train.rlaif_trainer._get_fine_tuning_options_and_model_arn')
+    def test_accepts_stopping_condition(self, mock_finetuning, mock_validate):
+        """Test RLAIFTrainer accepts stopping_condition parameter."""
+        from sagemaker.train.configs import StoppingCondition
+        
+        mock_validate.return_value = "test-group"
+        mock_hyperparams = Mock()
+        mock_hyperparams.to_dict.return_value = {}
+        mock_finetuning.return_value = (mock_hyperparams, "model-arn", False)
+        
+        stopping_condition = StoppingCondition(max_runtime_in_seconds=86400)
+        trainer = RLAIFTrainer(
+            model="test-model",
+            model_package_group="test-group",
+            reward_model_id="openai.gpt-oss-120b-1:0",
+            stopping_condition=stopping_condition
+        )
+        
+        assert trainer.stopping_condition == stopping_condition
+        assert trainer.stopping_condition.max_runtime_in_seconds == 86400

--- a/sagemaker-train/tests/unit/train/test_rlvr_trainer.py
+++ b/sagemaker-train/tests/unit/train/test_rlvr_trainer.py
@@ -360,3 +360,24 @@ class TestRLVRTrainer:
         
         # Should not raise an exception
         trainer._process_hyperparameters()
+
+    @patch('sagemaker.train.rlvr_trainer._validate_and_resolve_model_package_group')
+    @patch('sagemaker.train.rlvr_trainer._get_fine_tuning_options_and_model_arn')
+    def test_accepts_stopping_condition(self, mock_finetuning, mock_validate):
+        """Test RLVRTrainer accepts stopping_condition parameter."""
+        from sagemaker.train.configs import StoppingCondition
+        
+        mock_validate.return_value = "test-group"
+        mock_hyperparams = Mock()
+        mock_hyperparams.to_dict.return_value = {}
+        mock_finetuning.return_value = (mock_hyperparams, "model-arn", False)
+        
+        stopping_condition = StoppingCondition(max_runtime_in_seconds=259200)
+        trainer = RLVRTrainer(
+            model="test-model",
+            model_package_group="test-group",
+            stopping_condition=stopping_condition
+        )
+        
+        assert trainer.stopping_condition == stopping_condition
+        assert trainer.stopping_condition.max_runtime_in_seconds == 259200

--- a/sagemaker-train/tests/unit/train/test_sft_trainer.py
+++ b/sagemaker-train/tests/unit/train/test_sft_trainer.py
@@ -359,3 +359,36 @@ class TestSFTTrainer:
         
         # Should not raise an exception
         trainer._process_hyperparameters()
+
+    @patch('sagemaker.train.sft_trainer._validate_and_resolve_model_package_group')
+    @patch('sagemaker.train.sft_trainer._get_fine_tuning_options_and_model_arn')
+    def test_accepts_stopping_condition(self, mock_finetuning, mock_validate):
+        """Test SFTTrainer accepts stopping_condition parameter."""
+        from sagemaker.train.configs import StoppingCondition
+        
+        mock_validate.return_value = "test-group"
+        mock_hyperparams = Mock()
+        mock_hyperparams.to_dict.return_value = {}
+        mock_finetuning.return_value = (mock_hyperparams, "model-arn", False)
+        
+        stopping_condition = StoppingCondition(max_runtime_in_seconds=7200)
+        trainer = SFTTrainer(
+            model="test-model",
+            model_package_group="test-group",
+            stopping_condition=stopping_condition
+        )
+        
+        assert trainer.stopping_condition == stopping_condition
+        assert trainer.stopping_condition.max_runtime_in_seconds == 7200
+
+    @patch('sagemaker.train.sft_trainer._validate_and_resolve_model_package_group')
+    @patch('sagemaker.train.sft_trainer._get_fine_tuning_options_and_model_arn')
+    def test_default_stopping_condition_is_none(self, mock_finetuning, mock_validate):
+        """Test SFTTrainer defaults stopping_condition to None."""
+        mock_validate.return_value = "test-group"
+        mock_hyperparams = Mock()
+        mock_hyperparams.to_dict.return_value = {}
+        mock_finetuning.return_value = (mock_hyperparams, "model-arn", False)
+        
+        trainer = SFTTrainer(model="test-model", model_package_group="test-group")
+        assert trainer.stopping_condition is None


### PR DESCRIPTION
## Add stopping_condition parameter to model customization trainers

### Problem
Customers need to run multi-day training jobs with large datasets (1M+ samples), but there was no way to override the training runtime limit through the trainer APIs. SageMaker Training Jobs support up to 28 days, but the SDK didn't expose this configuration.

### Solution
Added `stopping_condition` parameter to all model customization trainers (SFT, DPO, RLVR, RLAIF) following the ModelTrainer pattern.

### Changes
- Added `stopping_condition: Optional[StoppingCondition] = None` parameter to:
  - `SFTTrainer`
  - `DPOTrainer`
  - `RLVRTrainer`
  - `RLAIFTrainer`
- Parameter is passed through `TrainDefaults.get_stopping_condition()` which defaults to 1 hour if not specified
- Added unit tests to existing test files (5 tests total)

### Usage
python
from sagemaker.train import SFTTrainer
from sagemaker.train.configs import StoppingCondition

trainer = SFTTrainer(
   model="meta-llama/Llama-2-7b-hf",
   model_package_group="my-model-group",
   training_dataset="s3://bucket/data.jsonl",
   stopping_condition=StoppingCondition(
       max_runtime_in_seconds=259200  # 3 days
   )
)

### Backward Compatibility
✅ Fully backward compatible - defaults to 1 hour if not specified

### Testing
- Added unit tests to `test_sft_trainer.py`, `test_dpo_trainer.py`, `test_rlvr_trainer.py`, `test_rlaif_trainer.py`
- All tests passing

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
