### PR TITLE
Bug fix: get_code_hash passes str instead of List[str] to get_training_code_has

### DIFF
--- a/sagemaker-core/src/sagemaker/core/workflow/utilities.py
+++ b/sagemaker-core/src/sagemaker/core/workflow/utilities.py
@@ -174,7 +174,7 @@ def get_code_hash(step: Entity) -> str:
             source_dir = source_code.source_dir
             requirements = source_code.requirements
             entry_point = source_code.entry_script
-            return get_training_code_hash(entry_point, source_dir, requirements)
+            return get_training_code_hash(entry_point, source_dir, [requirements] if requirements else [])
     return None
 
 


### PR DESCRIPTION
`sagemaker.core.workflow.utilities.get_training_code_hash` expects dependencies to be a list, but `SourceCode.requirements` is passed as a str. 

The change wrap requirements in a list before passing it: This ensures dependencies is always a List[str] inside get_training_code_hash, so the [source_dir] + dependencies and [entry_point] + dependencies list concatenations work correctly.

*Issue #, if available:*
N/A
*Description of changes:*
Bug Fix: Wrap SourceCode.requirements in a list before passing to get_training_code_hash
get_training_code_hash expects its dependencies parameter to be a List[str], but SourceCode.requirements is a str (a path to a requirements.txt file). When passed directly, the list concatenation [source_dir] + dependencies raises a TypeError:
```python
["my_source_dir"] + "requirements.txt"
TypeError: can only concatenate list (not "str") to list
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

*Root cause:*
`In get_code_hash,` the `TrainingStep` branch passes `requirements` directly:

```python
requirements = source_code.requirements  # str, e.g. "requirements.txt"
return get_training_code_hash(entry_point, source_dir, requirements)
```

Note that the `ProcessingStep` branch does not have this issue because it normalizes dependencies into a list via `get_processing_dependencies()` before passing them.

*Fix:*
Wrap `requirements` in a list before passing:

```python
return get_training_code_hash(
    entry_point, source_dir, [requirements] if requirements else []
)
```

This ensures `dependencies` is always a `List[str]` inside `get_training_code_hash`, so `[source_dir] + dependencies` and `[entry_point] + dependencies` work correctly.