### PR TITLE
Fix: Remove default for stopping condition for MC trainer

### DIFF
--- a/sagemaker-train/src/sagemaker/train/dpo_trainer.py
+++ b/sagemaker-train/src/sagemaker/train/dpo_trainer.py
@@ -99,7 +99,7 @@ class DPOTrainer(BaseTrainer):
             The VPC configuration for the training job.
         stopping_condition (Optional[StoppingCondition]):
             The stopping condition to override training runtime limit.
-            If not specified, defaults to 1 hour max runtime.
+            If not specified, uses SageMaker service default (24 hours for serverless training).
     """
     def __init__(
             self,
@@ -204,10 +204,6 @@ class DPOTrainer(BaseTrainer):
         current_training_job_name = _get_unique_name(
             self.base_job_name or f"{self._model_name}-dpo"
         )
-        
-        stopping_condition = TrainDefaults.get_stopping_condition(
-            stopping_condition=self.stopping_condition
-        )
 
         logger.info(f"Training Job Name: {current_training_job_name}")
         print(f"Training Job Name: {current_training_job_name}")
@@ -250,22 +246,28 @@ class DPOTrainer(BaseTrainer):
         vpc_config = self.networking if self.networking else None
         tags = _get_studio_tags(self._model_name, HUB_NAME)
 
+        # Build TrainingJob.create() arguments
+        create_args = {
+            "training_job_name": current_training_job_name,
+            "role_arn": role,
+            "input_data_config": channels,
+            "output_data_config": output_config,
+            "serverless_job_config": serverless_config,
+            "mlflow_config": mlflow_config,
+            "hyper_parameters": final_hyperparameters,
+            "model_package_config": model_package_config,
+            "vpc_config": vpc_config,
+            "session": sagemaker_session.boto_session,
+            "region": sagemaker_session.boto_session.region_name,
+            "tags": tags,
+        }
+        
+        # Only pass stopping_condition if explicitly provided by user
+        if self.stopping_condition is not None:
+            create_args["stopping_condition"] = self.stopping_condition
+
         try:
-            training_job = TrainingJob.create(
-                training_job_name=current_training_job_name,
-                role_arn=role,
-                input_data_config=channels,
-                output_data_config=output_config,
-                serverless_job_config=serverless_config,
-                mlflow_config=mlflow_config,
-                hyper_parameters=final_hyperparameters,
-                model_package_config=model_package_config,
-                vpc_config=vpc_config,
-                stopping_condition=stopping_condition,
-                session=sagemaker_session.boto_session,
-                region=sagemaker_session.boto_session.region_name,
-                tags=tags,
-            )
+            training_job = TrainingJob.create(**create_args)
         except Exception as e:
             logger.error("Error: %s", e)
             raise e

--- a/sagemaker-train/src/sagemaker/train/rlvr_trainer.py
+++ b/sagemaker-train/src/sagemaker/train/rlvr_trainer.py
@@ -105,7 +105,7 @@ class RLVRTrainer(BaseTrainer):
             The VPC configuration for the training job.
         stopping_condition (Optional[StoppingCondition]):
             The stopping condition to override training runtime limit.
-            If not specified, defaults to 1 hour max runtime.
+            If not specified, uses SageMaker service default (24 hours for serverless training).
     """
 
     def __init__(
@@ -208,10 +208,6 @@ class RLVRTrainer(BaseTrainer):
         current_training_job_name = _get_unique_name(
             self.base_job_name or f"{self._model_name}-rlvr"
         )
-        
-        stopping_condition = TrainDefaults.get_stopping_condition(
-            stopping_condition=self.stopping_condition
-        )
 
         logger.info(f"Training Job Name: {current_training_job_name}")
 
@@ -257,22 +253,28 @@ class RLVRTrainer(BaseTrainer):
         vpc_config = self.networking if self.networking else None
         tags = _get_studio_tags(self._model_name, HUB_NAME)
 
+        # Build TrainingJob.create() arguments
+        create_args = {
+            "training_job_name": current_training_job_name,
+            "role_arn": role,
+            "input_data_config": channels,
+            "output_data_config": output_config,
+            "serverless_job_config": serverless_config,
+            "mlflow_config": mlflow_config,
+            "hyper_parameters": final_hyperparameters,
+            "model_package_config": model_package_config,
+            "vpc_config": vpc_config,
+            "session": sagemaker_session.boto_session,
+            "region": sagemaker_session.boto_session.region_name,
+            "tags": tags,
+        }
+        
+        # Only pass stopping_condition if explicitly provided by user
+        if self.stopping_condition is not None:
+            create_args["stopping_condition"] = self.stopping_condition
+
         try:
-            training_job = TrainingJob.create(
-                training_job_name=current_training_job_name,
-                role_arn=role,
-                input_data_config=channels,
-                output_data_config=output_config,
-                serverless_job_config=serverless_config,
-                mlflow_config=mlflow_config,
-                hyper_parameters=final_hyperparameters,
-                model_package_config=model_package_config,
-                vpc_config=vpc_config,
-                stopping_condition=stopping_condition,
-                session=sagemaker_session.boto_session,
-                region=sagemaker_session.boto_session.region_name,
-                tags=tags,
-            )
+            training_job = TrainingJob.create(**create_args)
         except Exception as e:
             logger.error("Error: %s", e)
             raise e

--- a/sagemaker-train/src/sagemaker/train/sft_trainer.py
+++ b/sagemaker-train/src/sagemaker/train/sft_trainer.py
@@ -101,7 +101,7 @@ class SFTTrainer(BaseTrainer):
             The VPC configuration for the training job.
         stopping_condition (Optional[StoppingCondition]):
             The stopping condition to override training runtime limit.
-            If not specified, defaults to 1 hour max runtime.
+            If not specified, uses SageMaker service default (24 hours for serverless training).
     """
 
     def __init__(
@@ -205,10 +205,6 @@ class SFTTrainer(BaseTrainer):
         current_training_job_name = _get_unique_name(
             self.base_job_name or f"{self._model_name}-sft"
         )
-        
-        stopping_condition = TrainDefaults.get_stopping_condition(
-            stopping_condition=self.stopping_condition
-        )
 
         logger.info(f"Training Job Name: {current_training_job_name}")
 
@@ -251,22 +247,28 @@ class SFTTrainer(BaseTrainer):
         vpc_config = self.networking if self.networking else None
         tags = _get_studio_tags(self._model_name, HUB_NAME)
 
+        # Build TrainingJob.create() arguments
+        create_args = {
+            "training_job_name": current_training_job_name,
+            "role_arn": role,
+            "input_data_config": channels,
+            "output_data_config": output_config,
+            "serverless_job_config": serverless_config,
+            "mlflow_config": mlflow_config,
+            "hyper_parameters": final_hyperparameters,
+            "model_package_config": model_package_config,
+            "vpc_config": vpc_config,
+            "session": sagemaker_session.boto_session,
+            "region": sagemaker_session.boto_session.region_name,
+            "tags": tags,
+        }
+        
+        # Only pass stopping_condition if explicitly provided by user
+        if self.stopping_condition is not None:
+            create_args["stopping_condition"] = self.stopping_condition
+
         try:
-            training_job = TrainingJob.create(
-                training_job_name=current_training_job_name,
-                role_arn=role,
-                input_data_config=channels,
-                output_data_config=output_config,
-                serverless_job_config=serverless_config,
-                mlflow_config=mlflow_config,
-                hyper_parameters=final_hyperparameters,
-                model_package_config=model_package_config,
-                vpc_config=vpc_config,
-                stopping_condition=stopping_condition,
-                session=sagemaker_session.boto_session,
-                region=sagemaker_session.boto_session.region_name,
-                tags=tags,
-            )
+            training_job = TrainingJob.create(**create_args)
         except Exception as e:
             logger.error("Error: %s", e)
             raise e


### PR DESCRIPTION
Description:

This PR fixes an unintended breaking change introduced in #5579 where the stopping_condition parameter was added to model customization trainers (SFT, DPO, RLAIF, RLVR).

Problem:
The previous implementation applied ModelTrainer's 1-hour default (DEFAULT_MAX_RUNTIME_IN_SECONDS = 3600) to all serverless training jobs, reducing the runtime from the SageMaker service default of 24 hours to 1 hour.

Solution:
Only pass stopping_condition to TrainingJob.create() when explicitly provided by the user. When None, the SageMaker service applies its 24-hour default for serverless training.

Changes:
- Modified train() method in SFT, DPO, RLAIF, and RLVR trainers to conditionally pass stopping_condition
- Updated docstrings to reflect 24-hour service default
- All existing unit tests pass

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
