### PR TITLE
feature: add update_configuration method to Lambda helper

### DIFF
--- a/sagemaker-core/docs/index.rst
+++ b/sagemaker-core/docs/index.rst
@@ -16,3 +16,12 @@ SageMaker Core Shapes
 .. automodule:: sagemaker.core.shapes
     :members:
     :noindex:
+
+
+##############################
+SageMaker Core Lambda Helper
+##############################
+
+.. automodule:: sagemaker.core.lambda_helper
+    :members:
+    :noindex:


### PR DESCRIPTION
*Issue #, if available:* #3445

*Description of changes:*
Add Lambda.update_configuration() to support updating function configuration (timeout, memory, runtime, handler, role, vpc, env, layers) via update_function_configuration boto3 API. Includes retry logic for ResourceConflictException consistent with existing update().

Also fixes typo in update(): 'funtion:' -> 'function:' in ARN parsing.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
