### PR TITLE
fix: include jumpstart/region_config.json in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 recursive-include src/sagemaker *.py
 
 include src/sagemaker/image_uri_config/*.json
+include src/sagemaker/jumpstart/region_config.json
 include src/sagemaker/pytorch/training_recipes.json
 include src/sagemaker/serve/schema/*.json
 include src/sagemaker/serve/requirements.txt


### PR DESCRIPTION
## Description
The file `src/sagemaker/jumpstart/region_config.json` is missing from the source distribution (sdist). The `sagemaker.jumpstart.constants` module loads this file at import time and, when it is absent, logs an ERROR with `exc_info=True`. While the SDK continues to function (falling back to an empty set), monitoring tools such as Datadog capture the error and trigger production alerts.

## Fix
Add `include src/sagemaker/jumpstart/region_config.json` to `MANIFEST.in`.

## Testing
Verified locally that the file is included in the sdist after this change.

Fixes #5550