### PR TITLE
sagemaker-core rich upper bound relax back to 15.0.0

### DIFF
--- a/sagemaker-core/pyproject.toml
+++ b/sagemaker-core/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "PyYAML>=6.0, <7.0",
     "jsonschema<5.0.0",
     "platformdirs>=4.0.0, <5.0.0",
-    "rich>=13.0.0, <14.0.0",
+    "rich>=13.0.0, <15.0.0",
     "mock>4.0, <5.0",
     "importlib-metadata<7.0,>=1.4.0",
     "typing_extensions>=4.9.0",


### PR DESCRIPTION
*Issue #, if available:*
There seems to be a regression for `sagemaker-core` during migration from v1 to v2.
`rich` upperbound was 15.0.0 in `sagemaker-core` v1: [Ref](https://github.com/aws/sagemaker-core/blob/main/pyproject.toml#L20)


When SMD team is testing to build newly released v3 conda package into their image, there is a conflict:
The restriction of rich has conflict with `strands-agents-tools`, which has
`rich >=14.0.0,<15.0.0`

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
