### PR TITLE
Removing record-related telemetry decorators

### DIFF
--- a/src/sagemaker/feature_store/feature_group.py
+++ b/src/sagemaker/feature_store/feature_group.py
@@ -1069,6 +1069,7 @@ class FeatureGroup:
             feature_names=feature_names,
         ).get("Record")
 
+    @_telemetry_emitter(feature=Feature.FEATURE_STORE_V2, func_name="feature_group.put_record")
     def put_record(
         self,
         record: Sequence[FeatureValue],
@@ -1092,6 +1093,7 @@ class FeatureGroup:
             ttl_duration=ttl_duration.to_dict() if ttl_duration is not None else None,
         )
 
+    @_telemetry_emitter(feature=Feature.FEATURE_STORE_V2, func_name="feature_group.delete_record")
     def delete_record(
         self,
         record_identifier_value_as_string: str,


### PR DESCRIPTION
*Issue #, if available:*
Removing telemetry on record-related feature group operations. See PR to add telemetry: https://github.com/aws/sagemaker-python-sdk/pull/5557/changes

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
