### PR TITLE
docs: Add migration tool (MCP server) section to migration guide

### DIFF
--- a/migration.md
+++ b/migration.md
@@ -484,7 +484,7 @@ pipeline = Pipeline(
 |--------------|--------------|--------------|--------|
 | Run processing jobs | `Processor(...)`, `ScriptProcessor(...)` | `sagemaker.core.resources.ProcessingJob` | ❌ REMOVED |
 | PySpark processing | `PySparkProcessor(...)` | `sagemaker.core.resources.ProcessingJob` | ❌ REMOVED |
-| Feature Store | `FeatureGroup`, `FeatureStore` | `sagemaker.core.resources.ProcessingJob` | ❌ REMOVED |
+| Feature Store | `FeatureGroup`, `FeatureStore` | `sagemaker.core.resources.FeatureGroup`, `FeatureStore` | ✅ SUPPORTED |
 | Data Wrangler | `sagemaker.wrangler` | `sagemaker.core.resources.ProcessingJob` | ❌ REMOVED |
 | Ground Truth (Labeling) | Not directly in V2 SDK (AWS console) | `sagemaker.core.resources.GroundTruthJob` (28 classes) | 🆕 NEW IN V3 |
 


### PR DESCRIPTION
Add instructions for installing and configuring the SageMaker SDK migration MCP server tool. Includes setup for Kiro, Kiro CLI, VS Code (Cline), Claude Desktop, and Cursor. Documents available tools (analyze_code, transform_code, validate_code, ask_question), example usage, and troubleshooting steps.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
