### PR TITLE
feat(ci): Add Fortress Code Reviewer security scan workflow

### DIFF
--- a/.github/workflows/fortress-scan.yml
+++ b/.github/workflows/fortress-scan.yml
@@ -1,0 +1,62 @@
+name: Fortress Security Scan
+on:
+  pull_request_target:
+    branches:
+      - "master"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.head_ref }}
+  cancel-in-progress: true
+
+permissions:
+  id-token: write
+
+jobs:
+  collab-check:
+    runs-on: ubuntu-latest
+    outputs:
+      approval-env: ${{ steps.collab-check.outputs.result }}
+    steps:
+      - name: Collaborator Check
+        uses: actions/github-script@v7
+        id: collab-check
+        with:
+          github-token: ${{ secrets.COLLAB_CHECK_TOKEN }}
+          result-encoding: string
+          script: |
+            try {
+              const res = await github.rest.repos.checkCollaborator({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                username: "${{ github.event.pull_request.user.login }}",
+              });
+              console.log("Verified ${{ github.event.pull_request.user.login }} is a repo collaborator. Auto Approving.")
+              return res.status == "204" ? "auto-approve" : "manual-approval"
+            } catch (error) {
+              console.log("${{ github.event.pull_request.user.login }} is not a collaborator. Requiring Manual Approval.")
+              return "manual-approval"
+            }
+
+  wait-for-approval:
+    runs-on: ubuntu-latest
+    needs: [collab-check]
+    environment: ${{ needs.collab-check.outputs.approval-env }}
+    steps:
+      - run: echo "Workflow Approved! Starting Fortress Security Scan."
+
+  fortress-scan:
+    runs-on: ubuntu-latest
+    needs: [wait-for-approval]
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_AWS_ROLE_ARN }}
+          aws-region: us-west-2
+          role-duration-seconds: 10800
+
+      - name: Run Fortress Security Scan
+        uses: aws-actions/aws-codebuild-run-build@v1
+        with:
+          project-name: ${{ github.event.repository.name }}-ci-fortress-scan
+          source-version-override: 'refs/pull/${{ github.event.pull_request.number }}/head^{${{ github.event.pull_request.head.sha }}}'


### PR DESCRIPTION
## What

Add a GitHub Actions workflow to run Fortress Code Reviewer security scan on every PR against the master branch.

## Why

Enable automated AI-powered security vulnerability scanning on every PR to catch security issues before merge. Fortress uses AWS Bedrock (Claude) to analyze code for vulnerabilities.

## How

The workflow (`.github/workflows/fortress-scan.yml`):
- Triggers on `pull_request_target` against `master`
- Performs collaborator check (auto-approve for collaborators, manual approval for external contributors)
- Configures AWS credentials via OIDC
- Triggers the `sagemaker-python-sdk-ci-fortress-scan` CodeBuild project

The CodeBuild project (deployed via SageMakerMLFPySDKInfraCDK):
- Installs Fortress dependencies from PyPI at runtime
- Runs Fortress scan with `--disable-memory --disable-reasoning` for CI speed
- Reports findings via CodeBuild reports

## Testing

- Verified in gamma : Build SUCCEEDED
- Verified in prod: Build SUCCEEDED
- Install phase: ~37s, Scan phase: ~17 min