### PR TITLE
fix: include sagemaker.mlops subpackages in sagemaker-mlops wheel (Fixes #5612)

### DIFF
--- a/sagemaker-mlops/pyproject.toml
+++ b/sagemaker-mlops/pyproject.toml
@@ -65,7 +65,7 @@ version = { file = "VERSION"}
 [tool.setuptools.packages.find]
 where = ["src"]
 include = ["sagemaker*"]
-namespaces = true
+namespaces = false
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
## Summary

Set `namespaces=false` in `[tool.setuptools.packages.find]` to ensure subpackages `sagemaker.mlops`, `sagemaker.mlops.feature_store`, and `sagemaker.mlops.feature_store.feature_processor` are included in the wheel distribution.

## Root Cause

The `sagemaker-mlops` wheel was missing the `mlops` subpackage tree because `namespaces=true` (PEP 420 namespace package mode) caused setuptools to exclude subdirectories from the wheel.

## Fix

Changed in `sagemaker-mlops/pyproject.toml`:

```
[tool.setuptools.packages.find]
where = ["src"]
include = ["sagemaker*"]
- namespaces = true
+ namespaces = false
```

With `namespaces=false`, setuptools treats `sagemaker` as a regular package and correctly includes all discovered subpackages: `mlops`, `mlops.feature_store`, `mlops.feature_store.feature_processor`.

## Testing

After this fix, the wheel should include:
- `sagemaker_mlops-*/sagemaker/__init__.py`
- `sagemaker_mlops-*/sagemaker/mlops/__init__.py`
- `sagemaker_mlops-*/sagemaker/mlops/feature_store/__init__.py`
- `sagemaker_mlops-*/sagemaker/mlops/feature_store/feature_processor/__init__.py`
- All corresponding `.py` modules

Fixes #5612