### PR TITLE
fix: use `is None` instead of `== None` (PEP 8 E711)

### DIFF
--- a/sagemaker-core/src/sagemaker/core/tools/templates.py
+++ b/sagemaker-core/src/sagemaker/core/tools/templates.py
@@ -644,7 +644,7 @@ class Base(BaseModel):
 
             if value == Unassigned() :
                 unassigned_args.append(arg)
-            elif value == None or not value:
+            elif value is None or not value:
                 continue
             elif (
                 arg_snake.endswith("name")


### PR DESCRIPTION
## Summary

Fix PEP 8 E711 violation in `sagemaker-core/src/sagemaker/core/tools/templates.py`.

**Change:**
```python
# Before
elif value == None or not value:

# After
elif value is None or not value:
```

Comparison to `None` should always use `is` or `is not`, never the equality operators (`==`/`!=`). This is because `None` is a singleton and identity comparison is both semantically correct and slightly more efficient.

## Testing

No behavior change — this is a style/correctness fix. Existing tests continue to pass.