### PR TITLE
fix: Remove hardcoded secret key from Triton ONNX export path

### DIFF
--- a/sagemaker-serve/src/sagemaker/serve/model_builder_utils.py
+++ b/sagemaker-serve/src/sagemaker/serve/model_builder_utils.py
@@ -3075,7 +3075,8 @@ class _ModelBuilderUtils:
             export_path.mkdir(parents=True)
 
         if self.model:
-            self.secret_key = "dummy secret key for onnx backend"
+            # ONNX path: no pickle serialization, no serve.pkl, no integrity check needed.
+            # Do not set secret_key — there is nothing to sign.
 
             if self.framework == Framework.PYTORCH:
                 self._export_pytorch_to_onnx(


### PR DESCRIPTION
The ONNX export path in _prepare_for_triton() set self.secret_key to a hardcoded value 'dummy secret key for onnx backend'. This key was then passed as SAGEMAKER_SERVE_SECRET_KEY into container environment variables and exposed in plaintext via DescribeModel/DescribeEndpointConfig APIs.

The ONNX path does not use pickle serialization — models are exported to .onnx format and loaded natively by Triton's ONNX Runtime backend. There is no serve.pkl, no metadata.json, and no integrity check to perform. The secret key was dead code that also constituted a hardcoded credential (CWE-798).

With this change, self.secret_key remains empty string (set by _build_for_triton), and the existing cleanup in _build_for_transformers removes empty SAGEMAKER_SERVE_SECRET_KEY from env_vars before CreateModel.

Addresses: P400136088 (Bug 2 - Hardcoded secret key)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
