### PR TITLE
fix: replace bare except with except Exception (E722)

### DIFF
--- a/sagemaker-train/src/sagemaker/train/common_utils/finetune_utils.py
+++ b/sagemaker-train/src/sagemaker/train/common_utils/finetune_utils.py
@@ -446,7 +446,7 @@ def _resolve_model_and_name(model, sagemaker_session=None):
             try:
                 import boto3
                 region_name = boto3.Session().region_name or os.environ.get('AWS_DEFAULT_REGION')
-            except:
+            except Exception:
                 pass
     
     if isinstance(model, str):

--- a/sagemaker-train/src/sagemaker/train/evaluate/execution.py
+++ b/sagemaker-train/src/sagemaker/train/evaluate/execution.py
@@ -904,7 +904,7 @@ class EvaluationPipelineExecution(BaseModel):
             if ipython is not None and 'IPKernelApp' in ipython.config:
                 is_jupyter = True
                 from IPython.display import display, HTML, clear_output
-        except:
+        except Exception:
             pass
         
         if is_jupyter:
@@ -958,7 +958,7 @@ class EvaluationPipelineExecution(BaseModel):
                                 end = datetime.fromisoformat(step.end_time.replace('Z', '+00:00'))
                                 duration_seconds = (end - start).total_seconds()
                                 duration = f"{duration_seconds:.1f}s"
-                            except:
+                            except Exception:
                                 duration = "N/A"
                         elif step.start_time:
                             duration = "Running..."


### PR DESCRIPTION
## Summary

Replace bare `except:` clauses with explicit `except Exception:` in sagemaker-train utilities.

**Why:** Bare `except:` catches all exceptions including `SystemExit`, `KeyboardInterrupt`, and `GeneratorExit` (PEP 8 E722). Since these catch blocks are used for graceful fallbacks (not re-raising), `except Exception:` is the correct form — it avoids silently swallowing system-level signals.

**Change:**
```python
# Before
except:
    pass

# After
except Exception:
    pass
```

## Files Changed
- `sagemaker-train/src/sagemaker/train/evaluate/execution.py` (2 instances)
- `sagemaker-train/src/sagemaker/train/common_utils/finetune_utils.py` (1 instance)

## Testing
No behavior change for normal exceptions — `except Exception:` catches all standard exceptions. The only difference is that `KeyboardInterrupt`, `SystemExit`, and `GeneratorExit` will now correctly propagate, which is the intended Python behavior.