### PR TITLE
fixed integ tests

### DIFF
--- a/tests/integ/sagemaker/jumpstart/model/test_jumpstart_model.py
+++ b/tests/integ/sagemaker/jumpstart/model/test_jumpstart_model.py
@@ -87,7 +87,7 @@ def test_non_prepacked_jumpstart_model(setup):
 
 def test_prepacked_jumpstart_model(setup):
 
-    model_id = "huggingface-txt2img-conflictx-complex-lineart"
+    model_id = "model-txt2img-stabilityai-stable-diffusion-v2-1-base"
 
     model = JumpStartModel(
         model_id=model_id,
@@ -251,11 +251,10 @@ def test_instantiating_model(mock_warning_logger, setup):
 
 
 def test_jumpstart_model_register(setup):
-    model_id = "huggingface-txt2img-conflictx-complex-lineart"
+    model_id = "model-txt2img-stabilityai-stable-diffusion-v2-1-base"
 
     model = JumpStartModel(
         model_id=model_id,
-        model_version="1.1.0",
         role=get_sm_session().get_caller_identity_arn(),
         sagemaker_session=get_sm_session(),
     )

--- a/tests/integ/sagemaker/jumpstart/private_hub/model/test_jumpstart_private_hub_model.py
+++ b/tests/integ/sagemaker/jumpstart/private_hub/model/test_jumpstart_private_hub_model.py
@@ -39,7 +39,7 @@ MAX_INIT_TIME_SECONDS = 5
 
 TEST_MODEL_IDS = {
     "catboost-classification-model",
-    "huggingface-txt2img-conflictx-complex-lineart",
+    "model-txt2img-stabilityai-stable-diffusion-v2-1-base",
     "meta-textgeneration-llama-2-7b",
     "meta-textgeneration-llama-3-2-1b",
     "catboost-regression-model",

--- a/tests/integ/sagemaker/serve/test_schema_builder.py
+++ b/tests/integ/sagemaker/serve/test_schema_builder.py
@@ -82,7 +82,6 @@ def test_model_builder_negative_path(sagemaker_session):
             None,
         ),
         ("HuggingFaceH4/zephyr-7b-beta", "text-generation", "ml.g5.2xlarge", 900),
-        ("HuggingFaceH4/zephyr-7b-alpha", "text-generation", "ml.g5.2xlarge", 900),
     ],
 )
 def test_model_builder_happy_path_with_task_provided_local_schema_mode(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix integration test failures caused by deprecated JumpStart model IDs.

1. tests/integ/sagemaker/jumpstart/model/test_jumpstart_model.py
   - test_prepacked_jumpstart_model: Replaced model ID huggingface-txt2img-conflictx-complex-lineart with model-txt2img-stabilityai-stable-diffusion-v2-1-base. The previous model was deprecated in the JumpStart registry and raises 
DeprecatedJumpStartModelError.
   - test_jumpstart_model_register: Same model ID replacement. Also removed the pinned model_version="1.1.0" parameter since it was specific to the old deprecated model.

2. tests/integ/sagemaker/jumpstart/private_hub/model/test_jumpstart_private_hub_model.py
   - Replaced huggingface-txt2img-conflictx-complex-lineart with model-txt2img-stabilityai-stable-diffusion-v2-1-base in the TEST_MODEL_IDS set used for private hub model tests.

3. tests/integ/sagemaker/serve/test_schema_builder.py
   - Removed the HuggingFaceH4/zephyr-7b-alpha parametrized test case from test_model_builder_happy_path_with_task_provided_local_schema_mode. The JumpStart equivalent (huggingface-llm-huggingfaceh4-zephyr-7b-alpha) has been deprecated. The 
zephyr-7b-beta variant remains and covers the same test path (text-generation on ml.g5.2xlarge).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
