### PR TITLE
feat: add telemetry emitter to ScriptProcessor and FrameworkProcessor run methods

### DIFF
--- a/sagemaker-core/src/sagemaker/core/processing.py
+++ b/sagemaker-core/src/sagemaker/core/processing.py
@@ -77,6 +77,8 @@ from sagemaker.core.helper.pipeline_variable import PipelineVariable
 from sagemaker.core.workflow.execution_variables import ExecutionVariables
 from sagemaker.core.workflow.functions import Join
 from sagemaker.core.workflow.pipeline_context import runnable_by_pipeline
+from sagemaker.core.telemetry.telemetry_logging import _telemetry_emitter
+from sagemaker.core.telemetry.constants import Feature
 
 from sagemaker.core._studio import _append_project_tags
 from sagemaker.core.config.config_utils import _append_sagemaker_config_tags
@@ -771,6 +773,7 @@ class ScriptProcessor(Processor):
             network_config=network_config,
         )
 
+    @_telemetry_emitter(feature=Feature.PROCESSING, func_name="ScriptProcessor.run")
     @runnable_by_pipeline
     def run(
         self,
@@ -1171,6 +1174,7 @@ class FrameworkProcessor(ScriptProcessor):
             os.unlink(tmp.name)
             return s3_uri
 
+    @_telemetry_emitter(feature=Feature.PROCESSING, func_name="FrameworkProcessor.run")
     @runnable_by_pipeline
     def run(
         self,

--- a/sagemaker-core/src/sagemaker/core/telemetry/constants.py
+++ b/sagemaker-core/src/sagemaker/core/telemetry/constants.py
@@ -29,6 +29,7 @@ class Feature(Enum):
     MODEL_CUSTOMIZATION = 15
     MLOPS = 16
     FEATURE_STORE = 17
+    PROCESSING = 18
 
     def __str__(self):  # pylint: disable=E0307
         """Return the feature name."""

--- a/sagemaker-core/src/sagemaker/core/telemetry/telemetry_logging.py
+++ b/sagemaker-core/src/sagemaker/core/telemetry/telemetry_logging.py
@@ -61,6 +61,7 @@ FEATURE_TO_CODE = {
     str(Feature.MODEL_CUSTOMIZATION): 15,
     str(Feature.MLOPS): 16,
     str(Feature.FEATURE_STORE): 17,
+    str(Feature.PROCESSING): 18,
 }
 
 STATUS_TO_CODE = {


### PR DESCRIPTION
*Issue #, if available:*

Telemetry is currently not emitted for `FrameworkProcessor.run(..)` or `ScriptProcessor.run(..)`. This change:
- adds `telemetry.constants.Feature.PROCESSING` enum 
- adds telemetry decorator to  `FrameworkProcessor.run(..)` and `ScriptProcessor.run(..)`

**Testing**

Tested the following script locally and validated that the expected telemetry is emitted:

```python
import logging
import os

os.environ["AWS_DEFAULT_REGION"] = "us-west-2"

from sagemaker.core import set_attribution, Attribution
from sagemaker.core.processing import ScriptProcessor, FrameworkProcessor

set_attribution(Attribution.SAGEMAKER_AGENT_PLUGIN)

ROLE_ARN = "arn:aws:iam::<ACCOUNT ID>:role/SageMakerExecutionRole"
SKLEARN_IMAGE = "246618743249.dkr.ecr.us-west-2.amazonaws.com/sagemaker-scikit-learn:1.4-2-1.0.87.0"

script_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "test_script.py")
with open(script_path, "w") as f:
    f.write("print('hello from processing job')\n")

# --- ScriptProcessor ---
print("\n=== Submitting ScriptProcessor job ===")
script_processor = ScriptProcessor(
    role=ROLE_ARN,
    image_uri=SKLEARN_IMAGE,
    command=["python3"],
    instance_count=1,
    instance_type="ml.t3.medium",
)
script_processor.run(code=script_path, wait=True)
print(f"ScriptProcessor job name: {script_processor.latest_job.processing_job_name}")

# --- FrameworkProcessor ---
print("\n=== Submitting FrameworkProcessor job ===")
framework_processor = FrameworkProcessor(
    role=ROLE_ARN,
    image_uri=SKLEARN_IMAGE,
    command=["python3"],
    instance_count=1,
    instance_type="ml.t3.medium",
)
framework_processor.run(code=script_path, wait=True)
print(f"FrameworkProcessor job name: {framework_processor.latest_job.processing_job_name}")
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
