### PR TITLE
Fix #5627: SFT example notebook references inaccessible S3 dataset URI

### DIFF
--- a/v3-examples/model-customization-examples/sft_finetuning_example_notebook_pysdk_prod_v3.ipynb
+++ b/v3-examples/model-customization-examples/sft_finetuning_example_notebook_pysdk_prod_v3.ipynb
@@ -85,13 +85,19 @@
     "from sagemaker.ai_registry.dataset_utils import CustomizationTechnique\n",
     "\n",
     "\n",
-    "\n",
     "# Register dataset in SageMaker AI Registry\n",
     "# This creates a versioned dataset that can be referenced by ARN\n",
-    "# Provide a source (it can be local file path or S3 URL)\n",
+    "# Provide a source: a local file path or your own S3 URI pointing to a JSONL file.\n",
+    "# The dataset must be in JSONL format with each line containing a JSON object\n",
+    "# with 'prompt' and 'completion' fields. See the SageMaker documentation for details:\n",
+    "# https://docs.aws.amazon.com/sagemaker/latest/dg/model-customize-sft.html\n",
+    "#\n",
+    "# Replace the placeholder below with your own S3 URI or local file path:\n",
+    "MY_DATASET_S3_URI = \"s3://<your-bucket>/<path-to-your-dataset>.jsonl\"  # TODO: replace with your dataset URI\n",
+    "\n",
     "dataset = DataSet.create(\n",
     "    name=\"demo-1\",\n",
-    "    source=\"s3://mc-flows-sdk-testing/input_data/sft/sample_data_256_final.jsonl\"\n",
+    "    source=MY_DATASET_S3_URI\n",
     ")\n",
     "\n",
     "print(f\"Dataset ARN: {dataset.arn}\")"
@@ -163,7 +169,7 @@
     "    mlflow_experiment_name=\"test-finetuned-models-exp\", \n",
     "    mlflow_run_name=\"test-finetuned-models-run\", \n",
     "    training_dataset=dataset.arn, \n",
-    "    s3_output_path=\"s3://mc-flows-sdk-testing/output/\",\n",
+    "    s3_output_path=\"s3://<your-bucket>/output/\",  # TODO: replace with your S3 output path\n",
     "    accept_eula=True\n",
     ")\n"
    ]
@@ -378,7 +384,7 @@
     "    mlflow_experiment_name=\"test-finetuned-models-exp\", # Optional[str]\n",
     "    mlflow_run_name=\"test-finetuned-models-run\", # Optional[str]\n",
     "    training_dataset=dataset.arn, #Optional[]\n",
-    "    s3_output_path=\"s3://mc-flows-sdk-testing/output/\",\n",
+    "    s3_output_path=\"s3://<your-bucket>/output/\",  # TODO: replace with your S3 output path\n",
     ")\n"
    ]
   },
@@ -439,7 +445,7 @@
     "    mlflow_experiment_name=\"test-nova-finetuned-models-exp\", \n",
     "    mlflow_run_name=\"test-nova-finetuned-models-run\", \n",
     "    training_dataset=\"arn:aws:sagemaker:us-east-1:<>:hub-content/sdktest/DataSet/sft-nova-test-dataset/0.0.1\",\n",
-    "    s3_output_path=\"s3://mc-flows-sdk-testing-us-east-1/output/\"\n",
+    "    s3_output_path=\"s3://<your-bucket>/output/\"  # TODO: replace with your S3 output path\n",
     ")\n"
    ]
   },


### PR DESCRIPTION
Closes #5627

## Motivation

The SFT finetuning example notebook hardcoded an internal S3 URI (`s3://mc-flows-sdk-testing/...`) that external users cannot access, causing an immediate 403 Forbidden error when running the dataset registration cell.

## Changes

**File:** `v3-examples/model-customization-examples/sft_finetuning_example_notebook_pysdk_prod_v3.ipynb`

- **Dataset registration cell (~line 85):** Replaced the hardcoded `s3://mc-flows-sdk-testing/input_data/sft/sample_data_256_final.jsonl` source with a named placeholder variable `MY_DATASET_S3_URI = "s3://<your-bucket>/<path-to-your-dataset>.jsonl"` marked with a `# TODO` comment. Added an explanatory comment block describing the required JSONL format (`prompt`/`completion` fields per line) and linking to the SageMaker SFT documentation.
- **Training job cell (~line 169):** Replaced `s3_output_path="s3://mc-flows-sdk-testing/output/"` with `"s3://<your-bucket>/output/"` and a `# TODO` comment.
- **Second training job cell (~line 384):** Same `s3_output_path` substitution as above.
- **Nova training job cell (~line 445):** Replaced `s3_output_path="s3://mc-flows-sdk-testing-us-east-1/output/"` with the same placeholder pattern.

## Testing

Manual verification: open the notebook and confirm no cells reference `mc-flows-sdk-testing` — all four occurrences are replaced with `<your-bucket>` placeholders. A user following the notebook will now see the `TODO` markers before executing any cell that requires S3 access, preventing the 403 error. Substituting a valid bucket and a JSONL file with `prompt`/`completion` fields allows the notebook to run end-to-end successfully.