### PR TITLE
Fix API reference docs to auto-discover all public modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ sagemaker_train/src/**/container_drivers/sm_train.sh
 sagemaker_train/src/**/container_drivers/sourcecode.json
 sagemaker_train/src/**/container_drivers/distributed.json
 .kiro
+docs/api/generated/

--- a/docs/api/full_reference.rst
+++ b/docs/api/full_reference.rst
@@ -1,0 +1,32 @@
+Full Module Reference
+=====================
+
+Complete auto-generated API reference for all public modules in SageMaker Python SDK V3.
+
+
+.. autosummary::
+   :toctree: generated/
+   :recursive:
+
+   sagemaker.core
+
+
+.. autosummary::
+   :toctree: generated/
+   :recursive:
+
+   sagemaker.train
+
+
+.. autosummary::
+   :toctree: generated/
+   :recursive:
+
+   sagemaker.serve
+
+
+.. autosummary::
+   :toctree: generated/
+   :recursive:
+
+   sagemaker.mlops

--- a/docs/api/sagemaker_core.rst
+++ b/docs/api/sagemaker_core.rst
@@ -3,8 +3,60 @@ SageMaker Core
 
 Core SageMaker resources and utilities for managing AWS SageMaker services.
 
-.. autosummary::
-   :toctree: generated/
-   :recursive:
+.. currentmodule:: sagemaker.core
 
-   sagemaker.core
+Core Resources
+--------------
+
+.. automodule:: sagemaker.core.resources
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Session Management
+------------------
+
+.. automodule:: sagemaker.core.session_settings
+   :members:
+   :undoc-members:
+
+Configuration
+-------------
+
+.. automodule:: sagemaker.core.config_schema
+   :members:
+   :undoc-members:
+
+Processing
+----------
+
+.. automodule:: sagemaker.core.processing
+   :members:
+   :undoc-members:
+
+Transformers
+------------
+
+.. automodule:: sagemaker.core.transformer
+   :members:
+   :undoc-members:
+
+Utilities
+---------
+
+.. automodule:: sagemaker.core.common_utils
+   :members:
+   :undoc-members:
+
+.. automodule:: sagemaker.core.image_uris
+   :members:
+   :undoc-members:
+
+Exceptions
+----------
+
+.. automodule:: sagemaker.core.exceptions
+   :members:
+   :undoc-members:
+
+

--- a/docs/api/sagemaker_core.rst
+++ b/docs/api/sagemaker_core.rst
@@ -3,58 +3,8 @@ SageMaker Core
 
 Core SageMaker resources and utilities for managing AWS SageMaker services.
 
-.. currentmodule:: sagemaker.core
+.. autosummary::
+   :toctree: generated/
+   :recursive:
 
-Core Resources
---------------
-
-.. automodule:: sagemaker.core.resources
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-Session Management
-------------------
-
-.. automodule:: sagemaker.core.session_settings
-   :members:
-   :undoc-members:
-
-Configuration
--------------
-
-.. automodule:: sagemaker.core.config_schema
-   :members:
-   :undoc-members:
-
-Processing
-----------
-
-.. automodule:: sagemaker.core.processing
-   :members:
-   :undoc-members:
-
-Transformers
-------------
-
-.. automodule:: sagemaker.core.transformer
-   :members:
-   :undoc-members:
-
-Utilities
----------
-
-.. automodule:: sagemaker.core.common_utils
-   :members:
-   :undoc-members:
-
-.. automodule:: sagemaker.core.image_uris
-   :members:
-   :undoc-members:
-
-Exceptions
-----------
-
-.. automodule:: sagemaker.core.exceptions
-   :members:
-   :undoc-members:
+   sagemaker.core

--- a/docs/api/sagemaker_mlops.rst
+++ b/docs/api/sagemaker_mlops.rst
@@ -3,37 +3,8 @@ SageMaker MLOps
 
 MLOps capabilities including pipelines, workflows, and model management.
 
-.. currentmodule:: sagemaker.mlops
+.. autosummary::
+   :toctree: generated/
+   :recursive:
 
-Pipeline Management
--------------------
-
-.. automodule:: sagemaker.mlops
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-Workflow Management
--------------------
-
-.. automodule:: sagemaker.mlops.workflow
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-Local Development
------------------
-
-.. automodule:: sagemaker.mlops.local
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-
-Feature Store
--------------
-
-.. automodule:: sagemaker.mlops.feature_store
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   sagemaker.mlops

--- a/docs/api/sagemaker_mlops.rst
+++ b/docs/api/sagemaker_mlops.rst
@@ -3,8 +3,39 @@ SageMaker MLOps
 
 MLOps capabilities including pipelines, workflows, and model management.
 
-.. autosummary::
-   :toctree: generated/
-   :recursive:
+.. currentmodule:: sagemaker.mlops
 
-   sagemaker.mlops
+Pipeline Management
+-------------------
+
+.. automodule:: sagemaker.mlops
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Workflow Management
+-------------------
+
+.. automodule:: sagemaker.mlops.workflow
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Local Development
+-----------------
+
+.. automodule:: sagemaker.mlops.local
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+Feature Store
+-------------
+
+.. automodule:: sagemaker.mlops.feature_store
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+

--- a/docs/api/sagemaker_serve.rst
+++ b/docs/api/sagemaker_serve.rst
@@ -3,8 +3,14 @@ SageMaker Serve
 
 Model serving and inference capabilities for deploying and managing ML models.
 
-.. autosummary::
-   :toctree: generated/
-   :recursive:
+.. currentmodule:: sagemaker.serve
 
-   sagemaker.serve
+Model Deployment
+----------------
+
+.. automodule:: sagemaker.serve
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+

--- a/docs/api/sagemaker_serve.rst
+++ b/docs/api/sagemaker_serve.rst
@@ -3,12 +3,8 @@ SageMaker Serve
 
 Model serving and inference capabilities for deploying and managing ML models.
 
-.. currentmodule:: sagemaker.serve
+.. autosummary::
+   :toctree: generated/
+   :recursive:
 
-Model Deployment
-----------------
-
-.. automodule:: sagemaker.serve
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   sagemaker.serve

--- a/docs/api/sagemaker_train.rst
+++ b/docs/api/sagemaker_train.rst
@@ -1,10 +1,32 @@
 SageMaker Train
 ===============
 
-Training capabilities including model training, fine-tuning, hyperparameter tuning, and distributed training.
+Training capabilities including model training, hyperparameter tuning, and distributed training.
 
-.. autosummary::
-   :toctree: generated/
-   :recursive:
+.. currentmodule:: sagemaker.train
 
-   sagemaker.train
+Model Training
+--------------
+
+.. automodule:: sagemaker.train
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Distributed Training
+--------------------
+
+.. automodule:: sagemaker.train.distributed
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Model Evaluation
+----------------
+
+.. automodule:: sagemaker.train.evaluate
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+

--- a/docs/api/sagemaker_train.rst
+++ b/docs/api/sagemaker_train.rst
@@ -1,30 +1,10 @@
 SageMaker Train
 ===============
 
-Training capabilities including model training, hyperparameter tuning, and distributed training.
+Training capabilities including model training, fine-tuning, hyperparameter tuning, and distributed training.
 
-.. currentmodule:: sagemaker.train
+.. autosummary::
+   :toctree: generated/
+   :recursive:
 
-Model Training
---------------
-
-.. automodule:: sagemaker.train
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-Distributed Training
---------------------
-
-.. automodule:: sagemaker.train.distributed
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-Model Evaluation
-----------------
-
-.. automodule:: sagemaker.train.evaluate
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   sagemaker.train

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -39,6 +39,7 @@ exclude_patterns = [
 suppress_warnings = [
     'myst.header',  # Suppress header level warnings from notebooks
     'toc.not_readable',  # Suppress toctree warnings for symlinked files
+    'ref.python',  # Suppress "more than one target found" for duplicate class names across modules
 ]
 
 html_theme = 'sphinx_book_theme'
@@ -76,10 +77,27 @@ autodoc_default_options = {
     'members': True,
     'undoc-members': True,
     'show-inheritance': True,
+    'private-members': False,
 }
 
-# Generate autosummary stubs
+# Generate autosummary stubs recursively
 autosummary_generate = True
+
+# Suppress internal/implementation modules not intended for users
+exclude_patterns += [
+    '*/telemetry*',
+    '*/tools*',
+    '*/container_drivers*',
+    '*/runtime_environment*',
+    '*/model_server*',
+    '*/detector*',
+    '*/validations*',
+]
+
+# Modules that fail to import due to runtime dependencies or side effects
+autodoc_mock_imports = [
+    'triton_python_backend_utils',
+]
 
 # Don't mock imports - let them fail gracefully and show what's available
 autodoc_mock_imports = []

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,9 +37,10 @@ exclude_patterns = [
 
 # Suppress specific warnings
 suppress_warnings = [
-    'myst.header',  # Suppress header level warnings from notebooks
-    'toc.not_readable',  # Suppress toctree warnings for symlinked files
-    'ref.python',  # Suppress "more than one target found" for duplicate class names across modules
+    'myst.header',       # header level warnings from notebooks
+    'toc.not_readable',  # toctree warnings for symlinked files
+    'ref.python',        # "more than one target found" for duplicate class names
+    'autosummary',       # autosummary import failures for internal modules
 ]
 
 html_theme = 'sphinx_book_theme'
@@ -92,13 +93,18 @@ exclude_patterns += [
     '*/model_server*',
     '*/detector*',
     '*/validations*',
+    '*/image_retriever*',
 ]
 
 # Modules that fail to import due to runtime dependencies or side effects
 autodoc_mock_imports = [
     'triton_python_backend_utils',
+    'sagemaker.serve.model_server.in_process_model_server.app',
+    'sagemaker.serve.model_server.multi_model_server.inference',
+    'sagemaker.serve.model_server.tensorflow_serving.inference',
+    'sagemaker.serve.model_server.torchserve.inference',
+    'sagemaker.serve.model_server.torchserve.xgboost_inference',
+    'sagemaker.serve.model_server.triton.model',
 ]
 
-# Don't mock imports - let them fail gracefully and show what's available
-autodoc_mock_imports = []
 suppress_warnings = ['autodoc.import_error']

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -36,3 +36,10 @@ SageMaker Python SDK V3
    :hidden:
    
    api/index
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Full Module Reference
+   :hidden:
+
+   api/full_reference

--- a/sagemaker-core/src/sagemaker/core/__init__.py
+++ b/sagemaker-core/src/sagemaker/core/__init__.py
@@ -1,3 +1,4 @@
+"""SageMaker Core package for low-level resource management and SDK foundations."""
 from sagemaker.core.utils.utils import enable_textual_rich_console_and_traceback
 
 

--- a/sagemaker-core/src/sagemaker/core/image_retriever/test.py
+++ b/sagemaker-core/src/sagemaker/core/image_retriever/test.py
@@ -1,7 +1,0 @@
-a = 1
-b = 2
-print(locals())
-args = dict(locals())
-print(args)
-locals()["a"] = 3
-print(a)


### PR DESCRIPTION
### Description:
The API reference docs were manually listing only a handful of modules per subpackage, leaving most user-facing classes (e.g. `ModelTrainer, SFTTrainer, ModelBuilder, Pipeline, sagemaker.core.shapes`) undocumented on the readthedocs site.

### Changes:
- Replaced manual `.. automodule::` entries in all 4 API RST files (`sagemaker_core, sagemaker_train, sagemaker_serve, sagemaker_mlops`) with `.. autosummary:: :recursive:` 
- Sphinx now auto-discovers all public modules, so new modules are documented automatically without any manual RST updates
- Updated `conf.py` to suppress `internal/non-user-facing` modules (telemetry, tools, container_drivers, runtime_environment, model_server, detector, validations) and suppress known duplicate cross-reference warnings caused by shared class names across modules
- Added `docs/api/generated/` to `.gitignore` — this directory is generated at build time by ReadTheDocs and should not be committed

Testing: Verified locally with `make html` — docs build successfully and all previously missing classes are now rendered.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
