### PR TITLE
Fix: Add mlflowconfig to eval base model

### DIFF
--- a/sagemaker-train/src/sagemaker/train/evaluate/pipeline_templates.py
+++ b/sagemaker-train/src/sagemaker/train/evaluate/pipeline_templates.py
@@ -326,6 +326,10 @@ DETERMINISTIC_TEMPLATE = """{
 LLMAJ_TEMPLATE_BASE_MODEL_ONLY = """{
     "Version": "2020-12-01",
     "Metadata": {},
+    "MlflowConfig": {
+        "MlflowResourceArn": "{{ mlflow_resource_arn }}"{% if mlflow_experiment_name %},
+        "MlflowExperimentName": "{{ mlflow_experiment_name }}"{% endif %}
+    },
     "Parameters": [],
     "Steps": [
         {
@@ -457,6 +461,10 @@ LLMAJ_TEMPLATE_BASE_MODEL_ONLY = """{
 DETERMINISTIC_TEMPLATE_BASE_MODEL_ONLY = """{
     "Version": "2020-12-01",
     "Metadata": {},
+    "MlflowConfig": {
+        "MlflowResourceArn": "{{ mlflow_resource_arn }}"{% if mlflow_experiment_name %},
+        "MlflowExperimentName": "{{ mlflow_experiment_name }}"{% endif %}
+    },
     "Parameters": [],
     "Steps": [
         {
@@ -843,6 +851,10 @@ CUSTOM_SCORER_TEMPLATE = """{
 CUSTOM_SCORER_TEMPLATE_BASE_MODEL_ONLY = """{
     "Version": "2020-12-01",
     "Metadata": {},
+    "MlflowConfig": {
+        "MlflowResourceArn": "{{ mlflow_resource_arn }}"{% if mlflow_experiment_name %},
+        "MlflowExperimentName": "{{ mlflow_experiment_name }}"{% endif %}
+    },
     "Parameters": [],
     "Steps": [
         {

--- a/sagemaker-train/tests/integ/train/test_benchmark_evaluator.py
+++ b/sagemaker-train/tests/integ/train/test_benchmark_evaluator.py
@@ -307,7 +307,7 @@ class TestBenchmarkEvaluatorIntegration:
             benchmark=Benchmark.MMLU,
             model=BASE_MODEL_ONLY_CONFIG["base_model_id"],
             s3_output_path=BASE_MODEL_ONLY_CONFIG["s3_output_path"],
-            # mlflow_resource_arn=BASE_MODEL_ONLY_CONFIG["mlflow_tracking_server_arn"],
+            mlflow_resource_arn=BASE_MODEL_ONLY_CONFIG["mlflow_tracking_server_arn"],
             base_eval_name="integ-test-base-model-only",
             # Note: model_package_group not needed for JumpStart models
         )

--- a/sagemaker-train/tests/unit/train/evaluate/test_pipeline_templates.py
+++ b/sagemaker-train/tests/unit/train/evaluate/test_pipeline_templates.py
@@ -317,8 +317,9 @@ class TestDeterministicTemplateBaseModelOnly:
         
         base_model_step = pipeline_def["Steps"][0]
         
-        # Verify MLflow config is not present in BASE_MODEL_ONLY template
-        assert "MlflowConfig" not in pipeline_def
+        # Verify MLflow config is present in BASE_MODEL_ONLY template
+        assert "MlflowConfig" in pipeline_def
+        assert pipeline_def["MlflowConfig"]["MlflowResourceArn"] == BASE_CONTEXT["mlflow_resource_arn"]
         
         # Verify KMS key
         assert base_model_step["Arguments"]["OutputDataConfig"]["KmsKeyId"] == context["kms_key_id"]
@@ -403,8 +404,9 @@ class TestCustomScorerTemplateBaseModelOnly:
         
         pipeline_def = json.loads(rendered)
         
-        # Verify MLflow config is not present in BASE_MODEL_ONLY template
-        assert "MlflowConfig" not in pipeline_def
+        # Verify MLflow config is present in BASE_MODEL_ONLY template
+        assert "MlflowConfig" in pipeline_def
+        assert pipeline_def["MlflowConfig"]["MlflowResourceArn"] == BASE_CONTEXT["mlflow_resource_arn"]
         
         # Should have only 1 step
         assert len(pipeline_def["Steps"]) == 1
@@ -574,8 +576,9 @@ class TestLLMAJTemplateBaseModelOnly:
         
         pipeline_def = json.loads(rendered)
         
-        # Verify MLflow config is not present in BASE_MODEL_ONLY template
-        assert "MlflowConfig" not in pipeline_def
+        # Verify MLflow config is present in BASE_MODEL_ONLY template
+        assert "MlflowConfig" in pipeline_def
+        assert pipeline_def["MlflowConfig"]["MlflowResourceArn"] == BASE_CONTEXT["mlflow_resource_arn"]
         
         # Should have 2 steps: EvaluateBaseInferenceModel and EvaluateBaseModelMetrics
         assert len(pipeline_def["Steps"]) == 2


### PR DESCRIPTION
### Description

Fix MLflow tracking support for base model only evaluations.

The three `_BASE_MODEL_ONLY` pipeline templates (`DETERMINISTIC, CUSTOM_SCORER, LLMAJ`) were missing the `MlflowConfig` block that their fine-tuned counterparts already had. The auto-resolve infrastructure in `base_evaluator.py` was already wiring up `mlflow_resource_arn` for all evaluator types, but the resolved ARN was silently dropped because the templates had no `MlflowConfig` block to render it into.

### Changes:
- Added MlflowConfig block to `LLMAJ_TEMPLATE_BASE_MODEL_ONLY, DETERMINISTIC_TEMPLATE_BASE_MODEL_ONLY, and CUSTOM_SCORER_TEMPLATE_BASE_MODEL_ONLY` in `pipeline_templates.py`
- Updated unit tests in `test_pipeline_templates.py` to assert `MlflowConfig` is present (previously incorrectly asserted absent)
- Uncommented `mlflow_resource_arn` in `test_benchmark_evaluator.py` integ test for base model only evaluation to validate the fix end-to-end

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
