### PR TITLE
fix: make torch an optional dependency in sagemaker-core

### DIFF
--- a/sagemaker-core/pyproject.toml
+++ b/sagemaker-core/pyproject.toml
@@ -32,7 +32,6 @@ dependencies = [
     "smdebug_rulesconfig>=1.0.1",
     "schema>=0.7.5",
     "omegaconf>=2.1.0",
-    "torch>=1.9.0",
     "scipy>=1.5.0",
     # Remote function dependencies
     "cloudpickle>=2.0.0",
@@ -52,6 +51,9 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
+torch = [
+    "torch>=1.9.0",
+]
 codegen = [
     "black>=24.3.0, <25.0.0",
     "pandas>=2.0.0, <3.0.0",

--- a/sagemaker-core/src/sagemaker/core/deserializers/base.py
+++ b/sagemaker-core/src/sagemaker/core/deserializers/base.py
@@ -365,8 +365,11 @@ class TorchTensorDeserializer(SimpleBaseDeserializer):
             from torch import from_numpy
 
             self.convert_npy_to_tensor = from_numpy
-        except ImportError:
-            raise Exception("Unable to import pytorch.")
+        except ImportError as e:
+            raise ImportError(
+                "torch is required to use TorchTensorDeserializer. "
+                "Install it with: pip install sagemaker-core[torch]"
+            ) from e
 
     def deserialize(self, stream, content_type="tensor/pt"):
         """Deserialize streamed data to TorchTensor

--- a/sagemaker-core/src/sagemaker/core/serializers/base.py
+++ b/sagemaker-core/src/sagemaker/core/serializers/base.py
@@ -443,9 +443,15 @@ class TorchTensorSerializer(SimpleBaseSerializer):
 
     def __init__(self, content_type="tensor/pt"):
         super(TorchTensorSerializer, self).__init__(content_type=content_type)
-        from torch import Tensor
+        try:
+            from torch import Tensor
 
-        self.torch_tensor = Tensor
+            self.torch_tensor = Tensor
+        except ImportError as e:
+            raise ImportError(
+                "torch is required to use TorchTensorSerializer. "
+                "Install it with: pip install sagemaker-core[torch]"
+            ) from e
         self.numpy_serializer = NumpySerializer()
 
     def serialize(self, data):

--- a/sagemaker-core/tests/unit/deserializers/test_base_deserializers.py
+++ b/sagemaker-core/tests/unit/deserializers/test_base_deserializers.py
@@ -14,10 +14,12 @@ from __future__ import absolute_import
 
 import io
 import json
+import sys
 
 import numpy as np
 import pandas as pd
 import pytest
+from unittest.mock import patch
 
 from sagemaker.core.deserializers.base import (
     StringDeserializer,
@@ -28,6 +30,7 @@ from sagemaker.core.deserializers.base import (
     JSONDeserializer,
     PandasDeserializer,
     JSONLinesDeserializer,
+    TorchTensorDeserializer,
 )
 
 
@@ -251,3 +254,9 @@ def test_json_lines_deserializer(json_lines_deserializer, source, expected):
     content_type = "application/jsonlines"
     actual = json_lines_deserializer.deserialize(stream, content_type)
     assert actual == expected
+
+
+def test_torch_tensor_deserializer_import_error():
+    with patch.dict(sys.modules, {"torch": None}):
+        with pytest.raises(ImportError, match="pip install sagemaker-core\\[torch\\]"):
+            TorchTensorDeserializer()

--- a/sagemaker-core/tests/unit/serializers/test_base_serializers.py
+++ b/sagemaker-core/tests/unit/serializers/test_base_serializers.py
@@ -15,10 +15,12 @@ from __future__ import absolute_import
 import io
 import json
 import os
+import sys
 
 import numpy as np
 import pytest
 import scipy.sparse
+from unittest.mock import patch
 
 from sagemaker.core.serializers.base import (
     CSVSerializer,
@@ -29,6 +31,7 @@ from sagemaker.core.serializers.base import (
     JSONLinesSerializer,
     LibSVMSerializer,
     DataSerializer,
+    TorchTensorSerializer,
 )
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), "..", "..", "data")
@@ -358,3 +361,9 @@ def test_data_serializer_file_like(data_serializer):
     with open(validation_image_file_path, "rb") as f:
         validation_image_data = f.read()
     assert input_image_data == validation_image_data
+
+
+def test_torch_tensor_serializer_import_error():
+    with patch.dict(sys.modules, {"torch": None}):
+        with pytest.raises(ImportError, match="pip install sagemaker-core\\[torch\\]"):
+            TorchTensorSerializer()


### PR DESCRIPTION
## Summary
- `torch>=1.9.0` was declared as a hard dependency in `sagemaker-core/pyproject.toml` despite only being used by `TorchTensorSerializer` and `TorchTensorDeserializer`. This forced `torch` (a multi-GB package) onto all consumers of `sagemaker-core`, including those with no PyTorch workloads.
- Moved `torch` to `[project.optional-dependencies]` under the `torch` extra — install with `pip install sagemaker-core[torch]`
- Added proper `ImportError` handling with an actionable message in both classes (the serializer had no error handling at all; the deserializer raised a bare `Exception`)
- Added unit tests for the `ImportError` path in both classes