### PR TITLE
feat(djl): Update DJL LMI to v24.0.0

### DIFF
--- a/src/sagemaker/image_uri_config/djl-lmi.json
+++ b/src/sagemaker/image_uri_config/djl-lmi.json
@@ -46,7 +46,7 @@
                 "mx-central-1": "637423239942"
             },
             "repository": "djl-inference",
-            "tag_prefix": "0.36.0-lmi23.0.0-cu129"
+            "tag_prefix": "0.36.0-lmi24.0.0-cu129"
         },
         "0.35.0": {
             "registries": {

--- a/tests/unit/sagemaker/image_uris/test_djl.py
+++ b/tests/unit/sagemaker/image_uris/test_djl.py
@@ -86,7 +86,7 @@ EXPECTED_DJL_LMI_REGIONS = {
 # Known missing framework:version:region combinations that don't exist in ECR
 KNOWN_MISSING_COMBINATIONS = {
     "djl-lmi": {
-        "0.36.0-lmi23.0.0-cu129": {"ap-east-2"},
+        "0.36.0-lmi24.0.0-cu129": {"ap-east-2"},
         "0.35.0-lmi17.0.0-cu128": {"ap-east-2"},
         "0.34.0-lmi16.0.0-cu128": {"ap-east-2"},
         "0.33.0-lmi15.0.0-cu128": {"ap-east-2"},


### PR DESCRIPTION
Update djl-lmi image URI config from LMI 23.0.0 to LMI 24.0.0 (0.36.0-lmi24.0.0-cu129).

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
