### PR TITLE
Fix incorrect `model_trainer` method call to load hyperparameters from file

### DIFF
--- a/sagemaker-train/src/sagemaker/train/model_trainer.py
+++ b/sagemaker-train/src/sagemaker/train/model_trainer.py
@@ -1214,7 +1214,7 @@ class ModelTrainer(BaseModel):
             )
         if is_nova:
             if hyperparameters and isinstance(hyperparameters, str):
-                hyperparameters = cls._validate_and_load_hyperparameters_file(hyperparameters)
+                hyperparameters = cls._validate_and_fetch_hyperparameters_file(hyperparameters)
                 model_trainer_args["hyperparameters"].update(hyperparameters)
             elif hyperparameters and isinstance(hyperparameters, dict):
                 model_trainer_args["hyperparameters"].update(hyperparameters)


### PR DESCRIPTION
*Issue #5770*

*Description of changes:*
Using incorrect method name when loading hyperparameters from file

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
