### PR TITLE
fix: add us-west-2 to Nova supported regions

### DIFF
--- a/sagemaker-train/src/sagemaker/train/common_utils/finetune_utils.py
+++ b/sagemaker-train/src/sagemaker/train/common_utils/finetune_utils.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 # Region mappings for model availability
 OPEN_WEIGHTS_REGIONS = ['us-east-1', 'us-west-2', 'ap-northeast-1', 'eu-west-1']  # IAD, PDX, NRT, DUB
-NOVA_REGIONS = ['us-east-1']  # IAD only
+NOVA_REGIONS = ['us-east-1', 'us-west-2']  # IAD, PDX
 # Constants
 DEFAULT_REGION = "us-west-2"
 

--- a/sagemaker-train/tests/unit/train/common_utils/test_finetune_utils.py
+++ b/sagemaker-train/tests/unit/train/common_utils/test_finetune_utils.py
@@ -488,11 +488,12 @@ class TestFinetuneUtils:
         """Test Nova model validation passes for valid region"""
         # Should not raise any exception
         _validate_model_region_availability("nova-textgeneration-lite-v2", "us-east-1")
+        _validate_model_region_availability("nova-textgeneration-lite-v2", "us-west-2")
 
     def test__validate_model_region_availability_nova_invalid_region(self):
         """Test Nova model validation fails for invalid region"""
-        with pytest.raises(ValueError, match="Region 'us-west-2' does not support model customization"):
-            _validate_model_region_availability("nova-textgeneration-lite-v2", "us-west-2")
+        with pytest.raises(ValueError, match="Region 'eu-west-1' does not support model customization"):
+            _validate_model_region_availability("nova-textgeneration-lite-v2", "eu-west-1")
 
     def test__validate_model_region_availability_open_weights_valid_region(self):
         """Test open weights model validation passes for valid region"""


### PR DESCRIPTION
## Problem
`NOVA_REGIONS` in `finetune_utils.py` was hardcoded to `['us-east-1']`, causing all trainers (SFTTrainer, DPOTrainer, RLVRTrainer, RLAIFTrainer) to raise a `ValueError` when instantiated in `us-west-2`, even though the SageMaker service supports Nova fine-tuning there.

## Fix
Added `us-west-2` to `NOVA_REGIONS`. Updated `test__validate_model_region_availability_nova_invalid_region` to use `eu-west-1` (a genuinely unsupported region) and added `us-west-2` to the valid-region test.

## Testing
Nova fine-tuning in us-west-2 (PDX) has been verified working via the SageMaker console UI workflow — the PySDK should match service-level availability.

Unit tests run locally:
```
AWS_DEFAULT_REGION=us-east-1 python -m pytest tests/unit/train/common_utils/test_finetune_utils.py -v
55 passed in 3.08s
```