### PR TITLE
fix: improve error messages for waiter timeouts

### DIFF
--- a/sagemaker-core/src/sagemaker/core/resources.py
+++ b/sagemaker-core/src/sagemaker/core/resources.py
@@ -972,7 +972,7 @@ class Algorithm(Base):
                     )
 
                 if timeout is not None and time.time() - start_time >= timeout:
-                    raise TimeoutExceededError(resouce_type="Algorithm", status=current_status)
+                    raise TimeoutExceededError(resource_type="Algorithm", status=current_status)
                 time.sleep(poll)
 
     @Base.add_validate_call
@@ -1026,7 +1026,7 @@ class Algorithm(Base):
                     status.update(f"Current status: [bold]{current_status}")
 
                     if timeout is not None and time.time() - start_time >= timeout:
-                        raise TimeoutExceededError(resouce_type="Algorithm", status=current_status)
+                        raise TimeoutExceededError(resource_type="Algorithm", status=current_status)
                 except botocore.exceptions.ClientError as e:
                     error_code = e.response["Error"]["Code"]
 
@@ -1499,7 +1499,7 @@ class App(Base):
                     )
 
                 if timeout is not None and time.time() - start_time >= timeout:
-                    raise TimeoutExceededError(resouce_type="App", status=current_status)
+                    raise TimeoutExceededError(resource_type="App", status=current_status)
                 time.sleep(poll)
 
     @Base.add_validate_call
@@ -1557,7 +1557,7 @@ class App(Base):
                         return
 
                     if timeout is not None and time.time() - start_time >= timeout:
-                        raise TimeoutExceededError(resouce_type="App", status=current_status)
+                        raise TimeoutExceededError(resource_type="App", status=current_status)
                 except botocore.exceptions.ClientError as e:
                     error_code = e.response["Error"]["Code"]
 
@@ -3084,7 +3084,7 @@ class AutoMLJob(Base):
                     return
 
                 if timeout is not None and time.time() - start_time >= timeout:
-                    raise TimeoutExceededError(resouce_type="AutoMLJob", status=current_status)
+                    raise TimeoutExceededError(resource_type="AutoMLJob", status=current_status)
                 time.sleep(poll)
 
     @classmethod
@@ -3580,7 +3580,7 @@ class AutoMLJobV2(Base):
                     return
 
                 if timeout is not None and time.time() - start_time >= timeout:
-                    raise TimeoutExceededError(resouce_type="AutoMLJobV2", status=current_status)
+                    raise TimeoutExceededError(resource_type="AutoMLJobV2", status=current_status)
                 time.sleep(poll)
 
 
@@ -3838,7 +3838,7 @@ class AutoMLTask(Base):
                     )
 
                 if timeout is not None and time.time() - start_time >= timeout:
-                    raise TimeoutExceededError(resouce_type="AutoMLTask", status=current_status)
+                    raise TimeoutExceededError(resource_type="AutoMLTask", status=current_status)
                 time.sleep(poll)
 
 
@@ -4211,7 +4211,7 @@ class CapacitySchedule(Base):
 
                 if timeout is not None and time.time() - start_time >= timeout:
                     raise TimeoutExceededError(
-                        resouce_type="CapacitySchedule", status=current_status
+                        resource_type="CapacitySchedule", status=current_status
                     )
                 time.sleep(poll)
 
@@ -4716,7 +4716,7 @@ class Cluster(Base):
                     )
 
                 if timeout is not None and time.time() - start_time >= timeout:
-                    raise TimeoutExceededError(resouce_type="Cluster", status=current_status)
+                    raise TimeoutExceededError(resource_type="Cluster", status=current_status)
                 time.sleep(poll)
 
     @Base.add_validate_call
@@ -4770,7 +4770,7 @@ class Cluster(Base):
                     status.update(f"Current status: [bold]{current_status}")
 
                     if timeout is not None and time.time() - start_time >= timeout:
-                        raise TimeoutExceededError(resouce_type="Cluster", status=current_status)
+                        raise TimeoutExceededError(resource_type="Cluster", status=current_status)
                 except botocore.exceptions.ClientError as e:
                     error_code = e.response["Error"]["Code"]
 
@@ -5482,7 +5482,7 @@ class ClusterSchedulerConfig(Base):
 
                 if timeout is not None and time.time() - start_time >= timeout:
                     raise TimeoutExceededError(
-                        resouce_type="ClusterSchedulerConfig", status=current_status
+                        resource_type="ClusterSchedulerConfig", status=current_status
                     )
                 time.sleep(poll)
 
@@ -5542,7 +5542,7 @@ class ClusterSchedulerConfig(Base):
 
                     if timeout is not None and time.time() - start_time >= timeout:
                         raise TimeoutExceededError(
-                            resouce_type="ClusterSchedulerConfig", status=current_status
+                            resource_type="ClusterSchedulerConfig", status=current_status
                         )
                 except botocore.exceptions.ClientError as e:
                     error_code = e.response["Error"]["Code"]
@@ -6339,7 +6339,7 @@ class CompilationJob(Base):
                     return
 
                 if timeout is not None and time.time() - start_time >= timeout:
-                    raise TimeoutExceededError(resouce_type="CompilationJob", status=current_status)
+                    raise TimeoutExceededError(resource_type="CompilationJob", status=current_status)
                 time.sleep(poll)
 
     @classmethod
@@ -6811,7 +6811,7 @@ class ComputeQuota(Base):
                     )
 
                 if timeout is not None and time.time() - start_time >= timeout:
-                    raise TimeoutExceededError(resouce_type="ComputeQuota", status=current_status)
+                    raise TimeoutExceededError(resource_type="ComputeQuota", status=current_status)
                 time.sleep(poll)
 
     @Base.add_validate_call
@@ -6870,7 +6870,7 @@ class ComputeQuota(Base):
 
                     if timeout is not None and time.time() - start_time >= timeout:
                         raise TimeoutExceededError(
-                            resouce_type="ComputeQuota", status=current_status
+                            resource_type="ComputeQuota", status=current_status
                         )
                 except botocore.exceptions.ClientError as e:
                     error_code = e.response["Error"]["Code"]
@@ -9529,7 +9529,7 @@ class Domain(Base):
                     )
 
                 if timeout is not None and time.time() - start_time >= timeout:
-                    raise TimeoutExceededError(resouce_type="Domain", status=current_status)
+                    raise TimeoutExceededError(resource_type="Domain", status=current_status)
                 time.sleep(poll)
 
     @Base.add_validate_call
@@ -9591,7 +9591,7 @@ class Domain(Base):
                         )
 
                     if timeout is not None and time.time() - start_time >= timeout:
-                        raise TimeoutExceededError(resouce_type="Domain", status=current_status)
+                        raise TimeoutExceededError(resource_type="Domain", status=current_status)
                 except botocore.exceptions.ClientError as e:
                     error_code = e.response["Error"]["Code"]
 
@@ -10517,7 +10517,7 @@ class EdgePackagingJob(Base):
 
                 if timeout is not None and time.time() - start_time >= timeout:
                     raise TimeoutExceededError(
-                        resouce_type="EdgePackagingJob", status=current_status
+                        resource_type="EdgePackagingJob", status=current_status
                     )
                 time.sleep(poll)
 
@@ -11023,7 +11023,7 @@ class Endpoint(Base):
                     )
 
                 if timeout is not None and time.time() - start_time >= timeout:
-                    raise TimeoutExceededError(resouce_type="Endpoint", status=current_status)
+                    raise TimeoutExceededError(resource_type="Endpoint", status=current_status)
                 time.sleep(poll)
 
     @Base.add_validate_call
@@ -11077,7 +11077,7 @@ class Endpoint(Base):
                     status.update(f"Current status: [bold]{current_status}")
 
                     if timeout is not None and time.time() - start_time >= timeout:
-                        raise TimeoutExceededError(resouce_type="Endpoint", status=current_status)
+                        raise TimeoutExceededError(resource_type="Endpoint", status=current_status)
                 except botocore.exceptions.ClientError as e:
                     error_code = e.response["Error"]["Code"]
 
@@ -12437,7 +12437,7 @@ class EvaluationJob(Base):
                     return
 
                 if timeout is not None and time.time() - start_time >= timeout:
-                    raise TimeoutExceededError(resouce_type="EvaluationJob", status=current_status)
+                    raise TimeoutExceededError(resource_type="EvaluationJob", status=current_status)
                 time.sleep(poll)
 
     @classmethod
@@ -13387,7 +13387,7 @@ class FeatureGroup(Base):
                     )
 
                 if timeout is not None and time.time() - start_time >= timeout:
-                    raise TimeoutExceededError(resouce_type="FeatureGroup", status=current_status)
+                    raise TimeoutExceededError(resource_type="FeatureGroup", status=current_status)
                 time.sleep(poll)
 
     @Base.add_validate_call
@@ -13442,7 +13442,7 @@ class FeatureGroup(Base):
 
                     if timeout is not None and time.time() - start_time >= timeout:
                         raise TimeoutExceededError(
-                            resouce_type="FeatureGroup", status=current_status
+                            resource_type="FeatureGroup", status=current_status
                         )
                 except botocore.exceptions.ClientError as e:
                     error_code = e.response["Error"]["Code"]
@@ -14442,7 +14442,7 @@ class FlowDefinition(Base):
                     )
 
                 if timeout is not None and time.time() - start_time >= timeout:
-                    raise TimeoutExceededError(resouce_type="FlowDefinition", status=current_status)
+                    raise TimeoutExceededError(resource_type="FlowDefinition", status=current_status)
                 time.sleep(poll)
 
     @Base.add_validate_call
@@ -14497,7 +14497,7 @@ class FlowDefinition(Base):
 
                     if timeout is not None and time.time() - start_time >= timeout:
                         raise TimeoutExceededError(
-                            resouce_type="FlowDefinition", status=current_status
+                            resource_type="FlowDefinition", status=current_status
                         )
                 except botocore.exceptions.ClientError as e:
                     error_code = e.response["Error"]["Code"]
@@ -14849,7 +14849,7 @@ class GroundTruthJob(Base):
                     return
 
                 if timeout is not None and time.time() - start_time >= timeout:
-                    raise TimeoutExceededError(resouce_type="GroundTruthJob", status=current_status)
+                    raise TimeoutExceededError(resource_type="GroundTruthJob", status=current_status)
                 time.sleep(poll)
 
 
@@ -15096,7 +15096,7 @@ class GroundTruthProject(Base):
 
                 if timeout is not None and time.time() - start_time >= timeout:
                     raise TimeoutExceededError(
-                        resouce_type="GroundTruthProject", status=current_status
+                        resource_type="GroundTruthProject", status=current_status
                     )
                 time.sleep(poll)
 
@@ -15703,7 +15703,7 @@ class Hub(Base):
                     )
 
                 if timeout is not None and time.time() - start_time >= timeout:
-                    raise TimeoutExceededError(resouce_type="Hub", status=current_status)
+                    raise TimeoutExceededError(resource_type="Hub", status=current_status)
                 time.sleep(poll)
 
     @Base.add_validate_call
@@ -15757,7 +15757,7 @@ class Hub(Base):
                     status.update(f"Current status: [bold]{current_status}")
 
                     if timeout is not None and time.time() - start_time >= timeout:
-                        raise TimeoutExceededError(resouce_type="Hub", status=current_status)
+                        raise TimeoutExceededError(resource_type="Hub", status=current_status)
                 except botocore.exceptions.ClientError as e:
                     error_code = e.response["Error"]["Code"]
 
@@ -16148,7 +16148,7 @@ class HubContent(Base):
                     return
 
                 if timeout is not None and time.time() - start_time >= timeout:
-                    raise TimeoutExceededError(resouce_type="HubContent", status=current_status)
+                    raise TimeoutExceededError(resource_type="HubContent", status=current_status)
                 time.sleep(poll)
 
     @classmethod
@@ -16940,7 +16940,7 @@ class HumanTaskUi(Base):
                     return
 
                 if timeout is not None and time.time() - start_time >= timeout:
-                    raise TimeoutExceededError(resouce_type="HumanTaskUi", status=current_status)
+                    raise TimeoutExceededError(resource_type="HumanTaskUi", status=current_status)
                 time.sleep(poll)
 
     @Base.add_validate_call
@@ -16995,7 +16995,7 @@ class HumanTaskUi(Base):
 
                     if timeout is not None and time.time() - start_time >= timeout:
                         raise TimeoutExceededError(
-                            resouce_type="HumanTaskUi", status=current_status
+                            resource_type="HumanTaskUi", status=current_status
                         )
                 except botocore.exceptions.ClientError as e:
                     error_code = e.response["Error"]["Code"]
@@ -17453,7 +17453,7 @@ class HyperParameterTuningJob(Base):
 
                 if timeout is not None and time.time() - start_time >= timeout:
                     raise TimeoutExceededError(
-                        resouce_type="HyperParameterTuningJob", status=current_status
+                        resource_type="HyperParameterTuningJob", status=current_status
                     )
                 time.sleep(poll)
 
@@ -17509,7 +17509,7 @@ class HyperParameterTuningJob(Base):
 
                     if timeout is not None and time.time() - start_time >= timeout:
                         raise TimeoutExceededError(
-                            resouce_type="HyperParameterTuningJob", status=current_status
+                            resource_type="HyperParameterTuningJob", status=current_status
                         )
                 except botocore.exceptions.ClientError as e:
                     error_code = e.response["Error"]["Code"]
@@ -18200,7 +18200,7 @@ class Image(Base):
                     )
 
                 if timeout is not None and time.time() - start_time >= timeout:
-                    raise TimeoutExceededError(resouce_type="Image", status=current_status)
+                    raise TimeoutExceededError(resource_type="Image", status=current_status)
                 time.sleep(poll)
 
     @Base.add_validate_call
@@ -18262,7 +18262,7 @@ class Image(Base):
                         )
 
                     if timeout is not None and time.time() - start_time >= timeout:
-                        raise TimeoutExceededError(resouce_type="Image", status=current_status)
+                        raise TimeoutExceededError(resource_type="Image", status=current_status)
                 except botocore.exceptions.ClientError as e:
                     error_code = e.response["Error"]["Code"]
 
@@ -18816,7 +18816,7 @@ class ImageVersion(Base):
                     )
 
                 if timeout is not None and time.time() - start_time >= timeout:
-                    raise TimeoutExceededError(resouce_type="ImageVersion", status=current_status)
+                    raise TimeoutExceededError(resource_type="ImageVersion", status=current_status)
                 time.sleep(poll)
 
     @Base.add_validate_call
@@ -18879,7 +18879,7 @@ class ImageVersion(Base):
 
                     if timeout is not None and time.time() - start_time >= timeout:
                         raise TimeoutExceededError(
-                            resouce_type="ImageVersion", status=current_status
+                            resource_type="ImageVersion", status=current_status
                         )
                 except botocore.exceptions.ClientError as e:
                     error_code = e.response["Error"]["Code"]
@@ -19242,7 +19242,7 @@ class InferenceComponent(Base):
 
                 if timeout is not None and time.time() - start_time >= timeout:
                     raise TimeoutExceededError(
-                        resouce_type="InferenceComponent", status=current_status
+                        resource_type="InferenceComponent", status=current_status
                     )
                 time.sleep(poll)
 
@@ -19298,7 +19298,7 @@ class InferenceComponent(Base):
 
                     if timeout is not None and time.time() - start_time >= timeout:
                         raise TimeoutExceededError(
-                            resouce_type="InferenceComponent", status=current_status
+                            resource_type="InferenceComponent", status=current_status
                         )
                 except botocore.exceptions.ClientError as e:
                     error_code = e.response["Error"]["Code"]
@@ -19913,7 +19913,7 @@ class InferenceExperiment(Base):
 
                 if timeout is not None and time.time() - start_time >= timeout:
                     raise TimeoutExceededError(
-                        resouce_type="InferenceExperiment", status=current_status
+                        resource_type="InferenceExperiment", status=current_status
                     )
                 time.sleep(poll)
 
@@ -20373,7 +20373,7 @@ class InferenceRecommendationsJob(Base):
 
                 if timeout is not None and time.time() - start_time >= timeout:
                     raise TimeoutExceededError(
-                        resouce_type="InferenceRecommendationsJob", status=current_status
+                        resource_type="InferenceRecommendationsJob", status=current_status
                     )
                 time.sleep(poll)
 
@@ -20433,7 +20433,7 @@ class InferenceRecommendationsJob(Base):
 
                     if timeout is not None and time.time() - start_time >= timeout:
                         raise TimeoutExceededError(
-                            resouce_type="InferenceRecommendationsJob", status=current_status
+                            resource_type="InferenceRecommendationsJob", status=current_status
                         )
                 except botocore.exceptions.ClientError as e:
                     error_code = e.response["Error"]["Code"]
@@ -20979,7 +20979,7 @@ class LabelingJob(Base):
                     return
 
                 if timeout is not None and time.time() - start_time >= timeout:
-                    raise TimeoutExceededError(resouce_type="LabelingJob", status=current_status)
+                    raise TimeoutExceededError(resource_type="LabelingJob", status=current_status)
                 time.sleep(poll)
 
     @classmethod
@@ -21882,7 +21882,7 @@ class MlflowApp(Base):
                     )
 
                 if timeout is not None and time.time() - start_time >= timeout:
-                    raise TimeoutExceededError(resouce_type="MlflowApp", status=current_status)
+                    raise TimeoutExceededError(resource_type="MlflowApp", status=current_status)
                 time.sleep(poll)
 
     @Base.add_validate_call
@@ -21940,7 +21940,7 @@ class MlflowApp(Base):
                         return
 
                     if timeout is not None and time.time() - start_time >= timeout:
-                        raise TimeoutExceededError(resouce_type="MlflowApp", status=current_status)
+                        raise TimeoutExceededError(resource_type="MlflowApp", status=current_status)
                 except botocore.exceptions.ClientError as e:
                     error_code = e.response["Error"]["Code"]
 
@@ -22508,7 +22508,7 @@ class MlflowTrackingServer(Base):
 
                 if timeout is not None and time.time() - start_time >= timeout:
                     raise TimeoutExceededError(
-                        resouce_type="MlflowTrackingServer", status=current_status
+                        resource_type="MlflowTrackingServer", status=current_status
                     )
                 time.sleep(poll)
 
@@ -22564,7 +22564,7 @@ class MlflowTrackingServer(Base):
 
                     if timeout is not None and time.time() - start_time >= timeout:
                         raise TimeoutExceededError(
-                            resouce_type="MlflowTrackingServer", status=current_status
+                            resource_type="MlflowTrackingServer", status=current_status
                         )
                 except botocore.exceptions.ClientError as e:
                     error_code = e.response["Error"]["Code"]
@@ -23759,7 +23759,7 @@ class ModelCard(Base):
                     return
 
                 if timeout is not None and time.time() - start_time >= timeout:
-                    raise TimeoutExceededError(resouce_type="ModelCard", status=current_status)
+                    raise TimeoutExceededError(resource_type="ModelCard", status=current_status)
                 time.sleep(poll)
 
     @classmethod
@@ -24177,7 +24177,7 @@ class ModelCardExportJob(Base):
 
                 if timeout is not None and time.time() - start_time >= timeout:
                     raise TimeoutExceededError(
-                        resouce_type="ModelCardExportJob", status=current_status
+                        resource_type="ModelCardExportJob", status=current_status
                     )
                 time.sleep(poll)
 
@@ -25290,7 +25290,7 @@ class ModelPackage(Base):
                     )
 
                 if timeout is not None and time.time() - start_time >= timeout:
-                    raise TimeoutExceededError(resouce_type="ModelPackage", status=current_status)
+                    raise TimeoutExceededError(resource_type="ModelPackage", status=current_status)
                 time.sleep(poll)
 
     @Base.add_validate_call
@@ -25345,7 +25345,7 @@ class ModelPackage(Base):
 
                     if timeout is not None and time.time() - start_time >= timeout:
                         raise TimeoutExceededError(
-                            resouce_type="ModelPackage", status=current_status
+                            resource_type="ModelPackage", status=current_status
                         )
                 except botocore.exceptions.ClientError as e:
                     error_code = e.response["Error"]["Code"]
@@ -25759,7 +25759,7 @@ class ModelPackageGroup(Base):
 
                 if timeout is not None and time.time() - start_time >= timeout:
                     raise TimeoutExceededError(
-                        resouce_type="ModelPackageGroup", status=current_status
+                        resource_type="ModelPackageGroup", status=current_status
                     )
                 time.sleep(poll)
 
@@ -25815,7 +25815,7 @@ class ModelPackageGroup(Base):
 
                     if timeout is not None and time.time() - start_time >= timeout:
                         raise TimeoutExceededError(
-                            resouce_type="ModelPackageGroup", status=current_status
+                            resource_type="ModelPackageGroup", status=current_status
                         )
                 except botocore.exceptions.ClientError as e:
                     error_code = e.response["Error"]["Code"]
@@ -26817,7 +26817,7 @@ class MonitoringExecution(Base):
 
                 if timeout is not None and time.time() - start_time >= timeout:
                     raise TimeoutExceededError(
-                        resouce_type="MonitoringExecution", status=current_status
+                        resource_type="MonitoringExecution", status=current_status
                     )
                 time.sleep(poll)
 
@@ -27373,7 +27373,7 @@ class MonitoringSchedule(Base):
 
                 if timeout is not None and time.time() - start_time >= timeout:
                     raise TimeoutExceededError(
-                        resouce_type="MonitoringSchedule", status=current_status
+                        resource_type="MonitoringSchedule", status=current_status
                     )
                 time.sleep(poll)
 
@@ -27996,7 +27996,7 @@ class NotebookInstance(Base):
 
                 if timeout is not None and time.time() - start_time >= timeout:
                     raise TimeoutExceededError(
-                        resouce_type="NotebookInstance", status=current_status
+                        resource_type="NotebookInstance", status=current_status
                     )
                 time.sleep(poll)
 
@@ -28052,7 +28052,7 @@ class NotebookInstance(Base):
 
                     if timeout is not None and time.time() - start_time >= timeout:
                         raise TimeoutExceededError(
-                            resouce_type="NotebookInstance", status=current_status
+                            resource_type="NotebookInstance", status=current_status
                         )
                 except botocore.exceptions.ClientError as e:
                     error_code = e.response["Error"]["Code"]
@@ -28879,7 +28879,7 @@ class OptimizationJob(Base):
 
                 if timeout is not None and time.time() - start_time >= timeout:
                     raise TimeoutExceededError(
-                        resouce_type="OptimizationJob", status=current_status
+                        resource_type="OptimizationJob", status=current_status
                     )
                 time.sleep(poll)
 
@@ -29458,7 +29458,7 @@ class PartnerApp(Base):
                     )
 
                 if timeout is not None and time.time() - start_time >= timeout:
-                    raise TimeoutExceededError(resouce_type="PartnerApp", status=current_status)
+                    raise TimeoutExceededError(resource_type="PartnerApp", status=current_status)
                 time.sleep(poll)
 
     @Base.add_validate_call
@@ -29516,7 +29516,7 @@ class PartnerApp(Base):
                         return
 
                     if timeout is not None and time.time() - start_time >= timeout:
-                        raise TimeoutExceededError(resouce_type="PartnerApp", status=current_status)
+                        raise TimeoutExceededError(resource_type="PartnerApp", status=current_status)
                 except botocore.exceptions.ClientError as e:
                     error_code = e.response["Error"]["Code"]
 
@@ -29954,7 +29954,7 @@ class PersistentVolume(Base):
 
                 if timeout is not None and time.time() - start_time >= timeout:
                     raise TimeoutExceededError(
-                        resouce_type="PersistentVolume", status=current_status
+                        resource_type="PersistentVolume", status=current_status
                     )
                 time.sleep(poll)
 
@@ -30010,7 +30010,7 @@ class PersistentVolume(Base):
 
                     if timeout is not None and time.time() - start_time >= timeout:
                         raise TimeoutExceededError(
-                            resouce_type="PersistentVolume", status=current_status
+                            resource_type="PersistentVolume", status=current_status
                         )
                 except botocore.exceptions.ClientError as e:
                     error_code = e.response["Error"]["Code"]
@@ -30411,7 +30411,7 @@ class Pipeline(Base):
                     return
 
                 if timeout is not None and time.time() - start_time >= timeout:
-                    raise TimeoutExceededError(resouce_type="Pipeline", status=current_status)
+                    raise TimeoutExceededError(resource_type="Pipeline", status=current_status)
                 time.sleep(poll)
 
     @Base.add_validate_call
@@ -30465,7 +30465,7 @@ class Pipeline(Base):
                     status.update(f"Current status: [bold]{current_status}")
 
                     if timeout is not None and time.time() - start_time >= timeout:
-                        raise TimeoutExceededError(resouce_type="Pipeline", status=current_status)
+                        raise TimeoutExceededError(resource_type="Pipeline", status=current_status)
                 except botocore.exceptions.ClientError as e:
                     error_code = e.response["Error"]["Code"]
 
@@ -30877,7 +30877,7 @@ class PipelineExecution(Base):
 
                 if timeout is not None and time.time() - start_time >= timeout:
                     raise TimeoutExceededError(
-                        resouce_type="PipelineExecution", status=current_status
+                        resource_type="PipelineExecution", status=current_status
                     )
                 time.sleep(poll)
 
@@ -32164,7 +32164,7 @@ class ProcessingJob(Base):
                     return
 
                 if timeout is not None and time.time() - start_time >= timeout:
-                    raise TimeoutExceededError(resouce_type="ProcessingJob", status=current_status)
+                    raise TimeoutExceededError(resource_type="ProcessingJob", status=current_status)
                 time.sleep(poll)
 
     @classmethod
@@ -32913,7 +32913,7 @@ class Project(Base):
                     )
 
                 if timeout is not None and time.time() - start_time >= timeout:
-                    raise TimeoutExceededError(resouce_type="Project", status=current_status)
+                    raise TimeoutExceededError(resource_type="Project", status=current_status)
                 time.sleep(poll)
 
     @classmethod
@@ -33382,7 +33382,7 @@ class QuotaAllocation(Base):
 
                 if timeout is not None and time.time() - start_time >= timeout:
                     raise TimeoutExceededError(
-                        resouce_type="QuotaAllocation", status=current_status
+                        resource_type="QuotaAllocation", status=current_status
                     )
                 time.sleep(poll)
 
@@ -33442,7 +33442,7 @@ class QuotaAllocation(Base):
 
                     if timeout is not None and time.time() - start_time >= timeout:
                         raise TimeoutExceededError(
-                            resouce_type="QuotaAllocation", status=current_status
+                            resource_type="QuotaAllocation", status=current_status
                         )
                 except botocore.exceptions.ClientError as e:
                     error_code = e.response["Error"]["Code"]
@@ -34463,7 +34463,7 @@ class Space(Base):
                     )
 
                 if timeout is not None and time.time() - start_time >= timeout:
-                    raise TimeoutExceededError(resouce_type="Space", status=current_status)
+                    raise TimeoutExceededError(resource_type="Space", status=current_status)
                 time.sleep(poll)
 
     @Base.add_validate_call
@@ -34525,7 +34525,7 @@ class Space(Base):
                         )
 
                     if timeout is not None and time.time() - start_time >= timeout:
-                        raise TimeoutExceededError(resouce_type="Space", status=current_status)
+                        raise TimeoutExceededError(resource_type="Space", status=current_status)
                 except botocore.exceptions.ClientError as e:
                     error_code = e.response["Error"]["Code"]
 
@@ -35942,7 +35942,7 @@ class TrainingJob(Base):
 
                     if timeout is not None and time.time() - start_time >= timeout:
                         raise TimeoutExceededError(
-                            resouce_type="TrainingJob", status=current_status
+                            resource_type="TrainingJob", status=current_status
                         )
                 except botocore.exceptions.ClientError as e:
                     error_code = e.response["Error"]["Code"]
@@ -36728,7 +36728,7 @@ class TrainingPlan(Base):
                     )
 
                 if timeout is not None and time.time() - start_time >= timeout:
-                    raise TimeoutExceededError(resouce_type="TrainingPlan", status=current_status)
+                    raise TimeoutExceededError(resource_type="TrainingPlan", status=current_status)
                 time.sleep(poll)
 
     @classmethod
@@ -37308,7 +37308,7 @@ class TransformJob(Base):
                     return
 
                 if timeout is not None and time.time() - start_time >= timeout:
-                    raise TimeoutExceededError(resouce_type="TransformJob", status=current_status)
+                    raise TimeoutExceededError(resource_type="TransformJob", status=current_status)
                 time.sleep(poll)
 
     @classmethod
@@ -38381,7 +38381,7 @@ class TrialComponent(Base):
                     )
 
                 if timeout is not None and time.time() - start_time >= timeout:
-                    raise TimeoutExceededError(resouce_type="TrialComponent", status=current_status)
+                    raise TimeoutExceededError(resource_type="TrialComponent", status=current_status)
                 time.sleep(poll)
 
     @Base.add_validate_call
@@ -38436,7 +38436,7 @@ class TrialComponent(Base):
 
                     if timeout is not None and time.time() - start_time >= timeout:
                         raise TimeoutExceededError(
-                            resouce_type="TrialComponent", status=current_status
+                            resource_type="TrialComponent", status=current_status
                         )
                 except botocore.exceptions.ClientError as e:
                     error_code = e.response["Error"]["Code"]
@@ -39451,7 +39451,7 @@ class UserProfile(Base):
                     )
 
                 if timeout is not None and time.time() - start_time >= timeout:
-                    raise TimeoutExceededError(resouce_type="UserProfile", status=current_status)
+                    raise TimeoutExceededError(resource_type="UserProfile", status=current_status)
                 time.sleep(poll)
 
     @Base.add_validate_call
@@ -39514,7 +39514,7 @@ class UserProfile(Base):
 
                     if timeout is not None and time.time() - start_time >= timeout:
                         raise TimeoutExceededError(
-                            resouce_type="UserProfile", status=current_status
+                            resource_type="UserProfile", status=current_status
                         )
                 except botocore.exceptions.ClientError as e:
                     error_code = e.response["Error"]["Code"]
@@ -39941,7 +39941,7 @@ class Workforce(Base):
                     )
 
                 if timeout is not None and time.time() - start_time >= timeout:
-                    raise TimeoutExceededError(resouce_type="Workforce", status=current_status)
+                    raise TimeoutExceededError(resource_type="Workforce", status=current_status)
                 time.sleep(poll)
 
     @Base.add_validate_call
@@ -39995,7 +39995,7 @@ class Workforce(Base):
                     status.update(f"Current status: [bold]{current_status}")
 
                     if timeout is not None and time.time() - start_time >= timeout:
-                        raise TimeoutExceededError(resouce_type="Workforce", status=current_status)
+                        raise TimeoutExceededError(resource_type="Workforce", status=current_status)
                 except botocore.exceptions.ClientError as e:
                     error_code = e.response["Error"]["Code"]
 

--- a/sagemaker-core/src/sagemaker/core/resources.py
+++ b/sagemaker-core/src/sagemaker/core/resources.py
@@ -35883,7 +35883,11 @@ class TrainingJob(Base):
                     return
 
                 if timeout is not None and time.time() - start_time >= timeout:
-                    raise TimeoutExceededError(resouce_type="TrainingJob", status=current_status)
+                    raise TimeoutExceededError(
+                        resource_type="TrainingJob",
+                        status=current_status,
+                        message="Your training job is still running. Call .refresh() to check its current status.",
+                    )
                 time.sleep(poll)
 
     @Base.add_validate_call

--- a/sagemaker-core/src/sagemaker/core/tools/constants.py
+++ b/sagemaker-core/src/sagemaker/core/tools/constants.py
@@ -22,6 +22,11 @@ TERMINAL_STATES = set(["Completed", "Stopped", "Deleted", "Failed", "Succeeded",
 
 RESOURCE_WITH_LOGS = set(["TrainingJob", "ProcessingJob", "TransformJob"])
 
+DEFAULT_TIMEOUT_MESSAGE = "Increase the timeout and try again."
+RESOURCE_TIMEOUT_MESSAGES = {
+    "TrainingJob": "Your training job is still running. Call .refresh() to check its current status.",
+}
+
 CONFIGURABLE_ATTRIBUTE_SUBSTRINGS = [
     "kms",
     "s3",

--- a/sagemaker-core/src/sagemaker/core/tools/resources_codegen.py
+++ b/sagemaker-core/src/sagemaker/core/tools/resources_codegen.py
@@ -30,6 +30,8 @@ from sagemaker.core.tools.constants import (
     PYTHON_TYPES_TO_BASIC_JSON_TYPES,
     CONFIGURABLE_ATTRIBUTE_SUBSTRINGS,
     RESOURCE_WITH_LOGS,
+    DEFAULT_TIMEOUT_MESSAGE,
+    RESOURCE_TIMEOUT_MESSAGES,
 )
 from sagemaker.core.tools.method import Method, MethodType
 from sagemaker.core.utils.utils import (
@@ -1742,6 +1744,7 @@ class ResourcesCodeGen:
             logs_arg_doc=logs_arg_doc,
             init_wait_logs=init_wait_logs,
             print_wait_logs=print_wait_logs,
+            timeout_message=RESOURCE_TIMEOUT_MESSAGES.get(resource_name, DEFAULT_TIMEOUT_MESSAGE),
         )
         return formatted_method
 

--- a/sagemaker-core/src/sagemaker/core/tools/templates.py
+++ b/sagemaker-core/src/sagemaker/core/tools/templates.py
@@ -332,7 +332,7 @@ def wait(
                 return
 
             if timeout is not None and time.time() - start_time >= timeout:
-                raise TimeoutExceededError(resouce_type="{resource_name}", status=current_status)
+                raise TimeoutExceededError(resource_type="{resource_name}", status=current_status)
             time.sleep(poll)
 '''
 
@@ -385,7 +385,7 @@ def wait_for_status(
                 return
 {failed_error_block}
             if timeout is not None and time.time() - start_time >= timeout:
-                raise TimeoutExceededError(resouce_type="{resource_name}", status=current_status)
+                raise TimeoutExceededError(resource_type="{resource_name}", status=current_status)
             time.sleep(poll)
 '''
 
@@ -436,7 +436,7 @@ def wait_for_delete(
 {deleted_status_check}
 
                 if timeout is not None and time.time() - start_time >= timeout:
-                    raise TimeoutExceededError(resouce_type="{resource_name}", status=current_status)
+                    raise TimeoutExceededError(resource_type="{resource_name}", status=current_status)
             except botocore.exceptions.ClientError as e:
                 error_code = e.response["Error"]["Code"]
                 

--- a/sagemaker-core/src/sagemaker/core/tools/templates.py
+++ b/sagemaker-core/src/sagemaker/core/tools/templates.py
@@ -332,7 +332,7 @@ def wait(
                 return
 
             if timeout is not None and time.time() - start_time >= timeout:
-                raise TimeoutExceededError(resource_type="{resource_name}", status=current_status)
+                raise TimeoutExceededError(resource_type="{resource_name}", status=current_status, message="{timeout_message}")
             time.sleep(poll)
 '''
 

--- a/sagemaker-core/src/sagemaker/core/utils/exceptions.py
+++ b/sagemaker-core/src/sagemaker/core/utils/exceptions.py
@@ -79,16 +79,16 @@ class DeleteFailedStatusError(WaiterError):
 class TimeoutExceededError(WaiterError):
     """Raised when a specified timeout is exceeded"""
 
-    fmt = "Timeout exceeded while waiting for {resource_type}. Final Resource State: {status}. Increase the timeout and try again."
+    fmt = "Timeout exceeded while waiting for {resource_type}. Final Resource State: {status}. {message}"
 
-    def __init__(self, resource_type="(Unkown)", status="(Unkown)", reason="(Unkown)"):
+    def __init__(self, resource_type="(Unkown)", status="(Unkown)", message="Increase the timeout and try again."):
         """Initialize a TimeoutExceededError exception.
         Args:
             resource_type (str): The type of resource being waited on.
             status (str): The final status of the resource.
-            reason (str): The reason the resource entered a failed state.
+            message (str): Additional context or guidance for the user.
         """
-        super().__init__(resource_type=resource_type, status=status, reason=reason)
+        super().__init__(resource_type=resource_type, status=status, message=message)
 
 
 ### Intelligent Defaults Errors

--- a/sagemaker-core/src/sagemaker/core/utils/exceptions.py
+++ b/sagemaker-core/src/sagemaker/core/utils/exceptions.py
@@ -81,14 +81,15 @@ class TimeoutExceededError(WaiterError):
 
     fmt = "Timeout exceeded while waiting for {resource_type}. Final Resource State: {status}. {message}"
 
-    def __init__(self, resource_type="(Unkown)", status="(Unkown)", message="Increase the timeout and try again."):
+    def __init__(self, resource_type="(Unkown)", status="(Unkown)", reason="(Unkown)", message="Increase the timeout and try again."):
         """Initialize a TimeoutExceededError exception.
         Args:
             resource_type (str): The type of resource being waited on.
             status (str): The final status of the resource.
+            reason (str): The reason the resource entered a failed state.
             message (str): Additional context or guidance for the user.
         """
-        super().__init__(resource_type=resource_type, status=status, message=message)
+        super().__init__(resource_type=resource_type, status=status, reason=reason, message=message)
 
 
 ### Intelligent Defaults Errors

--- a/sagemaker-core/tests/unit/utils/test_exceptions.py
+++ b/sagemaker-core/tests/unit/utils/test_exceptions.py
@@ -1,0 +1,31 @@
+from sagemaker.core.utils.exceptions import TimeoutExceededError
+
+
+class TestTimeoutExceededError:
+    def test_default_message(self):
+        """Default message should match original behavior."""
+        err = TimeoutExceededError(resource_type="TrainingJob", status="InProgress")
+        assert str(err) == (
+            "Timeout exceeded while waiting for TrainingJob. "
+            "Final Resource State: InProgress. "
+            "Increase the timeout and try again."
+        )
+
+    def test_custom_message(self):
+        """Custom message should replace the default."""
+        err = TimeoutExceededError(
+            resource_type="EvaluationJob",
+            status="Executing",
+            message="Your evaluation job is still running. Call .refresh() to check its current status.",
+        )
+        assert str(err) == (
+            "Timeout exceeded while waiting for EvaluationJob. "
+            "Final Resource State: Executing. "
+            "Your evaluation job is still running. Call .refresh() to check its current status."
+        )
+
+    def test_default_params(self):
+        """No args should use defaults without crashing."""
+        err = TimeoutExceededError()
+        assert "(Unkown)" in str(err)
+        assert "Increase the timeout and try again." in str(err)

--- a/sagemaker-train/src/sagemaker/train/evaluate/execution.py
+++ b/sagemaker-train/src/sagemaker/train/evaluate/execution.py
@@ -1128,8 +1128,9 @@ class EvaluationPipelineExecution(BaseModel):
                 if timeout is not None and time.time() - start_time >= timeout:
                     from sagemaker.core.utils.exceptions import TimeoutExceededError
                     raise TimeoutExceededError(
-                        resource_type="PipelineExecution", 
-                        status=current_status
+                        resource_type="EvaluationJob", 
+                        status=current_status,
+                        message="Your evaluation job is still running. Use execution.refresh() to check its current status.",
                     )
                 
                 time.sleep(poll)
@@ -1179,8 +1180,9 @@ class EvaluationPipelineExecution(BaseModel):
                         if timeout is not None and time.time() - start_time >= timeout:
                             from sagemaker.core.utils.exceptions import TimeoutExceededError
                             raise TimeoutExceededError(
-                                resource_type="PipelineExecution",
-                                status=current_status
+                                resource_type="EvaluationJob",
+                                status=current_status,
+                                message="Your evaluation job is still running. Use execution.refresh() to check its current status.",
                             )
                         
                         time.sleep(poll)
@@ -1208,8 +1210,9 @@ class EvaluationPipelineExecution(BaseModel):
                     if timeout is not None and elapsed >= timeout:
                         from sagemaker.core.utils.exceptions import TimeoutExceededError
                         raise TimeoutExceededError(
-                            resource_type="PipelineExecution",
-                            status=current_status
+                            resource_type="EvaluationJob",
+                            status=current_status,
+                            message="Your evaluation job is still running. Use execution.refresh() to check its current status.",
                         )
                     
                     time.sleep(poll)

--- a/sagemaker-train/src/sagemaker/train/evaluate/execution.py
+++ b/sagemaker-train/src/sagemaker/train/evaluate/execution.py
@@ -1130,7 +1130,7 @@ class EvaluationPipelineExecution(BaseModel):
                     raise TimeoutExceededError(
                         resource_type="EvaluationJob", 
                         status=current_status,
-                        message="Your evaluation job is still running. Use execution.refresh() to check its current status.",
+                        message="Your evaluation job is still running. Call .refresh() to check its current status.",
                     )
                 
                 time.sleep(poll)
@@ -1182,7 +1182,7 @@ class EvaluationPipelineExecution(BaseModel):
                             raise TimeoutExceededError(
                                 resource_type="EvaluationJob",
                                 status=current_status,
-                                message="Your evaluation job is still running. Use execution.refresh() to check its current status.",
+                                message="Your evaluation job is still running. Call .refresh() to check its current status.",
                             )
                         
                         time.sleep(poll)
@@ -1212,7 +1212,7 @@ class EvaluationPipelineExecution(BaseModel):
                         raise TimeoutExceededError(
                             resource_type="EvaluationJob",
                             status=current_status,
-                            message="Your evaluation job is still running. Use execution.refresh() to check its current status.",
+                            message="Your evaluation job is still running. Call .refresh() to check its current status.",
                         )
                     
                     time.sleep(poll)

--- a/sagemaker-train/tests/unit/train/evaluate/test_execution.py
+++ b/sagemaker-train/tests/unit/train/evaluate/test_execution.py
@@ -1132,8 +1132,10 @@ class TestEvaluationPipelineExecutionWait:
         # Mock time to simulate timeout
         mock_time.side_effect = [0, 10, 20, 30, 40, 50, 60]  # Exceeds timeout
         
-        with pytest.raises(TimeoutExceededError):
+        with pytest.raises(TimeoutExceededError, match="EvaluationJob") as exc_info:
             execution.wait(target_status="Succeeded", poll=1, timeout=5)
+        assert "still running" in str(exc_info.value)
+        assert "refresh()" in str(exc_info.value)
 
     def test_wait_without_pipeline_execution(self):
         """Test wait when no pipeline execution is set."""

--- a/sagemaker-train/tests/unit/train/evaluate/test_execution.py
+++ b/sagemaker-train/tests/unit/train/evaluate/test_execution.py
@@ -1135,7 +1135,7 @@ class TestEvaluationPipelineExecutionWait:
         with pytest.raises(TimeoutExceededError, match="EvaluationJob") as exc_info:
             execution.wait(target_status="Succeeded", poll=1, timeout=5)
         assert "still running" in str(exc_info.value)
-        assert "refresh()" in str(exc_info.value)
+        assert ".refresh()" in str(exc_info.value)
 
     def test_wait_without_pipeline_execution(self):
         """Test wait when no pipeline execution is set."""


### PR DESCRIPTION
Improve timeout error messages for TrainingJob and EvaluationJob waits

When wait() times out, the current error says "Increase the timeout and try again" — which implies the job stopped and needs to be re-created. In reality, the job is still running server-side; only the client-side polling stopped.

Changes:

- Add message parameter to TimeoutExceededError so callers can provide context-specific guidance (defaults to existing message for backward compat)
- TrainingJob.wait(): timeout now says "Your training job is still running. Call .refresh() to check its current status."
- EvaluationPipelineExecution.wait(): timeout now says "Your evaluation job is still running. Use .refresh() to check its current status." Also changes resource_type from PipelineExecution to EvaluationJob for clarity.
- Fix pre-existing typo resouce_type → resource_type in TrainingJob.wait() (would have caused TypeError at runtime)