### PR TITLE
fix-windows-crlf-sm-train

### DIFF
--- a/sagemaker-train/src/sagemaker/train/model_trainer.py
+++ b/sagemaker-train/src/sagemaker/train/model_trainer.py
@@ -1053,7 +1053,7 @@ class ModelTrainer(BaseModel):
             execute_driver=execute_driver,
         )
 
-        with open(os.path.join(tmp_dir.name, TRAIN_SCRIPT), "w") as f:
+        with open(os.path.join(tmp_dir.name, TRAIN_SCRIPT), "w", newline="\n" ) as f:
             f.write(train_script)
 
     @classmethod


### PR DESCRIPTION
fix: force Unix newlines in ModelTrainer driver scripts to prevent CRLF exit code 2 on Windows

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
