### PR TITLE
fix: potential s3 path traversal

### DIFF
--- a/sagemaker-core/src/sagemaker/core/common_utils.py
+++ b/sagemaker-core/src/sagemaker/core/common_utils.py
@@ -467,13 +467,7 @@ def _download_files_under_prefix(bucket_name, prefix, target, s3):
         s3_relative_path = obj_sum.key[len(prefix) :].lstrip("/")
         file_path = os.path.join(target, s3_relative_path)
 
-        # Validate that the resolved file path stays within the target directory
-        file_path_real = os.path.realpath(file_path)
-        if not file_path_real.startswith(target_real + os.sep) and file_path_real != target_real:
-            raise ValueError(
-                f"Path traversal detected: S3 key '{obj_sum.key}' resolves to "
-                f"'{file_path_real}' which is outside the target directory '{target_real}'"
-            )
+        validate_path_within_directory(file_path, target, source_description=obj_sum.key)
 
         try:
             os.makedirs(os.path.dirname(file_path))
@@ -1681,6 +1675,31 @@ def _get_resolved_path(path):
     and handles platform-specific differences
     """
     return normpath(realpath(abspath(path)))
+
+
+def validate_path_within_directory(file_path, target_directory, source_description=""):
+    """Validate that file_path resolves to a location within target_directory.
+
+    Prevents path traversal attacks (CWE-22) by resolving both paths to their
+    canonical forms and checking containment.
+
+    Args:
+        file_path (str): The file path to validate.
+        target_directory (str): The directory that file_path must stay within.
+        source_description (str): Optional description of the source (e.g. S3 key)
+            included in the error message for debugging.
+
+    Raises:
+        ValueError: If file_path resolves to a location outside target_directory.
+    """
+    target_real = os.path.realpath(target_directory)
+    file_real = os.path.realpath(file_path)
+    if not file_real.startswith(target_real + os.sep) and file_real != target_real:
+        source_info = f"'{source_description}' resolves to " if source_description else ""
+        raise ValueError(
+            f"Path traversal detected: {source_info}"
+            f"'{file_real}' which is outside the target directory '{target_real}'"
+        )
 
 
 def _is_bad_path(path, base):

--- a/sagemaker-core/src/sagemaker/core/common_utils.py
+++ b/sagemaker-core/src/sagemaker/core/common_utils.py
@@ -457,6 +457,7 @@ def _download_files_under_prefix(bucket_name, prefix, target, s3):
         target (str): destination path where the downloaded items will be placed
         s3 (boto3.resources.base.ServiceResource): S3 resource
     """
+    target_real = os.path.realpath(target)
     bucket = s3.Bucket(bucket_name)
     for obj_sum in bucket.objects.filter(Prefix=prefix):
         # if obj_sum is a folder object skip it.
@@ -465,6 +466,14 @@ def _download_files_under_prefix(bucket_name, prefix, target, s3):
         obj = s3.Object(obj_sum.bucket_name, obj_sum.key)
         s3_relative_path = obj_sum.key[len(prefix) :].lstrip("/")
         file_path = os.path.join(target, s3_relative_path)
+
+        # Validate that the resolved file path stays within the target directory
+        file_path_real = os.path.realpath(file_path)
+        if not file_path_real.startswith(target_real + os.sep) and file_path_real != target_real:
+            raise ValueError(
+                f"Path traversal detected: S3 key '{obj_sum.key}' resolves to "
+                f"'{file_path_real}' which is outside the target directory '{target_real}'"
+            )
 
         try:
             os.makedirs(os.path.dirname(file_path))

--- a/sagemaker-core/src/sagemaker/core/helper/session_helper.py
+++ b/sagemaker-core/src/sagemaker/core/helper/session_helper.py
@@ -543,13 +543,37 @@ class Session(object):  # pylint: disable=too-many-public-methods
         # For each object key, create the directory on the local machine if needed, and then
         # download the file.
         downloaded_paths = []
+        path_real = os.path.realpath(path)
         for dir_path in directories:
+            # Validate directory paths stay within the target directory
+            dir_path_real = os.path.realpath(dir_path)
+            if (
+                not dir_path_real.startswith(path_real + os.sep)
+                and dir_path_real != path_real
+            ):
+                raise ValueError(
+                    f"Path traversal detected: S3 key resolves to "
+                    f"'{dir_path_real}' which is outside the target directory '{path_real}'"
+                )
             os.makedirs(os.path.dirname(dir_path), exist_ok=True)
         for key in keys:
             tail_s3_uri_path = os.path.basename(key)
             if not os.path.splitext(key_prefix)[1]:
                 tail_s3_uri_path = os.path.relpath(key, key_prefix)
             destination_path = os.path.join(path, tail_s3_uri_path)
+
+            # Validate that the resolved destination stays within the target directory
+            destination_path_real = os.path.realpath(destination_path)
+            if (
+                not destination_path_real.startswith(path_real + os.sep)
+                and destination_path_real != path_real
+            ):
+                raise ValueError(
+                    f"Path traversal detected: S3 key '{key}' resolves to "
+                    f"'{destination_path_real}' which is outside the target "
+                    f"directory '{path_real}'"
+                )
+
             if not os.path.exists(os.path.dirname(destination_path)):
                 os.makedirs(os.path.dirname(destination_path), exist_ok=True)
             s3.download_file(

--- a/sagemaker-core/src/sagemaker/core/helper/session_helper.py
+++ b/sagemaker-core/src/sagemaker/core/helper/session_helper.py
@@ -51,6 +51,7 @@ from sagemaker.core.common_utils import (
     TagsDict,
     instance_supports_kms,
     create_paginator_config,
+    validate_path_within_directory,
 )
 
 from sagemaker.core.config.config_utils import _log_sagemaker_config_merge
@@ -545,16 +546,7 @@ class Session(object):  # pylint: disable=too-many-public-methods
         downloaded_paths = []
         path_real = os.path.realpath(path)
         for dir_path in directories:
-            # Validate directory paths stay within the target directory
-            dir_path_real = os.path.realpath(dir_path)
-            if (
-                not dir_path_real.startswith(path_real + os.sep)
-                and dir_path_real != path_real
-            ):
-                raise ValueError(
-                    f"Path traversal detected: S3 key resolves to "
-                    f"'{dir_path_real}' which is outside the target directory '{path_real}'"
-                )
+            validate_path_within_directory(dir_path, path)
             os.makedirs(os.path.dirname(dir_path), exist_ok=True)
         for key in keys:
             tail_s3_uri_path = os.path.basename(key)
@@ -562,17 +554,9 @@ class Session(object):  # pylint: disable=too-many-public-methods
                 tail_s3_uri_path = os.path.relpath(key, key_prefix)
             destination_path = os.path.join(path, tail_s3_uri_path)
 
-            # Validate that the resolved destination stays within the target directory
-            destination_path_real = os.path.realpath(destination_path)
-            if (
-                not destination_path_real.startswith(path_real + os.sep)
-                and destination_path_real != path_real
-            ):
-                raise ValueError(
-                    f"Path traversal detected: S3 key '{key}' resolves to "
-                    f"'{destination_path_real}' which is outside the target "
-                    f"directory '{path_real}'"
-                )
+            validate_path_within_directory(
+                destination_path, path, source_description=key
+            )
 
             if not os.path.exists(os.path.dirname(destination_path)):
                 os.makedirs(os.path.dirname(destination_path), exist_ok=True)

--- a/sagemaker-core/src/sagemaker/core/local/entities.py
+++ b/sagemaker-core/src/sagemaker/core/local/entities.py
@@ -28,7 +28,12 @@ from sagemaker.core.local.utils import (
     move_to_destination,
     get_docker_host,
 )
-from sagemaker.core.common_utils import DeferredError, get_config_value, format_tags
+from sagemaker.core.common_utils import (
+    DeferredError,
+    get_config_value,
+    format_tags,
+    validate_path_within_directory,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -517,17 +522,9 @@ class _LocalTransformJob(object):
             filename = os.path.basename(fn)
             destination_path = os.path.join(working_dir, relative_path, filename + ".out")
 
-            # Validate that the destination stays within the working directory
-            destination_path_real = os.path.realpath(destination_path)
-            if (
-                not destination_path_real.startswith(working_dir_real + os.sep)
-                and destination_path_real != working_dir_real
-            ):
-                raise ValueError(
-                    f"Path traversal detected: file '{fn}' resolves to "
-                    f"'{destination_path_real}' which is outside the working "
-                    f"directory '{working_dir_real}'"
-                )
+            validate_path_within_directory(
+                destination_path, working_dir, source_description=fn
+            )
 
             copy_directory_structure(working_dir, relative_path)
 

--- a/sagemaker-core/src/sagemaker/core/local/entities.py
+++ b/sagemaker-core/src/sagemaker/core/local/entities.py
@@ -509,13 +509,27 @@ class _LocalTransformJob(object):
 
         working_dir = self._get_working_directory()
         dataset_dir = data_source.get_root_dir()
+        working_dir_real = os.path.realpath(working_dir)
 
         for fn in data_source.get_file_list():
 
             relative_path = os.path.dirname(os.path.relpath(fn, dataset_dir))
             filename = os.path.basename(fn)
-            copy_directory_structure(working_dir, relative_path)
             destination_path = os.path.join(working_dir, relative_path, filename + ".out")
+
+            # Validate that the destination stays within the working directory
+            destination_path_real = os.path.realpath(destination_path)
+            if (
+                not destination_path_real.startswith(working_dir_real + os.sep)
+                and destination_path_real != working_dir_real
+            ):
+                raise ValueError(
+                    f"Path traversal detected: file '{fn}' resolves to "
+                    f"'{destination_path_real}' which is outside the working "
+                    f"directory '{working_dir_real}'"
+                )
+
+            copy_directory_structure(working_dir, relative_path)
 
             with open(destination_path, "wb") as f:
                 for item in batch_provider.pad(fn, max_payload):

--- a/sagemaker-core/tests/unit/helper/test_session_helper.py
+++ b/sagemaker-core/tests/unit/helper/test_session_helper.py
@@ -651,6 +651,89 @@ class TestDownloadDataWithDirectories:
         mock_s3_client.download_file.assert_called_once()
 
 
+class TestDownloadDataPathTraversal:
+    """Test download_data blocks path traversal attacks via crafted S3 keys."""
+
+    def test_path_traversal_in_file_key(self, mock_boto_session, mock_sagemaker_client, tmp_path):
+        """Test that S3 keys with '..' traversal sequences are blocked."""
+        mock_s3_client = Mock()
+        mock_s3_client.list_objects_v2.return_value = {
+            "Contents": [
+                {"Key": "data/../../../../etc/passwd", "Size": 100},
+            ]
+        }
+
+        session = Session(boto_session=mock_boto_session, sagemaker_client=mock_sagemaker_client)
+        session.s3_client = mock_s3_client
+
+        with pytest.raises(ValueError, match="Path traversal detected"):
+            session.download_data(
+                path=str(tmp_path), bucket="test-bucket", key_prefix="data/"
+            )
+
+        mock_s3_client.download_file.assert_not_called()
+
+    def test_path_traversal_in_directory_key(
+        self, mock_boto_session, mock_sagemaker_client, tmp_path
+    ):
+        """Test that directory keys resolving outside target are blocked."""
+        mock_s3_client = Mock()
+        mock_s3_client.list_objects_v2.return_value = {
+            "Contents": [
+                {"Key": "data/../../../etc/cron.d/", "Size": 0},
+            ]
+        }
+
+        session = Session(boto_session=mock_boto_session, sagemaker_client=mock_sagemaker_client)
+        session.s3_client = mock_s3_client
+
+        with pytest.raises(ValueError, match="Path traversal detected"):
+            session.download_data(
+                path=str(tmp_path), bucket="test-bucket", key_prefix="data/"
+            )
+
+    def test_path_traversal_overwrite_aws_credentials(
+        self, mock_boto_session, mock_sagemaker_client, tmp_path
+    ):
+        """Test the exact attack scenario from the vulnerability report."""
+        mock_s3_client = Mock()
+        mock_s3_client.list_objects_v2.return_value = {
+            "Contents": [
+                {"Key": "data/../../../../Users/alice/.aws/credentials", "Size": 200},
+            ]
+        }
+
+        session = Session(boto_session=mock_boto_session, sagemaker_client=mock_sagemaker_client)
+        session.s3_client = mock_s3_client
+
+        with pytest.raises(ValueError, match="Path traversal detected"):
+            session.download_data(
+                path=str(tmp_path), bucket="shared-bucket", key_prefix="data/"
+            )
+
+        mock_s3_client.download_file.assert_not_called()
+
+    def test_safe_keys_are_allowed(self, mock_boto_session, mock_sagemaker_client, tmp_path):
+        """Test that normal S3 keys within the target directory are allowed."""
+        mock_s3_client = Mock()
+        mock_s3_client.list_objects_v2.return_value = {
+            "Contents": [
+                {"Key": "data/train.csv", "Size": 100},
+                {"Key": "data/models/model.pkl", "Size": 500},
+            ]
+        }
+
+        session = Session(boto_session=mock_boto_session, sagemaker_client=mock_sagemaker_client)
+        session.s3_client = mock_s3_client
+
+        result = session.download_data(
+            path=str(tmp_path), bucket="test-bucket", key_prefix="data/"
+        )
+
+        assert len(result) == 2
+        assert mock_s3_client.download_file.call_count == 2
+
+
 class TestUploadDataWithExtraArgs:
     """Test upload_data with extra arguments."""
 

--- a/sagemaker-core/tests/unit/local/test_entities.py
+++ b/sagemaker-core/tests/unit/local/test_entities.py
@@ -355,6 +355,107 @@ class TestLocalTransformJob:
         assert description["ModelName"] == "test-model"
 
 
+class TestPerformBatchInferencePathTraversal:
+    """Test _perform_batch_inference blocks path traversal attacks."""
+
+    @patch("sagemaker.core.local.local_session.LocalSession")
+    def test_path_traversal_in_file_list(self, mock_session_class):
+        """Test that file paths resolving outside working_dir are blocked."""
+        mock_session = Mock()
+        mock_client = Mock()
+        mock_client.describe_model.return_value = {
+            "PrimaryContainer": {
+                "Image": "test-image:latest",
+                "ModelDataUrl": "s3://bucket/model.tar.gz",
+                "Environment": {},
+            }
+        }
+        mock_session.sagemaker_client = mock_client
+
+        job = _LocalTransformJob("test-job", "test-model", mock_session)
+
+        with tempfile.TemporaryDirectory() as working_dir:
+            with tempfile.TemporaryDirectory() as dataset_dir:
+                # Mock _get_working_directory to return our temp dir
+                job._get_working_directory = Mock(return_value=working_dir)
+
+                # Create a mock data source with a traversal path
+                mock_data_source = Mock()
+                mock_data_source.get_root_dir.return_value = dataset_dir
+                # Simulate a file that would resolve outside working_dir via relpath
+                traversal_file = os.path.join(dataset_dir, "..", "..", "..", "etc", "passwd")
+                mock_data_source.get_file_list.return_value = [traversal_file]
+
+                mock_batch_provider = Mock()
+
+                job._prepare_data_transformation = Mock(
+                    return_value=(mock_data_source, mock_batch_provider)
+                )
+
+                input_data = {"ContentType": "text/csv"}
+                output_data = {"S3OutputPath": "s3://bucket/output", "Accept": "text/csv"}
+
+                with pytest.raises(ValueError, match="Path traversal detected"):
+                    job._perform_batch_inference(
+                        input_data, output_data, BatchStrategy="MultiRecord", MaxPayloadInMB="6"
+                    )
+
+    @patch("sagemaker.core.local.local_session.LocalSession")
+    def test_safe_file_paths_are_allowed(self, mock_session_class):
+        """Test that normal file paths within dataset_dir are allowed."""
+        mock_session = Mock()
+        mock_client = Mock()
+        mock_client.describe_model.return_value = {
+            "PrimaryContainer": {
+                "Image": "test-image:latest",
+                "ModelDataUrl": "s3://bucket/model.tar.gz",
+                "Environment": {},
+            }
+        }
+        mock_session.sagemaker_client = mock_client
+        mock_session.sagemaker_runtime_client = Mock()
+        mock_session.sagemaker_runtime_client.invoke_endpoint.return_value = {
+            "Body": Mock(read=Mock(return_value=b"result"), close=Mock())
+        }
+
+        job = _LocalTransformJob("test-job", "test-model", mock_session)
+
+        with tempfile.TemporaryDirectory() as working_dir:
+            with tempfile.TemporaryDirectory() as dataset_dir:
+                # Create a real file in the dataset dir
+                test_file = os.path.join(dataset_dir, "input.csv")
+                with open(test_file, "w") as f:
+                    f.write("test data")
+
+                job._get_working_directory = Mock(return_value=working_dir)
+
+                mock_data_source = Mock()
+                mock_data_source.get_root_dir.return_value = dataset_dir
+                mock_data_source.get_file_list.return_value = [test_file]
+
+                mock_batch_provider = Mock()
+                mock_batch_provider.pad.return_value = [b"test data"]
+
+                job._prepare_data_transformation = Mock(
+                    return_value=(mock_data_source, mock_batch_provider)
+                )
+
+                job.container = Mock()
+
+                input_data = {"ContentType": "text/csv"}
+                output_data = {"S3OutputPath": "s3://bucket/output", "Accept": "text/csv"}
+
+                # Patch move_to_destination to avoid S3 interaction
+                with patch("sagemaker.core.local.entities.move_to_destination"):
+                    job._perform_batch_inference(
+                        input_data, output_data, BatchStrategy="MultiRecord", MaxPayloadInMB="6"
+                    )
+
+                # Verify the output file was created inside working_dir
+                expected_output = os.path.join(working_dir, "input.csv.out")
+                assert os.path.exists(expected_output)
+
+
 class TestLocalModel:
     """Test cases for _LocalModel"""
 

--- a/sagemaker-core/tests/unit/test_common_utils.py
+++ b/sagemaker-core/tests/unit/test_common_utils.py
@@ -961,6 +961,94 @@ class TestDownloadFolder:
                 download_folder("bucket", "/../prefix/", tmpdir, mock_session)
 
 
+class TestDownloadFilesUnderPrefixPathTraversal:
+    """Test _download_files_under_prefix blocks path traversal attacks."""
+
+    def test_path_traversal_via_dotdot_in_key(self):
+        """Test that S3 keys with '..' traversal sequences are blocked."""
+        from sagemaker.core.common_utils import _download_files_under_prefix
+
+        mock_s3 = Mock()
+        mock_bucket = Mock()
+        mock_s3.Bucket.return_value = mock_bucket
+
+        # Simulate an S3 object with a traversal key
+        mock_obj_summary = Mock()
+        mock_obj_summary.key = "data/../../../../etc/passwd"
+        mock_obj_summary.bucket_name = "bucket"
+        mock_bucket.objects.filter.return_value = [mock_obj_summary]
+
+        mock_obj = Mock()
+        mock_s3.Object.return_value = mock_obj
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with pytest.raises(ValueError, match="Path traversal detected"):
+                _download_files_under_prefix("bucket", "data/", tmpdir, mock_s3)
+
+        # Ensure no file was actually downloaded
+        mock_obj.download_file.assert_not_called()
+
+    def test_path_traversal_via_relative_escape(self):
+        """Test that keys resolving outside target via relpath are blocked."""
+        from sagemaker.core.common_utils import _download_files_under_prefix
+
+        mock_s3 = Mock()
+        mock_bucket = Mock()
+        mock_s3.Bucket.return_value = mock_bucket
+
+        mock_obj_summary = Mock()
+        mock_obj_summary.key = "prefix/../../../etc/cron.d/backdoor"
+        mock_obj_summary.bucket_name = "bucket"
+        mock_bucket.objects.filter.return_value = [mock_obj_summary]
+
+        mock_obj = Mock()
+        mock_s3.Object.return_value = mock_obj
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with pytest.raises(ValueError, match="Path traversal detected"):
+                _download_files_under_prefix("bucket", "prefix/", tmpdir, mock_s3)
+
+        mock_obj.download_file.assert_not_called()
+
+    def test_safe_keys_are_allowed(self):
+        """Test that normal S3 keys within the target directory are allowed."""
+        from sagemaker.core.common_utils import _download_files_under_prefix
+
+        mock_s3 = Mock()
+        mock_bucket = Mock()
+        mock_s3.Bucket.return_value = mock_bucket
+
+        mock_obj_summary = Mock()
+        mock_obj_summary.key = "data/subdir/file.txt"
+        mock_obj_summary.bucket_name = "bucket"
+        mock_bucket.objects.filter.return_value = [mock_obj_summary]
+
+        mock_obj = Mock()
+        mock_s3.Object.return_value = mock_obj
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _download_files_under_prefix("bucket", "data/", tmpdir, mock_s3)
+
+        mock_obj.download_file.assert_called_once()
+
+    def test_folder_objects_are_skipped(self):
+        """Test that S3 folder objects (keys ending with /) are skipped."""
+        from sagemaker.core.common_utils import _download_files_under_prefix
+
+        mock_s3 = Mock()
+        mock_bucket = Mock()
+        mock_s3.Bucket.return_value = mock_bucket
+
+        mock_obj_summary = Mock()
+        mock_obj_summary.key = "data/subdir/"
+        mock_bucket.objects.filter.return_value = [mock_obj_summary]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _download_files_under_prefix("bucket", "data/", tmpdir, mock_s3)
+
+        mock_s3.Object.assert_not_called()
+
+
 class TestRepackModel:
     """Test repack_model function."""
 

--- a/sagemaker-serve/src/sagemaker/serve/model_format/mlflow/utils.py
+++ b/sagemaker-serve/src/sagemaker/serve/model_format/mlflow/utils.py
@@ -244,6 +244,7 @@ def _download_s3_artifacts(s3_path: str, dst_path: str, session: Session) -> Non
     s3 = session.boto_session.client("s3")
 
     os.makedirs(dst_path, exist_ok=True)
+    dst_path_real = os.path.realpath(dst_path)
 
     paginator = s3.get_paginator("list_objects_v2")
     for page in paginator.paginate(Bucket=s3_bucket, Prefix=s3_key):
@@ -251,6 +252,18 @@ def _download_s3_artifacts(s3_path: str, dst_path: str, session: Session) -> Non
             key = obj["Key"]
             rel_path = os.path.relpath(key, s3_key)
             local_file_path = os.path.join(dst_path, rel_path)
+
+            # Validate that the resolved path stays within the destination directory
+            local_file_path_real = os.path.realpath(local_file_path)
+            if (
+                not local_file_path_real.startswith(dst_path_real + os.sep)
+                and local_file_path_real != dst_path_real
+            ):
+                raise ValueError(
+                    f"Path traversal detected: S3 key '{key}' resolves to "
+                    f"'{local_file_path_real}' which is outside the target "
+                    f"directory '{dst_path_real}'"
+                )
 
             if not key.endswith("/"):
                 local_file_dir = os.path.dirname(local_file_path)

--- a/sagemaker-serve/src/sagemaker/serve/model_format/mlflow/utils.py
+++ b/sagemaker-serve/src/sagemaker/serve/model_format/mlflow/utils.py
@@ -22,6 +22,7 @@ import os
 
 from sagemaker.core.helper.session_helper import Session
 from sagemaker.core import image_uris
+from sagemaker.core.common_utils import validate_path_within_directory
 from sagemaker.serve.utils.types import ModelServer
 from sagemaker.serve.detector.image_detector import _cast_to_compatible_version
 from sagemaker.serve.model_format.mlflow.constants import (
@@ -253,17 +254,9 @@ def _download_s3_artifacts(s3_path: str, dst_path: str, session: Session) -> Non
             rel_path = os.path.relpath(key, s3_key)
             local_file_path = os.path.join(dst_path, rel_path)
 
-            # Validate that the resolved path stays within the destination directory
-            local_file_path_real = os.path.realpath(local_file_path)
-            if (
-                not local_file_path_real.startswith(dst_path_real + os.sep)
-                and local_file_path_real != dst_path_real
-            ):
-                raise ValueError(
-                    f"Path traversal detected: S3 key '{key}' resolves to "
-                    f"'{local_file_path_real}' which is outside the target "
-                    f"directory '{dst_path_real}'"
-                )
+            validate_path_within_directory(
+                local_file_path, dst_path, source_description=key
+            )
 
             if not key.endswith("/"):
                 local_file_dir = os.path.dirname(local_file_path)

--- a/sagemaker-serve/tests/unit/model_format/test_mlflow_utils.py
+++ b/sagemaker-serve/tests/unit/model_format/test_mlflow_utils.py
@@ -387,6 +387,109 @@ class TestDownloadS3Artifacts(unittest.TestCase):
         self.assertEqual(mock_s3_client.download_file.call_count, 2)
 
 
+class TestDownloadS3ArtifactsPathTraversal(unittest.TestCase):
+    """Test _download_s3_artifacts blocks path traversal attacks."""
+
+    @patch('sagemaker.serve.model_format.mlflow.utils.os.makedirs')
+    def test_path_traversal_via_dotdot_in_key(self, mock_makedirs):
+        """Test that S3 keys with '..' traversal sequences are blocked."""
+        mock_session = Mock()
+        mock_s3_client = Mock()
+        mock_session.boto_session.client.return_value = mock_s3_client
+
+        mock_paginator = Mock()
+        mock_s3_client.get_paginator.return_value = mock_paginator
+        mock_paginator.paginate.return_value = [
+            {
+                "Contents": [
+                    {"Key": "model/../../../../etc/passwd"},
+                ]
+            }
+        ]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with self.assertRaises(ValueError) as context:
+                _download_s3_artifacts("s3://my-bucket/model", tmpdir, mock_session)
+
+            self.assertIn("Path traversal detected", str(context.exception))
+
+        mock_s3_client.download_file.assert_not_called()
+
+    @patch('sagemaker.serve.model_format.mlflow.utils.os.makedirs')
+    def test_path_traversal_overwrite_ssh_keys(self, mock_makedirs):
+        """Test the attack scenario from the vulnerability report targeting SSH keys."""
+        mock_session = Mock()
+        mock_s3_client = Mock()
+        mock_session.boto_session.client.return_value = mock_s3_client
+
+        mock_paginator = Mock()
+        mock_s3_client.get_paginator.return_value = mock_paginator
+        mock_paginator.paginate.return_value = [
+            {
+                "Contents": [
+                    {"Key": "mlruns/exp1/model/../../../../Users/alice/.ssh/authorized_keys"},
+                ]
+            }
+        ]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with self.assertRaises(ValueError) as context:
+                _download_s3_artifacts(
+                    "s3://shared-bucket/mlruns/exp1/model", tmpdir, mock_session
+                )
+
+            self.assertIn("Path traversal detected", str(context.exception))
+
+        mock_s3_client.download_file.assert_not_called()
+
+    @patch('sagemaker.serve.model_format.mlflow.utils.os.makedirs')
+    def test_safe_keys_are_allowed(self, mock_makedirs):
+        """Test that normal S3 keys within the target directory are allowed."""
+        mock_session = Mock()
+        mock_s3_client = Mock()
+        mock_session.boto_session.client.return_value = mock_s3_client
+
+        mock_paginator = Mock()
+        mock_s3_client.get_paginator.return_value = mock_paginator
+        mock_paginator.paginate.return_value = [
+            {
+                "Contents": [
+                    {"Key": "model/MLmodel"},
+                    {"Key": "model/subdir/model.pkl"},
+                ]
+            }
+        ]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _download_s3_artifacts("s3://my-bucket/model", tmpdir, mock_session)
+
+        self.assertEqual(mock_s3_client.download_file.call_count, 2)
+
+    @patch('sagemaker.serve.model_format.mlflow.utils.os.makedirs')
+    def test_folder_keys_are_skipped(self, mock_makedirs):
+        """Test that S3 folder objects (keys ending with /) are not downloaded."""
+        mock_session = Mock()
+        mock_s3_client = Mock()
+        mock_session.boto_session.client.return_value = mock_s3_client
+
+        mock_paginator = Mock()
+        mock_s3_client.get_paginator.return_value = mock_paginator
+        mock_paginator.paginate.return_value = [
+            {
+                "Contents": [
+                    {"Key": "model/subdir/"},
+                    {"Key": "model/subdir/file.txt"},
+                ]
+            }
+        ]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _download_s3_artifacts("s3://my-bucket/model", tmpdir, mock_session)
+
+        # Only the file should be downloaded, not the folder
+        self.assertEqual(mock_s3_client.download_file.call_count, 1)
+
+
 class TestCopyDirectoryContents(unittest.TestCase):
     """Test _copy_directory_contents function."""
 


### PR DESCRIPTION
Fix potential s3 path traversal by using `realpath()` and containment checks before every S3-to-local file write


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
