### PR TITLE
fix: Fix failing train tests for v3

### DIFF
--- a/sagemaker-train/tests/integ/jumpstart/test_jumpstart_train.py
+++ b/sagemaker-train/tests/integ/jumpstart/test_jumpstart_train.py
@@ -30,7 +30,7 @@ from sagemaker.train.configs import Compute
             },
             # Override default instance type; the model's default
             # (ml.p3.2xlarge) is deprecated.
-            "compute": Compute(instance_type="ml.g5.xlarge"),
+            "compute": Compute(instance_type="ml.g4dn.xlarge"),
         },
         {"model_id": "xgboost-classification-model"},
         {"model_id": "catboost-regression-model"},

--- a/sagemaker-train/tests/integ/train/test_llm_as_judge_base_model_fix.py
+++ b/sagemaker-train/tests/integ/train/test_llm_as_judge_base_model_fix.py
@@ -76,6 +76,7 @@ TEST_CONFIG = {
 }
 
 
+@pytest.mark.serial
 class TestLLMAsJudgeBaseModelFix:
     """Integration test for base model fix in LLMAsJudgeEvaluator"""
 

--- a/sagemaker-train/tests/integ/train/test_llm_as_judge_base_model_fix.py
+++ b/sagemaker-train/tests/integ/train/test_llm_as_judge_base_model_fix.py
@@ -76,7 +76,6 @@ TEST_CONFIG = {
 }
 
 
-@pytest.mark.serial
 class TestLLMAsJudgeBaseModelFix:
     """Integration test for base model fix in LLMAsJudgeEvaluator"""
 
@@ -274,6 +273,32 @@ class TestLLMAsJudgeBaseModelFix:
         logger.info(f"✓ Pipeline started successfully")
         logger.info(f"  Execution ARN: {execution.arn}")
         
+        # Verify pipeline structure - should only have custom inference step
+        execution.refresh()
+        step_names = [step.name for step in execution.status.step_details] if execution.status.step_details else []
+        
+        logger.info(f"Pipeline steps ({len(step_names)}): {step_names}")
+        
+        # If no steps yet, wait a bit for pipeline to initialize
+        if not step_names:
+            logger.info("No steps found yet, waiting for pipeline initialization...")
+            import time
+            time.sleep(10)
+            execution.refresh()
+            step_names = [step.name for step in execution.status.step_details] if execution.status.step_details else []
+            logger.info(f"Pipeline steps after wait ({len(step_names)}): {step_names}")
+        
+        # Should NOT have base inference step (case-insensitive, flexible matching)
+        has_base_step = any("base" in name.lower() and "inference" in name.lower() for name in step_names)
+        has_custom_step = any("custom" in name.lower() and "inference" in name.lower() for name in step_names)
+        
+        assert not has_base_step, f"Pipeline should NOT have base inference step when evaluate_base_model=False. Found steps: {step_names}"
+        assert has_custom_step, f"Pipeline should have custom inference step. Found steps: {step_names}"
+        
+        logger.info(f"✓ Pipeline structure correct for evaluate_base_model=False")
+        logger.info(f"  Base model step: {'Found (ERROR!)' if has_base_step else 'Not present (correct)'}")
+        logger.info(f"  Custom model step: {'Found (correct)' if has_custom_step else 'Missing (ERROR!)'}")
+        
         # Wait for completion
         logger.info(f"\nWaiting for evaluation to complete...")
         
@@ -282,28 +307,6 @@ class TestLLMAsJudgeBaseModelFix:
             logger.info(f"\n✓ Evaluation completed successfully")
             
             assert execution.status.overall_status == "Succeeded"
-            
-            # Verify pipeline structure - should only have custom inference step
-            # Check after completion — step details are
-            # only reliable once the execution has finished.  Checking earlier
-            # is racy when tests run in parallel (pytest-xdist) because
-            # _get_or_create_pipeline may update a shared pipeline resource
-            # and the service can briefly return stale step metadata.
-            execution.refresh()
-            step_names = [step.name for step in execution.status.step_details] if execution.status.step_details else []
-            
-            logger.info(f"Pipeline steps ({len(step_names)}): {step_names}")
-            
-            # Should NOT have base inference step (case-insensitive, flexible matching)
-            has_base_step = any("base" in name.lower() and "inference" in name.lower() for name in step_names)
-            has_custom_step = any("custom" in name.lower() and "inference" in name.lower() for name in step_names)
-            
-            assert not has_base_step, f"Pipeline should NOT have base inference step when evaluate_base_model=False. Found steps: {step_names}"
-            assert has_custom_step, f"Pipeline should have custom inference step. Found steps: {step_names}"
-            
-            logger.info(f"✓ Pipeline structure correct for evaluate_base_model=False")
-            logger.info(f"  Base model step: {'Found (ERROR!)' if has_base_step else 'Not present (correct)'}")
-            logger.info(f"  Custom model step: {'Found (correct)' if has_custom_step else 'Missing (ERROR!)'}")
             
             logger.info("\n" + "=" * 80)
             logger.info("Backward Compatibility Test: PASSED")

--- a/sagemaker-train/tests/integ/train/test_llm_as_judge_base_model_fix.py
+++ b/sagemaker-train/tests/integ/train/test_llm_as_judge_base_model_fix.py
@@ -273,32 +273,6 @@ class TestLLMAsJudgeBaseModelFix:
         logger.info(f"✓ Pipeline started successfully")
         logger.info(f"  Execution ARN: {execution.arn}")
         
-        # Verify pipeline structure - should only have custom inference step
-        execution.refresh()
-        step_names = [step.name for step in execution.status.step_details] if execution.status.step_details else []
-        
-        logger.info(f"Pipeline steps ({len(step_names)}): {step_names}")
-        
-        # If no steps yet, wait a bit for pipeline to initialize
-        if not step_names:
-            logger.info("No steps found yet, waiting for pipeline initialization...")
-            import time
-            time.sleep(10)
-            execution.refresh()
-            step_names = [step.name for step in execution.status.step_details] if execution.status.step_details else []
-            logger.info(f"Pipeline steps after wait ({len(step_names)}): {step_names}")
-        
-        # Should NOT have base inference step (case-insensitive, flexible matching)
-        has_base_step = any("base" in name.lower() and "inference" in name.lower() for name in step_names)
-        has_custom_step = any("custom" in name.lower() and "inference" in name.lower() for name in step_names)
-        
-        assert not has_base_step, f"Pipeline should NOT have base inference step when evaluate_base_model=False. Found steps: {step_names}"
-        assert has_custom_step, f"Pipeline should have custom inference step. Found steps: {step_names}"
-        
-        logger.info(f"✓ Pipeline structure correct for evaluate_base_model=False")
-        logger.info(f"  Base model step: {'Found (ERROR!)' if has_base_step else 'Not present (correct)'}")
-        logger.info(f"  Custom model step: {'Found (correct)' if has_custom_step else 'Missing (ERROR!)'}")
-        
         # Wait for completion
         logger.info(f"\nWaiting for evaluation to complete...")
         
@@ -307,6 +281,28 @@ class TestLLMAsJudgeBaseModelFix:
             logger.info(f"\n✓ Evaluation completed successfully")
             
             assert execution.status.overall_status == "Succeeded"
+            
+            # Verify pipeline structure - should only have custom inference step
+            # Check after completion — step details are
+            # only reliable once the execution has finished.  Checking earlier
+            # is racy when tests run in parallel (pytest-xdist) because
+            # _get_or_create_pipeline may update a shared pipeline resource
+            # and the service can briefly return stale step metadata.
+            execution.refresh()
+            step_names = [step.name for step in execution.status.step_details] if execution.status.step_details else []
+            
+            logger.info(f"Pipeline steps ({len(step_names)}): {step_names}")
+            
+            # Should NOT have base inference step (case-insensitive, flexible matching)
+            has_base_step = any("base" in name.lower() and "inference" in name.lower() for name in step_names)
+            has_custom_step = any("custom" in name.lower() and "inference" in name.lower() for name in step_names)
+            
+            assert not has_base_step, f"Pipeline should NOT have base inference step when evaluate_base_model=False. Found steps: {step_names}"
+            assert has_custom_step, f"Pipeline should have custom inference step. Found steps: {step_names}"
+            
+            logger.info(f"✓ Pipeline structure correct for evaluate_base_model=False")
+            logger.info(f"  Base model step: {'Found (ERROR!)' if has_base_step else 'Not present (correct)'}")
+            logger.info(f"  Custom model step: {'Found (correct)' if has_custom_step else 'Missing (ERROR!)'}")
             
             logger.info("\n" + "=" * 80)
             logger.info("Backward Compatibility Test: PASSED")


### PR DESCRIPTION
Fix instance type for JumpStart training integration test

test_jumpstart_train[huggingface-spc-bert-base-cased] was failing with ValueError: Training is not supported for model ID with instance type: ml.g5.xlarge. The model's SupportedTrainingInstanceTypes only includes ml.g4dn.* and ml.p3.* variants. Replaced ml.g5.xlarge with ml.g4dn.xlarge.

Note on test_base_model_false_still_works failure:

The other failing test (TestLLMAsJudgeBaseModelFix::test_base_model_false_still_works) is a pre-existing flaky test unrelated to both this change and the release commits. None of the release changes touch the evaluation pipeline code path:

"Make _PipelineExecution a public class" affects the pipeline execution class visibility, not the evaluation pipeline template rendering or _get_or_create_pipeline logic.
"Add CodeArtifact support for ModelTrainer" and "Wire FrameworkProcessor code_location" affect training source code/dependency installation, not the evaluator module.
The S3 bucket/path fixes are in core S3 utilities, not in the evaluation pipeline template selection.
The git_utils and service-2.json changes are unrelated to evaluation.
The test fails due to a race condition in the test itself: pytest-xdist runs test_base_model_evaluation_uses_correct_weights (evaluate_base_model=True) and test_base_model_false_still_works (evaluate_base_model=False) in parallel. Both call _get_or_create_pipeline with the same pipeline name prefix, so one test's pipeline.update() overwrites the other's pipeline definition before execution starts. This is a shared-resource concurrency issue in the test infrastructure that predates these release changes. A separate fix (e.g., marking the class @pytest.mark.serial) is needed to address it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.