### PR TITLE
fix: increase default timeout for training jobs

### DIFF
--- a/sagemaker-train/src/sagemaker/train/common_utils/trainer_wait.py
+++ b/sagemaker-train/src/sagemaker/train/common_utils/trainer_wait.py
@@ -200,7 +200,7 @@ def get_mlflow_url(training_job) -> str:
 def wait(
         training_job: TrainingJob,
         poll: int = 5,
-        timeout: Optional[int] = 3000
+        timeout: Optional[int] = 43200
 ) -> None:
     """Wait for training job to complete with progress tracking.
 


### PR DESCRIPTION
*Description of changes:* Training jobs can take multiple hours. increasing default client wait generously (as little downside) to account for this. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
