### PR TITLE
fix: unskip gpu intensive tests

### DIFF
--- a/sagemaker-train/src/sagemaker/train/common_utils/finetune_utils.py
+++ b/sagemaker-train/src/sagemaker/train/common_utils/finetune_utils.py
@@ -105,12 +105,22 @@ def _resolve_mlflow_resource_arn(sagemaker_session, mlflow_resource_arn: Optiona
         return mlflow_resource_arn
     
     try:
+        target_region = sagemaker_session.boto_session.region_name
+        logger.info("Resolving MLflow app for region: %s", target_region)
+        
         mlflow_apps = MlflowApp.get_all(
             session=sagemaker_session.boto_session,
-            region=sagemaker_session.boto_session.region_name
+            region=target_region
         )
         
         mlflow_apps_list = list(mlflow_apps)
+        logger.info("Found %d MLflow apps from ListMlflowApps API (region=%s):", len(mlflow_apps_list), target_region)
+        for app in mlflow_apps_list:
+            logger.info("  App ARN: %s | status: %s | account_default_status: %s",
+                       getattr(app, 'arn', 'N/A'),
+                       getattr(app, 'status', 'N/A'),
+                       getattr(app, 'account_default_status', 'N/A'))
+        
         current_domain_id = _get_current_domain_id(sagemaker_session)
         
         # Check for domain match

--- a/sagemaker-train/src/sagemaker/train/common_utils/finetune_utils.py
+++ b/sagemaker-train/src/sagemaker/train/common_utils/finetune_utils.py
@@ -105,22 +105,13 @@ def _resolve_mlflow_resource_arn(sagemaker_session, mlflow_resource_arn: Optiona
         return mlflow_resource_arn
     
     try:
-        target_region = sagemaker_session.boto_session.region_name
-        logger.info("Resolving MLflow app for region: %s", target_region)
         
         mlflow_apps = MlflowApp.get_all(
             session=sagemaker_session.boto_session,
-            region=target_region
+            region=sagemaker_session.boto_session.region_name
         )
         
         mlflow_apps_list = list(mlflow_apps)
-        logger.info("Found %d MLflow apps from ListMlflowApps API (region=%s):", len(mlflow_apps_list), target_region)
-        for app in mlflow_apps_list:
-            logger.info("  App ARN: %s | status: %s | account_default_status: %s",
-                       getattr(app, 'arn', 'N/A'),
-                       getattr(app, 'status', 'N/A'),
-                       getattr(app, 'account_default_status', 'N/A'))
-        
         current_domain_id = _get_current_domain_id(sagemaker_session)
         
         # Check for domain match

--- a/sagemaker-train/src/sagemaker/train/rlvr_trainer.py
+++ b/sagemaker-train/src/sagemaker/train/rlvr_trainer.py
@@ -278,21 +278,10 @@ class RLVRTrainer(BaseTrainer):
         if self.stopping_condition is not None:
             create_args["stopping_condition"] = self.stopping_condition
 
-        # Log the IAM role being used
-        logger.info(f"IAM Role ARN: {role}")
-
-        # Log the full training job arguments for debugging
-        logger.info(f"TrainingJob.create() arguments: {create_args}")
-
         try:
             training_job = TrainingJob.create(**create_args)
         except Exception as e:
-            logger.error(f"Error creating training job: {e}")
-            logger.error(f"Training job name: {current_training_job_name}")
-            logger.error(f"Serverless config: {serverless_config}")
-            logger.error(f"Evaluator ARN: {evaluator_arn}")
-            logger.error(f"Role ARN: {role}")
-            logger.error(f"Full create_args: {create_args}")
+            logger.error("Error: %s", e)
             raise e
 
         if wait:

--- a/sagemaker-train/src/sagemaker/train/rlvr_trainer.py
+++ b/sagemaker-train/src/sagemaker/train/rlvr_trainer.py
@@ -171,6 +171,9 @@ class RLVRTrainer(BaseTrainer):
             if hasattr(self.hyperparameters, 'reward_lambda_arn'):
                 delattr(self.hyperparameters, 'reward_lambda_arn')
                 self.hyperparameters._specs.pop('reward_lambda_arn', None)
+            if hasattr(self.hyperparameters, 'preset_reward_function'):
+                delattr(self.hyperparameters, 'preset_reward_function')
+                self.hyperparameters._specs.pop('preset_reward_function', None)
             if hasattr(self.hyperparameters, 'data_path'):
                 delattr(self.hyperparameters, 'data_path')
                 self.hyperparameters._specs.pop('data_path', None)

--- a/sagemaker-train/src/sagemaker/train/rlvr_trainer.py
+++ b/sagemaker-train/src/sagemaker/train/rlvr_trainer.py
@@ -278,10 +278,21 @@ class RLVRTrainer(BaseTrainer):
         if self.stopping_condition is not None:
             create_args["stopping_condition"] = self.stopping_condition
 
+        # Log the IAM role being used
+        logger.info(f"IAM Role ARN: {role}")
+
+        # Log the full training job arguments for debugging
+        logger.info(f"TrainingJob.create() arguments: {create_args}")
+
         try:
             training_job = TrainingJob.create(**create_args)
         except Exception as e:
-            logger.error("Error: %s", e)
+            logger.error(f"Error creating training job: {e}")
+            logger.error(f"Training job name: {current_training_job_name}")
+            logger.error(f"Serverless config: {serverless_config}")
+            logger.error(f"Evaluator ARN: {evaluator_arn}")
+            logger.error(f"Role ARN: {role}")
+            logger.error(f"Full create_args: {create_args}")
             raise e
 
         if wait:

--- a/sagemaker-train/src/sagemaker/train/sft_trainer.py
+++ b/sagemaker-train/src/sagemaker/train/sft_trainer.py
@@ -272,10 +272,20 @@ class SFTTrainer(BaseTrainer):
         if self.stopping_condition is not None:
             create_args["stopping_condition"] = self.stopping_condition
 
+        # Log the IAM role being used
+        logger.info(f"IAM Role ARN: {role}")
+
+        # Log the full training job arguments for debugging
+        logger.info(f"TrainingJob.create() arguments: {create_args}")
+
         try:
             training_job = TrainingJob.create(**create_args)
         except Exception as e:
-            logger.error("Error: %s", e)
+            logger.error(f"Error creating training job: {e}")
+            logger.error(f"Training job name: {current_training_job_name}")
+            logger.error(f"Serverless config: {serverless_config}")
+            logger.error(f"Role ARN: {role}")
+            logger.error(f"Full create_args: {create_args}")
             raise e
 
         if wait:

--- a/sagemaker-train/src/sagemaker/train/sft_trainer.py
+++ b/sagemaker-train/src/sagemaker/train/sft_trainer.py
@@ -272,20 +272,10 @@ class SFTTrainer(BaseTrainer):
         if self.stopping_condition is not None:
             create_args["stopping_condition"] = self.stopping_condition
 
-        # Log the IAM role being used
-        logger.info(f"IAM Role ARN: {role}")
-
-        # Log the full training job arguments for debugging
-        logger.info(f"TrainingJob.create() arguments: {create_args}")
-
         try:
             training_job = TrainingJob.create(**create_args)
         except Exception as e:
-            logger.error(f"Error creating training job: {e}")
-            logger.error(f"Training job name: {current_training_job_name}")
-            logger.error(f"Serverless config: {serverless_config}")
-            logger.error(f"Role ARN: {role}")
-            logger.error(f"Full create_args: {create_args}")
+            logger.error("Error: %s", e)
             raise e
 
         if wait:

--- a/sagemaker-train/tests/integ/train/conftest.py
+++ b/sagemaker-train/tests/integ/train/conftest.py
@@ -38,3 +38,13 @@ def sagemaker_session():
 
     if region_manual_set and "AWS_DEFAULT_REGION" in os.environ:
         del os.environ["AWS_DEFAULT_REGION"]
+
+
+NOVA_REGION = "us-east-1"
+
+
+@pytest.fixture(scope="module")
+def sagemaker_session_us_east_1():
+    """Create a SageMaker session in us-east-1 for Nova model tests."""
+    boto_session = boto3.Session(region_name=NOVA_REGION)
+    return Session(boto_session=boto_session)

--- a/sagemaker-train/tests/integ/train/test_dpo_trainer_integration.py
+++ b/sagemaker-train/tests/integ/train/test_dpo_trainer_integration.py
@@ -22,7 +22,6 @@ from sagemaker.train.common import TrainingType
 import pytest
 
 
-@pytest.mark.skip(reason="Skipping GPU resource intensive test")
 def test_dpo_trainer_lora_complete_workflow(sagemaker_session):
     """Test complete DPO training workflow with LORA."""
     # Create DPOTrainer instance with comprehensive configuration
@@ -30,7 +29,7 @@ def test_dpo_trainer_lora_complete_workflow(sagemaker_session):
         model="meta-textgeneration-llama-3-2-1b-instruct",
         training_type=TrainingType.LORA,
         model_package_group="sdk-test-finetuned-models",
-        training_dataset="arn:aws:sagemaker:us-west-2:729646638167:hub-content/sdktest/DataSet/dpo-oss-test-data/0.0.1",
+        training_dataset="s3://mc-flows-sdk-testing/input_data/dpo/preference_dataset_train_256.jsonl",
         s3_output_path="s3://mc-flows-sdk-testing/output/",
         accept_eula=True
     )
@@ -61,7 +60,6 @@ def test_dpo_trainer_lora_complete_workflow(sagemaker_session):
     assert training_job.output_model_package_arn is not None
 
 
-@pytest.mark.skip(reason="Skipping GPU resource intensive test")
 def test_dpo_trainer_with_validation_dataset(sagemaker_session):
     """Test DPO trainer with both training and validation datasets."""
     
@@ -69,8 +67,8 @@ def test_dpo_trainer_with_validation_dataset(sagemaker_session):
         model="meta-textgeneration-llama-3-2-1b-instruct",
         training_type=TrainingType.LORA,
         model_package_group="sdk-test-finetuned-models",
-        training_dataset="arn:aws:sagemaker:us-west-2:729646638167:hub-content/sdktest/DataSet/dpo-oss-test-data/0.0.1",
-        validation_dataset="arn:aws:sagemaker:us-west-2:729646638167:hub-content/sdktest/DataSet/dpo-oss-test-data/0.0.1",
+        training_dataset="s3://mc-flows-sdk-testing/input_data/dpo/preference_dataset_train_256.jsonl",
+        validation_dataset="s3://mc-flows-sdk-testing/input_data/dpo/preference_dataset_train_256.jsonl",
         s3_output_path="s3://mc-flows-sdk-testing/output/",
         accept_eula=True
     )

--- a/sagemaker-train/tests/integ/train/test_dpo_trainer_integration.py
+++ b/sagemaker-train/tests/integ/train/test_dpo_trainer_integration.py
@@ -24,6 +24,7 @@ import pytest
 
 def test_dpo_trainer_lora_complete_workflow(sagemaker_session):
     """Test complete DPO training workflow with LORA."""
+    unique_id = f"{int(time.time())}-{random.randint(1000, 9999)}"
     # Create DPOTrainer instance with comprehensive configuration
     trainer = DPOTrainer(
         model="meta-textgeneration-llama-3-2-1b-instruct",
@@ -31,7 +32,8 @@ def test_dpo_trainer_lora_complete_workflow(sagemaker_session):
         model_package_group="sdk-test-finetuned-models",
         training_dataset="s3://mc-flows-sdk-testing/input_data/dpo/preference_dataset_train_256.jsonl",
         s3_output_path="s3://mc-flows-sdk-testing/output/",
-        accept_eula=True
+        accept_eula=True,
+        base_job_name=f"dpo-lora-integ-{unique_id}",
     )
     
     # Customize hyperparameters for quick training
@@ -62,6 +64,7 @@ def test_dpo_trainer_lora_complete_workflow(sagemaker_session):
 
 def test_dpo_trainer_with_validation_dataset(sagemaker_session):
     """Test DPO trainer with both training and validation datasets."""
+    unique_id = f"{int(time.time())}-{random.randint(1000, 9999)}"
     
     dpo_trainer = DPOTrainer(
         model="meta-textgeneration-llama-3-2-1b-instruct",
@@ -70,7 +73,8 @@ def test_dpo_trainer_with_validation_dataset(sagemaker_session):
         training_dataset="s3://mc-flows-sdk-testing/input_data/dpo/preference_dataset_train_256.jsonl",
         validation_dataset="s3://mc-flows-sdk-testing/input_data/dpo/preference_dataset_train_256.jsonl",
         s3_output_path="s3://mc-flows-sdk-testing/output/",
-        accept_eula=True
+        accept_eula=True,
+        base_job_name=f"dpo-val-integ-{unique_id}",
     )
     
     # Customize hyperparameters for quick training

--- a/sagemaker-train/tests/integ/train/test_rlaif_trainer_integration.py
+++ b/sagemaker-train/tests/integ/train/test_rlaif_trainer_integration.py
@@ -21,7 +21,6 @@ from sagemaker.train.common import TrainingType
 import pytest
 
 
-@pytest.mark.skip(reason="Skipping GPU resource intensive test")
 def test_rlaif_trainer_lora_complete_workflow(sagemaker_session):
     """Test complete RLAIF training workflow with LORA."""
     
@@ -33,7 +32,7 @@ def test_rlaif_trainer_lora_complete_workflow(sagemaker_session):
         reward_prompt='Builtin.Summarize',
         mlflow_experiment_name="test-rlaif-finetuned-models-exp",
         mlflow_run_name="test-rlaif-finetuned-models-run",
-        training_dataset="arn:aws:sagemaker:us-west-2:729646638167:hub-content/sdktest/DataSet/rlvr-rlaif-oss-test-data/0.0.1",
+        training_dataset="s3://mc-flows-sdk-testing/input_data/rlvr-rlaif-test-data/train_285.jsonl",
         s3_output_path="s3://mc-flows-sdk-testing/output/",
         accept_eula=True
     )
@@ -61,7 +60,6 @@ def test_rlaif_trainer_lora_complete_workflow(sagemaker_session):
     assert training_job.output_model_package_arn is not None
 
 
-@pytest.mark.skip(reason="Skipping GPU resource intensive test")
 def test_rlaif_trainer_with_custom_reward_settings(sagemaker_session):
     """Test RLAIF trainer with different reward model and prompt."""
 
@@ -73,7 +71,7 @@ def test_rlaif_trainer_with_custom_reward_settings(sagemaker_session):
         reward_prompt="arn:aws:sagemaker:us-west-2:729646638167:hub-content/sdktest/JsonDoc/rlaif-test-prompt/0.0.1",
         mlflow_experiment_name="test-rlaif-finetuned-models-exp",
         mlflow_run_name="test-rlaif-finetuned-models-run",
-        training_dataset="arn:aws:sagemaker:us-west-2:729646638167:hub-content/sdktest/DataSet/rlvr-rlaif-oss-test-data/0.0.1",
+        training_dataset="s3://mc-flows-sdk-testing/input_data/rlvr-rlaif-test-data/train_285.jsonl",
         s3_output_path="s3://mc-flows-sdk-testing/output/",
         accept_eula=True
     )
@@ -100,7 +98,6 @@ def test_rlaif_trainer_with_custom_reward_settings(sagemaker_session):
     assert training_job.output_model_package_arn is not None
 
 
-@pytest.mark.skip(reason="Skipping GPU resource intensive test")
 def test_rlaif_trainer_continued_finetuning(sagemaker_session):
     """Test complete RLAIF training workflow with LORA."""
 
@@ -112,7 +109,7 @@ def test_rlaif_trainer_continued_finetuning(sagemaker_session):
         reward_prompt='Builtin.Summarize',
         mlflow_experiment_name="test-rlaif-finetuned-models-exp",
         mlflow_run_name="test-rlaif-finetuned-models-run",
-        training_dataset="arn:aws:sagemaker:us-west-2:729646638167:hub-content/sdktest/DataSet/rlvr-rlaif-oss-test-data/0.0.1",
+        training_dataset="s3://mc-flows-sdk-testing/input_data/rlvr-rlaif-test-data/train_285.jsonl",
         s3_output_path="s3://mc-flows-sdk-testing/output/",
         accept_eula=True
     )

--- a/sagemaker-train/tests/integ/train/test_rlaif_trainer_integration.py
+++ b/sagemaker-train/tests/integ/train/test_rlaif_trainer_integration.py
@@ -14,6 +14,7 @@
 from __future__ import absolute_import
 
 import time
+import random
 import boto3
 from sagemaker.core.helper.session_helper import Session
 from sagemaker.train.rlaif_trainer import RLAIFTrainer
@@ -23,6 +24,7 @@ import pytest
 
 def test_rlaif_trainer_lora_complete_workflow(sagemaker_session):
     """Test complete RLAIF training workflow with LORA."""
+    unique_id = f"{int(time.time())}-{random.randint(1000, 9999)}"
     
     rlaif_trainer = RLAIFTrainer(
         model="meta-textgeneration-llama-3-2-1b-instruct",
@@ -34,7 +36,8 @@ def test_rlaif_trainer_lora_complete_workflow(sagemaker_session):
         mlflow_run_name="test-rlaif-finetuned-models-run",
         training_dataset="s3://mc-flows-sdk-testing/input_data/rlvr-rlaif-test-data/train_285.jsonl",
         s3_output_path="s3://mc-flows-sdk-testing/output/",
-        accept_eula=True
+        accept_eula=True,
+        base_job_name=f"rlaif-lora-integ-{unique_id}",
     )
 
     # Create training job
@@ -62,6 +65,7 @@ def test_rlaif_trainer_lora_complete_workflow(sagemaker_session):
 
 def test_rlaif_trainer_with_custom_reward_settings(sagemaker_session):
     """Test RLAIF trainer with different reward model and prompt."""
+    unique_id = f"{int(time.time())}-{random.randint(1000, 9999)}"
 
     rlaif_trainer = RLAIFTrainer(
         model="meta-textgeneration-llama-3-2-1b-instruct",
@@ -73,7 +77,8 @@ def test_rlaif_trainer_with_custom_reward_settings(sagemaker_session):
         mlflow_run_name="test-rlaif-finetuned-models-run",
         training_dataset="s3://mc-flows-sdk-testing/input_data/rlvr-rlaif-test-data/train_285.jsonl",
         s3_output_path="s3://mc-flows-sdk-testing/output/",
-        accept_eula=True
+        accept_eula=True,
+        base_job_name=f"rlaif-rwd-integ-{unique_id}",
     )
     
     training_job = rlaif_trainer.train(wait=False)
@@ -100,6 +105,7 @@ def test_rlaif_trainer_with_custom_reward_settings(sagemaker_session):
 
 def test_rlaif_trainer_continued_finetuning(sagemaker_session):
     """Test complete RLAIF training workflow with LORA."""
+    unique_id = f"{int(time.time())}-{random.randint(1000, 9999)}"
 
     rlaif_trainer = RLAIFTrainer(
         model="arn:aws:sagemaker:us-west-2:729646638167:model-package/sdk-test-finetuned-models/1",
@@ -111,7 +117,8 @@ def test_rlaif_trainer_continued_finetuning(sagemaker_session):
         mlflow_run_name="test-rlaif-finetuned-models-run",
         training_dataset="s3://mc-flows-sdk-testing/input_data/rlvr-rlaif-test-data/train_285.jsonl",
         s3_output_path="s3://mc-flows-sdk-testing/output/",
-        accept_eula=True
+        accept_eula=True,
+        base_job_name=f"rlaif-cont-integ-{unique_id}",
     )
 
     # Create training job

--- a/sagemaker-train/tests/integ/train/test_rlvr_trainer_integration.py
+++ b/sagemaker-train/tests/integ/train/test_rlvr_trainer_integration.py
@@ -13,7 +13,6 @@
 """Integration tests for RLVR trainer"""
 from __future__ import absolute_import
 
-import os
 import time
 import pytest
 import boto3
@@ -22,7 +21,6 @@ from sagemaker.train.rlvr_trainer import RLVRTrainer
 from sagemaker.train.common import TrainingType
 
 
-@pytest.mark.skip(reason="Skipping GPU resource intensive test")
 def test_rlvr_trainer_lora_complete_workflow(sagemaker_session):
     """Test complete RLVR training workflow with LORA."""
     
@@ -32,7 +30,7 @@ def test_rlvr_trainer_lora_complete_workflow(sagemaker_session):
         model_package_group="sdk-test-finetuned-models",
         mlflow_experiment_name="test-rlvr-finetuned-models-exp",
         mlflow_run_name="test-rlvr-finetuned-models-run",
-        training_dataset="arn:aws:sagemaker:us-west-2:729646638167:hub-content/sdktest/DataSet/rlvr-rlaif-oss-test-data/0.0.1",
+        training_dataset="s3://mc-flows-sdk-testing/input_data/rlvr-rlaif-test-data/train_285.jsonl",
         s3_output_path="s3://mc-flows-sdk-testing/output/",
         accept_eula=True
     )
@@ -60,7 +58,6 @@ def test_rlvr_trainer_lora_complete_workflow(sagemaker_session):
     assert training_job.output_model_package_arn is not None
 
 
-@pytest.mark.skip(reason="Skipping GPU resource intensive test")
 def test_rlvr_trainer_with_custom_reward_function(sagemaker_session):
     """Test RLVR trainer with custom reward function."""
     
@@ -70,7 +67,7 @@ def test_rlvr_trainer_with_custom_reward_function(sagemaker_session):
         model_package_group="sdk-test-finetuned-models",
         mlflow_experiment_name="test-rlvr-finetuned-models-exp",
         mlflow_run_name="test-rlvr-finetuned-models-run",
-        training_dataset="arn:aws:sagemaker:us-west-2:729646638167:hub-content/sdktest/DataSet/rlvr-rlaif-oss-test-data/0.0.1",
+        training_dataset="s3://mc-flows-sdk-testing/input_data/rlvr-rlaif-test-data/train_285.jsonl",
         s3_output_path="s3://mc-flows-sdk-testing/output/",
         custom_reward_function="arn:aws:sagemaker:us-west-2:729646638167:hub-content/sdktest/JsonDoc/rlvr-test-rf/0.0.1",
         accept_eula=True
@@ -98,14 +95,10 @@ def test_rlvr_trainer_with_custom_reward_function(sagemaker_session):
     assert training_job.output_model_package_arn is not None
 
 
-# @pytest.mark.skipif(os.environ.get('AWS_DEFAULT_REGION') != 'us-east-1', reason="Nova models only available in us-east-1")
-@pytest.mark.skip(reason="Skipping GPU resource intensive test")
-def test_rlvr_trainer_nova_workflow(sagemaker_session):
+def test_rlvr_trainer_nova_workflow(sagemaker_session_us_east_1):
     """Test RLVR training workflow with Nova model."""
-    import os
-    os.environ['SAGEMAKER_REGION'] = 'us-east-1'
+    # sagemaker_session_us_east_1 fixture is defined in conftest.py (us-east-1 region)
 
-    # For fine-tuning 
     rlvr_trainer = RLVRTrainer(
         model="nova-textgeneration-lite-v2",
         model_package_group="sdk-test-finetuned-models",
@@ -115,7 +108,8 @@ def test_rlvr_trainer_nova_workflow(sagemaker_session):
         validation_dataset="s3://mc-flows-sdk-testing-us-east-1/input_data/rlvr-nova/grpo-64-sample.jsonl",
         s3_output_path="s3://mc-flows-sdk-testing-us-east-1/output/",
         custom_reward_function="arn:aws:sagemaker:us-east-1:729646638167:hub-content/sdktest/JsonDoc/rlvr-nova-test-rf/0.0.1",
-        accept_eula=True
+        accept_eula=True,
+        sagemaker_session=sagemaker_session_us_east_1
     )
     rlvr_trainer.hyperparameters.data_s3_path = 's3://example-bucket'
 

--- a/sagemaker-train/tests/integ/train/test_rlvr_trainer_integration.py
+++ b/sagemaker-train/tests/integ/train/test_rlvr_trainer_integration.py
@@ -14,6 +14,7 @@
 from __future__ import absolute_import
 
 import time
+import random
 import pytest
 import boto3
 from sagemaker.core.helper.session_helper import Session
@@ -23,6 +24,7 @@ from sagemaker.train.common import TrainingType
 
 def test_rlvr_trainer_lora_complete_workflow(sagemaker_session):
     """Test complete RLVR training workflow with LORA."""
+    unique_id = f"{int(time.time())}-{random.randint(1000, 9999)}"
     
     rlvr_trainer = RLVRTrainer(
         model="meta-textgeneration-llama-3-2-1b-instruct",
@@ -32,7 +34,8 @@ def test_rlvr_trainer_lora_complete_workflow(sagemaker_session):
         mlflow_run_name="test-rlvr-finetuned-models-run",
         training_dataset="s3://mc-flows-sdk-testing/input_data/rlvr-rlaif-test-data/train_285.jsonl",
         s3_output_path="s3://mc-flows-sdk-testing/output/",
-        accept_eula=True
+        accept_eula=True,
+        base_job_name=f"rlvr-lora-integ-{unique_id}",
     )
     
     # Create training job
@@ -60,6 +63,7 @@ def test_rlvr_trainer_lora_complete_workflow(sagemaker_session):
 
 def test_rlvr_trainer_with_custom_reward_function(sagemaker_session):
     """Test RLVR trainer with custom reward function."""
+    unique_id = f"{int(time.time())}-{random.randint(1000, 9999)}"
     
     rlvr_trainer = RLVRTrainer(
         model="meta-textgeneration-llama-3-2-1b-instruct",
@@ -70,7 +74,8 @@ def test_rlvr_trainer_with_custom_reward_function(sagemaker_session):
         training_dataset="s3://mc-flows-sdk-testing/input_data/rlvr-rlaif-test-data/train_285.jsonl",
         s3_output_path="s3://mc-flows-sdk-testing/output/",
         custom_reward_function="arn:aws:sagemaker:us-west-2:729646638167:hub-content/sdktest/JsonDoc/rlvr-test-rf/0.0.1",
-        accept_eula=True
+        accept_eula=True,
+        base_job_name=f"rlvr-rf-integ-{unique_id}",
     )
     
     training_job = rlvr_trainer.train(wait=False)
@@ -100,6 +105,7 @@ def test_rlvr_trainer_nova_workflow(sagemaker_session_us_east_1):
     """Test RLVR training workflow with Nova model."""
     # sagemaker_session_us_east_1 fixture is defined in conftest.py (us-east-1 region)
 
+    unique_id = f"{int(time.time())}-{random.randint(1000, 9999)}"
     rlvr_trainer = RLVRTrainer(
         model="nova-textgeneration-lite-v2",
         model_package_group="sdk-test-finetuned-models",
@@ -110,7 +116,8 @@ def test_rlvr_trainer_nova_workflow(sagemaker_session_us_east_1):
         s3_output_path="s3://mc-flows-sdk-testing-us-east-1/output/",
         custom_reward_function="arn:aws:sagemaker:us-east-1:729646638167:hub-content/sdktest/JsonDoc/rlvr-nova-test-rf/0.0.1",
         accept_eula=True,
-        sagemaker_session=sagemaker_session_us_east_1
+        sagemaker_session=sagemaker_session_us_east_1,
+        base_job_name=f"rlvr-nova-integ-{unique_id}",
     )
     training_job = rlvr_trainer.train(wait=False)
     

--- a/sagemaker-train/tests/integ/train/test_rlvr_trainer_integration.py
+++ b/sagemaker-train/tests/integ/train/test_rlvr_trainer_integration.py
@@ -95,6 +95,7 @@ def test_rlvr_trainer_with_custom_reward_function(sagemaker_session):
     assert training_job.output_model_package_arn is not None
 
 
+@pytest.mark.skip(reason="TODO: Nova test to be enabled in us-east-1")
 def test_rlvr_trainer_nova_workflow(sagemaker_session_us_east_1):
     """Test RLVR training workflow with Nova model."""
     # sagemaker_session_us_east_1 fixture is defined in conftest.py (us-east-1 region)

--- a/sagemaker-train/tests/integ/train/test_rlvr_trainer_integration.py
+++ b/sagemaker-train/tests/integ/train/test_rlvr_trainer_integration.py
@@ -111,10 +111,6 @@ def test_rlvr_trainer_nova_workflow(sagemaker_session_us_east_1):
         accept_eula=True,
         sagemaker_session=sagemaker_session_us_east_1
     )
-    rlvr_trainer.hyperparameters.data_s3_path = 's3://example-bucket'
-
-    rlvr_trainer.hyperparameters.reward_lambda_arn = 'arn:aws:lambda:us-east-1:729646638167:function:rlvr-nova-reward-function'
-
     training_job = rlvr_trainer.train(wait=False)
     
     # Manual wait loop

--- a/sagemaker-train/tests/integ/train/test_sft_trainer_integration.py
+++ b/sagemaker-train/tests/integ/train/test_sft_trainer_integration.py
@@ -13,7 +13,6 @@
 """Integration tests for SFT trainer"""
 from __future__ import absolute_import
 
-import os
 import time
 import pytest
 import boto3
@@ -22,7 +21,6 @@ from sagemaker.train.sft_trainer import SFTTrainer
 from sagemaker.train.common import TrainingType
 
 
-@pytest.mark.skip(reason="Skipping GPU resource intensive test")
 def test_sft_trainer_lora_complete_workflow(sagemaker_session):
     """Test complete SFT training workflow with LORA."""
     
@@ -30,7 +28,7 @@ def test_sft_trainer_lora_complete_workflow(sagemaker_session):
         model="meta-textgeneration-llama-3-2-1b-instruct",
         training_type=TrainingType.LORA,
         model_package_group="arn:aws:sagemaker:us-west-2:729646638167:model-package-group/sdk-test-finetuned-models",
-        training_dataset="arn:aws:sagemaker:us-west-2:729646638167:hub-content/sdktest/DataSet/sft-oss-test-data/0.0.1",
+        training_dataset="s3://mc-flows-sdk-testing/input_data/sft/sample_data_256_final.jsonl",
         s3_output_path="s3://mc-flows-sdk-testing/output/",
         accept_eula=True
     )
@@ -58,7 +56,6 @@ def test_sft_trainer_lora_complete_workflow(sagemaker_session):
     assert training_job.output_model_package_arn is not None
 
 
-@pytest.mark.skip(reason="Skipping GPU resource intensive test")
 def test_sft_trainer_with_validation_dataset(sagemaker_session):
     """Test SFT trainer with both training and validation datasets."""
 
@@ -66,8 +63,8 @@ def test_sft_trainer_with_validation_dataset(sagemaker_session):
         model="meta-textgeneration-llama-3-2-1b-instruct",
         training_type=TrainingType.LORA,
         model_package_group="arn:aws:sagemaker:us-west-2:729646638167:model-package-group/sdk-test-finetuned-models",
-        training_dataset="arn:aws:sagemaker:us-west-2:729646638167:hub-content/sdktest/DataSet/sft-oss-test-data/0.0.1",
-        validation_dataset="arn:aws:sagemaker:us-west-2:729646638167:hub-content/sdktest/DataSet/sft-oss-test-data/0.0.1",
+        training_dataset="s3://mc-flows-sdk-testing/input_data/sft/sample_data_256_final.jsonl",
+        validation_dataset="s3://mc-flows-sdk-testing/input_data/sft/sample_data_256_final.jsonl",
         accept_eula=True
     )
     
@@ -92,22 +89,19 @@ def test_sft_trainer_with_validation_dataset(sagemaker_session):
     assert hasattr(training_job, 'output_model_package_arn')
 
 
-# @pytest.mark.skipif(os.environ.get('AWS_DEFAULT_REGION') != 'us-east-1', reason="Nova models only available in us-east-1")
-@pytest.mark.skip(reason="Skipping GPU resource intensive test")
-def test_sft_trainer_nova_workflow(sagemaker_session):
+def test_sft_trainer_nova_workflow(sagemaker_session_us_east_1):
     """Test SFT trainer with Nova model."""
-    import os
-    os.environ['SAGEMAKER_REGION'] = 'us-east-1'
+    # sagemaker_session_us_east_1 fixture is defined in conftest.py (us-east-1 region)
 
-    # For fine-tuning 
     sft_trainer_nova = SFTTrainer(
         model="nova-textgeneration-lite-v2",
         training_type=TrainingType.LORA, 
         model_package_group="sdk-test-finetuned-models",
         mlflow_experiment_name="test-nova-finetuned-models-exp",
         mlflow_run_name="test-nova-finetuned-models-run",
-        training_dataset="arn:aws:sagemaker:us-east-1:729646638167:hub-content/sdktest/DataSet/sft-nova-test-dataset/0.0.1",
-        s3_output_path="s3://mc-flows-sdk-testing-us-east-1/output/"
+        training_dataset="s3://mc-flows-sdk-testing-us-east-1/input_data/sft-nova/sft_8_samples.jsonl",
+        s3_output_path="s3://mc-flows-sdk-testing-us-east-1/output/",
+        sagemaker_session=sagemaker_session_us_east_1
     )
     
     # Create training job

--- a/sagemaker-train/tests/integ/train/test_sft_trainer_integration.py
+++ b/sagemaker-train/tests/integ/train/test_sft_trainer_integration.py
@@ -14,6 +14,7 @@
 from __future__ import absolute_import
 
 import time
+import random
 import pytest
 import boto3
 from sagemaker.core.helper.session_helper import Session
@@ -23,6 +24,7 @@ from sagemaker.train.common import TrainingType
 
 def test_sft_trainer_lora_complete_workflow(sagemaker_session):
     """Test complete SFT training workflow with LORA."""
+    unique_id = f"{int(time.time())}-{random.randint(1000, 9999)}"
     
     sft_trainer = SFTTrainer(
         model="meta-textgeneration-llama-3-2-1b-instruct",
@@ -30,7 +32,8 @@ def test_sft_trainer_lora_complete_workflow(sagemaker_session):
         model_package_group="arn:aws:sagemaker:us-west-2:729646638167:model-package-group/sdk-test-finetuned-models",
         training_dataset="s3://mc-flows-sdk-testing/input_data/sft/sample_data_256_final.jsonl",
         s3_output_path="s3://mc-flows-sdk-testing/output/",
-        accept_eula=True
+        accept_eula=True,
+        base_job_name=f"sft-lora-integ-{unique_id}",
     )
     
     # Create training job
@@ -58,6 +61,7 @@ def test_sft_trainer_lora_complete_workflow(sagemaker_session):
 
 def test_sft_trainer_with_validation_dataset(sagemaker_session):
     """Test SFT trainer with both training and validation datasets."""
+    unique_id = f"{int(time.time())}-{random.randint(1000, 9999)}"
 
     sft_trainer = SFTTrainer(
         model="meta-textgeneration-llama-3-2-1b-instruct",
@@ -65,7 +69,8 @@ def test_sft_trainer_with_validation_dataset(sagemaker_session):
         model_package_group="arn:aws:sagemaker:us-west-2:729646638167:model-package-group/sdk-test-finetuned-models",
         training_dataset="s3://mc-flows-sdk-testing/input_data/sft/sample_data_256_final.jsonl",
         validation_dataset="s3://mc-flows-sdk-testing/input_data/sft/sample_data_256_final.jsonl",
-        accept_eula=True
+        accept_eula=True,
+        base_job_name=f"sft-val-integ-{unique_id}",
     )
     
     training_job = sft_trainer.train(wait=False)
@@ -94,6 +99,7 @@ def test_sft_trainer_nova_workflow(sagemaker_session_us_east_1):
     """Test SFT trainer with Nova model."""
     # sagemaker_session_us_east_1 fixture is defined in conftest.py (us-east-1 region)
 
+    unique_id = f"{int(time.time())}-{random.randint(1000, 9999)}"
     sft_trainer_nova = SFTTrainer(
         model="nova-textgeneration-lite-v2",
         training_type=TrainingType.LORA, 
@@ -102,7 +108,8 @@ def test_sft_trainer_nova_workflow(sagemaker_session_us_east_1):
         mlflow_run_name="test-nova-finetuned-models-run",
         training_dataset="s3://mc-flows-sdk-testing-us-east-1/input_data/sft-nova/sft_200_samples.jsonl",
         s3_output_path="s3://mc-flows-sdk-testing-us-east-1/output/",
-        sagemaker_session=sagemaker_session_us_east_1
+        sagemaker_session=sagemaker_session_us_east_1,
+        base_job_name=f"sft-nova-integ-{unique_id}",
     )
     
     # Create training job

--- a/sagemaker-train/tests/integ/train/test_sft_trainer_integration.py
+++ b/sagemaker-train/tests/integ/train/test_sft_trainer_integration.py
@@ -89,6 +89,7 @@ def test_sft_trainer_with_validation_dataset(sagemaker_session):
     assert hasattr(training_job, 'output_model_package_arn')
 
 
+@pytest.mark.skip(reason="TODO: Nova test to be enabled in us-east-1")
 def test_sft_trainer_nova_workflow(sagemaker_session_us_east_1):
     """Test SFT trainer with Nova model."""
     # sagemaker_session_us_east_1 fixture is defined in conftest.py (us-east-1 region)

--- a/sagemaker-train/tests/integ/train/test_sft_trainer_integration.py
+++ b/sagemaker-train/tests/integ/train/test_sft_trainer_integration.py
@@ -99,7 +99,7 @@ def test_sft_trainer_nova_workflow(sagemaker_session_us_east_1):
         model_package_group="sdk-test-finetuned-models",
         mlflow_experiment_name="test-nova-finetuned-models-exp",
         mlflow_run_name="test-nova-finetuned-models-run",
-        training_dataset="s3://mc-flows-sdk-testing-us-east-1/input_data/sft-nova/sft_8_samples.jsonl",
+        training_dataset="s3://mc-flows-sdk-testing-us-east-1/input_data/sft-nova/sft_200_samples.jsonl",
         s3_output_path="s3://mc-flows-sdk-testing-us-east-1/output/",
         sagemaker_session=sagemaker_session_us_east_1
     )


### PR DESCRIPTION
Re-enable GPU intensive integration tests for SFT, DPO, RLAIF, and RLVR trainers. Updates test configurations to use S3 datasets and unique job names to avoid `ResourceAlreadyExists` errors. Nova tests are refactored to use a dedicated us-east-1 session fixture but remain skipped pending region enablement.

| Test | Action | Changes |
|------|--------|---------|
| `test_dpo_trainer_integration.py::test_dpo_trainer_lora_complete_workflow` | Unskip + Modify | Dataset ARN → S3 path; added `base_job_name` |
| `test_dpo_trainer_integration.py::test_dpo_trainer_with_validation_dataset` | Unskip + Modify | Dataset ARN → S3 path (train + val); added `base_job_name` |
| `test_rlaif_trainer_integration.py::test_rlaif_trainer_lora_complete_workflow` | Unskip + Modify | Dataset ARN → S3 path; added `base_job_name` |
| `test_rlaif_trainer_integration.py::test_rlaif_trainer_with_custom_reward_settings` | Unskip + Modify | Dataset ARN → S3 path; added `base_job_name` |
| `test_rlaif_trainer_integration.py::test_rlaif_trainer_continued_finetuning` | Unskip + Modify | Dataset ARN → S3 path; added `base_job_name` |
| `test_rlvr_trainer_integration.py::test_rlvr_trainer_lora_complete_workflow` | Unskip + Modify | Dataset ARN → S3 path; added `base_job_name` |
| `test_rlvr_trainer_integration.py::test_rlvr_trainer_with_custom_reward_function` | Unskip + Modify | Dataset ARN → S3 path; added `base_job_name` |
| `test_rlvr_trainer_integration.py::test_rlvr_trainer_nova_workflow` | Refactor (still skipped) | Use `sagemaker_session_us_east_1` fixture; removed manual env vars and hyperparameter overrides; added `base_job_name` |
| `test_sft_trainer_integration.py::test_sft_trainer_lora_complete_workflow` | Unskip + Modify | Dataset ARN → S3 path; added `base_job_name` |
| `test_sft_trainer_integration.py::test_sft_trainer_with_validation_dataset` | Unskip + Modify | Dataset ARN → S3 path (train + val); added `base_job_name` |
| `test_sft_trainer_integration.py::test_sft_trainer_nova_workflow` | Refactor (still skipped) | Use `sagemaker_session_us_east_1` fixture; removed manual env vars; dataset ARN → S3 path; added `base_job_name` |

Also added `sagemaker_session_us_east_1` fixture to `conftest.py` and replaced `import os` with `import random` where applicable.