### PR TITLE
  Fix base_model_arn construction to use private hub when SAGEMAKER_HUB_NAME is set

### DIFF
--- a/sagemaker-train/src/sagemaker/train/common_utils/model_resolution.py
+++ b/sagemaker-train/src/sagemaker/train/common_utils/model_resolution.py
@@ -211,8 +211,11 @@ class _ModelResolver:
                     arn_parts = model_pkg_arn.split(':')
                     if len(arn_parts) >= 4:
                         region = arn_parts[3]
-                        # Construct hub content ARN for SageMaker public hub
-                        base_model_arn = f"arn:aws:sagemaker:{region}:aws:hub-content/SageMakerPublicHub/Model/{hub_content_name}/{hub_content_version}"
+                        # Use SAGEMAKER_HUB_NAME if set (private hub), otherwise fall back to public hub
+                        hub_name = os.environ.get("SAGEMAKER_HUB_NAME", "SageMakerPublicHub")
+                        # Private hubs are account-scoped; public hub uses 'aws' as account
+                        hub_account = "aws" if hub_name == "SageMakerPublicHub" else arn_parts[4]
+                        base_model_arn = f"arn:aws:sagemaker:{region}:{hub_account}:hub-content/{hub_name}/Model/{hub_content_name}/{hub_content_version}"
         
         # If we couldn't extract or construct base model ARN, this is not a supported model package
         if not base_model_arn:


### PR DESCRIPTION
## Issue
When a model package doesn't have `hub_content_arn` in its container metadata, `model_resolution.py` falls back to constructing the ARN from `hub_content_name` and `hub_content_version`. The fallback hardcoded `SageMakerPublicHub` as the hub name, causing eval jobs to fail with `DownstreamServiceUnavailable` when the base model exists only in a private hub.
  
## Fix
use `SAGEMAKER_HUB_NAME` env var (already used throughout the SDK for hub resolution) to determine the hub name and account in the fallback ARN construction. Falls back to `SageMakerPublicHub` with aws account when the env var is not set, preserving existing behavior for public hub models.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
