### PR TITLE
fix: write ModelTrainer train script with LF line endings

### DIFF
--- a/sagemaker-train/src/sagemaker/train/model_trainer.py
+++ b/sagemaker-train/src/sagemaker/train/model_trainer.py
@@ -1061,7 +1061,7 @@ class ModelTrainer(BaseModel):
             execute_driver=execute_driver,
         )
 
-        with open(os.path.join(tmp_dir.name, TRAIN_SCRIPT), "w") as f:
+        with open(os.path.join(tmp_dir.name, TRAIN_SCRIPT), "w", newline="\n") as f:
             f.write(train_script)
 
     @classmethod

--- a/sagemaker-train/tests/unit/train/test_model_trainer.py
+++ b/sagemaker-train/tests/unit/train/test_model_trainer.py
@@ -559,9 +559,10 @@ def test_train_with_distributed_config(
         )
 
         assert os.path.exists(expected_train_script_path)
-        with open(expected_train_script_path, "r") as f:
+        with open(expected_train_script_path, "rb") as f:
             train_script_content = f.read()
-            assert test_case["expected_template"] in train_script_content
+            assert test_case["expected_template"] in train_script_content.decode("utf-8")
+            assert b"\r\n" not in train_script_content
 
         assert os.path.exists(expected_runner_json_path)
         with open(expected_runner_json_path, "r") as f:


### PR DESCRIPTION
## Description

`ModelTrainer` generates `sm_train.sh`, which is executed inside Linux training containers.

On Windows, writing this generated shell script with platform-default text-mode newline handling can produce CRLF (`\r\n`) line endings. Linux shell execution expects LF (`\n`) line endings, so generated shell scripts intended for Linux containers should be written with explicit LF newlines.

This change writes the generated train script with `newline="\n"` to avoid Windows-specific CRLF line endings.

This mirrors the existing fix pattern used elsewhere in the SDK for generated shell scripts executed in Linux containers.