### PR TITLE
fix(jumpstart): ignore unknown fields in HubContentDocument to handle hub schema additions

### DIFF
--- a/sagemaker-core/src/sagemaker/core/jumpstart/models.py
+++ b/sagemaker-core/src/sagemaker/core/jumpstart/models.py
@@ -473,6 +473,8 @@ class HubContentDocument(HostingComponentsModel, TrainingComponentsModel):
     The HubContentDocument class represents the metadata for a JumpStart model.
     """
 
+    model_config = ConfigDict(validate_assignment=True, extra="ignore")
+
     ModelTypes: List[ModelTypeEnum]
     Url: str
     MinSdkVersion: Optional[str] = None


### PR DESCRIPTION
The SageMakerPublicHub added new metadata fields (`InputModalities, OutputModalities, 
ModelAccess, Languages, ModelSize, ContextWindow, MlFramework`) to model hub content 
documents. `HubContentDocument` had no explicit `model_config`, causing Pydantic to reject 
these unknown fields with a `ValidationError` and breaking `test_all_hub_content_documents`.

Fix: `add model_config = ConfigDict(extra="ignore")` to `HubContentDocument` so the model 
is forward-compatible with hub schema additions without requiring SDK changes each time.
  
Failed test: `FAILED tests/integ/jumpstart/test_model.py::test_all_hub_content_documents`
https://tiny.amazon.com/gmlhcs1i/IsenLink

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
