### PR TITLE
Redact CodeArtifact tokens from pip install logs

### DIFF
--- a/sagemaker-core/src/sagemaker/core/utils/install_requirements.py
+++ b/sagemaker-core/src/sagemaker/core/utils/install_requirements.py
@@ -114,18 +114,19 @@ def _login_awscli(region, account, domain, repo):
 
 def _redact_url_credentials(value):
     """Redact credentials embedded in a URL for safe logging."""
-    parts = urlsplit(value)
+    try:
+        parts = urlsplit(value)
+    except ValueError:
+        return "<redacted-url>" if "@" in value else value
+
     if not parts.scheme or not parts.netloc:
         return value
-    if parts.username is None and parts.password is None:
+
+    _, separator, hostinfo = parts.netloc.rpartition("@")
+    if not separator:
         return value
 
-    host = parts.hostname or ""
-    if parts.port is not None:
-        host = f"{host}:{parts.port}"
-
-    netloc = f"****@{host}"
-
+    netloc = f"****@{hostinfo}"
     return urlunsplit((parts.scheme, netloc, parts.path, parts.query, parts.fragment))
 
 

--- a/sagemaker-core/src/sagemaker/core/utils/install_requirements.py
+++ b/sagemaker-core/src/sagemaker/core/utils/install_requirements.py
@@ -40,6 +40,7 @@ import os
 import re
 import subprocess
 import sys
+from urllib.parse import urlsplit, urlunsplit
 
 logger = logging.getLogger(__name__)
 
@@ -109,6 +110,27 @@ def _login_awscli(region, account, domain, repo):
             region,
         ]
     )
+
+
+def _redact_url_credentials(value):
+    """Redact credentials embedded in a URL for safe logging."""
+    parts = urlsplit(value)
+    if not parts.scheme or not parts.netloc:
+        return value
+    if parts.username is None and parts.password is None:
+        return value
+
+    host = parts.hostname or ""
+    if parts.port is not None:
+        host = f"{host}:{parts.port}"
+
+    netloc = f"****@{host}"
+
+    return urlunsplit((parts.scheme, netloc, parts.path, parts.query, parts.fragment))
+
+
+def _format_pip_cmd_for_log(pip_cmd):
+    return " ".join(_redact_url_credentials(arg) for arg in pip_cmd)
 
 
 def configure_pip(auth_method=CodeArtifactAuthMethod.AUTO):
@@ -185,7 +207,7 @@ def install_requirements(
     index = configure_pip(auth_method=auth_method)
     if index:
         pip_cmd.extend(["-i", index])
-    logger.info("Running: %s", " ".join(pip_cmd))
+    logger.info("Running: %s", _format_pip_cmd_for_log(pip_cmd))
     subprocess.check_call(pip_cmd)
 
 

--- a/sagemaker-core/tests/unit/test_install_requirements.py
+++ b/sagemaker-core/tests/unit/test_install_requirements.py
@@ -219,6 +219,20 @@ class TestInstallRequirements:
         assert "username-only-token" not in logged_cmd
         assert "https://****@example.com/simple/" in logged_cmd
 
+    def test_url_host_details_are_preserved_in_logged_command(self):
+        logged_cmd = _format_pip_cmd_for_log(
+            ["https://username:password@[2001:db8::1]:8443/simple/"]
+        )
+
+        assert logged_cmd == "https://****@[2001:db8::1]:8443/simple/"
+
+    def test_malformed_url_does_not_leak_credentials(self):
+        logged_cmd = _format_pip_cmd_for_log(
+            ["https://username:password@[invalid/simple/"]
+        )
+
+        assert logged_cmd == "<redacted-url>"
+
     def test_with_cli_fallback_no_index_flag(self):
         with mock.patch(f"{_MODULE}.configure_pip", return_value=None):
             with mock.patch("subprocess.check_call") as mock_call:

--- a/sagemaker-core/tests/unit/test_install_requirements.py
+++ b/sagemaker-core/tests/unit/test_install_requirements.py
@@ -12,6 +12,7 @@
 # language governing permissions and limitations under the License.
 from __future__ import absolute_import
 
+import logging
 import subprocess
 import sys
 from unittest import mock
@@ -21,6 +22,7 @@ import pytest
 from sagemaker.core.utils.install_requirements import (
     CA_REPOSITORY_ARN_ENV,
     CodeArtifactAuthMethod,
+    _format_pip_cmd_for_log,
     _parse_arn,
     configure_pip,
     install_requirements,
@@ -191,6 +193,31 @@ class TestInstallRequirements:
             with mock.patch("subprocess.check_call") as mock_call:
                 install_requirements("reqs.txt")
         mock_call.assert_called_once_with(_pip_cmd("-i", EXPECTED_INDEX))
+
+    def test_codeartifact_index_token_is_redacted_from_logs(self, caplog):
+        caplog.set_level(logging.INFO, logger=_MODULE)
+        with mock.patch(f"{_MODULE}.configure_pip", return_value=EXPECTED_INDEX):
+            with mock.patch("subprocess.check_call") as mock_call:
+                install_requirements("reqs.txt")
+
+        mock_call.assert_called_once_with(_pip_cmd("-i", EXPECTED_INDEX))
+        assert FAKE_TOKEN not in caplog.text
+        assert "https://****@" in caplog.text
+
+    def test_url_username_is_redacted_from_logged_command(self):
+        logged_cmd = _format_pip_cmd_for_log(
+            [
+                sys.executable,
+                "-m",
+                "pip",
+                "install",
+                "-i",
+                "https://username-only-token@example.com/simple/",
+            ]
+        )
+
+        assert "username-only-token" not in logged_cmd
+        assert "https://****@example.com/simple/" in logged_cmd
 
     def test_with_cli_fallback_no_index_flag(self):
         with mock.patch(f"{_MODULE}.configure_pip", return_value=None):


### PR DESCRIPTION
## Summary
- redact credentials embedded in package index URLs before logging pip commands
- keep the actual pip command unchanged
- add regression coverage for CodeArtifact index URL redaction

## Test
```bash
python -m pytest sagemaker-core/tests/unit/test_install_requirements.py -q
```