### PR TITLE
Revert "fix: unskip evaluator integ test classes in sm-train"

### DIFF
--- a/sagemaker-train/tests/integ/train/test_benchmark_evaluator.py
+++ b/sagemaker-train/tests/integ/train/test_benchmark_evaluator.py
@@ -72,7 +72,7 @@ NOVA_CONFIG = {
 }
 
 
-# @pytest.mark.skip(reason="Temporarily skipped - moved from tests/integ/sagemaker/modules/evaluate/")
+@pytest.mark.skip(reason="Temporarily skipped - moved from tests/integ/sagemaker/modules/evaluate/")
 class TestBenchmarkEvaluatorIntegration:
     """Integration tests for BenchmarkEvaluator with fine-tuned model package"""
 

--- a/sagemaker-train/tests/integ/train/test_custom_scorer_evaluator.py
+++ b/sagemaker-train/tests/integ/train/test_custom_scorer_evaluator.py
@@ -55,7 +55,7 @@ TEST_CONFIG = {
 }
 
 
-# @pytest.mark.skip(reason="Temporarily skipped - moved from tests/integ/sagemaker/modules/evaluate/")
+@pytest.mark.skip(reason="Temporarily skipped - moved from tests/integ/sagemaker/modules/evaluate/")
 class TestCustomScorerEvaluatorIntegration:
     """Integration tests for CustomScorerEvaluator with custom evaluator"""
 

--- a/sagemaker-train/tests/integ/train/test_llm_as_judge_evaluator.py
+++ b/sagemaker-train/tests/integ/train/test_llm_as_judge_evaluator.py
@@ -84,7 +84,7 @@ TEST_CONFIG = {
 }
 
 
-# @pytest.mark.skip(reason="Temporarily skipped - moved from tests/integ/sagemaker/modules/evaluate/")
+@pytest.mark.skip(reason="Temporarily skipped - moved from tests/integ/sagemaker/modules/evaluate/")
 class TestLLMAsJudgeEvaluatorIntegration:
     """Integration tests for LLMAsJudgeEvaluator"""
 


### PR DESCRIPTION
This reverts commit 5054cb8844cd503343b2f403d3d2eec5c668e07e.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
