### PR TITLE
Fix ModelBuilder networking initialization with core Networking objects

### DIFF
--- a/sagemaker-serve/src/sagemaker/serve/model_builder.py
+++ b/sagemaker-serve/src/sagemaker/serve/model_builder.py
@@ -463,8 +463,9 @@ class ModelBuilder(_InferenceRecommenderMixin, _ModelBuilderServers, _ModelBuild
     def _initialize_network_config(self) -> None:
         """Initialize network configuration from Networking object."""
         if self.network:
-            if self.network.vpc_config:
-                self.vpc_config = self.network.vpc_config
+            vpc_config = getattr(self.network, "vpc_config", None)
+            if vpc_config:
+                self.vpc_config = vpc_config
             else:
                 self.vpc_config = (
                     {

--- a/sagemaker-serve/tests/unit/test_model_builder_missing_coverage.py
+++ b/sagemaker-serve/tests/unit/test_model_builder_missing_coverage.py
@@ -87,6 +87,29 @@ class TestModelBuilderMissingCoverage(unittest.TestCase):
         assert builder.vpc_config is not None
         assert "Subnets" in builder.vpc_config
 
+    def test_initialize_network_config_with_real_networking_object(self):
+        """Test _initialize_network_config with Networking from sagemaker-core."""
+        from sagemaker.core.training.configs import Networking
+
+        network = Networking(
+            subnets=["subnet-123"],
+            security_group_ids=["sg-456"],
+            enable_network_isolation=True,
+        )
+
+        builder = ModelBuilder(
+            model=Mock(),
+            network=network,
+            role_arn="arn:aws:iam::123456789012:role/test",
+            sagemaker_session=self.mock_session,
+        )
+
+        assert builder.vpc_config == {
+            "Subnets": ["subnet-123"],
+            "SecurityGroupIds": ["sg-456"],
+        }
+        assert builder._enable_network_isolation is True
+
     def test_initialize_defaults_region_from_boto3(self):
         """Test _initialize_defaults region fallback to boto3 (lines 472-476)."""
         with patch('boto3.Session') as mock_boto_session:


### PR DESCRIPTION
## Summary
- avoid assuming that core Networking objects expose a vpc_config attribute
- preserve the existing VPC config path when a legacy network object does provide vpc_config
- add regression coverage using the real sagemaker.core.training.configs.Networking type

Fixes #5827.

## Testing
- python3 -m py_compile sagemaker-serve/src/sagemaker/serve/model_builder.py sagemaker-serve/tests/unit/test_model_builder_missing_coverage.py
- python3 -m compileall sagemaker-serve/src/sagemaker/serve/model_builder.py sagemaker-serve/tests/unit/test_model_builder_missing_coverage.py
- python3 - <<"PY"
  imported ModelBuilder with torch stubbed, instantiated a real Networking object, and verified that ModelBuilder initializes VpcConfig and network isolation without raising
  PY

## Notes
- I attempted to run the sagemaker-serve unit tests directly, but local collection on this machine is blocked by optional heavyweight runtime imports from module scope, most notably torch.
