### PR TITLE
feat: expose poll interval parameter on all trainers

### DIFF
--- a/sagemaker-train/src/sagemaker/train/dpo_trainer.py
+++ b/sagemaker-train/src/sagemaker/train/dpo_trainer.py
@@ -181,7 +181,8 @@ class DPOTrainer(BaseTrainer):
               training_dataset: Optional[Union[str, DataSet]] = None,
               validation_dataset: Optional[Union[str, DataSet]] = None,
               wait: bool = True,
-              wait_timeout: Optional[int] = None):
+              wait_timeout: Optional[int] = None,
+              poll: int = 5):
         """Execute the DPO training job.
 
         Parameters:
@@ -196,6 +197,8 @@ class DPOTrainer(BaseTrainer):
             wait_timeout (Optional[int]):
                 Maximum time in seconds to wait for the training job to complete. Only used when wait=True.
                 If None, uses the default timeout from the wait utility.
+            poll (int):
+                Polling interval in seconds for checking training job status. Defaults to 5.
 
         Returns:
             TrainingJob: The SageMaker training job object.
@@ -283,6 +286,7 @@ class DPOTrainer(BaseTrainer):
                 wait_kwargs = {}
                 if wait_timeout is not None:
                     wait_kwargs['timeout'] = wait_timeout
+                wait_kwargs['poll'] = poll
                 _wait(training_job, **wait_kwargs)
             except TimeoutExceededError as e:
                 logger.error("Error: %s", e)

--- a/sagemaker-train/src/sagemaker/train/rlaif_trainer.py
+++ b/sagemaker-train/src/sagemaker/train/rlaif_trainer.py
@@ -197,7 +197,7 @@ class RLAIFTrainer(BaseTrainer):
         
 
     @_telemetry_emitter(feature=Feature.MODEL_CUSTOMIZATION, func_name="RLAIFTrainer.train")
-    def train(self, training_dataset: Optional[Union[str, DataSet]] = None, validation_dataset: Optional[Union[str, DataSet]] = None, wait: bool = True, wait_timeout: Optional[int] = None):
+    def train(self, training_dataset: Optional[Union[str, DataSet]] = None, validation_dataset: Optional[Union[str, DataSet]] = None, wait: bool = True, wait_timeout: Optional[int] = None, poll: int = 5):
         """Execute the RLAIF training job.
 
         Parameters:
@@ -212,6 +212,8 @@ class RLAIFTrainer(BaseTrainer):
             wait_timeout (Optional[int]):
                 Maximum time in seconds to wait for the training job to complete. Only used when wait=True.
                 If None, uses the default timeout from the wait utility.
+            poll (int):
+                Polling interval in seconds for checking training job status. Defaults to 5.
 
         Returns:
             TrainingJob: The SageMaker training job object.
@@ -301,6 +303,7 @@ class RLAIFTrainer(BaseTrainer):
                 wait_kwargs = {}
                 if wait_timeout is not None:
                     wait_kwargs['timeout'] = wait_timeout
+                wait_kwargs['poll'] = poll
                 _wait(training_job, **wait_kwargs)
             except TimeoutExceededError as e:
                 logger.error("Error: %s", e)

--- a/sagemaker-train/src/sagemaker/train/rlvr_trainer.py
+++ b/sagemaker-train/src/sagemaker/train/rlvr_trainer.py
@@ -183,7 +183,7 @@ class RLVRTrainer(BaseTrainer):
 
     @_telemetry_emitter(feature=Feature.MODEL_CUSTOMIZATION, func_name="RLVRTrainer.train")
     def train(self, training_dataset: Optional[Union[str, DataSet]] = None,
-              validation_dataset: Optional[Union[str, DataSet]] = None, wait: bool = True, wait_timeout: Optional[int] = None):
+              validation_dataset: Optional[Union[str, DataSet]] = None, wait: bool = True, wait_timeout: Optional[int] = None, poll: int = 5):
         """Execute the RLVR training job.
 
         Parameters:
@@ -198,6 +198,8 @@ class RLVRTrainer(BaseTrainer):
             wait_timeout (Optional[int]):
                 Maximum time in seconds to wait for the training job to complete. Only used when wait=True.
                 If None, uses the default timeout from the wait utility.
+            poll (int):
+                Polling interval in seconds for checking training job status. Defaults to 5.
 
         Returns:
             TrainingJob: The SageMaker training job object.
@@ -289,6 +291,7 @@ class RLVRTrainer(BaseTrainer):
                 wait_kwargs = {}
                 if wait_timeout is not None:
                     wait_kwargs['timeout'] = wait_timeout
+                wait_kwargs['poll'] = poll
                 _wait(training_job, **wait_kwargs)
             except TimeoutExceededError as e:
                 logger.error("Error: %s", e)

--- a/sagemaker-train/src/sagemaker/train/sft_trainer.py
+++ b/sagemaker-train/src/sagemaker/train/sft_trainer.py
@@ -180,7 +180,7 @@ class SFTTrainer(BaseTrainer):
                 self.hyperparameters._specs.pop('validation_data_path', None)
 
     @_telemetry_emitter(feature=Feature.MODEL_CUSTOMIZATION, func_name="SFTTrainer.train")
-    def train(self, training_dataset: Optional[Union[str, DataSet]] = None, validation_dataset: Optional[Union[str, DataSet]] = None, wait: bool = True, wait_timeout: Optional[int] = None):
+    def train(self, training_dataset: Optional[Union[str, DataSet]] = None, validation_dataset: Optional[Union[str, DataSet]] = None, wait: bool = True, wait_timeout: Optional[int] = None, poll: int = 5):
         """Execute the SFT training job.
 
         Parameters:
@@ -195,6 +195,8 @@ class SFTTrainer(BaseTrainer):
             wait_timeout (Optional[int]):
                 Maximum time in seconds to wait for the training job to complete. Only used when wait=True.
                 If None, uses the default timeout from the wait utility.
+            poll (int):
+                Polling interval in seconds for checking training job status. Defaults to 5.
 
         Returns:
             TrainingJob: The SageMaker training job object.
@@ -283,6 +285,7 @@ class SFTTrainer(BaseTrainer):
                 wait_kwargs = {}
                 if wait_timeout is not None:
                     wait_kwargs['timeout'] = wait_timeout
+                wait_kwargs['poll'] = poll
                 _wait(training_job, **wait_kwargs)
             except TimeoutExceededError as e:
                 logger.error("Error: %s", e)

--- a/sagemaker-train/tests/unit/train/test_dpo_trainer.py
+++ b/sagemaker-train/tests/unit/train/test_dpo_trainer.py
@@ -420,7 +420,7 @@ class TestDPOTrainer:
         trainer = DPOTrainer(model="test-model", model_package_group="test-group", training_dataset="s3://bucket/train")
         trainer.train(wait=True, wait_timeout=600)
 
-        mock_wait.assert_called_once_with(mock_training_job, timeout=600)
+        mock_wait.assert_called_once_with(mock_training_job, timeout=600, poll=5)
 
     @patch('sagemaker.train.common_utils.trainer_wait.wait')
     @patch('sagemaker.train.dpo_trainer._resolve_model_and_name')
@@ -463,7 +463,7 @@ class TestDPOTrainer:
         trainer = DPOTrainer(model="test-model", model_package_group="test-group", training_dataset="s3://bucket/train")
         trainer.train(wait=True)
 
-        mock_wait.assert_called_once_with(mock_training_job)
+        mock_wait.assert_called_once_with(mock_training_job, poll=5)
 
     @patch('sagemaker.train.common_utils.trainer_wait.wait')
     @patch('sagemaker.train.dpo_trainer._resolve_model_and_name')

--- a/sagemaker-train/tests/unit/train/test_rlaif_trainer.py
+++ b/sagemaker-train/tests/unit/train/test_rlaif_trainer.py
@@ -596,7 +596,7 @@ class TestRLAIFTrainer:
         trainer = RLAIFTrainer(model="test-model", model_package_group="test-group", training_dataset="s3://bucket/train")
         trainer.train(wait=True, wait_timeout=600)
 
-        mock_wait.assert_called_once_with(mock_training_job, timeout=600)
+        mock_wait.assert_called_once_with(mock_training_job, timeout=600, poll=5)
 
     @patch('sagemaker.train.common_utils.trainer_wait.wait')
     @patch('sagemaker.train.common_utils.finetune_utils._get_beta_session')
@@ -639,7 +639,7 @@ class TestRLAIFTrainer:
         trainer = RLAIFTrainer(model="test-model", model_package_group="test-group", training_dataset="s3://bucket/train")
         trainer.train(wait=True)
 
-        mock_wait.assert_called_once_with(mock_training_job)
+        mock_wait.assert_called_once_with(mock_training_job, poll=5)
 
     @patch('sagemaker.train.common_utils.trainer_wait.wait')
     @patch('sagemaker.train.common_utils.finetune_utils._get_beta_session')

--- a/sagemaker-train/tests/unit/train/test_rlvr_trainer.py
+++ b/sagemaker-train/tests/unit/train/test_rlvr_trainer.py
@@ -423,7 +423,7 @@ class TestRLVRTrainer:
         trainer = RLVRTrainer(model="test-model", model_package_group="test-group", training_dataset="s3://bucket/train")
         trainer.train(wait=True, wait_timeout=600)
 
-        mock_wait.assert_called_once_with(mock_training_job, timeout=600)
+        mock_wait.assert_called_once_with(mock_training_job, timeout=600, poll=5)
 
     @patch('sagemaker.train.common_utils.trainer_wait.wait')
     @patch('sagemaker.train.common_utils.finetune_utils._get_beta_session')
@@ -466,7 +466,7 @@ class TestRLVRTrainer:
         trainer = RLVRTrainer(model="test-model", model_package_group="test-group", training_dataset="s3://bucket/train")
         trainer.train(wait=True)
 
-        mock_wait.assert_called_once_with(mock_training_job)
+        mock_wait.assert_called_once_with(mock_training_job, poll=5)
 
     @patch('sagemaker.train.common_utils.trainer_wait.wait')
     @patch('sagemaker.train.common_utils.finetune_utils._get_beta_session')

--- a/sagemaker-train/tests/unit/train/test_sft_trainer.py
+++ b/sagemaker-train/tests/unit/train/test_sft_trainer.py
@@ -434,7 +434,7 @@ class TestSFTTrainer:
         trainer = SFTTrainer(model="test-model", model_package_group="test-group", training_dataset="s3://bucket/train")
         trainer.train(wait=True, wait_timeout=600)
 
-        mock_wait.assert_called_once_with(mock_training_job, timeout=600)
+        mock_wait.assert_called_once_with(mock_training_job, timeout=600, poll=5)
 
     @patch('sagemaker.train.common_utils.trainer_wait.wait')
     @patch('sagemaker.train.common_utils.finetune_utils._get_beta_session')
@@ -477,7 +477,7 @@ class TestSFTTrainer:
         trainer = SFTTrainer(model="test-model", model_package_group="test-group", training_dataset="s3://bucket/train")
         trainer.train(wait=True)
 
-        mock_wait.assert_called_once_with(mock_training_job)
+        mock_wait.assert_called_once_with(mock_training_job, poll=5)
 
     @patch('sagemaker.train.common_utils.trainer_wait.wait')
     @patch('sagemaker.train.common_utils.finetune_utils._get_beta_session')


### PR DESCRIPTION
# Expose poll interval parameter on all trainers

Adds a `poll` parameter to `train()` on SFTTrainer, DPOTrainer, RLVRTrainer, and RLAIFTrainer, allowing callers to control how frequently the SDK polls for training job status updates.

## Problem

The `trainer_wait.wait()` function already accepts a `poll` parameter (default 5s), but there was no way to configure it from the trainer API. Users running in agent/script contexts want longer intervals (e.g., 30s) to reduce output noise and API calls.

## Changes

- Add `poll: int = 5` parameter to `train()` on all 4 trainers
- Pass through to `trainer_wait.wait()` via `wait_kwargs`
- Add docstring for the new parameter

```python
# Before: no way to control poll interval
trainer.train(wait=True)

# After: configurable
trainer.train(wait=True, poll=30)
```

## Testing

- 93 existing trainer unit tests pass (assertions updated to include `poll=5`)
- Manually validated with SFT and RLAIF jobs showing correct 10s intervals
