### PR TITLE
fix: restore BatchTransformInput.destination attribute in v3

### DIFF
--- a/sagemaker-core/src/sagemaker/core/model_monitor/model_monitoring.py
+++ b/sagemaker-core/src/sagemaker/core/model_monitor/model_monitoring.py
@@ -4174,7 +4174,7 @@ class BatchTransformInput(MonitoringInput):
 
         """
         self.data_captured_destination_s3_uri = data_captured_destination_s3_uri
-        self.s3_output.s3_uri = destination
+        self.destination = destination
         self.s3_input_mode = s3_input_mode
         self.s3_data_distribution_type = s3_data_distribution_type
         self.dataset_format = dataset_format
@@ -4193,7 +4193,7 @@ class BatchTransformInput(MonitoringInput):
         """Generates a request dictionary using the parameters provided to the class."""
         batch_transform_input_data = {
             "DataCapturedDestinationS3Uri": self.data_captured_destination_s3_uri,
-            "LocalPath": self.s3_output.s3_uri,
+            "LocalPath": self.destination,
             "S3InputMode": self.s3_input_mode,
             "S3DataDistributionType": self.s3_data_distribution_type,
             "DatasetFormat": self.dataset_format,

--- a/sagemaker-core/tests/unit/test_model_monitoring.py
+++ b/sagemaker-core/tests/unit/test_model_monitoring.py
@@ -29,6 +29,7 @@ from sagemaker.core.model_monitor.model_monitoring import (
     CONSTRAINT_VIOLATIONS_JSON_DEFAULT_FILE_NAME,
     DEFAULT_REPOSITORY_NAME,
 )
+from sagemaker.core.model_monitor.dataset_format import MonitoringDatasetFormat
 from sagemaker.core.processing import ProcessingInput, ProcessingOutput
 from sagemaker.core.shapes import ProcessingS3Input, ProcessingS3Output
 from sagemaker.core.network import NetworkConfig
@@ -140,8 +141,81 @@ class TestMonitoringOutput:
 
 class TestBatchTransformInput:
     def test_init_minimal(self):
-        # Skip this test as BatchTransformInput has initialization issues in the source code
-        pytest.skip("BatchTransformInput has initialization issues in the source code")
+        bti = BatchTransformInput(
+            data_captured_destination_s3_uri="s3://bucket/captured",
+            destination="/opt/ml/processing/input",
+            dataset_format=MonitoringDatasetFormat.csv(header=False),
+        )
+        assert bti.data_captured_destination_s3_uri == "s3://bucket/captured"
+        assert bti.destination == "/opt/ml/processing/input"
+        assert bti.s3_input_mode == "File"
+        assert bti.s3_data_distribution_type == "FullyReplicated"
+
+    def test_init_with_all_parameters(self):
+        bti = BatchTransformInput(
+            data_captured_destination_s3_uri="s3://bucket/captured",
+            destination="/opt/ml/processing/input",
+            dataset_format=MonitoringDatasetFormat.csv(header=False),
+            s3_input_mode="Pipe",
+            s3_data_distribution_type="ShardedByS3Key",
+            start_time_offset="-PT1H",
+            end_time_offset="-PT0H",
+            features_attribute="features",
+            inference_attribute="prediction",
+            probability_attribute="probability",
+            probability_threshold_attribute=0.5,
+            exclude_features_attribute="feature1,feature2",
+        )
+        assert bti.s3_input_mode == "Pipe"
+        assert bti.start_time_offset == "-PT1H"
+        assert bti.features_attribute == "features"
+
+    def test_to_request_dict_minimal(self):
+        bti = BatchTransformInput(
+            data_captured_destination_s3_uri="s3://bucket/captured",
+            destination="/opt/ml/processing/input",
+            dataset_format=MonitoringDatasetFormat.csv(header=False),
+        )
+        request_dict = bti._to_request_dict()
+        assert "BatchTransformInput" in request_dict
+        payload = request_dict["BatchTransformInput"]
+        assert payload["DataCapturedDestinationS3Uri"] == "s3://bucket/captured"
+        assert payload["LocalPath"] == "/opt/ml/processing/input"
+        assert payload["S3InputMode"] == "File"
+        assert payload["S3DataDistributionType"] == "FullyReplicated"
+
+    def test_to_request_dict_excludes_none_values(self):
+        bti = BatchTransformInput(
+            data_captured_destination_s3_uri="s3://bucket/captured",
+            destination="/opt/ml/processing/input",
+            dataset_format=MonitoringDatasetFormat.csv(header=False),
+        )
+        payload = bti._to_request_dict()["BatchTransformInput"]
+        assert "StartTimeOffset" not in payload
+        assert "EndTimeOffset" not in payload
+        assert "FeaturesAttribute" not in payload
+        assert "InferenceAttribute" not in payload
+        assert "ProbabilityAttribute" not in payload
+        assert "ProbabilityThresholdAttribute" not in payload
+        assert "ExcludeFeaturesAttribute" not in payload
+
+    def test_to_request_dict_includes_optional_values(self):
+        bti = BatchTransformInput(
+            data_captured_destination_s3_uri="s3://bucket/captured",
+            destination="/opt/ml/processing/input",
+            dataset_format=MonitoringDatasetFormat.csv(header=False),
+            start_time_offset="-PT1H",
+            end_time_offset="-PT0H",
+            probability_attribute="probability",
+            probability_threshold_attribute=0.5,
+            exclude_features_attribute="f1,f2",
+        )
+        payload = bti._to_request_dict()["BatchTransformInput"]
+        assert payload["StartTimeOffset"] == "-PT1H"
+        assert payload["EndTimeOffset"] == "-PT0H"
+        assert payload["ProbabilityAttribute"] == "probability"
+        assert payload["ProbabilityThresholdAttribute"] == 0.5
+        assert payload["ExcludeFeaturesAttribute"] == "f1,f2"
 
 
 class TestBaseliningJob:


### PR DESCRIPTION
## Issue, if available

`BatchTransformInput` in v3 raises `AttributeError: 'BatchTransformInput' object has no attribute 's3_output'` on instantiation, blocking any monitoring schedule that uses batch transform input. The bug is present in every 3.x release (v3.5.0 through current `master` HEAD) and was introduced in the V3 cutover commit `3203e4996`.

## Description of changes

In `sagemaker-core/src/sagemaker/core/model_monitor/model_monitoring.py`, `BatchTransformInput.__init__` assigns `self.s3_output.s3_uri = destination`, but `s3_output` is never created on the class or its `MonitoringInput` parent — it is only defined on the unrelated `MonitoringOutput` class (where `self.s3_output = MonitoringS3Output(...)` is set). `_to_request_dict` then reads the same missing attribute when populating `LocalPath`, so the regression is reachable in two places even if construction were patched.

This change reverts both call sites to use `self.destination` (a plain string attribute) — the contract used by v2.244.x, which was the last working release for affected users.

```diff
 # __init__
 self.data_captured_destination_s3_uri = data_captured_destination_s3_uri
-self.s3_output.s3_uri = destination
+self.destination = destination
 self.s3_input_mode = s3_input_mode

 # _to_request_dict
 batch_transform_input_data = {
     "DataCapturedDestinationS3Uri": self.data_captured_destination_s3_uri,
-    "LocalPath": self.s3_output.s3_uri,
+    "LocalPath": self.destination,
     "S3InputMode": self.s3_input_mode,
```

`TestBatchTransformInput::test_init_minimal` was previously skipped with `pytest.skip("BatchTransformInput has initialization issues in the source code")`. This change unskips it and adds 4 more tests that cover construction, full-parameter init, and `_to_request_dict` output (both default-only fields and all-optionals).

### Reproducer (fails on master, passes after this change)

```python
from sagemaker.core.model_monitor import BatchTransformInput, MonitoringDatasetFormat
BatchTransformInput(
    data_captured_destination_s3_uri="s3://bucket/captured",
    destination="/opt/ml/processing/input",
    dataset_format=MonitoringDatasetFormat.csv(header=False),
)
```

## Testing done

- `pytest tests/unit/test_model_monitoring.py -v` — all 36 tests pass (5 new + 31 existing); none skipped.
- End-to-end smoke test: instantiation succeeds and `_to_request_dict()` returns the expected `BatchTransformInput` payload with `LocalPath` populated from `destination`.
- `black --check` — clean on both modified files.
- `flake8`, `pylint`, `pydocstyle` — zero new findings; all violations on these files exist on `master` and are unrelated to this change.

## Merge Checklist

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to any/all AWS service clients that I've initialized as part of this change (n/a — no client init)
- [x] I have updated any necessary documentation (no doc changes needed — internal attribute swap)

#### Tests

- [x] I have added tests that prove my fix is effective (added 5 unit tests; unskipped 1 prior `pytest.skip`)
- [x] I have checked that my tests are not configured for a specific region or account
- [x] I have followed the [testing guidelines](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#running-the-unit-tests)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.