### PR TITLE
fix: Add CustomAttributes field to DefaultPayloadsModel

### DIFF
--- a/sagemaker-core/src/sagemaker/core/jumpstart/models.py
+++ b/sagemaker-core/src/sagemaker/core/jumpstart/models.py
@@ -190,6 +190,7 @@ class DefaultPayloadsModel(BaseConfig):
     PromptKey: Optional[str] = None
     OutputKeys: Optional[OutputKeysModel] = None
     Body: Union[str, Dict[str, Any]]
+    CustomAttributes: Optional[str] = None
 
 
 class HostingResourceRequirementsModel(BaseConfig):


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* This change allows hub content documents that include CustomAttributes in their payload definitions to be parsed without error, while remaining backward-compatible with existing payloads that don't use the field.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
