### PR TITLE
fix: set sagemaker_config=None on mock session in test_from_jumpstart_config_applies_volume_size

### DIFF
--- a/sagemaker-serve/tests/unit/test_model_builder_coverage_boost.py
+++ b/sagemaker-serve/tests/unit/test_model_builder_coverage_boost.py
@@ -424,6 +424,7 @@ class TestFromJumpStartConfig(unittest.TestCase):
 
         mock_session = Mock()
         mock_session.boto_region_name = "us-west-2"
+        mock_session.sagemaker_config = None
 
         mb = ModelBuilder.from_jumpstart_config(
             jumpstart_config=js_config,


### PR DESCRIPTION
fix unit test

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
