### PR TITLE
Unskip integ tests mlops

### DIFF
--- a/sagemaker-mlops/tests/integ/feature_store/feature_processor/test_feature_processor_integ.py
+++ b/sagemaker-mlops/tests/integ/feature_store/feature_processor/test_feature_processor_integ.py
@@ -528,10 +528,11 @@ def test_feature_processor_transform_offline_only_store_ingestion(
         )
 
 
-@pytest.mark.skipif(
-    sys.version_info[:2] not in [(3, 9), (3, 12)],
-    reason=f"SageMaker Spark image only supports Python 3.9 and 3.12, got {sys.version_info[:2]}",
-)
+# @pytest.mark.skipif(
+#     sys.version_info[:2] not in [(3, 9), (3, 12)],
+#     reason=f"SageMaker Spark image only supports Python 3.9 and 3.12, got {sys.version_info[:2]}",
+# )
+@pytest.mark.spark_py312
 @pytest.mark.slow_test
 def test_feature_processor_transform_offline_only_store_ingestion_run_with_remote(
     sagemaker_session,
@@ -669,10 +670,11 @@ def test_feature_processor_transform_offline_only_store_ingestion_run_with_remot
         )
 
 
-@pytest.mark.skipif(
-    sys.version_info[:2] not in [(3, 9), (3, 12)],
-    reason=f"SageMaker Spark image only supports Python 3.9 and 3.12, got {sys.version_info[:2]}",
-)
+# @pytest.mark.skipif(
+#     sys.version_info[:2] not in [(3, 9), (3, 12)],
+#     reason=f"SageMaker Spark image only supports Python 3.9 and 3.12, got {sys.version_info[:2]}",
+# )
+@pytest.mark.spark_py312
 @pytest.mark.slow_test
 def test_to_pipeline_and_execute(
     sagemaker_session,
@@ -792,10 +794,11 @@ def test_to_pipeline_and_execute(
         # cleanup_pipeline(pipeline_name="pipeline-name-01", sagemaker_session=sagemaker_session)
 
 
-@pytest.mark.skipif(
-    sys.version_info[:2] not in [(3, 9), (3, 12)],
-    reason=f"SageMaker Spark image only supports Python 3.9 and 3.12, got {sys.version_info[:2]}",
-)
+# @pytest.mark.skipif(
+#     sys.version_info[:2] not in [(3, 9), (3, 12)],
+#     reason=f"SageMaker Spark image only supports Python 3.9 and 3.12, got {sys.version_info[:2]}",
+# )
+@pytest.mark.spark_py312
 @pytest.mark.slow_test
 def test_to_pipeline_and_execute_with_lake_formation(
     sagemaker_session,
@@ -940,10 +943,11 @@ def test_to_pipeline_and_execute_with_lake_formation(
             cleanup_feature_group(car_data_fg, sagemaker_session=sagemaker_session)
 
 
-@pytest.mark.skipif(
-    sys.version_info[:2] not in [(3, 9), (3, 12)],
-    reason=f"SageMaker Spark image only supports Python 3.9 and 3.12, got {sys.version_info[:2]}",
-)
+# @pytest.mark.skipif(
+#     sys.version_info[:2] not in [(3, 9), (3, 12)],
+#     reason=f"SageMaker Spark image only supports Python 3.9 and 3.12, got {sys.version_info[:2]}",
+# )
+@pytest.mark.spark_py312
 @pytest.mark.slow_test
 def test_schedule_and_event_trigger(
     sagemaker_session,

--- a/sagemaker-mlops/tests/integ/feature_store/feature_processor/test_feature_processor_integ.py
+++ b/sagemaker-mlops/tests/integ/feature_store/feature_processor/test_feature_processor_integ.py
@@ -798,6 +798,11 @@ def test_to_pipeline_and_execute(
 #     sys.version_info[:2] not in [(3, 9), (3, 12)],
 #     reason=f"SageMaker Spark image only supports Python 3.9 and 3.12, got {sys.version_info[:2]}",
 # )
+@pytest.mark.skip(
+    reason="Lake Formation credential vending (GetTemporaryGlueTableCredentials) requires "
+    "full LF environment setup (resource registration, trust policy, data location grants) "
+    "that is not configured in CI. See quip-amazon.com/S3FEAMMMuKm0 for details."
+)
 @pytest.mark.spark_py312
 @pytest.mark.slow_test
 def test_to_pipeline_and_execute_with_lake_formation(

--- a/sagemaker-mlops/tests/integ/feature_store/feature_processor/test_feature_processor_spark_compat.py
+++ b/sagemaker-mlops/tests/integ/feature_store/feature_processor/test_feature_processor_spark_compat.py
@@ -54,6 +54,7 @@ def test_spark_session_factory_configs_include_dynamic_hadoop():
     assert f"org.apache.hadoop:hadoop-common:{hadoop_version}" in packages
 
 
+@pytest.mark.spark_py312
 @pytest.mark.slow_test
 def test_image_resolver_returns_uri_for_installed_pyspark():
     """Verify the image resolver returns a valid URI for the installed PySpark + Python version."""

--- a/sagemaker-mlops/tox.ini
+++ b/sagemaker-mlops/tox.ini
@@ -60,6 +60,7 @@ markers =
     cron
     local_mode
     slow_test
+    spark_py312: mark a test that requires Python 3.12 (Spark image compatibility).
     release
     image_uris_unit_test
     timeout: mark a test as a timeout.


### PR DESCRIPTION
### Summary

5 integ tests in `sagemaker-mlops` were conditionally skipped via `@pytest.mark.skipif` because they require SageMaker Spark container images, which only support Python 3.9 and 3.12. Since CI runs integ tests on Python 3.10, these tests were never executed.

This PR introduces a `spark_py312` marker to split mlops integ tests into two groups:
- **py310**: runs all integ tests *excluding* `spark_py312`
- **py312**: runs only `spark_py312` marked tests (Spark/Feature Processor tests that depend on SageMaker Spark images)

This allows both groups to run in CI without version conflicts. The corresponding buildspec change to add the py312 step will be done separately in the CI infra (SageMakerMLFPySDKInfraCDK).

### Changes

- Register `spark_py312` marker in `sagemaker-mlops/tox.ini`
- Replace `@pytest.mark.skipif` with `@pytest.mark.spark_py312` on 4 tests in `test_feature_processor_integ.py`
- Add `@pytest.mark.spark_py312` to 1 test in `test_feature_processor_spark_compat.py`
- `test_to_pipeline_and_execute_with_lake_formation` remains skipped (`@pytest.mark.skip`) due to unresolved Lake Formation environment configuration in CI (tracked separately)

### Testing

Validated via CodeBuild in Prod:
- py310 with `-m "not spark_py312"`: all tests pass, spark tests correctly excluded
- py312 with `-m spark_py312`: 4/5 tests pass, 1 skipped (Lake Formation)
