### PR TITLE
tests: unskip three tests with individual issues in train

### DIFF
--- a/sagemaker-train/src/sagemaker/train/container_drivers/distributed_drivers/mpi_driver.py
+++ b/sagemaker-train/src/sagemaker/train/container_drivers/distributed_drivers/mpi_driver.py
@@ -17,7 +17,11 @@ import os
 import sys
 import json
 
-from sagemaker.train.container_drivers.distributed_drivers.mpi_utils import (
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from distributed_drivers.mpi_utils import (  # noqa: E402 # pylint: disable=C0413,E0611
     start_sshd_daemon,
     bootstrap_master_node,
     bootstrap_worker_node,
@@ -27,7 +31,7 @@ from sagemaker.train.container_drivers.distributed_drivers.mpi_utils import (
 )
 
 
-from sagemaker.train.container_drivers.common.utils import (
+from common.utils import (  # noqa: E402 # pylint: disable=C0413,E0611
     logger,
     hyperparameters_to_cli_args,
     get_process_count,

--- a/sagemaker-train/tests/integ/train/test_benchmark_evaluator.py
+++ b/sagemaker-train/tests/integ/train/test_benchmark_evaluator.py
@@ -61,13 +61,12 @@ BASE_MODEL_ONLY_CONFIG = {
     "region": "us-west-2",
 }
 
-# Nova model evaluation configuration (from commented section in notebook)
+# Nova model evaluation configuration (uses our own test account in us-east-1)
 NOVA_CONFIG = {
-    "model_package_arn": "arn:aws:sagemaker:us-east-1:052150106756:model-package/test-nova-finetuned-models/3",
-    "dataset_s3_uri": "s3://sagemaker-us-east-1-052150106756/studio-users/d20251107t195443/datasets/2025-11-07T19-55-37-609Z/zc_test.jsonl",
-    "s3_output_path": "s3://mufi-test-serverless-iad/eval/",
-    "mlflow_tracking_server_arn": "arn:aws:sagemaker:us-east-1:052150106756:mlflow-tracking-server/mlflow-prod-server",
-    "model_package_group_arn": "arn:aws:sagemaker:us-east-1:052150106756:model-package-group/test-nova-finetuned-models",
+    "model_package_arn": "arn:aws:sagemaker:us-east-1:729646638167:model-package/sdk-test-finetuned-models/65",
+    "dataset_s3_uri": "s3://sagemaker-us-east-1-729646638167/model-customization/eval/zc_test.jsonl",
+    "s3_output_path": "s3://sagemaker-us-east-1-729646638167/model-customization/eval/",
+    "model_package_group_arn": "arn:aws:sagemaker:us-east-1:729646638167:model-package-group/sdk-test-finetuned-models",
     "region": "us-east-1",
 }
 
@@ -339,7 +338,7 @@ class TestBenchmarkEvaluatorIntegration:
         assert execution.status.overall_status == "Succeeded"
         logger.info("Base model only evaluation completed successfully")
 
-    # @pytest.mark.skip(reason="Requires us-east-1 test infrastructure - tracked in AI-5")
+    @pytest.mark.skip(reason="Pending us-east-1 test infrastructure migration to dedicated test account")
     def test_benchmark_evaluation_nova_model(self):
         """
         Test benchmark evaluation with Nova model.
@@ -347,8 +346,7 @@ class TestBenchmarkEvaluatorIntegration:
         This test uses a Nova fine-tuned model package in us-east-1 region.
         Configuration from commented section in benchmark_demo.ipynb.
         
-        Note: This test is currently skipped. Remove the @pytest.mark.skip decorator
-        when you want to enable it.
+        Note: This test is currently skipped pending us-east-1 test infra migration.
         """
         # Get benchmarks
         Benchmark = get_benchmarks()
@@ -360,7 +358,6 @@ class TestBenchmarkEvaluatorIntegration:
             benchmark=Benchmark.MMLU,
             model=NOVA_CONFIG["model_package_arn"],
             s3_output_path=NOVA_CONFIG["s3_output_path"],
-            mlflow_resource_arn=NOVA_CONFIG["mlflow_tracking_server_arn"],
             model_package_group=NOVA_CONFIG["model_package_group_arn"],
             base_eval_name="integ-test-nova-eval",
             region=NOVA_CONFIG["region"],

--- a/sagemaker-train/tests/integ/train/test_benchmark_evaluator.py
+++ b/sagemaker-train/tests/integ/train/test_benchmark_evaluator.py
@@ -23,8 +23,6 @@ from sagemaker.train.evaluate import (
     EvaluationPipelineExecution,
 )
 
-pytestmark = pytest.mark.gpu_intensive
-
 # Configure logging
 logging.basicConfig(
     level=logging.INFO,

--- a/sagemaker-train/tests/integ/train/test_benchmark_evaluator.py
+++ b/sagemaker-train/tests/integ/train/test_benchmark_evaluator.py
@@ -286,7 +286,7 @@ class TestBenchmarkEvaluatorIntegration:
         
         logger.info("Subtask validation tests passed")
 
-    @pytest.mark.skip(reason="Pipeline creation fails - under investigation")
+    # @pytest.mark.skip(reason="Pipeline creation fails - under investigation")
     def test_benchmark_evaluation_base_model_only(self):
         """
         Test benchmark evaluation with base model only (no fine-tuned model).
@@ -339,7 +339,7 @@ class TestBenchmarkEvaluatorIntegration:
         assert execution.status.overall_status == "Succeeded"
         logger.info("Base model only evaluation completed successfully")
 
-    @pytest.mark.skip(reason="Requires us-east-1 test infrastructure - tracked in AI-5")
+    # @pytest.mark.skip(reason="Requires us-east-1 test infrastructure - tracked in AI-5")
     def test_benchmark_evaluation_nova_model(self):
         """
         Test benchmark evaluation with Nova model.

--- a/sagemaker-train/tests/integ/train/test_model_trainer.py
+++ b/sagemaker-train/tests/integ/train/test_model_trainer.py
@@ -96,7 +96,7 @@ def test_hp_contract_basic_sh_script(sagemaker_session):
 
 
 # skip this test for now as requirments.txt is not resolved
-@pytest.mark.skip(reason="MPI distributed training does not resolve requirements.txt on worker nodes")
+# @pytest.mark.skip(reason="MPI distributed training does not resolve requirements.txt on worker nodes")
 def test_hp_contract_mpi_script(sagemaker_session):
     compute = Compute(instance_type="ml.m5.xlarge", instance_count=2)
     model_trainer = ModelTrainer(


### PR DESCRIPTION
`test_hp_contract_mpi_script` -- unskip with fix
`test_benchmark_evaluation_base_model_only` -- unskip
`test_benchmark_evaluation_nova_model` -- remain skipped but eliminate dependency to cross account resources

### `test_hp_contract_mpi_script` fix

**Problem:** `mpi_driver.py` used absolute imports (`from sagemaker.train.container_drivers.distributed_drivers.mpi_utils import ...`), but the `sagemaker-train` package is not installed in the training container. The driver scripts are uploaded as standalone files to `/opt/ml/input/data/sm_drivers/` and executed directly, so the absolute imports fail with `ModuleNotFoundError: No module named 'sagemaker.train'`.

**Fix:** Changed `mpi_driver.py` to use `sys.path.insert` + relative module name imports, matching the pattern already used by `torchrun_driver.py`, which works correctly in the container environment.
 