### PR TITLE
test: unskip two spark related tests

### DIFF
--- a/sagemaker-core/src/sagemaker/core/remote_function/job.py
+++ b/sagemaker-core/src/sagemaker/core/remote_function/job.py
@@ -860,6 +860,10 @@ class _JobSettings:
         except ImportError:
             pass
 
+        # Spark 3.3 and below do not support py312; use 3.5 which supports both py39 and py312
+        if py_version == "312" and spark_version in ("2.4", "3.0", "3.1", "3.2", "3.3"):
+            spark_version = "3.5"
+
         image_uri = image_uris.retrieve(
             framework=SPARK_NAME,
             region=region,

--- a/sagemaker-core/tests/integ/remote_function/conftest.py
+++ b/sagemaker-core/tests/integ/remote_function/conftest.py
@@ -172,6 +172,52 @@ def spark_test_container(sagemaker_session, sagemaker_sdk_tar_path, tmp_path_fac
 
 
 @pytest.fixture(scope="session")
+def spark_pre_execution_commands(sagemaker_session):
+    """Build sagemaker-core wheel, upload to S3, and return pre-execution install commands.
+
+    This mirrors the pattern used in sagemaker-mlops feature_processor integ tests.
+    The Spark processing image does not have sagemaker-core pre-installed, so we must
+    build the local dev wheel and install it in the container via pre_execution_commands.
+    """
+    import subprocess
+    import glob
+    import tempfile
+    from sagemaker.core.s3 import S3Uploader
+
+    repo_root = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "..", "..", "..", "..")
+    )
+    core_dir = os.path.join(repo_root, "sagemaker-core")
+
+    with tempfile.TemporaryDirectory() as dist_dir:
+        subprocess.run(
+            f"python -m build --wheel --outdir {dist_dir}",
+            shell=True,
+            cwd=core_dir,
+            check=True,
+        )
+        wheels = glob.glob(os.path.join(dist_dir, "sagemaker_core-*.whl"))
+        if not wheels:
+            raise FileNotFoundError(f"No sagemaker-core wheel found in {dist_dir}")
+        wheel_path = wheels[0]
+        wheel_name = os.path.basename(wheel_path)
+
+        s3_prefix = "s3://{}/spark-integ-test/wheels".format(
+            sagemaker_session.default_bucket()
+        )
+        S3Uploader.upload(wheel_path, s3_prefix, sagemaker_session=sagemaker_session)
+
+    PIP = "python3 -m pip install --root-user-action=ignore"
+    AWS = "python3 -m awscli"
+    cmds = [
+        f"{PIP} awscli",
+        f"{AWS} s3 cp {s3_prefix}/{wheel_name} /tmp/{wheel_name}",
+        f"{PIP} /tmp/{wheel_name}",
+    ]
+    return cmds
+
+
+@pytest.fixture(scope="session")
 def conda_env_yml():
     """Write conda yml file needed for tests."""
     conda_yml_file_name = "conda_env.yml"

--- a/sagemaker-core/tests/integ/remote_function/test_decorator.py
+++ b/sagemaker-core/tests/integ/remote_function/test_decorator.py
@@ -579,12 +579,13 @@ def test_with_user_and_workdir_set_in_the_image_client_error_case(
 #     reason="SageMaker Spark image only available for Python 3.9 and 3.12",
 # )
 @pytest.mark.spark_py312
-def test_decorator_with_spark_job(sagemaker_session, cpu_instance_type):
+def test_decorator_with_spark_job(sagemaker_session, cpu_instance_type, spark_pre_execution_commands):
     @remote(
         role=ROLE,
         instance_type=cpu_instance_type,
         sagemaker_session=sagemaker_session,
         keep_alive_period_in_seconds=60,
+        pre_execution_commands=spark_pre_execution_commands,
         spark_config=SparkConfig(
             configuration=[
                 {

--- a/sagemaker-core/tests/integ/remote_function/test_decorator.py
+++ b/sagemaker-core/tests/integ/remote_function/test_decorator.py
@@ -574,10 +574,11 @@ def test_with_user_and_workdir_set_in_the_image_client_error_case(
     assert client_error_message in str(error)
 
 
-@pytest.mark.skipif(
-    sys.version_info[:2] not in [(3, 9), (3, 12)],
-    reason="SageMaker Spark image only available for Python 3.9 and 3.12",
-)
+# @pytest.mark.skipif(
+#     sys.version_info[:2] not in [(3, 9), (3, 12)],
+#     reason="SageMaker Spark image only available for Python 3.9 and 3.12",
+# )
+@pytest.mark.spark_py312
 def test_decorator_with_spark_job(sagemaker_session, cpu_instance_type):
     @remote(
         role=ROLE,

--- a/sagemaker-core/tests/integ/remote_function/test_decorator.py
+++ b/sagemaker-core/tests/integ/remote_function/test_decorator.py
@@ -600,7 +600,14 @@ def test_decorator_with_spark_job(sagemaker_session, cpu_instance_type, spark_pr
 
         spark = SparkSession.builder.getOrCreate()
 
-        assert spark.conf.get("spark.app.name") == "remote-spark-test"
+        # Avoid bare assert here: pytest's assertion rewriting injects _pytest
+        # module references into the function bytecode, which causes
+        # deserialization to fail in the Spark container (no pytest installed).
+        app_name = spark.conf.get("spark.app.name")
+        if app_name != "remote-spark-test":
+            raise RuntimeError(
+                f"Expected spark.app.name='remote-spark-test', got '{app_name}'"
+            )
 
     test_spark_transform()
 

--- a/sagemaker-mlops/tests/integ/feature_store/feature_processor/test_feature_processor_integ.py
+++ b/sagemaker-mlops/tests/integ/feature_store/feature_processor/test_feature_processor_integ.py
@@ -798,11 +798,11 @@ def test_to_pipeline_and_execute(
 #     sys.version_info[:2] not in [(3, 9), (3, 12)],
 #     reason=f"SageMaker Spark image only supports Python 3.9 and 3.12, got {sys.version_info[:2]}",
 # )
-@pytest.mark.skip(
-    reason="Lake Formation credential vending (GetTemporaryGlueTableCredentials) requires "
-    "full LF environment setup (resource registration, trust policy, data location grants) "
-    "that is not configured in CI. See quip-amazon.com/S3FEAMMMuKm0 for details."
-)
+# @pytest.mark.skip(
+#     reason="Lake Formation credential vending (GetTemporaryGlueTableCredentials) requires "
+#     "full LF environment setup (resource registration, trust policy, data location grants) "
+#     "that is not configured in CI. See quip-amazon.com/S3FEAMMMuKm0 for details."
+# )
 @pytest.mark.spark_py312
 @pytest.mark.slow_test
 def test_to_pipeline_and_execute_with_lake_formation(


### PR DESCRIPTION
## Unskip `test_to_pipeline_and_execute_with_lake_formation`

This test was previously skipped because the CI account (`729646638167`) lacked the Lake Formation environment setup required for credential vending. The test creates a Feature Group with `LakeFormationConfig(enabled=True)` and runs a SageMaker Pipeline whose Spark job calls `GetTemporaryCredentialsForTableV2` to ingest data into the offline store.

### Root Cause of Previous Failure

The Feature Store Spark SDK calls `lakeformation:GetTemporaryCredentialsForTableV2` (the V2 credential vending API) during ingestion when `use_lake_formation_credentials=True`. This API requires:

1. The caller must **not** be a Data Lake Admin
2. The caller must have Lake Formation table-level permissions (SELECT/INSERT)
3. The S3 data location must be registered with Lake Formation
4. **`AllowFullTableExternalDataAccess` must be enabled** in the account's data lake settings — this is the setting that authorizes third-party engines (like Spark running in SageMaker Training) to call the credential vending API

### CI Account Configuration Applied

The following Lake Formation and IAM configurations were applied to account `729646638167` (us-west-2):

| Configuration | Detail |
|---|---|
| IAM inline policy on `PullRequestBuildRole` | `lakeformation:*` on `*` |
| LF Database grant | ALL on `sagemaker_featurestore` |
| LF Table wildcard grant | ALL on all tables in `sagemaker_featurestore` |
| LF Data Location Access | On `s3://sagemaker-test-featurestore-us-west-2-729646638167` |
| Data Lake Admin | `PullRequestBuildRole` removed (credential vending doesn't work for admins) |
| `AllowFullTableExternalDataAccess` | `true` (required for Spark credential vending) |
| `AllowExternalDataFiltering` | `true` |
| `AuthorizedSessionTagValueList` | `["*"]` |
| Trust policy on `PullRequestBuildRole` | Already includes `lakeformation.amazonaws.com` |

---

## Fix `test_decorator_with_spark_job` (sagemaker-core)

### Problem

The Spark integ test `test_decorator_with_spark_job` was failing with two issues:

1. **`ModuleNotFoundError: No module named 'sagemaker'`** — The Spark processing image (`sagemaker-spark-processing:3.5-cpu-py312-v1`) does not have `sagemaker-core` pre-installed. When `smspark-submit` runs `spark_app.py`, it tries to `from sagemaker.core.remote_function import invoke_function` and fails.

2. **`ModuleNotFoundError: No module named '_pytest'`** — Pytest's assertion rewriting injects `_pytest` module references into the function bytecode. When `cloudpickle` serializes the `@remote` function containing `assert`, the serialized payload captures this dependency. The Spark container doesn't have `pytest` installed, so deserialization fails.

### Root Cause

The **sagemaker-mlops** Spark integ tests (`test_feature_processor_integ.py`) already solve this problem with a well-established pattern:
1. Build local SDK wheels (`sagemaker`, `sagemaker-core`, `sagemaker-mlops`)
2. Upload them to S3
3. Install them in the Spark container via `pre_execution_commands`

The sagemaker-core Spark test was missing this entirely — it only passed `spark_config=SparkConfig(...)` without any `pre_execution_commands` or `dependencies`, relying on the container having the SDK pre-installed (which was true for the old v2 SDK images but not for v3/sagemaker-core).

### Fix

**Mirroring the existing pattern from `sagemaker-mlops/tests/integ/feature_store/feature_processor/test_feature_processor_integ.py`:**

1. **Added `spark_pre_execution_commands` fixture** in `conftest.py` — builds the local `sagemaker-core` wheel, uploads it to S3, and returns install commands. This directly mirrors `get_pre_execution_commands()` / `get_wheel_file_s3_uri()` in the mlops test.

2. **Added `pre_execution_commands=spark_pre_execution_commands`** to the `@remote` decorator call in the test, ensuring the Spark container has the correct dev version of `sagemaker-core` installed — same as how mlops passes `pre_execution_commands=pre_execution_commands` to its `@remote` calls.

3. **Replaced `assert` with `if/raise RuntimeError`** inside the remote function to avoid pytest's assertion rewriting polluting the serialized function with `_pytest` module references. (The mlops tests avoid this issue naturally because their remote functions don't use `assert`.)

4. **Added Spark 3.5 fallback for py312** in `job.py` — when the default Spark version doesn't support py312, fall back to Spark 3.5 which has a py312 image available.

