### PR TITLE
fix: Remove tags from TransformJob creation in Transformer

### DIFF
--- a/sagemaker-core/src/sagemaker/core/transformer.py
+++ b/sagemaker-core/src/sagemaker/core/transformer.py
@@ -409,6 +409,8 @@ class Transformer(object):
         from sagemaker.core.utils.code_injection.codec import transform as transform_util
 
         transformed = transform_util(serialized_request, "CreateTransformJobRequest")
+        # Remove tags from transformed dict as TransformJob resource doesn't accept it
+        transformed.pop("tags", None)
         self.latest_transform_job = TransformJob(**transformed)
 
         if wait:

--- a/sagemaker-core/tests/unit/test_transformer.py
+++ b/sagemaker-core/tests/unit/test_transformer.py
@@ -639,3 +639,22 @@ class TestTransformer:
         assert "resource_config" in config
         assert config["output_config"]["s3_output_path"] == "s3://bucket/output"
         assert config["resource_config"]["instance_count"] == 2
+
+    def test_transform_removes_tags_from_transform_job(self, mock_session):
+        """Test that tags are removed from transformed dict before TransformJob creation"""
+        transformer = Transformer(
+            model_name="test-model",
+            instance_count=1,
+            instance_type="ml.m5.xlarge",
+            sagemaker_session=mock_session,
+            tags=[{"Key": "test", "Value": "value"}],
+        )
+
+        with patch("sagemaker.core.transformer.TransformJob") as mock_job_class:
+            transformer.transform(
+                data="s3://bucket/input",
+                job_name="test-job",
+            )
+            mock_job_class.assert_called_once()
+            call_kwargs = mock_job_class.call_args[1]
+            assert "tags" not in call_kwargs


### PR DESCRIPTION
The TransformJob resource doesn't accept tags parameter during initialization. Remove tags from the transformed dict before passing to TransformJob constructor to prevent errors.

Similar to [4722723](https://github.com/aws/sagemaker-python-sdk/commit/472272350e50f2d36e280b2f80006c5141ebc935).