### PR TITLE
test: run integ-tests-us-east-1 for all submodules

### DIFF
--- a/.github/workflows/pr-checks-master.yml
+++ b/.github/workflows/pr-checks-master.yml
@@ -221,7 +221,7 @@ jobs:
   integ-tests-us-east-1:
     runs-on: ubuntu-latest
     needs: [detect-changes]
-    if: contains(fromJson(needs.detect-changes.outputs.submodules), 'sagemaker-train')
+    if: needs.detect-changes.outputs.submodules != '[]'
     steps:
       - name: Configure AWS Credentials (us-east-1)
         uses: aws-actions/configure-aws-credentials@v4
@@ -230,8 +230,8 @@ jobs:
           aws-region: us-east-1
           role-duration-seconds: 10800
 
-      - name: Run us-east-1 Integ Tests for sagemaker-train
+      - name: Run us-east-1 Integ Tests (all submodules)
         uses: aws-actions/aws-codebuild-run-build@v1
         with:
-          project-name: ${{ github.event.repository.name }}-ci-sagemaker-train-integ-tests
+          project-name: ${{ github.event.repository.name }}-ci-integ-tests-us-east-1
           source-version-override: 'refs/pull/${{ github.event.pull_request.number }}/head^{${{ github.event.pull_request.head.sha }}}'


### PR DESCRIPTION
The integ-tests-us-east-1 job only triggered when sagemaker-train changed and pointed at the train-only CodeBuild project, so us_east_1-marked tests in other submodules (e.g. the Nova deployment tests under sagemaker-serve) were skipped.

Trigger the job on any submodule change and point it at the new cross-submodule project sagemaker-python-sdk-ci-integ-tests-us-east-1, which runs the us_east_1-marked, non-gpu_intensive integ tests across all submodules in us-east-1.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
