### PR TITLE
fix: lazy-init boto3 clients in AIRHub to avoid NoRegionError at import time

### DIFF
--- a/sagemaker-train/src/sagemaker/ai_registry/air_hub.py
+++ b/sagemaker-train/src/sagemaker/ai_registry/air_hub.py
@@ -27,9 +27,23 @@ from sagemaker.core.telemetry.constants import Feature
 class AIRHub:
     """AI Registry Hub class for managing hub content operations."""
     
-    # Use production SageMaker endpoint (default)
-    _sagemaker_client = boto3.client("sagemaker")
-    _s3_client = boto3.client("s3")
+    # Lazily initialized clients to avoid requiring AWS region at import time.
+    _sagemaker_client = None
+    _s3_client = None
+
+    @classmethod
+    def _get_sagemaker_client(cls):
+        """Get or create the default SageMaker client (lazy initialization)."""
+        if cls._sagemaker_client is None:
+            cls._sagemaker_client = boto3.client("sagemaker")
+        return cls._sagemaker_client
+
+    @classmethod
+    def _get_s3_client(cls):
+        """Get or create the default S3 client (lazy initialization)."""
+        if cls._s3_client is None:
+            cls._s3_client = boto3.client("s3")
+        return cls._s3_client
 
     @classmethod
     def _generate_hub_names(cls, region: str, account_id: str) -> None:
@@ -71,7 +85,7 @@ class AIRHub:
         cls._ensure_hub_name_initialized()
         
         if client is None:
-            client = cls._sagemaker_client
+            client = cls._get_sagemaker_client()
 
         try:
             client.describe_hub(HubName=cls.hubName)
@@ -113,7 +127,7 @@ class AIRHub:
         Returns:
             Response from import_hub_content API call
         """
-        client = session.sagemaker_client if session is not None else cls._sagemaker_client
+        client = session.sagemaker_client if session is not None else cls._get_sagemaker_client()
 
         cls._create_airegistry_hub_if_not_exists(client)
 
@@ -151,7 +165,7 @@ class AIRHub:
         """
         cls._ensure_hub_name_initialized()
 
-        client = session.sagemaker_client if session is not None else cls._sagemaker_client
+        client = session.sagemaker_client if session is not None else cls._get_sagemaker_client()
         
         request = {
             "HubName": cls.hubName,
@@ -198,7 +212,7 @@ class AIRHub:
         """
         cls._ensure_hub_name_initialized()
 
-        client = session.sagemaker_client if session is not None else cls._sagemaker_client
+        client = session.sagemaker_client if session is not None else cls._get_sagemaker_client()
         
         request = {
             "HubName": cls.hubName,
@@ -224,7 +238,7 @@ class AIRHub:
         """
         cls._ensure_hub_name_initialized()
         
-        client = session.sagemaker_client if session is not None else cls._sagemaker_client
+        client = session.sagemaker_client if session is not None else cls._get_sagemaker_client()
         
         request = {
             "HubName": cls.hubName,
@@ -249,7 +263,7 @@ class AIRHub:
         """
         cls._ensure_hub_name_initialized()
         
-        client = session.sagemaker_client if session is not None else cls._sagemaker_client
+        client = session.sagemaker_client if session is not None else cls._get_sagemaker_client()
         
         request = {
             "HubName": cls.hubName,
@@ -272,7 +286,7 @@ class AIRHub:
         Returns:
             S3 URI of uploaded file
         """
-        AIRHub._s3_client.upload_file(local_file_path, bucket, prefix)
+        AIRHub._get_s3_client().upload_file(local_file_path, bucket, prefix)
         return f"s3://{bucket}/{prefix}"
 
     @staticmethod
@@ -287,4 +301,4 @@ class AIRHub:
         parsed = urlparse(s3_uri)
         bucket = parsed.netloc
         key = parsed.path.lstrip("/")
-        AIRHub._s3_client.download_file(bucket, key, local_path)
+        AIRHub._get_s3_client().download_file(bucket, key, local_path)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The AIRHub class in sagemaker-train constructs boto3.client("sagemaker") and boto3.client("s3") as class-level attributes, which execute at import time. Since the MTRL Launch PR (v3.13.0) added from sagemaker.train.multi_turn_rl_trainer import MultiTurnRLTrainer to model_builder.py, import sagemaker.serve now transitively imports AIRHub, causing a NoRegionError in any environment without AWS region configured (e.g., conda-forge build CI).

This change converts those class-level client constructions to lazy initialization via _get_sagemaker_client() and _get_s3_client() classmethods. The clients are still created once and cached — the only difference is they're created on first use rather than at import time.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
