### PR TITLE
Test commit to verify PR-check submodule selection

### DIFF
--- a/sagemaker-core/tests/integ/s3_utils.py
+++ b/sagemaker-core/tests/integ/s3_utils.py
@@ -58,3 +58,4 @@ def extract_files_from_s3(s3_url, tmpdir, sagemaker_session):
 
     with tarfile.open(model, "r") as tar_file:
         custom_extractall_tarfile(tar_file, tmpdir)
+# Test-only change to verify PR-check submodule selection (no behavior change).

--- a/sagemaker-serve/src/sagemaker/serve/configs.py
+++ b/sagemaker-serve/src/sagemaker/serve/configs.py
@@ -32,3 +32,4 @@ class Compute:
     """Compute configuration for model deployment."""
     instance_type: Optional[str]
     instance_count: Optional[int] = 1
+# Source change to verify PR-check submodule selection (no behavior change).


### PR DESCRIPTION
Adds a comment-only change to a core test file (test-only) and a serve source file (source) to confirm the selector picks core + serve + mlops (serve's source change propagates to mlops, core is added on its own as a test-only change).

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
