### PR TITLE
chore: deprecate Python 3.9 support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -220,7 +220,6 @@ Supported Python Versions
 
 SageMaker Python SDK is tested on:
 
-- Python 3.9
 - Python 3.10
 - Python 3.11
 - Python 3.12

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -16,7 +16,7 @@ Prerequisites
 ---------------
 
 **Python Version**
-  SageMaker Python SDK V3 supports Python 3.9, 3.10, 3.11, and 3.12
+  SageMaker Python SDK V3 supports Python 3.10, 3.11, and 3.12
 
 **Operating Systems**
   - Linux

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -6,7 +6,7 @@ Get started with SageMaker Python SDK V3 in minutes. This guide walks you throug
 Prerequisites
 -------------
 
-* Python 3.9+ installed
+* Python 3.10+ installed
 * AWS account with appropriate permissions
 * AWS credentials configured
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "sagemaker"
 dynamic = ["version"]
 description = "Open source library for training and deploying models on Amazon SageMaker."
 readme = "README.rst"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [
   { name = "Amazon Web Services" },
 ]
@@ -27,7 +27,6 @@ classifiers = [
   "License :: OSI Approved :: Apache Software License",
   "Natural Language :: English",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",

--- a/sagemaker-core/pyproject.toml
+++ b/sagemaker-core/pyproject.toml
@@ -39,12 +39,11 @@ dependencies = [
     "tblib>=1.7.0",
     "cryptography>=46.0.0",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: Apache Software License",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/sagemaker-core/tox.ini
+++ b/sagemaker-core/tox.ini
@@ -5,7 +5,7 @@
 
 [tox]
 isolated_build = true
-envlist = black-format,flake8,pylint,docstyle,sphinx,doc8,twine,py39,py310,py311,py312
+envlist = black-format,flake8,pylint,docstyle,sphinx,doc8,twine,py310,py311,py312
 skip_missing_interpreters = False
 
 [flake8]
@@ -86,7 +86,7 @@ allowlist_externals =
     pytest
 commands =
     python -c "import os; os.system('install-custom-pkgs --install-boto-wheels')"
-    pip install 'apache-airflow==2.10.4' --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.10.4/constraints-3.9.txt"
+    pip install 'apache-airflow==2.10.4' --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.10.4/constraints-3.10.txt"
     pip install 'torch==2.3.1+cpu' -f 'https://download.pytorch.org/whl/torch_stable.html'
     pip install 'torchvision==0.18.1+cpu' -f 'https://download.pytorch.org/whl/torch_stable.html'
     pip install 'dill>=0.3.9'
@@ -98,7 +98,7 @@ deps =
     .[test]
     mock
 depends =
-    {py39,py310,py311,py312}: clean
+    {py310,py311,py312}: clean
 
 [testenv:py312]
 basepython = python3.12

--- a/sagemaker-mlops/pyproject.toml
+++ b/sagemaker-mlops/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "SageMaker MLOps package for workflow orchestration and model building"
 readme = "README.md"
 license = {file = "LICENSE"}
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [
     {name = "Amazon Web Services"},
 ]
@@ -17,7 +17,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/sagemaker-mlops/tox.ini
+++ b/sagemaker-mlops/tox.ini
@@ -5,7 +5,7 @@
 
 [tox]
 isolated_build = true
-envlist = black-format,flake8,pylint,docstyle,sphinx,doc8,twine,py39,py310,py311,py312
+envlist = black-format,flake8,pylint,docstyle,sphinx,doc8,twine,py310,py311,py312
 
 skip_missing_interpreters = False
 
@@ -88,7 +88,7 @@ allowlist_externals =
     pytest
 commands =
     python -c "import os; os.system('install-custom-pkgs --install-boto-wheels')"
-    pip install 'apache-airflow==2.10.4' --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.10.4/constraints-3.9.txt"
+    pip install 'apache-airflow==2.10.4' --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.10.4/constraints-3.10.txt"
     pip install 'torch==2.8.0' 'torchvision==0.23.0'
     pip install 'dill>=0.3.9'
 
@@ -101,7 +101,7 @@ deps =
     .[test]
     mock
 depends =
-    {py39,py310,py311,py312}: clean
+    {py310,py311,py312}: clean
 
 [testenv:py312]
 basepython = python3.12

--- a/sagemaker-serve/pyproject.toml
+++ b/sagemaker-serve/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "SageMaker Serve package for model serving and deployment"
 readme = "README.md"
 license = {file = "LICENSE"}
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [
     {name = "Amazon Web Services"},
 ]
@@ -17,7 +17,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/sagemaker-serve/tox.ini
+++ b/sagemaker-serve/tox.ini
@@ -5,7 +5,7 @@
 
 [tox]
 isolated_build = true
-envlist = black-format,flake8,pylint,docstyle,sphinx,doc8,twine,py39,py310,py311,py312
+envlist = black-format,flake8,pylint,docstyle,sphinx,doc8,twine,py310,py311,py312
 
 skip_missing_interpreters = False
 
@@ -88,7 +88,7 @@ allowlist_externals =
     pytest
 commands =
     python -c "import os; os.system('install-custom-pkgs --install-boto-wheels')"
-    pip install 'apache-airflow==2.10.4' --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.10.4/constraints-3.9.txt"
+    pip install 'apache-airflow==2.10.4' --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.10.4/constraints-3.10.txt"
     pip install 'torch==2.8.0' 'torchvision==0.23.0'
     pip install 'onnx>=1.16.0,<1.17.0' 'onnxruntime>=1.19.0,<1.20.0'
     pip install 'dill>=0.3.9'
@@ -102,7 +102,7 @@ deps =
     .[test]
     mock
 depends =
-    {py39,py310,py311,py312}: clean
+    {py310,py311,py312}: clean
 
 [testenv:py312]
 basepython = python3.12

--- a/sagemaker-train/README.rst
+++ b/sagemaker-train/README.rst
@@ -67,7 +67,6 @@ Supported Python Versions
 
 SageMaker Python SDK is tested on:
 
-- Python 3.9
 - Python 3.10
 - Python 3.11
 - Python 3.12

--- a/sagemaker-train/pyproject.toml
+++ b/sagemaker-train/pyproject.toml
@@ -7,7 +7,7 @@ name = "sagemaker-train"
 dynamic = ["version"]
 description = "Open source library for training and deploying models on Amazon SageMaker."
 readme = "README.rst"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [
   { name = "Amazon Web Services" },
 ]
@@ -27,7 +27,6 @@ classifiers = [
   #"License :: OSI Approved :: Apache Software License",
   "Natural Language :: English",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",

--- a/sagemaker-train/tox.ini
+++ b/sagemaker-train/tox.ini
@@ -5,7 +5,7 @@
 
 [tox]
 isolated_build = true
-envlist = black-format,flake8,pylint,docstyle,sphinx,doc8,twine,py39,py310,py311,py312
+envlist = black-format,flake8,pylint,docstyle,sphinx,doc8,twine,py310,py311,py312
 
 skip_missing_interpreters = False
 
@@ -89,7 +89,7 @@ allowlist_externals =
     pytest
 commands =
     python -c "import os; os.system('install-custom-pkgs --install-boto-wheels')"
-    pip install 'apache-airflow==2.10.4' --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.10.4/constraints-3.9.txt"
+    pip install 'apache-airflow==2.10.4' --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.10.4/constraints-3.10.txt"
     pip install 'torch==2.3.1+cpu' -f 'https://download.pytorch.org/whl/torch_stable.html'
     pip install 'torchvision==0.18.1+cpu' -f 'https://download.pytorch.org/whl/torch_stable.html'
     pip install 'dill>=0.3.9'
@@ -101,7 +101,7 @@ deps =
     .[test]
     mock
 depends =
-    {py39,py310,py311,py312}: clean
+    {py310,py311,py312}: clean
 
 [testenv:py312]
 basepython = python3.12


### PR DESCRIPTION
## Description

  Python 3.9 has reached end-of-life. This PR removes Python 3.9 from the
  SageMaker Python SDK's supported runtimes. The new minimum supported version
  is **Python 3.10** (supported: 3.10, 3.11, 3.12).

  Mirrors the prior py3.8 deprecation (#5123, #5133).

  ## Changes

  - **Package metadata** (5 × `pyproject.toml`): `requires-python` `>=3.9` → `>=3.10`;
    removed the `Programming Language :: Python :: 3.9` classifier.
  - **tox** (4 × `tox.ini`): dropped `py39` from `envlist` and `depends`; bumped the
    Apache Airflow constraint from `constraints-3.9.txt` → `constraints-3.10.txt` to
    match the new minimum.
  - **CI matrix** (`.github/workflows/pr-checks-master-v2.yml`): dropped `py39` from the
  - **Docs**: removed Python 3.9 from `README.rst`, `sagemaker-train/README.rst`,
    `docs/installation.rst`, and `docs/quickstart.rst`.

  Container/framework image Python versions (e.g. `py39` image-URI tags, framework
  config JSON) are intentionally **not** changed — those refer to SageMaker container
  runtimes, not the SDK's own runtime.

  > Note: The CI testing infrastructure that still runs py3.9 unit jobs lives in the
  > internal `SageMakerMLFPySDKInfraCDK` package and is updated in a separate CR.
