### PR TITLE
Use extract_path (not CWD) as tar-extraction containment base

### DIFF
--- a/sagemaker-core/src/sagemaker/core/common_utils.py
+++ b/sagemaker-core/src/sagemaker/core/common_utils.py
@@ -1767,7 +1767,7 @@ def _is_bad_link(info, base):
     return _is_bad_path(info.linkname, base=tip)
 
 
-def _get_safe_members(members):
+def _get_safe_members(members, base_path):
     """A generator that yields members that are safe to extract.
 
     It filters out bad paths and bad links.
@@ -1778,7 +1778,7 @@ def _get_safe_members(members):
     Yields:
         tarfile.TarInfo: The tar file info.
     """
-    base = _get_resolved_path("")
+    base = _get_resolved_path(base_path)
 
     for file_info in members:
         if _is_bad_path(file_info.name, base):
@@ -1842,7 +1842,7 @@ def custom_extractall_tarfile(tar, extract_path):
     if hasattr(tarfile, "data_filter"):
         tar.extractall(path=extract_path, filter="data")
     else:
-        tar.extractall(path=extract_path, members=_get_safe_members(tar))
+        tar.extractall(path=extract_path, members=_get_safe_members(tar, extract_path))
         # Re-validate extracted paths to catch symlink race conditions
         _validate_extracted_paths(extract_path)
 


### PR DESCRIPTION
## What

Passes `extract_path` into `_get_safe_members` so the tar path-traversal filter validates members against the intended extraction target rather than the process current working directory.

Three minimal changes in `sagemaker-core/src/sagemaker/core/common_utils.py`:

1. `def _get_safe_members(members):` → `def _get_safe_members(members, base_path):`
2. `base = _get_resolved_path("")` → `base = _get_resolved_path(base_path)`
3. `_get_safe_members(tar)` → `_get_safe_members(tar, extract_path)` at the call-site in `custom_extractall_tarfile`

No reformatting. No other callers of `_get_safe_members` exist in this file.

## Why

The pre-3.12 fallback path in `custom_extractall_tarfile` (taken when `tarfile` lacks `data_filter`, i.e. Python < 3.12) called `_get_safe_members` with `_get_resolved_path("")` as its containment base. `_get_resolved_path("")` resolves to the process current working directory, not to `extract_path`. A crafted model or code tarball whose member names traverse outside the CWD-relative base would therefore pass the member filter even if the escape destination lies outside `extract_path`.

The post-extraction validator `_validate_extracted_paths` correctly uses `_get_resolved_path(extract_path)` as its base, but it only walks files that were actually written inside `extract_path` — so it cannot detect escapes that already landed outside that directory.

The sibling implementation in `sagemaker-mlops/src/sagemaker/mlops/workflow/_repack_model.py` already has the correct signature: `_get_safe_members(members, base)` where `base` is the resolved `extract_path`. This fix brings `common_utils.py` into alignment with that implementation and with `_validate_extracted_paths`.
