### PR TITLE
fix(ci): Use source-version-override so CI Health builds checkout the right branch

### DIFF
--- a/.github/workflows/ci-health.yml
+++ b/.github/workflows/ci-health.yml
@@ -21,7 +21,7 @@ jobs:
         uses: aws-actions/aws-codebuild-run-build@v1
         with:
           project-name: sagemaker-python-sdk-ci-health-canaries-v3
-          source-version: refs/heads/master
+          source-version-override: refs/heads/master
   canaries-v2:
     runs-on: ubuntu-latest
     steps:
@@ -35,7 +35,7 @@ jobs:
         uses: aws-actions/aws-codebuild-run-build@v1
         with:
           project-name: sagemaker-python-sdk-ci-health-canaries-v2
-          source-version: refs/heads/master-v2
+          source-version-override: refs/heads/master-v2
   unit-tests-v2:
     runs-on: ubuntu-latest
     strategy:
@@ -53,7 +53,7 @@ jobs:
         uses: aws-actions/aws-codebuild-run-build@v1
         with:
           project-name: sagemaker-python-sdk-ci-health-unit-tests
-          source-version: refs/heads/master-v2
+          source-version-override: refs/heads/master-v2
           env-vars-for-codebuild: |
             PY_VERSION
         env:
@@ -71,7 +71,7 @@ jobs:
         uses: aws-actions/aws-codebuild-run-build@v1
         with:
           project-name: sagemaker-python-sdk-ci-health-slow-tests
-          source-version: refs/heads/master-v2
+          source-version-override: refs/heads/master-v2
   localmode-tests-v2:
     runs-on: ubuntu-latest
     steps:
@@ -85,7 +85,7 @@ jobs:
         uses: aws-actions/aws-codebuild-run-build@v1
         with:
           project-name: sagemaker-python-sdk-ci-health-localmode-tests
-          source-version: refs/heads/master-v2
+          source-version-override: refs/heads/master-v2
   unit-test-v3:
     runs-on: ubuntu-latest
     strategy:
@@ -103,7 +103,7 @@ jobs:
         uses: aws-actions/aws-codebuild-run-build@v1
         with:
           project-name: sagemaker-python-sdk-ci-health-unit-test-v3
-          source-version: refs/heads/master
+          source-version-override: refs/heads/master
           env-vars-for-codebuild: |
             SUBMODULE
         env:


### PR DESCRIPTION
The CI Health jobs passed the branch via `source-version`, which is not a valid input for aws-actions/aws-codebuild-run-build. The action ignored it and fell back to its default behavior of forcing sourceVersion to the commit that triggered the workflow (master / V3). As a result the v2 jobs (unit-tests-v2, slow-tests-v2, localmode-tests-v2) ran V2's tox commands against the V3 monorepo layout, where the repo root has no tox.ini, and failed within a minute with "tox config file not found".

Rename all six occurrences to the correct input name `source-version-override` so each job checks out its intended branch (master-v2 for the v2 jobs and canaries-v2, master for canaries-v3 and unit-test-v3).

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
