### PR TITLE
fix(tags): use sagemaker-sdk: prefix instead of sagemaker-studio: for…

### DIFF
--- a/sagemaker-serve/src/sagemaker/serve/model_builder.py
+++ b/sagemaker-serve/src/sagemaker/serve/model_builder.py
@@ -2508,7 +2508,7 @@ class ModelBuilder(_InferenceRecommenderMixin, _ModelBuilderServers, _ModelBuild
                     containers=[container_def],
                     enable_network_isolation=True,
                     tags=[
-                        {"key": "sagemaker-studio:jumpstart-model-id",
+                        {"key": "sagemaker-sdk:jumpstart-model-id",
                          "value": base_model.hub_content_name},
                     ],
                 )
@@ -4848,10 +4848,10 @@ class ModelBuilder(_InferenceRecommenderMixin, _ModelBuilderServers, _ModelBuild
         )
 
         tags = [
-            {"key": "sagemaker-studio:jumpstart-model-id", "value": base_model.hub_content_name},
+            {"key": "sagemaker-sdk:jumpstart-model-id", "value": base_model.hub_content_name},
         ]
         if base_model.recipe_name:
-            tags.append({"key": "sagemaker-studio:recipe-name", "value": base_model.recipe_name})
+            tags.append({"key": "sagemaker-sdk:recipe-name", "value": base_model.recipe_name})
 
         endpoint = Endpoint.create(
             endpoint_name=endpoint_name,

--- a/sagemaker-train/src/sagemaker/train/dpo_trainer.py
+++ b/sagemaker-train/src/sagemaker/train/dpo_trainer.py
@@ -6,7 +6,7 @@ from sagemaker.train.common import TrainingType, CustomizationTechnique, JOB_TYP
 from sagemaker.core.resources import TrainingJob, ModelPackageGroup, ModelPackage
 from sagemaker.core.shapes import VpcConfig
 from sagemaker.train.defaults import TrainDefaults
-from sagemaker.train.utils import _get_unique_name, _get_studio_tags
+from sagemaker.train.utils import _get_unique_name, _get_jumpstart_tags
 from sagemaker.train.configs import StoppingCondition
 from sagemaker.train.common_utils.finetune_utils import (
     _get_fine_tuning_options_and_model_arn,
@@ -251,7 +251,7 @@ class DPOTrainer(BaseTrainer):
         )
 
         vpc_config = self.networking if self.networking else None
-        tags = _get_studio_tags(self._model_name, get_sagemaker_hub_name())
+        tags = _get_jumpstart_tags(self._model_name, get_sagemaker_hub_name())
 
         # Build TrainingJob.create() arguments
         create_args = {

--- a/sagemaker-train/src/sagemaker/train/multi_turn_rl_trainer.py
+++ b/sagemaker-train/src/sagemaker/train/multi_turn_rl_trainer.py
@@ -44,7 +44,7 @@ from sagemaker.train.common_utils.constants import MIN_MLFLOW_VERSION
 from sagemaker.train.common_utils.recipe_utils import _list_hub_models_by_recipe, _is_nova_model
 from sagemaker.train.constants import get_sagemaker_hub_name
 from sagemaker.train.defaults import TrainDefaults
-from sagemaker.train.utils import _get_unique_name, _get_studio_tags
+from sagemaker.train.utils import _get_unique_name, _get_jumpstart_tags
 
 logger = logging.getLogger(__name__)
 
@@ -279,7 +279,7 @@ class MultiTurnRLTrainer(BaseTrainer):
             self.training_dataset = training_dataset
         job_config_doc = self._build_job_config_document()
 
-        tags = _get_studio_tags(self._model_name, get_sagemaker_hub_name())
+        tags = _get_jumpstart_tags(self._model_name, get_sagemaker_hub_name())
 
         try:
             job = Job.create(

--- a/sagemaker-train/src/sagemaker/train/rlaif_trainer.py
+++ b/sagemaker-train/src/sagemaker/train/rlaif_trainer.py
@@ -5,7 +5,7 @@ from sagemaker.train.common import TrainingType, CustomizationTechnique, JOB_TYP
 from sagemaker.core.resources import TrainingJob, ModelPackageGroup, MlflowTrackingServer, ModelPackage
 from sagemaker.core.shapes import VpcConfig
 from sagemaker.train.defaults import TrainDefaults
-from sagemaker.train.utils import _get_unique_name, _get_studio_tags
+from sagemaker.train.utils import _get_unique_name, _get_jumpstart_tags
 from sagemaker.train.common_utils.recipe_utils import _get_hub_content_metadata
 from sagemaker.ai_registry.dataset import DataSet
 from sagemaker.ai_registry.evaluator import Evaluator
@@ -268,7 +268,7 @@ class RLAIFTrainer(BaseTrainer):
         )
 
         vpc_config = self.networking if self.networking else None
-        tags = _get_studio_tags(self._model_name, get_sagemaker_hub_name())
+        tags = _get_jumpstart_tags(self._model_name, get_sagemaker_hub_name())
 
         # Build TrainingJob.create() arguments
         create_args = {

--- a/sagemaker-train/src/sagemaker/train/rlvr_trainer.py
+++ b/sagemaker-train/src/sagemaker/train/rlvr_trainer.py
@@ -5,7 +5,7 @@ from sagemaker.train.common import TrainingType, CustomizationTechnique, JOB_TYP
 from sagemaker.core.resources import TrainingJob, ModelPackageGroup, MlflowTrackingServer, ModelPackage
 from sagemaker.core.shapes import VpcConfig
 from sagemaker.train.defaults import TrainDefaults
-from sagemaker.train.utils import _get_unique_name, _get_studio_tags
+from sagemaker.train.utils import _get_unique_name, _get_jumpstart_tags
 from sagemaker.ai_registry.dataset import DataSet
 from sagemaker.ai_registry.evaluator import Evaluator
 from sagemaker.train.configs import StoppingCondition
@@ -259,7 +259,7 @@ class RLVRTrainer(BaseTrainer):
         )
 
         vpc_config = self.networking if self.networking else None
-        tags = _get_studio_tags(self._model_name, get_sagemaker_hub_name())
+        tags = _get_jumpstart_tags(self._model_name, get_sagemaker_hub_name())
 
         # Build TrainingJob.create() arguments
         create_args = {

--- a/sagemaker-train/src/sagemaker/train/sft_trainer.py
+++ b/sagemaker-train/src/sagemaker/train/sft_trainer.py
@@ -6,7 +6,7 @@ from sagemaker.train.common import TrainingType, CustomizationTechnique, JOB_TYP
 from sagemaker.core.resources import TrainingJob, ModelPackageGroup, ModelPackage
 from sagemaker.core.shapes import VpcConfig
 from sagemaker.train.defaults import TrainDefaults
-from sagemaker.train.utils import _get_unique_name, _get_studio_tags
+from sagemaker.train.utils import _get_unique_name, _get_jumpstart_tags
 from sagemaker.ai_registry.dataset import DataSet
 from sagemaker.train.configs import StoppingCondition
 from sagemaker.train.common_utils.finetune_utils import (
@@ -250,7 +250,7 @@ class SFTTrainer(BaseTrainer):
         )
 
         vpc_config = self.networking if self.networking else None
-        tags = _get_studio_tags(self._model_name, get_sagemaker_hub_name())
+        tags = _get_jumpstart_tags(self._model_name, get_sagemaker_hub_name())
 
         # Build TrainingJob.create() arguments
         create_args = {

--- a/sagemaker-train/src/sagemaker/train/utils.py
+++ b/sagemaker-train/src/sagemaker/train/utils.py
@@ -240,14 +240,14 @@ def _run_clone_command_silent(repo_url, dest_dir):
             logger.error(f"Error output:\n{e}")
             raise
 
-def _get_studio_tags(model_id: str, hub_name: str):
+def _get_jumpstart_tags(model_id: str, hub_name: str):
     return [
         {
-            "key": "sagemaker-studio:jumpstart-model-id",
+            "key": "sagemaker-sdk:jumpstart-model-id",
             "value": model_id
         },
         {
-            "key": "sagemaker-studio:jumpstart-hub-name",
+            "key": "sagemaker-sdk:jumpstart-hub-name",
             "value": hub_name
         }
     ]

--- a/sagemaker-train/tests/unit/train/test_dpo_trainer.py
+++ b/sagemaker-train/tests/unit/train/test_dpo_trainer.py
@@ -269,8 +269,8 @@ class TestDPOTrainer:
         mock_training_job_create.assert_called_once()
         call_kwargs = mock_training_job_create.call_args[1]
         assert call_kwargs["tags"] == [
-            {"key": "sagemaker-studio:jumpstart-model-id", "value": "test-model"},
-            {"key": "sagemaker-studio:jumpstart-hub-name", "value": "SageMakerPublicHub"}
+            {"key": "sagemaker-sdk:jumpstart-model-id", "value": "test-model"},
+            {"key": "sagemaker-sdk:jumpstart-hub-name", "value": "SageMakerPublicHub"}
         ]
 
     @patch('sagemaker.train.dpo_trainer._validate_and_resolve_model_package_group')

--- a/sagemaker-train/tests/unit/train/test_rlaif_trainer.py
+++ b/sagemaker-train/tests/unit/train/test_rlaif_trainer.py
@@ -274,8 +274,8 @@ class TestRLAIFTrainer:
         mock_training_job_create.assert_called_once()
         call_kwargs = mock_training_job_create.call_args[1]
         assert call_kwargs["tags"] == [
-            {"key": "sagemaker-studio:jumpstart-model-id", "value": "test-model"},
-            {"key": "sagemaker-studio:jumpstart-hub-name", "value": "SageMakerPublicHub"}
+            {"key": "sagemaker-sdk:jumpstart-model-id", "value": "test-model"},
+            {"key": "sagemaker-sdk:jumpstart-hub-name", "value": "SageMakerPublicHub"}
         ]
 
     @patch('sagemaker.train.rlaif_trainer._validate_and_resolve_model_package_group')

--- a/sagemaker-train/tests/unit/train/test_rlvr_trainer.py
+++ b/sagemaker-train/tests/unit/train/test_rlvr_trainer.py
@@ -272,8 +272,8 @@ class TestRLVRTrainer:
         mock_training_job_create.assert_called_once()
         call_kwargs = mock_training_job_create.call_args[1]
         assert call_kwargs["tags"] == [
-            {"key": "sagemaker-studio:jumpstart-model-id", "value": "test-model"},
-            {"key": "sagemaker-studio:jumpstart-hub-name", "value": "SageMakerPublicHub"}
+            {"key": "sagemaker-sdk:jumpstart-model-id", "value": "test-model"},
+            {"key": "sagemaker-sdk:jumpstart-hub-name", "value": "SageMakerPublicHub"}
         ]
 
     @patch('sagemaker.train.rlvr_trainer._validate_and_resolve_model_package_group')

--- a/sagemaker-train/tests/unit/train/test_sft_trainer.py
+++ b/sagemaker-train/tests/unit/train/test_sft_trainer.py
@@ -284,8 +284,8 @@ class TestSFTTrainer:
         mock_training_job_create.assert_called_once()
         call_kwargs = mock_training_job_create.call_args[1]
         assert call_kwargs["tags"] == [
-            {"key": "sagemaker-studio:jumpstart-model-id", "value": "test-model"},
-            {"key": "sagemaker-studio:jumpstart-hub-name", "value": "SageMakerPublicHub"}
+            {"key": "sagemaker-sdk:jumpstart-model-id", "value": "test-model"},
+            {"key": "sagemaker-sdk:jumpstart-hub-name", "value": "SageMakerPublicHub"}
         ]
 
     def test_process_hyperparameters_removes_constructor_handled_keys(self):


### PR DESCRIPTION
… JumpStart tags

The SDK should tag resources with sagemaker-sdk:jumpstart-model-id (and related keys) to distinguish SDK-initiated operations from Studio UI ones. This fixes incorrect source attribution in usage data.

- Rename _get_studio_tags() to _get_jumpstart_tags() in train/utils.py
- Change tag key prefix from sagemaker-studio: to sagemaker-sdk: everywhere
- Update all trainer call sites and unit tests

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
