### PR TITLE
fix: simplify subscription recipe handling and fix unit tests

### DIFF
--- a/sagemaker-train/src/sagemaker/train/common_utils/finetune_utils.py
+++ b/sagemaker-train/src/sagemaker/train/common_utils/finetune_utils.py
@@ -571,10 +571,6 @@ def _get_fine_tuning_options_and_model_arn(model_name: str, customization_techni
             if "{customer_id}" in s3_uri:
                 s3_uri = s3_uri.replace("{customer_id}", sagemaker_session.boto_session.client("sts").get_caller_identity()["Account"])
             s3 = sagemaker_session.boto_session.client("s3")
-            # Handle {customer_id} placeholder (subscription recipes use access point URIs)
-            if "{customer_id}" in s3_uri:
-                account_id = sagemaker_session.boto_session.client("sts").get_caller_identity()["Account"]
-                s3_uri = s3_uri.replace("{customer_id}", account_id)
             uri_path = s3_uri.replace("s3://", "")
             # Handle access point ARN URIs (subscription recipes use S3 access points).
             # Format: arn:aws:s3:<region>:<account>:accesspoint/<name>/<key>
@@ -617,48 +613,7 @@ def _get_fine_tuning_options_and_model_arn(model_name: str, customization_techni
                             v_copy['default'] = None  # No default — won't appear in to_dict() unless set
                         options_dict[k] = v_copy
             except Exception as e:
-                if recipe.get("IsSubscriptionModel"):
-                    raise ValueError(
-                        f"Could not access subscription recipe for model '{model_name}'. "
-                        f"This model only provides subscription-based recipes. "
-                        f"Please verify that your account has an active Nova Forge subscription. "
-                        f"Refer: https://docs.aws.amazon.com/sagemaker/latest/dg/nova-forge.html#nova-forge-prereq-access"
-                    ) from e
-                else:
-                    raise
-
-        # Auto-detect and merge subscription recipe's override_params if available
-        # (only needed when the primary recipe is NOT a subscription recipe)
-        if not recipe.get("IsSubscriptionModel"):
-            if (isinstance(training_type, TrainingType) and training_type == TrainingType.LORA) or training_type == "LORA":
-                sub_recipe = next((r for r in recipes_with_template if r.get("Peft") and r.get("IsSubscriptionModel")), None)
-            else:
-                sub_recipe = next((r for r in recipes_with_template if not r.get("Peft") and r.get("IsSubscriptionModel")), None)
-
-            if sub_recipe and sub_recipe.get("SmtjOverrideParamsS3Uri"):
-                try:
-                    sub_s3_uri = sub_recipe["SmtjOverrideParamsS3Uri"].replace("{customer_id}", sagemaker_session.boto_session.client("sts").get_caller_identity()["Account"])
-                    sub_uri_path = sub_s3_uri.replace("s3://", "")
-                    # Handle access point ARN URIs
-                    if sub_uri_path.startswith("arn:"):
-                        arn_parts = sub_uri_path.split("/", 2)
-                        sub_bucket = arn_parts[0] + "/" + arn_parts[1]
-                        sub_key = arn_parts[2] if len(arn_parts) > 2 else ""
-                    else:
-                        sub_bucket, sub_key = sub_uri_path.split("/", 1)
-                    s3_sub = sagemaker_session.boto_session.client("s3")
-                    sub_obj = s3_sub.get_object(Bucket=sub_bucket, Key=sub_key)
-                    sub_options = json.loads(sub_obj["Body"].read())
-                    # Merge: subscription params into _specs only (don't set defaults)
-                    # This makes them settable but not serialized unless user explicitly sets them
-                    for k, v in sub_options.items():
-                        if k not in options_dict:
-                            v_copy = v.copy() if isinstance(v, dict) else v
-                            if isinstance(v_copy, dict):
-                                v_copy['default'] = None  # No default — won't appear in to_dict() unless set
-                            options_dict[k] = v_copy
-                except Exception as e:
-                    logger.warning(f"Could not fetch subscription recipe override_params: {type(e).__name__}: {e}")
+                logger.debug(f"Could not fetch subscription recipe override_params: {type(e).__name__}: {e}")
 
         if options_dict:
             return FineTuningOptions(options_dict), model_arn, is_gated_model

--- a/sagemaker-train/tests/unit/train/evaluate/test_mtrl_evaluator_handshake.py
+++ b/sagemaker-train/tests/unit/train/evaluate/test_mtrl_evaluator_handshake.py
@@ -281,13 +281,14 @@ class TestCustomScorerEvaluatorWithMTRLTrainer:
 class TestEvaluateSubmissionWithMTRLTrainer:
     """Test that evaluate() can be called successfully when model is an MTRLTrainer."""
 
+    @patch('sagemaker.train.evaluate.base_evaluator.resolve_and_validate_role', side_effect=lambda provided_role, **kwargs: provided_role)
     @patch('sagemaker.train.evaluate.base_evaluator._resolve_mlflow_resource_arn')
     @patch('sagemaker.train.common_utils.model_resolution._ModelResolver._resolve_model_package_arn')
     @patch('sagemaker.train.evaluate.base_evaluator.BaseEvaluator._get_or_create_artifact_arn')
     @patch('sagemaker.train.evaluate.execution.EvaluationPipelineExecution.start')
     @patch('sagemaker.train.evaluate.benchmark_evaluator.BenchMarkEvaluator.hyperparameters', new_callable=PropertyMock)
     def test_benchmark_evaluate_submission_with_mtrl_trainer(
-        self, mock_hyperparams, mock_start, mock_artifact, mock_resolve_mp, mock_mlflow
+        self, mock_hyperparams, mock_start, mock_artifact, mock_resolve_mp, mock_mlflow, mock_role
     ):
         """BenchMarkEvaluator.evaluate() should successfully submit when model is MTRLTrainer."""
         from sagemaker.train.evaluate import BenchMarkEvaluator, get_benchmarks
@@ -325,13 +326,14 @@ class TestEvaluateSubmissionWithMTRLTrainer:
         assert execution.arn is not None
         mock_start.assert_called_once()
 
+    @patch('sagemaker.train.evaluate.base_evaluator.resolve_and_validate_role', side_effect=lambda provided_role, **kwargs: provided_role)
     @patch('sagemaker.train.evaluate.base_evaluator._resolve_mlflow_resource_arn')
     @patch('sagemaker.train.common_utils.model_resolution._ModelResolver._resolve_model_package_arn')
     @patch('sagemaker.train.evaluate.base_evaluator.BaseEvaluator._get_or_create_artifact_arn')
     @patch('sagemaker.train.evaluate.execution.EvaluationPipelineExecution.start')
     @patch('sagemaker.train.evaluate.custom_scorer_evaluator.CustomScorerEvaluator.hyperparameters', new_callable=PropertyMock)
     def test_custom_scorer_evaluate_submission_with_mtrl_trainer(
-        self, mock_hyperparams, mock_start, mock_artifact, mock_resolve_mp, mock_mlflow
+        self, mock_hyperparams, mock_start, mock_artifact, mock_resolve_mp, mock_mlflow, mock_role
     ):
         """CustomScorerEvaluator.evaluate() should successfully submit when model is MTRLTrainer."""
         from sagemaker.train.evaluate import CustomScorerEvaluator

--- a/sagemaker-train/tests/unit/train/test_hyperpod_connect_permissions.py
+++ b/sagemaker-train/tests/unit/train/test_hyperpod_connect_permissions.py
@@ -58,7 +58,7 @@ def _make_base_trainer():
     trainer.validation_dataset = None
     trainer.s3_output_path = "s3://bucket/out/"
     trainer.hyperparameters = None
-    trainer._recipe_path = "recipe-name"
+    trainer._recipe_path = None
     trainer._overrides = None
     return trainer
 
@@ -89,6 +89,9 @@ class TestTrainHyperPodVerifiesConnectPermissions:
         with patch(
             "sagemaker.train.common_utils.finetune_utils.get_training_image",
             return_value=None,
+        ), patch(
+            "sagemaker.train.base_trainer.get_hyperpod_recipe_path",
+            return_value="fine-tuning/nova/test-recipe",
         ):
             trainer._train_hyperpod(wait=False)
 
@@ -131,6 +134,9 @@ class TestTrainHyperPodVerifiesConnectPermissions:
         with patch(
             "sagemaker.train.common_utils.finetune_utils.get_training_image",
             return_value=None,
+        ), patch(
+            "sagemaker.train.base_trainer.get_hyperpod_recipe_path",
+            return_value="fine-tuning/nova/test-recipe",
         ):
             job_name = trainer._train_hyperpod(wait=False)
 
@@ -201,6 +207,9 @@ class TestTrainHyperPodConnectPermissionsEndToEnd:
         with patch(
             "sagemaker.train.common_utils.finetune_utils.get_training_image",
             return_value=None,
+        ), patch(
+            "sagemaker.train.base_trainer.get_hyperpod_recipe_path",
+            return_value="fine-tuning/nova/test-recipe",
         ), caplog.at_level(
             logging.WARNING, logger="sagemaker.core.helper.iam_role_resolver"
         ):
@@ -240,6 +249,9 @@ class TestTrainHyperPodConnectPermissionsEndToEnd:
         with patch(
             "sagemaker.train.common_utils.finetune_utils.get_training_image",
             return_value=None,
+        ), patch(
+            "sagemaker.train.base_trainer.get_hyperpod_recipe_path",
+            return_value="fine-tuning/nova/test-recipe",
         ), caplog.at_level(
             logging.WARNING, logger="sagemaker.core.helper.iam_role_resolver"
         ):

--- a/sagemaker-train/tests/unit/train/test_model_trainer_pipeline_variable.py
+++ b/sagemaker-train/tests/unit/train/test_model_trainer_pipeline_variable.py
@@ -50,7 +50,8 @@ DEFAULT_OUTPUT = OutputDataConfig(
 
 @pytest.fixture(scope="module", autouse=True)
 def modules_session():
-    with patch("sagemaker.train.Session", spec=Session) as session_mock:
+    with patch("sagemaker.train.Session", spec=Session) as session_mock, \
+         patch("sagemaker.train.defaults.resolve_and_validate_role", side_effect=lambda provided_role, **kwargs: provided_role or DEFAULT_ROLE):
         session_instance = session_mock.return_value
         session_instance.default_bucket.return_value = DEFAULT_BUCKET
         session_instance.get_caller_identity_arn.return_value = DEFAULT_ROLE


### PR DESCRIPTION
Remove duplicate {customer_id} replacement and redundant subscription recipe override_params merge logic. Update tests to mock resolve_and_validate_role and get_hyperpod_recipe_path introduced in recent IAM/recipe validation changes.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
