### PR TITLE
Bump upstream sagemaker-core to >=2.15.0 and sagemaker-train/serve/mlops to >=1.15.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,10 +32,10 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-  "sagemaker-core>=2.14.0,<3.0.0",
-  "sagemaker-train>=1.14.0,<2.0.0",
-  "sagemaker-serve>=1.14.0,<2.0.0",
-  "sagemaker-mlops>=1.14.0,<2.0.0",
+  "sagemaker-core>=2.15.0,<3.0.0",
+  "sagemaker-train>=1.15.0,<2.0.0",
+  "sagemaker-serve>=1.15.0,<2.0.0",
+  "sagemaker-mlops>=1.15.0,<2.0.0",
 ]
 
 [project.optional-dependencies]

--- a/sagemaker-mlops/pyproject.toml
+++ b/sagemaker-mlops/pyproject.toml
@@ -22,9 +22,9 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    "sagemaker-core>=2.14.0",
-    "sagemaker-train>=1.14.0",
-    "sagemaker-serve>=1.14.0",
+    "sagemaker-core>=2.15.0",
+    "sagemaker-train>=1.15.0",
+    "sagemaker-serve>=1.15.0",
     "cryptography>=46.0.0",
     "boto3>=1.42.2,<2.0",
     "botocore>=1.42.2,<2.0",

--- a/sagemaker-serve/pyproject.toml
+++ b/sagemaker-serve/pyproject.toml
@@ -22,8 +22,8 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    "sagemaker-core>=2.14.0",
-    "sagemaker-train>=1.14.0",
+    "sagemaker-core>=2.15.0",
+    "sagemaker-train>=1.15.0",
     "boto3>=1.42.2,<2.0",
     "botocore>=1.35.75,<2.0",
     "deepdiff",

--- a/sagemaker-train/pyproject.toml
+++ b/sagemaker-train/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    "sagemaker-core>=2.14.0",
+    "sagemaker-core>=2.15.0",
     "graphene>=3,<4",
     "typing_extensions>=4.9.0",
     "tblib>=1.7.0",


### PR DESCRIPTION
Bump upstream sagemaker-core to >=2.15.0 and sagemaker-train/serve/mlops to >=1.15.0 in all pyproject.toml files.