### PR TITLE
feat: add v2 -> v3 runtime migration warnings

### DIFF
--- a/src/sagemaker/__init__.py
+++ b/src/sagemaker/__init__.py
@@ -76,5 +76,11 @@ from sagemaker.automl.automlv2 import (  # noqa: F401
 
 from sagemaker.debugger import ProfilerConfig, Profiler  # noqa: F401
 from sagemaker.partner_app.auth_provider import PartnerAppAuthProvider  # noqa: F401
+from sagemaker.deprecations import warn_v2_deprecation  # noqa: F401
 
 __version__ = importlib_metadata.version("sagemaker")
+
+# This guarantees every v2 user sees the v2 -> v3 notice regardless of which API
+# they use. It fires once per process and is suppressible via the
+# SAGEMAKER_SUPPRESS_V2_WARNING environment variable (see sagemaker.deprecations).
+warn_v2_deprecation()

--- a/src/sagemaker/base_predictor.py
+++ b/src/sagemaker/base_predictor.py
@@ -26,6 +26,7 @@ from sagemaker.deprecations import (
     removed_kwargs,
     renamed_kwargs,
     renamed_warning,
+    warn_v2_deprecation,
 )
 from sagemaker.deserializers import (  # noqa: F401 # pylint: disable=unused-import
     BytesDeserializer,
@@ -131,6 +132,15 @@ class Predictor(PredictorBase):
             component_name (str): Name of the Amazon SageMaker inference component
                 corresponding the predictor.
         """
+        # Reports the concrete subclass name since predictors route through
+        # Predictor.__init__.
+        # The migration guide maps Predictor to the Endpoint resource in
+        # sagemaker-core but does not publish an exact import path, so we name
+        # the symbol and defer to the guide rather than quoting an import.
+        warn_v2_deprecation(
+            feature=type(self).__name__,
+            v3_replacement="sagemaker.core.resources.Endpoint",
+        )
         removed_kwargs("content_type", kwargs)
         removed_kwargs("accept", kwargs)
         endpoint_name = renamed_kwargs("endpoint", "endpoint_name", endpoint_name, kwargs)

--- a/src/sagemaker/deprecations.py
+++ b/src/sagemaker/deprecations.py
@@ -14,11 +14,92 @@
 from __future__ import absolute_import
 
 import logging
+import os
 import warnings
 
 logger = logging.getLogger(__name__)
 
 V2_URL = "https://sagemaker.readthedocs.io/en/stable/v2.html"
+
+# Migration guide for the v2 -> v3 (major version) transition.
+V3_MIGRATION_URL = "https://github.com/aws/sagemaker-python-sdk/blob/master/migration.md"
+
+# Setting this environment variable to a truthy value silences the v2 -> v3
+# migration warnings. Intended for users who cannot migrate yet (e.g. pinned
+# production jobs, CI) and do not want the nudge on every run.
+SUPPRESS_V2_WARNING_ENV_VAR = "SAGEMAKER_SUPPRESS_V2_WARNING"
+
+# Tracks the v2 -> v3 nudges already emitted in this process so that each
+# distinct feature warns at most once, regardless of how many objects are
+# created. Keyed by feature name (None for the package-level nudge).
+_v2_deprecation_warned = set()
+
+
+class SageMakerV2DeprecationWarning(FutureWarning):
+    """Warning for the SageMaker Python SDK v2 -> v3 migration.
+
+    Subclasses ``FutureWarning`` rather than ``DeprecationWarning`` so the
+    message is shown by default to end users running application code (Python
+    silences ``DeprecationWarning`` outside of ``__main__``). Users can still
+    silence it through the standard ``warnings`` filters, the ``PYTHONWARNINGS``
+    environment variable, or by setting ``SAGEMAKER_SUPPRESS_V2_WARNING=1``.
+    """
+
+
+def _v2_suppressed():
+    """Return True if the v2 -> v3 migration warnings are suppressed via env var."""
+    return bool(os.environ.get(SUPPRESS_V2_WARNING_ENV_VAR))
+
+
+def warn_v2_deprecation(feature=None, v3_replacement=None, v3_import=None, stacklevel=2):
+    """Emit a visible, once-per-process warning about the v2 -> v3 migration.
+
+    Args:
+        feature (str): Name of the v2 feature being flagged (e.g. ``"Estimator"``).
+            When ``None``, emits the package-level nudge shown on ``import sagemaker``.
+        v3_replacement (str): The exact v3 symbol (or fully qualified path) that
+            replaces this feature, e.g. ``"ModelTrainer"`` or
+            ``"sagemaker.core.shapes.TransformJob"``. Optional.
+        v3_import (str): The exact import statement for the v3 replacement, e.g.
+            ``"from sagemaker.train import ModelTrainer"``. Quoted verbatim in the
+            message so users can copy-paste it. Optional; provide only when the
+            migration guide gives a confirmed import path.
+        stacklevel (int): Passed through to ``warnings.warn`` so the warning is
+            attributed to the caller's frame. Defaults to 2.
+
+    Notes:
+        The warning fires at most once per distinct ``feature`` per process and
+        is a no-op when ``SAGEMAKER_SUPPRESS_V2_WARNING`` is set.
+    """
+    if _v2_suppressed():
+        return
+    if feature in _v2_deprecation_warned:
+        return
+    _v2_deprecation_warned.add(feature)
+
+    if feature is None:
+        msg = (
+            "You are using the SageMaker Python SDK v2, which is on path of deprecation. "
+            "v3 is the actively developed major version."
+        )
+    else:
+        msg = f"{feature} is part of the SageMaker Python SDK v2, which is on path of deprecation."
+        if v3_replacement:
+            # Backtick-quote concrete symbols/paths (no spaces); leave descriptive
+            # phrases (used when the migration guide gives no exact symbol) unquoted.
+            if " " in v3_replacement:
+                msg += f" In v3, use {v3_replacement}"
+            else:
+                msg += f" In v3, use `{v3_replacement}`"
+            if v3_import:
+                msg += f" (`{v3_import}`)"
+            msg += "."
+    msg += (
+        f"\nSee {V3_MIGRATION_URL} for the migration guide. "
+        f"Set {SUPPRESS_V2_WARNING_ENV_VAR}=1 to silence this warning."
+    )
+    warnings.warn(msg, SageMakerV2DeprecationWarning, stacklevel=stacklevel)
+    logger.warning(msg)
 
 
 def _warn(msg, sdk_version=None):

--- a/src/sagemaker/estimator.py
+++ b/src/sagemaker/estimator.py
@@ -53,7 +53,12 @@ from sagemaker.debugger import (  # noqa: F401 # pylint: disable=unused-import
     get_rule_container_image_uri,
     RuleBase,
 )
-from sagemaker.deprecations import removed_function, removed_kwargs, renamed_kwargs
+from sagemaker.deprecations import (
+    removed_function,
+    removed_kwargs,
+    renamed_kwargs,
+    warn_v2_deprecation,
+)
 from sagemaker.fw_utils import (
     UploadedCode,
     _region_supports_debugger,
@@ -577,6 +582,14 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):  # pylint: disable=too-man
                     }
 
         """
+        # Reports the concrete subclass name (Estimator, PyTorch, TensorFlow,
+        # HuggingFace, SKLearn, XGBoost, AlgorithmEstimator, JumpStartEstimator, ...)
+        # since every estimator routes through EstimatorBase.__init__.
+        warn_v2_deprecation(
+            feature=type(self).__name__,
+            v3_replacement="ModelTrainer",
+            v3_import="from sagemaker.train import ModelTrainer",
+        )
         instance_count = renamed_kwargs(
             "train_instance_count", "instance_count", instance_count, kwargs
         )

--- a/src/sagemaker/experiments/experiment.py
+++ b/src/sagemaker/experiments/experiment.py
@@ -18,6 +18,7 @@ import time
 from botocore.exceptions import ClientError
 
 from sagemaker.apiutils import _base_types
+from sagemaker.deprecations import warn_v2_deprecation
 from sagemaker.experiments.trial import _Trial
 from sagemaker.experiments.trial_component import _TrialComponent
 from sagemaker.utils import format_tags
@@ -88,6 +89,10 @@ class Experiment(_base_types.Record):
         Returns:
             experiments.experiment.Experiment: A SageMaker `Experiment` object
         """
+        warn_v2_deprecation(
+            feature="Experiment",
+            v3_replacement="the experiment tracking resources under sagemaker.core.experiments",
+        )
         return cls._construct(
             cls._boto_load_method,
             experiment_name=experiment_name,
@@ -121,6 +126,10 @@ class Experiment(_base_types.Record):
         Returns:
             experiments.experiment.Experiment: A SageMaker `Experiment` object
         """
+        warn_v2_deprecation(
+            feature="Experiment",
+            v3_replacement="the experiment tracking resources under sagemaker.core.experiments",
+        )
         return cls._construct(
             cls._boto_create_method,
             experiment_name=experiment_name,

--- a/src/sagemaker/experiments/run.py
+++ b/src/sagemaker/experiments/run.py
@@ -24,6 +24,7 @@ import dateutil
 from numpy import array
 
 from sagemaker.apiutils import _utils
+from sagemaker.deprecations import warn_v2_deprecation
 from sagemaker.experiments import _api_types
 from sagemaker.experiments._api_types import (
     TrialComponentArtifact,
@@ -168,6 +169,10 @@ class Run(object):
             artifact_prefix (str): The S3 key prefix used to generate the S3 path
                 to upload the artifact to (default: "trial-component-artifacts").
         """
+        warn_v2_deprecation(
+            feature="Run",
+            v3_replacement="the experiment tracking resources under sagemaker.core.experiments",
+        )
         # TODO: we should revert the lower casting once backend fix reaches prod
         self.experiment_name = experiment_name.lower()
         sagemaker_session = sagemaker_session or _utils.default_session()

--- a/src/sagemaker/mlflow/tracking_server.py
+++ b/src/sagemaker/mlflow/tracking_server.py
@@ -17,6 +17,7 @@
 from __future__ import absolute_import
 from typing import Optional, TYPE_CHECKING
 from sagemaker.apiutils import _utils
+from sagemaker.deprecations import warn_v2_deprecation
 
 if TYPE_CHECKING:
     from sagemaker import Session
@@ -43,6 +44,10 @@ def generate_mlflow_presigned_url(
     Returns:
         (str): Authorized Url to acess the Mlflow UI.
     """
+    warn_v2_deprecation(
+        feature="The MLflow integration",
+        v3_replacement="the MLflow classes under sagemaker.mlops",
+    )
     session = sagemaker_session or _utils.default_session()
     api_response = session.create_presigned_mlflow_tracking_server_url(
         name, expires_in_seconds, session_expiration_duration_in_seconds

--- a/src/sagemaker/model.py
+++ b/src/sagemaker/model.py
@@ -53,6 +53,7 @@ from sagemaker.model_card.helpers import _hash_content_str
 from sagemaker.model_card.schema_constraints import ModelApprovalStatusEnum
 from sagemaker.session import Session
 from sagemaker.container_base_model import ContainerBaseModel
+from sagemaker.deprecations import warn_v2_deprecation
 from sagemaker.model_metrics import ModelMetrics
 from sagemaker.drift_check_baselines import DriftCheckBaselines
 from sagemaker.explainer import ExplainerConfig
@@ -340,6 +341,14 @@ class Model(ModelBase, InferenceRecommenderMixin):
                 content (default: None).
 
         """
+        # Reports the concrete subclass name (Model, MultiDataModel,
+        # JumpStartModel, framework models, ...) since they route through
+        # Model.__init__.
+        warn_v2_deprecation(
+            feature=type(self).__name__,
+            v3_replacement="ModelBuilder",
+            v3_import="from sagemaker.serve import ModelBuilder",
+        )
         self.model_data = model_data
         self.additional_model_data_sources = additional_model_data_sources
         self.image_uri = image_uri

--- a/src/sagemaker/model_card/model_card.py
+++ b/src/sagemaker/model_card/model_card.py
@@ -20,6 +20,7 @@ from typing import Optional, Union, List, Any, Dict
 from botocore.exceptions import ClientError
 from boto3.session import Session as boto3_Session
 from six.moves.urllib.parse import urlparse
+from sagemaker.deprecations import warn_v2_deprecation
 from sagemaker.session import Session
 
 from sagemaker.model_card.schema_constraints import (
@@ -1433,6 +1434,10 @@ class ModelCard(object):
             sagemaker_session (Session, optional): A SageMaker Session object, used for SageMaker interactions (default: None). If not specified, a SageMaker Session is created using the default AWS configuration chain.
             model_package_details (ModelPackage, optional): Model package version metadata information (default: None).
         """  # noqa E501 # pylint: disable=line-too-long
+        warn_v2_deprecation(
+            feature="ModelCard",
+            v3_replacement="the model card resources under sagemaker.core",
+        )
         self.sagemaker_session = sagemaker_session or Session()
         self.name = name
         self.arn = arn

--- a/src/sagemaker/model_monitor/model_monitoring.py
+++ b/src/sagemaker/model_monitor/model_monitoring.py
@@ -44,6 +44,7 @@ from sagemaker.config.config_schema import (
     MONITORING_JOB_OUTPUT_KMS_KEY_ID_PATH,
     MONITORING_JOB_ROLE_ARN_PATH,
 )
+from sagemaker.deprecations import warn_v2_deprecation
 from sagemaker.exceptions import UnexpectedStatusException
 from sagemaker.model_monitor.monitoring_files import Constraints, ConstraintViolations, Statistics
 from sagemaker.model_monitor.monitoring_alert import (
@@ -170,6 +171,12 @@ class ModelMonitor(object):
                 inter-container traffic, security group IDs, and subnets.
 
         """
+        # Reports the concrete subclass name (ModelMonitor, DefaultModelMonitor,
+        # ModelQualityMonitor, ...) since they route through ModelMonitor.__init__.
+        warn_v2_deprecation(
+            feature=type(self).__name__,
+            v3_replacement="sagemaker.core.shapes.MonitoringSchedule",
+        )
         self.image_uri = image_uri
         self.instance_count = instance_count
         self.instance_type = instance_type

--- a/src/sagemaker/predictor_async.py
+++ b/src/sagemaker/predictor_async.py
@@ -18,6 +18,7 @@ import uuid
 from botocore.exceptions import WaiterError
 
 from sagemaker import s3
+from sagemaker.deprecations import warn_v2_deprecation
 from sagemaker.exceptions import PollingTimeoutError, AsyncInferenceModelError
 from sagemaker.async_inference import WaiterConfig, AsyncInferenceResponse
 from sagemaker.s3 import parse_s3_url
@@ -40,6 +41,11 @@ class AsyncPredictor:
                 object has useful methods and variables. ``AsyncPredictor``
                 stands on top of it with capability for async inference.
         """
+        warn_v2_deprecation(
+            feature="AsyncPredictor",
+            v3_replacement="ModelBuilder.deploy(...)",
+            v3_import="from sagemaker.serve import ModelBuilder",
+        )
         self.predictor = predictor
         self.endpoint_name = predictor.endpoint_name
         self.sagemaker_session = predictor.sagemaker_session or Session()

--- a/src/sagemaker/processing.py
+++ b/src/sagemaker/processing.py
@@ -42,6 +42,7 @@ from sagemaker.config import (
     PROCESSING_JOB_VOLUME_KMS_KEY_ID_PATH,
 )
 from sagemaker.dataset_definition.inputs import DatasetDefinition, S3Input
+from sagemaker.deprecations import warn_v2_deprecation
 from sagemaker.job import _Job
 from sagemaker.local import LocalSession
 from sagemaker.network import NetworkConfig
@@ -131,6 +132,14 @@ class Processor(object):
                 object that configures network isolation, encryption of
                 inter-container traffic, security group IDs, and subnets.
         """
+        # Reports the concrete subclass name (Processor, ScriptProcessor,
+        # PySparkProcessor, FrameworkProcessor, SKLearnProcessor, ...) since they
+        # route through Processor.__init__.
+        warn_v2_deprecation(
+            feature=type(self).__name__,
+            v3_replacement="DataProcessor",
+            v3_import="from sagemaker.mlops.processing import DataProcessor",
+        )
         self.image_uri = image_uri
         self.instance_count = instance_count
         self.instance_type = instance_type

--- a/src/sagemaker/transformer.py
+++ b/src/sagemaker/transformer.py
@@ -28,6 +28,7 @@ from sagemaker.config import (
     TRANSFORM_RESOURCES_VOLUME_KMS_KEY_ID_PATH,
     PIPELINE_ROLE_ARN_PATH,
 )
+from sagemaker.deprecations import warn_v2_deprecation
 from sagemaker.job import _Job
 from sagemaker.session import Session, get_execution_role
 from sagemaker.inputs import BatchDataCaptureConfig
@@ -111,6 +112,10 @@ class Transformer(object):
             volume_kms_key (str or PipelineVariable): Optional. KMS key ID for encrypting
                 the volume attached to the ML compute instance (default: None).
         """
+        warn_v2_deprecation(
+            feature=type(self).__name__,
+            v3_replacement="sagemaker.core.shapes.TransformJob",
+        )
         self.model_name = model_name
         self.strategy = strategy
 

--- a/src/sagemaker/tuner.py
+++ b/src/sagemaker/tuner.py
@@ -29,7 +29,7 @@ from sagemaker.amazon.amazon_estimator import (
 )
 from sagemaker.amazon.hyperparameter import Hyperparameter as hp  # noqa
 from sagemaker.analytics import HyperparameterTuningJobAnalytics
-from sagemaker.deprecations import removed_function
+from sagemaker.deprecations import removed_function, warn_v2_deprecation
 from sagemaker.estimator import EstimatorBase, Framework
 from sagemaker.inputs import FileSystemInput, TrainingInput
 from sagemaker.job import _Job
@@ -683,6 +683,13 @@ class HyperparameterTuner(object):
                 static and will not be assigned a tunable range with Autotune functionality.
                 (default: None).
         """
+        # The migration guide moves HPT to sagemaker-core but does not publish a
+        # single import path (it spans multiple classes), so we point at the
+        # namespace and defer to the guide.
+        warn_v2_deprecation(
+            feature=type(self).__name__,
+            v3_replacement="the hyperparameter tuning classes under sagemaker.core",
+        )
         if hyperparameter_ranges is None or len(hyperparameter_ranges) == 0:
             if not autotune:
                 raise ValueError("Need to specify hyperparameter ranges or set autotune=True.")

--- a/src/sagemaker/workflow/pipeline.py
+++ b/src/sagemaker/workflow/pipeline.py
@@ -26,6 +26,7 @@ from botocore.exceptions import ClientError, WaiterError
 
 from sagemaker import s3, LocalSession
 from sagemaker._studio import _append_project_tags
+from sagemaker.deprecations import warn_v2_deprecation
 from sagemaker.config import PIPELINE_ROLE_ARN_PATH, PIPELINE_TAGS_PATH
 from sagemaker.remote_function.core.serialization import deserialize_obj_from_s3
 from sagemaker.remote_function.core.stored_function import RESULTS_FOLDER
@@ -115,6 +116,11 @@ class Pipeline:
                 the workflow customizes the pipeline definition using the configurations
                 specified. By default, custom job-prefixing is turned off.
         """
+        warn_v2_deprecation(
+            feature="Pipeline",
+            v3_replacement="Pipeline",
+            v3_import="from sagemaker.mlops.pipeline import Pipeline",
+        )
         self.name = name
         self.parameters = parameters if parameters else []
         self.pipeline_experiment_config = pipeline_experiment_config

--- a/tests/unit/test_deprecations.py
+++ b/tests/unit/test_deprecations.py
@@ -14,6 +14,7 @@ from __future__ import absolute_import
 
 import pytest
 
+import sagemaker.deprecations as deprecations
 from sagemaker.deprecations import (
     deprecated_class,
     deprecated_deserialize,
@@ -25,7 +26,19 @@ from sagemaker.deprecations import (
     renamed_kwargs,
     deprecation_warning,
     deprecated,
+    warn_v2_deprecation,
+    SageMakerV2DeprecationWarning,
+    SUPPRESS_V2_WARNING_ENV_VAR,
 )
+
+
+@pytest.fixture(autouse=True)
+def reset_v2_warning_state(monkeypatch):
+    """Reset the once-per-process dedup set and env var around each test."""
+    monkeypatch.delenv(SUPPRESS_V2_WARNING_ENV_VAR, raising=False)
+    deprecations._v2_deprecation_warned.clear()
+    yield
+    deprecations._v2_deprecation_warned.clear()
 
 
 def test_renamed_kwargs():
@@ -224,3 +237,85 @@ def test_deprecated_class():
     B = deprecated_class(A, "foo")
     with pytest.warns(DeprecationWarning):
         B()
+
+
+def test_warn_v2_deprecation_package_level():
+    with pytest.warns(SageMakerV2DeprecationWarning) as w:
+        warn_v2_deprecation()
+    msg = str(w[-1].message)
+    assert "SageMaker Python SDK v2" in msg
+    assert "deprecation" in msg
+    assert "migration.md" in msg
+    assert SUPPRESS_V2_WARNING_ENV_VAR in msg
+
+
+def test_warn_v2_deprecation_is_future_warning():
+    # FutureWarning is shown by default; DeprecationWarning is not. Subclassing
+    # FutureWarning is what makes the nudge visible to end users.
+    assert issubclass(SageMakerV2DeprecationWarning, FutureWarning)
+
+
+def test_warn_v2_deprecation_feature_with_replacement():
+    with pytest.warns(SageMakerV2DeprecationWarning) as w:
+        warn_v2_deprecation(feature="Estimator", v3_replacement="ModelTrainer")
+    msg = str(w[-1].message)
+    assert "Estimator" in msg
+    assert "ModelTrainer" in msg
+
+
+def test_warn_v2_deprecation_once_per_feature():
+    import warnings
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        warn_v2_deprecation(feature="Estimator")
+        warn_v2_deprecation(feature="Estimator")
+        warn_v2_deprecation(feature="Model")
+    # Estimator fires once despite two calls; Model fires once -> 2 total.
+    categories = [x for x in w if issubclass(x.category, SageMakerV2DeprecationWarning)]
+    assert len(categories) == 2
+
+
+def test_warn_v2_deprecation_suppressed_by_env_var(monkeypatch):
+    import warnings
+
+    monkeypatch.setenv(SUPPRESS_V2_WARNING_ENV_VAR, "1")
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        warn_v2_deprecation()
+        warn_v2_deprecation(feature="Estimator")
+    assert len(w) == 0
+
+
+def test_warn_v2_deprecation_reports_subclass_name():
+    # Base-class __init__ sites pass feature=type(self).__name__ so the warning
+    # names the concrete subclass (e.g. PyTorch) rather than the base.
+    with pytest.warns(SageMakerV2DeprecationWarning) as w:
+        warn_v2_deprecation(feature="PyTorch", v3_replacement="ModelTrainer")
+    assert "PyTorch" in str(w[-1].message)
+
+
+def test_warn_v2_deprecation_quotes_exact_import():
+    # When a v3_import is supplied, the exact import statement is quoted verbatim
+    # so users can copy-paste it.
+    with pytest.warns(SageMakerV2DeprecationWarning) as w:
+        warn_v2_deprecation(
+            feature="Estimator",
+            v3_replacement="ModelTrainer",
+            v3_import="from sagemaker.train import ModelTrainer",
+        )
+    msg = str(w[-1].message)
+    assert "`ModelTrainer`" in msg
+    assert "from sagemaker.train import ModelTrainer" in msg
+
+
+def test_warn_v2_deprecation_without_import_still_names_symbol():
+    # Surfaces with no published import path still name the v3 symbol/namespace
+    # and omit the import parenthetical.
+    with pytest.warns(SageMakerV2DeprecationWarning) as w:
+        warn_v2_deprecation(
+            feature="Transformer", v3_replacement="sagemaker.core.shapes.TransformJob"
+        )
+    msg = str(w[-1].message)
+    assert "sagemaker.core.shapes.TransformJob" in msg
+    assert "import" not in msg.split("\n")[0]  # no import parenthetical on the first line


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Adds visible, suppressible runtime warnings that guide SageMaker Python SDK **v2** users toward **v3**, now that the v2 line is on the path of deprecation. This targets the `master-v2` maintenance branch.

Two tiers, both built on a new `warn_v2_deprecation()` helper in `sagemaker.deprecations`:

- **Tier 1 (package level):** a single nudge emitted on `import sagemaker`, so every v2 user sees the migration notice regardless of which API they use.
***Sample code and output:***
```
Code:  import sagemaker 
Output : SageMakerV2DeprecationWarning: You are using the SageMaker Python SDK v2, which is on path of deprecation. v3 is the actively developed major version.
See https://github.com/aws/sagemaker-python-sdk/blob/master/migration.md for the migration guide. Set SAGEMAKER_SUPPRESS_V2_WARNING=1 to silence this warning.
```



- **Tier 2 (per interface):** a targeted warning at the constructor of each major v2 interface that names the exact v3 replacement (plus a copy-pasteable import where the [migration guide](https://github.com/aws/sagemaker-python-sdk/blob/master/migration.md) publishes one). Base-class call sites use `type(self).__name__`, so subclasses report their own name.

Interfaces covered by Tier 2: `Estimator`/framework estimators, `Model`, `Predictor`, `Transformer`, `HyperparameterTuner`, `Processor`, `Pipeline`, `ModelMonitor`, `AutoML`/`AutoMLV2`, `Experiment`, `Run`, `ModelCard`, `AsyncPredictor`, and the MLflow integration.

***Sample code and output:***
```
Code:  
from sagemaker.transformer import Transformer
Transformer(model_name="demo-model" , ***)
---
Output : /sagemaker/transformer.py:115: SageMakerV2DeprecationWarning: Transformer is part of the SageMaker Python SDK v2, which is on path of deprecation. In v3, use `sagemaker.core.shapes.TransformJob`.
See https://github.com/aws/sagemaker-python-sdk/blob/master/migration.md for the migration guide. Set SAGEMAKER_SUPPRESS_V2_WARNING=1 to silence this warning.
```


Design notes:
- `SageMakerV2DeprecationWarning` subclasses `FutureWarning` so it is shown by default (`DeprecationWarning` is silenced outside `__main__`).
- Fires at most once per feature per process; also emitted via `logger.warning` for log-captured environments (e.g. training jobs).
- Suppressible with `SAGEMAKER_SUPPRESS_V2_WARNING=1` or standard Python warning filters.
- Workflow `Step.__init__` is intentionally **not** instrumented because it breaks existing `len(w)` warning-count assertions; `Pipeline` covers that surface.

*Testing done:*

- Added unit tests in `tests/unit/test_deprecations.py` covering: default visibility (`FutureWarning`), once-per-process dedup, `SAGEMAKER_SUPPRESS_V2_WARNING` suppression, subclass naming, and exact-import rendering. **24/24 pass.**
- Ran each touched module's unit suite in isolation (estimator, model, predictor, transformer, tuner, processing, pipeline, model_monitoring, automl, experiments, model_card, predictor_async, mlflow) — green except pre-existing, environment-related failures (missing optional `mlflow`/`sklearn`, offline botocore `endpoints.json`, a flaky timestamp-collision monitor test), each confirmed failing identically on the unmodified base via `git stash`.
- `flake8` and `black --line-length 100` clean on all changed files.

## Merge Checklist

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
  - Note: changes are additive (new warnings only); no API signatures or behavior change. Targeted at the v2 maintenance line. Flagging for team confirmation that emitting a default-visible `FutureWarning` on import is acceptable messaging.
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change. (N/A — no new clients initialized)
- [ ] I have updated any necessary documentation, including READMEs and API docs (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used `unique_name_from_base` to create resource names in integ tests (if appropriate) (N/A — unit tests only)
- [x] If adding any dependency in requirements.txt files, I have spell checked and ensured they exist in PyPi (N/A — no new dependencies)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
