### PR TITLE
docs: add v2 -> v3 version lifecycle table to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,9 +39,45 @@ If you have **your own algorithms** built into SageMaker compatible Docker conta
 
 For detailed documentation, including the API reference, see `Read the Docs <https://sagemaker.readthedocs.io>`_.
 
+Version Lifecycle
+-----------------
+
+The SageMaker Python SDK follows the `AWS SDKs and Tools maintenance policy
+<https://docs.aws.amazon.com/sdkref/latest/guide/maint-policy.html>`_.
+Version 3 became generally available on 2025-11-19 and is the actively
+developed major version. Version 2 is in maintenance mode: it receives
+critical bug fixes and security updates only, and will not receive new
+features, API updates, or new region support.
+
+We recommend all users migrate to v3. See the `migration guide
+<https://github.com/aws/sagemaker-python-sdk/blob/master/migration.md>`_.
+
+The following table shows the lifecycle phases for **version 2** of the
+SageMaker Python SDK:
+
+=========================  =============  =============
+Phase                      Start Date     End Date
+=========================  =============  =============
+General Availability       2020-08-04     N/A
+Maintenance mode           2026-07-06     2027-07-05
+End-of-Support             2027-07-06     N/A
+=========================  =============  =============
+
+- **General Availability** -- the SDK is fully supported, with regular
+  releases for new services, API updates, and bug and security fixes.
+- **Maintenance mode** -- AWS limits releases to critical bug fixes and
+  security issues only. No new APIs, features, or region support.
+- **End-of-Support** -- the SDK no longer receives updates or releases.
+  Previously published versions remain available on PyPI and the source
+  remains on GitHub.
+
+To pin to v2 during migration: ``pip install "sagemaker<3"``.
+To upgrade to v3: ``pip install --upgrade sagemaker``.
+
 Table of Contents
 -----------------
 
+#. `Version Lifecycle <#version-lifecycle>`__
 #. `Installing SageMaker Python SDK <#installing-the-sagemaker-python-sdk>`__
 #. `Using the SageMaker Python SDK <https://sagemaker.readthedocs.io/en/stable/overview.html>`__
 #. `Using MXNet <https://sagemaker.readthedocs.io/en/stable/using_mxnet.html>`__


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Adds a **Version Lifecycle** section to the v2 README documenting the SageMaker Python SDK lifecycle per the [AWS SDKs and Tools maintenance policy](https://docs.aws.amazon.com/sdkref/latest/guide/maint-policy.html).

The section states that v3 is GA (2025-11-19) and the actively developed major version, that v2 is in maintenance mode (critical bug fixes + security only), and includes:

- a **Phase / Start Date / End Date** table (General Availability, Maintenance mode, End-of-Support) modeled on the AWS SDK for Java v1 lifecycle table,
- per-phase support definitions taken from the policy,
- the migration-guide link, and
- `pip install "sagemaker<3"` (pin) / `pip install --upgrade sagemaker` (upgrade) commands.

Also adds a Table of Contents entry. Dates were aligned with the product team following the policy (maintenance announcement anchored to v3 GA; +6 months to maintenance, +12 months to end-of-support). v2.0.0 GA date (2020-08-04) confirmed from PyPI.

This complements the runtime deprecation-warning work in #5978 (the policy lists both updated docs and in-SDK deprecation warnings as required communication channels).

*Testing done:*

Docs-only change. Validated that `README.rst` parses cleanly with docutils (no RST errors; simple-table columns align). No code changed.

## Merge Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible (documentation only; no code or API change)
- [x] I used the commit message format described in CONTRIBUTING
- [x] I have updated any necessary documentation (this PR is the documentation update)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.