### PR TITLE
Correct DJL-LMI ISO/ADC accounts + add THF/ISO-E (djl-lmi, huggingface-llm-neuronx)

### DIFF
--- a/sagemaker-core/src/sagemaker/core/common_utils.py
+++ b/sagemaker-core/src/sagemaker/core/common_utils.py
@@ -62,6 +62,7 @@ ALTERNATE_DOMAINS = {
     "us-isof-south-1": "csp.hci.ic.gov",
     "us-isof-east-1": "csp.hci.ic.gov",
     "eu-isoe-west-1": "cloud.adc-e.uk",
+    "eusc-de-east-1": "amazonaws.eu",
 }
 
 ECR_URI_PATTERN = r"^(\d+)(\.)dkr(\.)ecr(\.)(.+)(\.)(.*)(/)(.*:.*)$"

--- a/sagemaker-core/src/sagemaker/core/image_uri_config/djl-lmi.json
+++ b/sagemaker-core/src/sagemaker/core/image_uri_config/djl-lmi.json
@@ -43,7 +43,15 @@
                 "ap-southeast-7": "590183813437",
                 "ap-southeast-4": "457447274322",
                 "ap-southeast-5": "550225433462",
-                "mx-central-1": "637423239942"
+                "mx-central-1": "637423239942",
+                "ap-east-2": "975050140332",
+                "ap-southeast-6": "633930458069",
+                "eu-isoe-west-1": "371248457586",
+                "eusc-de-east-1": "204133271717",
+                "us-iso-east-1": "886529160074",
+                "us-isob-east-1": "094389454867",
+                "us-isof-east-1": "303241398832",
+                "us-isof-south-1": "454834333376"
             },
             "repository": "djl-inference",
             "tag_prefix": "0.36.0-lmi26.0.0-cu130"
@@ -86,12 +94,14 @@
                 "ap-southeast-4": "457447274322",
                 "ap-southeast-5": "550225433462",
                 "mx-central-1": "637423239942",
-                "us-iso-east-1": "763104351884",
-                "us-iso-west-1": "763104351884",
-                "us-isob-east-1": "763104351884",
-                "us-isob-west-1": "763104351884",
-                "us-isof-east-1": "763104351884",
-                "us-isof-south-1": "763104351884"
+                "us-iso-east-1": "886529160074",
+                "us-isob-east-1": "094389454867",
+                "us-isof-east-1": "303241398832",
+                "us-isof-south-1": "454834333376",
+                "ap-east-2": "975050140332",
+                "ap-southeast-6": "633930458069",
+                "eu-isoe-west-1": "371248457586",
+                "eusc-de-east-1": "204133271717"
             },
             "repository": "djl-inference",
             "tag_prefix": "0.35.0-lmi17.0.0-cu128"
@@ -134,12 +144,14 @@
                 "ap-southeast-4": "457447274322",
                 "ap-southeast-5": "550225433462",
                 "mx-central-1": "637423239942",
-                "us-iso-east-1": "763104351884",
-                "us-iso-west-1": "763104351884",
-                "us-isob-east-1": "763104351884",
-                "us-isob-west-1": "763104351884",
-                "us-isof-east-1": "763104351884",
-                "us-isof-south-1": "763104351884"
+                "us-iso-east-1": "886529160074",
+                "us-isob-east-1": "094389454867",
+                "us-isof-east-1": "303241398832",
+                "us-isof-south-1": "454834333376",
+                "ap-east-2": "975050140332",
+                "ap-southeast-6": "633930458069",
+                "eu-isoe-west-1": "371248457586",
+                "eusc-de-east-1": "204133271717"
             },
             "repository": "djl-inference",
             "tag_prefix": "0.34.0-lmi16.0.0-cu128"
@@ -182,12 +194,14 @@
                 "ap-southeast-4": "457447274322",
                 "ap-southeast-5": "550225433462",
                 "mx-central-1": "637423239942",
-                "us-iso-east-1": "763104351884",
-                "us-iso-west-1": "763104351884",
-                "us-isob-east-1": "763104351884",
-                "us-isob-west-1": "763104351884",
-                "us-isof-east-1": "763104351884",
-                "us-isof-south-1": "763104351884"
+                "us-iso-east-1": "886529160074",
+                "us-isob-east-1": "094389454867",
+                "us-isof-east-1": "303241398832",
+                "us-isof-south-1": "454834333376",
+                "ap-east-2": "975050140332",
+                "ap-southeast-6": "633930458069",
+                "eu-isoe-west-1": "371248457586",
+                "eusc-de-east-1": "204133271717"
             },
             "repository": "djl-inference",
             "tag_prefix": "0.33.0-lmi15.0.0-cu128"
@@ -229,7 +243,10 @@
                 "ap-southeast-7": "590183813437",
                 "ap-southeast-4": "457447274322",
                 "ap-southeast-5": "550225433462",
-                "mx-central-1": "637423239942"
+                "mx-central-1": "637423239942",
+                "ap-east-2": "975050140332",
+                "ap-southeast-6": "633930458069",
+                "eusc-de-east-1": "204133271717"
             },
             "repository": "djl-inference",
             "tag_prefix": "0.32.0-lmi14.0.0-cu126"
@@ -271,7 +288,10 @@
                 "ap-southeast-7": "590183813437",
                 "ap-southeast-4": "457447274322",
                 "ap-southeast-5": "550225433462",
-                "mx-central-1": "637423239942"
+                "mx-central-1": "637423239942",
+                "ap-east-2": "975050140332",
+                "ap-southeast-6": "633930458069",
+                "eusc-de-east-1": "204133271717"
             },
             "repository": "djl-inference",
             "tag_prefix": "0.31.0-lmi13.0.0-cu124"
@@ -313,7 +333,10 @@
                 "ap-southeast-7": "590183813437",
                 "ap-southeast-4": "457447274322",
                 "ap-southeast-5": "550225433462",
-                "mx-central-1": "637423239942"
+                "mx-central-1": "637423239942",
+                "ap-east-2": "975050140332",
+                "ap-southeast-6": "633930458069",
+                "eusc-de-east-1": "204133271717"
             },
             "repository": "djl-inference",
             "tag_prefix": "0.30.0-lmi12.0.0-cu124"
@@ -355,7 +378,10 @@
                 "ap-southeast-7": "590183813437",
                 "ap-southeast-4": "457447274322",
                 "ap-southeast-5": "550225433462",
-                "mx-central-1": "637423239942"
+                "mx-central-1": "637423239942",
+                "ap-east-2": "975050140332",
+                "ap-southeast-6": "633930458069",
+                "eusc-de-east-1": "204133271717"
             },
             "repository": "djl-inference",
             "tag_prefix": "0.29.0-lmi11.0.0-cu124"
@@ -397,7 +423,15 @@
                 "ap-southeast-7": "590183813437",
                 "ap-southeast-4": "457447274322",
                 "ap-southeast-5": "550225433462",
-                "mx-central-1": "637423239942"
+                "mx-central-1": "637423239942",
+                "ap-east-2": "975050140332",
+                "ap-southeast-6": "633930458069",
+                "eu-isoe-west-1": "371248457586",
+                "eusc-de-east-1": "204133271717",
+                "us-iso-east-1": "886529160074",
+                "us-isob-east-1": "094389454867",
+                "us-isof-east-1": "303241398832",
+                "us-isof-south-1": "454834333376"
             },
             "repository": "djl-inference",
             "tag_prefix": "0.28.0-lmi10.0.0-cu124"

--- a/sagemaker-core/src/sagemaker/core/image_uri_config/huggingface-llm-neuronx.json
+++ b/sagemaker-core/src/sagemaker/core/image_uri_config/huggingface-llm-neuronx.json
@@ -55,7 +55,9 @@
                     "us-isof-east-1": "303241398832",
                     "us-isof-south-1": "454834333376",
                     "us-west-1": "763104351884",
-                    "us-west-2": "763104351884"
+                    "us-west-2": "763104351884",
+                    "eu-isoe-west-1": "371248457586",
+                    "eusc-de-east-1": "204133271717"
                 },
                 "tag_prefix": "1.13.1-optimum0.0.16",
                 "repository": "huggingface-pytorch-tgi-inference",
@@ -109,7 +111,9 @@
                     "us-isof-east-1": "303241398832",
                     "us-isof-south-1": "454834333376",
                     "us-west-1": "763104351884",
-                    "us-west-2": "763104351884"
+                    "us-west-2": "763104351884",
+                    "eu-isoe-west-1": "371248457586",
+                    "eusc-de-east-1": "204133271717"
                 },
                 "tag_prefix": "1.13.1-optimum0.0.17",
                 "repository": "huggingface-pytorch-tgi-inference",
@@ -163,7 +167,9 @@
                     "us-isof-east-1": "303241398832",
                     "us-isof-south-1": "454834333376",
                     "us-west-1": "763104351884",
-                    "us-west-2": "763104351884"
+                    "us-west-2": "763104351884",
+                    "eu-isoe-west-1": "371248457586",
+                    "eusc-de-east-1": "204133271717"
                 },
                 "tag_prefix": "1.13.1-optimum0.0.18",
                 "repository": "huggingface-pytorch-tgi-inference",
@@ -217,7 +223,9 @@
                     "us-isof-east-1": "303241398832",
                     "us-isof-south-1": "454834333376",
                     "us-west-1": "763104351884",
-                    "us-west-2": "763104351884"
+                    "us-west-2": "763104351884",
+                    "eu-isoe-west-1": "371248457586",
+                    "eusc-de-east-1": "204133271717"
                 },
                 "tag_prefix": "1.13.1-optimum0.0.19",
                 "repository": "huggingface-pytorch-tgi-inference",
@@ -271,7 +279,9 @@
                     "us-isof-east-1": "303241398832",
                     "us-isof-south-1": "454834333376",
                     "us-west-1": "763104351884",
-                    "us-west-2": "763104351884"
+                    "us-west-2": "763104351884",
+                    "eu-isoe-west-1": "371248457586",
+                    "eusc-de-east-1": "204133271717"
                 },
                 "tag_prefix": "1.13.1-optimum0.0.20",
                 "repository": "huggingface-pytorch-tgi-inference",
@@ -325,7 +335,9 @@
                     "us-isof-east-1": "303241398832",
                     "us-isof-south-1": "454834333376",
                     "us-west-1": "763104351884",
-                    "us-west-2": "763104351884"
+                    "us-west-2": "763104351884",
+                    "eu-isoe-west-1": "371248457586",
+                    "eusc-de-east-1": "204133271717"
                 },
                 "tag_prefix": "1.13.1-optimum0.0.21",
                 "repository": "huggingface-pytorch-tgi-inference",
@@ -379,7 +391,9 @@
                     "us-isof-east-1": "303241398832",
                     "us-isof-south-1": "454834333376",
                     "us-west-1": "763104351884",
-                    "us-west-2": "763104351884"
+                    "us-west-2": "763104351884",
+                    "eu-isoe-west-1": "371248457586",
+                    "eusc-de-east-1": "204133271717"
                 },
                 "tag_prefix": "2.1.2-optimum0.0.22",
                 "repository": "huggingface-pytorch-tgi-inference",
@@ -433,7 +447,9 @@
                     "us-isof-east-1": "303241398832",
                     "us-isof-south-1": "454834333376",
                     "us-west-1": "763104351884",
-                    "us-west-2": "763104351884"
+                    "us-west-2": "763104351884",
+                    "eu-isoe-west-1": "371248457586",
+                    "eusc-de-east-1": "204133271717"
                 },
                 "tag_prefix": "2.1.2-optimum0.0.23",
                 "repository": "huggingface-pytorch-tgi-inference",
@@ -487,7 +503,9 @@
                     "us-isof-east-1": "303241398832",
                     "us-isof-south-1": "454834333376",
                     "us-west-1": "763104351884",
-                    "us-west-2": "763104351884"
+                    "us-west-2": "763104351884",
+                    "eu-isoe-west-1": "371248457586",
+                    "eusc-de-east-1": "204133271717"
                 },
                 "tag_prefix": "2.1.2-optimum0.0.24",
                 "repository": "huggingface-pytorch-tgi-inference",
@@ -541,7 +559,9 @@
                     "us-isof-east-1": "303241398832",
                     "us-isof-south-1": "454834333376",
                     "us-west-1": "763104351884",
-                    "us-west-2": "763104351884"
+                    "us-west-2": "763104351884",
+                    "eu-isoe-west-1": "371248457586",
+                    "eusc-de-east-1": "204133271717"
                 },
                 "tag_prefix": "2.1.2-optimum0.0.25",
                 "repository": "huggingface-pytorch-tgi-inference",
@@ -595,7 +615,9 @@
                     "us-isof-east-1": "303241398832",
                     "us-isof-south-1": "454834333376",
                     "us-west-1": "763104351884",
-                    "us-west-2": "763104351884"
+                    "us-west-2": "763104351884",
+                    "eu-isoe-west-1": "371248457586",
+                    "eusc-de-east-1": "204133271717"
                 },
                 "tag_prefix": "2.1.2-optimum0.0.27",
                 "repository": "huggingface-pytorch-tgi-inference",
@@ -649,7 +671,9 @@
                     "us-isof-east-1": "303241398832",
                     "us-isof-south-1": "454834333376",
                     "us-west-1": "763104351884",
-                    "us-west-2": "763104351884"
+                    "us-west-2": "763104351884",
+                    "eu-isoe-west-1": "371248457586",
+                    "eusc-de-east-1": "204133271717"
                 },
                 "tag_prefix": "2.1.2-optimum0.0.28",
                 "repository": "huggingface-pytorch-tgi-inference",
@@ -703,7 +727,9 @@
                     "us-isof-east-1": "303241398832",
                     "us-isof-south-1": "454834333376",
                     "us-west-1": "763104351884",
-                    "us-west-2": "763104351884"
+                    "us-west-2": "763104351884",
+                    "eu-isoe-west-1": "371248457586",
+                    "eusc-de-east-1": "204133271717"
                 },
                 "tag_prefix": "2.5.1-optimum3.3.4",
                 "repository": "huggingface-pytorch-tgi-inference",
@@ -757,7 +783,9 @@
                     "us-isof-east-1": "303241398832",
                     "us-isof-south-1": "454834333376",
                     "us-west-1": "763104351884",
-                    "us-west-2": "763104351884"
+                    "us-west-2": "763104351884",
+                    "eu-isoe-west-1": "371248457586",
+                    "eusc-de-east-1": "204133271717"
                 },
                 "tag_prefix": "2.7.0-optimum3.3.6",
                 "repository": "huggingface-pytorch-tgi-inference",


### PR DESCRIPTION
Corrects djl-lmi us-iso* accounts (763104351884 -> partition-local) on 0.33-0.35, drops unreplicated us-iso-west-1/us-isob-west-1. Adds THF (eusc-de-east-1 = 204133271717) and EU-ISOE (eu-isoe-west-1 = 371248457586) to djl-lmi and huggingface-llm-neuronx (all versions). Region accounts confirmed GA for sagemaker+dl-containers in RIP (deep_learning_containers_prod).