### PR TITLE
Add BatchWriteRecord and ListRecod apis to Sagemaker Feature Store Runtime

### DIFF
--- a/sagemaker-core/sample/sagemaker-featurestore-runtime/2020-07-01/service-2.json
+++ b/sagemaker-core/sample/sagemaker-featurestore-runtime/2020-07-01/service-2.json
@@ -5,11 +5,13 @@
     "endpointPrefix":"featurestore-runtime.sagemaker",
     "jsonVersion":"1.1",
     "protocol":"rest-json",
+    "protocols":["rest-json"],
     "serviceFullName":"Amazon SageMaker Feature Store Runtime",
     "serviceId":"SageMaker FeatureStore Runtime",
     "signatureVersion":"v4",
     "signingName":"sagemaker",
-    "uid":"sagemaker-featurestore-runtime-2020-07-01"
+    "uid":"sagemaker-featurestore-runtime-2020-07-01",
+    "auth":["aws.auth#sigv4"]
   },
   "operations":{
     "BatchGetRecord":{
@@ -28,6 +30,23 @@
       ],
       "documentation":"<p>Retrieves a batch of <code>Records</code> from a <code>FeatureGroup</code>.</p>"
     },
+    "BatchWriteRecord":{
+      "name":"BatchWriteRecord",
+      "http":{
+        "method":"POST",
+        "requestUri":"/BatchWriteRecord"
+      },
+      "input":{"shape":"BatchWriteRecordRequest"},
+      "output":{"shape":"BatchWriteRecordResponse"},
+      "errors":[
+        {"shape":"ValidationError"},
+        {"shape":"ResourceNotFound"},
+        {"shape":"InternalFailure"},
+        {"shape":"ServiceUnavailable"},
+        {"shape":"AccessForbidden"}
+      ],
+      "documentation":"<p>Writes a batch of <code>Records</code> to one or more <code>FeatureGroup</code>s. Use this API for bulk ingestion of records into the <code>OnlineStore</code> and <code>OfflineStore</code>.</p> <p>You can set the ingested records to expire at a given time to live (TTL) duration after the record's event time by specifying the <code>TtlDuration</code> parameter. A request level <code>TtlDuration</code> applies to all entries that do not specify their own <code>TtlDuration</code>.</p>"
+    },
     "DeleteRecord":{
       "name":"DeleteRecord",
       "http":{
@@ -41,7 +60,7 @@
         {"shape":"ServiceUnavailable"},
         {"shape":"AccessForbidden"}
       ],
-      "documentation":"<p>Deletes a <code>Record</code> from a <code>FeatureGroup</code> in the <code>OnlineStore</code>. Feature Store supports both <code>SoftDelete</code> and <code>HardDelete</code>. For <code>SoftDelete</code> (default), feature columns are set to <code>null</code> and the record is no longer retrievable by <code>GetRecord</code> or <code>BatchGetRecord</code>. For <code>HardDelete</code>, the complete <code>Record</code> is removed from the <code>OnlineStore</code>. In both cases, Feature Store appends the deleted record marker to the <code>OfflineStore</code>. The deleted record marker is a record with the same <code>RecordIdentifer</code> as the original, but with <code>is_deleted</code> value set to <code>True</code>, <code>EventTime</code> set to the delete input <code>EventTime</code>, and other feature values set to <code>null</code>.</p> <p>Note that the <code>EventTime</code> specified in <code>DeleteRecord</code> should be set later than the <code>EventTime</code> of the existing record in the <code>OnlineStore</code> for that <code>RecordIdentifer</code>. If it is not, the deletion does not occur:</p> <ul> <li> <p>For <code>SoftDelete</code>, the existing (not deleted) record remains in the <code>OnlineStore</code>, though the delete record marker is still written to the <code>OfflineStore</code>.</p> </li> <li> <p> <code>HardDelete</code> returns <code>EventTime</code>: <code>400 ValidationException</code> to indicate that the delete operation failed. No delete record marker is written to the <code>OfflineStore</code>.</p> </li> </ul> <p>When a record is deleted from the <code>OnlineStore</code>, the deleted record marker is appended to the <code>OfflineStore</code>. If you have the Iceberg table format enabled for your <code>OfflineStore</code>, you can remove all history of a record from the <code>OfflineStore</code> using Amazon Athena or Apache Spark. For information on how to hard delete a record from the <code>OfflineStore</code> with the Iceberg table format enabled, see <a href=\"https://docs.aws.amazon.com/sagemaker/latest/dg/feature-store-delete-records-offline-store.html#feature-store-delete-records-offline-store\">Delete records from the offline store</a>.</p>"
+      "documentation":"<p>Deletes a <code>Record</code> from a <code>FeatureGroup</code> in the <code>OnlineStore</code>. Feature Store supports both <code>SoftDelete</code> and <code>HardDelete</code>. For <code>SoftDelete</code> (default), feature columns are set to <code>null</code> and the record is no longer retrievable by <code>GetRecord</code> or <code>BatchGetRecord</code>. For <code>HardDelete</code>, the complete <code>Record</code> is removed from the <code>OnlineStore</code>. In both cases, Feature Store appends the deleted record marker to the <code>OfflineStore</code>. The deleted record marker is a record with the same <code>RecordIdentifer</code> as the original, but with <code>is_deleted</code> value set to <code>True</code>, <code>EventTime</code> set to the delete input <code>EventTime</code>, and other feature values set to <code>null</code>.</p> <p>Note that the <code>EventTime</code> specified in <code>DeleteRecord</code> should be set later than the <code>EventTime</code> of the existing record in the <code>OnlineStore</code> for that <code>RecordIdentifer</code>. If it is not, the deletion does not occur:</p> <ul> <li> <p>For <code>SoftDelete</code>, the existing (not deleted) record remains in the <code>OnlineStore</code>, though the delete record marker is still written to the <code>OfflineStore</code>.</p> </li> <li> <p> <code>HardDelete</code> returns <code>EventTime</code>: <code>400 ValidationException</code> to indicate that the delete operation failed. No delete record marker is written to the <code>OfflineStore</code>.</p> </li> </ul> <p>When a record is deleted from the <code>OnlineStore</code>, the deleted record marker is appended to the <code>OfflineStore</code>. If you have the Iceberg table format enabled for your <code>OfflineStore</code>, you can remove all history of a record from the <code>OfflineStore</code> using Amazon Athena or Apache Spark. For information on how to hard delete a record from the <code>OfflineStore</code> with the Iceberg table format enabled, see <a href=\"https://docs.aws.amazon.com/sagemaker/latest/dg/feature-store-delete-records.html#feature-store-delete-records-offline-store\">Delete records from the offline store</a>.</p>"
     },
     "GetRecord":{
       "name":"GetRecord",
@@ -59,6 +78,24 @@
         {"shape":"AccessForbidden"}
       ],
       "documentation":"<p>Use for <code>OnlineStore</code> serving from a <code>FeatureStore</code>. Only the latest records stored in the <code>OnlineStore</code> can be retrieved. If no Record with <code>RecordIdentifierValue</code> is found, then an empty result is returned. </p>"
+    },
+    "ListRecords":{
+      "name":"ListRecords",
+      "http":{
+        "method":"POST",
+        "requestUri":"/FeatureGroup/{FeatureGroupName}/ListRecords"
+      },
+      "input":{"shape":"ListRecordsRequest"},
+      "output":{"shape":"ListRecordsResponse"},
+      "errors":[
+        {"shape":"ValidationError"},
+        {"shape":"ResourceNotFound"},
+        {"shape":"InternalFailure"},
+        {"shape":"ServiceUnavailable"},
+        {"shape":"AccessForbidden"}
+      ],
+      "documentation":"<p>Lists the <code>RecordIdentifier</code> values of all records stored in a <code>FeatureGroup</code>'s <code>OnlineStore</code>. This enables you to discover which records exist without retrieving the full record data.</p>",
+      "readonly":true
     },
     "PutRecord":{
       "name":"PutRecord",
@@ -216,6 +253,98 @@
       "member":{"shape":"BatchGetRecordResultDetail"},
       "min":0
     },
+    "BatchWriteRecordEntries":{
+      "type":"list",
+      "member":{"shape":"BatchWriteRecordEntry"},
+      "max":25,
+      "min":1
+    },
+    "BatchWriteRecordEntry":{
+      "type":"structure",
+      "required":[
+        "FeatureGroupName",
+        "Record"
+      ],
+      "members":{
+        "FeatureGroupName":{
+          "shape":"FeatureGroupNameOrArn",
+          "documentation":"<p>The name or Amazon Resource Name (ARN) of the <code>FeatureGroup</code> to write the record to.</p>"
+        },
+        "Record":{
+          "shape":"Record",
+          "documentation":"<p>List of FeatureValues to be inserted. This will be a full over-write.</p>"
+        },
+        "TargetStores":{
+          "shape":"TargetStores",
+          "documentation":"<p>A list of stores to which you're adding the record. By default, Feature Store adds the record to all of the stores that you're using for the <code>FeatureGroup</code>.</p>"
+        },
+        "TtlDuration":{
+          "shape":"TtlDuration",
+          "documentation":"<p>Time to live duration for this entry, where the record is hard deleted after the expiration time is reached; <code>ExpiresAt</code> = <code>EventTime</code> + <code>TtlDuration</code>. This overrides the request level <code>TtlDuration</code>.</p>"
+        }
+      },
+      "documentation":"<p>An entry to write as part of a <code>BatchWriteRecord</code> request.</p>"
+    },
+    "BatchWriteRecordError":{
+      "type":"structure",
+      "required":[
+        "Entry",
+        "ErrorCode",
+        "ErrorMessage"
+      ],
+      "members":{
+        "Entry":{
+          "shape":"BatchWriteRecordEntry",
+          "documentation":"<p>The entry that failed to be written.</p>"
+        },
+        "ErrorCode":{
+          "shape":"ValueAsString",
+          "documentation":"<p>The error code for the failed record write.</p>"
+        },
+        "ErrorMessage":{
+          "shape":"Message",
+          "documentation":"<p>The error message for the failed record write.</p>"
+        }
+      },
+      "documentation":"<p>The error that has occurred when attempting to write a record in a batch.</p>"
+    },
+    "BatchWriteRecordErrors":{
+      "type":"list",
+      "member":{"shape":"BatchWriteRecordError"},
+      "min":0
+    },
+    "BatchWriteRecordRequest":{
+      "type":"structure",
+      "required":["Entries"],
+      "members":{
+        "Entries":{
+          "shape":"BatchWriteRecordEntries",
+          "documentation":"<p>A list of records to write. Each entry specifies the <code>FeatureGroup</code>, the record data, and optionally target stores and a TTL duration.</p>"
+        },
+        "TtlDuration":{
+          "shape":"TtlDuration",
+          "documentation":"<p>Time to live duration applied to all entries in the batch that do not specify their own <code>TtlDuration</code>; <code>ExpiresAt</code> = <code>EventTime</code> + <code>TtlDuration</code>. For information on HardDelete, see the <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_feature_store_DeleteRecord.html\">DeleteRecord</a> API in the Amazon SageMaker API Reference guide.</p>"
+        }
+      }
+    },
+    "BatchWriteRecordResponse":{
+      "type":"structure",
+      "required":[
+        "Errors",
+        "UnprocessedEntries"
+      ],
+      "members":{
+        "Errors":{
+          "shape":"BatchWriteRecordErrors",
+          "documentation":"<p>A list of errors that occurred when writing records in the batch.</p>"
+        },
+        "UnprocessedEntries":{
+          "shape":"UnprocessedBatchWriteRecordEntries",
+          "documentation":"<p>A list of entries that were not processed. These entries can be retried.</p>"
+        }
+      }
+    },
+    "Boolean":{"type":"boolean"},
     "DeleteRecordRequest":{
       "type":"structure",
       "required":[
@@ -364,6 +493,54 @@
       "fault":true,
       "synthetic":true
     },
+    "ListRecordsMaxResults":{
+      "type":"integer",
+      "max":100,
+      "min":1
+    },
+    "ListRecordsNextToken":{
+      "type":"string",
+      "max":8192,
+      "min":1
+    },
+    "ListRecordsRequest":{
+      "type":"structure",
+      "required":["FeatureGroupName"],
+      "members":{
+        "FeatureGroupName":{
+          "shape":"FeatureGroupNameOrArn",
+          "documentation":"<p>The name or Amazon Resource Name (ARN) of the feature group to list records from.</p>",
+          "location":"uri",
+          "locationName":"FeatureGroupName"
+        },
+        "MaxResults":{
+          "shape":"ListRecordsMaxResults",
+          "documentation":"<p>The maximum number of record identifiers to return in a single page of results. For the <code>InMemory</code> tier, this value is a hint and not a strict requirement. The response may contain more or fewer results than the specified <code>MaxResults</code>.</p>"
+        },
+        "NextToken":{
+          "shape":"ListRecordsNextToken",
+          "documentation":"<p>A token to resume pagination of <code>ListRecords</code> results.</p>"
+        },
+        "IncludeSoftDeletedRecords":{
+          "shape":"Boolean",
+          "documentation":"<p>If set to <code>true</code>, the result includes records that have been soft deleted.</p>"
+        }
+      }
+    },
+    "ListRecordsResponse":{
+      "type":"structure",
+      "required":["RecordIdentifiers"],
+      "members":{
+        "RecordIdentifiers":{
+          "shape":"RecordIdentifierList",
+          "documentation":"<p>A list of record identifier values for the records stored in the <code>OnlineStore</code>.</p>"
+        },
+        "NextToken":{
+          "shape":"ListRecordsNextToken",
+          "documentation":"<p>A token to resume pagination if the response includes more record identifiers than <code>MaxResults</code>.</p>"
+        }
+      }
+    },
     "Message":{
       "type":"string",
       "max":2048
@@ -399,6 +576,10 @@
       "type":"list",
       "member":{"shape":"FeatureValue"},
       "min":1
+    },
+    "RecordIdentifierList":{
+      "type":"list",
+      "member":{"shape":"ValueAsString"}
     },
     "RecordIdentifiers":{
       "type":"list",
@@ -470,6 +651,11 @@
     "TtlDurationValue":{
       "type":"integer",
       "min":1
+    },
+    "UnprocessedBatchWriteRecordEntries":{
+      "type":"list",
+      "member":{"shape":"BatchWriteRecordEntry"},
+      "min":0
     },
     "UnprocessedIdentifiers":{
       "type":"list",

--- a/sagemaker-core/src/sagemaker/core/resources.py
+++ b/sagemaker-core/src/sagemaker/core/resources.py
@@ -12394,6 +12394,122 @@ class FeatureGroup(Base):
         transformed_response = transform(response, "BatchGetRecordResponse")
         return BatchGetRecordResponse(**transformed_response)
 
+    @Base.add_validate_call
+    def batch_write_record(
+        self,
+        entries: List[BatchWriteRecordEntry],
+        ttl_duration: Optional[TtlDuration] = Unassigned(),
+        session: Optional[Session] = None,
+        region: Optional[str] = None,
+    ) -> Optional[BatchWriteRecordResponse]:
+        """
+        Writes a batch of Records to one or more FeatureGroups.
+
+        Parameters:
+            entries: A list of records to write. Each entry specifies the FeatureGroup, the record data, and optionally target stores and a TTL duration.
+            ttl_duration: Time to live duration applied to all entries in the batch that do not specify their own TtlDuration; ExpiresAt = EventTime + TtlDuration. For information on HardDelete, see the DeleteRecord API in the Amazon SageMaker API Reference guide.
+            session: Boto3 session.
+            region: Region name.
+
+        Returns:
+            BatchWriteRecordResponse
+
+        Raises:
+            botocore.exceptions.ClientError: This exception is raised for AWS service related errors.
+                The error message and error code can be parsed from the exception as follows:
+                ```
+                try:
+                    # AWS service call here
+                except botocore.exceptions.ClientError as e:
+                    error_message = e.response['Error']['Message']
+                    error_code = e.response['Error']['Code']
+                ```
+            AccessForbidden: You do not have permission to perform an action.
+            InternalFailure: An internal failure occurred. Try your request again. If the problem persists, contact Amazon Web Services customer support.
+            ResourceNotFound: Resource being access is not found.
+            ServiceUnavailable: The service is currently unavailable.
+            ValidationError: There was an error validating your request.
+        """
+
+        operation_input_args = {
+            "Entries": entries,
+            "TtlDuration": ttl_duration,
+        }
+        # serialize the input request
+        operation_input_args = serialize(operation_input_args)
+        logger.debug(f"Serialized input request: {operation_input_args}")
+
+        client = Base.get_sagemaker_client(
+            session=session, region_name=region, service_name="sagemaker-featurestore-runtime"
+        )
+
+        logger.debug(f"Calling batch_write_record API")
+        response = client.batch_write_record(**operation_input_args)
+        logger.debug(f"Response: {response}")
+
+        transformed_response = transform(response, "BatchWriteRecordResponse")
+        return BatchWriteRecordResponse(**transformed_response)
+
+    @Base.add_validate_call
+    def list_records(
+        self,
+        max_results: Optional[int] = Unassigned(),
+        next_token: Optional[StrPipeVar] = Unassigned(),
+        include_soft_deleted_records: Optional[bool] = Unassigned(),
+        session: Optional[Session] = None,
+        region: Optional[str] = None,
+    ) -> Optional[ListRecordsResponse]:
+        """
+        Lists the RecordIdentifier values of all records stored in a FeatureGroup's OnlineStore.
+
+        Parameters:
+            max_results: The maximum number of record identifiers to return in a single page of results. For the InMemory tier, this value is a hint and not a strict requirement. The response may contain more or fewer results than the specified MaxResults.
+            next_token: A token to resume pagination of ListRecords results.
+            include_soft_deleted_records: If set to true, the result includes records that have been soft deleted.
+            session: Boto3 session.
+            region: Region name.
+
+        Returns:
+            ListRecordsResponse
+
+        Raises:
+            botocore.exceptions.ClientError: This exception is raised for AWS service related errors.
+                The error message and error code can be parsed from the exception as follows:
+                ```
+                try:
+                    # AWS service call here
+                except botocore.exceptions.ClientError as e:
+                    error_message = e.response['Error']['Message']
+                    error_code = e.response['Error']['Code']
+                ```
+            AccessForbidden: You do not have permission to perform an action.
+            InternalFailure: An internal failure occurred. Try your request again. If the problem persists, contact Amazon Web Services customer support.
+            ResourceNotFound: Resource being access is not found.
+            ServiceUnavailable: The service is currently unavailable.
+            ValidationError: There was an error validating your request.
+        """
+
+        operation_input_args = {
+            "FeatureGroupName": self.feature_group_name,
+            "MaxResults": max_results,
+            "NextToken": next_token,
+            "IncludeSoftDeletedRecords": include_soft_deleted_records,
+        }
+        # serialize the input request
+        operation_input_args = serialize(operation_input_args)
+        logger.debug(f"Serialized input request: {operation_input_args}")
+
+        client = Base.get_sagemaker_client(
+            session=session, region_name=region, service_name="sagemaker-featurestore-runtime"
+        )
+
+        logger.debug(f"Calling list_records API")
+        response = client.list_records(**operation_input_args)
+        logger.debug(f"Response: {response}")
+
+        transformed_response = transform(response, "ListRecordsResponse")
+        return ListRecordsResponse(**transformed_response)
+
 
 class FeatureMetadata(Base):
     """

--- a/sagemaker-core/src/sagemaker/core/shapes/shapes.py
+++ b/sagemaker-core/src/sagemaker/core/shapes/shapes.py
@@ -325,6 +325,71 @@ class BatchGetRecordResponse(Base):
     unprocessed_identifiers: List[BatchGetRecordIdentifier]
 
 
+class TtlDuration(Base):
+    """
+    TtlDuration
+      Time to live duration, where the record is hard deleted after the expiration time is reached; ExpiresAt = EventTime + TtlDuration. For information on HardDelete, see the DeleteRecord API in the Amazon SageMaker API Reference guide.
+
+    Attributes
+    ----------------------
+    unit:  TtlDuration time unit.
+    value:  TtlDuration time value.
+    """
+
+    unit: Optional[StrPipeVar] = Unassigned()
+    value: Optional[int] = Unassigned()
+
+
+class BatchWriteRecordEntry(Base):
+    """
+    BatchWriteRecordEntry
+      An entry to write as part of a BatchWriteRecord request.
+
+    Attributes
+    ----------------------
+    feature_group_name: The name or Amazon Resource Name (ARN) of the FeatureGroup to write the record to.
+    record: List of FeatureValues to be inserted. This will be a full over-write.
+    target_stores: A list of stores to which you're adding the record. By default, Feature Store adds the record to all of the stores that you're using for the FeatureGroup.
+    ttl_duration: Time to live duration for this entry, where the record is hard deleted after the expiration time is reached; ExpiresAt = EventTime + TtlDuration. This overrides the request level TtlDuration.
+    """
+
+    feature_group_name: Union[StrPipeVar, object]
+    record: List[FeatureValue]
+    target_stores: Optional[List[StrPipeVar]] = Unassigned()
+    ttl_duration: Optional[TtlDuration] = Unassigned()
+
+
+class BatchWriteRecordError(Base):
+    """
+    BatchWriteRecordError
+      The error that has occurred when attempting to write a record in a batch.
+
+    Attributes
+    ----------------------
+    entry: The entry that failed to be written.
+    error_code: The error code for the failed record write.
+    error_message: The error message for the failed record write.
+    """
+
+    entry: BatchWriteRecordEntry
+    error_code: StrPipeVar
+    error_message: StrPipeVar
+
+
+class BatchWriteRecordResponse(Base):
+    """
+    BatchWriteRecordResponse
+
+    Attributes
+    ----------------------
+    errors: A list of errors that occurred when writing records in the batch.
+    unprocessed_entries: A list of entries that were not processed. These entries can be retried.
+    """
+
+    errors: List[BatchWriteRecordError]
+    unprocessed_entries: List[BatchWriteRecordEntry]
+
+
 class GetRecordResponse(Base):
     """
     GetRecordResponse
@@ -339,19 +404,18 @@ class GetRecordResponse(Base):
     expires_at: Optional[StrPipeVar] = Unassigned()
 
 
-class TtlDuration(Base):
+class ListRecordsResponse(Base):
     """
-    TtlDuration
-      Time to live duration, where the record is hard deleted after the expiration time is reached; ExpiresAt = EventTime + TtlDuration. For information on HardDelete, see the DeleteRecord API in the Amazon SageMaker API Reference guide.
+    ListRecordsResponse
 
     Attributes
     ----------------------
-    unit:  TtlDuration time unit.
-    value:  TtlDuration time value.
+    record_identifiers: A list of record identifier values for the records stored in the OnlineStore.
+    next_token: A token to resume pagination if the response includes more record identifiers than MaxResults.
     """
 
-    unit: Optional[StrPipeVar] = Unassigned()
-    value: Optional[int] = Unassigned()
+    record_identifiers: List[StrPipeVar]
+    next_token: Optional[StrPipeVar] = Unassigned()
 
 
 class ResourceNotFound(Base):

--- a/sagemaker-core/src/sagemaker/core/tools/additional_operations.json
+++ b/sagemaker-core/src/sagemaker/core/tools/additional_operations.json
@@ -474,6 +474,23 @@
             "return_type": "BatchGetRecordResponse",
             "method_type": "object",
             "service_name": "sagemaker-featurestore-runtime"
+        },
+        "BatchWriteRecord": {
+            "operation_name": "BatchWriteRecord",
+            "resource_name": "FeatureGroup",
+            "method_name": "batch_write_record",
+            "return_type": "BatchWriteRecordResponse",
+            "method_type": "object",
+            "service_name": "sagemaker-featurestore-runtime"
+        },
+        "ListRecords": {
+            "operation_name": "ListRecords",
+            "resource_name": "FeatureGroup",
+            "method_name": "list_records",
+            "return_type": "ListRecordsResponse",
+            "method_type": "object",
+            "service_name": "sagemaker-featurestore-runtime",
+            "exclude_resource_attributes": ["next_token"]
         }
     }
 }

--- a/sagemaker-core/src/sagemaker/core/tools/resources_codegen.py
+++ b/sagemaker-core/src/sagemaker/core/tools/resources_codegen.py
@@ -1493,13 +1493,23 @@ class ResourcesCodeGen:
         else:
             decorator = ""
             method_args = add_indent("self,\n", 4)
+            # Allow operations to exclude specific resource attributes from self-mapping
+            # This is needed when a resource attribute name collides with an unrelated
+            # operation input (e.g., FeatureGroup.next_token vs ListRecords.NextToken)
+            exclude_resource_attrs_override = getattr(method, "exclude_resource_attributes", [])
+            effective_resource_attributes = [
+                attr for attr in resource_attributes if attr not in exclude_resource_attrs_override
+            ]
             method_args += (
-                self._generate_method_args(operation_input_shape_name, resource_attributes) + "\n"
+                self._generate_method_args(
+                    operation_input_shape_name, effective_resource_attributes
+                )
+                + "\n"
             )
             operation_input_args = self._generate_operation_input_args_updated(
-                operation_metadata, False, resource_attributes
+                operation_metadata, False, effective_resource_attributes
             )
-            exclude_resource_attrs = resource_attributes
+            exclude_resource_attrs = effective_resource_attributes
         method_args += add_indent("session: Optional[Session] = None,\n", 4)
         method_args += add_indent("region: Optional[str] = None,", 4)
 

--- a/sagemaker-core/src/sagemaker/core/utils/code_injection/shape_dag.py
+++ b/sagemaker-core/src/sagemaker/core/utils/code_injection/shape_dag.py
@@ -1597,6 +1597,51 @@ SHAPE_DAG = {
         ],
         "type": "structure",
     },
+    "BatchWriteRecordEntries": {
+        "member_shape": "BatchWriteRecordEntry",
+        "member_type": "structure",
+        "type": "list",
+    },
+    "BatchWriteRecordEntry": {
+        "members": [
+            {"name": "FeatureGroupName", "shape": "FeatureGroupNameOrArn", "type": "string"},
+            {"name": "Record", "shape": "Record", "type": "list"},
+            {"name": "TargetStores", "shape": "TargetStores", "type": "list"},
+            {"name": "TtlDuration", "shape": "TtlDuration", "type": "structure"},
+        ],
+        "type": "structure",
+    },
+    "BatchWriteRecordError": {
+        "members": [
+            {"name": "Entry", "shape": "BatchWriteRecordEntry", "type": "structure"},
+            {"name": "ErrorCode", "shape": "ValueAsString", "type": "string"},
+            {"name": "ErrorMessage", "shape": "Message", "type": "string"},
+        ],
+        "type": "structure",
+    },
+    "BatchWriteRecordErrors": {
+        "member_shape": "BatchWriteRecordError",
+        "member_type": "structure",
+        "type": "list",
+    },
+    "BatchWriteRecordRequest": {
+        "members": [
+            {"name": "Entries", "shape": "BatchWriteRecordEntries", "type": "list"},
+            {"name": "TtlDuration", "shape": "TtlDuration", "type": "structure"},
+        ],
+        "type": "structure",
+    },
+    "BatchWriteRecordResponse": {
+        "members": [
+            {"name": "Errors", "shape": "BatchWriteRecordErrors", "type": "list"},
+            {
+                "name": "UnprocessedEntries",
+                "shape": "UnprocessedBatchWriteRecordEntries",
+                "type": "list",
+            },
+        ],
+        "type": "structure",
+    },
     "BedrockCustomModelDeploymentMetadata": {
         "members": [{"name": "Arn", "shape": "String1024", "type": "string"}],
         "type": "structure",
@@ -12221,6 +12266,22 @@ SHAPE_DAG = {
         ],
         "type": "structure",
     },
+    "ListRecordsRequest": {
+        "members": [
+            {"name": "FeatureGroupName", "shape": "FeatureGroupNameOrArn", "type": "string"},
+            {"name": "MaxResults", "shape": "ListRecordsMaxResults", "type": "integer"},
+            {"name": "NextToken", "shape": "ListRecordsNextToken", "type": "string"},
+            {"name": "IncludeSoftDeletedRecords", "shape": "Boolean", "type": "boolean"},
+        ],
+        "type": "structure",
+    },
+    "ListRecordsResponse": {
+        "members": [
+            {"name": "RecordIdentifiers", "shape": "RecordIdentifierList", "type": "list"},
+            {"name": "NextToken", "shape": "ListRecordsNextToken", "type": "string"},
+        ],
+        "type": "structure",
+    },
     "ListResourceCatalogsRequest": {
         "members": [
             {"name": "NameContains", "shape": "ResourceCatalogName", "type": "string"},
@@ -15583,6 +15644,11 @@ SHAPE_DAG = {
         "type": "structure",
     },
     "Record": {"member_shape": "FeatureValue", "member_type": "structure", "type": "list"},
+    "RecordIdentifierList": {
+        "member_shape": "ValueAsString",
+        "member_type": "string",
+        "type": "list",
+    },
     "RecordIdentifiers": {"member_shape": "ValueAsString", "member_type": "string", "type": "list"},
     "RedshiftDatasetDefinition": {
         "members": [
@@ -17742,6 +17808,11 @@ SHAPE_DAG = {
             },
         ],
         "type": "structure",
+    },
+    "UnprocessedBatchWriteRecordEntries": {
+        "member_shape": "BatchWriteRecordEntry",
+        "member_type": "structure",
+        "type": "list",
     },
     "UnprocessedIdentifiers": {
         "member_shape": "BatchGetRecordIdentifier",

--- a/sagemaker-core/tests/unit/generated/test_feature_store_operations.py
+++ b/sagemaker-core/tests/unit/generated/test_feature_store_operations.py
@@ -1,0 +1,324 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+"""Unit tests for FeatureGroup batch_write_record and list_records methods."""
+from __future__ import absolute_import
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+from sagemaker.core.resources import FeatureGroup
+from sagemaker.core.shapes.shapes import (
+    BatchWriteRecordEntry,
+    BatchWriteRecordResponse,
+    FeatureValue,
+    ListRecordsResponse,
+    TtlDuration,
+)
+
+
+@pytest.fixture
+def mock_feature_group():
+    """Create a FeatureGroup instance with mocked internals."""
+    fg = FeatureGroup.model_construct(
+        feature_group_name="test-feature-group",
+        next_token=None,
+    )
+    return fg
+
+
+class TestBatchWriteRecord:
+    """Tests for FeatureGroup.batch_write_record method."""
+
+    @patch("sagemaker.core.resources.transform")
+    @patch("sagemaker.core.resources.Base.get_sagemaker_client")
+    def test_batch_write_record_success(self, mock_get_client, mock_transform, mock_feature_group):
+        """Test that batch_write_record calls the client with correct arguments."""
+        mock_client = MagicMock()
+        mock_client.batch_write_record.return_value = {
+            "Errors": [],
+            "UnprocessedEntries": [],
+        }
+        mock_get_client.return_value = mock_client
+        mock_transform.return_value = {
+            "errors": [],
+            "unprocessed_entries": [],
+        }
+
+        entries = [
+            BatchWriteRecordEntry(
+                feature_group_name="test-feature-group",
+                record=[FeatureValue(feature_name="feature1", value_as_string="value1")],
+            )
+        ]
+
+        mock_feature_group.batch_write_record(entries=entries)
+
+        mock_get_client.assert_called_once_with(
+            session=None, region_name=None, service_name="sagemaker-featurestore-runtime"
+        )
+        mock_client.batch_write_record.assert_called_once()
+        call_kwargs = mock_client.batch_write_record.call_args[1]
+        assert "Entries" in call_kwargs
+        mock_transform.assert_called_once()
+
+    @patch("sagemaker.core.resources.transform")
+    @patch("sagemaker.core.resources.Base.get_sagemaker_client")
+    def test_batch_write_record_with_ttl_duration(
+        self, mock_get_client, mock_transform, mock_feature_group
+    ):
+        """Test batch_write_record with optional ttl_duration parameter."""
+        mock_client = MagicMock()
+        mock_client.batch_write_record.return_value = {
+            "Errors": [],
+            "UnprocessedEntries": [],
+        }
+        mock_get_client.return_value = mock_client
+        mock_transform.return_value = {
+            "errors": [],
+            "unprocessed_entries": [],
+        }
+
+        entries = [
+            BatchWriteRecordEntry(
+                feature_group_name="test-feature-group",
+                record=[FeatureValue(feature_name="feature1", value_as_string="value1")],
+            )
+        ]
+        ttl = TtlDuration(unit="Hours", value=24)
+
+        mock_feature_group.batch_write_record(entries=entries, ttl_duration=ttl)
+
+        mock_get_client.assert_called_once_with(
+            session=None, region_name=None, service_name="sagemaker-featurestore-runtime"
+        )
+        mock_client.batch_write_record.assert_called_once()
+        call_kwargs = mock_client.batch_write_record.call_args[1]
+        assert "Entries" in call_kwargs
+        assert "TtlDuration" in call_kwargs
+
+    @patch("sagemaker.core.resources.transform")
+    @patch("sagemaker.core.resources.Base.get_sagemaker_client")
+    def test_batch_write_record_returns_response(
+        self, mock_get_client, mock_transform, mock_feature_group
+    ):
+        """Test that batch_write_record returns a BatchWriteRecordResponse."""
+        mock_client = MagicMock()
+        mock_client.batch_write_record.return_value = {
+            "Errors": [],
+            "UnprocessedEntries": [],
+        }
+        mock_get_client.return_value = mock_client
+        mock_transform.return_value = {
+            "errors": [],
+            "unprocessed_entries": [],
+        }
+
+        entries = [
+            BatchWriteRecordEntry(
+                feature_group_name="test-feature-group",
+                record=[FeatureValue(feature_name="feature1", value_as_string="value1")],
+            )
+        ]
+
+        result = mock_feature_group.batch_write_record(entries=entries)
+
+        assert isinstance(result, BatchWriteRecordResponse)
+        assert result.errors == []
+        assert result.unprocessed_entries == []
+
+    @patch("sagemaker.core.resources.transform")
+    @patch("sagemaker.core.resources.Base.get_sagemaker_client")
+    def test_batch_write_record_returns_response_with_nested_data(
+        self, mock_get_client, mock_transform, mock_feature_group
+    ):
+        """Test that batch_write_record correctly deserializes nested response data."""
+        mock_client = MagicMock()
+        mock_client.batch_write_record.return_value = {
+            "Errors": [
+                {
+                    "Entry": {
+                        "FeatureGroupName": "test-feature-group",
+                        "Record": [{"FeatureName": "f1", "ValueAsString": "v1"}],
+                    },
+                    "ErrorCode": "ValidationError",
+                    "ErrorMessage": "Invalid feature value",
+                }
+            ],
+            "UnprocessedEntries": [
+                {
+                    "FeatureGroupName": "test-feature-group",
+                    "Record": [{"FeatureName": "f2", "ValueAsString": "v2"}],
+                }
+            ],
+        }
+        mock_get_client.return_value = mock_client
+        mock_transform.return_value = {
+            "errors": [
+                {
+                    "entry": {
+                        "feature_group_name": "test-feature-group",
+                        "record": [{"feature_name": "f1", "value_as_string": "v1"}],
+                    },
+                    "error_code": "ValidationError",
+                    "error_message": "Invalid feature value",
+                }
+            ],
+            "unprocessed_entries": [
+                {
+                    "feature_group_name": "test-feature-group",
+                    "record": [{"feature_name": "f2", "value_as_string": "v2"}],
+                }
+            ],
+        }
+
+        entries = [
+            BatchWriteRecordEntry(
+                feature_group_name="test-feature-group",
+                record=[FeatureValue(feature_name="feature1", value_as_string="value1")],
+            )
+        ]
+
+        result = mock_feature_group.batch_write_record(entries=entries)
+
+        assert isinstance(result, BatchWriteRecordResponse)
+        assert len(result.errors) == 1
+        assert len(result.unprocessed_entries) == 1
+
+
+class TestListRecords:
+    """Tests for FeatureGroup.list_records method."""
+
+    @patch("sagemaker.core.resources.transform")
+    @patch("sagemaker.core.resources.Base.get_sagemaker_client")
+    def test_list_records_success(self, mock_get_client, mock_transform, mock_feature_group):
+        """Test that list_records calls the client with FeatureGroupName."""
+        mock_client = MagicMock()
+        mock_client.list_records.return_value = {
+            "RecordIdentifiers": ["id1", "id2"],
+        }
+        mock_get_client.return_value = mock_client
+        mock_transform.return_value = {
+            "record_identifiers": ["id1", "id2"],
+        }
+
+        mock_feature_group.list_records()
+
+        mock_get_client.assert_called_once_with(
+            session=None, region_name=None, service_name="sagemaker-featurestore-runtime"
+        )
+        mock_client.list_records.assert_called_once()
+        call_kwargs = mock_client.list_records.call_args[1]
+        assert call_kwargs["FeatureGroupName"] == "test-feature-group"
+        mock_transform.assert_called_once()
+
+    @patch("sagemaker.core.resources.transform")
+    @patch("sagemaker.core.resources.Base.get_sagemaker_client")
+    def test_list_records_with_parameters(
+        self, mock_get_client, mock_transform, mock_feature_group
+    ):
+        """Test list_records with max_results and include_soft_deleted_records."""
+        mock_client = MagicMock()
+        mock_client.list_records.return_value = {
+            "RecordIdentifiers": ["id1"],
+            "NextToken": "token123",
+        }
+        mock_get_client.return_value = mock_client
+        mock_transform.return_value = {
+            "record_identifiers": ["id1"],
+            "next_token": "token123",
+        }
+
+        mock_feature_group.list_records(
+            max_results=10, include_soft_deleted_records=True
+        )
+
+        mock_get_client.assert_called_once_with(
+            session=None, region_name=None, service_name="sagemaker-featurestore-runtime"
+        )
+        mock_client.list_records.assert_called_once()
+        call_kwargs = mock_client.list_records.call_args[1]
+        assert call_kwargs["FeatureGroupName"] == "test-feature-group"
+        assert call_kwargs["MaxResults"] == 10
+        assert call_kwargs["IncludeSoftDeletedRecords"] is True
+
+    @patch("sagemaker.core.resources.transform")
+    @patch("sagemaker.core.resources.Base.get_sagemaker_client")
+    def test_list_records_returns_response(
+        self, mock_get_client, mock_transform, mock_feature_group
+    ):
+        """Test that list_records returns a ListRecordsResponse."""
+        mock_client = MagicMock()
+        mock_client.list_records.return_value = {
+            "RecordIdentifiers": ["id1", "id2", "id3"],
+        }
+        mock_get_client.return_value = mock_client
+        mock_transform.return_value = {
+            "record_identifiers": ["id1", "id2", "id3"],
+        }
+
+        result = mock_feature_group.list_records()
+
+        assert isinstance(result, ListRecordsResponse)
+        assert result.record_identifiers == ["id1", "id2", "id3"]
+
+    @patch("sagemaker.core.resources.transform")
+    @patch("sagemaker.core.resources.Base.get_sagemaker_client")
+    def test_list_records_does_not_use_self_next_token(
+        self, mock_get_client, mock_transform
+    ):
+        """Test that list_records does NOT pass self.next_token (from DescribeFeatureGroup) to ListRecords."""
+        fg = FeatureGroup.model_construct(
+            feature_group_name="test-feature-group",
+            next_token="describe-pagination-token",
+        )
+        mock_client = MagicMock()
+        mock_client.list_records.return_value = {
+            "RecordIdentifiers": ["id1"],
+        }
+        mock_get_client.return_value = mock_client
+        mock_transform.return_value = {
+            "record_identifiers": ["id1"],
+        }
+
+        fg.list_records()
+
+        call_kwargs = mock_client.list_records.call_args[1]
+        # self.next_token should NOT be passed to ListRecords
+        assert "NextToken" not in call_kwargs
+
+    @patch("sagemaker.core.resources.transform")
+    @patch("sagemaker.core.resources.Base.get_sagemaker_client")
+    def test_list_records_accepts_next_token_parameter(
+        self, mock_get_client, mock_transform
+    ):
+        """Test that list_records accepts next_token as a pagination parameter."""
+        fg = FeatureGroup.model_construct(
+            feature_group_name="test-feature-group",
+            next_token="describe-pagination-token",
+        )
+        mock_client = MagicMock()
+        mock_client.list_records.return_value = {
+            "RecordIdentifiers": ["id1"],
+            "NextToken": "next-page-token",
+        }
+        mock_get_client.return_value = mock_client
+        mock_transform.return_value = {
+            "record_identifiers": ["id1"],
+            "next_token": "next-page-token",
+        }
+
+        fg.list_records(next_token="list-records-page-2-token")
+
+        call_kwargs = mock_client.list_records.call_args[1]
+        # The explicitly passed next_token should be used, not self.next_token
+        assert call_kwargs["NextToken"] == "list-records-page-2-token"


### PR DESCRIPTION
## Summary

Adds **`BatchWriteRecord`** and **`ListRecords`** FeatureStore Runtime operations to the **`FeatureGroup`** resource class.

## Changes

- **`service-2.json`**: Updated from botocore 1.43.38 (adds `BatchWriteRecord`, `ListRecords` operations and related shapes)
- **`additional_operations.json`**: Maps new operations to `FeatureGroup` resource with `exclude_resource_attributes` for `ListRecords`
- **`shape_dag.py`**: Adds DAG entries for new shapes (`BatchWriteRecordEntry`, `BatchWriteRecordResponse`, `ListRecordsRequest`, etc.)
- **`resources_codegen.py`**: Adds **`exclude_resource_attributes`** support to prevent incorrect self-mapping when a resource attribute name collides with an unrelated operation input
- **`resources.py`** (generated): New `batch_write_record()` and `list_records()` methods on `FeatureGroup`
- **`shapes.py`** (generated): New shape classes for `BatchWriteRecord`/`ListRecords` request/response types
- **`test_feature_store_operations.py`**: Unit tests covering both methods, pagination, and nested response deserialization

## Codegen Fix: `exclude_resource_attributes`

The codegen maps API input fields to `self.<attr>` when the field name matches a resource class attribute. This caused a bug: **`ListRecords.NextToken`** was mapped to **`self.next_token`**, which is the `DescribeFeatureGroup` pagination token (for `FeatureDefinitions`) — a completely different pagination context.

The fix adds an **`exclude_resource_attributes`** field to `additional_operations.json` that prevents specific resource attributes from being auto-mapped, making them regular method parameters instead.

## Testing

- **Unit tests**: 9 tests pass
- **Integration tests**: Ran locally against an existing `FeatureGroup` in us-west-2 (not included in this PR)