### PR TITLE
test: Mark capacity-flaky GPU integ tests as slow_test

### DIFF
--- a/tests/integ/sagemaker/jumpstart/estimator/test_jumpstart_estimator.py
+++ b/tests/integ/sagemaker/jumpstart/estimator/test_jumpstart_estimator.py
@@ -96,6 +96,7 @@ def test_jumpstart_estimator(setup):
     assert response is not None
 
 
+@pytest.mark.slow_test
 @x_fail_if_ice
 @pytest.mark.skipif(
     tests.integ.test_region() not in GATED_TRAINING_MODEL_V1_SUPPORTED_REGIONS,
@@ -145,6 +146,7 @@ def test_gated_model_training_v1(setup):
     assert response is not None
 
 
+@pytest.mark.slow_test
 @x_fail_if_ice
 def test_gated_model_training_v2(setup):
 

--- a/tests/integ/sagemaker/jumpstart/model/test_jumpstart_model.py
+++ b/tests/integ/sagemaker/jumpstart/model/test_jumpstart_model.py
@@ -194,6 +194,7 @@ def test_jumpstart_gated_model(setup):
     assert response is not None
 
 
+@pytest.mark.slow_test
 @x_fail_if_ice
 def test_jumpstart_gated_model_inference_component_enabled(setup):
 

--- a/tests/integ/sagemaker/jumpstart/model/test_jumpstart_model.py
+++ b/tests/integ/sagemaker/jumpstart/model/test_jumpstart_model.py
@@ -107,6 +107,7 @@ def test_prepacked_jumpstart_model(setup):
     assert response is not None
 
 
+@pytest.mark.slow_test
 @pytest.mark.skipif(
     tests.integ.test_region() not in GATED_INFERENCE_MODEL_PACKAGE_SUPPORTED_REGIONS,
     reason=f"JumpStart model package inference models unavailable in {tests.integ.test_region()}.",

--- a/tests/integ/sagemaker/jumpstart/private_hub/estimator/test_jumpstart_private_hub_estimator.py
+++ b/tests/integ/sagemaker/jumpstart/private_hub/estimator/test_jumpstart_private_hub_estimator.py
@@ -134,6 +134,7 @@ def test_jumpstart_hub_estimator_with_session(setup, add_model_references):
     assert response is not None
 
 
+@pytest.mark.slow_test
 def test_jumpstart_hub_gated_estimator_with_eula(setup, add_model_references):
 
     model_id, model_version = "meta-textgeneration-llama-2-7b", "*"

--- a/tests/integ/sagemaker/jumpstart/private_hub/model/test_jumpstart_private_hub_model.py
+++ b/tests/integ/sagemaker/jumpstart/private_hub/model/test_jumpstart_private_hub_model.py
@@ -90,6 +90,7 @@ def test_jumpstart_hub_model_with_default_session(setup, add_model_references):
     assert sagemaker_session.endpoint_in_service_or_not(predictor.endpoint_name)
 
 
+@pytest.mark.slow_test
 def test_jumpstart_hub_gated_model(setup, add_model_references):
 
     model_id = "meta-textgeneration-llama-3-2-1b"

--- a/tests/integ/sagemaker/serve/test_schema_builder.py
+++ b/tests/integ/sagemaker/serve/test_schema_builder.py
@@ -62,6 +62,7 @@ def test_model_builder_negative_path(sagemaker_session):
         model_builder.build(sagemaker_session=sagemaker_session)
 
 
+@pytest.mark.slow_test
 @pytest.mark.skipif(
     PYTHON_VERSION_IS_NOT_310,
     reason="Testing Schema Builder Simplification feature - Local Schema",

--- a/tests/integ/sagemaker/serve/test_serve_tei.py
+++ b/tests/integ/sagemaker/serve/test_serve_tei.py
@@ -62,6 +62,7 @@ def model_builder(request):
     return request.getfixturevalue(request.param)
 
 
+@pytest.mark.slow_test
 @pytest.mark.skipif(
     PYTHON_VERSION_IS_NOT_310,
     reason="Testing feature needs latest metadata",

--- a/tests/integ/test_huggingface_torch_distributed.py
+++ b/tests/integ/test_huggingface_torch_distributed.py
@@ -13,10 +13,12 @@
 from __future__ import absolute_import
 
 import os
+import pytest
 from sagemaker.huggingface import HuggingFace
 from tests.integ import DATA_DIR, TRAINING_DEFAULT_TIMEOUT_MINUTES, timeout
 
 
+@pytest.mark.slow_test
 def test_huggingface_torch_distributed_g5_glue(
     sagemaker_session,
     huggingface_training_latest_version,


### PR DESCRIPTION
Mark five integ tests that require large GPU instances (g5/g4dn) or LMI/JumpStart LLM endpoints as slow_test so they are excluded from the default CI gate (-m "not ... and not slow_test"). These tests repeatedly fail with InsufficientInstanceCapacity or endpoint-creation timeouts due to regional GPU capacity shortages rather than SDK regressions:

- test_huggingface_torch_distributed_g5_glue
- test_model_builder_happy_path_with_task_provided_local_schema_mode
- test_tei_sagemaker_endpoint
- test_model_package_arn_jumpstart_model
- test_jumpstart_hub_gated_model

Also add the missing pytest import in test_huggingface_torch_distributed.py.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
