### PR TITLE
docs: add noindex and canonical tags to deprecated V2 docs

### DIFF
--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -1,0 +1,10 @@
+{# Theme layout override for the deprecated V2 docs build. #}
+{# Injects <meta name="robots" content="noindex"> into every page's <head> so #}
+{# search engines drop these V2 pages from their results. The canonical link is #}
+{# emitted automatically by Sphinx from html_baseurl in conf.py, so do NOT add a #}
+{# <link rel="canonical"> here (duplicate canonicals are a defect). #}
+{% extends "!layout.html" %}
+{% block extrahead %}
+  {{ super() }}
+  <meta name="robots" content="noindex">
+{% endblock %}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -38,7 +38,17 @@ extensions = [
 ]
 
 # Add any paths that contain templates here, relative to this directory.
+# The _templates/layout.html override injects a <meta name="robots" content="noindex">
+# tag into every page's <head> so search engines drop the deprecated V2 docs from
+# their results (search de-indexing lever).
 templates_path = ["_templates"]
+
+# Canonical URL. Sphinx emits <link rel="canonical"> on each page using this base URL,
+# declaring the V3 ("stable") page as the authoritative URL for each V2 page so search
+# engines and automation consolidate signals on V3. A page built at
+# /en/v2/<path>.html points its canonical at https://sagemaker.readthedocs.io/en/stable/<path>.html
+# (same relative path under the V3 tree). Only accurate where a same-path V3 page exists.
+html_baseurl = "https://sagemaker.readthedocs.io/en/stable/"
 
 source_suffix = ".rst"  # The suffix of source filenames.
 master_doc = "index"  # The master toctree document.


### PR DESCRIPTION
Steer search engines and automation away from the deprecated SageMaker Python SDK V2 documentation and toward V3. This is the Layer A (training-data) metadata lever from the V2->V3 version-management strategy: consolidate search signals on V3 and drop stale V2 pages from search results so future crawls surface V3.

- Set html_baseurl so Sphinx emits a <link rel="canonical"> on every page pointing at the corresponding V3 ("stable") URL.
- Add a _templates/layout.html theme override that injects <meta name="robots" content="noindex"> into every page's <head>.

noindex and canonical are per-page <head> tags, so they are correctly applied on the V2 build. The complementary robots.txt (AI-training crawler opt-out) is intentionally not included here: ReadTheDocs only serves robots.txt from the default version at the domain root, so it must live on the V3/default branch instead of the V2 build.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
