### PR TITLE
Feat: show_metrics() and stream_logs() helper functions

### DIFF
--- a/sagemaker-train/pyproject.toml
+++ b/sagemaker-train/pyproject.toml
@@ -68,6 +68,7 @@ notebook = [
     "ipywidgets>=8.0.0",
     "rich>=13.0.0",
     "matplotlib>=3.5.0",
+    "pandas",
 ]
 
 [tool.setuptools.packages.find]

--- a/sagemaker-train/src/sagemaker/train/base_trainer.py
+++ b/sagemaker-train/src/sagemaker/train/base_trainer.py
@@ -1,7 +1,9 @@
 import copy
 import os
+import time
 import yaml
 from abc import ABC, abstractmethod
+from datetime import datetime as _datetime
 from typing import Optional, Dict, Any, List, Union
 import json
 import logging
@@ -15,7 +17,8 @@ import yaml
 import boto3
 
 from sagemaker.core.helper.session_helper import Session
-from sagemaker.core.training.configs import Tag, Networking, InputData, Channel, OutputDataConfig
+from sagemaker.core.training.configs import Tag, Networking, InputData, Channel, OutputDataConfig, HyperPodCompute
+from sagemaker.core.utils.logs import MultiLogStreamHandler
 from sagemaker.core.shapes import shapes
 from sagemaker.core.resources import TrainingJob
 from sagemaker.train.common_utils.recipe_utils import _is_nova_model, resolve_recipe, get_resolved_recipe_from_context, NoRecipeError
@@ -31,8 +34,12 @@ from sagemaker.train.common_utils.finetune_utils import (
 )
 from sagemaker.train.common_utils.mlflow_config_utils import resolve_mlflow_tracking_fields
 from sagemaker.train.common_utils.validator import validate_hyperpod_compute
+from sagemaker.train.common_utils.cloudwatch_metrics import fetch_and_plot_metrics, _get_smhp_log_group
 from sagemaker.train.defaults import TrainDefaults
 from sagemaker.train.utils import _get_unique_name
+
+logger = logging.getLogger(__name__)
+
 
 class BaseTrainer(ABC):
     """Abstract base class for all SageMaker training workflows.
@@ -300,9 +307,12 @@ class BaseTrainer(ABC):
             ValueError: If no training job has been run yet, or no logs/metrics
                 are found.
         """
-        from datetime import datetime as _datetime
-        from sagemaker.core.training.configs import HyperPodCompute
-        from sagemaker.train.common_utils.cloudwatch_metrics import fetch_and_plot_metrics
+        # Gate to Nova models only 
+        model_name = getattr(self, '_model_name', None)
+        if model_name and not _is_nova_model(model_name):
+            raise NotImplementedError(
+                "show_metrics() is currently only supported for Nova models. "
+            )
 
         # Validate that we have a training job to get metrics from
         if not hasattr(self, '_latest_training_job') or self._latest_training_job is None:
@@ -322,12 +332,6 @@ class BaseTrainer(ABC):
 
         # Determine platform from compute config
         compute = getattr(self, 'compute', None)
-        if isinstance(compute, HyperPodCompute):
-            platform = "smhp"
-            cluster_name = compute.cluster_name
-        else:
-            platform = "smtj"
-            cluster_name = None
 
         # Get customization technique
         customization_technique = getattr(self, '_customization_technique', None)
@@ -365,10 +369,9 @@ class BaseTrainer(ABC):
 
         return fetch_and_plot_metrics(
             job_id=job_id,
-            platform=platform,
+            compute=compute,
             customization_technique=customization_technique,
             sagemaker_session=sagemaker_session,
-            cluster_name=cluster_name,
             metrics=metrics,
             starting_step=starting_step,
             ending_step=ending_step,
@@ -394,10 +397,6 @@ class BaseTrainer(ABC):
         Raises:
             ValueError: If no training job has been run yet.
         """
-        import time
-        from datetime import datetime as _datetime
-        from sagemaker.core.training.configs import HyperPodCompute
-
         if not hasattr(self, '_latest_training_job') or self._latest_training_job is None:
             raise ValueError(
                 "No training job found. Call .train(wait=False) first, "
@@ -422,9 +421,6 @@ class BaseTrainer(ABC):
 
     def _stream_logs_smtj(self, training_job, poll: int) -> None:
         """Stream logs for an SMTJ training job using MultiLogStreamHandler."""
-        import time
-        from sagemaker.core.utils.logs import MultiLogStreamHandler
-        from sagemaker.core.resources import TrainingJob
 
         # Resolve job name
         if hasattr(training_job, 'training_job_name'):
@@ -443,9 +439,8 @@ class BaseTrainer(ABC):
             expected_stream_count=instance_count,
         )
 
-        print(f"Streaming logs for job: {job_name}")
-        print(f"Log group: {log_group}")
-        print("-" * 60)
+        logger.info(f"Streaming logs for job: {job_name}")
+        logger.info(f"Log group: {log_group}")
 
         terminal_statuses = {"Completed", "Failed", "Stopped"}
 
@@ -453,7 +448,7 @@ class BaseTrainer(ABC):
             for stream_name, event in handler.get_latest_log_events():
                 message = event.get("message", "").rstrip()
                 if message:
-                    print(message)
+                    logger.info(message)
 
             # Check job status
             try:
@@ -464,9 +459,8 @@ class BaseTrainer(ABC):
                     for stream_name, event in handler.get_latest_log_events():
                         message = event.get("message", "").rstrip()
                         if message:
-                            print(message)
-                    print("-" * 60)
-                    print(f"Job {job_name} finished with status: {status}")
+                            logger.info(message)
+                    logger.info(f"Job {job_name} finished with status: {status}")
                     return
             except Exception:
                 pass
@@ -475,8 +469,6 @@ class BaseTrainer(ABC):
 
     def _stream_logs_smhp(self, training_job, compute, poll: int, start_time_ms=None) -> None:
         """Stream logs for a HyperPod job using filter_log_events polling."""
-        import time
-        from sagemaker.train.common_utils.cloudwatch_metrics import _get_smhp_log_group
 
         job_id = training_job if isinstance(training_job, str) else str(training_job)
 
@@ -485,13 +477,12 @@ class BaseTrainer(ABC):
         )
         region_name = sagemaker_session.boto_session.region_name
         logs_client = sagemaker_session.boto_session.client("logs", region_name=region_name)
-        log_group = _get_smhp_log_group(compute.cluster_name, sagemaker_session)
+        log_group = _get_smhp_log_group(compute.cluster_name, sagemaker_session.sagemaker_client)
 
-        print(f"Streaming logs for HyperPod job: {job_id}")
-        print(f"Cluster: {compute.cluster_name}")
-        print(f"Log group: {log_group}")
-        print("Press Ctrl+C to stop streaming.")
-        print("-" * 60)
+        logger.info(f"Streaming logs for HyperPod job: {job_id}")
+        logger.info(f"Cluster: {compute.cluster_name}")
+        logger.info(f"Log group: {log_group}")
+        logger.info("Press Ctrl+C to stop streaming.")
 
         # Pick start time (user-provided > training job start time > now)
         if start_time_ms is not None:
@@ -522,7 +513,7 @@ class BaseTrainer(ABC):
                         seen_event_ids.add(event_id)
                         message = event.get("message", "").rstrip()
                         if message:
-                            print(message)
+                            logger.info(message)
                         ts = event.get("timestamp", 0)
                         if ts > last_timestamp:
                             last_timestamp = ts
@@ -534,8 +525,7 @@ class BaseTrainer(ABC):
             try:
                 time.sleep(poll)
             except KeyboardInterrupt:
-                print("\n" + "-" * 60)
-                print("Log streaming stopped by user.")
+                logger.info("Log streaming stopped by user.")
                 return
 
     def _validate_instance_count(self, instance_count, sagemaker_session):

--- a/sagemaker-train/src/sagemaker/train/base_trainer.py
+++ b/sagemaker-train/src/sagemaker/train/base_trainer.py
@@ -268,6 +268,276 @@ class BaseTrainer(ABC):
 
         return final_hyperparameters
 
+    def show_metrics(
+        self,
+        metrics: Optional[List[str]] = None,
+        starting_step: Optional[int] = None,
+        ending_step: Optional[int] = None,
+        start_time: Optional[Any] = None,
+        end_time: Optional[Any] = None,
+    ) -> Any:
+        """Plot training metrics extracted from CloudWatch logs using matplotlib.
+
+        Args:
+            metrics: Optional list of metric names to plot. If None, plots all
+                available metrics for the training technique. 
+            starting_step: Only plot metrics from this global step onwards.
+            ending_step: Only plot metrics up to this global step.
+            start_time: Optional start time for log retrieval. Accepts a
+                datetime object or epoch milliseconds (int). When not provided,
+                auto-resolved from the training job's start time.
+            end_time: Optional end time for log retrieval. Accepts a
+                datetime object or epoch milliseconds (int). When not provided,
+                defaults to now.
+
+        Returns:
+            pandas.DataFrame containing the extracted metrics with columns
+            ["global_step", <metric_name>].
+
+        Raises:
+            NotImplementedError: If the training technique does not support metric
+                extraction (e.g., DPO).
+            ValueError: If no training job has been run yet, or no logs/metrics
+                are found.
+        """
+        from datetime import datetime as _datetime
+        from sagemaker.core.training.configs import HyperPodCompute
+        from sagemaker.train.common_utils.cloudwatch_metrics import fetch_and_plot_metrics
+
+        # Validate that we have a training job to get metrics from
+        if not hasattr(self, '_latest_training_job') or self._latest_training_job is None:
+            raise ValueError(
+                "No training job found. Call .train() first, then call .show_metrics() "
+                "to view training metrics."
+            )
+
+        # Resolve job ID
+        training_job = self._latest_training_job
+        if hasattr(training_job, 'training_job_name'):
+            job_id = training_job.training_job_name
+        elif isinstance(training_job, str):
+            job_id = training_job
+        else:
+            job_id = str(training_job)
+
+        # Determine platform from compute config
+        compute = getattr(self, 'compute', None)
+        if isinstance(compute, HyperPodCompute):
+            platform = "smhp"
+            cluster_name = compute.cluster_name
+        else:
+            platform = "smtj"
+            cluster_name = None
+
+        # Get customization technique
+        customization_technique = getattr(self, '_customization_technique', None)
+        if not customization_technique:
+            raise ValueError(
+                "Could not determine training technique. "
+                "show_metrics() requires a trainer with a known customization technique."
+            )
+
+        # Resolve session
+        sagemaker_session = TrainDefaults.get_sagemaker_session(
+            sagemaker_session=self.sagemaker_session
+        )
+
+        # Resolve start_time: user-provided > training job metadata > None
+        start_time_ms = None
+        if start_time is not None:
+            if isinstance(start_time, _datetime):
+                start_time_ms = int(start_time.timestamp() * 1000)
+            else:
+                start_time_ms = int(start_time)
+        elif hasattr(training_job, 'training_start_time') and training_job.training_start_time:
+            try:
+                start_time_ms = int(training_job.training_start_time.timestamp() * 1000)
+            except Exception:
+                pass
+
+        # Resolve end_time: user-provided > None (defaults to now in fetch layer)
+        end_time_ms = None
+        if end_time is not None:
+            if isinstance(end_time, _datetime):
+                end_time_ms = int(end_time.timestamp() * 1000)
+            else:
+                end_time_ms = int(end_time)
+
+        return fetch_and_plot_metrics(
+            job_id=job_id,
+            platform=platform,
+            customization_technique=customization_technique,
+            sagemaker_session=sagemaker_session,
+            cluster_name=cluster_name,
+            metrics=metrics,
+            starting_step=starting_step,
+            ending_step=ending_step,
+            start_time=start_time_ms,
+            end_time=end_time_ms,
+        )
+
+    def stream_logs(self, poll: int = 5, start_time: Optional[Any] = None) -> None:
+        """Stream CloudWatch logs in real-time (like ``kubectl logs -f``).
+
+        Continuously polls for new log events and prints them as they arrive.
+        Blocks until the training job reaches a terminal state (SMTJ) or
+        the user interrupts with Ctrl+C (HyperPod).
+
+        Args:
+            poll: Polling interval in seconds between log fetches. Defaults to 5.
+            start_time: Optional start time to stream logs from. Accepts a
+                datetime object or epoch milliseconds (int). Useful when
+                attaching to a job that's already running. If not provided,
+                auto-resolved from the training job's start time (SMTJ) or
+                defaults to now (HyperPod).
+
+        Raises:
+            ValueError: If no training job has been run yet.
+        """
+        import time
+        from datetime import datetime as _datetime
+        from sagemaker.core.training.configs import HyperPodCompute
+
+        if not hasattr(self, '_latest_training_job') or self._latest_training_job is None:
+            raise ValueError(
+                "No training job found. Call .train(wait=False) first, "
+                "then call .stream_logs() to stream logs in real-time."
+            )
+
+        # Resolve start_time for SMHP jobs
+        start_time_ms = None
+        if start_time is not None:
+            if isinstance(start_time, _datetime):
+                start_time_ms = int(start_time.timestamp() * 1000)
+            else:
+                start_time_ms = int(start_time)
+
+        training_job = self._latest_training_job
+        compute = getattr(self, 'compute', None)
+
+        if isinstance(compute, HyperPodCompute):
+            self._stream_logs_smhp(training_job, compute, poll, start_time_ms)
+        else:
+            self._stream_logs_smtj(training_job, poll)
+
+    def _stream_logs_smtj(self, training_job, poll: int) -> None:
+        """Stream logs for an SMTJ training job using MultiLogStreamHandler."""
+        import time
+        from sagemaker.core.utils.logs import MultiLogStreamHandler
+        from sagemaker.core.resources import TrainingJob
+
+        # Resolve job name
+        if hasattr(training_job, 'training_job_name'):
+            job_name = training_job.training_job_name
+        else:
+            job_name = str(training_job)
+
+        log_group = "/aws/sagemaker/TrainingJobs"
+        instance_count = 1
+        if hasattr(self, 'compute') and self.compute and hasattr(self.compute, 'instance_count'):
+            instance_count = self.compute.instance_count or 1
+
+        handler = MultiLogStreamHandler(
+            log_group_name=log_group,
+            log_stream_name_prefix=job_name,
+            expected_stream_count=instance_count,
+        )
+
+        print(f"Streaming logs for job: {job_name}")
+        print(f"Log group: {log_group}")
+        print("-" * 60)
+
+        terminal_statuses = {"Completed", "Failed", "Stopped"}
+
+        while True:
+            for stream_name, event in handler.get_latest_log_events():
+                message = event.get("message", "").rstrip()
+                if message:
+                    print(message)
+
+            # Check job status
+            try:
+                job = TrainingJob.get(training_job_name=job_name)
+                status = job.training_job_status
+                if status in terminal_statuses:
+                    # Final flush
+                    for stream_name, event in handler.get_latest_log_events():
+                        message = event.get("message", "").rstrip()
+                        if message:
+                            print(message)
+                    print("-" * 60)
+                    print(f"Job {job_name} finished with status: {status}")
+                    return
+            except Exception:
+                pass
+
+            time.sleep(poll)
+
+    def _stream_logs_smhp(self, training_job, compute, poll: int, start_time_ms=None) -> None:
+        """Stream logs for a HyperPod job using filter_log_events polling."""
+        import time
+        from sagemaker.train.common_utils.cloudwatch_metrics import _get_smhp_log_group
+
+        job_id = training_job if isinstance(training_job, str) else str(training_job)
+
+        sagemaker_session = TrainDefaults.get_sagemaker_session(
+            sagemaker_session=self.sagemaker_session
+        )
+        region_name = sagemaker_session.boto_session.region_name
+        logs_client = sagemaker_session.boto_session.client("logs", region_name=region_name)
+        log_group = _get_smhp_log_group(compute.cluster_name, sagemaker_session)
+
+        print(f"Streaming logs for HyperPod job: {job_id}")
+        print(f"Cluster: {compute.cluster_name}")
+        print(f"Log group: {log_group}")
+        print("Press Ctrl+C to stop streaming.")
+        print("-" * 60)
+
+        # Pick start time (user-provided > training job start time > now)
+        if start_time_ms is not None:
+            last_timestamp = start_time_ms
+        elif hasattr(training_job, 'training_start_time') and training_job.training_start_time:
+            try:
+                last_timestamp = int(training_job.training_start_time.timestamp() * 1000)
+            except Exception:
+                last_timestamp = int(time.time() * 1000)
+        else:
+            last_timestamp = int(time.time() * 1000)
+        seen_event_ids = set()
+
+        while True:
+            try:
+                params = {
+                    "logGroupName": log_group,
+                    "logStreamNamePrefix": "SagemakerHyperPodTrainingJob",
+                    "filterPattern": f'"{job_id}"',
+                    "startTime": last_timestamp,
+                }
+                response = logs_client.filter_log_events(**params)
+                events = response.get("events", [])
+
+                for event in events:
+                    event_id = event.get("eventId", "")
+                    if event_id not in seen_event_ids:
+                        seen_event_ids.add(event_id)
+                        message = event.get("message", "").rstrip()
+                        if message:
+                            print(message)
+                        ts = event.get("timestamp", 0)
+                        if ts > last_timestamp:
+                            last_timestamp = ts
+            except Exception as e:
+                logger.debug(f"Error fetching HP logs: {e}")
+
+            # Note: HyperPod jobs don't have a simple status API to poll for completion.
+            # This polls till the user interrupts with Ctrl+C. 
+            try:
+                time.sleep(poll)
+            except KeyboardInterrupt:
+                print("\n" + "-" * 60)
+                print("Log streaming stopped by user.")
+                return
+
     def _validate_instance_count(self, instance_count, sagemaker_session):
         """Validate instance/node count against allowed values from SMHP recipe."""
         smhp_replicas_enum = _get_smhp_replicas_enum(

--- a/sagemaker-train/src/sagemaker/train/common_utils/cloudwatch_metrics.py
+++ b/sagemaker-train/src/sagemaker/train/common_utils/cloudwatch_metrics.py
@@ -16,6 +16,9 @@ import re
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
+from sagemaker.core.training.configs import HyperPodCompute
+
+
 logger = logging.getLogger(__name__)
 
 GLOBAL_STEP_REGEX = r"global_step[=:]\s*([\d.]+)"
@@ -45,14 +48,12 @@ def _get_smtj_log_group() -> str:
     return "/aws/sagemaker/TrainingJobs"
 
 
-def _get_smhp_log_group(cluster_name: str, sagemaker_session) -> str:
+def _get_smhp_log_group(cluster_name: str, sagemaker_client) -> str:
     """Return the CW log group for a HyperPod cluster.
 
     The log group follows the pattern:
         /aws/sagemaker/Clusters/{cluster_name}/{cluster_id}
     """
-    region_name = sagemaker_session.boto_session.region_name
-    sagemaker_client = sagemaker_session.boto_session.client("sagemaker", region_name=region_name)
     response = sagemaker_client.describe_cluster(ClusterName=cluster_name)
     cluster_arn = response["ClusterArn"]
     cluster_id = cluster_arn.split("/")[-1]
@@ -316,10 +317,9 @@ def plot_metrics(
 
 def fetch_and_plot_metrics(
     job_id: str,
-    platform: str,
+    compute,
     customization_technique: str,
     sagemaker_session,
-    cluster_name: Optional[str] = None,
     metrics: Optional[List[str]] = None,
     starting_step: Optional[int] = None,
     ending_step: Optional[int] = None,
@@ -332,10 +332,9 @@ def fetch_and_plot_metrics(
 
     Args:
         job_id: Training job name (SMTJ) or HyperPod job name.
-        platform: "smtj" or "smhp".
+        compute: Determines whether to use SMHP or SMTJ strategy.
         customization_technique: "SFT", "CPT", or "RLVR".
         sagemaker_session: SageMaker session (provides boto_session).
-        cluster_name: Required for SMHP platform — the HyperPod cluster name.
         metrics: Optional list of metric names to extract.
         starting_step: Filter to steps >= this value.
         ending_step: Filter to steps <= this value.
@@ -350,6 +349,9 @@ def fetch_and_plot_metrics(
         ValueError: If no logs or metrics are found.
     """
     technique = customization_technique.upper()
+
+    # Determine platform from compute type
+    platform = "smhp" if isinstance(compute, HyperPodCompute) else "smtj"
 
     if technique in _UNSUPPORTED_TECHNIQUES:
         raise NotImplementedError(
@@ -369,14 +371,14 @@ def fetch_and_plot_metrics(
     region_name = sagemaker_session.boto_session.region_name
     logs_client = sagemaker_session.boto_session.client("logs", region_name=region_name)
 
-    # Fetch logs based on platform
-    if platform == "smhp":
-        if not cluster_name:
+    # Fetch logs based on compute type
+    if isinstance(compute, HyperPodCompute):
+        if not compute.cluster_name:
             raise ValueError(
                 "cluster_name is required for HyperPod metrics. "
                 "This should be available from the compute configuration."
             )
-        log_group = _get_smhp_log_group(cluster_name, sagemaker_session)
+        log_group = _get_smhp_log_group(compute.cluster_name, sagemaker_session.sagemaker_client)
         log_events = _fetch_smhp_logs(
             job_id=job_id,
             logs_client=logs_client,
@@ -385,7 +387,6 @@ def fetch_and_plot_metrics(
             end_time=end_time,
         )
     else:
-        # SMTJ (serverless or serverful)
         log_group = _get_smtj_log_group()
         log_events = _fetch_smtj_logs(
             job_name=job_id,

--- a/sagemaker-train/src/sagemaker/train/common_utils/cloudwatch_metrics.py
+++ b/sagemaker-train/src/sagemaker/train/common_utils/cloudwatch_metrics.py
@@ -1,0 +1,430 @@
+"""CloudWatch log-based training metrics extraction and plotting.
+
+Parses CloudWatch log events from SageMaker Training Jobs and HyperPod clusters
+to extract step-level training metrics (loss, reward scores) and plot them.
+
+Supports:
+- SFT/CPT on SMTJ and SMHP: reduced_train_loss
+- RLVR on SMTJ: critic/rewards/mean
+- RLVR on SMHP: train_rm_score
+"""
+
+from __future__ import absolute_import
+
+import logging
+import re
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+GLOBAL_STEP_REGEX = r"global_step[=:]\s*([\d.]+)"
+TRAINING_LOSS_REGEX = r"reduced_train_loss[=:]\s*(-?[\d.]+(?:[eE][+-]?\d+)?)"
+LEARNING_RATE_REGEX = r"(?<![a-z_])lr[=:]\s*(-?[\d.]+(?:[eE][+-]?\d+)?)"
+SMHP_RLVR_REWARD_SCORE_REGEX = r"train_rm_score:\s*(-?[\d.]+(?:[eE][+-]?\d+)?)"
+SMTJ_RLVR_REWARD_SCORE_REGEX = r"critic/rewards/mean[=:]\s*(-?[\d.]+(?:[eE][+-]?\d+)?)"
+
+# Metric patterns keyed by (platform, customization_technique)
+AVAILABLE_METRICS: Dict[str, Dict[str, Dict[str, str]]] = {
+    "smtj": {
+        "SFT": {"training_loss": TRAINING_LOSS_REGEX, "lr": LEARNING_RATE_REGEX},
+        "CPT": {"training_loss": TRAINING_LOSS_REGEX, "lr": LEARNING_RATE_REGEX},
+        "RLVR": {"reward_score": SMTJ_RLVR_REWARD_SCORE_REGEX},
+    },
+    "smhp": {
+        "SFT": {"training_loss": TRAINING_LOSS_REGEX, "lr": LEARNING_RATE_REGEX},
+        "CPT": {"training_loss": TRAINING_LOSS_REGEX, "lr": LEARNING_RATE_REGEX},
+        "RLVR": {"reward_score": SMHP_RLVR_REWARD_SCORE_REGEX},
+    },
+}
+
+_UNSUPPORTED_TECHNIQUES = {"DPO", "RLAIF"}
+
+def _get_smtj_log_group() -> str:
+    """Return the CW log group for SageMaker Training Jobs."""
+    return "/aws/sagemaker/TrainingJobs"
+
+
+def _get_smhp_log_group(cluster_name: str, sagemaker_session) -> str:
+    """Return the CW log group for a HyperPod cluster.
+
+    The log group follows the pattern:
+        /aws/sagemaker/Clusters/{cluster_name}/{cluster_id}
+    """
+    region_name = sagemaker_session.boto_session.region_name
+    sagemaker_client = sagemaker_session.boto_session.client("sagemaker", region_name=region_name)
+    response = sagemaker_client.describe_cluster(ClusterName=cluster_name)
+    cluster_arn = response["ClusterArn"]
+    cluster_id = cluster_arn.split("/")[-1]
+    return f"/aws/sagemaker/Clusters/{cluster_name}/{cluster_id}"
+
+
+def _fetch_smtj_logs(
+    job_name: str,
+    logs_client,
+    log_group: str,
+    start_time: Optional[int] = None,
+    end_time: Optional[int] = None,
+) -> List[Dict[str, Any]]:
+    """Fetch CloudWatch log events for an SMTJ training job."""
+    # Find the job's dedicated log stream
+    try:
+        response = logs_client.describe_log_streams(
+            logGroupName=log_group,
+            logStreamNamePrefix=job_name,
+        )
+    except Exception as e:
+        logger.warning(f"Could not describe log streams for job '{job_name}': {e}")
+        return []
+
+    streams = response.get("logStreams", [])
+    if not streams:
+        logger.warning(f"No log stream found for job '{job_name}' in {log_group}")
+        return []
+
+    log_stream_name = streams[0]["logStreamName"]
+
+    # Read events with get_log_events
+    all_events: List[Dict[str, Any]] = []
+    next_token = None
+    end_time_ms = end_time or int(datetime.now().timestamp() * 1000)
+
+    while True:
+        params: Dict[str, Any] = {
+            "logGroupName": log_group,
+            "logStreamName": log_stream_name,
+            "startFromHead": False,
+            "endTime": end_time_ms,
+        }
+        if start_time:
+            params["startTime"] = start_time
+        if next_token:
+            params["nextToken"] = next_token
+
+        response = logs_client.get_log_events(**params)
+        events = response.get("events", [])
+        all_events.extend(events)
+
+        current_token = next_token
+        next_token = response.get("nextBackwardToken")
+        if next_token == current_token:
+            break
+
+    return all_events
+
+
+def _fetch_smhp_logs(
+    job_id: str,
+    logs_client,
+    log_group: str,
+    start_time: Optional[int] = None,
+    end_time: Optional[int] = None,
+) -> List[Dict[str, Any]]:
+    """Fetch CloudWatch log events for a HyperPod training job.
+
+    HyperPod doesn't separate log streams by job — uses filter_log_events
+    with the job ID as the filter pattern.
+    """
+    all_events: List[Dict[str, Any]] = []
+    next_token = None
+    end_time_ms = end_time or int(datetime.now().timestamp() * 1000)
+
+    while True:
+        params: Dict[str, Any] = {
+            "logGroupName": log_group,
+            "logStreamNamePrefix": "SagemakerHyperPodTrainingJob",
+            "filterPattern": f'"{job_id}"',
+            "endTime": end_time_ms,
+        }
+        if start_time:
+            params["startTime"] = start_time
+        if next_token:
+            params["nextToken"] = next_token
+
+        try:
+            response = logs_client.filter_log_events(**params)
+        except Exception as e:
+            logger.warning(f"Could not filter log events for HP job '{job_id}': {e}")
+            return all_events
+
+        events = response.get("events", [])
+        all_events.extend(events)
+
+        next_token = response.get("nextToken")
+        if not next_token:
+            break
+
+    return all_events
+
+
+def parse_metrics_from_logs(
+    logs: List[Dict[str, Any]],
+    platform: str,
+    customization_technique: str,
+    metrics: Optional[List[str]] = None,
+) -> "pandas.DataFrame":
+    """Parse training metrics from CloudWatch log events.
+
+    Scans each log line for global_step, then extracts the relevant metric
+    value from the same line based on the platform and training technique.
+
+    Args:
+        logs: List of CW log event dicts (each with a "message" key).
+        platform: "smtj" or "smhp".
+        customization_technique: "SFT", "CPT", or "RLVR".
+        metrics: Optional list of metric names to extract. If None, extracts all
+            available metrics for the given platform/technique combination.
+
+    Returns:
+        pandas DataFrame with columns ["global_step", <metric_name>, ...].
+
+    Raises:
+        ImportError: If pandas is not installed.
+        NotImplementedError: If the technique is not supported.
+        ValueError: If a requested metric is not available.
+    """
+    try:
+        import pandas
+    except ImportError:
+        raise ImportError(
+            "pandas is required for metric extraction. "
+            "Install it with: pip install pandas\n"
+        )
+
+    technique = customization_technique.upper()
+
+    if technique in _UNSUPPORTED_TECHNIQUES:
+        raise NotImplementedError(
+            f"Training metrics extraction is not supported for {technique} jobs. "
+            f"Supported techniques: SFT, CPT, RLVR."
+        )
+
+    available = AVAILABLE_METRICS.get(platform, {}).get(technique)
+    if not available:
+        raise NotImplementedError(
+            f"No metric patterns defined for technique '{technique}' on platform '{platform}'. "
+            f"Supported: {list(AVAILABLE_METRICS.get(platform, {}).keys())}"
+        )
+
+    if not metrics:
+        metrics = list(available.keys())
+
+    patterns = []
+    for metric_name in metrics:
+        if metric_name not in available:
+            raise ValueError(
+                f"Metric '{metric_name}' is not available for {technique} on {platform}. "
+                f"Available metrics: {list(available.keys())}"
+            )
+        patterns.append(available[metric_name])
+
+    # Parse log lines — extract each metric independently per line.
+    # A line must have global_step plus at least one requested metric to be included.
+    all_rows: List[List] = []
+    log_lines = [line for log in logs for line in log.get("message", "").splitlines()]
+
+    for line in log_lines:
+        step_match = re.search(GLOBAL_STEP_REGEX, line)
+        if not step_match:
+            continue
+
+        step_value = int(float(step_match.group(1)))
+        row_values: List = [step_value]
+        found_any = False
+
+        for pattern in patterns:
+            match = re.search(pattern, line)
+            if match:
+                row_values.append(float(match.group(1)))
+                found_any = True
+            else:
+                row_values.append(None)
+
+        if found_any:
+            all_rows.append(row_values)
+
+    return pandas.DataFrame(all_rows, columns=["global_step"] + metrics)
+
+
+def plot_metrics(
+    metrics_df: "pandas.DataFrame",
+    title: str = "Training Metrics",
+    starting_step: Optional[int] = None,
+    ending_step: Optional[int] = None,
+) -> None:
+    """Plot training metrics using matplotlib.
+
+    Args:
+        metrics_df: DataFrame with "global_step" column and one or more metric columns.
+        title: Plot title.
+        starting_step: Filter to steps >= this value.
+        ending_step: Filter to steps <= this value.
+
+    Raises:
+        ImportError: If matplotlib is not installed.
+        ValueError: If no metrics found in the specified range.
+    """
+    try:
+        import matplotlib.pyplot as plt
+    except ImportError:
+        raise ImportError(
+            "matplotlib is required for plotting metrics. "
+            "Install it with: pip install matplotlib\n"
+        )
+
+    if metrics_df.empty:
+        raise ValueError("No metrics data available to plot.")
+
+    # Deduplicate and filter by step range
+    df = metrics_df.drop_duplicates(subset=["global_step"], keep="last").copy()
+
+    if starting_step is not None:
+        df = df[df["global_step"] >= starting_step]
+    if ending_step is not None:
+        df = df[df["global_step"] <= ending_step]
+
+    if df.empty:
+        range_desc = f"[{starting_step or 'start'} - {ending_step or 'end'}]"
+        raise ValueError(f"No metrics found in the specified step range {range_desc}")
+
+    df = df.sort_values("global_step").reset_index(drop=True)
+
+    # Plot each metric in its own subplot (stacked vertically)
+    metric_columns = [col for col in df.columns if col != "global_step"]
+    # Only plot columns that have at least one non-null value
+    metric_columns = [col for col in metric_columns if df[col].notna().any()]
+
+    num_metrics = len(metric_columns)
+    if num_metrics == 0:
+        raise ValueError("No plottable metric data found.")
+
+    fig, axes = plt.subplots(num_metrics, 1, figsize=(10, 4 * num_metrics), squeeze=False)
+
+    for idx, col in enumerate(metric_columns):
+        ax = axes[idx, 0]
+        col_data = df[["global_step", col]].dropna(subset=[col])
+        ax.plot(col_data["global_step"], col_data[col], linewidth=1.5)
+        ax.set_xlabel("Global Step")
+        ax.set_ylabel(col)
+        ax.set_title(col)
+        ax.grid(True, alpha=0.3)
+
+    fig.suptitle(title, fontweight="bold", fontsize=13)
+    fig.tight_layout()
+    plt.show()
+
+
+def fetch_and_plot_metrics(
+    job_id: str,
+    platform: str,
+    customization_technique: str,
+    sagemaker_session,
+    cluster_name: Optional[str] = None,
+    metrics: Optional[List[str]] = None,
+    starting_step: Optional[int] = None,
+    ending_step: Optional[int] = None,
+    start_time: Optional[int] = None,
+    end_time: Optional[int] = None,
+) -> "pandas.DataFrame":
+    """Fetch CW logs, parse metrics, and plot them.
+
+    This is the main entry point used by BaseTrainer.show_metrics().
+
+    Args:
+        job_id: Training job name (SMTJ) or HyperPod job name.
+        platform: "smtj" or "smhp".
+        customization_technique: "SFT", "CPT", or "RLVR".
+        sagemaker_session: SageMaker session (provides boto_session).
+        cluster_name: Required for SMHP platform — the HyperPod cluster name.
+        metrics: Optional list of metric names to extract.
+        starting_step: Filter to steps >= this value.
+        ending_step: Filter to steps <= this value.
+        start_time: Optional epoch ms to filter logs from (speeds up retrieval).
+        end_time: Optional epoch ms to filter logs until.
+
+    Returns:
+        pandas DataFrame with the extracted metrics.
+
+    Raises:
+        NotImplementedError: If the technique is not supported (e.g., DPO).
+        ValueError: If no logs or metrics are found.
+    """
+    technique = customization_technique.upper()
+
+    if technique in _UNSUPPORTED_TECHNIQUES:
+        raise NotImplementedError(
+            f"show_metrics() is not supported for {technique} jobs. "
+            f"Supported training techniques: SFT, CPT, RLVR."
+        )
+
+    # Validate technique is recognized before doing any expensive log fetching
+    available = AVAILABLE_METRICS.get(platform, {}).get(technique)
+    if not available:
+        supported = list(AVAILABLE_METRICS.get(platform, {}).keys())
+        raise ValueError(
+            f"'{customization_technique}' is not a supported training technique. "
+            f"Supported techniques for platform '{platform}': {supported}"
+        )
+
+    region_name = sagemaker_session.boto_session.region_name
+    logs_client = sagemaker_session.boto_session.client("logs", region_name=region_name)
+
+    # Fetch logs based on platform
+    if platform == "smhp":
+        if not cluster_name:
+            raise ValueError(
+                "cluster_name is required for HyperPod metrics. "
+                "This should be available from the compute configuration."
+            )
+        log_group = _get_smhp_log_group(cluster_name, sagemaker_session)
+        log_events = _fetch_smhp_logs(
+            job_id=job_id,
+            logs_client=logs_client,
+            log_group=log_group,
+            start_time=start_time,
+            end_time=end_time,
+        )
+    else:
+        # SMTJ (serverless or serverful)
+        log_group = _get_smtj_log_group()
+        log_events = _fetch_smtj_logs(
+            job_name=job_id,
+            logs_client=logs_client,
+            log_group=log_group,
+            start_time=start_time,
+            end_time=end_time,
+        )
+
+    if not log_events:
+        raise ValueError(
+            f"No CloudWatch logs found for job '{job_id}' in log group '{log_group}'. "
+            f"The job may still be starting, or logs may not be available yet."
+        )
+
+    # Parse metrics from logs
+    metrics_df = parse_metrics_from_logs(
+        logs=log_events,
+        platform=platform,
+        customization_technique=technique,
+        metrics=metrics,
+    )
+
+    if metrics_df.empty:
+        raise ValueError(
+            f"No training metrics could be extracted from logs for job '{job_id}'. "
+            f"The job may not have started training steps yet."
+        )
+
+    # Sort by global_step before plotting and returning
+    metrics_df = metrics_df.sort_values("global_step").reset_index(drop=True)
+
+    # Plot
+    title = f"Training Metrics: {job_id}"
+    plot_metrics(
+        metrics_df=metrics_df,
+        title=title,
+        starting_step=starting_step,
+        ending_step=ending_step,
+    )
+
+    return metrics_df

--- a/sagemaker-train/tests/unit/train/common_utils/test_cloudwatch_metrics.py
+++ b/sagemaker-train/tests/unit/train/common_utils/test_cloudwatch_metrics.py
@@ -2,11 +2,14 @@
 
 from __future__ import absolute_import
 
+from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
 import pandas
 import pytest
 
+from sagemaker.core.training.configs import Compute, HyperPodCompute
+from sagemaker.train.base_trainer import BaseTrainer
 from sagemaker.train.common_utils.cloudwatch_metrics import (
     _fetch_smhp_logs,
     _fetch_smtj_logs,
@@ -130,7 +133,10 @@ class TestFetchAndPlotMetrics:
     def test_smtj_sft_end_to_end(self, mock_fetch, mock_plot):
         mock_fetch.return_value = FAKE_SFT_LOGS
 
-        df = fetch_and_plot_metrics("my-job", "smtj", "SFT", self._session())
+        df = fetch_and_plot_metrics(
+            "my-job", Compute(instance_type="ml.p5.48xlarge", instance_count=1),
+            "SFT", self._session(),
+        )
 
         assert len(df) == 3
         assert "training_loss" in df.columns
@@ -143,21 +149,30 @@ class TestFetchAndPlotMetrics:
         mock_lg.return_value = "/aws/sagemaker/Clusters/c/id"
         mock_fetch.return_value = FAKE_RLVR_SMHP_LOGS
 
-        df = fetch_and_plot_metrics("hp-job", "smhp", "RLVR", self._session(), cluster_name="c")
+        df = fetch_and_plot_metrics(
+            "hp-job", HyperPodCompute(cluster_name="c", instance_type="ml.p5.48xlarge", node_count=1),
+            "RLVR", self._session(),
+        )
 
         assert len(df) == 2
         assert "reward_score" in df.columns
 
     def test_invalid_technique_raises_before_fetching(self):
         with pytest.raises(ValueError, match="not a supported training technique"):
-            fetch_and_plot_metrics("job", "smtj", "RFT", self._session())
+            fetch_and_plot_metrics(
+                "job", Compute(instance_type="ml.p5.48xlarge", instance_count=1),
+                "RFT", self._session(),
+            )
 
     @patch("sagemaker.train.common_utils.cloudwatch_metrics._fetch_smtj_logs")
     def test_no_logs_found_raises(self, mock_fetch):
         mock_fetch.return_value = []
 
         with pytest.raises(ValueError, match="No CloudWatch logs found"):
-            fetch_and_plot_metrics("missing-job", "smtj", "SFT", self._session())
+            fetch_and_plot_metrics(
+                "missing-job", Compute(instance_type="ml.p5.48xlarge", instance_count=1),
+                "SFT", self._session(),
+            )
 
     @patch("sagemaker.train.common_utils.cloudwatch_metrics.plot_metrics")
     @patch("sagemaker.train.common_utils.cloudwatch_metrics._fetch_smtj_logs")
@@ -168,7 +183,10 @@ class TestFetchAndPlotMetrics:
             {"message": "global_step=1 reduced_train_loss=5.0"},
         ]
 
-        df = fetch_and_plot_metrics("job", "smtj", "SFT", self._session(), metrics=["training_loss"])
+        df = fetch_and_plot_metrics(
+            "job", Compute(instance_type="ml.p5.48xlarge", instance_count=1),
+            "SFT", self._session(), metrics=["training_loss"],
+        )
 
         assert df["global_step"].tolist() == [1, 5]
 
@@ -177,8 +195,6 @@ class TestStreamLogs:
 
     def _make_trainer(self, compute=None, latest_job=None):
         """Create a minimal trainer stub for stream_logs testing."""
-        from sagemaker.train.base_trainer import BaseTrainer
-
         class _StubTrainer(BaseTrainer):
             _customization_technique = "SFT"
 
@@ -202,9 +218,6 @@ class TestStreamLogs:
     @patch("sagemaker.train.common_utils.cloudwatch_metrics._get_smhp_log_group")
     def test_smhp_dispatches_with_start_time(self, mock_log_group, mock_session):
         """SMHP stream_logs passes start_time to the polling loop."""
-        from datetime import datetime, timezone
-        from sagemaker.core.training.configs import HyperPodCompute
-
         mock_log_group.return_value = "/aws/sagemaker/Clusters/c/id"
         mock_sess = MagicMock()
         mock_sess.boto_session.region_name = "us-east-1"
@@ -233,11 +246,9 @@ class TestStreamLogs:
         assert call_kwargs["startTime"] == expected_ts
 
     @patch("sagemaker.core.resources.TrainingJob.get")
-    @patch("sagemaker.core.utils.logs.MultiLogStreamHandler")
+    @patch("sagemaker.train.base_trainer.MultiLogStreamHandler")
     def test_smtj_stops_on_completed(self, mock_handler_cls, mock_get_job):
         """SMTJ stream_logs exits when job status is Completed."""
-        from sagemaker.core.training.configs import Compute
-
         # Mock the handler to return one event then empty
         mock_handler = MagicMock()
         mock_handler.get_latest_log_events.side_effect = [
@@ -260,3 +271,11 @@ class TestStreamLogs:
         trainer.stream_logs()
 
         mock_get_job.assert_called()
+
+    def test_show_metrics_rejects_oss_models(self):
+        """show_metrics() raises NotImplementedError for non-Nova models."""
+        trainer = self._make_trainer(latest_job="some-job")
+        trainer._model_name = "test-oss-model"
+
+        with pytest.raises(NotImplementedError, match="only supported for Nova models"):
+            trainer.show_metrics()

--- a/sagemaker-train/tests/unit/train/common_utils/test_cloudwatch_metrics.py
+++ b/sagemaker-train/tests/unit/train/common_utils/test_cloudwatch_metrics.py
@@ -1,0 +1,262 @@
+"""Unit tests for cloudwatch_metrics module."""
+
+from __future__ import absolute_import
+
+from unittest.mock import MagicMock, patch
+
+import pandas
+import pytest
+
+from sagemaker.train.common_utils.cloudwatch_metrics import (
+    _fetch_smhp_logs,
+    _fetch_smtj_logs,
+    fetch_and_plot_metrics,
+    parse_metrics_from_logs,
+)
+
+
+FAKE_SFT_LOGS = [
+    {"message": "Training epoch 0, iteration 0/9 | lr: 6.25e-07 | global_batch_size: 32 | global_step: 1 | reduced_train_loss: 9.240 | ..."},
+    {"message": "Training epoch 0, iteration 1/9 | lr: 1.25e-06 | global_batch_size: 32 | global_step: 2 | reduced_train_loss: 7.750 | ..."},
+    {"message": "Training epoch 0, iteration 2/9 | lr: 1.87e-06 | global_batch_size: 32 | global_step: 3 | reduced_train_loss: 6.615 | ..."},
+    {"message": "Some other log line without any metrics"},
+]
+
+FAKE_RLVR_SMTJ_LOGS = [
+    {"message": "global_step=1 critic/rewards/mean=0.123"},
+    {"message": "global_step=2 critic/rewards/mean=0.456"},
+    {"message": "PPO iteration complete, buffers flushed"},
+]
+
+FAKE_RLVR_SMHP_LOGS = [
+    {"message": "global_step: 1 train_rm_score: 0.55"},
+    {"message": "global_step: 2 train_rm_score: 0.72"},
+]
+
+
+class TestParseMetrics:
+
+    def test_sft_extracts_loss_and_lr(self):
+        df = parse_metrics_from_logs(FAKE_SFT_LOGS, "smtj", "SFT")
+
+        assert len(df) == 3
+        assert list(df.columns) == ["global_step", "training_loss", "lr"]
+        assert df["training_loss"].iloc[0] == pytest.approx(9.240)
+        assert df["lr"].iloc[0] == pytest.approx(6.25e-07)
+
+    def test_rlvr_smtj_extracts_reward_score(self):
+        df = parse_metrics_from_logs(FAKE_RLVR_SMTJ_LOGS, "smtj", "RLVR")
+
+        assert len(df) == 2
+        assert list(df.columns) == ["global_step", "reward_score"]
+        assert df["reward_score"].iloc[0] == pytest.approx(0.123)
+
+    def test_rlvr_smhp_extracts_reward_score(self):
+        df = parse_metrics_from_logs(FAKE_RLVR_SMHP_LOGS, "smhp", "RLVR")
+
+        assert len(df) == 2
+        assert df["reward_score"].iloc[0] == pytest.approx(0.55)
+
+    def test_subset_metrics_lr_only(self):
+        df = parse_metrics_from_logs(FAKE_SFT_LOGS, "smtj", "SFT", metrics=["lr"])
+
+        assert list(df.columns) == ["global_step", "lr"]
+        assert "training_loss" not in df.columns
+
+    def test_partial_metrics_fills_nan(self):
+        """Lines missing a metric get NaN for that column."""
+        logs = [
+            {"message": "global_step=1 reduced_train_loss=5.0"},
+            {"message": "global_step=2 reduced_train_loss=4.0 lr=1e-5"},
+        ]
+        df = parse_metrics_from_logs(logs, "smtj", "SFT")
+
+        assert len(df) == 2
+        assert pandas.isna(df["lr"].iloc[0])
+        assert df["lr"].iloc[1] == pytest.approx(1e-5)
+
+    def test_dpo_raises_not_implemented(self):
+        with pytest.raises(NotImplementedError, match="not supported for DPO"):
+            parse_metrics_from_logs([], "smtj", "DPO")
+
+    def test_empty_logs_returns_empty_dataframe(self):
+        df = parse_metrics_from_logs([], "smtj", "SFT")
+        assert df.empty
+
+
+class TestFetchLogs:
+
+    def test_smtj_fetches_from_dedicated_stream(self):
+        mock_client = MagicMock()
+        mock_client.describe_log_streams.return_value = {
+            "logStreams": [{"logStreamName": "my-job/algo-1"}]
+        }
+        mock_client.get_log_events.side_effect = [
+            {"events": [{"message": "global_step=1 reduced_train_loss=5.0"}], "nextBackwardToken": "t1"},
+            {"events": [], "nextBackwardToken": "t1"},
+        ]
+
+        events = _fetch_smtj_logs("my-job", mock_client, "/aws/sagemaker/TrainingJobs")
+        assert len(events) == 1
+
+    def test_smtj_no_stream_returns_empty(self):
+        mock_client = MagicMock()
+        mock_client.describe_log_streams.return_value = {"logStreams": []}
+
+        events = _fetch_smtj_logs("nonexistent-job", mock_client, "/aws/sagemaker/TrainingJobs")
+        assert events == []
+
+    def test_smhp_uses_filter_with_job_id(self):
+        mock_client = MagicMock()
+        mock_client.filter_log_events.return_value = {
+            "events": [{"message": "global_step: 1 train_rm_score: 0.5"}],
+        }
+
+        events = _fetch_smhp_logs("hp-job-123", mock_client, "/aws/sagemaker/Clusters/c/id")
+        assert len(events) == 1
+        call_kwargs = mock_client.filter_log_events.call_args[1]
+        assert '"hp-job-123"' in call_kwargs["filterPattern"]
+
+
+class TestFetchAndPlotMetrics:
+
+    def _session(self):
+        s = MagicMock()
+        s.boto_session.region_name = "us-east-1"
+        return s
+
+    @patch("sagemaker.train.common_utils.cloudwatch_metrics.plot_metrics")
+    @patch("sagemaker.train.common_utils.cloudwatch_metrics._fetch_smtj_logs")
+    def test_smtj_sft_end_to_end(self, mock_fetch, mock_plot):
+        mock_fetch.return_value = FAKE_SFT_LOGS
+
+        df = fetch_and_plot_metrics("my-job", "smtj", "SFT", self._session())
+
+        assert len(df) == 3
+        assert "training_loss" in df.columns
+        mock_plot.assert_called_once()
+
+    @patch("sagemaker.train.common_utils.cloudwatch_metrics.plot_metrics")
+    @patch("sagemaker.train.common_utils.cloudwatch_metrics._fetch_smhp_logs")
+    @patch("sagemaker.train.common_utils.cloudwatch_metrics._get_smhp_log_group")
+    def test_smhp_rlvr_end_to_end(self, mock_lg, mock_fetch, mock_plot):
+        mock_lg.return_value = "/aws/sagemaker/Clusters/c/id"
+        mock_fetch.return_value = FAKE_RLVR_SMHP_LOGS
+
+        df = fetch_and_plot_metrics("hp-job", "smhp", "RLVR", self._session(), cluster_name="c")
+
+        assert len(df) == 2
+        assert "reward_score" in df.columns
+
+    def test_invalid_technique_raises_before_fetching(self):
+        with pytest.raises(ValueError, match="not a supported training technique"):
+            fetch_and_plot_metrics("job", "smtj", "RFT", self._session())
+
+    @patch("sagemaker.train.common_utils.cloudwatch_metrics._fetch_smtj_logs")
+    def test_no_logs_found_raises(self, mock_fetch):
+        mock_fetch.return_value = []
+
+        with pytest.raises(ValueError, match="No CloudWatch logs found"):
+            fetch_and_plot_metrics("missing-job", "smtj", "SFT", self._session())
+
+    @patch("sagemaker.train.common_utils.cloudwatch_metrics.plot_metrics")
+    @patch("sagemaker.train.common_utils.cloudwatch_metrics._fetch_smtj_logs")
+    def test_result_sorted_by_step(self, mock_fetch, mock_plot):
+        """Out-of-order events (startFromHead=False) are sorted in returned DataFrame."""
+        mock_fetch.return_value = [
+            {"message": "global_step=5 reduced_train_loss=1.0"},
+            {"message": "global_step=1 reduced_train_loss=5.0"},
+        ]
+
+        df = fetch_and_plot_metrics("job", "smtj", "SFT", self._session(), metrics=["training_loss"])
+
+        assert df["global_step"].tolist() == [1, 5]
+
+class TestStreamLogs:
+    """Tests for BaseTrainer.stream_logs() dispatch and behavior."""
+
+    def _make_trainer(self, compute=None, latest_job=None):
+        """Create a minimal trainer stub for stream_logs testing."""
+        from sagemaker.train.base_trainer import BaseTrainer
+
+        class _StubTrainer(BaseTrainer):
+            _customization_technique = "SFT"
+
+            def train(self, *args, **kwargs):
+                pass
+
+        trainer = _StubTrainer.__new__(_StubTrainer)
+        trainer.compute = compute
+        trainer.sagemaker_session = None
+        trainer._latest_training_job = latest_job
+        return trainer
+
+    def test_no_job_raises_valueerror(self):
+        """stream_logs() raises if no training job exists."""
+        trainer = self._make_trainer(latest_job=None)
+
+        with pytest.raises(ValueError, match="No training job found"):
+            trainer.stream_logs()
+
+    @patch("sagemaker.train.base_trainer.TrainDefaults.get_sagemaker_session")
+    @patch("sagemaker.train.common_utils.cloudwatch_metrics._get_smhp_log_group")
+    def test_smhp_dispatches_with_start_time(self, mock_log_group, mock_session):
+        """SMHP stream_logs passes start_time to the polling loop."""
+        from datetime import datetime, timezone
+        from sagemaker.core.training.configs import HyperPodCompute
+
+        mock_log_group.return_value = "/aws/sagemaker/Clusters/c/id"
+        mock_sess = MagicMock()
+        mock_sess.boto_session.region_name = "us-east-1"
+        mock_logs_client = MagicMock()
+        mock_sess.boto_session.client.return_value = mock_logs_client
+        mock_session.return_value = mock_sess
+
+        mock_logs_client.filter_log_events.return_value = {
+            "events": [{"eventId": "e1", "message": "hello", "timestamp": 1000}]
+        }
+
+        trainer = self._make_trainer(
+            compute=HyperPodCompute(cluster_name="c", instance_type="ml.p5.48xlarge", node_count=1),
+            latest_job="my-hp-job",
+        )
+
+        # Simulate KeyboardInterrupt on first sleep to stop the loop
+        with patch("time.sleep", side_effect=KeyboardInterrupt):
+            trainer.stream_logs(
+                start_time=datetime(2026, 7, 8, 14, 0, 0, tzinfo=timezone.utc)
+            )
+
+        # Verify filter_log_events was called with the user-provided startTime
+        call_kwargs = mock_logs_client.filter_log_events.call_args[1]
+        expected_ts = int(datetime(2026, 7, 8, 14, 0, 0, tzinfo=timezone.utc).timestamp() * 1000)
+        assert call_kwargs["startTime"] == expected_ts
+
+    @patch("sagemaker.core.resources.TrainingJob.get")
+    @patch("sagemaker.core.utils.logs.MultiLogStreamHandler")
+    def test_smtj_stops_on_completed(self, mock_handler_cls, mock_get_job):
+        """SMTJ stream_logs exits when job status is Completed."""
+        from sagemaker.core.training.configs import Compute
+
+        # Mock the handler to return one event then empty
+        mock_handler = MagicMock()
+        mock_handler.get_latest_log_events.side_effect = [
+            iter([("stream", {"message": "Training complete"})]),
+            iter([]),  # final flush
+        ]
+        mock_handler_cls.return_value = mock_handler
+
+        # Mock job status as Completed
+        mock_job = MagicMock()
+        mock_job.training_job_status = "Completed"
+        mock_get_job.return_value = mock_job
+
+        trainer = self._make_trainer(
+            compute=Compute(instance_type="ml.p5.48xlarge", instance_count=1),
+            latest_job=MagicMock(training_job_name="my-smtj-job"),
+        )
+
+        # Should return without hanging (job is already Completed)
+        trainer.stream_logs()
+
+        mock_get_job.assert_called()

--- a/v3-examples/model-customization-examples/sft_finetuning_example_notebook_pysdk_prod_v3.ipynb
+++ b/v3-examples/model-customization-examples/sft_finetuning_example_notebook_pysdk_prod_v3.ipynb
@@ -335,16 +335,35 @@
   {
    "cell_type": "markdown",
    "id": "1f34ece2",
-   "source": "#### Fetch the Model Package ARN from a previous Training Job\n\nAfter a serverless training job completes, it produces an `OutputModelPackageArn` that can be used as the base model for iterative (continued) fine-tuning. Here's how to retrieve it:",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "#### Fetch the Model Package ARN from a previous Training Job\n",
+    "\n",
+    "After a serverless training job completes, it produces an `OutputModelPackageArn` that can be used as the base model for iterative (continued) fine-tuning. Here's how to retrieve it:"
+   ]
   },
   {
    "cell_type": "code",
-   "id": "aa54acf7",
-   "source": "from sagemaker.core.resources import TrainingJob\n\n# Get the completed training job\nprevious_job = TrainingJob.get(training_job_name=\"<your-previous-training-job-name>\")\n\n# The output model package ARN is available on completed serverless training jobs\noutput_model_package_arn = previous_job.output_model_package_arn\nprint(f\"Output Model Package ARN: {output_model_package_arn}\")\n\n# Use this ARN to get the ModelPackage for iterative training\nfrom sagemaker.core.resources import ModelPackage\n\nmodel_package = ModelPackage.get(model_package_name=output_model_package_arn)\npretty_print(model_package)",
-   "metadata": {},
    "execution_count": null,
-   "outputs": []
+   "id": "aa54acf7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sagemaker.core.resources import TrainingJob\n",
+    "\n",
+    "# Get the completed training job\n",
+    "previous_job = TrainingJob.get(training_job_name=\"<your-previous-training-job-name>\")\n",
+    "\n",
+    "# The output model package ARN is available on completed serverless training jobs\n",
+    "output_model_package_arn = previous_job.output_model_package_arn\n",
+    "print(f\"Output Model Package ARN: {output_model_package_arn}\")\n",
+    "\n",
+    "# Use this ARN to get the ModelPackage for iterative training\n",
+    "from sagemaker.core.resources import ModelPackage\n",
+    "\n",
+    "model_package = ModelPackage.get(model_package_name=output_model_package_arn)\n",
+    "pretty_print(model_package)"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -436,7 +455,14 @@
    "cell_type": "markdown",
    "id": "1c8263d4",
    "metadata": {},
-   "source": "## Finetuning with Serverful Compute (TrainingJobCompute)\n\nUse `TrainingJobCompute` to run training on dedicated instances. This enables:\n- Recipe overrides and validation\n- Iterative training from S3 checkpoints via `base_model_name`\n- Uncompressed output with `disable_output_compression=True`"
+   "source": [
+    "## Finetuning with Serverful Compute (TrainingJobCompute)\n",
+    "\n",
+    "Use `TrainingJobCompute` to run training on dedicated instances. This enables:\n",
+    "- Recipe overrides and validation\n",
+    "- Iterative training from S3 checkpoints via `base_model_name`\n",
+    "- Uncompressed output with `disable_output_compression=True`"
+   ]
   },
   {
    "cell_type": "code",
@@ -444,15 +470,47 @@
    "id": "5a9b3598",
    "metadata": {},
    "outputs": [],
-   "source": "from sagemaker.core.training.configs import TrainingJobCompute\n\n# Base training on serverful compute\nsft_trainer_serverful = SFTTrainer(\n    model=\"meta-textgeneration-llama-3-2-1b-instruct\",\n    training_type=TrainingType.LORA,\n    compute=TrainingJobCompute(instance_type=\"ml.p5.48xlarge\", instance_count=4),\n    training_dataset=dataset.arn,\n    s3_output_path=\"s3://my-bucket/output/\",\n    disable_output_compression=True,\n    accept_eula=True,\n)\n\ntraining_job = sft_trainer_serverful.train(wait=False)\nprint(f\"Serverful SFT job submitted: {training_job.training_job_name}\")"
+   "source": [
+    "from sagemaker.core.training.configs import TrainingJobCompute\n",
+    "\n",
+    "# Base training on serverful compute\n",
+    "sft_trainer_serverful = SFTTrainer(\n",
+    "    model=\"meta-textgeneration-llama-3-2-1b-instruct\",\n",
+    "    training_type=TrainingType.LORA,\n",
+    "    compute=TrainingJobCompute(instance_type=\"ml.p5.48xlarge\", instance_count=4),\n",
+    "    training_dataset=dataset.arn,\n",
+    "    s3_output_path=\"s3://my-bucket/output/\",\n",
+    "    disable_output_compression=True,\n",
+    "    accept_eula=True,\n",
+    ")\n",
+    "\n",
+    "training_job = sft_trainer_serverful.train(wait=False)\n",
+    "print(f\"Serverful SFT job submitted: {training_job.training_job_name}\")"
+   ]
   },
   {
    "cell_type": "code",
-   "id": "59155cc1",
-   "source": "# Iterative training from S3 checkpoint (serverful)\n# Requires base_model_name to identify model for recipe lookup\nsft_trainer_iterative = SFTTrainer(\n    model=\"s3://my-bucket/output/my-sft-job/output/model/\",\n    base_model_name=\"meta-textgeneration-llama-3-2-1b-instruct\",\n    training_type=TrainingType.LORA,\n    compute=TrainingJobCompute(instance_type=\"ml.p5.48xlarge\", instance_count=4),\n    training_dataset=dataset.arn,\n    s3_output_path=\"s3://my-bucket/iterative-output/\",\n    disable_output_compression=True,\n    accept_eula=True,\n)\n\ntraining_job = sft_trainer_iterative.train(wait=False)\nprint(f\"Iterative SFT job submitted: {training_job.training_job_name}\")",
-   "metadata": {},
    "execution_count": null,
-   "outputs": []
+   "id": "59155cc1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Iterative training from S3 checkpoint (serverful)\n",
+    "# Requires base_model_name to identify model for recipe lookup\n",
+    "sft_trainer_iterative = SFTTrainer(\n",
+    "    model=\"s3://my-bucket/output/my-sft-job/output/model/\",\n",
+    "    base_model_name=\"meta-textgeneration-llama-3-2-1b-instruct\",\n",
+    "    training_type=TrainingType.LORA,\n",
+    "    compute=TrainingJobCompute(instance_type=\"ml.p5.48xlarge\", instance_count=4),\n",
+    "    training_dataset=dataset.arn,\n",
+    "    s3_output_path=\"s3://my-bucket/iterative-output/\",\n",
+    "    disable_output_compression=True,\n",
+    "    accept_eula=True,\n",
+    ")\n",
+    "\n",
+    "training_job = sft_trainer_iterative.train(wait=False)\n",
+    "print(f\"Iterative SFT job submitted: {training_job.training_job_name}\")"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -504,6 +562,106 @@
    "source": [
     "training_job = sft_trainer_nova.train(\n",
     "    wait=True,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Training Monitoring\n",
+    "\n",
+    "After submitting a training job, you can monitor its progress using `show_metrics()` and `stream_logs()`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Stream Logs\n",
+    "\n",
+    "Stream CloudWatch logs in real-time. For SMTJ jobs, streaming automatically stops when the job completes. For HyperPod jobs, press Ctrl+C to stop."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define the job you want to run. \n",
+    "sft_trainer_nova = SFTTrainer(\n",
+    "    #model=\"test-nova-lite-v2\", \n",
+    "    #model=\"nova-textgeneration-micro\",\n",
+    "    model=\"nova-textgeneration-lite-v2\",\n",
+    "    training_type=TrainingType.LORA, \n",
+    "    model_package_group=\"sdk-test-finetuned-models\", \n",
+    "    mlflow_experiment_name=\"test-nova-finetuned-models-exp\", \n",
+    "    mlflow_run_name=\"test-nova-finetuned-models-run\", \n",
+    "    training_dataset=\"arn:aws:sagemaker:us-east-1:<>:hub-content/sdktest/DataSet/sft-nova-test-dataset/0.0.1\",\n",
+    "    s3_output_path=\"s3://<your-bucket>/output/\"  # TODO: replace with your S3 output path\n",
+    ")\n",
+    "\n",
+    "# Start a job without waiting, then stream logs live\n",
+    "training_job = sft_trainer_nova.train(wait=False)\n",
+    "sft_trainer_nova.stream_logs()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Show Training Metrics\n",
+    "\n",
+    "Plot training metrics (loss, learning rate) from CloudWatch logs. This can be called during or after training."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot all available metrics (training_loss and lr for SFT/CPT, reward for RLVR)\n",
+    "df = sft_trainer_nova.show_metrics()\n",
+    "\n",
+    "# Plot only training_loss\n",
+    "df = sft_trainer_nova.show_metrics(metrics=[\"training_loss\"])\n",
+    "\n",
+    "# Provide a start/end time range to speed up log retrieval for SMHP jobs.\n",
+    "df = trainer.show_metrics(\n",
+    "    start_time=datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc),\n",
+    "    end_time=datetime(2026, 1, 2, 0, 0, 0, tzinfo=timezone.utc)\n",
+    ")\n",
+    "\n",
+    "# Prints out the dataframe in a table-format.\n",
+    "print(df)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Reconnecting to a Past Job\n",
+    "\n",
+    "If your kernel restarted, you can re-attach to an existing job and view its metrics.\n",
+    "For HyperPod jobs, provide `start_time` to speed up log retrieval."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datetime import datetime, timezone\n",
+    "\n",
+    "# Re-create trainer with same config, attach existing job\n",
+    "sft_trainer_nova._latest_training_job = \"<YOUR_JOB_NAME>\"\n",
+    "\n",
+    "# For HyperPod, provide start_time to bound the log search\n",
+    "df = sft_trainer_nova.show_metrics(\n",
+    "    start_time=datetime(2026, 7, 8, 14, 0, 0, tzinfo=timezone.utc)\n",
     ")"
    ]
   }


### PR DESCRIPTION
*Issue #, if available:* 'Monitoring training/eval jobs with CW logs' task

*Description of changes:*
* Added cloudwatch_metrics.py with CW log parsing for training_loss, lr, reward_score
* Supports SMTJ and SMHP
* Added `show_metrics()` on BaseTrainer with start_time/end_time, step range filtering
* Added `stream_logs()` on BaseTrainer (SMTJ auto-stops on completion, SMHP via Ctrl+C)
* `show_metrics()` generates separate subplots per metric
* Added pandas to pyproject.toml for generating graphs
* Added 18 unit tests covering parsing, fetching, end-to-end, and streaming
* The two functions can be used on a 'trainer' object that has a job name attached. If the session ends, the user can make a placeholder trainer object and add the job name so it's able to use the functions again. 
* These functions only work training jobs since eval jobs don't have metrics stored in the CW logs and the logs don't have enough information for `stream_logs()` to provide information on progress. However, the latter can be added if we want. 
* Added changes requested from initial PR (clean up code, use logger > print, notebook example, update parameters)

*Tests:*
* Ran both methods on some completed and in-progress jobs to make sure they're able to capture the metrics and logs properly. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
