### PR TITLE
test: fix hardcoded HyperPod cluster name in Nova integ tests

### DIFF
--- a/sagemaker-train/tests/integ/train/test_cpt_data_mixing_hyperpod.py
+++ b/sagemaker-train/tests/integ/train/test_cpt_data_mixing_hyperpod.py
@@ -29,6 +29,7 @@ from __future__ import absolute_import
 
 import json
 import logging
+import os
 import subprocess
 import time
 import random
@@ -46,7 +47,9 @@ logger = logging.getLogger(__name__)
 
 # Test configuration
 REGION = "us-east-1"
-CLUSTER_NAME = "riv-rig"
+# HyperPod cluster provisioned for the pysdk integ-test account in us-east-1.
+# Overridable via env var so a cluster rename does not require a code change.
+CLUSTER_NAME = os.environ.get("PYSDK_HYPERPOD_CLUSTER_NAME", "pysdk-hp-integ-tests")
 INSTANCE_TYPE = "ml.p5.48xlarge"
 NODE_COUNT = 2
 MODEL_NAME = "nova-textgeneration-micro"

--- a/sagemaker-train/tests/integ/train/test_cpt_hyperpod.py
+++ b/sagemaker-train/tests/integ/train/test_cpt_hyperpod.py
@@ -29,6 +29,7 @@ from __future__ import absolute_import
 
 import json
 import logging
+import os
 import subprocess
 import time
 import random
@@ -45,7 +46,9 @@ logger = logging.getLogger(__name__)
 
 # Test configuration
 REGION = "us-east-1"
-CLUSTER_NAME = "riv-rig"
+# HyperPod cluster provisioned for the pysdk integ-test account in us-east-1.
+# Overridable via env var so a cluster rename does not require a code change.
+CLUSTER_NAME = os.environ.get("PYSDK_HYPERPOD_CLUSTER_NAME", "pysdk-hp-integ-tests")
 INSTANCE_TYPE = "ml.p5.48xlarge"
 NODE_COUNT = 2
 MODEL_NAME = "nova-textgeneration-micro"

--- a/sagemaker-train/tests/integ/train/test_sft_data_mixing_hyperpod.py
+++ b/sagemaker-train/tests/integ/train/test_sft_data_mixing_hyperpod.py
@@ -30,6 +30,7 @@ from __future__ import absolute_import
 
 import json
 import logging
+import os
 import time
 import random
 
@@ -49,7 +50,9 @@ logger = logging.getLogger(__name__)
 REGION = "us-east-1"
 DATA_PREFIX = "test-sft-data-mixing-hyperpod-integ"
 NUM_TRAINING_SAMPLES = 300
-HYPERPOD_CLUSTER_NAME = "riv-rig"
+# HyperPod cluster provisioned for the pysdk integ-test account in us-east-1.
+# Overridable via env var so a cluster rename does not require a code change.
+HYPERPOD_CLUSTER_NAME = os.environ.get("PYSDK_HYPERPOD_CLUSTER_NAME", "pysdk-hp-integ-tests")
 HYPERPOD_INSTANCE_TYPE = "ml.p5.48xlarge"
 
 


### PR DESCRIPTION
The GPU integ tests in us-east-1 fail with ResourceNotFound because the CPT/SFT HyperPod tests hardcode the cluster name "riv-rig" (introduced in the Nova release), which does not exist in the test account. The actual provisioned cluster is "pysdk-hp-integ-tests".

Read the cluster name from the PYSDK_HYPERPOD_CLUSTER_NAME env var with a default of "pysdk-hp-integ-tests" so a future cluster rename no longer requires a code change. Applied to test_cpt_hyperpod.py, test_cpt_data_mixing_hyperpod.py, and test_sft_data_mixing_hyperpod.py.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
