### PR TITLE
fix: drop claude-sonnet-4-20250514 from LLM-as-Judge evaluator allowlist

### DIFF
--- a/sagemaker-train/src/sagemaker/train/constants.py
+++ b/sagemaker-train/src/sagemaker/train/constants.py
@@ -67,7 +67,6 @@ _ALLOWED_EVALUATOR_MODELS = {
     "mistral.mistral-large-2402-v1:0": ["us-west-2", "us-east-1", "eu-west-1"],
     "meta.llama3-1-70b-instruct-v1:0": ["us-west-2", "us-east-1"],
     "anthropic.claude-3-haiku-20240307-v1:0": ["us-west-2", "us-east-1", "ap-northeast-1", "eu-west-1"],
-    "anthropic.claude-sonnet-4-20250514-v1:0": ["us-west-2", "us-east-1", "ap-northeast-1", "eu-west-1"],
     "anthropic.claude-haiku-4-5-20251001-v1:0": ["us-west-2", "us-east-1", "ap-northeast-1", "eu-west-1"],
     "anthropic.claude-sonnet-4-5-20250929-v1:0": ["us-west-2", "us-east-1", "ap-northeast-1", "eu-west-1"],
     "anthropic.claude-opus-4-5-20251101-v1:0": ["us-west-2", "us-east-1", "ap-northeast-1", "eu-west-1"],

--- a/sagemaker-train/src/sagemaker/train/evaluate/llm_as_judge_evaluator.py
+++ b/sagemaker-train/src/sagemaker/train/evaluate/llm_as_judge_evaluator.py
@@ -110,7 +110,7 @@ class LLMAsJudgeEvaluator(BaseEvaluator):
             # Both formats work - with or without 'Builtin.' prefix
             evaluator = LLMAsJudgeEvaluator(
                 base_model="llama-3-3-70b-instruct",
-                evaluator_model="anthropic.claude-sonnet-4-20250514-v1:0",
+                evaluator_model="anthropic.claude-sonnet-4-5-20250929-v1:0",
                 dataset="s3://my-bucket/my-dataset.jsonl",
                 builtin_metrics=["Correctness", "Helpfulness"],  # Prefix optional
                 mlflow_resource_arn="arn:aws:sagemaker:us-west-2:123456789012:mlflow-tracking-server/my-server",
@@ -144,7 +144,7 @@ class LLMAsJudgeEvaluator(BaseEvaluator):
             # Example evaluating only custom model (skip base model)
             evaluator = LLMAsJudgeEvaluator(
                 base_model="llama-3-3-70b-instruct",
-                evaluator_model="anthropic.claude-sonnet-4-20250514-v1:0",
+                evaluator_model="anthropic.claude-sonnet-4-5-20250929-v1:0",
                 dataset="s3://my-bucket/my-dataset.jsonl",
                 builtin_metrics=["Correctness"],  # Prefix optional
                 evaluate_base_model=False,
@@ -776,7 +776,7 @@ class LLMAsJudgeEvaluator(BaseEvaluator):
             
                 evaluator = LLMAsJudgeEvaluator(
                     base_model="llama-3-3-70b-instruct",
-                    evaluator_model="anthropic.claude-sonnet-4-20250514-v1:0",
+                    evaluator_model="anthropic.claude-sonnet-4-5-20250929-v1:0",
                     dataset="s3://my-bucket/my-dataset.jsonl",
                     builtin_metrics=["Correctness", "Helpfulness"],
                     s3_output_path="s3://my-bucket/output"

--- a/sagemaker-train/tests/unit/train/evaluate/test_llm_as_judge_evaluator.py
+++ b/sagemaker-train/tests/unit/train/evaluate/test_llm_as_judge_evaluator.py
@@ -31,7 +31,7 @@ DEFAULT_MLFLOW_ARN = "arn:aws:sagemaker:us-west-2:123456789012:mlflow-tracking-s
 DEFAULT_MODEL_PACKAGE_GROUP_ARN = "arn:aws:sagemaker:us-west-2:123456789012:model-package-group/test-group"
 DEFAULT_BASE_MODEL_ARN = "arn:aws:sagemaker:us-west-2:aws:hub-content/SageMakerPublicHub/Model/llama3-2-1b-instruct/1.0.0"
 DEFAULT_ARTIFACT_ARN = "arn:aws:sagemaker:us-west-2:123456789012:artifact/test-artifact"
-DEFAULT_EVALUATOR_MODEL = "anthropic.claude-sonnet-4-20250514-v1:0"
+DEFAULT_EVALUATOR_MODEL = "anthropic.claude-sonnet-4-5-20250929-v1:0"
 
 
 @patch('sagemaker.train.common_utils.model_resolution._resolve_base_model')
@@ -851,7 +851,6 @@ def test_llm_as_judge_evaluator_valid_evaluator_models(mock_artifact, mock_resol
     # (covered by test_llm_as_judge_evaluator_region_restriction).
     valid_models = [
         "anthropic.claude-3-haiku-20240307-v1:0",
-        "anthropic.claude-sonnet-4-20250514-v1:0",
         "anthropic.claude-haiku-4-5-20251001-v1:0",
         "anthropic.claude-sonnet-4-5-20250929-v1:0",
         "anthropic.claude-opus-4-5-20251101-v1:0",


### PR DESCRIPTION
## Description of changes

Removes `anthropic.claude-sonnet-4-20250514-v1:0` (Claude Sonnet 4) from the `_ALLOWED_EVALUATOR_MODELS` allowlist used by `LLMAsJudgeEvaluator`, and re-points the default judge model referenced in the docstring examples and unit tests to `anthropic.claude-sonnet-4-5-20250929-v1:0` (Claude Sonnet 4.5), which remains on the allowlist across all four supported regions.

Follow-up to #5987.

- **`constants.py`** — remove the Claude Sonnet 4 entry from `_ALLOWED_EVALUATOR_MODELS`.
- **`llm_as_judge_evaluator.py`** — update the three docstring examples that used Claude Sonnet 4 as the judge model to Claude Sonnet 4.5.
- **`test_llm_as_judge_evaluator.py`** — update the default judge model and drop the now-invalid entry from the `valid_models` list (Claude Sonnet 4.5 was already present).

The integ configs already use Claude Haiku 4.5 as the judge model, so no integ changes are needed.

## Testing

`sagemaker-train` evaluate unit test suite passes locally: **557 passed, 7 skipped**.

## Merge Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have updated any necessary documentation, including docstrings
- [x] I have added tests that prove my fix is effective (unit tests updated and passing)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.