### PR TITLE
test: skip Nova HyperPod integ tests unavailable in PySDK CI account

### DIFF
--- a/sagemaker-train/tests/integ/train/test_cpt_data_mixing_hyperpod.py
+++ b/sagemaker-train/tests/integ/train/test_cpt_data_mixing_hyperpod.py
@@ -124,6 +124,10 @@ def training_resources(sagemaker_session_us_east_1):
     }
 
 
+@pytest.mark.skip(
+    reason="Requires the hyperpod CLI and P5 capacity, neither of which is available "
+    "in the PySDK CI account (784379639078). Runs only in a Nova-owned account."
+)
 @pytest.mark.gpu_intensive
 @pytest.mark.us_east_1
 def test_cpt_trainer_nova_micro_with_data_mixing_hyperpod(

--- a/sagemaker-train/tests/integ/train/test_cpt_hyperpod.py
+++ b/sagemaker-train/tests/integ/train/test_cpt_hyperpod.py
@@ -123,6 +123,10 @@ def training_resources(sagemaker_session_us_east_1):
     }
 
 
+@pytest.mark.skip(
+    reason="Requires the hyperpod CLI and P5 capacity, neither of which is available "
+    "in the PySDK CI account (784379639078). Runs only in a Nova-owned account."
+)
 @pytest.mark.gpu_intensive
 @pytest.mark.us_east_1
 def test_cpt_trainer_nova_micro_hyperpod(

--- a/sagemaker-train/tests/integ/train/test_sft_data_mixing_hyperpod.py
+++ b/sagemaker-train/tests/integ/train/test_sft_data_mixing_hyperpod.py
@@ -122,6 +122,10 @@ def training_resources(sagemaker_session_us_east_1):
     }
 
 
+@pytest.mark.skip(
+    reason="Requires the hyperpod CLI and P5 capacity, neither of which is available "
+    "in the PySDK CI account (784379639078). Runs only in a Nova-owned account."
+)
 @pytest.mark.gpu_intensive
 @pytest.mark.us_east_1
 def test_sft_trainer_nova_micro_data_mixing_hyperpod(sagemaker_session_us_east_1, training_resources):

--- a/sagemaker-train/tests/integ/train/test_sft_trainer_data_mixing_integration.py
+++ b/sagemaker-train/tests/integ/train/test_sft_trainer_data_mixing_integration.py
@@ -118,6 +118,10 @@ def training_resources(sagemaker_session_us_east_1):
     }
 
 
+@pytest.mark.skip(
+    reason="Requires the hyperpod CLI and P5 capacity, neither of which is available "
+    "in the PySDK CI account (784379639078). Runs only in a Nova-owned account."
+)
 @pytest.mark.gpu_intensive
 @pytest.mark.us_east_1
 def test_sft_trainer_nova_lite2_with_data_mixing(sagemaker_session_us_east_1, training_resources):


### PR DESCRIPTION
These four Nova HyperPod integ tests cannot run in the PySDK CI account (784379639078): CodeBuild has no hyperpod CLI and the account has no P5 capacity. They were validated manually in a Nova-owned account. They previously skipped for lack of a Nova Forge subscription; now that the subscription exists they fail instead of skip, so mark them skipped explicitly.

Skipped:
- test_cpt_trainer_nova_micro_hyperpod
- test_cpt_trainer_nova_micro_with_data_mixing_hyperpod
- test_sft_trainer_nova_micro_data_mixing_hyperpod
- test_sft_trainer_nova_lite2_with_data_mixing

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
