### PR TITLE
Release 3.15.1 (updated)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 ## v3.15.1 (2026-07-09)
 
+### New Features
+
+- feat: Add granular telemetry signals decorator params and error classification (#5963)
+
 ### Bug Fixes
 
+- fix: always apply evaluator identity keywords and allow explicit domain_id (#5989)
 - fix: ModelBuilder resolves private hub artifacts correctly (#5985)
 - fix: refresh LLMAsJudgeEvaluator allowed evaluator models (#5987)
 - fix: define LAMBDA_ARN_REGEX in finetune_utils to fix RLVRTrainer NameError (#5988)
@@ -23,6 +28,7 @@
 - Add Triton Server v26.05 image URI config (#5999)
 - Add sklearn 1.4-2-py312 and xgboost 3.2-0 image URI configs (#6008)
 - test: Fix/v3 tests (#5996)
+- test: wip nova hyperpod integ tests (#5990)
 
 ## v3.15.0 (2026-06-22)
 

--- a/sagemaker-core/CHANGELOG.md
+++ b/sagemaker-core/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 ## v2.15.1 (2026-07-09)
 
+### New Features
+
+- feat: Add granular telemetry signals decorator params and error classification (#5963)
+
 ### Bug Fixes
 
 - fix: Correct DJL-LMI ISO/ADC accounts + add THF/ISO-E (djl-lmi, huggingface-llm-neuronx) (#5980)

--- a/sagemaker-mlops/CHANGELOG.md
+++ b/sagemaker-mlops/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 ## v1.15.1 (2026-07-09)
 
-- Update module dependencies
+### New Features
+
+- feat: Add granular telemetry signals decorator params and error classification (#5963)
 
 ## v1.15.0 (2026-06-22)
 

--- a/sagemaker-serve/CHANGELOG.md
+++ b/sagemaker-serve/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 ## v1.15.1 (2026-07-09)
 
+### New Features
+
+- feat: Add granular telemetry signals decorator params and error classification (#5963)
+
 ### Bug Fixes
 
 - fix: ModelBuilder resolves private hub artifacts correctly (#5985)

--- a/sagemaker-train/CHANGELOG.md
+++ b/sagemaker-train/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 ## v1.15.1 (2026-07-09)
 
+### New Features
+
+- feat: Add granular telemetry signals decorator params and error classification (#5963)
+
 ### Bug Fixes
 
+- fix: always apply evaluator identity keywords and allow explicit domain_id (#5989)
 - fix: refresh LLMAsJudgeEvaluator allowed evaluator models (#5987)
 - fix: define LAMBDA_ARN_REGEX in finetune_utils to fix RLVRTrainer NameError (#5988)
 - fix: RLVR validation bugfix (#6000)
@@ -11,6 +16,7 @@
 ### Other
 
 - test: Fix/v3 tests (#5996)
+- test: wip nova hyperpod integ tests (#5990)
 
 ## v1.15.0 (2026-06-22)
 


### PR DESCRIPTION
Patch release. Includes bug fixes (private hub artifact resolution, RLVR/evaluator fixes, evaluator identity keywords + domain_id, DJL-LMI ISO/ADC account correction, serve xgboost install), granular telemetry signals, image URI config updates (Triton v26.05, sklearn 1.4-2-py312, xgboost 3.2-0), Nova HyperPod integ tests, and AI-agent v3 guidance docs.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
