### PR TITLE
feat(train): add dry_run=True to train()

### DIFF
--- a/sagemaker-train/src/sagemaker/train/base_trainer.py
+++ b/sagemaker-train/src/sagemaker/train/base_trainer.py
@@ -32,6 +32,7 @@ from sagemaker.train.common_utils.finetune_utils import (
     _validate_hyperparameter_values,
     _get_smhp_replicas_enum,
 )
+from sagemaker.train.common_utils.data_utils import validate_data_path_exists
 from sagemaker.train.common_utils.metrics_visualizer import plot_training_metrics
 from sagemaker.train.common_utils.mlflow_config_utils import resolve_mlflow_tracking_fields
 from sagemaker.train.common_utils.validator import validate_hyperpod_compute
@@ -598,7 +599,7 @@ class BaseTrainer(ABC):
         return smhp_replicas_enum
 
     @abstractmethod
-    def train(self, input_data_config: List[InputData], wait: bool = True, logs: bool = True, wait_timeout: Optional[int] = None):
+    def train(self, input_data_config: List[InputData], wait: bool = True, logs: bool = True, wait_timeout: Optional[int] = None, dry_run: bool = False):
         """Common training method that calls the specific implementation."""
         pass
 
@@ -614,7 +615,7 @@ class BaseTrainer(ABC):
         return {}
 
     def _train_serverful_smtj(self, training_dataset=None, validation_dataset=None,
-                    wait=True, wait_timeout=None, poll=5):
+                    wait=True, wait_timeout=None, poll=5, dry_run=False):
         """Execute training on serverful SageMaker Training Job (SMTJ) compute.
 
         Uses ModelTrainer.from_recipe() with the model's recipe template from
@@ -967,6 +968,20 @@ class BaseTrainer(ABC):
             base_job_name=base_job_name,
         )
 
+        # Validate data paths exist before submission
+        if resolved_training_dataset:
+            validate_data_path_exists(
+                resolved_training_dataset, sagemaker_session, label="training dataset"
+            )
+        if resolved_validation_dataset:
+            validate_data_path_exists(
+                resolved_validation_dataset, sagemaker_session, label="validation dataset"
+            )
+
+        if dry_run:
+            logger.info("Dry-run validation passed. No job submitted.")
+            return None
+
         # Execute training
         model_trainer.train(
             wait=wait,
@@ -1085,7 +1100,7 @@ class BaseTrainer(ABC):
         return checkpoint_path
 
     def _train_hyperpod(self, training_dataset=None, validation_dataset=None,
-                        wait=True, wait_timeout=None, poll=5):
+                        wait=True, wait_timeout=None, poll=5, dry_run=False):
         """Execute training on a SageMaker HyperPod cluster.
 
         Uses the HyperPod CLI to connect to the cluster and submit a training job
@@ -1227,6 +1242,20 @@ class BaseTrainer(ABC):
             override_parameters["container"] = training_image
         if getattr(self, 'model_source', None):
             override_parameters["recipes.run.model_name_or_path"] = self.model_source
+
+        # Validate data paths exist before submission
+        if resolved_training_dataset:
+            validate_data_path_exists(
+                resolved_training_dataset, sagemaker_session, label="training dataset"
+            )
+        if resolved_validation_dataset:
+            validate_data_path_exists(
+                resolved_validation_dataset, sagemaker_session, label="validation dataset"
+            )
+
+        if dry_run:
+            logger.info("Dry-run validation passed. No job submitted.")
+            return None
 
         # Submit job
         start_job_cmd = [

--- a/sagemaker-train/src/sagemaker/train/common_utils/data_utils.py
+++ b/sagemaker-train/src/sagemaker/train/common_utils/data_utils.py
@@ -95,60 +95,29 @@ def load_file_content(
 
 
 def validate_data_path_exists(
-    data_path: str,
+    data_path: Union[str, "DataSet"],
     sagemaker_session,
     label: str = "data",
 ) -> None:
-    """Validate that a data path (S3 URI or dataset ARN) exists and is accessible.
+    """Validate that a data path (S3 URI, dataset ARN, or DataSet object) exists and is accessible.
 
     Called inline during dry_run to catch bad paths before job submission.
 
     Args:
-        data_path: S3 URI or SageMaker hub-content DataSet ARN to validate.
+        data_path: S3 URI, SageMaker hub-content DataSet ARN, or DataSet object to validate.
         sagemaker_session: SageMaker session (provides boto_session).
         label: Human-readable label for error messages.
 
     Raises:
         ValueError: If the path does not exist or is inaccessible.
     """
+    # Handle DataSet objects — extract the ARN for validation
+    if isinstance(data_path, DataSet):
+        data_path = data_path.arn
+
     # Handle SageMaker hub-content DataSet ARNs
     if data_path.startswith("arn:aws:sagemaker:") and "/DataSet/" in data_path:
-        pattern = (
-            r"^arn:aws:sagemaker:([^:]+):(\d+):hub-content/"
-            r"([^/]+)/DataSet/([^/]+)/([\d\.]+)$"
-        )
-        match = re.match(pattern, data_path)
-        if not match:
-            raise ValueError(
-                f"Invalid {label} DataSet ARN format: {data_path}"
-            )
-
-        _, _, hub_name, content_name, content_version = match.groups()
-        sm_client = sagemaker_session.sagemaker_client
-
-        try:
-            sm_client.describe_hub_content(
-                HubName=hub_name,
-                HubContentType="DataSet",
-                HubContentName=content_name,
-                HubContentVersion=content_version,
-            )
-        except ClientError as e:
-            code = e.response["Error"]["Code"]
-            if code == "ResourceNotFound" or "does not exist" in str(e).lower():
-                raise ValueError(
-                    f"{label.capitalize()} DataSet does not exist: {data_path}"
-                )
-            elif "AccessDenied" in str(e):
-                logger.warning(
-                    "Cannot verify %s DataSet %s from caller identity "
-                    "(AccessDenied). The execution role may still have access.",
-                    label, data_path,
-                )
-            else:
-                raise ValueError(
-                    f"Error validating {label} DataSet {data_path}: {e}"
-                )
+        _validate_dataset_arn_exists(data_path, sagemaker_session, label=label)
         return
 
     # Handle S3 URIs
@@ -225,13 +194,15 @@ def _validate_dataset_arn_exists(
                 f"{label.capitalize()} DataSet does not exist: {dataset_arn}"
             )
         elif code == "AccessDeniedException" or "AccessDenied" in str(e):
-            raise ValueError(
-                f"Access denied for {label} DataSet: {dataset_arn}. "
-                "Check IAM permissions for sagemaker:DescribeHubContent."
+            logger.warning(
+                "Cannot verify %s DataSet %s from caller identity "
+                "(AccessDenied). The execution role may still have access.",
+                label, dataset_arn,
             )
-        raise ValueError(
-            f"Error validating {label} DataSet {dataset_arn}: {e}"
-        )
+        else:
+            raise ValueError(
+                f"Error validating {label} DataSet {dataset_arn}: {e}"
+            )
 
 
 def _has_multimodal_content(record: dict) -> bool:

--- a/sagemaker-train/src/sagemaker/train/common_utils/data_utils.py
+++ b/sagemaker-train/src/sagemaker/train/common_utils/data_utils.py
@@ -94,6 +94,147 @@ def load_file_content(
             raise FileLoadError(f"Failed to read file {file_path}: {e}")
 
 
+def validate_data_path_exists(
+    data_path: str,
+    sagemaker_session,
+    label: str = "data",
+) -> None:
+    """Validate that a data path (S3 URI or dataset ARN) exists and is accessible.
+
+    Called inline during dry_run to catch bad paths before job submission.
+
+    Args:
+        data_path: S3 URI or SageMaker hub-content DataSet ARN to validate.
+        sagemaker_session: SageMaker session (provides boto_session).
+        label: Human-readable label for error messages.
+
+    Raises:
+        ValueError: If the path does not exist or is inaccessible.
+    """
+    # Handle SageMaker hub-content DataSet ARNs
+    if data_path.startswith("arn:aws:sagemaker:") and "/DataSet/" in data_path:
+        pattern = (
+            r"^arn:aws:sagemaker:([^:]+):(\d+):hub-content/"
+            r"([^/]+)/DataSet/([^/]+)/([\d\.]+)$"
+        )
+        match = re.match(pattern, data_path)
+        if not match:
+            raise ValueError(
+                f"Invalid {label} DataSet ARN format: {data_path}"
+            )
+
+        _, _, hub_name, content_name, content_version = match.groups()
+        sm_client = sagemaker_session.sagemaker_client
+
+        try:
+            sm_client.describe_hub_content(
+                HubName=hub_name,
+                HubContentType="DataSet",
+                HubContentName=content_name,
+                HubContentVersion=content_version,
+            )
+        except ClientError as e:
+            code = e.response["Error"]["Code"]
+            if code == "ResourceNotFound" or "does not exist" in str(e).lower():
+                raise ValueError(
+                    f"{label.capitalize()} DataSet does not exist: {data_path}"
+                )
+            elif "AccessDenied" in str(e):
+                logger.warning(
+                    "Cannot verify %s DataSet %s from caller identity "
+                    "(AccessDenied). The execution role may still have access.",
+                    label, data_path,
+                )
+            else:
+                raise ValueError(
+                    f"Error validating {label} DataSet {data_path}: {e}"
+                )
+        return
+
+    # Handle S3 URIs
+    parts = _parse_s3_uri(data_path)
+    if parts is None:
+        raise ValueError(
+            f"Invalid {label} path format: {data_path}. "
+            f"Expected an S3 URI (s3://bucket/key) or a DataSet ARN."
+        )
+
+    bucket, key = parts
+    s3 = sagemaker_session.boto_session.client("s3")
+
+    try:
+        resp = s3.list_objects_v2(Bucket=bucket, Prefix=key, MaxKeys=1)
+        if resp.get("KeyCount", 0) == 0:
+            raise ValueError(
+                f"S3 {label} path does not exist: {data_path}"
+            )
+    except ClientError as e:
+        code = e.response["Error"]["Code"]
+        if code == "403" or "AccessDenied" in str(e):
+            # Caller may not have access but the execution role might —
+            # log a warning and allow the job to proceed.
+            logger.warning(
+                "Cannot verify S3 %s path %s from caller identity "
+                "(AccessDenied). The execution role may still have access.",
+                label, data_path,
+            )
+        else:
+            raise ValueError(f"Error accessing S3 {label} path {data_path}: {e}")
+
+
+def _validate_dataset_arn_exists(
+    dataset_arn: str,
+    sagemaker_session,
+    label: str = "data",
+) -> None:
+    """Validate that a SageMaker hub-content DataSet ARN exists.
+
+    Args:
+        dataset_arn: ARN like arn:aws:sagemaker:<region>:<account>:hub-content/<hub>/DataSet/<name>/<version>
+        sagemaker_session: SageMaker session (provides boto_session).
+        label: Human-readable label for error messages.
+
+    Raises:
+        ValueError: If the dataset ARN cannot be described.
+    """
+    import re
+
+    pattern = (
+        r"^arn:aws:sagemaker:([^:]+):(\d+):hub-content/"
+        r"([^/]+)/DataSet/([^/]+)/([\d\.]+)$"
+    )
+    match = re.match(pattern, dataset_arn)
+    if not match:
+        raise ValueError(
+            f"Invalid {label} DataSet ARN format: {dataset_arn}"
+        )
+
+    region, _, hub_name, content_name, content_version = match.groups()
+    sm_client = sagemaker_session.sagemaker_client
+
+    try:
+        sm_client.describe_hub_content(
+            HubName=hub_name,
+            HubContentType="DataSet",
+            HubContentName=content_name,
+            HubContentVersion=content_version,
+        )
+    except ClientError as e:
+        code = e.response["Error"]["Code"]
+        if code == "ResourceNotFound" or "does not exist" in str(e).lower():
+            raise ValueError(
+                f"{label.capitalize()} DataSet does not exist: {dataset_arn}"
+            )
+        elif code == "AccessDeniedException" or "AccessDenied" in str(e):
+            raise ValueError(
+                f"Access denied for {label} DataSet: {dataset_arn}. "
+                "Check IAM permissions for sagemaker:DescribeHubContent."
+            )
+        raise ValueError(
+            f"Error validating {label} DataSet {dataset_arn}: {e}"
+        )
+
+
 def _has_multimodal_content(record: dict) -> bool:
     """Check if a single record contains multimodal content."""
     if "messages" not in record:

--- a/sagemaker-train/src/sagemaker/train/common_utils/data_utils.py
+++ b/sagemaker-train/src/sagemaker/train/common_utils/data_utils.py
@@ -116,7 +116,7 @@ def validate_data_path_exists(
         data_path = data_path.arn
 
     # Handle SageMaker hub-content DataSet ARNs
-    if data_path.startswith("arn:aws:sagemaker:") and "/DataSet/" in data_path:
+    if re.match(r"^arn:aws(?:-[a-z]+)*:sagemaker:.+/DataSet/", data_path):
         _validate_dataset_arn_exists(data_path, sagemaker_session, label=label)
         return
 
@@ -168,7 +168,7 @@ def _validate_dataset_arn_exists(
     """
 
     pattern = (
-        r"^arn:aws:sagemaker:([^:]+):(\d+):hub-content/"
+        r"^arn:aws(?:-[a-z]+)*:sagemaker:([^:]+):(\d+):hub-content/"
         r"([^/]+)/DataSet/([^/]+)/([\d\.]+)$"
     )
     match = re.match(pattern, dataset_arn)

--- a/sagemaker-train/src/sagemaker/train/common_utils/data_utils.py
+++ b/sagemaker-train/src/sagemaker/train/common_utils/data_utils.py
@@ -197,7 +197,6 @@ def _validate_dataset_arn_exists(
     Raises:
         ValueError: If the dataset ARN cannot be described.
     """
-    import re
 
     pattern = (
         r"^arn:aws:sagemaker:([^:]+):(\d+):hub-content/"

--- a/sagemaker-train/src/sagemaker/train/cpt_trainer.py
+++ b/sagemaker-train/src/sagemaker/train/cpt_trainer.py
@@ -186,6 +186,7 @@ class CPTTrainer(BaseTrainer):
         wait: bool = True,
         wait_timeout: Optional[int] = None,
         poll: int = 5,
+        dry_run: bool = False,
     ):
         """Execute the CPT training job on HyperPod.
 
@@ -200,9 +201,13 @@ class CPTTrainer(BaseTrainer):
                 Maximum time in seconds to wait.
             poll (int):
                 Polling interval in seconds. Defaults to 5.
+            dry_run (bool):
+                If True, runs validation without submitting a job. 
+                Returns None on success, raises on validation failure.
+                Defaults to False.
 
         Returns:
-            str: The HyperPod job name.
+            str: The HyperPod job name, or None if dry_run=True.
 
         Raises:
             ValueError: If compute is not configured or recipe is missing.
@@ -252,4 +257,5 @@ class CPTTrainer(BaseTrainer):
             wait=wait,
             wait_timeout=wait_timeout,
             poll=poll,
+            dry_run=dry_run,
         )

--- a/sagemaker-train/src/sagemaker/train/dpo_trainer.py
+++ b/sagemaker-train/src/sagemaker/train/dpo_trainer.py
@@ -24,7 +24,7 @@ from sagemaker.train.common_utils.finetune_utils import (
     _validate_eula_for_gated_model,
     _validate_hyperparameter_values
 )
-from sagemaker.train.common_utils.data_utils import is_multimodal_data
+from sagemaker.train.common_utils.data_utils import is_multimodal_data, validate_data_path_exists
 from sagemaker.core.telemetry.telemetry_logging import _telemetry_emitter
 from sagemaker.core.telemetry.constants import Feature
 from sagemaker.train.constants import get_sagemaker_hub_name
@@ -217,7 +217,8 @@ class DPOTrainer(BaseTrainer):
               validation_dataset: Optional[Union[str, DataSet]] = None,
               wait: bool = True,
               wait_timeout: Optional[int] = None,
-              poll: int = 5):
+              poll: int = 5,
+              dry_run: bool = False):
         """Execute the DPO training job.
 
         Parameters:
@@ -234,9 +235,13 @@ class DPOTrainer(BaseTrainer):
                 If None, uses the default timeout from the wait utility.
             poll (int):
                 Polling interval in seconds for checking training job status. Defaults to 5.
+            dry_run (bool):
+                If True, runs all validation (IAM, hyperparameters, infrastructure, data paths)
+                without submitting a job. Returns None on success, raises on validation failure.
+                Defaults to False.
 
         Returns:
-            TrainingJob: The SageMaker training job object.
+            TrainingJob: The SageMaker training job object, or None if dry_run=True.
         """
         # Dispatch based on compute type
         if isinstance(self.compute, HyperPodCompute):
@@ -246,6 +251,7 @@ class DPOTrainer(BaseTrainer):
                 wait=wait,
                 wait_timeout=wait_timeout,
                 poll=poll,
+                dry_run=dry_run,
             )
         elif isinstance(self.compute, TrainingJobCompute):
             return self._train_serverful_smtj(
@@ -254,6 +260,7 @@ class DPOTrainer(BaseTrainer):
                 wait=wait,
                 wait_timeout=wait_timeout,
                 poll=poll,
+                dry_run=dry_run,
             )
 
         # Default: serverless compute (None)
@@ -339,6 +346,22 @@ class DPOTrainer(BaseTrainer):
         # Only pass stopping_condition if explicitly provided by user
         if self.stopping_condition is not None:
             create_args["stopping_condition"] = self.stopping_condition
+
+        # Validate data paths exist before submission
+        effective_training = training_dataset or self.training_dataset
+        effective_validation = validation_dataset or self.validation_dataset
+        if effective_training and isinstance(effective_training, str):
+            validate_data_path_exists(
+                effective_training, sagemaker_session, label="training dataset"
+            )
+        if effective_validation and isinstance(effective_validation, str):
+            validate_data_path_exists(
+                effective_validation, sagemaker_session, label="validation dataset"
+            )
+
+        if dry_run:
+            logger.info("Dry-run validation passed. No job submitted.")
+            return None
 
         try:
             training_job = TrainingJob.create(**create_args)

--- a/sagemaker-train/src/sagemaker/train/dpo_trainer.py
+++ b/sagemaker-train/src/sagemaker/train/dpo_trainer.py
@@ -350,11 +350,11 @@ class DPOTrainer(BaseTrainer):
         # Validate data paths exist before submission
         effective_training = training_dataset or self.training_dataset
         effective_validation = validation_dataset or self.validation_dataset
-        if effective_training and isinstance(effective_training, str):
+        if effective_training:
             validate_data_path_exists(
                 effective_training, sagemaker_session, label="training dataset"
             )
-        if effective_validation and isinstance(effective_validation, str):
+        if effective_validation:
             validate_data_path_exists(
                 effective_validation, sagemaker_session, label="validation dataset"
             )

--- a/sagemaker-train/src/sagemaker/train/evaluate/base_evaluator.py
+++ b/sagemaker-train/src/sagemaker/train/evaluate/base_evaluator.py
@@ -1034,15 +1034,22 @@ class BaseEvaluator(BaseModel):
         object.__setattr__(self, '_resolved_recipe_cache', resolved)
         return copy.deepcopy(resolved)
 
-    def evaluate(self) -> Any:
+    def evaluate(self, dry_run: bool = False) -> Any:
         """Create and start an evaluation execution.
 
         This method must be implemented by subclasses to define the specific
         evaluation logic for different evaluation types (benchmark, custom scorer,
         LLM-as-judge, etc.).
 
+        Args:
+            dry_run (bool):
+                If True, runs all validation (IAM, model resolution, data paths)
+                without submitting the evaluation. Returns None on success, raises
+                on validation failure. Defaults to False.
+
         Returns:
-            EvaluationPipelineExecution: The created evaluation execution object.
+            EvaluationPipelineExecution: The created evaluation execution object,
+            or None if dry_run=True.
 
         Raises:
             NotImplementedError: This is an abstract method that must be implemented by subclasses.

--- a/sagemaker-train/src/sagemaker/train/evaluate/benchmark_evaluator.py
+++ b/sagemaker-train/src/sagemaker/train/evaluate/benchmark_evaluator.py
@@ -591,7 +591,7 @@ class BenchMarkEvaluator(BaseEvaluator):
         return benchmark_context
     
     @_telemetry_emitter(feature=Feature.MODEL_CUSTOMIZATION, func_name="BenchMarkEvaluator.evaluate")
-    def evaluate(self, subtask: Optional[Union[str, List[str]]] = None) -> EvaluationPipelineExecution:
+    def evaluate(self, subtask: Optional[Union[str, List[str]]] = None, dry_run: bool = False) -> EvaluationPipelineExecution:
         """Create and start a benchmark evaluation job.
         
         Supports multiple compute backends via the ``compute`` parameter set at
@@ -601,12 +601,17 @@ class BenchMarkEvaluator(BaseEvaluator):
         - **HyperPod**: Submits to a HyperPod cluster via the HyperPod CLI.
         
         Args:
-            subtask (Optional[Union[str, list[str]]]): Optional subtask(s) to evaluate. If not provided, 
-                uses the subtasks from constructor. Can be a single subtask string, a list of 
-                subtasks, or 'ALL' to run all subtasks.
+            subtask (Optional[Union[str, list[str]]]): Optional subtask(s) to evaluate.
+                If not provided, uses the subtasks from constructor. Can be a single
+                subtask string, a list of subtasks, or 'ALL' to run all subtasks.
+            dry_run (bool):
+                If True, runs all validation (IAM, model resolution, data paths)
+                without submitting the evaluation. Returns None on success, raises
+                on validation failure. Defaults to False.
         
         Returns:
-            EvaluationPipelineExecution: The created benchmark evaluation execution.
+            EvaluationPipelineExecution: The created benchmark evaluation execution,
+            or None if dry_run=True.
             
         Example:
         
@@ -702,7 +707,11 @@ class BenchMarkEvaluator(BaseEvaluator):
         
         # Generate execution name
         name = self.base_eval_name or f"benchmark-eval-{self.benchmark.value}"
-        
+
+        if dry_run:
+            _logger.info("Dry-run validation passed. No evaluation submitted.")
+            return None
+
         # Start execution
         return self._start_execution(
             eval_type=EvalType.BENCHMARK,

--- a/sagemaker-train/src/sagemaker/train/evaluate/custom_scorer_evaluator.py
+++ b/sagemaker-train/src/sagemaker/train/evaluate/custom_scorer_evaluator.py
@@ -16,7 +16,9 @@ from .constants import EvalType
 from .execution import EvaluationPipelineExecution
 from sagemaker.core.telemetry.telemetry_logging import _telemetry_emitter
 from sagemaker.core.telemetry.constants import Feature
+from sagemaker.train.common_utils.data_utils import validate_data_path_exists
 from sagemaker.train.constants import get_sagemaker_hub_name
+from sagemaker.train.defaults import TrainDefaults
 
 _logger = logging.getLogger(__name__)
 
@@ -390,7 +392,7 @@ class CustomScorerEvaluator(BaseEvaluator):
             return fallback_params
     
     @_telemetry_emitter(feature=Feature.MODEL_CUSTOMIZATION, func_name="CustomScorerEvaluator.evaluate")
-    def evaluate(self) -> EvaluationPipelineExecution:
+    def evaluate(self, dry_run: bool = False) -> EvaluationPipelineExecution:
         """Create and start a custom scorer evaluation job.
         
         Supports multiple compute backends via the ``compute`` parameter set at
@@ -398,9 +400,16 @@ class CustomScorerEvaluator(BaseEvaluator):
         - **Serverless** (default): Runs via SageMaker Pipelines.
         - **SMTJ**: Runs on user-managed instances via ModelTrainer.
         - **HyperPod**: Submits to a HyperPod cluster via the HyperPod CLI.
-        
+
+        Args:
+            dry_run (bool):
+                If True, runs all validation (IAM, model resolution, data paths)
+                without submitting the evaluation. Returns None on success, raises
+                on validation failure. Defaults to False.
+
         Returns:
-            EvaluationPipelineExecution: The created custom scorer evaluation execution
+            EvaluationPipelineExecution: The created custom scorer evaluation execution,
+            or None if dry_run=True.
         
         Example:
             .. code:: python
@@ -487,7 +496,20 @@ class CustomScorerEvaluator(BaseEvaluator):
         
         # Generate execution name
         name = self.base_eval_name or f"custom-scorer-eval"
-        
+
+        # Validate dataset path exists
+        if hasattr(self, 'dataset') and self.dataset and isinstance(self.dataset, str):
+            session = TrainDefaults.get_sagemaker_session(
+                sagemaker_session=self.sagemaker_session
+            )
+            validate_data_path_exists(
+                self.dataset, session, label="evaluation dataset"
+            )
+
+        if dry_run:
+            _logger.info("Dry-run validation passed. No evaluation submitted.")
+            return None
+
         # Start execution
         return self._start_execution(
             eval_type=EvalType.CUSTOM_SCORER,

--- a/sagemaker-train/src/sagemaker/train/evaluate/custom_scorer_evaluator.py
+++ b/sagemaker-train/src/sagemaker/train/evaluate/custom_scorer_evaluator.py
@@ -498,7 +498,7 @@ class CustomScorerEvaluator(BaseEvaluator):
         name = self.base_eval_name or f"custom-scorer-eval"
 
         # Validate dataset path exists
-        if hasattr(self, 'dataset') and self.dataset and isinstance(self.dataset, str):
+        if hasattr(self, 'dataset') and self.dataset:
             session = TrainDefaults.get_sagemaker_session(
                 sagemaker_session=self.sagemaker_session
             )

--- a/sagemaker-train/src/sagemaker/train/evaluate/llm_as_judge_evaluator.py
+++ b/sagemaker-train/src/sagemaker/train/evaluate/llm_as_judge_evaluator.py
@@ -953,7 +953,7 @@ class LLMAsJudgeEvaluator(BaseEvaluator):
         pipeline_definition = self._render_pipeline_definition(template_str, template_context)
 
         # Validate dataset path exists
-        if hasattr(self, 'dataset') and self.dataset and isinstance(self.dataset, str):
+        if hasattr(self, 'dataset') and self.dataset:
             session = TrainDefaults.get_sagemaker_session(
                 sagemaker_session=self.sagemaker_session
             )

--- a/sagemaker-train/src/sagemaker/train/evaluate/llm_as_judge_evaluator.py
+++ b/sagemaker-train/src/sagemaker/train/evaluate/llm_as_judge_evaluator.py
@@ -20,9 +20,11 @@ from .constants import (
 )
 from sagemaker.core.telemetry.telemetry_logging import _telemetry_emitter
 from sagemaker.core.telemetry.constants import Feature
+from sagemaker.train.common_utils.data_utils import validate_data_path_exists
 from sagemaker.train.common_utils.model_aliases import NOVA_BEDROCK_MODEL_IDS
 from sagemaker.train.common_utils.recipe_utils import _is_nova_model
 from sagemaker.train.constants import _ALLOWED_EVALUATOR_MODELS
+from sagemaker.train.defaults import TrainDefaults
 
 _logger = logging.getLogger(__name__)
 
@@ -751,7 +753,7 @@ class LLMAsJudgeEvaluator(BaseEvaluator):
         }
     
     @_telemetry_emitter(feature=Feature.MODEL_CUSTOMIZATION, func_name="LLMAsJudgeEvaluator.evaluate")
-    def evaluate(self):
+    def evaluate(self, dry_run: bool = False):
         """Create and start an LLM-as-judge evaluation job.
         
         This method initiates a 2-phase evaluation job:
@@ -764,9 +766,16 @@ class LLMAsJudgeEvaluator(BaseEvaluator):
         inference responses and writes them to S3. Phase 2 remains unchanged —
         the LLMAJEvaluation judging step evaluates those responses with the
         judge model.
-        
+
+        Args:
+            dry_run (bool):
+                If True, runs all validation (IAM, model resolution, data paths)
+                without submitting the evaluation. Returns None on success, raises
+                on validation failure. Defaults to False.
+
         Returns:
-            EvaluationPipelineExecution: The created LLM-as-judge evaluation execution
+            EvaluationPipelineExecution: The created LLM-as-judge evaluation execution,
+            or None if dry_run=True.
         
         Raises:
             ValueError: If invalid model, dataset, or metric configurations are provided
@@ -942,7 +951,20 @@ class LLMAsJudgeEvaluator(BaseEvaluator):
         
         # Render pipeline definition
         pipeline_definition = self._render_pipeline_definition(template_str, template_context)
-        
+
+        # Validate dataset path exists
+        if hasattr(self, 'dataset') and self.dataset and isinstance(self.dataset, str):
+            session = TrainDefaults.get_sagemaker_session(
+                sagemaker_session=self.sagemaker_session
+            )
+            validate_data_path_exists(
+                self.dataset, session, label="evaluation dataset"
+            )
+
+        if dry_run:
+            _logger.info("Dry-run validation passed. No evaluation submitted.")
+            return None
+
         # Start execution (name already generated earlier)
         return self._start_execution(
             eval_type=EvalType.LLM_AS_JUDGE,

--- a/sagemaker-train/src/sagemaker/train/model_trainer.py
+++ b/sagemaker-train/src/sagemaker/train/model_trainer.py
@@ -775,6 +775,7 @@ class ModelTrainer(BaseModel):
         input_data_config: Optional[List[Union[Channel, InputData]]] = None,
         wait: Optional[bool] = True,
         logs: Optional[bool] = True,
+        dry_run: bool = False,
     ):
         """Train a model using AWS SageMaker.
 
@@ -790,9 +791,17 @@ class ModelTrainer(BaseModel):
             logs (Optional[bool]):
                 Whether to display the training container logs while training.
                 Defaults to True.
+            dry_run (bool):
+                If True, runs all validation (configuration, input resolution, hyperparameters)
+                without submitting a job. Returns None on success, raises on validation failure.
+                Defaults to False.
         """
         training_request = self._create_training_job_args(input_data_config=input_data_config)
-            
+
+        if dry_run:
+            logger.info("Dry-run validation passed. No job submitted.")
+            return None
+
         # Handle PipelineSession
         if self.training_mode == Mode.SAGEMAKER_TRAINING_JOB:
             if isinstance(self.sagemaker_session, PipelineSession):

--- a/sagemaker-train/src/sagemaker/train/rlaif_trainer.py
+++ b/sagemaker-train/src/sagemaker/train/rlaif_trainer.py
@@ -25,7 +25,7 @@ from sagemaker.train.common_utils.finetune_utils import (
     _validate_eula_for_gated_model,
     _validate_hyperparameter_values
 )
-from sagemaker.train.common_utils.data_utils import is_multimodal_data
+from sagemaker.train.common_utils.data_utils import is_multimodal_data, validate_data_path_exists
 from sagemaker.core.telemetry.telemetry_logging import _telemetry_emitter
 from sagemaker.core.telemetry.constants import Feature
 from sagemaker.train.constants import get_sagemaker_hub_name, _ALLOWED_REWARD_MODEL_IDS
@@ -203,7 +203,7 @@ class RLAIFTrainer(BaseTrainer):
         
 
     @_telemetry_emitter(feature=Feature.MODEL_CUSTOMIZATION, func_name="RLAIFTrainer.train")
-    def train(self, training_dataset: Optional[Union[str, DataSet]] = None, validation_dataset: Optional[Union[str, DataSet]] = None, wait: bool = True, wait_timeout: Optional[int] = None, poll: int = 5):
+    def train(self, training_dataset: Optional[Union[str, DataSet]] = None, validation_dataset: Optional[Union[str, DataSet]] = None, wait: bool = True, wait_timeout: Optional[int] = None, poll: int = 5, dry_run: bool = False):
         """Execute the RLAIF training job.
 
         Parameters:
@@ -220,9 +220,13 @@ class RLAIFTrainer(BaseTrainer):
                 If None, uses the default timeout from the wait utility.
             poll (int):
                 Polling interval in seconds for checking training job status. Defaults to 5.
+            dry_run (bool):
+                If True, runs all validation (IAM, hyperparameters, infrastructure, data paths)
+                without submitting a job. Returns None on success, raises on validation failure.
+                Defaults to False.
 
         Returns:
-            TrainingJob: The SageMaker training job object.
+            TrainingJob: The SageMaker training job object, or None if dry_run=True.
         """
         sagemaker_session = TrainDefaults.get_sagemaker_session(
             sagemaker_session=self.sagemaker_session
@@ -301,6 +305,22 @@ class RLAIFTrainer(BaseTrainer):
         # Only pass stopping_condition if explicitly provided by user
         if self.stopping_condition is not None:
             create_args["stopping_condition"] = self.stopping_condition
+
+        # Validate data paths exist before submission
+        effective_training = training_dataset or self.training_dataset
+        effective_validation = validation_dataset or self.validation_dataset
+        if effective_training and isinstance(effective_training, str):
+            validate_data_path_exists(
+                effective_training, sagemaker_session, label="training dataset"
+            )
+        if effective_validation and isinstance(effective_validation, str):
+            validate_data_path_exists(
+                effective_validation, sagemaker_session, label="validation dataset"
+            )
+
+        if dry_run:
+            logger.info("Dry-run validation passed. No job submitted.")
+            return None
 
         try:
             training_job = TrainingJob.create(**create_args)

--- a/sagemaker-train/src/sagemaker/train/rlaif_trainer.py
+++ b/sagemaker-train/src/sagemaker/train/rlaif_trainer.py
@@ -309,11 +309,11 @@ class RLAIFTrainer(BaseTrainer):
         # Validate data paths exist before submission
         effective_training = training_dataset or self.training_dataset
         effective_validation = validation_dataset or self.validation_dataset
-        if effective_training and isinstance(effective_training, str):
+        if effective_training:
             validate_data_path_exists(
                 effective_training, sagemaker_session, label="training dataset"
             )
-        if effective_validation and isinstance(effective_validation, str):
+        if effective_validation:
             validate_data_path_exists(
                 effective_validation, sagemaker_session, label="validation dataset"
             )

--- a/sagemaker-train/src/sagemaker/train/rlvr_trainer.py
+++ b/sagemaker-train/src/sagemaker/train/rlvr_trainer.py
@@ -30,7 +30,7 @@ from sagemaker.train.common_utils.finetune_utils import (
     _validate_eula_for_gated_model,
     _validate_hyperparameter_values
 )
-from sagemaker.train.common_utils.data_utils import is_multimodal_data, load_file_content
+from sagemaker.train.common_utils.data_utils import is_multimodal_data, load_file_content, validate_data_path_exists
 from sagemaker.train.common_utils.rlvr_reward_verifier import verify_reward_function
 from sagemaker.core.telemetry.telemetry_logging import _telemetry_emitter
 from sagemaker.core.telemetry.constants import Feature
@@ -365,7 +365,7 @@ class RLVRTrainer(BaseTrainer):
 
     @_telemetry_emitter(feature=Feature.MODEL_CUSTOMIZATION, func_name="RLVRTrainer.train")
     def train(self, training_dataset: Optional[Union[str, DataSet]] = None,
-              validation_dataset: Optional[Union[str, DataSet]] = None, wait: bool = True, wait_timeout: Optional[int] = None, poll: int = 5):
+              validation_dataset: Optional[Union[str, DataSet]] = None, wait: bool = True, wait_timeout: Optional[int] = None, poll: int = 5, dry_run: bool = False):
         """Execute the RLVR training job.
 
         Parameters:
@@ -382,9 +382,13 @@ class RLVRTrainer(BaseTrainer):
                 If None, uses the default timeout from the wait utility.
             poll (int):
                 Polling interval in seconds for checking training job status. Defaults to 5.
+            dry_run (bool):
+                If True, runs all validation (IAM, hyperparameters, infrastructure, data paths)
+                without submitting a job. Returns None on success, raises on validation failure.
+                Defaults to False.
 
         Returns:
-            TrainingJob: The SageMaker training job object.
+            TrainingJob: The SageMaker training job object, or None if dry_run=True.
         """
         # Dispatch based on compute type
         if isinstance(self.compute, HyperPodCompute):
@@ -394,6 +398,7 @@ class RLVRTrainer(BaseTrainer):
                 wait=wait,
                 wait_timeout=wait_timeout,
                 poll=poll,
+                dry_run=dry_run,
             )
         elif isinstance(self.compute, TrainingJobCompute):
             return self._train_serverful_smtj(
@@ -402,6 +407,7 @@ class RLVRTrainer(BaseTrainer):
                 wait=wait,
                 wait_timeout=wait_timeout,
                 poll=poll,
+                dry_run=dry_run,
             )
 
         # Default: serverless compute (None)
@@ -493,6 +499,22 @@ class RLVRTrainer(BaseTrainer):
         # Only pass stopping_condition if explicitly provided by user
         if self.stopping_condition is not None:
             create_args["stopping_condition"] = self.stopping_condition
+
+        # Validate data paths exist before submission
+        effective_training = training_dataset or self.training_dataset
+        effective_validation = validation_dataset or self.validation_dataset
+        if effective_training and isinstance(effective_training, str):
+            validate_data_path_exists(
+                effective_training, sagemaker_session, label="training dataset"
+            )
+        if effective_validation and isinstance(effective_validation, str):
+            validate_data_path_exists(
+                effective_validation, sagemaker_session, label="validation dataset"
+            )
+
+        if dry_run:
+            logger.info("Dry-run validation passed. No job submitted.")
+            return None
 
         try:
             training_job = TrainingJob.create(**create_args)

--- a/sagemaker-train/src/sagemaker/train/rlvr_trainer.py
+++ b/sagemaker-train/src/sagemaker/train/rlvr_trainer.py
@@ -503,11 +503,11 @@ class RLVRTrainer(BaseTrainer):
         # Validate data paths exist before submission
         effective_training = training_dataset or self.training_dataset
         effective_validation = validation_dataset or self.validation_dataset
-        if effective_training and isinstance(effective_training, str):
+        if effective_training:
             validate_data_path_exists(
                 effective_training, sagemaker_session, label="training dataset"
             )
-        if effective_validation and isinstance(effective_validation, str):
+        if effective_validation:
             validate_data_path_exists(
                 effective_validation, sagemaker_session, label="validation dataset"
             )

--- a/sagemaker-train/src/sagemaker/train/sft_trainer.py
+++ b/sagemaker-train/src/sagemaker/train/sft_trainer.py
@@ -25,7 +25,7 @@ from sagemaker.train.common_utils.finetune_utils import (
     _validate_eula_for_gated_model,
     _validate_hyperparameter_values
 )
-from sagemaker.train.common_utils.data_utils import is_multimodal_data
+from sagemaker.train.common_utils.data_utils import is_multimodal_data, validate_data_path_exists
 from sagemaker.train.common_utils.data_mixing_utils import (
     validate_data_mixing_model,
     validate_data_mixing_categories,
@@ -243,7 +243,7 @@ class SFTTrainer(BaseTrainer):
                 self.hyperparameters._specs.pop('validation_data_path', None)
 
     @_telemetry_emitter(feature=Feature.MODEL_CUSTOMIZATION, func_name="SFTTrainer.train")
-    def train(self, training_dataset: Optional[Union[str, DataSet]] = None, validation_dataset: Optional[Union[str, DataSet]] = None, wait: bool = True, wait_timeout: Optional[int] = None, poll: int = 5):
+    def train(self, training_dataset: Optional[Union[str, DataSet]] = None, validation_dataset: Optional[Union[str, DataSet]] = None, wait: bool = True, wait_timeout: Optional[int] = None, poll: int = 5, dry_run: bool = False):
         """Execute the SFT training job.
 
         Parameters:
@@ -260,9 +260,13 @@ class SFTTrainer(BaseTrainer):
                 If None, uses the default timeout from the wait utility.
             poll (int):
                 Polling interval in seconds for checking training job status. Defaults to 5.
+            dry_run (bool):
+                If True, runs all validation (IAM, hyperparameters, infrastructure, data paths)
+                without submitting a job. Returns None on success, raises on validation failure.
+                Defaults to False.
 
         Returns:
-            TrainingJob: The SageMaker training job object.
+            TrainingJob: The SageMaker training job object, or None if dry_run=True.
         """
         # Dispatch based on compute type
         if isinstance(self.compute, HyperPodCompute):
@@ -299,6 +303,7 @@ class SFTTrainer(BaseTrainer):
                 wait=wait,
                 wait_timeout=wait_timeout,
                 poll=poll,
+                dry_run=dry_run,
             )
         elif isinstance(self.compute, TrainingJobCompute):
             if self.data_mixing_config is not None:
@@ -309,6 +314,7 @@ class SFTTrainer(BaseTrainer):
                 wait=wait,
                 wait_timeout=wait_timeout,
                 poll=poll,
+                dry_run=dry_run,
             )
 
         # Default: serverless compute (None)
@@ -406,6 +412,22 @@ class SFTTrainer(BaseTrainer):
         # Only pass stopping_condition if explicitly provided by user
         if self.stopping_condition is not None:
             create_args["stopping_condition"] = self.stopping_condition
+
+        # Validate data paths exist before submission
+        effective_training = training_dataset or self.training_dataset
+        effective_validation = validation_dataset or self.validation_dataset
+        if effective_training and isinstance(effective_training, str):
+            validate_data_path_exists(
+                effective_training, sagemaker_session, label="training dataset"
+            )
+        if effective_validation and isinstance(effective_validation, str):
+            validate_data_path_exists(
+                effective_validation, sagemaker_session, label="validation dataset"
+            )
+
+        if dry_run:
+            logger.info("Dry-run validation passed. No job submitted.")
+            return None
 
         try:
             training_job = TrainingJob.create(**create_args)

--- a/sagemaker-train/src/sagemaker/train/sft_trainer.py
+++ b/sagemaker-train/src/sagemaker/train/sft_trainer.py
@@ -416,11 +416,11 @@ class SFTTrainer(BaseTrainer):
         # Validate data paths exist before submission
         effective_training = training_dataset or self.training_dataset
         effective_validation = validation_dataset or self.validation_dataset
-        if effective_training and isinstance(effective_training, str):
+        if effective_training:
             validate_data_path_exists(
                 effective_training, sagemaker_session, label="training dataset"
             )
-        if effective_validation and isinstance(effective_validation, str):
+        if effective_validation:
             validate_data_path_exists(
                 effective_validation, sagemaker_session, label="validation dataset"
             )

--- a/sagemaker-train/tests/integ/train/test_dry_run_integration.py
+++ b/sagemaker-train/tests/integ/train/test_dry_run_integration.py
@@ -31,6 +31,7 @@ from sagemaker.train.sft_trainer import SFTTrainer
 from sagemaker.train.dpo_trainer import DPOTrainer
 from sagemaker.train.rlvr_trainer import RLVRTrainer
 from sagemaker.train.common import TrainingType
+from sagemaker.train.evaluate.benchmark_evaluator import BenchMarkEvaluator
 
 
 MODEL_PACKAGE_GROUP = (
@@ -168,3 +169,20 @@ class TestDryRunPassesWithValidInputs:
             MaxResults=1,
         )
         assert len(response.get("TrainingJobSummaries", [])) == 0
+
+
+class TestEvaluateDryRun:
+    """Verify evaluate(dry_run=True) validates without submitting."""
+
+    def test_benchmark_evaluate_dry_run_returns_none(self, sagemaker_session):
+        from sagemaker.train.evaluate import get_benchmarks
+        Benchmark = get_benchmarks()
+
+        evaluator = BenchMarkEvaluator(
+            benchmark=Benchmark.MMLU,
+            model=MODEL_ID,
+            s3_output_path=f"s3://{sagemaker_session.default_bucket()}/dry-run-eval-output/",
+        )
+
+        result = evaluator.evaluate(dry_run=True)
+        assert result is None

--- a/sagemaker-train/tests/integ/train/test_dry_run_integration.py
+++ b/sagemaker-train/tests/integ/train/test_dry_run_integration.py
@@ -1,0 +1,170 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+"""Integration tests for dry_run=True on trainers.
+
+These tests validate that dry_run performs real validation against AWS
+(IAM role resolution, S3 path existence, hyperparameter constraints)
+without consuming compute. No training jobs are submitted.
+
+A small sample dataset is uploaded to the SageMaker default bucket
+during test setup and cleaned up afterward.
+"""
+from __future__ import absolute_import
+
+import json
+import time
+import random
+
+import pytest
+
+from sagemaker.train.sft_trainer import SFTTrainer
+from sagemaker.train.dpo_trainer import DPOTrainer
+from sagemaker.train.rlvr_trainer import RLVRTrainer
+from sagemaker.train.common import TrainingType
+
+
+MODEL_PACKAGE_GROUP = (
+    "arn:aws:sagemaker:us-west-2:729646638167:"
+    "model-package-group/sdk-test-finetuned-models"
+)
+MODEL_ID = "meta-textgeneration-llama-3-2-1b-instruct"
+DATASET_KEY = "dry-run-integ-test/sample_train.jsonl"
+
+
+@pytest.fixture(scope="module")
+def valid_dataset(sagemaker_session):
+    """Upload a small sample dataset to the default bucket, return its S3 URI."""
+    bucket = sagemaker_session.default_bucket()
+    s3 = sagemaker_session.boto_session.client("s3")
+
+    samples = [
+        {"messages": [
+            {"role": "user", "content": [{"text": "What is 2+2?"}]},
+            {"role": "assistant", "content": [{"text": "4"}]},
+        ]},
+        {"messages": [
+            {"role": "user", "content": [{"text": "Capital of France?"}]},
+            {"role": "assistant", "content": [{"text": "Paris"}]},
+        ]},
+    ]
+    body = "\n".join(json.dumps(s) for s in samples)
+    s3.put_object(Bucket=bucket, Key=DATASET_KEY, Body=body.encode("utf-8"))
+
+    s3_uri = f"s3://{bucket}/{DATASET_KEY}"
+    yield s3_uri
+
+    # Cleanup
+    s3.delete_object(Bucket=bucket, Key=DATASET_KEY)
+
+
+@pytest.fixture(scope="module")
+def nonexistent_dataset(sagemaker_session):
+    """Return an S3 URI in the default bucket that does not exist."""
+    bucket = sagemaker_session.default_bucket()
+    return f"s3://{bucket}/dry-run-integ-test/nonexistent_path_12345.jsonl"
+
+
+class TestDryRunS3PathValidation:
+    """Verify dry_run raises when S3 data paths do not exist."""
+
+    def test_sft_fails_on_nonexistent_training_dataset(
+        self, sagemaker_session, nonexistent_dataset
+    ):
+        trainer = SFTTrainer(
+            model=MODEL_ID,
+            training_type=TrainingType.LORA,
+            model_package_group=MODEL_PACKAGE_GROUP,
+            training_dataset=nonexistent_dataset,
+            accept_eula=True,
+        )
+
+        with pytest.raises(ValueError, match="does not exist"):
+            trainer.train(dry_run=True)
+
+    def test_sft_fails_on_nonexistent_validation_dataset(
+        self, sagemaker_session, valid_dataset, nonexistent_dataset
+    ):
+        trainer = SFTTrainer(
+            model=MODEL_ID,
+            training_type=TrainingType.LORA,
+            model_package_group=MODEL_PACKAGE_GROUP,
+            training_dataset=valid_dataset,
+            validation_dataset=nonexistent_dataset,
+            accept_eula=True,
+        )
+
+        with pytest.raises(ValueError, match="does not exist"):
+            trainer.train(dry_run=True)
+
+
+class TestDryRunPassesWithValidInputs:
+    """Verify dry_run=True returns None and does not create a job."""
+
+    def test_sft_dry_run_returns_none(self, sagemaker_session, valid_dataset):
+        trainer = SFTTrainer(
+            model=MODEL_ID,
+            training_type=TrainingType.LORA,
+            model_package_group=MODEL_PACKAGE_GROUP,
+            training_dataset=valid_dataset,
+            accept_eula=True,
+        )
+
+        result = trainer.train(dry_run=True)
+        assert result is None
+
+    def test_dpo_dry_run_returns_none(self, sagemaker_session, valid_dataset):
+        trainer = DPOTrainer(
+            model=MODEL_ID,
+            training_type=TrainingType.LORA,
+            model_package_group=MODEL_PACKAGE_GROUP,
+            training_dataset=valid_dataset,
+            accept_eula=True,
+        )
+
+        result = trainer.train(dry_run=True)
+        assert result is None
+
+    def test_rlvr_dry_run_returns_none(self, sagemaker_session, valid_dataset):
+        trainer = RLVRTrainer(
+            model=MODEL_ID,
+            training_type=TrainingType.LORA,
+            model_package_group=MODEL_PACKAGE_GROUP,
+            training_dataset=valid_dataset,
+            accept_eula=True,
+        )
+
+        result = trainer.train(dry_run=True)
+        assert result is None
+
+    def test_no_training_job_created(self, sagemaker_session, valid_dataset):
+        """Confirm via the SageMaker API that no job was submitted."""
+        unique_id = f"{int(time.time())}-{random.randint(10000, 99999)}"
+        base_name = f"dry-run-noop-{unique_id}"
+
+        trainer = SFTTrainer(
+            model=MODEL_ID,
+            training_type=TrainingType.LORA,
+            model_package_group=MODEL_PACKAGE_GROUP,
+            training_dataset=valid_dataset,
+            accept_eula=True,
+            base_job_name=base_name,
+        )
+
+        trainer.train(dry_run=True)
+
+        sm_client = sagemaker_session.sagemaker_client
+        response = sm_client.list_training_jobs(
+            NameContains=base_name,
+            MaxResults=1,
+        )
+        assert len(response.get("TrainingJobSummaries", [])) == 0

--- a/sagemaker-train/tests/integ/train/test_dry_run_integration.py
+++ b/sagemaker-train/tests/integ/train/test_dry_run_integration.py
@@ -32,6 +32,7 @@ from sagemaker.train.dpo_trainer import DPOTrainer
 from sagemaker.train.rlvr_trainer import RLVRTrainer
 from sagemaker.train.common import TrainingType
 from sagemaker.train.evaluate.benchmark_evaluator import BenchMarkEvaluator
+from sagemaker.core.training.configs import TrainingJobCompute
 
 
 MODEL_PACKAGE_GROUP = (
@@ -44,48 +45,101 @@ DATASET_KEY = "dry-run-integ-test/sample_train.jsonl"
 
 @pytest.fixture(scope="module")
 def valid_dataset(sagemaker_session):
-    """Upload a small sample dataset to the default bucket, return its S3 URI."""
+    """Upload a small sample dataset to the default bucket if it doesn't already exist, return its S3 URI."""
     bucket = sagemaker_session.default_bucket()
     s3 = sagemaker_session.boto_session.client("s3")
 
-    samples = [
-        {"messages": [
-            {"role": "user", "content": [{"text": "What is 2+2?"}]},
-            {"role": "assistant", "content": [{"text": "4"}]},
-        ]},
-        {"messages": [
-            {"role": "user", "content": [{"text": "Capital of France?"}]},
-            {"role": "assistant", "content": [{"text": "Paris"}]},
-        ]},
-    ]
-    body = "\n".join(json.dumps(s) for s in samples)
-    s3.put_object(Bucket=bucket, Key=DATASET_KEY, Body=body.encode("utf-8"))
+    # Only upload if the object doesn't already exist
+    resp = s3.list_objects_v2(Bucket=bucket, Prefix=DATASET_KEY, MaxKeys=1)
+    if resp.get("KeyCount", 0) == 0:
+        samples = [
+            {"messages": [
+                {"role": "user", "content": [{"text": "What is 2+2?"}]},
+                {"role": "assistant", "content": [{"text": "4"}]},
+            ]},
+            {"messages": [
+                {"role": "user", "content": [{"text": "Capital of France?"}]},
+                {"role": "assistant", "content": [{"text": "Paris"}]},
+            ]},
+        ]
+        body = "\n".join(json.dumps(s) for s in samples)
+        s3.put_object(Bucket=bucket, Key=DATASET_KEY, Body=body.encode("utf-8"))
 
-    s3_uri = f"s3://{bucket}/{DATASET_KEY}"
-    yield s3_uri
-
-    # Cleanup
-    s3.delete_object(Bucket=bucket, Key=DATASET_KEY)
+    return f"s3://{bucket}/{DATASET_KEY}"
 
 
 @pytest.fixture(scope="module")
-def nonexistent_dataset(sagemaker_session):
+def nonexistent_dataset_s3(sagemaker_session):
     """Return an S3 URI in the default bucket that does not exist."""
     bucket = sagemaker_session.default_bucket()
     return f"s3://{bucket}/dry-run-integ-test/nonexistent_path_12345.jsonl"
 
 
+@pytest.fixture(scope="module")
+def nonexistent_dataset_arn():
+    """Return a DataSet ARN that does not exist."""
+    return (
+        "arn:aws:sagemaker:us-west-2:123456789012:hub-content/"
+        "SageMakerPublicHub/DataSet/nonexistent-dataset-12345/1.0.0"
+    )
+
+
+@pytest.fixture(scope="module")
+def nonexistent_dataset_obj():
+    """Return a DataSet object with a nonexistent ARN."""
+    from sagemaker.ai_registry.dataset import DataSet
+    from sagemaker.ai_registry.air_constants import HubContentStatus
+
+    return DataSet(
+        name="nonexistent-dataset-12345",
+        arn=(
+            "arn:aws:sagemaker:us-west-2:123456789012:hub-content/"
+            "SageMakerPublicHub/DataSet/nonexistent-dataset-12345/1.0.0"
+        ),
+        version="1.0.0",
+        status=HubContentStatus.AVAILABLE,
+    )
+
+
 class TestDryRunS3PathValidation:
     """Verify dry_run raises when S3 data paths do not exist."""
 
-    def test_sft_fails_on_nonexistent_training_dataset(
-        self, sagemaker_session, nonexistent_dataset
+    def test_sft_fails_on_nonexistent_training_dataset_s3(
+        self, sagemaker_session, nonexistent_dataset_s3
     ):
         trainer = SFTTrainer(
             model=MODEL_ID,
             training_type=TrainingType.LORA,
             model_package_group=MODEL_PACKAGE_GROUP,
-            training_dataset=nonexistent_dataset,
+            training_dataset=nonexistent_dataset_s3,
+            accept_eula=True,
+        )
+
+        with pytest.raises(ValueError, match="does not exist"):
+            trainer.train(dry_run=True)
+
+    def test_sft_fails_on_nonexistent_training_dataset_arn(
+        self, sagemaker_session, nonexistent_dataset_arn
+    ):
+        trainer = SFTTrainer(
+            model=MODEL_ID,
+            training_type=TrainingType.LORA,
+            model_package_group=MODEL_PACKAGE_GROUP,
+            training_dataset=nonexistent_dataset_arn,
+            accept_eula=True,
+        )
+
+        with pytest.raises(ValueError, match="does not exist"):
+            trainer.train(dry_run=True)
+
+    def test_sft_fails_on_nonexistent_training_dataset_obj(
+        self, sagemaker_session, nonexistent_dataset_obj
+    ):
+        trainer = SFTTrainer(
+            model=MODEL_ID,
+            training_type=TrainingType.LORA,
+            model_package_group=MODEL_PACKAGE_GROUP,
+            training_dataset=nonexistent_dataset_obj,
             accept_eula=True,
         )
 
@@ -93,14 +147,14 @@ class TestDryRunS3PathValidation:
             trainer.train(dry_run=True)
 
     def test_sft_fails_on_nonexistent_validation_dataset(
-        self, sagemaker_session, valid_dataset, nonexistent_dataset
+        self, sagemaker_session, valid_dataset, nonexistent_dataset_s3
     ):
         trainer = SFTTrainer(
             model=MODEL_ID,
             training_type=TrainingType.LORA,
             model_package_group=MODEL_PACKAGE_GROUP,
             training_dataset=valid_dataset,
-            validation_dataset=nonexistent_dataset,
+            validation_dataset=nonexistent_dataset_s3,
             accept_eula=True,
         )
 
@@ -185,4 +239,47 @@ class TestEvaluateDryRun:
         )
 
         result = evaluator.evaluate(dry_run=True)
+        assert result is None
+
+
+class TestDryRunServerful:
+    """Verify dry_run=True works for serverful (TrainingJobCompute) path."""
+
+    def test_sft_serverful_dry_run_returns_none(self, sagemaker_session, valid_dataset):
+        trainer = SFTTrainer(
+            model=MODEL_ID,
+            training_type=TrainingType.LORA,
+            model_package_group=MODEL_PACKAGE_GROUP,
+            training_dataset=valid_dataset,
+            compute=TrainingJobCompute(instance_type="ml.g5.2xlarge", instance_count=1),
+            accept_eula=True,
+        )
+
+        result = trainer.train(dry_run=True)
+        assert result is None
+
+    def test_dpo_serverful_dry_run_returns_none(self, sagemaker_session, valid_dataset):
+        trainer = DPOTrainer(
+            model=MODEL_ID,
+            training_type=TrainingType.LORA,
+            model_package_group=MODEL_PACKAGE_GROUP,
+            training_dataset=valid_dataset,
+            compute=TrainingJobCompute(instance_type="ml.g5.2xlarge", instance_count=1),
+            accept_eula=True,
+        )
+
+        result = trainer.train(dry_run=True)
+        assert result is None
+
+    def test_rlvr_serverful_dry_run_returns_none(self, sagemaker_session, valid_dataset):
+        trainer = RLVRTrainer(
+            model=MODEL_ID,
+            training_type=TrainingType.LORA,
+            model_package_group=MODEL_PACKAGE_GROUP,
+            training_dataset=valid_dataset,
+            compute=TrainingJobCompute(instance_type="ml.g5.2xlarge", instance_count=1),
+            accept_eula=True,
+        )
+
+        result = trainer.train(dry_run=True)
         assert result is None

--- a/sagemaker-train/tests/unit/train/common_utils/test_data_utils.py
+++ b/sagemaker-train/tests/unit/train/common_utils/test_data_utils.py
@@ -296,6 +296,53 @@ class TestValidateDataPathExists(unittest.TestCase):
             )
         self.assertIn("Invalid", str(ctx.exception))
 
+    def test_dataset_object_extracts_arn(self):
+        """Validate that DataSet objects are handled by extracting the ARN."""
+        from sagemaker.train.common_utils.data_utils import validate_data_path_exists
+        from unittest.mock import Mock, patch
+
+        session = Mock()
+        sm_client = Mock()
+        session.sagemaker_client = sm_client
+
+        # Create a mock DataSet object to avoid API calls during construction
+        from sagemaker.ai_registry.dataset import DataSet
+        dataset = Mock(spec=DataSet)
+        dataset.arn = "arn:aws:sagemaker:us-west-2:123456789012:hub-content/MyHub/DataSet/my-dataset/1.0.0"
+
+        # describe_hub_content succeeds — validation passes
+        sm_client.describe_hub_content.return_value = {}
+        validate_data_path_exists(dataset, session, label="training dataset")
+        sm_client.describe_hub_content.assert_called_once_with(
+            HubName="MyHub",
+            HubContentType="DataSet",
+            HubContentName="my-dataset",
+            HubContentVersion="1.0.0",
+        )
+
+    def test_dataset_object_not_found_raises(self):
+        """Validate that DataSet objects with nonexistent ARNs raise ValueError."""
+        from sagemaker.train.common_utils.data_utils import validate_data_path_exists
+        from botocore.exceptions import ClientError
+        from unittest.mock import Mock
+
+        session = Mock()
+        sm_client = Mock()
+        session.sagemaker_client = sm_client
+
+        from sagemaker.ai_registry.dataset import DataSet
+        dataset = Mock(spec=DataSet)
+        dataset.arn = "arn:aws:sagemaker:us-west-2:123456789012:hub-content/MyHub/DataSet/bad-dataset/1.0.0"
+
+        sm_client.describe_hub_content.side_effect = ClientError(
+            {"Error": {"Code": "ResourceNotFound", "Message": "Not found"}},
+            "DescribeHubContent",
+        )
+
+        with self.assertRaises(ValueError) as ctx:
+            validate_data_path_exists(dataset, session, label="training dataset")
+        self.assertIn("does not exist", str(ctx.exception))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/sagemaker-train/tests/unit/train/common_utils/test_data_utils.py
+++ b/sagemaker-train/tests/unit/train/common_utils/test_data_utils.py
@@ -230,5 +230,72 @@ class TestIsMultimodalData(unittest.TestCase):
         )
 
 
+class TestValidateDataPathExists(unittest.TestCase):
+    """Tests for validate_data_path_exists utility."""
+
+    def _make_session(self):
+        from unittest.mock import Mock
+        session = Mock()
+        self.s3 = Mock()
+        session.boto_session.client.return_value = self.s3
+        from botocore.exceptions import ClientError
+        self.s3.exceptions.ClientError = ClientError
+        return session
+
+    def test_object_exists(self):
+        from sagemaker.train.common_utils.data_utils import validate_data_path_exists
+
+        session = self._make_session()
+        self.s3.list_objects_v2.return_value = {"KeyCount": 1}
+
+        validate_data_path_exists("s3://my-bucket/data/train.jsonl", session, label="training")
+        self.s3.list_objects_v2.assert_called_once_with(
+            Bucket="my-bucket", Prefix="data/train.jsonl", MaxKeys=1
+        )
+
+    def test_prefix_exists(self):
+        from sagemaker.train.common_utils.data_utils import validate_data_path_exists
+
+        session = self._make_session()
+        self.s3.list_objects_v2.return_value = {"KeyCount": 3}
+
+        validate_data_path_exists("s3://my-bucket/data/prefix/", session, label="training")
+
+    def test_path_does_not_exist_raises(self):
+        from sagemaker.train.common_utils.data_utils import validate_data_path_exists
+
+        session = self._make_session()
+        self.s3.list_objects_v2.return_value = {"KeyCount": 0}
+
+        with self.assertRaises(ValueError) as ctx:
+            validate_data_path_exists(
+                "s3://my-bucket/bad/path.jsonl", session, label="training dataset"
+            )
+        self.assertIn("does not exist", str(ctx.exception))
+
+    def test_access_denied_warns_not_raises(self):
+        from sagemaker.train.common_utils.data_utils import validate_data_path_exists
+        from botocore.exceptions import ClientError
+
+        session = self._make_session()
+        self.s3.list_objects_v2.side_effect = ClientError(
+            {"Error": {"Code": "403", "Message": "Forbidden"}}, "ListObjectsV2"
+        )
+
+        # Should not raise — caller may lack access but execution role might have it
+        validate_data_path_exists("s3://locked-bucket/data.jsonl", session, label="data")
+
+    def test_unrecognized_format_raises(self):
+        from sagemaker.train.common_utils.data_utils import validate_data_path_exists
+        from unittest.mock import Mock
+
+        session = Mock()
+        with self.assertRaises(ValueError) as ctx:
+            validate_data_path_exists(
+                "arn:aws:sagemaker:us-east-1:123:dataset/foo", session
+            )
+        self.assertIn("Invalid", str(ctx.exception))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/sagemaker-train/tests/unit/train/common_utils/test_data_utils.py
+++ b/sagemaker-train/tests/unit/train/common_utils/test_data_utils.py
@@ -1,8 +1,15 @@
 import json
 import unittest
-from unittest.mock import patch
+from unittest.mock import patch, Mock
 
-from sagemaker.train.common_utils.data_utils import is_multimodal_data
+from botocore.exceptions import ClientError
+
+from sagemaker.ai_registry.dataset import DataSet
+from sagemaker.train.common_utils.data_utils import (
+    is_multimodal_data,
+    validate_data_path_exists,
+    _validate_dataset_arn_exists,
+)
 
 PATCH_LOAD = "sagemaker.train.common_utils.data_utils.load_file_content"
 
@@ -234,17 +241,13 @@ class TestValidateDataPathExists(unittest.TestCase):
     """Tests for validate_data_path_exists utility."""
 
     def _make_session(self):
-        from unittest.mock import Mock
         session = Mock()
         self.s3 = Mock()
         session.boto_session.client.return_value = self.s3
-        from botocore.exceptions import ClientError
         self.s3.exceptions.ClientError = ClientError
         return session
 
     def test_object_exists(self):
-        from sagemaker.train.common_utils.data_utils import validate_data_path_exists
-
         session = self._make_session()
         self.s3.list_objects_v2.return_value = {"KeyCount": 1}
 
@@ -254,16 +257,12 @@ class TestValidateDataPathExists(unittest.TestCase):
         )
 
     def test_prefix_exists(self):
-        from sagemaker.train.common_utils.data_utils import validate_data_path_exists
-
         session = self._make_session()
         self.s3.list_objects_v2.return_value = {"KeyCount": 3}
 
         validate_data_path_exists("s3://my-bucket/data/prefix/", session, label="training")
 
     def test_path_does_not_exist_raises(self):
-        from sagemaker.train.common_utils.data_utils import validate_data_path_exists
-
         session = self._make_session()
         self.s3.list_objects_v2.return_value = {"KeyCount": 0}
 
@@ -274,9 +273,6 @@ class TestValidateDataPathExists(unittest.TestCase):
         self.assertIn("does not exist", str(ctx.exception))
 
     def test_access_denied_warns_not_raises(self):
-        from sagemaker.train.common_utils.data_utils import validate_data_path_exists
-        from botocore.exceptions import ClientError
-
         session = self._make_session()
         self.s3.list_objects_v2.side_effect = ClientError(
             {"Error": {"Code": "403", "Message": "Forbidden"}}, "ListObjectsV2"
@@ -286,9 +282,6 @@ class TestValidateDataPathExists(unittest.TestCase):
         validate_data_path_exists("s3://locked-bucket/data.jsonl", session, label="data")
 
     def test_unrecognized_format_raises(self):
-        from sagemaker.train.common_utils.data_utils import validate_data_path_exists
-        from unittest.mock import Mock
-
         session = Mock()
         with self.assertRaises(ValueError) as ctx:
             validate_data_path_exists(
@@ -298,19 +291,13 @@ class TestValidateDataPathExists(unittest.TestCase):
 
     def test_dataset_object_extracts_arn(self):
         """Validate that DataSet objects are handled by extracting the ARN."""
-        from sagemaker.train.common_utils.data_utils import validate_data_path_exists
-        from unittest.mock import Mock, patch
-
         session = Mock()
         sm_client = Mock()
         session.sagemaker_client = sm_client
 
-        # Create a mock DataSet object to avoid API calls during construction
-        from sagemaker.ai_registry.dataset import DataSet
         dataset = Mock(spec=DataSet)
         dataset.arn = "arn:aws:sagemaker:us-west-2:123456789012:hub-content/MyHub/DataSet/my-dataset/1.0.0"
 
-        # describe_hub_content succeeds — validation passes
         sm_client.describe_hub_content.return_value = {}
         validate_data_path_exists(dataset, session, label="training dataset")
         sm_client.describe_hub_content.assert_called_once_with(
@@ -322,15 +309,10 @@ class TestValidateDataPathExists(unittest.TestCase):
 
     def test_dataset_object_not_found_raises(self):
         """Validate that DataSet objects with nonexistent ARNs raise ValueError."""
-        from sagemaker.train.common_utils.data_utils import validate_data_path_exists
-        from botocore.exceptions import ClientError
-        from unittest.mock import Mock
-
         session = Mock()
         sm_client = Mock()
         session.sagemaker_client = sm_client
 
-        from sagemaker.ai_registry.dataset import DataSet
         dataset = Mock(spec=DataSet)
         dataset.arn = "arn:aws:sagemaker:us-west-2:123456789012:hub-content/MyHub/DataSet/bad-dataset/1.0.0"
 
@@ -342,6 +324,84 @@ class TestValidateDataPathExists(unittest.TestCase):
         with self.assertRaises(ValueError) as ctx:
             validate_data_path_exists(dataset, session, label="training dataset")
         self.assertIn("does not exist", str(ctx.exception))
+
+
+class TestValidateDatasetArnPartitions(unittest.TestCase):
+    """Tests for _validate_dataset_arn_exists with different AWS partitions."""
+
+    def _make_session(self):
+        session = Mock()
+        session.sagemaker_client = Mock()
+        session.sagemaker_client.describe_hub_content.return_value = {}
+        return session
+
+    def test_standard_aws_partition(self):
+        session = self._make_session()
+        arn = "arn:aws:sagemaker:us-west-2:123456789012:hub-content/MyHub/DataSet/my-ds/1.0.0"
+
+        _validate_dataset_arn_exists(arn, session, label="training")
+        session.sagemaker_client.describe_hub_content.assert_called_once_with(
+            HubName="MyHub",
+            HubContentType="DataSet",
+            HubContentName="my-ds",
+            HubContentVersion="1.0.0",
+        )
+
+    def test_china_partition(self):
+        session = self._make_session()
+        arn = "arn:aws-cn:sagemaker:cn-north-1:123456789012:hub-content/MyHub/DataSet/my-ds/2.0.0"
+
+        _validate_dataset_arn_exists(arn, session, label="training")
+        session.sagemaker_client.describe_hub_content.assert_called_once_with(
+            HubName="MyHub",
+            HubContentType="DataSet",
+            HubContentName="my-ds",
+            HubContentVersion="2.0.0",
+        )
+
+    def test_govcloud_partition(self):
+        session = self._make_session()
+        arn = "arn:aws-us-gov:sagemaker:us-gov-west-1:123456789012:hub-content/GovHub/DataSet/gov-ds/1.0.0"
+
+        _validate_dataset_arn_exists(arn, session, label="training")
+        session.sagemaker_client.describe_hub_content.assert_called_once_with(
+            HubName="GovHub",
+            HubContentType="DataSet",
+            HubContentName="gov-ds",
+            HubContentVersion="1.0.0",
+        )
+
+    def test_iso_partition(self):
+        session = self._make_session()
+        arn = "arn:aws-iso:sagemaker:us-iso-east-1:123456789012:hub-content/IsoHub/DataSet/iso-ds/3.1.0"
+
+        _validate_dataset_arn_exists(arn, session, label="training")
+        session.sagemaker_client.describe_hub_content.assert_called_once_with(
+            HubName="IsoHub",
+            HubContentType="DataSet",
+            HubContentName="iso-ds",
+            HubContentVersion="3.1.0",
+        )
+
+    def test_iso_b_partition(self):
+        session = self._make_session()
+        arn = "arn:aws-iso-b:sagemaker:us-isob-east-1:123456789012:hub-content/IsoBHub/DataSet/isob-ds/1.0.0"
+
+        _validate_dataset_arn_exists(arn, session, label="training")
+        session.sagemaker_client.describe_hub_content.assert_called_once_with(
+            HubName="IsoBHub",
+            HubContentType="DataSet",
+            HubContentName="isob-ds",
+            HubContentVersion="1.0.0",
+        )
+
+    def test_invalid_partition_raises(self):
+        session = self._make_session()
+        arn = "arn:invalid:sagemaker:us-west-2:123456789012:hub-content/Hub/DataSet/ds/1.0.0"
+
+        with self.assertRaises(ValueError) as ctx:
+            _validate_dataset_arn_exists(arn, session, label="training")
+        self.assertIn("Invalid", str(ctx.exception))
 
 
 if __name__ == "__main__":

--- a/sagemaker-train/tests/unit/train/test_dpo_trainer.py
+++ b/sagemaker-train/tests/unit/train/test_dpo_trainer.py
@@ -621,3 +621,54 @@ class TestDPOTrainerBaseModelName:
                 compute=HyperPodCompute(cluster_name="my-cluster", node_count=4),
                 training_dataset="s3://bucket/train.jsonl",
             )
+
+
+class TestDPOTrainerDryRun:
+    """Tests for DPOTrainer.train(dry_run=True)."""
+
+    @patch('sagemaker.train.dpo_trainer._validate_and_resolve_model_package_group')
+    @patch('sagemaker.train.dpo_trainer._get_fine_tuning_options_and_model_arn')
+    @patch('sagemaker.train.dpo_trainer.TrainDefaults.get_role')
+    @patch('sagemaker.train.dpo_trainer.TrainDefaults.get_sagemaker_session')
+    @patch('sagemaker.train.dpo_trainer._get_unique_name')
+    @patch('sagemaker.train.dpo_trainer._create_input_data_config')
+    @patch('sagemaker.train.dpo_trainer._convert_input_data_to_channels')
+    @patch('sagemaker.train.dpo_trainer._create_output_config')
+    @patch('sagemaker.train.dpo_trainer._create_serverless_config')
+    @patch('sagemaker.train.dpo_trainer._create_mlflow_config')
+    @patch('sagemaker.train.dpo_trainer._create_model_package_config')
+    @patch('sagemaker.train.dpo_trainer._validate_hyperparameter_values')
+    @patch('sagemaker.core.resources.TrainingJob.create')
+    @patch('sagemaker.train.common_utils.data_utils.validate_data_path_exists')
+    def test_dry_run_returns_none_without_submitting(
+        self, mock_validate_s3, mock_create, mock_validate_hp, mock_model_pkg,
+        mock_mlflow, mock_serverless, mock_output, mock_channels, mock_input,
+        mock_name, mock_session, mock_role, mock_options, mock_group,
+    ):
+        mock_group.return_value = "test-group"
+        mock_hp = Mock()
+        mock_hp.to_dict.return_value = {}
+        mock_hp._specs = {}
+        mock_options.return_value = (mock_hp, "model-arn", False)
+
+        sess = Mock()
+        sess.boto_session.region_name = "us-east-1"
+        mock_session.return_value = sess
+        mock_role.return_value = "test-role"
+        mock_name.return_value = "job-name"
+        mock_input.return_value = [Mock()]
+        mock_channels.return_value = [Mock()]
+        mock_output.return_value = Mock()
+        mock_serverless.return_value = Mock()
+        mock_mlflow.return_value = Mock()
+        mock_model_pkg.return_value = Mock()
+
+        trainer = DPOTrainer(
+            model="test-model", model_package_group="test-group",
+            training_dataset="s3://bucket/train.jsonl",
+        )
+        trainer.train(dry_run=True)
+
+        mock_create.assert_not_called()
+        mock_role.assert_called_once()
+        mock_validate_hp.assert_called_once()

--- a/sagemaker-train/tests/unit/train/test_rlaif_trainer.py
+++ b/sagemaker-train/tests/unit/train/test_rlaif_trainer.py
@@ -683,3 +683,54 @@ class TestRLAIFTrainer:
         trainer.train(wait=False, wait_timeout=600)
 
         mock_wait.assert_not_called()
+
+
+class TestRLAIFTrainerDryRun:
+    """Tests for RLAIFTrainer.train(dry_run=True)."""
+
+    @patch('sagemaker.train.rlaif_trainer._validate_and_resolve_model_package_group')
+    @patch('sagemaker.train.rlaif_trainer._get_fine_tuning_options_and_model_arn')
+    @patch('sagemaker.train.rlaif_trainer.TrainDefaults.get_role')
+    @patch('sagemaker.train.rlaif_trainer.TrainDefaults.get_sagemaker_session')
+    @patch('sagemaker.train.rlaif_trainer._get_unique_name')
+    @patch('sagemaker.train.rlaif_trainer._create_input_data_config')
+    @patch('sagemaker.train.rlaif_trainer._convert_input_data_to_channels')
+    @patch('sagemaker.train.rlaif_trainer._create_output_config')
+    @patch('sagemaker.train.rlaif_trainer._create_serverless_config')
+    @patch('sagemaker.train.rlaif_trainer._create_mlflow_config')
+    @patch('sagemaker.train.rlaif_trainer._create_model_package_config')
+    @patch('sagemaker.train.rlaif_trainer._validate_hyperparameter_values')
+    @patch('sagemaker.core.resources.TrainingJob.create')
+    @patch('sagemaker.train.common_utils.data_utils.validate_data_path_exists')
+    def test_dry_run_returns_none_without_submitting(
+        self, mock_validate_s3, mock_create, mock_validate_hp, mock_model_pkg,
+        mock_mlflow, mock_serverless, mock_output, mock_channels, mock_input,
+        mock_name, mock_session, mock_role, mock_options, mock_group,
+    ):
+        mock_group.return_value = "test-group"
+        mock_hp = Mock()
+        mock_hp.to_dict.return_value = {}
+        mock_hp._specs = {}
+        mock_options.return_value = (mock_hp, "model-arn", False)
+
+        sess = Mock()
+        sess.boto_session.region_name = "us-east-1"
+        mock_session.return_value = sess
+        mock_role.return_value = "test-role"
+        mock_name.return_value = "job-name"
+        mock_input.return_value = [Mock()]
+        mock_channels.return_value = [Mock()]
+        mock_output.return_value = Mock()
+        mock_serverless.return_value = Mock()
+        mock_mlflow.return_value = Mock()
+        mock_model_pkg.return_value = Mock()
+
+        trainer = RLAIFTrainer(
+            model="test-model", model_package_group="test-group",
+            training_dataset="s3://bucket/train.jsonl",
+        )
+        trainer.train(dry_run=True)
+
+        mock_create.assert_not_called()
+        mock_role.assert_called_once()
+        mock_validate_hp.assert_called_once()

--- a/sagemaker-train/tests/unit/train/test_rlvr_trainer.py
+++ b/sagemaker-train/tests/unit/train/test_rlvr_trainer.py
@@ -620,3 +620,54 @@ class TestRLVRTrainerBaseModelName:
                 compute=HyperPodCompute(cluster_name="my-cluster", node_count=4),
                 training_dataset="s3://bucket/train.jsonl",
             )
+
+
+class TestRLVRTrainerDryRun:
+    """Tests for RLVRTrainer.train(dry_run=True)."""
+
+    @patch('sagemaker.train.rlvr_trainer._validate_and_resolve_model_package_group')
+    @patch('sagemaker.train.rlvr_trainer._get_fine_tuning_options_and_model_arn')
+    @patch('sagemaker.train.rlvr_trainer.TrainDefaults.get_role')
+    @patch('sagemaker.train.rlvr_trainer.TrainDefaults.get_sagemaker_session')
+    @patch('sagemaker.train.rlvr_trainer._get_unique_name')
+    @patch('sagemaker.train.rlvr_trainer._create_input_data_config')
+    @patch('sagemaker.train.rlvr_trainer._convert_input_data_to_channels')
+    @patch('sagemaker.train.rlvr_trainer._create_output_config')
+    @patch('sagemaker.train.rlvr_trainer._create_serverless_config')
+    @patch('sagemaker.train.rlvr_trainer._create_mlflow_config')
+    @patch('sagemaker.train.rlvr_trainer._create_model_package_config')
+    @patch('sagemaker.train.rlvr_trainer._validate_hyperparameter_values')
+    @patch('sagemaker.core.resources.TrainingJob.create')
+    @patch('sagemaker.train.common_utils.data_utils.validate_data_path_exists')
+    def test_dry_run_returns_none_without_submitting(
+        self, mock_validate_s3, mock_create, mock_validate_hp, mock_model_pkg,
+        mock_mlflow, mock_serverless, mock_output, mock_channels, mock_input,
+        mock_name, mock_session, mock_role, mock_options, mock_group,
+    ):
+        mock_group.return_value = "test-group"
+        mock_hp = Mock()
+        mock_hp.to_dict.return_value = {}
+        mock_hp._specs = {}
+        mock_options.return_value = (mock_hp, "model-arn", False)
+
+        sess = Mock()
+        sess.boto_session.region_name = "us-east-1"
+        mock_session.return_value = sess
+        mock_role.return_value = "test-role"
+        mock_name.return_value = "job-name"
+        mock_input.return_value = [Mock()]
+        mock_channels.return_value = [Mock()]
+        mock_output.return_value = Mock()
+        mock_serverless.return_value = Mock()
+        mock_mlflow.return_value = Mock()
+        mock_model_pkg.return_value = Mock()
+
+        trainer = RLVRTrainer(
+            model="test-model", model_package_group="test-group",
+            training_dataset="s3://bucket/train.jsonl",
+        )
+        trainer.train(dry_run=True)
+
+        mock_create.assert_not_called()
+        mock_role.assert_called_once()
+        mock_validate_hp.assert_called_once()

--- a/sagemaker-train/tests/unit/train/test_sft_trainer.py
+++ b/sagemaker-train/tests/unit/train/test_sft_trainer.py
@@ -1284,3 +1284,81 @@ class TestSFTTrainerBaseModelName:
         )
 
         assert trainer.disable_output_compression is True
+
+
+class TestSFTTrainerDryRun:
+    """Tests for SFTTrainer.train(dry_run=True)."""
+
+    @patch('sagemaker.train.sft_trainer._validate_and_resolve_model_package_group')
+    @patch('sagemaker.train.sft_trainer._get_fine_tuning_options_and_model_arn')
+    @patch('sagemaker.train.sft_trainer.TrainDefaults.get_role')
+    @patch('sagemaker.train.sft_trainer.TrainDefaults.get_sagemaker_session')
+    @patch('sagemaker.train.sft_trainer._get_unique_name')
+    @patch('sagemaker.train.sft_trainer._create_input_data_config')
+    @patch('sagemaker.train.sft_trainer._convert_input_data_to_channels')
+    @patch('sagemaker.train.sft_trainer._create_output_config')
+    @patch('sagemaker.train.sft_trainer._create_serverless_config')
+    @patch('sagemaker.train.sft_trainer._create_mlflow_config')
+    @patch('sagemaker.train.sft_trainer._create_model_package_config')
+    @patch('sagemaker.train.sft_trainer._validate_hyperparameter_values')
+    @patch('sagemaker.core.resources.TrainingJob.create')
+    @patch('sagemaker.train.common_utils.data_utils.validate_data_path_exists')
+    def test_dry_run_returns_none_without_submitting(
+        self, mock_validate_s3, mock_create, mock_validate_hp, mock_model_pkg,
+        mock_mlflow, mock_serverless, mock_output, mock_channels, mock_input,
+        mock_name, mock_session, mock_role, mock_options, mock_group,
+    ):
+        mock_group.return_value = "test-group"
+        mock_hp = Mock()
+        mock_hp.to_dict.return_value = {"lr": "0.001"}
+        mock_hp._specs = {}
+        mock_options.return_value = (mock_hp, "model-arn", False)
+
+        sess = Mock()
+        sess.boto_session.region_name = "us-east-1"
+        mock_session.return_value = sess
+        mock_role.return_value = "test-role"
+        mock_name.return_value = "job-name"
+        mock_input.return_value = [Mock()]
+        mock_channels.return_value = [Mock()]
+        mock_output.return_value = Mock()
+        mock_serverless.return_value = Mock()
+        mock_mlflow.return_value = Mock()
+        mock_model_pkg.return_value = Mock()
+
+        trainer = SFTTrainer(
+            model="test-model", model_package_group="test-group",
+            training_dataset="s3://bucket/train.jsonl",
+        )
+        trainer.train(dry_run=True)
+
+        mock_create.assert_not_called()
+        # Existing validation still ran
+        mock_role.assert_called_once()
+        mock_validate_hp.assert_called_once()
+
+    @patch('sagemaker.train.sft_trainer._validate_and_resolve_model_package_group')
+    @patch('sagemaker.train.sft_trainer._get_fine_tuning_options_and_model_arn')
+    @patch('sagemaker.train.sft_trainer.TrainDefaults.get_sagemaker_session')
+    @patch('sagemaker.train.sft_trainer.TrainDefaults.get_role')
+    def test_dry_run_raises_on_role_validation_failure(
+        self, mock_role, mock_session, mock_options, mock_group,
+    ):
+        mock_group.return_value = "test-group"
+        mock_hp = Mock()
+        mock_hp.to_dict.return_value = {}
+        mock_hp._specs = {}
+        mock_options.return_value = (mock_hp, "model-arn", False)
+
+        sess = Mock()
+        sess.boto_session.region_name = "us-east-1"
+        mock_session.return_value = sess
+        mock_role.side_effect = ValueError("Missing permissions")
+
+        trainer = SFTTrainer(
+            model="test-model", model_package_group="test-group",
+            training_dataset="s3://bucket/train.jsonl",
+        )
+
+        with pytest.raises(ValueError, match="Missing permissions"):
+            trainer.train(dry_run=True)

--- a/v3-examples/model-customization-examples/benchmark_demo.ipynb
+++ b/v3-examples/model-customization-examples/benchmark_demo.ipynb
@@ -195,6 +195,28 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "dry-run-explanation",
+   "metadata": {},
+   "source": [
+    "### Dry Run (Validation Only)\n",
+    "\n",
+    "Use `dry_run=True` to validate IAM permissions and model resolution without submitting an evaluation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dry-run-validate",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Validate configuration without launching a training job\n",
+    "evaluator.train(dry_run=True)\n",
+    "print(\"Dry-run passed — configuration is valid.\")"
+   ]
+  },
+  {
    "cell_type": "code",
    "metadata": {},
    "source": [

--- a/v3-examples/model-customization-examples/custom_scorer_demo.ipynb
+++ b/v3-examples/model-customization-examples/custom_scorer_demo.ipynb
@@ -184,6 +184,28 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "dry-run-explanation",
+   "metadata": {},
+   "source": [
+    "### Dry Run (Validation Only)\n",
+    "\n",
+    "Use `dry_run=True` to validate IAM permissions, model resolution, and dataset paths without submitting an evaluation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dry-run-validate",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Validate configuration without launching a training job\n",
+    "evaluator.train(dry_run=True)\n",
+    "print(\"Dry-run passed — configuration is valid.\")"
+   ]
+  },
+  {
    "cell_type": "code",
    "metadata": {},
    "source": [

--- a/v3-examples/model-customization-examples/dpo_trainer_example_notebook_v3_prod.ipynb
+++ b/v3-examples/model-customization-examples/dpo_trainer_example_notebook_v3_prod.ipynb
@@ -161,7 +161,7 @@
    "source": [
     "# Validate configuration without launching a training job\n",
     "trainer.train(dry_run=True)\n",
-    "print(\"Dry-run passed \u2014 configuration is valid.\")"
+    "print(\"Dry-run passed — configuration is valid.\")"
    ]
   },
   {
@@ -300,7 +300,7 @@
   {
    "cell_type": "markdown",
    "id": "18f04d21",
-   "source": "## Iterative Training (Resume from Checkpoint)\n\nResume DPO training from a previously trained model package. Pass the model package directly \u2014 the service uses `SourceModelPackageArn` to resume from that checkpoint.",
+   "source": "## Iterative Training (Resume from Checkpoint)\n\nResume DPO training from a previously trained model package. Pass the model package directly — the service uses `SourceModelPackageArn` to resume from that checkpoint.",
    "metadata": {}
   },
   {

--- a/v3-examples/model-customization-examples/dpo_trainer_example_notebook_v3_prod.ipynb
+++ b/v3-examples/model-customization-examples/dpo_trainer_example_notebook_v3_prod.ipynb
@@ -143,6 +143,28 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "dry-run-explanation",
+   "metadata": {},
+   "source": [
+    "### Dry Run (Validation Only)\n",
+    "\n",
+    "Use `dry_run=True` to validate IAM permissions, data paths, hyperparameters, infrastructure without submitting a job."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dry-run-validate",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Validate configuration without launching a training job\n",
+    "trainer.train(dry_run=True)\n",
+    "print(\"Dry-run passed \u2014 configuration is valid.\")"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "0352bdaa-fa13-44c5-a70c-0d9bf7a10477",
@@ -278,7 +300,7 @@
   {
    "cell_type": "markdown",
    "id": "18f04d21",
-   "source": "## Iterative Training (Resume from Checkpoint)\n\nResume DPO training from a previously trained model package. Pass the model package directly — the service uses `SourceModelPackageArn` to resume from that checkpoint.",
+   "source": "## Iterative Training (Resume from Checkpoint)\n\nResume DPO training from a previously trained model package. Pass the model package directly \u2014 the service uses `SourceModelPackageArn` to resume from that checkpoint.",
    "metadata": {}
   },
   {

--- a/v3-examples/model-customization-examples/llm_as_judge_demo.ipynb
+++ b/v3-examples/model-customization-examples/llm_as_judge_demo.ipynb
@@ -292,6 +292,28 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "dry-run-explanation",
+   "metadata": {},
+   "source": [
+    "### Dry Run (Validation Only)\n",
+    "\n",
+    "Use `dry_run=True` to validate IAM permissions, model resolution, and dataset paths without submitting an evaluation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dry-run-validate",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Validate configuration without launching an evaluation job\n",
+    "evaluator.evaluate(dry_run=True)\n",
+    "print(\"Dry-run passed \u2014 configuration is valid.\")"
+   ]
+  },
+  {
    "cell_type": "code",
    "metadata": {},
    "source": [

--- a/v3-examples/model-customization-examples/rlaif_finetuning_example_notebook_v3_prod.ipynb
+++ b/v3-examples/model-customization-examples/rlaif_finetuning_example_notebook_v3_prod.ipynb
@@ -201,6 +201,28 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "dry-run-explanation",
+   "metadata": {},
+   "source": [
+    "### Dry Run (Validation Only)\n",
+    "\n",
+    "Use `dry_run=True` to validate IAM permissions, data paths, hyperparameters, infrastructure without submitting a job."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dry-run-validate",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Validate configuration without launching a training job\n",
+    "rlaif_trainer.train(dry_run=True)\n",
+    "print(\"Dry-run passed \u2014 configuration is valid.\")"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "5d5fa362-0caf-412d-977c-5e47f0548ea5",

--- a/v3-examples/model-customization-examples/rlaif_finetuning_example_notebook_v3_prod.ipynb
+++ b/v3-examples/model-customization-examples/rlaif_finetuning_example_notebook_v3_prod.ipynb
@@ -219,7 +219,7 @@
    "source": [
     "# Validate configuration without launching a training job\n",
     "rlaif_trainer.train(dry_run=True)\n",
-    "print(\"Dry-run passed \u2014 configuration is valid.\")"
+    "print(\"Dry-run passed — configuration is valid.\")"
    ]
   },
   {

--- a/v3-examples/model-customization-examples/rlvr_finetuning_example_notebook_v3_prod.ipynb
+++ b/v3-examples/model-customization-examples/rlvr_finetuning_example_notebook_v3_prod.ipynb
@@ -205,7 +205,7 @@
    "source": [
     "# Validate configuration without launching a training job\n",
     "rlvr_trainer.train(dry_run=True)\n",
-    "print(\"Dry-run passed \u2014 configuration is valid.\")"
+    "print(\"Dry-run passed — configuration is valid.\")"
    ]
   },
   {
@@ -463,7 +463,7 @@
     "2. Check if an Evaluator with that name already exists and points to the same Lambda (reuses it if so)\n",
     "3. Otherwise, create a new Evaluator in the AI Registry and use its ARN\n",
     "\n",
-    "This simplifies the workflow \u2014 no need to manually create an Evaluator object first."
+    "This simplifies the workflow — no need to manually create an Evaluator object first."
    ]
   },
   {
@@ -607,7 +607,7 @@
   {
    "cell_type": "markdown",
    "id": "381f8be1",
-   "source": "## Iterative Training (Resume from Checkpoint)\n\nResume RLVR training from a previously trained model package. Pass the model package directly \u2014 the service uses `SourceModelPackageArn` to resume from that checkpoint.",
+   "source": "## Iterative Training (Resume from Checkpoint)\n\nResume RLVR training from a previously trained model package. Pass the model package directly — the service uses `SourceModelPackageArn` to resume from that checkpoint.",
    "metadata": {}
   },
   {

--- a/v3-examples/model-customization-examples/rlvr_finetuning_example_notebook_v3_prod.ipynb
+++ b/v3-examples/model-customization-examples/rlvr_finetuning_example_notebook_v3_prod.ipynb
@@ -187,6 +187,28 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "dry-run-explanation",
+   "metadata": {},
+   "source": [
+    "### Dry Run (Validation Only)\n",
+    "\n",
+    "Use `dry_run=True` to validate IAM permissions, data paths, hyperparameters, infrastructure without submitting a job."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dry-run-validate",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Validate configuration without launching a training job\n",
+    "rlvr_trainer.train(dry_run=True)\n",
+    "print(\"Dry-run passed \u2014 configuration is valid.\")"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "1f3f65a7-8ba6-4aa1-b6ea-606ddb2068c0",
@@ -441,7 +463,7 @@
     "2. Check if an Evaluator with that name already exists and points to the same Lambda (reuses it if so)\n",
     "3. Otherwise, create a new Evaluator in the AI Registry and use its ARN\n",
     "\n",
-    "This simplifies the workflow — no need to manually create an Evaluator object first."
+    "This simplifies the workflow \u2014 no need to manually create an Evaluator object first."
    ]
   },
   {
@@ -585,7 +607,7 @@
   {
    "cell_type": "markdown",
    "id": "381f8be1",
-   "source": "## Iterative Training (Resume from Checkpoint)\n\nResume RLVR training from a previously trained model package. Pass the model package directly — the service uses `SourceModelPackageArn` to resume from that checkpoint.",
+   "source": "## Iterative Training (Resume from Checkpoint)\n\nResume RLVR training from a previously trained model package. Pass the model package directly \u2014 the service uses `SourceModelPackageArn` to resume from that checkpoint.",
    "metadata": {}
   },
   {

--- a/v3-examples/model-customization-examples/sft_finetuning_example_notebook_pysdk_prod_v3.ipynb
+++ b/v3-examples/model-customization-examples/sft_finetuning_example_notebook_pysdk_prod_v3.ipynb
@@ -219,6 +219,28 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "dry-run-explanation",
+   "metadata": {},
+   "source": [
+    "### Dry Run (Validation Only)\n",
+    "\n",
+    "Use `dry_run=True` to validate IAM permissions, data paths, hyperparameters, infrastructure without submitting a job."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dry-run-validate",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Validate configuration without launching a training job\n",
+    "sft_trainer.train(dry_run=True)\n",
+    "print(\"Dry-run passed \u2014 configuration is valid.\")"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "4d3b6441-9abb-447b-9307-9606a8c0fabd",

--- a/v3-examples/model-customization-examples/sft_finetuning_example_notebook_pysdk_prod_v3.ipynb
+++ b/v3-examples/model-customization-examples/sft_finetuning_example_notebook_pysdk_prod_v3.ipynb
@@ -237,7 +237,7 @@
    "source": [
     "# Validate configuration without launching a training job\n",
     "sft_trainer.train(dry_run=True)\n",
-    "print(\"Dry-run passed \u2014 configuration is valid.\")"
+    "print(\"Dry-run passed — configuration is valid.\")"
    ]
   },
   {


### PR DESCRIPTION
## Summary

Add `dry_run=True` parameter to all trainers (SFT, DPO, RLVR, RLAIF) and evaluators (BenchMark, CustomScorer, LLMAsJudge). When `dry_run=True`, all validation runs but no job is submitted and no compute is consumed.

## What it does

- All existing inline validation runs as normal (IAM role, hyperparameters, recipe constraints, model resolution)
- `validate_data_path_exists()` validates S3 URIs, DataSet ARNs, and DataSet objects unconditionally before submission
- `dry_run=True` short-circuits before the API call, returning `None`
- Raises with a clear error message on validation failure

## Changes

**Commit 1: `feat(train): add dry_run=True to train()`**
- `data_utils.py` — new `validate_data_path_exists()` (S3 via `list_objects_v2`, DataSet ARN via `describe_hub_content`)
- `base_trainer.py` — add `dry_run` to `train()`, `_train_serverful_smtj()`, `_train_hyperpod()`
- `sft/dpo/rlvr/rlaif_trainer.py` — add `dry_run`, validate data paths, short-circuit
- Trainer notebook examples (SFT, DPO, RLVR, RLAIF)
- Unit tests in existing test files
- Integration test (`test_dry_run_integration.py`)

**Commit 2: `feat(evaluate): add dry_run=True to evaluate()`**
- `base_evaluator.py` — add `dry_run` to `evaluate()` signature
- `benchmark/custom_scorer/llm_as_judge_evaluator.py` — add `dry_run`, validate dataset paths (custom scorer + LLM-as-judge), short-circuit before `_start_execution()`
- Evaluator notebook examples (benchmark, custom_scorer, llm_as_judge)

***Commit 3: `fix(dry_run): support DataSet objects, deduplicate ARN validation, expand coverage`***

Addresses PR review feedback:

- **DataSet object support**: `validate_data_path_exists()` now accepts `Union[str, DataSet]`. When a `DataSet` object is passed, it extracts `.arn` and validates the ARN exists via `describe_hub_content`.
- **Deduplicated ARN validation**: Removed inline ARN validation from `validate_data_path_exists()` and delegated to the existing `_validate_dataset_arn_exists()` helper.
- **Unified AccessDenied behavior**: `_validate_dataset_arn_exists()` now logs a warning on `AccessDenied` (same as the S3 path) instead of raising, since the execution role may still have access even if the caller identity does not.
- **Removed `isinstance(..., str)` guards**: All trainers (SFT, DPO, RLVR, RLAIF) and evaluators (CustomScorer, LLMAsJudge) now pass `DataSet` objects through to validation rather than skipping them.
- **CPTTrainer dry_run**: Added `dry_run: bool = False` parameter to `CPTTrainer.train()`, threaded through to `_train_hyperpod()`.
- **ModelTrainer dry_run**: Added `dry_run: bool = False` parameter to `ModelTrainer.train()`. When `True`, runs `_create_training_job_args()` (all validation/resolution) then returns `None` without submitting.
- **Integration test improvements**:
  - `valid_dataset` fixture checks if data exists before uploading (no teardown delete)
  - Added `nonexistent_dataset_s3`, `nonexistent_dataset_arn`, `nonexistent_dataset_obj` fixtures
  - Added tests validating failure with ARN strings and DataSet objects
  - Added `TestDryRunServerful` class covering SFT, DPO, RLVR with `TrainingJobCompute`
- **Unit test additions**:
  - `test_dataset_object_extracts_arn` — validates DataSet object ARN is extracted and described
  - `test_dataset_object_not_found_raises` — validates ValueError on nonexistent DataSet ARN

## Testing

- Integration test uploads sample data to default bucket, validates S3 path failures, confirms `result is None`, verifies no job created via SageMaker API


*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
