### PR TITLE
feat: add sklearn 1.9-0 image URI config

### DIFF
--- a/sagemaker-core/src/sagemaker/core/image_uri_config/sklearn.json
+++ b/sagemaker-core/src/sagemaker/core/image_uri_config/sklearn.json
@@ -240,6 +240,54 @@
                     "us-west-2": "246618743249"
                 },
                 "repository": "sagemaker-scikit-learn"
+            },
+            "1.9-0": {
+                "processors": [
+                    "cpu"
+                ],
+                "py_versions": [
+                    "py3"
+                ],
+                "registries": {
+                    "af-south-1": "510948584623",
+                    "ap-east-1": "651117190479",
+                    "ap-northeast-1": "354813040037",
+                    "ap-northeast-2": "366743142698",
+                    "ap-northeast-3": "867004704886",
+                    "ap-south-1": "720646828776",
+                    "ap-south-2": "628508329040",
+                    "ap-southeast-1": "121021644041",
+                    "ap-southeast-2": "783357654285",
+                    "ap-southeast-3": "951798379941",
+                    "ap-southeast-4": "106583098589",
+                    "ca-central-1": "341280168497",
+                    "ca-west-1": "190319476487",
+                    "cn-north-1": "450853457545",
+                    "cn-northwest-1": "451049120500",
+                    "eu-central-1": "492215442770",
+                    "eu-central-2": "680994064768",
+                    "eu-north-1": "662702820516",
+                    "eu-south-1": "978288397137",
+                    "eu-south-2": "104374241257",
+                    "eu-west-1": "141502667606",
+                    "eu-west-2": "764974769150",
+                    "eu-west-3": "659782779980",
+                    "il-central-1": "898809789911",
+                    "me-central-1": "272398656194",
+                    "me-south-1": "801668240914",
+                    "sa-east-1": "737474898029",
+                    "us-east-1": "683313688378",
+                    "us-east-2": "257758044811",
+                    "us-gov-east-1": "237065988967",
+                    "us-gov-west-1": "414596584902",
+                    "us-iso-east-1": "833128469047",
+                    "us-isob-east-1": "281123927165",
+                    "us-isof-east-1": "108575199400",
+                    "us-isof-south-1": "124985052026",
+                    "us-west-1": "746614075791",
+                    "us-west-2": "246618743249"
+                },
+                "repository": "sagemaker-scikit-learn"
             }
         }
     },
@@ -486,6 +534,54 @@
                 "repository": "sagemaker-scikit-learn"
             },
             "1.4-2-py312": {
+                "processors": [
+                    "cpu"
+                ],
+                "py_versions": [
+                    "py3"
+                ],
+                "registries": {
+                    "af-south-1": "510948584623",
+                    "ap-east-1": "651117190479",
+                    "ap-northeast-1": "354813040037",
+                    "ap-northeast-2": "366743142698",
+                    "ap-northeast-3": "867004704886",
+                    "ap-south-1": "720646828776",
+                    "ap-south-2": "628508329040",
+                    "ap-southeast-1": "121021644041",
+                    "ap-southeast-2": "783357654285",
+                    "ap-southeast-3": "951798379941",
+                    "ap-southeast-4": "106583098589",
+                    "ca-central-1": "341280168497",
+                    "ca-west-1": "190319476487",
+                    "cn-north-1": "450853457545",
+                    "cn-northwest-1": "451049120500",
+                    "eu-central-1": "492215442770",
+                    "eu-central-2": "680994064768",
+                    "eu-north-1": "662702820516",
+                    "eu-south-1": "978288397137",
+                    "eu-south-2": "104374241257",
+                    "eu-west-1": "141502667606",
+                    "eu-west-2": "764974769150",
+                    "eu-west-3": "659782779980",
+                    "il-central-1": "898809789911",
+                    "me-central-1": "272398656194",
+                    "me-south-1": "801668240914",
+                    "sa-east-1": "737474898029",
+                    "us-east-1": "683313688378",
+                    "us-east-2": "257758044811",
+                    "us-gov-east-1": "237065988967",
+                    "us-gov-west-1": "414596584902",
+                    "us-iso-east-1": "833128469047",
+                    "us-isob-east-1": "281123927165",
+                    "us-isof-east-1": "108575199400",
+                    "us-isof-south-1": "124985052026",
+                    "us-west-1": "746614075791",
+                    "us-west-2": "246618743249"
+                },
+                "repository": "sagemaker-scikit-learn"
+            },
+            "1.9-0": {
                 "processors": [
                     "cpu"
                 ],


### PR DESCRIPTION
Add scikit-learn 1.9-0 image URI configuration for inference and training.

Image: `246618743249.dkr.ecr.us-west-2.amazonaws.com/sagemaker-scikit-learn:1.9-0-cpu-py3`
Tags: `1.9-0-cpu-py3`, `1.9-0-1.0.0.0`, `1.9-0`

Same registry map as existing sklearn entries (1.4-2-py312).