### PR TITLE
fix: resolve MTRL eval base-model ARN against the configured hub (not always SageMakerPublicHub)

### DIFF
--- a/sagemaker-train/src/sagemaker/train/common_utils/model_resolution.py
+++ b/sagemaker-train/src/sagemaker/train/common_utils/model_resolution.py
@@ -357,12 +357,20 @@ class _ModelResolver:
                 model_pkg_arn = getattr(model_package, 'model_package_arn', None)
                 
                 if hub_content_name and hub_content_version and model_pkg_arn:
-                    # Extract region from model package ARN
+                    # Extract region and account from model package ARN
                     arn_parts = model_pkg_arn.split(':')
-                    if len(arn_parts) >= 4:
+                    if len(arn_parts) >= 5:
                         region = arn_parts[3]
-                        # Base model always lives in SageMakerPublicHub (SAGEMAKER_HUB_NAME is for training recipes only)
-                        base_model_arn = f"arn:aws:sagemaker:{region}:aws:hub-content/SageMakerPublicHub/Model/{hub_content_name}/{hub_content_version}"
+                        account = arn_parts[4]
+                        # Reconstruct the base-model hub-content ARN in the hub the
+                        # model was customized against. Defaults to SageMakerPublicHub
+                        # but honors SAGEMAKER_HUB_NAME so private/custom hubs (e.g. an
+                        # integ-test hub) resolve correctly. Public-hub content is
+                        # account-less ("aws"); private-hub content lives under the
+                        # model package's own account.
+                        hub_name = get_sagemaker_hub_name()
+                        hub_account = "aws" if hub_name == "SageMakerPublicHub" else account
+                        base_model_arn = f"arn:aws:sagemaker:{region}:{hub_account}:hub-content/{hub_name}/Model/{hub_content_name}/{hub_content_version}"
         
         # If we couldn't extract or construct base model ARN, this is not a supported model package
         if not base_model_arn:

--- a/sagemaker-train/tests/unit/train/common_utils/test_model_resolution.py
+++ b/sagemaker-train/tests/unit/train/common_utils/test_model_resolution.py
@@ -401,38 +401,83 @@ class TestResolveModelPackageArn:
     @patch('sagemaker.train.common_utils.model_resolution._ModelResolver._get_session')
     @patch('sagemaker.train.common_utils.model_resolution._ModelResolver._validate_model_package_arn')
     def test_resolve_arn_construct_hub_content_arn(self, mock_validate, mock_get_session, mock_model_package_class):
-        """Test ARN resolution when HubContentArn needs to be constructed."""
+        """Test ARN resolution when HubContentArn needs to be constructed.
+
+        With no SAGEMAKER_HUB_NAME override, the base model is assumed to live
+        in the account-less SageMakerPublicHub.
+        """
         arn = "arn:aws:sagemaker:us-west-2:123456789012:model-package/my-model/1"
-        
+
         # Mock session
         mock_session = MagicMock()
         mock_session.boto_session.region_name = 'us-west-2'
         mock_get_session.return_value = mock_session
-        
+
         # Mock ModelPackage without hub_content_arn (needs to be constructed)
         mock_package = MagicMock()
         mock_package.model_package_arn = arn
-        
+
         mock_container = MagicMock()
         mock_base_model = MagicMock()
         mock_base_model.hub_content_name = 'base-model'
         mock_base_model.hub_content_version = '1.0'
         mock_base_model.hub_content_arn = None  # Not provided, needs construction
         mock_container.base_model = mock_base_model
-        
+
         mock_package.inference_specification = MagicMock()
         mock_package.inference_specification.containers = [mock_container]
-        
+
         mock_model_package_class.get.return_value = mock_package
-        
+
         resolver = _ModelResolver()
-        result = resolver._resolve_model_package_arn(arn)
-        
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("SAGEMAKER_HUB_NAME", None)
+            result = resolver._resolve_model_package_arn(arn)
+
         # Should construct ARN from region and hub content name/version
         expected_arn = "arn:aws:sagemaker:us-west-2:aws:hub-content/SageMakerPublicHub/Model/base-model/1.0"
         assert result.base_model_arn == expected_arn
         assert result.base_model_name == "base-model"
         assert result.hub_content_name == "base-model"
+
+    @patch('sagemaker.core.resources.ModelPackage')
+    @patch('sagemaker.train.common_utils.model_resolution._ModelResolver._get_session')
+    @patch('sagemaker.train.common_utils.model_resolution._ModelResolver._validate_model_package_arn')
+    def test_resolve_arn_construct_hub_content_arn_private_hub(self, mock_validate, mock_get_session, mock_model_package_class):
+        """When SAGEMAKER_HUB_NAME points at a private hub, the reconstructed
+        base-model ARN targets that hub under the model package's own account
+        (not the account-less public hub)."""
+        arn = "arn:aws:sagemaker:us-west-2:123456789012:model-package/my-model/1"
+
+        mock_session = MagicMock()
+        mock_session.boto_session.region_name = 'us-west-2'
+        mock_get_session.return_value = mock_session
+
+        # Mock ModelPackage without hub_content_arn (needs to be constructed)
+        mock_package = MagicMock()
+        mock_package.model_package_arn = arn
+
+        mock_container = MagicMock()
+        mock_base_model = MagicMock()
+        mock_base_model.hub_content_name = 'mock-oss-test'
+        mock_base_model.hub_content_version = '0.0.1'
+        mock_base_model.hub_content_arn = None  # Not provided, needs construction
+        mock_container.base_model = mock_base_model
+
+        mock_package.inference_specification = MagicMock()
+        mock_package.inference_specification.containers = [mock_container]
+
+        mock_model_package_class.get.return_value = mock_package
+
+        resolver = _ModelResolver()
+        with patch.dict(os.environ, {"SAGEMAKER_HUB_NAME": "sdktest"}):
+            result = resolver._resolve_model_package_arn(arn)
+
+        # Private hub: uses the model package's account (123456789012), not "aws"
+        expected_arn = "arn:aws:sagemaker:us-west-2:123456789012:hub-content/sdktest/Model/mock-oss-test/0.0.1"
+        assert result.base_model_arn == expected_arn
+        assert result.base_model_name == "mock-oss-test"
+        assert result.hub_content_name == "mock-oss-test"
     
     @patch('sagemaker.core.resources.ModelPackage')
     @patch('sagemaker.train.common_utils.model_resolution._ModelResolver._get_session')


### PR DESCRIPTION
## Issue

MTRL evaluation of a fine-tuned model via `MultiTurnRLTrainer.attach(...)` (or a `ModelPackage`) fails server-side inside the evaluation pipeline:

```
StepDetail(name='EvaluateFineTunedModel', status='Failed',
  failure_reason="ClientError: Failed to invoke sagemaker:CreateJob.
  Error Details: ResourceNotFound: Hub content with name mock-oss-test does not exist.")
```

## Root cause

When the base model is resolved from a model package, its hub-content ARN is reconstructed from the package's `BaseModel` metadata. The backend populates only `HubContentName` + `HubContentVersion` (no `HubContentArn`), so the SDK rebuilds the ARN in `_resolve_model_package_object` — and that reconstruction was **hardcoded** to `SageMakerPublicHub` with an account-less (`aws`) owner:

```python
# Base model always lives in SageMakerPublicHub (SAGEMAKER_HUB_NAME is for training recipes only)
base_model_arn = f"arn:aws:sagemaker:{region}:aws:hub-content/SageMakerPublicHub/Model/{name}/{version}"
```

For a model customized against a **private/custom hub** (`SAGEMAKER_HUB_NAME`), this yields a public-hub ARN that doesn't exist, and the eval pipeline's `CreateJob` fails with `ResourceNotFound`.

The bare-string / JumpStart-ID path does **not** have this bug — it already resolves via `_resolve_jumpstart_model(..., get_sagemaker_hub_name())`, which honors `SAGEMAKER_HUB_NAME`. Only the model-package / attached-job path ignored it.

This affects any customer who fine-tunes an MTRL model whose base model lives in a private/custom hub and then evaluates it via `attach()` or a `ModelPackage` — not just integration tests.

## Fix

In `_resolve_model_package_object`, reconstruct the base-model ARN in the hub the model was actually customized against:

- Use `get_sagemaker_hub_name()` (honors `SAGEMAKER_HUB_NAME`, still defaults to `SageMakerPublicHub`) instead of a hardcoded string.
- Use the correct ARN owner: account-less `aws` for the public hub, the model package's own account for a private hub.

## Verification

- Reproduced against a live account: resolver now yields
  `arn:aws:sagemaker:us-west-2:<acct>:hub-content/sdktest/Model/mock-oss-test/0.0.1`,
  and `describe-hub-content` confirms that ARN is `Available` — so the pipeline's `CreateJob` finds the base model.
- Unit tests: `tests/unit/train/common_utils/test_model_resolution.py` — 38 passed.
  - Added `test_resolve_arn_construct_hub_content_arn_private_hub` (private-hub case).
  - Pinned the existing `test_resolve_arn_construct_hub_content_arn` to the default public hub.

## Notes

- This unblocks the `gpu_intensive` nightly integ test `test_evaluate_with_attached_trainer`, which currently fails because `mock-oss-test` lives only in the private `sdktest` hub.
- A complementary backend improvement (populate `HubContentArn` in the model package `BaseModel` block at registration time) would let the SDK skip reconstruction entirely — the SDK already prefers `hub_content_arn` when present. That is out of scope for this SDK change.