### PR TITLE
fix(examples): correct ai_registry_example CRUD ordering and versions…

### DIFF
--- a/v3-examples/model-customization-examples/ai_registry_example.ipynb
+++ b/v3-examples/model-customization-examples/ai_registry_example.ipynb
@@ -90,32 +90,7 @@
    "outputs": [],
    "source": [
     "versions = dataset.get_versions()\n",
-    "pprint(versions.__dict__)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "332be046d91fcefc",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# delete specific version\n",
-    "dataset.delete(version=\"0.0.4\")\n",
-    "#dataset.delete(version=\"use a version from versions\")\n",
-    "#pprint(versions)\n",
-    "# specified deleted version should not be part of output"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "510d1a015e7a565c",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# deletes all versions of this dataset by default\n",
-    "dataset.delete()"
+    "pprint(versions)"
    ]
   },
   {
@@ -195,6 +170,31 @@
    "source": [
     "versions = dataset.get_versions()\n",
     "pprint(versions)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "332be046d91fcefc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# delete specific version\n",
+    "dataset.delete(version=\"0.0.4\")\n",
+    "#dataset.delete(version=\"use a version from versions\")\n",
+    "#pprint(versions)\n",
+    "# specified deleted version should not be part of output"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "510d1a015e7a565c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# deletes all versions of this dataset by default\n",
+    "dataset.delete()"
    ]
   },
   {


### PR DESCRIPTION
… print

Two issues made v3-examples/model-customization-examples/ai_registry_example.ipynb fail when run top to bottom:

1. `pprint(versions.__dict__)` raised `AttributeError: 'list' object has no attribute '__dict__'` because DataSet.get_versions() returns a list (List[DataSet]). Changed to `pprint(versions)`, matching the other get_versions cells in the same notebook.

2. The "delete specific version" and "delete all versions" cells ran in the middle of the DataSet section, deleting the `sdkv3-gen-ds2` dataset before the later "Use a dataset by name" (DataSet.get) and create_version cells, which then failed with ResourceNotFound. Moved both delete cells to the end of the DataSet section so the read/versioning demos run against the live dataset and cleanup happens last.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
