### PR TITLE
fix: post Codecov results as GitHub Checks, not only commit statuses

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -36,6 +36,16 @@ coverage:
         target: 70%
         threshold: 1%
 
+# Post coverage results as GitHub Checks (visible on the PR "Checks" tab), not only
+# as legacy commit statuses. Checks are Codecov's default, but making it explicit
+# documents the intent and re-enables line annotations once the Codecov GitHub App
+# has "Checks: read & write" permission on the repo. NOTE: this yaml alone is not
+# sufficient — if Codecov posts only commit statuses (visible under the PR
+# "Conversation" merge box but NOT the "Checks" tab), the Codecov GitHub App has lost
+# its Checks permission and an org/repo admin must re-authorize it.
+github_checks:
+  annotations: true
+
 comment:
   layout: "header, diff, flags, components"
   require_changes: true


### PR DESCRIPTION
## Issue

Codecov coverage results are no longer visible on the PR **Checks** tab. Since early July 2026 Codecov posts only **legacy commit statuses** (`codecov/project`, `codecov/patch`) for this repo — these render under the PR **Conversation** merge box ("Show all checks") but **not** on `/checks`.

Verified via the GitHub API across PRs:

| PR | Created | Codecov check-runs | Codecov commit statuses |
|---|---|--:|--:|
| #5969 | Jun 26 | **2** (on /checks) | 0 |
| #6004 | Jul 08 | 0 | 6 |
| #6041 | Jul 17 | 0 | 5 |

The switch happened between late June and early July and affects **every** PR — including ones carrying no `codecov.yml` at all.

## Root cause

GitHub Checks are Codecov's **default** behavior (no yaml required), so the fact that config-less PRs also lost them indicates the regression is at the **GitHub App integration level** — the Codecov GitHub App losing its **"Checks: read & write"** permission on the repo (e.g. an app reinstall or a GitHub-required permission update that was never re-accepted). When Codecov cannot write Checks, it silently falls back to commit statuses.

## Fix (two parts)

**1. This PR (documents intent + re-enables annotations):** adds
```yaml
github_checks:
  annotations: true
```
Checks are already the default, so this is explicit-intent + re-enables line annotations once the app permission is restored. The `patch` status (required for checks to appear) is already configured.

**2. Required admin action (not in this PR):** an org/repo admin must re-authorize the Codecov GitHub App so it regains Checks permission:
- **GitHub → `aws` org → Settings → GitHub Apps → Codecov → Configure** — accept any pending permission request / ensure **Checks: Read & write** is granted for `sagemaker-python-sdk`, **or**
- reconnect the integration from the **Codecov dashboard** (app.codecov.io → repo → Settings).

This yaml change alone will **not** move results back to the Checks tab without step 2.

## Testing

- `python -c "import yaml; yaml.safe_load(open('codecov.yml'))"` → parses.
- Codecov config validator (`curl --data-binary @codecov.yml https://codecov.io/validate`) → `Valid!`.