### PR TITLE
fix(examples): correct recipe-override precedence asserts in SFT notebook

### DIFF
--- a/v3-examples/model-customization-examples/recipe_override_sft_trainer_example.ipynb
+++ b/v3-examples/model-customization-examples/recipe_override_sft_trainer_example.ipynb
@@ -154,7 +154,7 @@
     "    overrides={\n",
     "        \"training_config\": {\n",
     "            \"learning_rate\": 5e-6,   # Override: lower learning rate\n",
-    "            \"num_epochs\": 5          # Override: more epochs\n",
+    "            \"max_steps\": 20          # Override: more steps\n",
     "        }\n",
     "    }\n",
     ")\n",
@@ -373,7 +373,7 @@
     "| Parameter | Recipe File | Override | Resolved (Used) | Source |\n",
     "|-----------|------------|----------|-----------------|--------|\n",
     "| `learning_rate` | 1e-5 | 5e-6 | **5e-6** | Override wins |\n",
-    "| `num_epochs` | 3 | 5 | **5** | Override wins |\n",
+    "| `max_steps` | 10 (default) | 20 | **20** | Override wins |\n",
     "| `batch_size` | 8 | (not set) | **8** | Recipe file |\n",
     "| `sequence_length` | 2048 | (not set) | **2048** | Recipe file |"
    ],
@@ -398,8 +398,8 @@
     "    print(f\"  {key}: {value}\")\n",
     "\n",
     "# Overrides win over recipe file values\n",
-    "assert training_config[\"learning_rate\"] == 5e-6, \"Override should win\"\n",
-    "assert training_config[\"num_epochs\"] == 5, \"Override should win\"\n",
+    "assert training_config[\"optim_config\"][\"lr\"] == 5e-6, \"Override should win\"\n",
+    "assert training_config[\"max_steps\"] == 20, \"Override should win\"\n",
     "\n",
     "print(\"\\nAll precedence checks passed!\")"
    ],


### PR DESCRIPTION
recipe_override_sft_trainer_example asserted on training_config["learning_rate"] and training_config["num_epochs"], but the resolved Nova recipe exposes neither key, so the notebook fails with KeyError: 'learning_rate'.

- The "learning_rate" override is applied under training_config.optim_config.lr (that value is correctly 5e-6), not a top-level training_config.learning_rate.
- "num_epochs" is not a Nova recipe key at all — Nova SFT is step-based (max_steps), so the recipe resolver drops the num_epochs override with a warning ("Override key 'training_config.num_epochs' ... will be dropped").

Assert on training_config["optim_config"]["lr"] and drop the invalid num_epochs assertion. Verified by executing the notebook end to end (training job Completed).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
