### PR TITLE
fix(examples): show LLM-as-judge results for Nova (InspectAI-routed) evaluations

### DIFF
--- a/sagemaker-train/src/sagemaker/train/common_utils/show_results_utils.py
+++ b/sagemaker-train/src/sagemaker/train/common_utils/show_results_utils.py
@@ -677,6 +677,11 @@ def _show_llmaj_results(
         pipeline_execution, "EvaluateBaseModelMetrics"
     )
 
+    if not custom_job_name and not base_job_name:
+        custom_job_name = _extract_training_job_name_from_steps(
+            pipeline_execution, "EvaluateWithJudge"
+        )
+
     # Handle single-model evaluation scenarios
     if not custom_job_name and not base_job_name:
         raise ValueError(


### PR DESCRIPTION
LLMAsJudgeEvaluator.show_results() raised '[PySDK Error] Could not extract training job name from pipeline steps' for Nova models even when the evaluation pipeline succeeded. Nova models auto-route to an InspectAI + Bedrock evaluation whose pipeline emits an 'EvaluateWithJudge' step rather than EvaluateCustomModelMetrics / EvaluateBaseModelMetrics, so _show_llmaj_results extracted neither a custom nor base job name and raised.

Fall back to the 'EvaluateWithJudge' step when neither standard step is present; that step's training job holds the judge results (.../EvaluateWithJudge-*/output/output/.../bedrock_llm_judge_results.json).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
