### PR TITLE
[DO NOT MERGE] test: verify Codecov config takes effect

### DIFF
--- a/sagemaker-mlops/src/sagemaker/mlops/__init__.py
+++ b/sagemaker-mlops/src/sagemaker/mlops/__init__.py
@@ -15,6 +15,10 @@ Key components:
 Example usage:
     from sagemaker.mlops import ModelBuilder
     from sagemaker.mlops.workflow import Pipeline, TrainingStep
+
+Note:
+    No-op docstring line added only to trigger CI for a Codecov config
+    verification (DO NOT MERGE).
 """
 from __future__ import absolute_import
 


### PR DESCRIPTION
## ⚠️ DO NOT MERGE — verification PR

This PR exists only to confirm that the merged `codecov.yml` (PR #6034) actually takes effect on a PR whose branch contains it. It makes a **no-op docstring-only change** in `sagemaker.mlops` to force a unit-test coverage upload so Codecov recomputes.

Recent PRs (#6041, #6051) still show the old ~90% test-inflated number because their branches were cut before `codecov.yml` merged and don't contain it. This branch is cut from **current master** (which has `codecov.yml`), so Codecov should now:

- **Exclude test files** via the `ignore:` list (previously ~98% of measured files were test files).
- Report **product-only project coverage (~71%)**, not the old ~90%.
- Apply the **project floor 65% / patch 70%** status targets.

Expected: `codecov/project` and `codecov/patch` reflect the corrected, product-only numbers.

Will be closed without merging once verified.