### PR TITLE
[DO NOT MERGE] test: verify Codecov config takes effect (same-repo)

### DIFF
--- a/sagemaker-mlops/src/sagemaker/mlops/__init__.py
+++ b/sagemaker-mlops/src/sagemaker/mlops/__init__.py
@@ -15,6 +15,10 @@ Key components:
 Example usage:
     from sagemaker.mlops import ModelBuilder
     from sagemaker.mlops.workflow import Pipeline, TrainingStep
+
+Note:
+    No-op docstring line added only to trigger CI for a Codecov config
+    verification (DO NOT MERGE).
 """
 from __future__ import absolute_import
 


### PR DESCRIPTION
## ⚠️ DO NOT MERGE — verification PR

Confirms the merged `codecov.yml` (PR #6034) takes effect. Makes a **no-op docstring-only change** in `sagemaker.mlops` to force a unit-test coverage upload so Codecov recomputes.

**Why same-repo (not a fork):** the earlier fork-based attempt (#6054) uploaded coverage but Codecov errored it (`state=error, sessions=0`) because the CodeBuild uploader gets no PR/branch context for fork PRs (`pr=false`, empty branch). Same-repo branches upload with full context (verified: #6051 processed cleanly with `sessions=4`), so Codecov will actually process and post here.

This branch is cut from **current master** (which contains `codecov.yml`). Expected result:
- test files **excluded** via `ignore:` (previously ~98% of measured files were test files)
- **project ~71%** product-only, not the old ~90%
- status targets **project 65% / patch 70%**

Will be closed without merging once verified.