### PR TITLE
[DO NOT MERGE] test: verify Codecov across all 4 submodules

### DIFF
--- a/sagemaker-core/src/sagemaker/core/__init__.py
+++ b/sagemaker-core/src/sagemaker/core/__init__.py
@@ -30,3 +30,4 @@ from sagemaker.core.telemetry.attribution import Attribution, set_attribution  #
 
 # Note: HyperparameterTuner and WarmStartTypes are in sagemaker.train.tuner
 # They are not re-exported from core to avoid circular dependencies
+# No-op line to trigger CI for a Codecov config verification (DO NOT MERGE).

--- a/sagemaker-mlops/src/sagemaker/mlops/__init__.py
+++ b/sagemaker-mlops/src/sagemaker/mlops/__init__.py
@@ -31,3 +31,4 @@ __all__ = [
     "ModelBuilder",
     "workflow",  # Submodule
 ]
+# No-op line to trigger CI for a Codecov config verification (DO NOT MERGE).

--- a/sagemaker-serve/src/sagemaker/serve/__init__.py
+++ b/sagemaker-serve/src/sagemaker/serve/__init__.py
@@ -57,3 +57,4 @@ __all__ = [
     "WorkloadValidationError",
     "start_benchmark",
 ]
+# No-op line to trigger CI for a Codecov config verification (DO NOT MERGE).

--- a/sagemaker-train/src/sagemaker/train/__init__.py
+++ b/sagemaker-train/src/sagemaker/train/__init__.py
@@ -120,3 +120,4 @@ def __getattr__(name):
         from sagemaker.core.training.configs import HyperPodCompute
         return HyperPodCompute
     raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
+# No-op line to trigger CI for a Codecov config verification (DO NOT MERGE).


### PR DESCRIPTION
## ⚠️ DO NOT MERGE — verification PR

Appends a **no-op comment** to each of the four submodule `__init__.py` files (core / train / serve / mlops) so **all four unit-test jobs run and upload coverage**.

### Why all 4
The merged `codecov.yml` currently has `after_n_builds: 4` (fix in flight: #6056). Codecov waits for 4 uploads before finalizing, so single-submodule PRs never get a report (seen on #6055: `state=error, sessions=0`). Touching all four submodules produces 4 uploads, letting the report finalize **even under the current config**.

### What this verifies
With master's `codecov.yml` applied, once all 4 uploads land Codecov should show:
- test files **excluded** via the `ignore:` list (previously ~98% of measured files were test files)
- **project ~71%** product-only, not the old test-inflated ~90%
- status targets **project 65% / patch 70%**

Note: the CI buildspec still runs `--cov=.` (the `--cov=sagemaker` change is a separate internal CR), so this validates the **server-side `ignore:` layer**. If coverage lands near ~71% with 0 test files, the `ignore:` layer is sufficient on its own.

Same-repo branch (fork PRs upload without PR context and error — see closed #6054). Will be closed without merging once verified.