### PR TITLE
fix(examples): add missing json/re imports in DPO notebook pretty_print

### DIFF
--- a/v3-examples/model-customization-examples/dpo_trainer_example_notebook_v3_prod.ipynb
+++ b/v3-examples/model-customization-examples/dpo_trainer_example_notebook_v3_prod.ipynb
@@ -200,6 +200,8 @@
    },
    "outputs": [],
    "source": [
+    "import json\n",
+    "import re\n",
     "from pprint import pprint\n",
     "from sagemaker.core.utils.utils import Unassigned\n",
     "\n",


### PR DESCRIPTION
dpo_trainer_example_notebook_v3_prod defines a pretty_print helper that calls json.dumps() and re.findall(), but the cell imports neither json nor re -- they are only imported in a later cell. So the first pretty_print(training_job) call fails with NameError: name 'json' is not defined.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
