### PR TITLE
docs: update model customization reference link in v3 examples

### DIFF
--- a/v3-examples/model-customization-examples/dpo_trainer_example_notebook_v3_prod.ipynb
+++ b/v3-examples/model-customization-examples/dpo_trainer_example_notebook_v3_prod.ipynb
@@ -123,7 +123,7 @@
    "source": [
     "#### Reference \n",
     "Refer this doc for other models that support Model Customization: \n",
-    "https://docs.aws.amazon.com/bedrock/latest/userguide/custom-model-supported.html"
+    "https://docs.aws.amazon.com/sagemaker/latest/dg/model-customize-open-weight.html"
    ]
   },
   {

--- a/v3-examples/model-customization-examples/rlaif_finetuning_example_notebook_v3_prod.ipynb
+++ b/v3-examples/model-customization-examples/rlaif_finetuning_example_notebook_v3_prod.ipynb
@@ -139,7 +139,7 @@
    "source": [
     "#### Reference \n",
     "Refer this doc for other models that support Model Customization: \n",
-    "https://docs.aws.amazon.com/bedrock/latest/userguide/custom-model-supported.html\n",
+    "https://docs.aws.amazon.com/sagemaker/latest/dg/model-customize-open-weight.html\n",
     "\n",
     "Refer this for supported reward models: \n",
     "https://github.com/aws/sagemaker-python-sdk/blob/master/sagemaker-train/src/sagemaker/train/constants.py#L46"

--- a/v3-examples/model-customization-examples/rlvr_finetuning_example_notebook_v3_prod.ipynb
+++ b/v3-examples/model-customization-examples/rlvr_finetuning_example_notebook_v3_prod.ipynb
@@ -129,7 +129,7 @@
    "source": [
     "#### Reference \n",
     "Refer this doc for other models that support Model Customization: \n",
-    "https://docs.aws.amazon.com/bedrock/latest/userguide/custom-model-supported.html"
+    "https://docs.aws.amazon.com/sagemaker/latest/dg/model-customize-open-weight.html"
    ]
   },
   {

--- a/v3-examples/model-customization-examples/sft_finetuning_example_notebook_pysdk_prod_v3.ipynb
+++ b/v3-examples/model-customization-examples/sft_finetuning_example_notebook_pysdk_prod_v3.ipynb
@@ -151,7 +151,7 @@
    "source": [
     "#### Reference \n",
     "Refer this doc for other models that support Model Customization: \n",
-    "https://docs.aws.amazon.com/bedrock/latest/userguide/custom-model-supported.html"
+    "https://docs.aws.amazon.com/sagemaker/latest/dg/model-customize-open-weight.html"
    ]
   },
   {


### PR DESCRIPTION
## Summary

Updates the "other models that support Model Customization" reference link in the v3 model-customization example notebooks.

Model customization supported model reference now points to the SageMaker developer guide, which is the correct reference for these SageMaker v3 examples:
- `https://docs.aws.amazon.com/sagemaker/latest/dg/model-customize-open-weight.html`

## Files changed
- `docs/v3-examples/model-customization-examples/dpo_trainer_example_notebook_v3_prod.ipynb`
- `docs/v3-examples/model-customization-examples/rlaif_finetuning_example_notebook_v3_prod.ipynb`
- `docs/v3-examples/model-customization-examples/rlvr_finetuning_example_notebook_v3_prod.ipynb`
- `docs/v3-examples/model-customization-examples/sft_finetuning_example_notebook_pysdk_prod_v3.ipynb`

Each change is a single-line reference URL update inside the "#### Reference" markdown cell. No code or executable cells were modified.