### PR TITLE
fix(examples): resolve endpoint config name in e2e cleanup

### DIFF
--- a/v3-examples/inference-examples/train-inference-e2e-example.ipynb
+++ b/v3-examples/inference-examples/train-inference-e2e-example.ipynb
@@ -352,7 +352,9 @@
    "outputs": [],
    "source": [
     "# Clean up resources\n",
-    "core_endpoint_config = EndpointConfig.get(endpoint_config_name=core_endpoint.endpoint_name)\n",
+    "from sagemaker.core.resources import Endpoint\n",
+    "_endpoint = Endpoint.get(endpoint_name=core_endpoint.endpoint_name)\n",
+    "core_endpoint_config = EndpointConfig.get(endpoint_config_name=_endpoint.endpoint_config_name)\n",
     "\n",
     "# Delete in the correct order\n",
     "core_model.delete()\n",


### PR DESCRIPTION
The train-inference-e2e-example cleanup cell looked up the endpoint configuration by the endpoint's name, but deploy() creates the config under an auto-generated name. DescribeEndpointConfig then failed with "Could not find endpoint configuration <endpoint-name>", aborting teardown and leaving the model, endpoint, and config behind.

Resolve the real config name from the endpoint before deleting.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
