### PR TITLE
[DO NOT MERGE] test: verify Codecov after --cov=sagemaker CR deploy

### DIFF
--- a/sagemaker-core/src/sagemaker/core/__init__.py
+++ b/sagemaker-core/src/sagemaker/core/__init__.py
@@ -30,3 +30,4 @@ from sagemaker.core.telemetry.attribution import Attribution, set_attribution  #
 
 # Note: HyperparameterTuner and WarmStartTypes are in sagemaker.train.tuner
 # They are not re-exported from core to avoid circular dependencies
+# No-op line to trigger CI for a Codecov verification (DO NOT MERGE).

--- a/sagemaker-mlops/src/sagemaker/mlops/__init__.py
+++ b/sagemaker-mlops/src/sagemaker/mlops/__init__.py
@@ -31,3 +31,4 @@ __all__ = [
     "ModelBuilder",
     "workflow",  # Submodule
 ]
+# No-op line to trigger CI for a Codecov verification (DO NOT MERGE).

--- a/sagemaker-serve/src/sagemaker/serve/__init__.py
+++ b/sagemaker-serve/src/sagemaker/serve/__init__.py
@@ -57,3 +57,4 @@ __all__ = [
     "WorkloadValidationError",
     "start_benchmark",
 ]
+# No-op line to trigger CI for a Codecov verification (DO NOT MERGE).

--- a/sagemaker-train/src/sagemaker/train/__init__.py
+++ b/sagemaker-train/src/sagemaker/train/__init__.py
@@ -120,3 +120,4 @@ def __getattr__(name):
         from sagemaker.core.training.configs import HyperPodCompute
         return HyperPodCompute
     raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
+# No-op line to trigger CI for a Codecov verification (DO NOT MERGE).


### PR DESCRIPTION
## ⚠️ DO NOT MERGE — verification PR

Re-verification after the CI buildspec CR (`--cov=.` → `--cov=sagemaker`) was deployed to prod. No-op comment in all 4 submodule `__init__.py` files so every unit-test job runs and uploads coverage.

### Goal
Confirm the deployed CR produces **product-only coverage** (~71%, test files excluded via the merged `codecov.yml` `ignore:`) instead of the old test-inflated ~90%.

### Known caveats (may still block a clean PR result)
- **`after_n_builds: 4`** is still on master (fix #6056 not yet merged). Uses 4 submodules to try to satisfy the count.
- **CodeBuild uploader** previously sent `branch=` empty, `pr=false`, and no per-submodule `-F` flag, which caused the earlier 4-module run (#6057) to collapse to `sessions=1, 3 files, 37%` and post no PR status. If the deploy did **not** also fix the uploader, coverage may still not attach to this PR — in that case check the commit report on codecov.io directly.

Will be closed without merging once we read the result.