### PR TITLE
ci: Split CI Health workflow into V2 and V3

### DIFF
--- a/.github/workflows/ci-health-v2.yml
+++ b/.github/workflows/ci-health-v2.yml
@@ -1,14 +1,15 @@
-name: CI Health
+name: CI Health V2
 on:
   schedule:
-    - cron: "0 */3 * * *"
+    # Once a day at 05:00 UTC (9pm PDT / 10pm PST).
+    - cron: "0 5 * * *"
   workflow_dispatch:
-    
+
 permissions:
     id-token: write # This is required for requesting the JWT
 
 jobs:
-  canaries-v3:
+  canaries-v2-master:
     runs-on: ubuntu-latest
     steps:
       - name: Configure AWS Credentials
@@ -17,12 +18,12 @@ jobs:
           role-to-assume: ${{ secrets.CI_AWS_ROLE_ARN }}
           aws-region: us-west-2
           role-duration-seconds: 10800
-      - name: Run Canaries V3
+      - name: Run Canaries V2 (master)
         uses: aws-actions/aws-codebuild-run-build@v1
         with:
-          project-name: sagemaker-python-sdk-ci-health-canaries-v3
-          source-version-override: refs/heads/master
-  canaries-v2:
+          project-name: sagemaker-python-sdk-ci-health-canaries-v2-master
+          source-version-override: refs/heads/master-v2
+  canaries-v2-release:
     runs-on: ubuntu-latest
     steps:
       - name: Configure AWS Credentials
@@ -31,10 +32,10 @@ jobs:
           role-to-assume: ${{ secrets.CI_AWS_ROLE_ARN }}
           aws-region: us-west-2
           role-duration-seconds: 10800
-      - name: Run Canaries V2
+      - name: Run Canaries V2 (release)
         uses: aws-actions/aws-codebuild-run-build@v1
         with:
-          project-name: sagemaker-python-sdk-ci-health-canaries-v2
+          project-name: sagemaker-python-sdk-ci-health-canaries-v2-release
           source-version-override: refs/heads/master-v2
   unit-tests-v2:
     runs-on: ubuntu-latest
@@ -86,25 +87,3 @@ jobs:
         with:
           project-name: sagemaker-python-sdk-ci-health-localmode-tests
           source-version-override: refs/heads/master-v2
-  unit-test-v3:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        submodule: [sagemaker-core, sagemaker-train, sagemaker-serve, sagemaker-mlops]
-    steps:
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.CI_AWS_ROLE_ARN }}
-          aws-region: us-west-2
-          role-duration-seconds: 10800
-      - name: Run Unit Tests V3 for ${{ matrix.submodule }}
-        uses: aws-actions/aws-codebuild-run-build@v1
-        with:
-          project-name: sagemaker-python-sdk-ci-health-unit-test-v3
-          source-version-override: refs/heads/master
-          env-vars-for-codebuild: |
-            SUBMODULE
-        env:
-          SUBMODULE: ${{ matrix.submodule }}

--- a/.github/workflows/ci-health-v3.yml
+++ b/.github/workflows/ci-health-v3.yml
@@ -1,0 +1,77 @@
+name: CI Health V3
+on:
+  schedule:
+    # Once a day at 05:00 UTC (9pm PDT / 10pm PST).
+    - cron: "0 5 * * *"
+  workflow_dispatch:
+
+permissions:
+    id-token: write # This is required for requesting the JWT
+
+jobs:
+  unit-test-v3:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        submodule: [sagemaker-core, sagemaker-train, sagemaker-serve, sagemaker-mlops]
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_AWS_ROLE_ARN }}
+          aws-region: us-west-2
+          role-duration-seconds: 10800
+      - name: Run Unit Tests V3 for ${{ matrix.submodule }}
+        uses: aws-actions/aws-codebuild-run-build@v1
+        with:
+          project-name: sagemaker-python-sdk-ci-health-unit-test-v3
+          source-version-override: refs/heads/master
+          env-vars-for-codebuild: |
+            SUBMODULE
+        env:
+          SUBMODULE: ${{ matrix.submodule }}
+  canaries-v3-master:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        submodule: [sagemaker-core, sagemaker-train, sagemaker-serve, sagemaker-mlops]
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_AWS_ROLE_ARN }}
+          aws-region: us-west-2
+          role-duration-seconds: 10800
+      - name: Run Canaries V3 master for ${{ matrix.submodule }}
+        uses: aws-actions/aws-codebuild-run-build@v1
+        with:
+          project-name: sagemaker-python-sdk-ci-health-canaries-v3-master
+          source-version-override: refs/heads/master
+          env-vars-for-codebuild: |
+            SUBMODULE
+        env:
+          SUBMODULE: ${{ matrix.submodule }}
+  canaries-v3-release:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        submodule: [sagemaker-core, sagemaker-train, sagemaker-serve, sagemaker-mlops]
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_AWS_ROLE_ARN }}
+          aws-region: us-west-2
+          role-duration-seconds: 10800
+      - name: Run Canaries V3 release for ${{ matrix.submodule }}
+        uses: aws-actions/aws-codebuild-run-build@v1
+        with:
+          project-name: sagemaker-python-sdk-ci-health-canaries-v3-release
+          source-version-override: refs/heads/master
+          env-vars-for-codebuild: |
+            SUBMODULE
+        env:
+          SUBMODULE: ${{ matrix.submodule }}

--- a/.github/workflows/gpu-integ-tests.yml
+++ b/.github/workflows/gpu-integ-tests.yml
@@ -1,12 +1,12 @@
 name: GPU Integ Tests
 on:
   schedule:
-    # US Pacific (PST, UTC-8): 10:00 PM / 1:00 AM / 4:00 AM -> 06/09/12 UTC.
+    # US Pacific (PST, UTC-8): 0:00 AM / 3:00 AM / 6:00 AM -> 08/11/14 UTC.
     # All three fire within the same UTC day so the run-level CloudWatch metric
     # (GpuIntegRunFailure) aggregates correctly per day.
-    - cron: "0 6 * * *"
-    - cron: "0 9 * * *"
-    - cron: "0 12 * * *"
+    - cron: "0 8 * * *"
+    - cron: "0 11 * * *"
+    - cron: "0 14 * * *"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Replace the single CI Health workflow with two independent workflows:
- ci-health-v2.yml: canaries-v2-master, canaries-v2-release, unit-tests-v2 (python-version matrix), slow-tests-v2, localmode-tests-v2.
- ci-health-v3.yml: unit-test-v3 and canaries-v3-master / canaries-v3-release, the latter two driven by a submodule matrix (SUBMODULE env var) so one CodeBuild project runs all four submodules in parallel.

Both workflows run once a day at 05:00 UTC (9pm PDT / 10pm PST) instead of every three hours, and keep workflow_dispatch for manual runs. The new canary jobs target the split CodeBuild projects created in SageMakerMLFPySDKInfraCDK.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
