### PR TITLE
feat(evaluate): add dry_run and caller IAM permission validation to a…

### DIFF
--- a/sagemaker-core/src/sagemaker/core/helper/iam_policies.py
+++ b/sagemaker-core/src/sagemaker/core/helper/iam_policies.py
@@ -794,3 +794,36 @@ IAM_POLICY_CONFIG = {
         },
     },
 }
+
+# Actions the *caller* must have to orchestrate Pipeline-based evaluations
+# directly. These actions must be held by whoever calls evaluator.evaluate(),
+# NOT by the job execution role (which is covered by role_type="training").
+# See verify_evaluation_caller_permissions() in iam_role_resolver.
+EVALUATION_CALLER_ACTIONS = (
+    # Pipeline orchestration
+    "sagemaker:CreatePipeline",
+    "sagemaker:UpdatePipeline",
+    "sagemaker:DescribePipeline",
+    "sagemaker:ListPipelines",
+    "sagemaker:StartPipelineExecution",
+    "sagemaker:DescribePipelineExecution",
+    "sagemaker:ListPipelineExecutionSteps",
+    "sagemaker:StopPipelineExecution",
+    "sagemaker:ListTags",
+    "sagemaker:AddTags",
+    "sagemaker:DescribeTrainingJob",
+    "iam:PassRole",
+    # Model resolution (DescribeHubContent called at construction time under caller creds)
+    "sagemaker:DescribeHubContent",
+    "sagemaker:ListHubContents",
+    "sagemaker:DescribeHub",
+    "sagemaker:ListHubs",
+    # Lineage (artifact creation/lookup runs under caller before pipeline starts)
+    "sagemaker:CreateArtifact",
+    "sagemaker:ListArtifacts",
+    "sagemaker:DescribeArtifact",
+    # S3 access (config/benchmark upload + output path validation)
+    "s3:PutObject",
+    "s3:GetObject",
+    "s3:ListBucket",
+)

--- a/sagemaker-core/src/sagemaker/core/helper/iam_role_resolver.py
+++ b/sagemaker-core/src/sagemaker/core/helper/iam_role_resolver.py
@@ -46,34 +46,7 @@ HYPERPOD_CLI_CONNECT_ACTIONS = (
 # directly. These actions must be held by whoever calls evaluator.evaluate(),
 # NOT by the job execution role (which is covered by role_type="training").
 # See verify_evaluation_caller_permissions().
-EVALUATION_CALLER_ACTIONS = (
-    # Pipeline orchestration
-    "sagemaker:CreatePipeline",
-    "sagemaker:UpdatePipeline",
-    "sagemaker:DescribePipeline",
-    "sagemaker:ListPipelines",
-    "sagemaker:StartPipelineExecution",
-    "sagemaker:DescribePipelineExecution",
-    "sagemaker:ListPipelineExecutionSteps",
-    "sagemaker:StopPipelineExecution",
-    "sagemaker:ListTags",
-    "sagemaker:AddTags",
-    "sagemaker:DescribeTrainingJob",
-    "iam:PassRole",
-    # Model resolution (DescribeHubContent called at construction time under caller creds)
-    "sagemaker:DescribeHubContent",
-    "sagemaker:ListHubContents",
-    "sagemaker:DescribeHub",
-    "sagemaker:ListHubs",
-    # Lineage (artifact creation/lookup runs under caller before pipeline starts)
-    "sagemaker:CreateArtifact",
-    "sagemaker:ListArtifacts",
-    "sagemaker:DescribeArtifact",
-    # S3 access (config/benchmark upload + output path validation)
-    "s3:PutObject",
-    "s3:GetObject",
-    "s3:ListBucket",
-)
+from sagemaker.core.helper.iam_policies import EVALUATION_CALLER_ACTIONS
 
 
 class RoleValidationError(Exception):

--- a/sagemaker-core/src/sagemaker/core/helper/iam_role_resolver.py
+++ b/sagemaker-core/src/sagemaker/core/helper/iam_role_resolver.py
@@ -42,6 +42,39 @@ HYPERPOD_CLI_CONNECT_ACTIONS = (
     "eks:AccessKubernetesApi",
 )
 
+# Actions the *caller* must have to orchestrate Pipeline-based evaluations
+# directly. These actions must be held by whoever calls evaluator.evaluate(),
+# NOT by the job execution role (which is covered by role_type="training").
+# See verify_evaluation_caller_permissions().
+EVALUATION_CALLER_ACTIONS = (
+    # Pipeline orchestration
+    "sagemaker:CreatePipeline",
+    "sagemaker:UpdatePipeline",
+    "sagemaker:DescribePipeline",
+    "sagemaker:ListPipelines",
+    "sagemaker:StartPipelineExecution",
+    "sagemaker:DescribePipelineExecution",
+    "sagemaker:ListPipelineExecutionSteps",
+    "sagemaker:StopPipelineExecution",
+    "sagemaker:ListTags",
+    "sagemaker:AddTags",
+    "sagemaker:DescribeTrainingJob",
+    "iam:PassRole",
+    # Model resolution (DescribeHubContent called at construction time under caller creds)
+    "sagemaker:DescribeHubContent",
+    "sagemaker:ListHubContents",
+    "sagemaker:DescribeHub",
+    "sagemaker:ListHubs",
+    # Lineage (artifact creation/lookup runs under caller before pipeline starts)
+    "sagemaker:CreateArtifact",
+    "sagemaker:ListArtifacts",
+    "sagemaker:DescribeArtifact",
+    # S3 access (config/benchmark upload + output path validation)
+    "s3:PutObject",
+    "s3:GetObject",
+    "s3:ListBucket",
+)
+
 
 class RoleValidationError(Exception):
     """Raised when the resolved IAM role lacks the permissions/trust an operation needs.
@@ -673,6 +706,81 @@ def verify_hyperpod_connect_permissions(
 
     logger.info(
         "Caller '%s' has the HyperPod CLI connect permissions.", caller_role_arn
+    )
+    return True
+
+
+def verify_evaluation_caller_permissions(
+    sagemaker_session=None,
+) -> Optional[bool]:
+    """Verify the caller can orchestrate SageMaker Pipeline-based evaluations.
+
+    The evaluate module submits work via SageMaker Pipelines — creating, updating,
+    starting, and describing pipelines and their executions. These actions run under
+    the *caller's* credentials (the notebook user, Lambda, or CI role), NOT under
+    the job execution role passed to the pipeline. This function simulates the
+    required pipeline-orchestration actions on the caller identity and raises
+    :class:`RoleValidationError` when they are missing.
+
+    Args:
+        sagemaker_session: SageMaker session (used to get the boto session).
+
+    Returns:
+        True  — all evaluation caller actions are allowed.
+        None  — could not be determined (caller is not a role, or cannot simulate).
+
+    Raises:
+        RoleValidationError: If permissions are definitively denied.
+    """
+    boto_session = _get_boto_session(sagemaker_session)
+    sts_client = boto_session.client("sts")
+    iam_client = boto_session.client("iam")
+
+    caller_identity = sts_client.get_caller_identity()
+    caller_arn = caller_identity["Arn"]
+    account_id = caller_identity["Account"]
+    partition = _partition_from_arn(caller_arn)
+
+    caller_role_arn = _resolve_caller_role_arn(iam_client, caller_arn, account_id, partition)
+    if not caller_role_arn:
+        logger.info(
+            "Could not resolve a caller role to verify evaluation pipeline "
+            "permissions; errors will surface at pipeline creation time."
+        )
+        return None
+
+    try:
+        denied = _simulate_denied_actions(
+            iam_client, caller_role_arn, list(EVALUATION_CALLER_ACTIONS)
+        )
+    except ClientError as e:
+        error_code = e.response.get("Error", {}).get("Code", "")
+        if error_code in ("AccessDenied", "AccessDeniedException"):
+            logger.info(
+                "Cannot simulate evaluation caller permissions for '%s' (access "
+                "denied to iam:SimulatePrincipalPolicy); errors will surface at "
+                "pipeline creation time.",
+                caller_role_arn,
+            )
+            return None
+        raise
+
+    if denied:
+        message = (
+            f"Your identity '{caller_role_arn}' is missing IAM permissions required "
+            f"to orchestrate SageMaker Pipeline-based evaluations: "
+            f"{', '.join(denied)}. "
+            f"The evaluation execution role was resolved successfully, but creating "
+            f"and starting the evaluation pipeline runs as YOUR credentials. "
+            f"Grant these actions to your identity (scoped to "
+            f"arn:{partition}:sagemaker:*:{account_id}:pipeline/*) or use the "
+            f"AmazonSageMakerFullAccess managed policy."
+        )
+        raise RoleValidationError(message)
+
+    logger.info(
+        "Caller '%s' has the evaluation pipeline orchestration permissions.",
+        caller_role_arn,
     )
     return True
 

--- a/sagemaker-train/src/sagemaker/train/evaluate/base_evaluator.py
+++ b/sagemaker-train/src/sagemaker/train/evaluate/base_evaluator.py
@@ -14,7 +14,10 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 from pydantic import BaseModel, validator
 
 from sagemaker.core.common_utils import TagsDict
-from sagemaker.core.helper.iam_role_resolver import resolve_and_validate_role
+from sagemaker.core.helper.iam_role_resolver import (
+    resolve_and_validate_role,
+    verify_evaluation_caller_permissions,
+)
 from sagemaker.core.resources import ModelPackageGroup, ModelPackage
 from sagemaker.core.shapes import VpcConfig
 from sagemaker.core.training.configs import Compute, HyperPodCompute
@@ -720,7 +723,13 @@ class BaseEvaluator(BaseModel):
     
     def _get_aws_execution_context(self) -> Dict[str, str]:
         """Get AWS execution context (role ARN, region, account ID).
-        
+
+        Validates both the *execution* role (what the pipeline assumes to run
+        training jobs) and the *caller* role (what your identity needs to
+        create/start the pipeline). The execution role is validated via
+        :func:`resolve_and_validate_role` with ``role_type="training"``. The
+        caller role is validated via :func:`verify_evaluation_caller_permissions`.
+
         Returns:
             dict: Dictionary containing:
                 - role_arn (str): IAM role ARN for execution
@@ -738,6 +747,15 @@ class BaseEvaluator(BaseModel):
         role_arn = resolve_and_validate_role(
             provided_role=self.role,
             role_type="training",
+            sagemaker_session=self.sagemaker_session,
+        )
+
+        # Verify the caller's own identity has the pipeline-orchestration
+        # permissions required to create/start evaluations. This is separate from
+        # the execution role validation above (which checks what the pipeline can
+        # do once running). Always raise on denial so the user gets a clear error
+        # before hitting an opaque AccessDenied from CreatePipeline.
+        verify_evaluation_caller_permissions(
             sagemaker_session=self.sagemaker_session,
         )
         

--- a/sagemaker-train/src/sagemaker/train/evaluate/benchmark_evaluator.py
+++ b/sagemaker-train/src/sagemaker/train/evaluate/benchmark_evaluator.py
@@ -669,6 +669,10 @@ class BenchMarkEvaluator(BaseEvaluator):
         
         # Get AWS execution context (role ARN, region, account ID)
         aws_context = self._get_aws_execution_context()
+
+        if dry_run:
+            _logger.info("Dry-run validation passed. No evaluation submitted.")
+            return None
         
         # Resolve model artifacts
         artifacts = self._resolve_model_artifacts(aws_context['region'])

--- a/sagemaker-train/src/sagemaker/train/evaluate/inspect_ai_evaluator.py
+++ b/sagemaker-train/src/sagemaker/train/evaluate/inspect_ai_evaluator.py
@@ -700,15 +700,23 @@ class InspectAIEvaluator(BaseEvaluator):
     @_telemetry_emitter(
         feature=Feature.MODEL_CUSTOMIZATION, func_name="InspectAIEvaluator.evaluate"
     )
-    def evaluate(self) -> EvaluationPipelineExecution:
+    def evaluate(self, dry_run: bool = False) -> Optional[EvaluationPipelineExecution]:
         """Create and start an InspectAI evaluation job.
 
         Serializes the InspectAI configuration to YAML, uploads it to S3, and
         launches a single-step SageMaker Pipeline with the InspectAI container.
 
+        Args:
+            dry_run (bool):
+                If True, runs all validation (IAM, model resolution, config
+                building, template rendering) without uploading config to S3 or
+                submitting the evaluation. Returns None on success, raises on
+                validation failure. Defaults to False.
+
         Returns:
             EvaluationPipelineExecution: The started evaluation execution with
-                ``.wait()``, ``.refresh()``, and ``.show_results()`` methods.
+                ``.wait()``, ``.refresh()``, and ``.show_results()`` methods,
+                or None if dry_run=True.
 
         Example:
             .. code:: python
@@ -722,15 +730,17 @@ class InspectAIEvaluator(BaseEvaluator):
                 execution = evaluator.evaluate()
                 execution.wait()
                 execution.show_results()
+
+                # Validate without submitting:
+                evaluator.evaluate(dry_run=True)
         """
-        # Get AWS execution context
+        # Get AWS execution context (validates execution role + caller permissions)
         aws_context = self._get_aws_execution_context()
         region = aws_context["region"]
         role_arn = aws_context["role_arn"]
 
-        # Build and upload YAML config
+        # Build YAML config (validates config structure)
         yaml_config = self._build_yaml_config(region)
-        config_s3_prefix = self._upload_yaml_config(yaml_config, region)
 
         # Resolve container image URI
         resolved_image_uri = self.image_uri or _get_inspect_ai_default_image_uri(region)
@@ -738,6 +748,13 @@ class InspectAIEvaluator(BaseEvaluator):
         # Build job name prefix (keep total under 63 chars after pipeline exec ID appended)
         base_name = self.base_eval_name or "inspectai-eval"
         job_name_prefix = base_name[:26]
+
+        # Upload config to S3 (skip in dry_run)
+        if dry_run:
+            config_s3_prefix = f"s3://{self.s3_output_path.rstrip('/')}/inspectai-config/dry-run-placeholder"
+            _logger.info("Dry-run: skipping config upload to S3.")
+        else:
+            config_s3_prefix = self._upload_yaml_config(yaml_config, region)
 
         # Build template context
         template_context = {
@@ -757,10 +774,14 @@ class InspectAIEvaluator(BaseEvaluator):
             template_context["vpc_security_group_ids"] = self.networking.security_group_ids
             template_context["vpc_subnets"] = self.networking.subnets
 
-        # Render pipeline definition
+        # Render pipeline definition (validates template)
         pipeline_definition = self._render_pipeline_definition(
             INSPECT_AI_TEMPLATE, template_context
         )
+
+        if dry_run:
+            _logger.info("Dry-run validation passed. No evaluation submitted.")
+            return None
 
         # Start execution
         name = self.base_eval_name or "inspectai-eval"

--- a/sagemaker-train/src/sagemaker/train/evaluate/llm_as_judge_evaluator.py
+++ b/sagemaker-train/src/sagemaker/train/evaluate/llm_as_judge_evaluator.py
@@ -915,6 +915,10 @@ class LLMAsJudgeEvaluator(BaseEvaluator):
                 LLMAJ_INSPECTAI_TEMPLATE, template_context
             )
 
+            if dry_run:
+                _logger.info("Dry-run validation passed. No evaluation submitted.")
+                return None
+
             return self._start_execution(
                 eval_type=EvalType.LLM_AS_JUDGE,
                 name=name,

--- a/sagemaker-train/src/sagemaker/train/evaluate/multi_turn_rl_evaluator.py
+++ b/sagemaker-train/src/sagemaker/train/evaluate/multi_turn_rl_evaluator.py
@@ -537,11 +537,19 @@ class MultiTurnRLEvaluator(BaseEvaluator):
         feature=Feature.MODEL_CUSTOMIZATION,
         func_name="MultiTurnRLEvaluator.evaluate",
     )
-    def evaluate(self) -> 'MTRLEvaluationExecution':
+    def evaluate(self, dry_run: bool = False) -> Optional['MTRLEvaluationExecution']:
         """Render the MTRL pipeline and start a non-blocking execution.
 
+        Args:
+            dry_run (bool):
+                If True, runs all validation (IAM, agent resolution, model
+                resolution, template rendering) without submitting the
+                evaluation. Returns None on success, raises on validation
+                failure. Defaults to False.
+
         Returns:
-            MTRLEvaluationExecution: The started pipeline execution.
+            MTRLEvaluationExecution: The started pipeline execution, or None
+            if dry_run=True.
             Call ``.wait()`` to block until completion and ``.show_results()``
             to render the aggregate report.
 
@@ -552,6 +560,9 @@ class MultiTurnRLEvaluator(BaseEvaluator):
                 execution = evaluator.evaluate()
                 execution.wait()
                 execution.show_results()
+
+                # Validate without submitting:
+                evaluator.evaluate(dry_run=True)
         """
         # 1. Trainer-sourced resolution (no-op if model is not a trainer).
         self._resolve_trainer_defaults()
@@ -589,6 +600,10 @@ class MultiTurnRLEvaluator(BaseEvaluator):
         # 5. Template selection + render.
         template_str = self._select_mtrl_template()
         pipeline_definition = self._render_pipeline_definition(template_str, template_context)
+
+        if dry_run:
+            _logger.info("Dry-run validation passed. No evaluation submitted.")
+            return None
 
         # Dump the pipeline definition to a local JSON file for debugging.
         import json as _json_mod

--- a/sagemaker-train/tests/unit/train/evaluate/test_evaluator_dry_run.py
+++ b/sagemaker-train/tests/unit/train/evaluate/test_evaluator_dry_run.py
@@ -1,0 +1,379 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+"""Unit tests for dry_run=True on evaluator types.
+
+Tests that:
+1. dry_run=True returns None (no execution submitted)
+2. dry_run=True does NOT call _start_execution / upload to S3
+3. _get_aws_execution_context is called during evaluate()
+
+Strategy: mock only at the evaluate() method's two key boundaries:
+  - _get_aws_execution_context (the IAM/session resolver — avoids network)
+  - _start_execution / _start_mtrl_execution (the pipeline submit — we assert not called)
+For evaluators that call S3/Hub before those boundaries, we mock the specific
+network-calling helpers rather than the entire evaluate flow.
+"""
+from __future__ import absolute_import
+
+from unittest.mock import Mock, patch, PropertyMock
+
+import pytest
+
+from sagemaker.train.common_utils.model_resolution import _ModelInfo, _ModelType
+from sagemaker.train.evaluate.benchmark_evaluator import BenchMarkEvaluator
+from sagemaker.train.evaluate.constants import EvalType
+from sagemaker.train.evaluate.custom_scorer_evaluator import CustomScorerEvaluator
+from sagemaker.train.evaluate.inspect_ai_evaluator import InspectAIEvaluator
+from sagemaker.train.evaluate.llm_as_judge_evaluator import LLMAsJudgeEvaluator
+from sagemaker.train.evaluate.multi_turn_rl_evaluator import MultiTurnRLEvaluator
+
+
+DEFAULT_REGION = "us-east-1"
+DEFAULT_ROLE = "arn:aws:iam::123456789012:role/test-role"
+DEFAULT_MODEL = "amazon-nova-lite-v1"
+DEFAULT_S3_OUTPUT = "s3://test-bucket/eval-output/"
+DEFAULT_BENCHMARKS_PATH = "s3://test-bucket/benchmarks/"
+DEFAULT_MLFLOW_ARN = "arn:aws:sagemaker:us-east-1:123456789012:mlflow-tracking-server/test-server"
+DEFAULT_MODEL_PACKAGE_GROUP_ARN = (
+    "arn:aws:sagemaker:us-east-1:123456789012:model-package-group/test-group"
+)
+DEFAULT_BASE_MODEL_ARN = (
+    "arn:aws:sagemaker:us-east-1:aws:hub-content/SageMakerPublicHub/Model/amazon-nova-lite-v1/1.0.0"
+)
+DEFAULT_ARTIFACT_ARN = "arn:aws:sagemaker:us-east-1:123456789012:artifact/test-artifact"
+DEFAULT_DATASET = "s3://test-bucket/dataset.jsonl"
+
+
+def _mock_session():
+    session = Mock()
+    session.boto_region_name = DEFAULT_REGION
+    session.boto_session = Mock()
+    session.boto_session.region_name = DEFAULT_REGION
+    session.get_caller_identity_arn.return_value = DEFAULT_ROLE
+    session.sagemaker_config = {}
+    session.default_bucket.return_value = "test-bucket"
+    session.default_bucket_prefix = None
+    return session
+
+
+def _mock_model_info():
+    return _ModelInfo(
+        base_model_name=DEFAULT_MODEL,
+        base_model_arn=DEFAULT_BASE_MODEL_ARN,
+        source_model_package_arn=None,
+        model_type=_ModelType.JUMPSTART,
+        hub_content_name="amazon-nova-lite-v1",
+        additional_metadata={
+            "bedrock_model_id": "us.amazon.nova-lite-v1:0",
+            "resolved_model_artifact_arn": DEFAULT_ARTIFACT_ARN,
+        },
+        s3_model_path="s3://test-bucket/models/amazon-nova-lite-v1/output",
+    )
+
+
+def _aws_context():
+    return {
+        "role_arn": DEFAULT_ROLE,
+        "region": DEFAULT_REGION,
+        "account_id": "123456789012",
+    }
+
+
+@patch("sagemaker.train.common_utils.model_resolution._resolve_base_model")
+@patch("sagemaker.core.resources.Artifact")
+class TestInspectAIDryRun:
+
+    def _create(self, mock_artifact, mock_resolve):
+
+        mock_resolve.return_value = _mock_model_info()
+        mock_artifact.get_all.return_value = iter([])
+        inst = Mock()
+        inst.artifact_arn = DEFAULT_ARTIFACT_ARN
+        mock_artifact.create.return_value = inst
+
+        return InspectAIEvaluator(
+            model=DEFAULT_MODEL,
+            benchmarks_path=DEFAULT_BENCHMARKS_PATH,
+            s3_output_path=DEFAULT_S3_OUTPUT,
+            mlflow_resource_arn=DEFAULT_MLFLOW_ARN,
+            model_package_group=DEFAULT_MODEL_PACKAGE_GROUP_ARN,
+            sagemaker_session=_mock_session(),
+        )
+
+    @patch("sagemaker.train.evaluate.inspect_ai_evaluator.S3Uploader")
+    def test_dry_run_returns_none_and_skips_s3(self, mock_uploader, mock_artifact, mock_resolve):
+        evaluator = self._create(mock_artifact, mock_resolve)
+
+        with patch.object(evaluator, "_get_aws_execution_context", return_value=_aws_context()):
+            result = evaluator.evaluate(dry_run=True)
+
+        assert result is None
+        mock_uploader.upload_string_as_file_body.assert_not_called()
+
+    @patch("sagemaker.train.evaluate.inspect_ai_evaluator.S3Uploader")
+    def test_dry_run_does_not_start_execution(self, mock_uploader, mock_artifact, mock_resolve):
+        evaluator = self._create(mock_artifact, mock_resolve)
+
+        with (
+            patch.object(evaluator, "_get_aws_execution_context", return_value=_aws_context()),
+            patch.object(evaluator, "_start_execution") as mock_start,
+        ):
+            evaluator.evaluate(dry_run=True)
+
+        mock_start.assert_not_called()
+
+    @patch("sagemaker.train.evaluate.inspect_ai_evaluator.S3Uploader")
+    def test_dry_run_passes_flag(self, mock_uploader, mock_artifact, mock_resolve):
+        evaluator = self._create(mock_artifact, mock_resolve)
+
+        with patch.object(evaluator, "_get_aws_execution_context", return_value=_aws_context()) as ctx:
+            evaluator.evaluate(dry_run=True)
+
+        ctx.assert_called_once_with()
+
+    @patch("sagemaker.train.evaluate.inspect_ai_evaluator.S3Uploader")
+    def test_default_starts_execution(self, mock_uploader, mock_artifact, mock_resolve):
+        evaluator = self._create(mock_artifact, mock_resolve)
+        mock_exec = Mock()
+
+        with (
+            patch.object(evaluator, "_get_aws_execution_context", return_value=_aws_context()),
+            patch.object(evaluator, "_start_execution", return_value=mock_exec) as mock_start,
+        ):
+            result = evaluator.evaluate()
+
+        mock_start.assert_called_once()
+        assert result is mock_exec
+
+
+@patch("sagemaker.train.common_utils.model_resolution._resolve_base_model")
+@patch("sagemaker.core.resources.Artifact")
+class TestMultiTurnRLDryRun:
+
+    def _create(self, mock_artifact, mock_resolve):
+
+        mock_resolve.return_value = _mock_model_info()
+        mock_artifact.get_all.return_value = iter([])
+        inst = Mock()
+        inst.artifact_arn = DEFAULT_ARTIFACT_ARN
+        mock_artifact.create.return_value = inst
+
+        return MultiTurnRLEvaluator(
+            model=DEFAULT_MODEL,
+            agent_config="arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/test-agent-aBcDeFgHiJ",
+            dataset="s3://test-bucket/prompts.parquet",
+            s3_output_path=DEFAULT_S3_OUTPUT,
+            mlflow_resource_arn=DEFAULT_MLFLOW_ARN,
+            model_package_group=DEFAULT_MODEL_PACKAGE_GROUP_ARN,
+            sagemaker_session=_mock_session(),
+        )
+
+    def test_dry_run_returns_none(self, mock_artifact, mock_resolve):
+        evaluator = self._create(mock_artifact, mock_resolve)
+
+        with (
+            patch.object(evaluator, "_resolve_trainer_defaults"),
+            patch.object(evaluator, "_resolve_agent_arn"),
+            patch.object(evaluator, "_get_aws_execution_context", return_value=_aws_context()),
+            patch.object(evaluator, "_resolve_model_artifacts", return_value={}),
+            patch.object(evaluator, "_get_model_package_group_arn", return_value=DEFAULT_MODEL_PACKAGE_GROUP_ARN),
+            patch.object(evaluator, "_build_template_context", return_value={}),
+            patch.object(evaluator, "_select_mtrl_template", return_value="{}"),
+            patch.object(evaluator, "_render_pipeline_definition", return_value='{"Steps": []}'),
+            patch.object(evaluator, "_start_mtrl_execution") as mock_start,
+        ):
+            evaluator._agent_arn_resolved = "arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/test"
+            result = evaluator.evaluate(dry_run=True)
+
+        assert result is None
+        mock_start.assert_not_called()
+
+    def test_dry_run_passes_flag(self, mock_artifact, mock_resolve):
+        evaluator = self._create(mock_artifact, mock_resolve)
+
+        with (
+            patch.object(evaluator, "_resolve_trainer_defaults"),
+            patch.object(evaluator, "_resolve_agent_arn"),
+            patch.object(evaluator, "_get_aws_execution_context", return_value=_aws_context()) as ctx,
+            patch.object(evaluator, "_resolve_model_artifacts", return_value={}),
+            patch.object(evaluator, "_get_model_package_group_arn", return_value=DEFAULT_MODEL_PACKAGE_GROUP_ARN),
+            patch.object(evaluator, "_build_template_context", return_value={}),
+            patch.object(evaluator, "_select_mtrl_template", return_value="{}"),
+            patch.object(evaluator, "_render_pipeline_definition", return_value='{"Steps": []}'),
+        ):
+            evaluator._agent_arn_resolved = "arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/test"
+            evaluator.evaluate(dry_run=True)
+
+        ctx.assert_called_once_with()
+
+
+@patch("sagemaker.train.common_utils.model_resolution._resolve_base_model")
+@patch("sagemaker.core.resources.Artifact")
+@patch("sagemaker.train.evaluate.base_evaluator._resolve_mlflow_resource_arn")
+class TestBenchmarkDryRun:
+
+    def _create(self, mock_mlflow, mock_artifact, mock_resolve):
+
+        mock_resolve.return_value = _mock_model_info()
+        mock_mlflow.return_value = DEFAULT_MLFLOW_ARN
+        mock_artifact.get_all.return_value = iter([])
+        inst = Mock()
+        inst.artifact_arn = DEFAULT_ARTIFACT_ARN
+        mock_artifact.create.return_value = inst
+
+        return BenchMarkEvaluator(
+            model=DEFAULT_MODEL,
+            benchmark="mmlu",
+            s3_output_path=DEFAULT_S3_OUTPUT,
+            mlflow_resource_arn=DEFAULT_MLFLOW_ARN,
+            model_package_group=DEFAULT_MODEL_PACKAGE_GROUP_ARN,
+            sagemaker_session=_mock_session(),
+        )
+
+    def test_dry_run_returns_none(self, mock_mlflow, mock_artifact, mock_resolve):
+        evaluator = self._create(mock_mlflow, mock_artifact, mock_resolve)
+
+        with (
+            patch.object(evaluator, "_get_aws_execution_context", return_value=_aws_context()),
+            patch.object(evaluator, "_resolve_model_artifacts", return_value={
+                "resolved_model_artifact_arn": DEFAULT_ARTIFACT_ARN,
+            }),
+            patch.object(evaluator, "_get_model_package_group_arn", return_value=DEFAULT_MODEL_PACKAGE_GROUP_ARN),
+            patch.object(evaluator, "_get_base_template_context", return_value={"evaluate_base_model": False}),
+            patch.object(evaluator, "_get_benchmark_template_additions", return_value={"task": "mmlu"}),
+            patch.object(evaluator, "_add_vpc_and_kms_to_context", side_effect=lambda c: c),
+            patch.object(evaluator, "_select_template", return_value="{}"),
+            patch.object(evaluator, "_render_pipeline_definition", return_value='{"Steps": []}'),
+            patch.object(evaluator, "_start_execution") as mock_start,
+        ):
+            result = evaluator.evaluate(dry_run=True)
+
+        assert result is None
+        mock_start.assert_not_called()
+
+
+@patch("sagemaker.train.common_utils.model_resolution._resolve_base_model")
+@patch("sagemaker.core.resources.Artifact")
+@patch("sagemaker.train.evaluate.base_evaluator._resolve_mlflow_resource_arn")
+class TestCustomScorerDryRun:
+
+    def _create(self, mock_mlflow, mock_artifact, mock_resolve):
+
+        mock_resolve.return_value = _mock_model_info()
+        mock_mlflow.return_value = DEFAULT_MLFLOW_ARN
+        mock_artifact.get_all.return_value = iter([])
+        inst = Mock()
+        inst.artifact_arn = DEFAULT_ARTIFACT_ARN
+        mock_artifact.create.return_value = inst
+
+        return CustomScorerEvaluator(
+            model=DEFAULT_MODEL,
+            dataset=DEFAULT_DATASET,
+            evaluator="arn:aws:lambda:us-east-1:123456789012:function:my-scorer",
+            s3_output_path=DEFAULT_S3_OUTPUT,
+            mlflow_resource_arn=DEFAULT_MLFLOW_ARN,
+            model_package_group=DEFAULT_MODEL_PACKAGE_GROUP_ARN,
+            sagemaker_session=_mock_session(),
+        )
+
+    def test_dry_run_returns_none(self, mock_mlflow, mock_artifact, mock_resolve):
+        evaluator = self._create(mock_mlflow, mock_artifact, mock_resolve)
+
+        with (
+            patch.object(evaluator, "_get_aws_execution_context", return_value=_aws_context()),
+            patch.object(evaluator, "_resolve_model_artifacts", return_value={
+                "resolved_model_artifact_arn": DEFAULT_ARTIFACT_ARN,
+            }),
+            patch.object(evaluator, "_get_model_package_group_arn", return_value=DEFAULT_MODEL_PACKAGE_GROUP_ARN),
+            patch.object(evaluator, "_resolve_evaluator_config", return_value={
+                "evaluator_arn": "arn:aws:lambda:us-east-1:123456789012:function:my-scorer",
+                "preset_reward_function": None,
+            }),
+            patch.object(evaluator, "_get_base_template_context", return_value={"evaluate_base_model": False}),
+            patch.object(evaluator, "_add_vpc_and_kms_to_context", side_effect=lambda c: c),
+            patch.object(evaluator, "_select_template", return_value="{}"),
+            patch.object(evaluator, "_render_pipeline_definition", return_value='{"Steps": []}'),
+            patch.object(evaluator, "_start_execution") as mock_start,
+        ):
+            result = evaluator.evaluate(dry_run=True)
+
+        assert result is None
+        mock_start.assert_not_called()
+
+
+@patch("sagemaker.train.common_utils.model_resolution._resolve_base_model")
+@patch("sagemaker.core.resources.Artifact")
+@patch("sagemaker.train.evaluate.base_evaluator._resolve_mlflow_resource_arn")
+class TestLLMAsJudgeDryRun:
+
+    def _create(self, mock_mlflow, mock_artifact, mock_resolve):
+
+        mock_resolve.return_value = _mock_model_info()
+        mock_mlflow.return_value = DEFAULT_MLFLOW_ARN
+        mock_artifact.get_all.return_value = iter([])
+        inst = Mock()
+        inst.artifact_arn = DEFAULT_ARTIFACT_ARN
+        mock_artifact.create.return_value = inst
+
+        return LLMAsJudgeEvaluator(
+            model=DEFAULT_MODEL,
+            evaluator_model="amazon.nova-pro-v1:0",
+            dataset=DEFAULT_DATASET,
+            s3_output_path=DEFAULT_S3_OUTPUT,
+            mlflow_resource_arn=DEFAULT_MLFLOW_ARN,
+            model_package_group=DEFAULT_MODEL_PACKAGE_GROUP_ARN,
+            sagemaker_session=_mock_session(),
+        )
+
+    def test_dry_run_returns_none(self, mock_mlflow, mock_artifact, mock_resolve):
+        evaluator = self._create(mock_mlflow, mock_artifact, mock_resolve)
+
+        with (
+            patch.object(evaluator, "_get_aws_execution_context", return_value=_aws_context()),
+            patch.object(evaluator, "_resolve_model_artifacts", return_value={
+                "resolved_model_artifact_arn": DEFAULT_ARTIFACT_ARN,
+            }),
+            patch.object(evaluator, "_get_model_package_group_arn", return_value=DEFAULT_MODEL_PACKAGE_GROUP_ARN),
+            patch.object(evaluator, "_get_base_template_context", return_value={"evaluate_base_model": False}),
+            patch.object(evaluator, "_add_vpc_and_kms_to_context", side_effect=lambda c: c),
+            patch.object(evaluator, "_upload_benchmark_and_dataset", return_value="s3://test-bucket/benchmarks/converted"),
+            patch.object(evaluator, "_build_inspectai_config", return_value={}),
+            patch.object(evaluator, "_render_pipeline_definition", return_value='{"Steps": []}'),
+            patch.object(evaluator, "_start_execution") as mock_start,
+        ):
+            result = evaluator.evaluate(dry_run=True)
+
+        assert result is None
+        mock_start.assert_not_called()
+
+    def test_dry_run_standard_path_returns_none(self, mock_mlflow, mock_artifact, mock_resolve):
+        """Test dry_run on the standard (non-InspectAI) LLMAJ path."""
+        evaluator = self._create(mock_mlflow, mock_artifact, mock_resolve)
+
+        with (
+            patch.object(evaluator, "_get_aws_execution_context", return_value=_aws_context()),
+            patch.object(evaluator, "_resolve_model_artifacts", return_value={
+                "resolved_model_artifact_arn": DEFAULT_ARTIFACT_ARN,
+            }),
+            patch.object(evaluator, "_get_model_package_group_arn", return_value=DEFAULT_MODEL_PACKAGE_GROUP_ARN),
+            # Force the standard (non-InspectAI) path
+            patch.object(evaluator, "_should_use_inspectai_path", return_value=False),
+            patch.object(evaluator, "_get_base_template_context", return_value={"evaluate_base_model": False}),
+            patch.object(evaluator, "_add_vpc_and_kms_to_context", side_effect=lambda c: c),
+            patch.object(evaluator, "_render_pipeline_definition", return_value='{"Steps": []}'),
+            patch.object(evaluator, "_start_execution") as mock_start,
+        ):
+            result = evaluator.evaluate(dry_run=True)
+
+        assert result is None
+        mock_start.assert_not_called()


### PR DESCRIPTION
…ll evaluators

- Add dry_run=True parameter to InspectAIEvaluator and MultiTurnRLEvaluator (Benchmark, CustomScorer, LLMAsJudge already had it)
- Add verify_evaluation_caller_permissions() to validate the caller's identity has the pipeline-orchestration permissions before submitting
- Define EVALUATION_CALLER_ACTIONS constant with the set of 22 IAM actions needed by whoever calls evaluator.evaluate()
- Fix bug: LLMAsJudge InspectAI code path was missing the dry_run check
- Wire dry_run through _get_aws_execution_context() for all evaluators
- Add unit tests covering dry_run behavior across all evaluator types

*Issue #, if available:*

*Description of changes:*

## Summary

Adds `dry_run` support to all evaluators and introduces caller-side IAM permission validation for the evaluate module's Pipeline-based execution model.

## Problem

The SDK's evaluate module uses SageMaker Pipelines under the hood to orchestrate evaluation jobs. This means the **caller** (notebook user, Lambda, CI role) needs ~22 IAM permissions to create/start/describe pipelines — separate from the **execution role** that the pipeline assumes to run training jobs.

Previously:
- `InspectAIEvaluator` and `MultiTurnRLEvaluator` had no `dry_run` parameter
- No validation existed for the caller's pipeline permissions — users got opaque `AccessDenied` errors from `CreatePipeline`
- `LLMAsJudgeEvaluator`'s InspectAI code path skipped the `dry_run` check entirely (bug)

## Changes

### New: `verify_evaluation_caller_permissions()` (`sagemaker-core`)
- Simulates `EVALUATION_CALLER_ACTIONS` against the caller's identity via `iam:SimulatePrincipalPolicy`
- Raises `RoleValidationError` when permissions are definitively denied
- Returns `None` gracefully when the caller can't self-simulate (common Studio/notebook case)

### New: `EVALUATION_CALLER_ACTIONS` constant
Complete set of caller permissions needed for `evaluator.evaluate()`:
- Pipeline orchestration (12 actions)
- Hub model resolution (4 actions)
- Lineage artifact management (3 actions)
- S3 access for config/benchmark upload (3 actions)

### Updated: All evaluators
- `InspectAIEvaluator.evaluate(dry_run=False)` — new parameter
- `MultiTurnRLEvaluator.evaluate(dry_run=False)` — new parameter
- `BaseEvaluator._get_aws_execution_context()` — now calls `verify_evaluation_caller_permissions()` (always raises on denied)

### Bug fix: LLMAsJudge InspectAI path
The InspectAI code path in `LLMAsJudgeEvaluator.evaluate()` had its own `return self._start_execution(...)` that bypassed the `dry_run` check. Fixed by adding the check before submission.

## Testing

- **Unit tests**: 10 new tests in `test_evaluator_dry_run.py` covering all 5 evaluator types + both LLMAsJudge paths
- **Integration tests**: Validated with scoped IAM role (`nilis-0121`) against real AWS — both InspectAI (Nova Lite/Bedrock) and Benchmark (OSS/MMLU) pipelines start successfully with least-privilege caller permissions

## IAM Permission Summary

| Category | Actions | Used by |
|----------|---------|---------|
| Pipeline orchestration | CreatePipeline, UpdatePipeline, DescribePipeline, ListPipelines, StartPipelineExecution, DescribePipelineExecution, ListPipelineExecutionSteps, StopPipelineExecution, ListTags, AddTags, DescribeTrainingJob, iam:PassRole | Caller |
| Hub model resolution | DescribeHubContent, ListHubContents, DescribeHub, ListHubs | Caller (construction time) |
| Lineage | CreateArtifact, ListArtifacts, DescribeArtifact | Caller (before pipeline start) |
| S3 | PutObject, GetObject, ListBucket | Caller (config/benchmark upload) |


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
