### PR TITLE
test(integ): absorb iam:SimulatePrincipalPolicy throttling across integ suites

### DIFF
--- a/sagemaker-mlops/tests/integ/conftest.py
+++ b/sagemaker-mlops/tests/integ/conftest.py
@@ -59,6 +59,84 @@ CONDA_YML_FILE_TEMPLATE = (
 
 
 # ---------------------------------------------------------------------------
+# IAM SimulatePrincipalPolicy throttling mitigation
+#
+# These tests run under ``pytest -n auto`` (dozens of xdist workers). Many of
+# them resolve/validate an IAM execution role via ``resolve_and_validate_role``
+# (e.g. during ``Pipeline`` create/upsert and feature-processor scheduling),
+# which internally calls the low-TPS ``iam:SimulatePrincipalPolicy`` API. With
+# many workers hitting it at once IAM throttles the request, surfacing as
+# ``ClientError: (Throttling) ... Rate exceeded``. This mitigation is a purely
+# test-harness concurrency fix and is intentionally identical to the block in
+# the sagemaker-train / sagemaker-serve integ conftests.
+# ---------------------------------------------------------------------------
+
+# botocore adaptive retry settings for throttling-prone IAM validation calls.
+# Applied via env vars so every client in the worker inherits them, regardless of
+# which boto session the SDK ends up using to build its IAM client.
+_RETRY_MODE = "adaptive"
+_MAX_ATTEMPTS = "10"
+
+# Only tolerate throttling on the IAM permission simulation used during role
+# validation, so unrelated throttling still fails loudly.
+_THROTTLE_ERROR_CODES = ("Throttling", "ThrottlingException", "RequestLimitExceeded")
+_SIMULATE_OP = "SimulatePrincipalPolicy"
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _configure_boto_adaptive_retries():
+    """Give every boto3 client in this xdist worker adaptive retries so the IAM
+    clients built by the role resolver absorb transient SimulatePrincipalPolicy
+    throttling. Restores any pre-existing values on teardown."""
+    previous = {
+        "AWS_RETRY_MODE": os.environ.get("AWS_RETRY_MODE"),
+        "AWS_MAX_ATTEMPTS": os.environ.get("AWS_MAX_ATTEMPTS"),
+    }
+    os.environ["AWS_RETRY_MODE"] = _RETRY_MODE
+    os.environ["AWS_MAX_ATTEMPTS"] = _MAX_ATTEMPTS
+    yield
+    for key, value in previous.items():
+        if value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = value
+
+
+def _is_simulate_policy_throttle(exc):
+    """Return True if ``exc`` is a SimulatePrincipalPolicy throttling ClientError."""
+    from botocore.exceptions import ClientError
+
+    if not isinstance(exc, ClientError):
+        return False
+    error_code = exc.response.get("Error", {}).get("Code", "")
+    operation = getattr(exc, "operation_name", "") or ""
+    return error_code in _THROTTLE_ERROR_CODES and operation == _SIMULATE_OP
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_makereport(item, call):
+    """Skip (rather than fail) on residual SimulatePrincipalPolicy throttling that
+    survives the adaptive retries under heavy concurrency. Applies to setup and
+    call phases, since role resolution frequently happens in fixture setup."""
+    outcome = yield
+    report = outcome.get_result()
+
+    if report.when not in ("setup", "call") or not report.failed:
+        return
+
+    exc = call.excinfo.value if call.excinfo else None
+    # Walk the exception chain so a wrapped ClientError is still detected.
+    while exc is not None:
+        if _is_simulate_policy_throttle(exc):
+            report.outcome = "skipped"
+            report.wasxfail = (
+                "iam:SimulatePrincipalPolicy throttled under concurrent test load"
+            )
+            break
+        exc = exc.__cause__ or exc.__context__
+
+
+# ---------------------------------------------------------------------------
 # CLI options
 # ---------------------------------------------------------------------------
 

--- a/sagemaker-train/tests/integ/conftest.py
+++ b/sagemaker-train/tests/integ/conftest.py
@@ -1,3 +1,4 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You
 # may not use this file except in compliance with the License. A copy of
@@ -9,31 +10,32 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-"""Shared pytest configuration for sagemaker-serve integration tests.
+"""Shared pytest configuration for sagemaker-train integration tests.
 
-These tests run under ``pytest -n auto`` (dozens of xdist workers). Several of
-them resolve/validate an IAM execution role during ``ModelBuilder.build()`` /
-``.deploy()``, which internally calls the low-TPS ``iam:SimulatePrincipalPolicy``
-API. With many workers hitting it at once IAM throttles the request, surfacing as
-``ClientError: (Throttling) ... Rate exceeded`` and failing the build.
+These tests run under ``pytest -n auto`` (dozens of xdist workers). Many of them
+resolve/validate an IAM execution role via ``TrainDefaults.get_role`` ->
+``resolve_and_validate_role``, which internally calls the low-TPS
+``iam:SimulatePrincipalPolicy`` API. With many workers hitting it at once IAM
+throttles the request, surfacing as ``ClientError: (Throttling) ... Rate
+exceeded`` and failing the test during setup.
 
-This is purely a test-harness concurrency problem, so the mitigation lives here in
-the test layer rather than in SDK source. It is intentionally identical to the
-block in ``sagemaker-train`` / ``sagemaker-mlops`` integ conftests:
+This is purely a test-harness concurrency problem, so the mitigation lives here
+in the test layer rather than in SDK source. It is intentionally identical to the
+block in ``sagemaker-serve`` / ``sagemaker-mlops`` integ conftests:
 
 * ``_configure_boto_adaptive_retries`` (autouse) — set adaptive retries via the
-  ``AWS_RETRY_MODE`` / ``AWS_MAX_ATTEMPTS`` environment variables. Env vars apply
-  to *every* boto3 client created in the worker, so the internal IAM calls ride
-  out transient throttling whether the resolver falls back to the default session
-  or builds its client from an explicitly-passed ``Session`` (several serve tests
-  pass their own session, whose IAM client would otherwise carry botocore's
-  default 4-attempt retry policy). ``adaptive`` mode also adds client-side rate
-  limiting to smooth bursts.
+  ``AWS_RETRY_MODE`` / ``AWS_MAX_ATTEMPTS`` environment variables. Unlike setting
+  a retry ``Config`` on a single boto session, env vars apply to *every* boto3
+  client created in the worker — including the IAM clients the role resolver
+  builds from an explicitly-passed ``Session`` (which carries no retry config of
+  its own). ``adaptive`` mode adds client-side rate limiting so bursts of
+  ``SimulatePrincipalPolicy`` calls ride out transient throttling.
 
 * ``pytest_runtest_makereport`` — a belt-and-suspenders fallback. If a residual
   ``SimulatePrincipalPolicy`` throttling error still escapes after the adaptive
   retries, convert the failure into a skip so a transient rate limit never reds
-  the build. Genuine failures are untouched.
+  the build. Genuine failures (and throttling on any other operation) are
+  untouched.
 """
 from __future__ import absolute_import
 


### PR DESCRIPTION
## Issue

Integration tests run under `pytest -n auto` (dozens of xdist workers). Many of them resolve/validate an IAM execution role via `resolve_and_validate_role` — invoked from `TrainDefaults.get_role`, `ModelBuilder.build()/.deploy()`, `Pipeline` create/upsert, and the feature-processor scheduler. That function calls the **low-TPS `iam:SimulatePrincipalPolicy`** API (plus a `get_role` for the trust check). With many workers hitting it at once, IAM throttles the request:

```
botocore.exceptions.ClientError: An error occurred (Throttling) when calling the
SimulatePrincipalPolicy operation (reached max retries: 4): Rate exceeded
```

`_evaluate_permissions` only degrades `AccessDenied`/`NoSuchEntity`; `Throttling` re-raises and fails the test — often during **fixture setup**, not just the call phase.

## Fix (test layer only — no SDK source change)

Add an identical, self-contained mitigation to the **serve**, **train**, and **mlops** integ conftests:

1. **`_configure_boto_adaptive_retries`** (autouse, session-scoped) — sets adaptive retries via the `AWS_RETRY_MODE` / `AWS_MAX_ATTEMPTS` environment variables. Env vars apply to **every** boto3 client created in the worker, so the IAM calls ride out transient throttling **whether the resolver falls back to the default session or builds its client from an explicitly-passed `Session`**. Pre-existing env values are restored on teardown.
2. **`pytest_runtest_makereport`** — belt-and-suspenders: converts a residual `SimulatePrincipalPolicy` throttle that survives retries into a **skip** (checked in both `setup` and `call` phases). Throttling on any *other* operation still fails loudly.

### Why not the previous serve-only approach?
The prior serve conftest set a retry `Config` on `boto3.DEFAULT_SESSION`. That only helps when the resolver falls back to the default session — several serve tests (and the train/mlops fixtures) pass their **own** `Session(boto_session=...)`, whose IAM client carried botocore's default 4-attempt policy and was unaffected. Env vars close that gap and let all three suites share one implementation.

### Scope
- New parent `sagemaker-train/tests/integ/conftest.py` covers `train/`, `ai_registry/`, and `jumpstart/`.
- `sagemaker-core` integ is intentionally **not** modified — `resolve_and_validate_role` has no call path there, so it never hits `SimulatePrincipalPolicy`.

## Testing
- All three conftests compile (`py_compile`) and lint clean.
- Unit-checked the throttle-detection helper: matches `Throttling`/`ThrottlingException`/`RequestLimitExceeded` **only** on `SimulatePrincipalPolicy`; ignores other ops, other error codes, and non-`ClientError` exceptions.

## Type of change
- [x] Bug fix / test-infrastructure fix (non-breaking; test-layer only)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] Changes are limited to test conftests; no SDK source or public API is touched
- [x] No new dependencies introduced

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
