### PR TITLE
fix(ci): point PR unit-tests at the CDK-managed V3 project

### DIFF
--- a/.github/workflows/pr-checks-master.yml
+++ b/.github/workflows/pr-checks-master.yml
@@ -208,8 +208,18 @@ jobs:
       - name: Run Unit Tests for ${{ matrix.submodule }}
         uses: aws-actions/aws-codebuild-run-build@v1
         with:
-          project-name: ${{ github.event.repository.name }}-ci-${{ matrix.submodule }}-unit-tests
+          # Use the single CDK-managed V3 unit-test project (driven by the SUBMODULE
+          # env var), the same project the CI-health workflow uses. The previous
+          # per-submodule projects (sagemaker-python-sdk-ci-<submodule>-unit-tests)
+          # were created manually, are not CDK/pipeline-managed, and had drifted
+          # stale (e.g. still running `--cov=.` instead of the deployed
+          # `--cov=sagemaker`), so PR coverage never reflected buildspec fixes.
+          project-name: ${{ github.event.repository.name }}-ci-health-unit-test-v3
           source-version-override: 'refs/pull/${{ github.event.pull_request.number }}/head^{${{ github.event.pull_request.head.sha }}}'
+          env-vars-for-codebuild: |
+            SUBMODULE
+        env:
+          SUBMODULE: ${{ matrix.submodule }}
 
   integ-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Issue

The PR-check `unit-tests` job invokes per-submodule CodeBuild projects named `sagemaker-python-sdk-ci-<submodule>-unit-tests`. Investigation showed these are **orphaned, manually-created projects** — not managed by the `SageMakerMLFPySDKInfraCDK` pipeline:

| | `ci-sagemaker-core-unit-tests` (PR checks use) | `ci-health-unit-test-v3` (CDK-managed) |
|---|---|---|
| CloudFormation tags | **none** (manual) | `aws:cloudformation:*` present |
| buildspec | `tox … --cov=.` | `tox … --cov=sagemaker` |
| lastModified | **2026-06-15** (stale) | 2026-07-20 |

Because the manual projects aren't pipeline-managed, the deployed buildspec CR (`--cov=.` → `--cov=sagemaker`) never reached them. PR coverage therefore kept reporting the old, test-file-inflated numbers (`~90%` / `sessions=1, 3 files, 37%` on merged uploads) instead of the intended product-only coverage. Verified end-to-end: a fresh build on the PR-check project (commit `6b41b3f0`, run 2026-07-22) still executed `--cov=.`.

## Fix

Point the `unit-tests` job at the single CDK/pipeline-managed project **`sagemaker-python-sdk-ci-health-unit-test-v3`** (`createCIUnitV3BuildSpec`), driven by the `SUBMODULE` env var — exactly how `ci-health.yml` already invokes it. That project carries the deployed `--cov=sagemaker` buildspec, so:

- PR coverage now reflects the intended product-only measurement (test files excluded).
- CI wiring stays in sync with the CDK, so future buildspec changes deploy through the pipeline and reach PR checks automatically.

The `source-version-override` is preserved so the PR's own code is tested (not master). The matrix still fans out per changed submodule via `detect-changes`.

## Follow-ups (separate)
- Retire the orphaned manual `sagemaker-python-sdk-ci-<submodule>-unit-tests` projects.
- The CodeBuild→Codecov uploader still sends empty `branch`/`pr=false`/no `-F` flags (a separate buildspec issue), which affects whether the report attaches to the PR and whether the 4 sub-uploads merge. Tracked separately.

## Testing
- `python -c "import yaml; yaml.safe_load(open('.github/workflows/pr-checks-master.yml'))"` → parses.
- Confirmed target project `sagemaker-python-sdk-ci-health-unit-test-v3` exists, is CFN-managed, and its deployed buildspec contains `--cov=sagemaker`.