### PR TITLE
fix/issue 5897 crlf sm train

### DIFF
--- a/sagemaker-train/src/sagemaker/train/model_trainer.py
+++ b/sagemaker-train/src/sagemaker/train/model_trainer.py
@@ -1132,7 +1132,7 @@ class ModelTrainer(BaseModel):
             execute_driver=execute_driver,
         )
 
-        with open(os.path.join(tmp_dir.name, TRAIN_SCRIPT), "w") as f:
+        with open(os.path.join(tmp_dir.name, TRAIN_SCRIPT), "w", newline="\n") as f:
             f.write(train_script)
 
     @classmethod


### PR DESCRIPTION
Fixes #5897

## Problem

`ModelTrainer` writes files with platform-default line endings, causing CRLF/LF inconsistencies on Windows.

## Fix

Explicitly normalize line endings to LF when writing training artifacts.

## Scope

Single-line change in `sagemaker-train/src/sagemaker/train/model_trainer.py`.

## Verification

Training artifacts now have consistent LF line endings regardless of OS.