### PR TITLE
fix: resolve Nova model artifacts via TrainingJob.get() in bedrock-modelbuilder-deployment example

### DIFF
--- a/v3-examples/model-customization-examples/bedrock-modelbuilder-deployment.ipynb
+++ b/v3-examples/model-customization-examples/bedrock-modelbuilder-deployment.ipynb
@@ -164,9 +164,7 @@
     "# Train and wait for completion\n",
     "sft_trainer.train(wait=True)\n",
     "\n",
-    "# Re-fetch the completed job so model_artifacts is resolved -- Nova training jobs\n",
-    "# don't populate it on the trainer's cached _latest_training_job (unlike the\n",
-    "# TrainingJob.get() cell above, get() synthesizes the artifacts path).\n",
+    "# Fetch the completed job to read its model artifacts.\n",
     "job = TrainingJob.get(training_job_name=sft_trainer._latest_training_job.training_job_name)\n",
     "print(f\"Checkpoint: {job.model_artifacts.s3_model_artifacts}\")"
    ]

--- a/v3-examples/model-customization-examples/bedrock-modelbuilder-deployment.ipynb
+++ b/v3-examples/model-customization-examples/bedrock-modelbuilder-deployment.ipynb
@@ -164,8 +164,11 @@
     "# Train and wait for completion\n",
     "sft_trainer.train(wait=True)\n",
     "\n",
-    "# The trainer now has model_artifacts resolved on _latest_training_job\n",
-    "print(f\"Checkpoint: {sft_trainer._latest_training_job.model_artifacts.s3_model_artifacts}\")"
+    "# Re-fetch the completed job so model_artifacts is resolved -- Nova training jobs\n",
+    "# don't populate it on the trainer's cached _latest_training_job (unlike the\n",
+    "# TrainingJob.get() cell above, get() synthesizes the artifacts path).\n",
+    "job = TrainingJob.get(training_job_name=sft_trainer._latest_training_job.training_job_name)\n",
+    "print(f\"Checkpoint: {job.model_artifacts.s3_model_artifacts}\")"
    ]
   },
   {


### PR DESCRIPTION
### Issue
In `v3-examples/model-customization-examples/bedrock-modelbuilder-deployment.ipynb`, after `sft_trainer.train(wait=True)` the notebook prints:

```python
print(f"Checkpoint: {sft_trainer._latest_training_job.model_artifacts.s3_model_artifacts}")
```

For **Nova** training jobs this raises `AttributeError: 'Unassigned' object has no attribute 's3_model_artifacts'`, halting the notebook before the deploy step. Confirmed against a real completed job: `DescribeTrainingJob` returns `ModelArtifacts: null` for Nova (artifacts go to the managed escrow bucket), so `model_artifacts` is `Unassigned`. The SDK synthesizes `model_artifacts` from `OutputDataConfig` — but only inside `TrainingJob.get()`, not on the trainer's cached `_latest_training_job`.

### Fix
Re-fetch the completed job with `TrainingJob.get(...)` (which triggers the synthesis) and print from that — the same pattern the earlier `TrainingJob.get()` cell in this notebook already uses. Minimal change to the one cell.

(Note: this unblocks the subsequent `BedrockModelBuilder(model=sft_trainer).deploy(...)` cell, which relies on the trainer object directly.)