### PR TITLE
fix(ci): disable 'Fix this' links in AI review comments

### DIFF
--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -110,6 +110,9 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           use_bedrock: "true"
           track_progress: true
+          # Don't append "Fix this" deep-links (which open Claude Code) to review
+          # comments — external contributors can't use them and they add noise.
+          include_fix_links: false
           # Bash is intentionally NOT allowed. The PR diff at /tmp/pr.diff is the
           # only ground truth; the model reads it and uses Read/Grep/Glob against
           # the trusted base checkout for context. It must not execute commands


### PR DESCRIPTION
## What

Sets `include_fix_links: false` on the `claude-code-action` step in the AI Code Review workflow.

## Why

By default the action appends a **"Fix this"** deep-link to each review comment that opens Claude Code with the issue's context. For this repo that link is noise:
- ~90% of PRs come from **external forks** — those contributors can't use a Claude Code deep-link into this setup.
- It adds clutter to every inline comment.

`include_fix_links` is the action's official input for this ([action.yml](https://github.com/anthropics/claude-code-action/blob/v1/action.yml), described as *"Include 'Fix this' links in PR code review feedback that open Claude Code with context to fix the issue"*). It's independent of `track_progress`, so the live progress comment is unaffected.

## Effect

Review comments will no longer contain the "Fix this" link. No other behavior changes; no infra changes.
