### PR TITLE
test(integ): let exhausted IAM throttling fail instead of skipping

### DIFF
--- a/sagemaker-mlops/tests/integ/conftest.py
+++ b/sagemaker-mlops/tests/integ/conftest.py
@@ -69,6 +69,11 @@ CONDA_YML_FILE_TEMPLATE = (
 # ``ClientError: (Throttling) ... Rate exceeded``. This mitigation is a purely
 # test-harness concurrency fix and is intentionally identical to the block in
 # the sagemaker-train / sagemaker-serve integ conftests.
+#
+# Throttling that still exhausts the adaptive retry budget is deliberately left
+# to fail the test loudly (rather than being converted to a skip), so a
+# persistent rate-limit regression stays visible instead of silently
+# disappearing from the results.
 # ---------------------------------------------------------------------------
 
 # botocore adaptive retry settings for throttling-prone IAM validation calls.
@@ -76,11 +81,6 @@ CONDA_YML_FILE_TEMPLATE = (
 # which boto session the SDK ends up using to build its IAM client.
 _RETRY_MODE = "adaptive"
 _MAX_ATTEMPTS = "10"
-
-# Only tolerate throttling on the IAM permission simulation used during role
-# validation, so unrelated throttling still fails loudly.
-_THROTTLE_ERROR_CODES = ("Throttling", "ThrottlingException", "RequestLimitExceeded")
-_SIMULATE_OP = "SimulatePrincipalPolicy"
 
 
 @pytest.fixture(autouse=True, scope="session")
@@ -100,40 +100,6 @@ def _configure_boto_adaptive_retries():
             os.environ.pop(key, None)
         else:
             os.environ[key] = value
-
-
-def _is_simulate_policy_throttle(exc):
-    """Return True if ``exc`` is a SimulatePrincipalPolicy throttling ClientError."""
-    from botocore.exceptions import ClientError
-
-    if not isinstance(exc, ClientError):
-        return False
-    error_code = exc.response.get("Error", {}).get("Code", "")
-    operation = getattr(exc, "operation_name", "") or ""
-    return error_code in _THROTTLE_ERROR_CODES and operation == _SIMULATE_OP
-
-
-@pytest.hookimpl(hookwrapper=True)
-def pytest_runtest_makereport(item, call):
-    """Skip (rather than fail) on residual SimulatePrincipalPolicy throttling that
-    survives the adaptive retries under heavy concurrency. Applies to setup and
-    call phases, since role resolution frequently happens in fixture setup."""
-    outcome = yield
-    report = outcome.get_result()
-
-    if report.when not in ("setup", "call") or not report.failed:
-        return
-
-    exc = call.excinfo.value if call.excinfo else None
-    # Walk the exception chain so a wrapped ClientError is still detected.
-    while exc is not None:
-        if _is_simulate_policy_throttle(exc):
-            report.outcome = "skipped"
-            report.wasxfail = (
-                "iam:SimulatePrincipalPolicy throttled under concurrent test load"
-            )
-            break
-        exc = exc.__cause__ or exc.__context__
 
 
 # ---------------------------------------------------------------------------

--- a/sagemaker-serve/tests/integ/conftest.py
+++ b/sagemaker-serve/tests/integ/conftest.py
@@ -20,17 +20,17 @@ API. With many workers hitting it at once IAM throttles the request, surfacing a
 This is purely a test-harness concurrency problem, so the mitigation lives here in
 the test layer rather than in SDK source:
 
-* ``_configure_default_boto_retries`` (autouse) — approach "A": set an adaptive
-  retry policy on boto3's *default* session. The role resolver, when no explicit
-  session is passed, falls back to ``sagemaker.core...Session()`` whose boto
-  session is ``boto3.DEFAULT_SESSION`` (see session_helper._initialize). Clients
-  created from it therefore inherit these retries, letting the internal IAM calls
-  ride out transient throttling without any source change.
+* ``_configure_default_boto_retries`` (autouse) — set an adaptive retry policy on
+  boto3's *default* session. The role resolver, when no explicit session is
+  passed, falls back to ``sagemaker.core...Session()`` whose boto session is
+  ``boto3.DEFAULT_SESSION`` (see session_helper._initialize). Clients created from
+  it therefore inherit these retries, letting the internal IAM calls ride out
+  transient throttling without any source change.
 
-* ``pytest_runtest_makereport`` — approach "C": a belt-and-suspenders fallback. If
-  a residual ``SimulatePrincipalPolicy`` throttling error still escapes after the
-  adaptive retries, convert the failure into an xfail so a transient rate limit
-  never reds the build. Genuine failures are untouched.
+Throttling that still exhausts the adaptive retry budget is deliberately left to
+fail the test loudly (rather than being converted to a skip), so a persistent
+rate-limit regression stays visible instead of silently disappearing from the
+results.
 """
 from __future__ import absolute_import
 
@@ -41,11 +41,6 @@ from botocore.config import Config
 # Adaptive retry budget for throttling-prone IAM validation calls.
 _ADAPTIVE_RETRY_CONFIG = Config(retries={"max_attempts": 10, "mode": "adaptive"})
 
-# Only tolerate throttling on the IAM permission simulation used during role
-# validation, so unrelated throttling still fails loudly.
-_THROTTLE_ERROR_CODES = ("Throttling", "ThrottlingException", "RequestLimitExceeded")
-_SIMULATE_OP = "SimulatePrincipalPolicy"
-
 
 @pytest.fixture(autouse=True, scope="session")
 def _configure_default_boto_retries():
@@ -54,36 +49,3 @@ def _configure_default_boto_retries():
     boto3.setup_default_session()
     boto3.DEFAULT_SESSION._session.set_default_client_config(_ADAPTIVE_RETRY_CONFIG)
     yield
-
-
-def _is_simulate_policy_throttle(exc):
-    """Return True if ``exc`` is a SimulatePrincipalPolicy throttling ClientError."""
-    from botocore.exceptions import ClientError
-
-    if not isinstance(exc, ClientError):
-        return False
-    error_code = exc.response.get("Error", {}).get("Code", "")
-    operation = getattr(exc, "operation_name", "") or ""
-    return error_code in _THROTTLE_ERROR_CODES and operation == _SIMULATE_OP
-
-
-@pytest.hookimpl(hookwrapper=True)
-def pytest_runtest_makereport(item, call):
-    """Skip (rather than fail) on residual SimulatePrincipalPolicy throttling that
-    survives the adaptive retries under heavy concurrency."""
-    outcome = yield
-    report = outcome.get_result()
-
-    if report.when != "call" or not report.failed:
-        return
-
-    exc = call.excinfo.value if call.excinfo else None
-    # Walk the exception chain so a wrapped ClientError is still detected.
-    while exc is not None:
-        if _is_simulate_policy_throttle(exc):
-            report.outcome = "skipped"
-            report.wasxfail = (
-                "iam:SimulatePrincipalPolicy throttled under concurrent test load"
-            )
-            break
-        exc = exc.__cause__ or exc.__context__

--- a/sagemaker-serve/tests/integ/conftest.py
+++ b/sagemaker-serve/tests/integ/conftest.py
@@ -18,14 +18,17 @@ API. With many workers hitting it at once IAM throttles the request, surfacing a
 ``ClientError: (Throttling) ... Rate exceeded`` and failing the build.
 
 This is purely a test-harness concurrency problem, so the mitigation lives here in
-the test layer rather than in SDK source:
+the test layer rather than in SDK source. It is intentionally identical to the
+block in ``sagemaker-train`` / ``sagemaker-mlops`` integ conftests:
 
-* ``_configure_default_boto_retries`` (autouse) — set an adaptive retry policy on
-  boto3's *default* session. The role resolver, when no explicit session is
-  passed, falls back to ``sagemaker.core...Session()`` whose boto session is
-  ``boto3.DEFAULT_SESSION`` (see session_helper._initialize). Clients created from
-  it therefore inherit these retries, letting the internal IAM calls ride out
-  transient throttling without any source change.
+* ``_configure_boto_adaptive_retries`` (autouse) — set adaptive retries via the
+  ``AWS_RETRY_MODE`` / ``AWS_MAX_ATTEMPTS`` environment variables. Env vars apply
+  to *every* boto3 client created in the worker, so the internal IAM calls ride
+  out transient throttling whether the resolver falls back to the default session
+  or builds its client from an explicitly-passed ``Session`` (several serve tests
+  pass their own session, whose IAM client would otherwise carry botocore's
+  default 4-attempt retry policy). ``adaptive`` mode also adds client-side rate
+  limiting to smooth bursts.
 
 Throttling that still exhausts the adaptive retry budget is deliberately left to
 fail the test loudly (rather than being converted to a skip), so a persistent
@@ -57,3 +60,8 @@ def _configure_boto_adaptive_retries():
     os.environ["AWS_RETRY_MODE"] = _RETRY_MODE
     os.environ["AWS_MAX_ATTEMPTS"] = _MAX_ATTEMPTS
     yield
+    for key, value in previous.items():
+        if value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = value

--- a/sagemaker-train/tests/integ/conftest.py
+++ b/sagemaker-train/tests/integ/conftest.py
@@ -31,11 +31,10 @@ block in ``sagemaker-serve`` / ``sagemaker-mlops`` integ conftests:
   its own). ``adaptive`` mode adds client-side rate limiting so bursts of
   ``SimulatePrincipalPolicy`` calls ride out transient throttling.
 
-* ``pytest_runtest_makereport`` — a belt-and-suspenders fallback. If a residual
-  ``SimulatePrincipalPolicy`` throttling error still escapes after the adaptive
-  retries, convert the failure into a skip so a transient rate limit never reds
-  the build. Genuine failures (and throttling on any other operation) are
-  untouched.
+Throttling that still exhausts the adaptive retry budget is deliberately left to
+fail the test loudly (rather than being converted to a skip), so a persistent
+rate-limit regression stays visible instead of silently disappearing from the
+results.
 """
 from __future__ import absolute_import
 
@@ -48,11 +47,6 @@ import pytest
 # which boto session the SDK ends up using to build its IAM client.
 _RETRY_MODE = "adaptive"
 _MAX_ATTEMPTS = "10"
-
-# Only tolerate throttling on the IAM permission simulation used during role
-# validation, so unrelated throttling still fails loudly.
-_THROTTLE_ERROR_CODES = ("Throttling", "ThrottlingException", "RequestLimitExceeded")
-_SIMULATE_OP = "SimulatePrincipalPolicy"
 
 
 @pytest.fixture(autouse=True, scope="session")
@@ -72,37 +66,3 @@ def _configure_boto_adaptive_retries():
             os.environ.pop(key, None)
         else:
             os.environ[key] = value
-
-
-def _is_simulate_policy_throttle(exc):
-    """Return True if ``exc`` is a SimulatePrincipalPolicy throttling ClientError."""
-    from botocore.exceptions import ClientError
-
-    if not isinstance(exc, ClientError):
-        return False
-    error_code = exc.response.get("Error", {}).get("Code", "")
-    operation = getattr(exc, "operation_name", "") or ""
-    return error_code in _THROTTLE_ERROR_CODES and operation == _SIMULATE_OP
-
-
-@pytest.hookimpl(hookwrapper=True)
-def pytest_runtest_makereport(item, call):
-    """Skip (rather than fail) on residual SimulatePrincipalPolicy throttling that
-    survives the adaptive retries under heavy concurrency. Applies to setup and
-    call phases, since role resolution frequently happens in fixture setup."""
-    outcome = yield
-    report = outcome.get_result()
-
-    if report.when not in ("setup", "call") or not report.failed:
-        return
-
-    exc = call.excinfo.value if call.excinfo else None
-    # Walk the exception chain so a wrapped ClientError is still detected.
-    while exc is not None:
-        if _is_simulate_policy_throttle(exc):
-            report.outcome = "skipped"
-            report.wasxfail = (
-                "iam:SimulatePrincipalPolicy throttled under concurrent test load"
-            )
-            break
-        exc = exc.__cause__ or exc.__context__


### PR DESCRIPTION
## Issue

The integ-test IAM throttling mitigation (merged in #6081) included a `pytest_runtest_makereport` hook that converted a `SimulatePrincipalPolicy` throttle **surviving the adaptive retries** into a **skipped** test. That masks a real regression: if the account is genuinely, persistently rate-limited, the affected tests silently drop out of the results instead of turning the build red. A skip reads as "not run," not "broken."

## Fix

Keep the transient-throttling protection, drop the failure-hiding part:

- **Kept** — `_configure_default_boto_retries` (autouse, session-scoped). Adaptive retries (`max_attempts=10`, `mode="adaptive"`) still smooth transient bursts, which is what fixes the common flaky-throttle case.
- **Removed** — the `pytest_runtest_makereport` skip conversion, plus its now-unused `_is_simulate_policy_throttle` helper and `_THROTTLE_ERROR_CODES` / `_SIMULATE_OP` constants.

Net effect: a throttle that exhausts the retry budget now **fails the test loudly**, so a persistent rate-limit regression stays visible.

## Testing
- `python -m py_compile` passes.
- Verified the remaining imports (`boto3`, `pytest`, `Config`) are all still used; no orphaned references to the removed hook/helper/constants remain.

## Type of change
- [x] Bug fix (non-breaking; test-layer only)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] Changes are limited to a test conftest; no SDK source or public API is touched
- [x] No new dependencies introduced

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
