### PR TITLE
Fix gpu integ test failure due to outdated MPG

### DIFF
--- a/sagemaker-train/tests/integ/train/test_mtrl_trainer_integration.py
+++ b/sagemaker-train/tests/integ/train/test_mtrl_trainer_integration.py
@@ -60,7 +60,7 @@ ACCOUNT_CONFIGS = {
         "dataset": "s3://sagemaker-rft-729646638167/prompts/gsm8k_small/prompts.parquet",
         "s3_output_path": "s3://sagemaker-us-west-2-729646638167/mtrl-integ/eval-output/",
         "mlflow_resource_arn": "arn:aws:sagemaker:us-west-2:729646638167:mlflow-app/app-TTAUWUNMUHH6",
-        "model_package_group": "arn:aws:sagemaker:us-west-2:729646638167:model-package-group/openai-reasoning-gpt-oss-20b-mtrl-mpg",
+        "model_package_group": "arn:aws:sagemaker:us-west-2:729646638167:model-package-group/mock-oss-test-mtrl-mpg",
     },
     # PREPROD — Staging account (391266019386)
     "391266019386": {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

* test *
 ```
 ======================================================================= test session starts =======================================================================
platform darwin -- Python 3.12.10, pytest-8.4.2, pluggy-1.6.0 -- /Users/rsareddy/workplace/virtual_envs/sagemaker-v3/bin/python3.12
cachedir: .pytest_cache
rootdir: /Users/rsareddy/workplace/sagemaker-sdk-forked-mtrl-vpc-support/sagemaker-python-sdk/sagemaker-train
configfile: pyproject.toml
plugins: cov-7.0.0, anyio-4.13.0
collected 1 item                                                                                                                                                  

tests/integ/train/test_mtrl_trainer_integration.py::TestMTRLEvalIntegration::test_evaluate_finetuned_model PASSED                                           [100%]

```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
