### PR TITLE
Fix mlflow (oss models) metrics viz

### DIFF
--- a/sagemaker-train/src/sagemaker/train/base_trainer.py
+++ b/sagemaker-train/src/sagemaker/train/base_trainer.py
@@ -701,7 +701,12 @@ class BaseTrainer(ABC):
     def _stream_logs_smhp(self, training_job, compute, poll: int, start_time_ms=None) -> None:
         """Stream logs for a HyperPod job using filter_log_events polling."""
 
-        job_id = training_job if isinstance(training_job, str) else str(training_job)
+        if isinstance(training_job, str):
+            job_id = training_job
+        elif hasattr(training_job, 'training_job_name'):
+            job_id = training_job.training_job_name
+        else:
+            job_id = str(training_job)
 
         sagemaker_session = TrainDefaults.get_sagemaker_session(
             sagemaker_session=self.sagemaker_session

--- a/sagemaker-train/src/sagemaker/train/common_utils/metrics_visualizer.py
+++ b/sagemaker-train/src/sagemaker/train/common_utils/metrics_visualizer.py
@@ -1,7 +1,10 @@
 """MLflow metrics visualization utilities for SageMaker training jobs."""
 
+import io
+import base64
 import logging
 from typing import Optional, List, Dict, Any
+
 from sagemaker.core.resources import TrainingJob
 
 logger = logging.getLogger(__name__)
@@ -209,7 +212,6 @@ def plot_training_metrics(
     import mlflow
     from mlflow.tracking import MlflowClient
     from IPython.display import display
-    import logging
     
     logging.getLogger('botocore.credentials').setLevel(logging.WARNING)
     
@@ -242,9 +244,6 @@ def plot_training_metrics(
     # calling display(fig) directly we render to an in-memory PNG and embed
     # it inside a scrollable HTML <div>. This lets the notebook display all
     # metrics without choking on pixel-count limits.
-    import io
-    import base64
-
     rows = (num_metrics + 1) // 2
     fig, axes = plt.subplots(rows, 2, figsize=(figsize[0], figsize[1] * rows), squeeze=False)
     axes = axes.flatten()

--- a/sagemaker-train/src/sagemaker/train/common_utils/metrics_visualizer.py
+++ b/sagemaker-train/src/sagemaker/train/common_utils/metrics_visualizer.py
@@ -231,13 +231,24 @@ def plot_training_metrics(
         history = client.get_metric_history(run_id, metric_name)
         if history:
             metric_data[metric_name] = history
-    
-    # Plot
+
     num_metrics = len(metric_data)
+    if num_metrics == 0:
+        logger.warning("No metric history found for run %s. Nothing to plot.", run_id)
+        return
+
+    # Build the figure at full size (2 columns, all metrics). The inline
+    # backend can't rasterize this when it gets too tall, so instead of
+    # calling display(fig) directly we render to an in-memory PNG and embed
+    # it inside a scrollable HTML <div>. This lets the notebook display all
+    # metrics without choking on pixel-count limits.
+    import io
+    import base64
+
     rows = (num_metrics + 1) // 2
-    fig, axes = plt.subplots(rows, 2, figsize=(figsize[0], figsize[1] * rows))
-    axes = axes.flatten() if num_metrics > 1 else [axes]
-    
+    fig, axes = plt.subplots(rows, 2, figsize=(figsize[0], figsize[1] * rows), squeeze=False)
+    axes = axes.flatten()
+
     for idx, (metric_name, history) in enumerate(metric_data.items()):
         steps = [h.step for h in history]
         values = [h.value for h in history]
@@ -246,14 +257,31 @@ def plot_training_metrics(
         axes[idx].set_ylabel('Value')
         axes[idx].set_title(metric_name, fontweight='bold')
         axes[idx].grid(True, alpha=0.3)
-    
-    for idx in range(len(metric_data), len(axes)):
+
+    for idx in range(num_metrics, len(axes)):
         axes[idx].set_visible(False)
-    
-    plt.suptitle(f'Training Metrics: {training_job.training_job_name}', fontweight='bold', fontsize=14)
-    plt.tight_layout(rect=[0, 0, 1, 0.98])  # Leave small space for suptitle
-    display(fig)
-    plt.close()
+
+    fig.suptitle(
+        f'Training Metrics: {training_job.training_job_name}',
+        fontweight='bold', fontsize=14,
+    )
+    fig.tight_layout(rect=[0, 0, 1, 0.98])
+
+    # Render to PNG buffer for inline display
+    buf = io.BytesIO()
+    fig.savefig(buf, format="png", dpi=80, bbox_inches="tight")
+    plt.close(fig)
+    buf.seek(0)
+
+    # Embed as a scrollable HTML image in the notebook
+    b64 = base64.b64encode(buf.getvalue()).decode()
+    from IPython.display import HTML
+    display(HTML(
+        f'<div style="max-height:800px; overflow-y:scroll; border:1px solid #ccc; '
+        f'border-radius:4px; padding:4px;">'
+        f'<img src="data:image/png;base64,{b64}" style="width:100%;" />'
+        f'</div>'
+    ))
 
 
 def get_available_metrics(training_job: TrainingJob) -> List[str]:


### PR DESCRIPTION
## Description

Fix related to mlflow (oss models) metrics visualization.

### 1. `plot_training_metrics` failed to render tall figures inline

When plotting many metrics, the combined figure grew too tall for the
inline backend to rasterize, so `display(fig)` produced no output. A
single-metric run also broke because `plt.subplots` returned a bare Axes
that couldn't be flattened.

Changes:
- Return early with a warning when no metric history is found
- Pass `squeeze=False` to `plt.subplots` so `axes` is always a 2D array
  that can be flattened, fixing the single-metric case
- Render the figure to an in-memory PNG and embed it inside a scrollable
  HTML `<div>`, allowing all metrics to display without hitting the
  backend's pixel-count limits

## Testing

- Verified metrics plotting renders correctly for zero, one, and many
  metrics

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
