### PR TITLE
[DO NOT MERGE] test: verify PR coverage after #6082 routing fix

### DIFF
--- a/sagemaker-core/src/sagemaker/core/__init__.py
+++ b/sagemaker-core/src/sagemaker/core/__init__.py
@@ -30,3 +30,4 @@ from sagemaker.core.telemetry.attribution import Attribution, set_attribution  #
 
 # Note: HyperparameterTuner and WarmStartTypes are in sagemaker.train.tuner
 # They are not re-exported from core to avoid circular dependencies
+# No-op line to trigger CI for a Codecov verification post-#6082 (DO NOT MERGE).

--- a/sagemaker-mlops/src/sagemaker/mlops/__init__.py
+++ b/sagemaker-mlops/src/sagemaker/mlops/__init__.py
@@ -31,3 +31,4 @@ __all__ = [
     "ModelBuilder",
     "workflow",  # Submodule
 ]
+# No-op line to trigger CI for a Codecov verification post-#6082 (DO NOT MERGE).

--- a/sagemaker-serve/src/sagemaker/serve/__init__.py
+++ b/sagemaker-serve/src/sagemaker/serve/__init__.py
@@ -57,3 +57,4 @@ __all__ = [
     "WorkloadValidationError",
     "start_benchmark",
 ]
+# No-op line to trigger CI for a Codecov verification post-#6082 (DO NOT MERGE).

--- a/sagemaker-train/src/sagemaker/train/__init__.py
+++ b/sagemaker-train/src/sagemaker/train/__init__.py
@@ -120,3 +120,4 @@ def __getattr__(name):
         from sagemaker.core.training.configs import HyperPodCompute
         return HyperPodCompute
     raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
+# No-op line to trigger CI for a Codecov verification post-#6082 (DO NOT MERGE).


### PR DESCRIPTION
## ⚠️ DO NOT MERGE — verification PR

Re-verification now that **#6082 is merged** (PR unit-tests route to the CDK-managed `ci-health-unit-test-v3` project, which runs `--cov=sagemaker`). No-op comment in all 4 submodule `__init__.py` files so every unit-test job runs and uploads coverage.

### Expected
With #6082 live, the unit-test jobs now run the fixed buildspec, so uploaded coverage.xml is **product-only** (test files excluded).

### Known remaining caveats
- **#6056 not merged** — `after_n_builds: 4` still on master, so this uses 4 submodules to produce 4 uploads.
- **Uploader still bare** — the CodeBuild codecov upload call still lacks `-B/-P/-F`, so uploads carry `branch=` empty / `pr=false` / no flags. If that's still the case, coverage may still not attach to the PR (and the 4 uploads may collapse to `sessions=1`). This PR will tell us definitively whether the uploader fix is the last remaining blocker.

Will be closed without merging once we read the result.