### PR TITLE
fix: update job key used for show_metrics/stream_logs in MTRL

### DIFF
--- a/sagemaker-serve/src/sagemaker/serve/bedrock_model_builder.py
+++ b/sagemaker-serve/src/sagemaker/serve/bedrock_model_builder.py
@@ -361,7 +361,7 @@ class BedrockModelBuilder:
                         self._get_bedrock_client(), model_arn
                     )
                     if existing_deployment:
-                        logger.warning(
+                        logger.info(
                             "Reusing existing custom model %s and deployment %s "
                             "(matched model-source tag). No new resources were created. "
                             "Pass reuse_resources=False to force new resources.",
@@ -372,7 +372,7 @@ class BedrockModelBuilder:
                             "modelArn": model_arn,
                             "customModelDeploymentArn": existing_deployment,
                         }
-                    logger.warning(
+                    logger.info(
                         "Reusing existing custom model %s (matched model-source tag); "
                         "creating a new deployment on it. Pass reuse_resources=False to "
                         "force a new model.",

--- a/sagemaker-serve/src/sagemaker/serve/model_builder.py
+++ b/sagemaker-serve/src/sagemaker/serve/model_builder.py
@@ -167,6 +167,8 @@ from sagemaker.serve.model_reuse import (
     MODEL_SOURCE_TAG_KEY,
 )
 from sagemaker.core.training.utils import resolve_nova_checkpoint_uri
+from sagemaker.train.common_utils.model_aliases import normalize_model_name
+
 
 _LOWEST_MMS_VERSION = "1.2"
 SCRIPT_PARAM_NAME = "sagemaker_program"
@@ -1072,6 +1074,71 @@ class ModelBuilder(_InferenceRecommenderMixin, _ModelBuilderServers, _ModelBuild
             f"Please use a model that supports deployment or contact AWS support for assistance."
         )
 
+    def _resolve_hosting_config_from_base_model_name(self):
+        """Resolve image_uri, env_vars, and instance_type from Hub using base_model_name.
+
+        Used when no model package is available (e.g. serverful SMTJ training jobs).
+        The base_model_name is normalized to a Hub content name, then the Hub document
+        is fetched to extract hosting configuration — replicating what the model-package
+        path does via _fetch_and_cache_recipe_config().
+        """
+
+        base_model_name = self._base_model_name()
+        if not base_model_name:
+            raise ValueError(
+                "base_model_name is required when deploying a model from an S3 checkpoint "
+                "(e.g. a serverful SMTJ training job) because no model package is available "
+                "to auto-resolve the inference container image. "
+                "Set trainer.base_model_name before calling build()."
+            )
+
+        # If user already provided image_uri, skip hub resolution
+        if self.image_uri:
+            logger.info(f"Using provided image_uri: {self.image_uri}")
+            return
+
+        hub_content_name = normalize_model_name(base_model_name)
+        hub_name = getattr(self, "hub_name", None) or "SageMakerPublicHub"
+
+        try:
+            hub_content = HubContent.get(
+                hub_content_type="Model",
+                hub_name=hub_name,
+                hub_content_name=hub_content_name,
+            )
+            hub_document = json.loads(hub_content.hub_content_document)
+        except Exception as e:
+            raise ValueError(
+                f"Could not resolve hosting configuration from Hub for model "
+                f"'{base_model_name}' (hub_content_name='{hub_content_name}'). "
+                f"Please provide image_uri explicitly to ModelBuilder. Error: {e}"
+            )
+
+        # Try to find hosting configs in the RecipeCollection
+        for recipe in hub_document.get("RecipeCollection", []):
+            hosting_configs = recipe.get("HostingConfigs", [])
+            if hosting_configs:
+                config = self._select_hosting_config_entry(hosting_configs)
+                self.image_uri = config.get("EcrAddress")
+                if self.image_uri:
+                    logger.info(f"Resolved image_uri from Hub: {self.image_uri}")
+                    return
+
+        raise ValueError(
+            f"Could not resolve inference image URI from Hub for model "
+            f"'{base_model_name}' (hub_content_name='{hub_content_name}'). "
+            f"No hosting configuration found in the hub document. "
+            f"Please provide image_uri explicitly to ModelBuilder."
+        )
+
+    @staticmethod
+    def _select_hosting_config_entry(hosting_configs):
+        """Select the best hosting config entry, preferring 'Default' profile."""
+        return next(
+            (cfg for cfg in hosting_configs if cfg.get("Profile") == "Default"),
+            hosting_configs[0],
+        )
+
     # Nova escrow ECR accounts per region
     _NOVA_ESCROW_ACCOUNTS = {
         "us-east-1": "708977205387",
@@ -1267,7 +1334,13 @@ class ModelBuilder(_InferenceRecommenderMixin, _ModelBuilderServers, _ModelBuild
             return hub_config
 
         model_package = self._fetch_model_package()
-        hub_content_name = model_package.inference_specification.containers[0].base_model.hub_content_name
+        if model_package:
+            hub_content_name = model_package.inference_specification.containers[0].base_model.hub_content_name
+        else:
+            # No model package (e.g. SMTJ trainer): resolve from base_model_name
+            from sagemaker.train.common_utils.model_aliases import normalize_model_name
+            base_model_name = self._base_model_name()
+            hub_content_name = normalize_model_name(base_model_name) if base_model_name else None
 
         configs = self._NOVA_HOSTING_CONFIGS.get(hub_content_name)
         if not configs:
@@ -2904,27 +2977,16 @@ class ModelBuilder(_InferenceRecommenderMixin, _ModelBuilderServers, _ModelBuild
 
             # Fetch recipe config first to set image_uri, instance_type, env_vars,
             # and s3_upload_path. Only possible when a model package is available;
-            # trainers built from an S3 checkpoint carry no package, so the caller
-            # must supply image_uri/instance_type/env_vars directly.
+            # trainers built from an S3 checkpoint carry no package, so we resolve
+            # hosting config from the Hub using base_model_name.
             if model_package is not None:
                 base_model = model_package.inference_specification.containers[0].base_model
                 if base_model is not None:
                     self._fetch_and_cache_recipe_config()
             else:
-                # No model package available (e.g. serverful SMTJ training job).
-                # Validate required fields that would normally be auto-resolved.
-                missing_fields = []
-                if not self.image_uri:
-                    missing_fields.append("image_uri")
-                if isinstance(self.model, BaseTrainer) and not self.model.base_model_name:
-                    missing_fields.append("trainer.base_model_name")
-                if missing_fields:
-                    raise ValueError(
-                        f"When deploying a model from an S3 checkpoint (e.g. a serverful SMTJ "
-                        f"training job), the following must be provided because no model package "
-                        f"is available to auto-resolve them: {', '.join(missing_fields)}. "
-                        f"Set these on the ModelBuilder or trainer before calling build()."
-                    )
+                # No model package (e.g. serverful SMTJ training job).
+                # Resolve hosting config from Hub using base_model_name.
+                self._resolve_hosting_config_from_base_model_name()
 
             # Nova models use a completely different deployment architecture
             if self._is_nova_model():

--- a/sagemaker-serve/src/sagemaker/serve/model_builder.py
+++ b/sagemaker-serve/src/sagemaker/serve/model_builder.py
@@ -1075,28 +1075,18 @@ class ModelBuilder(_InferenceRecommenderMixin, _ModelBuilderServers, _ModelBuild
         )
 
     def _resolve_hosting_config_from_base_model_name(self):
-        """Resolve image_uri, env_vars, and instance_type from Hub using base_model_name.
+        """Resolve image_uri from Hub using base_model_name.
 
         Used when no model package is available (e.g. serverful SMTJ training jobs).
         The base_model_name is normalized to a Hub content name, then the Hub document
-        is fetched to extract hosting configuration — replicating what the model-package
-        path does via _fetch_and_cache_recipe_config().
+        is fetched to extract the inference container image URI.
         """
-
-        base_model_name = self._base_model_name()
-        if not base_model_name:
-            raise ValueError(
-                "base_model_name is required when deploying a model from an S3 checkpoint "
-                "(e.g. a serverful SMTJ training job) because no model package is available "
-                "to auto-resolve the inference container image. "
-                "Set trainer.base_model_name before calling build()."
-            )
-
         # If user already provided image_uri, skip hub resolution
         if self.image_uri:
             logger.info(f"Using provided image_uri: {self.image_uri}")
             return
 
+        base_model_name = self._base_model_name()
         hub_content_name = normalize_model_name(base_model_name)
         hub_name = getattr(self, "hub_name", None) or "SageMakerPublicHub"
 
@@ -1338,7 +1328,6 @@ class ModelBuilder(_InferenceRecommenderMixin, _ModelBuilderServers, _ModelBuild
             hub_content_name = model_package.inference_specification.containers[0].base_model.hub_content_name
         else:
             # No model package (e.g. SMTJ trainer): resolve from base_model_name
-            from sagemaker.train.common_utils.model_aliases import normalize_model_name
             base_model_name = self._base_model_name()
             hub_content_name = normalize_model_name(base_model_name) if base_model_name else None
 
@@ -2985,7 +2974,16 @@ class ModelBuilder(_InferenceRecommenderMixin, _ModelBuilderServers, _ModelBuild
                     self._fetch_and_cache_recipe_config()
             else:
                 # No model package (e.g. serverful SMTJ training job).
-                # Resolve hosting config from Hub using base_model_name.
+                # base_model_name is required to identify the model type and resolve
+                # hosting config, escrow URI, tags, etc.
+                if not self._base_model_name():
+                    raise ValueError(
+                        "trainer.base_model_name is required when deploying a model from an "
+                        "S3 checkpoint (e.g. a serverful SMTJ training job) because no model "
+                        "package is available to identify the model. "
+                        "Set trainer.base_model_name before calling build()."
+                    )
+                # Resolve image_uri from Hub using base_model_name.
                 self._resolve_hosting_config_from_base_model_name()
 
             # Nova models use a completely different deployment architecture

--- a/sagemaker-serve/src/sagemaker/serve/model_builder.py
+++ b/sagemaker-serve/src/sagemaker/serve/model_builder.py
@@ -2853,6 +2853,16 @@ class ModelBuilder(_InferenceRecommenderMixin, _ModelBuilderServers, _ModelBuild
 
         self.serve_settings = self._get_serve_setting()
 
+        # Validate BaseTrainer has a completed training job before proceeding
+        if isinstance(self.model, BaseTrainer):
+            if not hasattr(self.model, "_latest_training_job") or self.model._latest_training_job is None:
+                raise ValueError(
+                    "The trainer passed to ModelBuilder does not have a completed training job. "
+                    "Either call trainer.train() first, or manually set "
+                    "trainer._latest_training_job = TrainingJob.get(training_job_name='<job-name>') "
+                    "to attach a previously completed job."
+                )
+
         # Handle model customization (fine-tuned models)
         if self._is_model_customization():
             if mode is not None and mode != Mode.SAGEMAKER_ENDPOINT:
@@ -2900,6 +2910,21 @@ class ModelBuilder(_InferenceRecommenderMixin, _ModelBuilderServers, _ModelBuild
                 base_model = model_package.inference_specification.containers[0].base_model
                 if base_model is not None:
                     self._fetch_and_cache_recipe_config()
+            else:
+                # No model package available (e.g. serverful SMTJ training job).
+                # Validate required fields that would normally be auto-resolved.
+                missing_fields = []
+                if not self.image_uri:
+                    missing_fields.append("image_uri")
+                if isinstance(self.model, BaseTrainer) and not self.model.base_model_name:
+                    missing_fields.append("trainer.base_model_name")
+                if missing_fields:
+                    raise ValueError(
+                        f"When deploying a model from an S3 checkpoint (e.g. a serverful SMTJ "
+                        f"training job), the following must be provided because no model package "
+                        f"is available to auto-resolve them: {', '.join(missing_fields)}. "
+                        f"Set these on the ModelBuilder or trainer before calling build()."
+                    )
 
             # Nova models use a completely different deployment architecture
             if self._is_nova_model():

--- a/sagemaker-serve/src/sagemaker/serve/model_builder.py
+++ b/sagemaker-serve/src/sagemaker/serve/model_builder.py
@@ -4056,7 +4056,7 @@ class ModelBuilder(_InferenceRecommenderMixin, _ModelBuilderServers, _ModelBuild
                 reusable_endpoint = self._find_reusable_endpoint()
                 if reusable_endpoint:
                     self._reused_endpoint_name = reusable_endpoint
-                logger.warning(
+                logger.info(
                     "Reusing existing Model %r (matched model-source tag). "
                     "No new Model will be created. Pass reuse_resources=False "
                     "to force a new Model.",
@@ -5518,7 +5518,7 @@ class ModelBuilder(_InferenceRecommenderMixin, _ModelBuilderServers, _ModelBuild
                         endpoint_name,
                         reusable_endpoint,
                     )
-                logger.warning(
+                logger.info(
                     "Reusing existing endpoint %r (matched model-source tag and "
                     "deployment configuration). No new resources were created. "
                     "Pass reuse_resources=False to force a new endpoint.",

--- a/sagemaker-train/src/sagemaker/train/base_trainer.py
+++ b/sagemaker-train/src/sagemaker/train/base_trainer.py
@@ -396,11 +396,20 @@ class BaseTrainer(ABC):
             ValueError: If no training job has been run yet, no logs/metrics
                 are found, or MLflow is not configured for OSS models.
         """
-        # Validate that we have a training job to get metrics from
-        if not hasattr(self, '_latest_training_job') or self._latest_training_job is None:
-            raise ValueError(
-                "No training job found. Call .train() first, then call .show_metrics() "
-                "to view training metrics."
+        # Resolve the job reference. Prefer _latest_training_job (CreateTrainingJob),
+        # fall back to _latest_job (generic CreateJob API used by MTRL).
+        resolved_job = getattr(self, '_latest_training_job', None)
+        if resolved_job is None:
+            latest_job = getattr(self, '_latest_job', None)
+            if latest_job is None:
+                raise ValueError(
+                    "No training job found. Call .train() first, then call .show_metrics() "
+                    "to view training metrics. If training has already completed, set the "
+                    "job name directly via trainer._latest_training_job = '<job-name>' or "
+                    "trainer._latest_job = '<job-name>'."
+                )
+            resolved_job = (
+                latest_job.job_name if hasattr(latest_job, 'job_name') else str(latest_job)
             )
 
         # Route based on model type
@@ -408,18 +417,19 @@ class BaseTrainer(ABC):
         is_nova = _is_nova_model(model_name) if model_name else False
 
         if is_nova:
-            return self._show_metrics_cloudwatch(metrics, starting_step, ending_step, start_time, end_time)
+            return self._show_metrics_cloudwatch(resolved_job, metrics, starting_step, ending_step, start_time, end_time)
         else:
-            return self._show_metrics_mlflow(metrics, starting_step, ending_step)
+            return self._show_metrics_mlflow(resolved_job, metrics, starting_step, ending_step)
 
     def _show_metrics_mlflow(
         self,
+        resolved_job,
         metrics: Optional[List[str]] = None,
         starting_step: Optional[int] = None,
         ending_step: Optional[int] = None,
     ) -> None:
         """Pull and plot training metrics from MLflow for non-Nova models."""
-        training_job = self._latest_training_job
+        training_job = resolved_job
 
         # Resolve the TrainingJob object if it's a string
         if isinstance(training_job, str):
@@ -453,6 +463,7 @@ class BaseTrainer(ABC):
 
     def _show_metrics_cloudwatch(
         self,
+        resolved_job,
         metrics: Optional[List[str]] = None,
         starting_step: Optional[int] = None,
         ending_step: Optional[int] = None,
@@ -461,7 +472,7 @@ class BaseTrainer(ABC):
     ) -> Any:
         """Parse and plot training metrics from CloudWatch logs (Nova models)."""
         
-        training_job = self._latest_training_job
+        training_job = resolved_job
         if hasattr(training_job, 'training_job_name'):
             job_id = training_job.training_job_name
         elif isinstance(training_job, str):
@@ -628,10 +639,21 @@ class BaseTrainer(ABC):
         Raises:
             ValueError: If no training job has been run yet.
         """
-        if not hasattr(self, '_latest_training_job') or self._latest_training_job is None:
-            raise ValueError(
-                "No training job found. Call .train(wait=False) first, "
-                "then call .stream_logs() to stream logs in real-time."
+        # Resolve the job reference. Prefer _latest_training_job (CreateTrainingJob),
+        # fall back to _latest_job (generic CreateJob API used by MTRL).
+        resolved_job = getattr(self, '_latest_training_job', None)
+        if resolved_job is None:
+            latest_job = getattr(self, '_latest_job', None)
+            if latest_job is None:
+                raise ValueError(
+                    "No training job found. Call .train(wait=False) first, "
+                    "then call .stream_logs() to stream logs in real-time. "
+                    "If training has already completed, set the job name directly via "
+                    "trainer._latest_training_job = '<job-name>' or "
+                    "trainer._latest_job = '<job-name>'."
+                )
+            resolved_job = (
+                latest_job.job_name if hasattr(latest_job, 'job_name') else str(latest_job)
             )
 
         # Resolve start_time for SMHP jobs
@@ -642,7 +664,7 @@ class BaseTrainer(ABC):
             else:
                 start_time_ms = int(start_time)
 
-        training_job = self._latest_training_job
+        training_job = resolved_job
         compute = getattr(self, 'compute', None)
 
         if isinstance(compute, HyperPodCompute):

--- a/sagemaker-train/src/sagemaker/train/common_utils/cloudwatch_metrics.py
+++ b/sagemaker-train/src/sagemaker/train/common_utils/cloudwatch_metrics.py
@@ -33,11 +33,13 @@ AVAILABLE_METRICS: Dict[str, Dict[str, Dict[str, str]]] = {
         "SFT": {"training_loss": TRAINING_LOSS_REGEX, "lr": LEARNING_RATE_REGEX},
         "CPT": {"training_loss": TRAINING_LOSS_REGEX, "lr": LEARNING_RATE_REGEX},
         "RLVR": {"reward_score": SMTJ_RLVR_REWARD_SCORE_REGEX},
+        "MTRL": {"reward_score": SMTJ_RLVR_REWARD_SCORE_REGEX},
     },
     "smhp": {
         "SFT": {"training_loss": TRAINING_LOSS_REGEX, "lr": LEARNING_RATE_REGEX},
         "CPT": {"training_loss": TRAINING_LOSS_REGEX, "lr": LEARNING_RATE_REGEX},
         "RLVR": {"reward_score": SMHP_RLVR_REWARD_SCORE_REGEX},
+        "MTRL": {"reward_score": SMHP_RLVR_REWARD_SCORE_REGEX},
     },
 }
 

--- a/sagemaker-train/src/sagemaker/train/common_utils/data_utils.py
+++ b/sagemaker-train/src/sagemaker/train/common_utils/data_utils.py
@@ -248,7 +248,7 @@ def is_multimodal_data(dataset: Union[str, "DataSet"]) -> bool:
         True if multimodal fields detected, False otherwise
     """
 
-    logger.info(f"Auto-detecting whether dataset is multimodal: {dataset}")
+    logger.debug(f"Auto-detecting whether dataset is multimodal: {dataset}")
 
     if isinstance(dataset, DataSet):
         data_s3_path = dataset.source

--- a/sagemaker-train/src/sagemaker/train/cpt_trainer.py
+++ b/sagemaker-train/src/sagemaker/train/cpt_trainer.py
@@ -40,7 +40,6 @@ from sagemaker.train.common_utils.telemetry_params import BASE_TRAINER_TELEMETRY
 from sagemaker.core.telemetry.constants import Feature
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 
 class CPTTrainer(BaseTrainer):

--- a/sagemaker-train/src/sagemaker/train/dpo_trainer.py
+++ b/sagemaker-train/src/sagemaker/train/dpo_trainer.py
@@ -31,7 +31,6 @@ from sagemaker.core.telemetry.constants import Feature
 from sagemaker.train.constants import get_sagemaker_hub_name
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 
 class DPOTrainer(BaseTrainer):

--- a/sagemaker-train/src/sagemaker/train/model_trainer.py
+++ b/sagemaker-train/src/sagemaker/train/model_trainer.py
@@ -810,6 +810,8 @@ class ModelTrainer(BaseModel):
         """
         training_request = self._create_training_job_args(input_data_config=input_data_config)
 
+        logger.info(f"Training Job Name: {training_request['training_job_name']}")
+
         if dry_run:
             logger.info("Dry-run validation passed. No job submitted.")
             return None

--- a/sagemaker-train/src/sagemaker/train/multi_turn_rl_trainer.py
+++ b/sagemaker-train/src/sagemaker/train/multi_turn_rl_trainer.py
@@ -173,6 +173,8 @@ class MultiTurnRLTrainer(BaseTrainer):
             and 'job_name_prefix'. If not specified, no notifications are sent.
     """
 
+    _customization_technique = "MTRL"
+
     def __init__(
         self,
         model: Union[str, ModelPackage],

--- a/sagemaker-train/src/sagemaker/train/sft_trainer.py
+++ b/sagemaker-train/src/sagemaker/train/sft_trainer.py
@@ -41,7 +41,6 @@ from sagemaker.train.constants import get_sagemaker_hub_name
 from sagemaker.core.training.constants import TrainingPlatform
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 
 class SFTTrainer(BaseTrainer):


### PR DESCRIPTION
Updated logging level and fixed two erorrs:

MTRL's train() stores the job as  self._latest_job  (multi_turn_rl_trainer.py L336) but show_metrics() checks  self._latest_training_job  (base_trainer.py L400) so it raises "no training job found. Call .train() first" immediately after a successful train()

Secondly, MTRL never sets  _customization_technique  and has no entry in AVAILABLE_METRICS (only SFT/CPT/RLVR exist) so then it raises "Could not determine training technique.