### PR TITLE
[mtrl] Fix undefined STAGE in S3_TRAINING_DATA path

### DIFF
--- a/v3-examples/model-customization-examples/mtrl_finetuning_example_notebook_v3_prod.ipynb
+++ b/v3-examples/model-customization-examples/mtrl_finetuning_example_notebook_v3_prod.ipynb
@@ -120,7 +120,7 @@
     "from sagemaker.ai_registry.dataset import DataSet\n",
     "\n",
     "# Option A: Use an S3 path directly\n",
-    "S3_TRAINING_DATA = f\"s3://{REGION}-{CUSTOMER_ACCOUNT}-{STAGE}-rftjob-input/test-data/prompts/math-100-parquet/\"\n",
+    "S3_TRAINING_DATA = \"s3://<your-bucket>/<path-to-your-training-data>/\"  # TODO: replace with your training data S3 URI\n",
     "\n",
     "# Option B: Register a dataset in SageMaker AI Registry\n",
     "# This creates a versioned dataset that can be referenced by ARN\n",


### PR DESCRIPTION
## Issue
The 3rd code cell of `v3-examples/model-customization-examples/mtrl_finetuning_example_notebook_v3_prod.ipynb` fails to execute with `NameError: name 'STAGE' is not defined`.

The cell built the training-data path from an f-string referencing an undefined `STAGE` variable and an internal `-rftjob-input` bucket pattern:

```python
S3_TRAINING_DATA = f"s3://{REGION}-{CUSTOMER_ACCOUNT}-{STAGE}-rftjob-input/test-data/prompts/math-100-parquet/"
```

`REGION` and `CUSTOMER_ACCOUNT` are defined earlier in the notebook, but `STAGE` is not — a leftover from when MTRL was tested internally in gamma/prod. An SA following the [MTRL best-practices blog](https://aws.amazon.com/blogs/machine-learning/best-practices-for-multi-turn-reinforcement-learning-in-amazon-sagemaker-ai/) and this notebook hit this error.

## Fix
Replace the internal STAGE-based path with a customer-facing placeholder S3 URI, matching the convention already used in the sibling `sft_finetuning_example_notebook_pysdk_prod_v3.ipynb`:

```python
S3_TRAINING_DATA = "s3://<your-bucket>/<path-to-your-training-data>/"  # TODO: replace with your training data S3 URI
```

Customers (and the notebook test engine, which substitutes a real dataset S3 URI) can now fill in their own dataset path.

## Notes
- Single-line change; notebook validated as well-formed JSON.
- Keeps this notebook in sync with the same fix in `aws/amazon-sagemaker-examples` (aws/amazon-sagemaker-examples#4904).
