### PR TITLE
fix: forward tolerance flags from get_jumpstart_configs

### DIFF
--- a/src/sagemaker/jumpstart/estimator.py
+++ b/src/sagemaker/jumpstart/estimator.py
@@ -1206,6 +1206,8 @@ class JumpStartEstimator(Estimator):
             region=self.region,
             scope=JumpStartScriptScope.TRAINING,
             sagemaker_session=self.sagemaker_session,
+            tolerate_vulnerable_model=self.tolerate_vulnerable_model,
+            tolerate_deprecated_model=self.tolerate_deprecated_model,
         )
         return list(configs_dict.values())
 

--- a/src/sagemaker/jumpstart/model.py
+++ b/src/sagemaker/jumpstart/model.py
@@ -401,6 +401,8 @@ class JumpStartModel(Model):
             sagemaker_session=self.sagemaker_session,
             model_type=self.model_type,
             hub_arn=self.hub_arn,
+            tolerate_vulnerable_model=self.tolerate_vulnerable_model,
+            tolerate_deprecated_model=self.tolerate_deprecated_model,
         )
 
     def log_subscription_warning(self) -> None:

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -1146,8 +1146,19 @@ def get_jumpstart_configs(
     scope: enums.JumpStartScriptScope = enums.JumpStartScriptScope.INFERENCE,
     model_type: enums.JumpStartModelType = enums.JumpStartModelType.OPEN_WEIGHTS,
     hub_arn: Optional[str] = None,
+    tolerate_vulnerable_model: bool = False,
+    tolerate_deprecated_model: bool = False,
 ) -> Dict[str, JumpStartMetadataConfig]:
     """Returns metadata configs for the given model ID and region.
+
+    Args:
+        tolerate_vulnerable_model (bool): True if vulnerable versions of model
+            specifications should be tolerated (exception not raised). If False, raises an
+            exception if the script used by this version of the model has dependencies with known
+            security vulnerabilities. (Default: False).
+        tolerate_deprecated_model (bool): True if deprecated models should be tolerated
+            (exception not raised). False if these models should raise an exception.
+            (Default: False).
 
     Raises:
         ValueError: If the script scope is not supported by JumpStart.
@@ -1160,6 +1171,8 @@ def get_jumpstart_configs(
         scope=scope,
         model_type=model_type,
         hub_arn=hub_arn,
+        tolerate_vulnerable_model=tolerate_vulnerable_model,
+        tolerate_deprecated_model=tolerate_deprecated_model,
     )
 
     if scope == enums.JumpStartScriptScope.INFERENCE:

--- a/tests/unit/sagemaker/jumpstart/estimator/test_estimator.py
+++ b/tests/unit/sagemaker/jumpstart/estimator/test_estimator.py
@@ -2301,6 +2301,37 @@ class EstimatorTest(unittest.TestCase):
 
         mock_estimator_fit.assert_called_once_with(wait=True, job_name="pt-ic-mobilenet-v2-8675309")
 
+    @mock.patch("sagemaker.jumpstart.estimator.get_jumpstart_configs")
+    @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor._get_manifest")
+    @mock.patch("sagemaker.jumpstart.factory.estimator.Session")
+    @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
+    @mock.patch("sagemaker.jumpstart.estimator.Estimator.__init__")
+    @mock.patch("sagemaker.jumpstart.factory.estimator.JUMPSTART_DEFAULT_REGION_NAME", region)
+    def test_estimator_list_training_configs_forwards_tolerance(
+        self,
+        mock_estimator_init: mock.Mock,
+        mock_get_model_specs: mock.Mock,
+        mock_session: mock.Mock,
+        mock_get_manifest: mock.Mock,
+        mock_get_jumpstart_configs: mock.Mock,
+    ):
+        mock_get_model_specs.side_effect = get_prototype_spec_with_configs
+        mock_get_manifest.side_effect = (
+            lambda region, model_type, *args, **kwargs: get_prototype_manifest(region, model_type)
+        )
+        mock_get_jumpstart_configs.return_value = {}
+        mock_session.return_value = sagemaker_session
+
+        estimator = JumpStartEstimator(
+            model_id="pytorch-ic-mobilenet-v2",
+            tolerate_vulnerable_model=True,
+            tolerate_deprecated_model=True,
+        )
+
+        assert estimator.list_training_configs() == []
+        assert mock_get_jumpstart_configs.call_args.kwargs["tolerate_vulnerable_model"] is True
+        assert mock_get_jumpstart_configs.call_args.kwargs["tolerate_deprecated_model"] is True
+
     @mock.patch("sagemaker.utils.sagemaker_timestamp")
     @mock.patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor._get_manifest")
     @mock.patch("sagemaker.jumpstart.factory.estimator.Session")

--- a/tests/unit/sagemaker/jumpstart/test_utils.py
+++ b/tests/unit/sagemaker/jumpstart/test_utils.py
@@ -1812,6 +1812,110 @@ class TestConfigs:
             "ml.p3.2xlarge",
         ]
 
+    @patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
+    def test_get_jumpstart_configs_vulnerable_model_raises_by_default(
+        self,
+        patched_get_model_specs,
+    ):
+        def make_vulnerable_spec(*largs, **kwargs):
+            spec = get_base_spec_with_prototype_configs()
+            spec.inference_vulnerable = True
+            spec.inference_vulnerabilities = ["CVE-2024-11393"]
+            return spec
+
+        patched_get_model_specs.side_effect = make_vulnerable_spec
+
+        with pytest.raises(VulnerableJumpStartModelError):
+            utils.get_jumpstart_configs(
+                "mock-region", "mock-model", "mock-model-version", config_names=["gpu-inference"]
+            )
+
+    @patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
+    def test_get_jumpstart_configs_tolerates_vulnerable_model(
+        self,
+        patched_get_model_specs,
+    ):
+        def make_vulnerable_spec(*largs, **kwargs):
+            spec = get_base_spec_with_prototype_configs()
+            spec.inference_vulnerable = True
+            spec.inference_vulnerabilities = ["CVE-2024-11393"]
+            return spec
+
+        patched_get_model_specs.side_effect = make_vulnerable_spec
+
+        configs = utils.get_jumpstart_configs(
+            "mock-region",
+            "mock-model",
+            "mock-model-version",
+            config_names=["gpu-inference"],
+            tolerate_vulnerable_model=True,
+        )
+
+        assert configs.keys() == {"gpu-inference"}
+
+    @patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
+    def test_get_jumpstart_configs_deprecated_model_raises_by_default(
+        self,
+        patched_get_model_specs,
+    ):
+        def make_deprecated_spec(*largs, **kwargs):
+            spec = get_base_spec_with_prototype_configs()
+            spec.deprecated = True
+            return spec
+
+        patched_get_model_specs.side_effect = make_deprecated_spec
+
+        with pytest.raises(DeprecatedJumpStartModelError):
+            utils.get_jumpstart_configs(
+                "mock-region", "mock-model", "mock-model-version", config_names=["gpu-inference"]
+            )
+
+    @patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
+    def test_get_jumpstart_configs_tolerates_deprecated_model(
+        self,
+        patched_get_model_specs,
+    ):
+        def make_deprecated_spec(*largs, **kwargs):
+            spec = get_base_spec_with_prototype_configs()
+            spec.deprecated = True
+            return spec
+
+        patched_get_model_specs.side_effect = make_deprecated_spec
+
+        configs = utils.get_jumpstart_configs(
+            "mock-region",
+            "mock-model",
+            "mock-model-version",
+            config_names=["gpu-inference"],
+            tolerate_deprecated_model=True,
+        )
+
+        assert configs.keys() == {"gpu-inference"}
+
+    @patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
+    def test_get_jumpstart_configs_tolerates_vulnerable_training_model(
+        self,
+        patched_get_model_specs,
+    ):
+        def make_vulnerable_spec(*largs, **kwargs):
+            spec = get_base_spec_with_prototype_configs()
+            spec.training_vulnerable = True
+            spec.training_vulnerabilities = ["CVE-2024-11393"]
+            return spec
+
+        patched_get_model_specs.side_effect = make_vulnerable_spec
+
+        configs = utils.get_jumpstart_configs(
+            "mock-region",
+            "mock-model",
+            "mock-model-version",
+            config_names=["gpu-training"],
+            scope=JumpStartScriptScope.TRAINING,
+            tolerate_vulnerable_model=True,
+        )
+
+        assert configs.keys() == {"gpu-training"}
+
 
 class TestBenchmarkStats:
     @patch("sagemaker.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")


### PR DESCRIPTION
*Issue #, if available:* #6130

*Description of changes:*

**Problem**

`tolerate_vulnerable_model=True` and `tolerate_deprecated_model=True` do not work on `JumpStartModel`. Passing them for a flagged model still raises, so the object cannot be constructed and `deploy` is unreachable. The flags are the documented escape hatch for exactly this case, and there is no supported way to reach a flagged model without them.

`JumpStartModel.__init__` honors both flags through every lookup and then discards them on its final statement. That statement calls `get_jumpstart_configs`, which accepted neither flag. It called `verify_model_region_and_return_specs` without them, so the callee fell back to its `False` defaults and re-ran the model gate that the caller had just asked to skip.

The failure is also hard to attribute. The traceback points into `utils.py` inside the gate rather than at anything the caller passed, and it fires after `super().__init__()` has already succeeded.

This blocks any release pipeline that deploys JumpStart models for validation. Such a pipeline has to deploy a model that is flagged, precisely because its job is to test that model.

**Solution**

Add `tolerate_vulnerable_model` and `tolerate_deprecated_model` to `get_jumpstart_configs` and forward both to `verify_model_region_and_return_specs`. Both default to `False`, so every existing caller keeps its current behavior and the gate still fires by default.

`JumpStartModel.__init__` then passes the two attributes it already set earlier in the same constructor, so no new plumbing is needed. A flagged model now resolves empty configs and construction completes, which is the same outcome the flags already produce elsewhere. The returned configs feed only `list_deployment_configs` and the benchmark metrics helpers, so no other path degrades.

`JumpStartEstimator.list_training_configs` had the identical gap and is fixed by the same signature change. Its docstring already documented raising `VulnerableJumpStartModelError`, and that behavior is unchanged for a caller that has not opted into tolerance.

The same gap exists on `master` in `sagemaker-core`, and is fixed by #6137. This PR is the 2.x half.

*Testing done:*

Five tests in `TestConfigs`. Three assert tolerance works for a vulnerable inference model, a deprecated model, and a vulnerable training model. Two assert the gate still raises by default, which is the regression guard for existing callers.

One more in `test_estimator.py` covers `JumpStartEstimator.list_training_configs`, which had no test at all. That gap left the estimator call site uncovered and showed up as a small project coverage drop on the first push.

The three tolerance tests fail before the change, on the dropped argument:

```
E  TypeError: get_jumpstart_configs() got an unexpected keyword argument 'tolerate_vulnerable_model'
E  TypeError: get_jumpstart_configs() got an unexpected keyword argument 'tolerate_deprecated_model'
E  TypeError: get_jumpstart_configs() got an unexpected keyword argument 'tolerate_vulnerable_model'
3 failed, 7 passed
```

All pass after:

```
$ python -m pytest tests/unit/sagemaker/jumpstart/test_utils.py::TestConfigs -q
10 passed
```

No regressions across the JumpStart suite. Baseline `master-v2` and this branch fail the same 4 tests, all unrelated to configs and failing before the change:

```
baseline:     4 failed, 366 passed
this branch:  4 failed, 371 passed
```

The 4 are `test_model_display_benchmark_metrics`, `test_jumpstart_local_metadata_override_specs_not_exist_both_directories`, `test_jumpstart_model_specs`, and `test_inference_configs_parsing`.

Lint on the touched files, using the versions pinned in `requirements/tox`:

```
$ black --check <touched files>     # 24.3.0: 4 files would be left unchanged
$ flake8 <touched files>            # exit 0, no output
$ pydocstyle <touched src files>    # exit 0, no output
$ pylint --rcfile=.pylintrc <touched src files>   # rated 9.98/10, gate is 9.9
```

Pylint reports two `unnecessary-dunder-call` findings in `set_deployment_config` and `set_training_config`. Both are pre-existing and outside this diff, which is additions only.

No integration test is included. Reproducing this requires a model whose published specs carry a vulnerability or deprecation flag, which is not something a test can provision, and the fix is a pure argument-forwarding change fully covered by unit tests.

## Merge Checklist

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)
- [x] If adding any dependency in requirements.txt files, I have spell checked and ensured they exist in PyPi

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

