### PR TITLE
fix: forward tolerance flags from get_jumpstart_configs

### DIFF
--- a/sagemaker-core/src/sagemaker/core/jumpstart/utils.py
+++ b/sagemaker-core/src/sagemaker/core/jumpstart/utils.py
@@ -1196,8 +1196,19 @@ def get_jumpstart_configs(
     scope: enums.JumpStartScriptScope = enums.JumpStartScriptScope.INFERENCE,
     model_type: enums.JumpStartModelType = enums.JumpStartModelType.OPEN_WEIGHTS,
     hub_arn: Optional[str] = None,
+    tolerate_vulnerable_model: bool = False,
+    tolerate_deprecated_model: bool = False,
 ) -> Dict[str, JumpStartMetadataConfig]:
     """Returns metadata configs for the given model ID and region.
+
+    Args:
+        tolerate_vulnerable_model (bool): True if vulnerable versions of model
+            specifications should be tolerated (exception not raised). If False, raises an
+            exception if the script used by this version of the model has dependencies with known
+            security vulnerabilities. (Default: False).
+        tolerate_deprecated_model (bool): True if deprecated models should be tolerated
+            (exception not raised). False if these models should raise an exception.
+            (Default: False).
 
     Raises:
         ValueError: If the script scope is not supported by JumpStart.
@@ -1210,6 +1221,8 @@ def get_jumpstart_configs(
         scope=scope,
         model_type=model_type,
         hub_arn=hub_arn,
+        tolerate_vulnerable_model=tolerate_vulnerable_model,
+        tolerate_deprecated_model=tolerate_deprecated_model,
     )
 
     if scope == enums.JumpStartScriptScope.INFERENCE:

--- a/sagemaker-core/tests/unit/test_jumpstart_utils.py
+++ b/sagemaker-core/tests/unit/test_jumpstart_utils.py
@@ -25,6 +25,7 @@ from sagemaker.core.jumpstart.types import (
     JumpStartBenchmarkStat,
     DeploymentConfigMetadata,
 )
+from sagemaker.core.jumpstart.exceptions import VulnerableJumpStartModelError
 from sagemaker.core.jumpstart.models import HubContentDocument
 from sagemaker.core.helper.pipeline_variable import PipelineVariable
 
@@ -1354,6 +1355,98 @@ class TestGetJumpstartConfigs:
         mock_verify.return_value = mock_specs
 
         result = utils.get_jumpstart_configs("us-west-2", "test-model", "1.0.0")
+        assert result == {}
+
+    @patch("sagemaker.core.jumpstart.utils.verify_model_region_and_return_specs")
+    def test_get_jumpstart_configs_does_not_tolerate_by_default(self, mock_verify):
+        """Test the model gate is left enabled when the caller asks for nothing"""
+        mock_specs = Mock()
+        mock_specs.inference_configs = None
+        mock_verify.return_value = mock_specs
+
+        utils.get_jumpstart_configs("us-west-2", "test-model", "1.0.0")
+
+        assert mock_verify.call_args.kwargs["tolerate_vulnerable_model"] is False
+        assert mock_verify.call_args.kwargs["tolerate_deprecated_model"] is False
+
+    @patch("sagemaker.core.jumpstart.utils.verify_model_region_and_return_specs")
+    def test_get_jumpstart_configs_forwards_tolerance(self, mock_verify):
+        """Test tolerance reaches the spec lookup that runs the model gate"""
+        mock_specs = Mock()
+        mock_specs.inference_configs = None
+        mock_verify.return_value = mock_specs
+
+        utils.get_jumpstart_configs(
+            "us-west-2",
+            "test-model",
+            "1.0.0",
+            tolerate_vulnerable_model=True,
+            tolerate_deprecated_model=True,
+        )
+
+        assert mock_verify.call_args.kwargs["tolerate_vulnerable_model"] is True
+        assert mock_verify.call_args.kwargs["tolerate_deprecated_model"] is True
+
+    @patch("sagemaker.core.jumpstart.utils.verify_model_region_and_return_specs")
+    def test_get_jumpstart_configs_forwards_tolerance_for_training_scope(self, mock_verify):
+        """Test tolerance reaches the spec lookup on the training scope too"""
+        mock_specs = Mock()
+        mock_specs.training_configs = None
+        mock_verify.return_value = mock_specs
+
+        utils.get_jumpstart_configs(
+            "us-west-2",
+            "test-model",
+            "1.0.0",
+            scope=enums.JumpStartScriptScope.TRAINING,
+            tolerate_vulnerable_model=True,
+            tolerate_deprecated_model=True,
+        )
+
+        assert mock_verify.call_args.kwargs["tolerate_vulnerable_model"] is True
+        assert mock_verify.call_args.kwargs["tolerate_deprecated_model"] is True
+
+    @patch("sagemaker.core.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
+    def test_get_jumpstart_configs_vulnerable_model_raises_by_default(self, mock_get_specs):
+        """Test a vulnerable model still trips the gate when tolerance is not requested"""
+        model_specs = Mock(spec=JumpStartModelSpecs)
+        model_specs.deprecated = False
+        model_specs.inference_vulnerable = True
+        model_specs.inference_vulnerabilities = ["CVE-2024-11393"]
+        mock_get_specs.return_value = model_specs
+
+        with pytest.raises(VulnerableJumpStartModelError):
+            utils.get_jumpstart_configs("us-west-2", "test-model", "1.0.0")
+
+    @patch("sagemaker.core.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
+    def test_get_jumpstart_configs_tolerates_vulnerable_model(self, mock_get_specs):
+        """Test a vulnerable model resolves configs instead of tripping the gate"""
+        model_specs = Mock(spec=JumpStartModelSpecs)
+        model_specs.deprecated = False
+        model_specs.inference_vulnerable = True
+        model_specs.inference_vulnerabilities = ["CVE-2024-11393"]
+        model_specs.inference_configs = None
+        mock_get_specs.return_value = model_specs
+
+        result = utils.get_jumpstart_configs(
+            "us-west-2", "test-model", "1.0.0", tolerate_vulnerable_model=True
+        )
+
+        assert result == {}
+
+    @patch("sagemaker.core.jumpstart.accessors.JumpStartModelsAccessor.get_model_specs")
+    def test_get_jumpstart_configs_tolerates_deprecated_model(self, mock_get_specs):
+        """Test a deprecated model resolves configs instead of tripping the gate"""
+        model_specs = Mock(spec=JumpStartModelSpecs)
+        model_specs.deprecated = True
+        model_specs.inference_vulnerable = False
+        model_specs.inference_configs = None
+        mock_get_specs.return_value = model_specs
+
+        result = utils.get_jumpstart_configs(
+            "us-west-2", "test-model", "1.0.0", tolerate_deprecated_model=True
+        )
+
         assert result == {}
 
 

--- a/sagemaker-serve/src/sagemaker/serve/model_builder_utils.py
+++ b/sagemaker-serve/src/sagemaker/serve/model_builder_utils.py
@@ -2850,6 +2850,8 @@ class _ModelBuilderUtils:
                 model_id=model,
                 model_version=getattr(self, "model_version", None) or "*",
                 sagemaker_session=getattr(self, "sagemaker_session", None),
+                tolerate_vulnerable_model=getattr(self, "tolerate_vulnerable_model", None) or False,
+                tolerate_deprecated_model=getattr(self, "tolerate_deprecated_model", None) or False,
             )
 
     def _user_agent_decorator(self, func):

--- a/sagemaker-serve/tests/unit/test_model_builder_utils_additional_gaps.py
+++ b/sagemaker-serve/tests/unit/test_model_builder_utils_additional_gaps.py
@@ -611,6 +611,40 @@ class TestEnsureMetadataConfigs(unittest.TestCase):
         # Should remain None for non-string models
         self.assertIsNone(utils._metadata_configs)
 
+    @patch("sagemaker.core.jumpstart.utils.get_jumpstart_configs")
+    def test_ensure_metadata_configs_forwards_tolerance(self, mock_get_configs):
+        """Test tolerance flags reach the config lookup that runs the model gate."""
+        utils = _ModelBuilderUtils()
+        utils._metadata_configs = None
+        utils.model = "huggingface-llm-falcon-7b"
+        utils.region = "us-west-2"
+        utils.sagemaker_session = Mock()
+        utils.tolerate_vulnerable_model = True
+        utils.tolerate_deprecated_model = True
+
+        mock_get_configs.return_value = {}
+
+        utils._ensure_metadata_configs()
+
+        self.assertTrue(mock_get_configs.call_args.kwargs["tolerate_vulnerable_model"])
+        self.assertTrue(mock_get_configs.call_args.kwargs["tolerate_deprecated_model"])
+
+    @patch("sagemaker.core.jumpstart.utils.get_jumpstart_configs")
+    def test_ensure_metadata_configs_defaults_tolerance_to_false(self, mock_get_configs):
+        """Test the model gate stays enabled when tolerance is not set."""
+        utils = _ModelBuilderUtils()
+        utils._metadata_configs = None
+        utils.model = "huggingface-llm-falcon-7b"
+        utils.region = "us-west-2"
+        utils.sagemaker_session = Mock()
+
+        mock_get_configs.return_value = {}
+
+        utils._ensure_metadata_configs()
+
+        self.assertFalse(mock_get_configs.call_args.kwargs["tolerate_vulnerable_model"])
+        self.assertFalse(mock_get_configs.call_args.kwargs["tolerate_deprecated_model"])
+
 
 class TestGetServeSettings(unittest.TestCase):
     """Test _get_serve_setting method - skipped (requires proper session setup)."""


### PR DESCRIPTION
*Issue #, if available:* #6130

*Description of changes:*

**Problem**

`get_jumpstart_configs` accepted no `tolerate_vulnerable_model` or `tolerate_deprecated_model` argument. It called `verify_model_region_and_return_specs` without them, so the callee fell back to its `False` defaults and re-ran the model gate. A caller that had asked to tolerate a flagged model still got `VulnerableJumpStartModelError` or `DeprecatedJumpStartModelError`, so both flags were unusable for exactly the models they exist to allow.

In v3 the reachable caller is `ModelBuilder._ensure_metadata_configs`, which resolves the same configs lazily and had no way to opt out of the gate. A `ModelBuilder` carrying `tolerate_vulnerable_model=True` still failed on a flagged model, even though every other lookup in that class already forwards the flag.

This blocks any release pipeline that deploys JumpStart models for validation. Such a pipeline has to deploy a model that is flagged, precisely because its job is to test that model.

The same gap exists in 2.x and is fixed by #6136. This PR is the v3 half.

**Solution**

Add `tolerate_vulnerable_model` and `tolerate_deprecated_model` to `get_jumpstart_configs` and forward both to `verify_model_region_and_return_specs`. Both default to `False`, so every existing caller keeps its current behavior and the gate still fires by default.

Pass both from `_ensure_metadata_configs`, using the same `getattr` idiom the surrounding call sites already use for these two flags, normalized to a bool so an unset attribute means "do not tolerate". A flagged model then resolves empty configs and the caller proceeds, which is the same outcome the flags already produce elsewhere.

*Testing done:*

Six tests in `TestGetJumpstartConfigs`. Two assert the flags reach the spec lookup that runs the gate, on the inference and training scopes. Two exercise the gate end to end through `JumpStartModelsAccessor.get_model_specs`, confirming a vulnerable model and a deprecated model resolve configs instead of raising. Two are regression guards: the gate still raises for a vulnerable model by default, and the default forwarded value is `False`.

Two more in `TestEnsureMetadataConfigs` cover the `ModelBuilder` caller: tolerance reaches the lookup when set, and defaults to `False` when unset.

Five of the six new `sagemaker-core` tests fail before the change, on the dropped argument:

```
E  TypeError: get_jumpstart_configs() got an unexpected keyword argument 'tolerate_vulnerable_model'
E  TypeError: get_jumpstart_configs() got an unexpected keyword argument 'tolerate_deprecated_model'
E  KeyError: 'tolerate_vulnerable_model'
5 failed, 3 passed
```

Both new `sagemaker-serve` tests fail before the change:

```
E  KeyError: 'tolerate_vulnerable_model'
2 failed, 2 passed
```

All pass after, with no regressions in either package:

```
$ python -m pytest sagemaker-core/tests/unit/test_jumpstart_utils.py -q
174 passed, 1 skipped

$ python -m pytest sagemaker-core/tests/unit -k jumpstart -q
693 passed, 4 skipped, 2841 deselected

$ python -m pytest sagemaker-serve/tests/unit/test_model_builder_utils_additional_gaps.py -q
44 passed, 3 subtests passed
```

Lint introduces nothing new. `flake8` 7.1.2 reports the same 135 findings on the touched files before and after this change, all pre-existing and on lines this diff does not touch. Under `black` 26.3.1 the added lines are already formatted. All four touched files are reformatted by that version on unmodified `master`, so this diff deliberately leaves that pre-existing formatting alone rather than mixing an unrelated reformat into a bug fix.

No integration test is included. Reproducing this requires a model whose published specs carry a vulnerability or deprecation flag, which is not something a test can provision, and the fix is a pure argument-forwarding change fully covered by unit tests.

## Merge Checklist

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)
- [x] If adding any dependency in requirements.txt files, I have spell checked and ensured they exist in PyPi

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
