### PR TITLE
djl-lmi: bump 0.36.0 tag_prefix to lmi28.0.0 (LMI 28.0.0 release, v2.x)

### DIFF
--- a/src/sagemaker/image_uri_config/djl-lmi.json
+++ b/src/sagemaker/image_uri_config/djl-lmi.json
@@ -46,7 +46,7 @@
                 "mx-central-1": "637423239942"
             },
             "repository": "djl-inference",
-            "tag_prefix": "0.36.0-lmi27.0.0-cu130"
+            "tag_prefix": "0.36.0-lmi28.0.0-cu130"
         },
         "0.35.0": {
             "registries": {

--- a/tests/unit/sagemaker/image_uris/test_djl.py
+++ b/tests/unit/sagemaker/image_uris/test_djl.py
@@ -86,6 +86,7 @@ EXPECTED_DJL_LMI_REGIONS = {
 # Known missing framework:version:region combinations that don't exist in ECR
 KNOWN_MISSING_COMBINATIONS = {
     "djl-lmi": {
+        "0.36.0-lmi28.0.0-cu130": {"ap-east-2"},
         "0.36.0-lmi27.0.0-cu130": {"ap-east-2"},
         "0.36.0-lmi26.0.0-cu130": {"ap-east-2"},
         "0.36.0-lmi23.0.0-cu129": {"ap-east-2"},


### PR DESCRIPTION
Bumps the DJL-LMI `0.36.0` image `tag_prefix` to `0.36.0-lmi28.0.0-cu130` for the LMI 28.0.0 release (SageMaker Python SDK 2.x / master-v2).

- `src/sagemaker/image_uri_config/djl-lmi.json`: update the `0.36.0` key's `tag_prefix` in-place.
- `tests/unit/sagemaker/image_uris/test_djl.py`: add the `0.36.0-lmi28.0.0-cu130` KNOWN_MISSING (ap-east-2) entry.

⚠️ **2.x (master-v2) requires PM/TPM approval (Shweta Singh) before merge.**

Part of the LMI 28.0.0 release. Do not merge until the image is published to public ECR.