### PR TITLE
test(serve): SD/KT-IC integ must use g6.2xlarge, not g4dn (T4)

### DIFF
--- a/sagemaker-serve/tests/integ/test_ai_inference_recommender_sdkt_ic_integration.py
+++ b/sagemaker-serve/tests/integ/test_ai_inference_recommender_sdkt_ic_integration.py
@@ -30,10 +30,10 @@ from sagemaker.core.training.configs import Compute
 logger = logging.getLogger(__name__)
 
 # Small, ungated, chat-templated model. A GPU instance is required by the
-# JumpStart vLLM/LMI container (not by the model size); a single-GPU g4dn.xlarge
-# (T4) is ample for a 0.6B model.
+# JumpStart vLLM/LMI container (not by the model size); a single-GPU
+# g6.2xlarge (L4) is ample for a 0.6B model.
 MODEL_ID = "huggingface-reasoning-qwen3-06b"
-INSTANCE_TYPE = "ml.g4dn.xlarge"
+INSTANCE_TYPE = "ml.g6.2xlarge"
 # Right-sized for a 0.6B on a single GPU; an oversized request overflows the
 # host and the IC never leaves Creating.
 IC_MIN_MEMORY_MB = 4096


### PR DESCRIPTION
The LMI/vLLM JumpStart container (CUDA 12.x) does not start on ml.g4dn.xlarge (T4/Turing): the Inference Component fails with CannotStartContainerError. Switch INSTANCE_TYPE to ml.g6.2xlarge (L4), the smallest instance on which it starts. Verified live: the deploy() IC path reaches InService on g6.2xlarge with both base_model + draft_model AdditionalModelDataSources intact.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
