### PR TITLE
fix(serve): Move endpoint reuse discovery to deploy time

### DIFF
--- a/sagemaker-serve/src/sagemaker/serve/model_builder.py
+++ b/sagemaker-serve/src/sagemaker/serve/model_builder.py
@@ -4053,15 +4053,12 @@ class ModelBuilder(_InferenceRecommenderMixin, _ModelBuilderServers, _ModelBuild
         )
 
         # Resource reuse: if an existing Model built from the same source is
-        # found (by model-source tag), skip creating a new one. Also discover the
-        # endpoint for deploy() to reuse later.
+        # found (by model-source tag), skip creating a new one. Endpoint reuse is
+        # resolved separately at deploy() time; build() only handles the Model.
         if reuse_resources and not is_inference_component_build:
             self.serve_settings = self._get_serve_setting()
             reused_model = self._find_reusable_model()
             if reused_model is not None:
-                reusable_endpoint = self._find_reusable_endpoint()
-                if reusable_endpoint:
-                    self._reused_endpoint_name = reusable_endpoint
                 logger.info(
                     "Reusing existing Model %r (matched model-source tag). "
                     "No new Model will be created. Pass reuse_resources=False "
@@ -5505,21 +5502,14 @@ class ModelBuilder(_InferenceRecommenderMixin, _ModelBuilderServers, _ModelBuild
                 "inference_component_name (IC update). The flag is ignored."
             )
 
-        # Resource reuse is opt-in per call. build() may have cached a candidate
-        # in _reused_endpoint_name, but without deploy-time context (instance_type
-        # is a deploy() arg), so re-validate the cache before trusting it and fall
-        # back to a fresh discovery on a miss or mismatch.
+        # Resource reuse is opt-in per call. Endpoint discovery happens here at
+        # deploy() time, where the deploy-time context (instance_type) is known;
+        # build() does not look for or cache an endpoint.
         if reuse_resources and not is_inference_component_deploy:
             requested_instance_type = instance_type or self.instance_type
-            cached_endpoint = getattr(self, "_reused_endpoint_name", None)
-            if cached_endpoint and self._reused_endpoint_matches_config(
-                cached_endpoint, instance_type=requested_instance_type
-            ):
-                reusable_endpoint = cached_endpoint
-            else:
-                reusable_endpoint = self._find_reusable_endpoint(
-                    instance_type=requested_instance_type
-                )
+            reusable_endpoint = self._find_reusable_endpoint(
+                instance_type=requested_instance_type
+            )
             if reusable_endpoint:
                 if endpoint_name and endpoint_name != reusable_endpoint:
                     logger.warning(

--- a/sagemaker-serve/src/sagemaker/serve/model_reuse.py
+++ b/sagemaker-serve/src/sagemaker/serve/model_reuse.py
@@ -373,10 +373,6 @@ def _resolve_ready_arn(
         logger.warning("Could not check resource status: %s. Proceeding without.", e)
         return None
 
-    logger.info(f"Current status: {status}")
-
-    logger.info("[reuse_resources] Existing resource %s has status '%s'", resource_arn, status)
-
     if status in _ACTIVE_STATUSES:
         return resource_arn
 

--- a/sagemaker-serve/src/sagemaker/serve/model_reuse.py
+++ b/sagemaker-serve/src/sagemaker/serve/model_reuse.py
@@ -373,6 +373,10 @@ def _resolve_ready_arn(
         logger.warning("Could not check resource status: %s. Proceeding without.", e)
         return None
 
+    logger.info(f"Current status: {status}")
+
+    logger.info("[reuse_resources] Existing resource %s has status '%s'", resource_arn, status)
+
     if status in _ACTIVE_STATUSES:
         return resource_arn
 
@@ -381,6 +385,13 @@ def _resolve_ready_arn(
         return None
 
     if status in _CREATING_STATUSES:
+        logger.info(
+            "Existing resource %s is still Creating; polling every %ds up to %ds "
+            "before it can be reused",
+            resource_arn,
+            poll_interval,
+            max_wait,
+        )
         return _poll_until_ready(client, resource_arn, status_checker, poll_interval, max_wait)
 
     logger.warning("Resource %s has unexpected status '%s'. Proceeding to create new.", resource_arn, status)
@@ -405,6 +416,14 @@ def _poll_until_ready(
         except Exception as e:
             logger.warning("Could not check resource status during poll: %s. Proceeding without.", e)
             return None
+
+        logger.info(
+            "Polling resource %s: status='%s' (%ds/%ds elapsed)",
+            resource_arn,
+            status,
+            elapsed,
+            max_wait,
+        )
 
         if status in _ACTIVE_STATUSES:
             return resource_arn


### PR DESCRIPTION
Endpoint reuse depends on deploy-time context (instance_type is a
deploy() argument), so discovering and caching a candidate endpoint
during build() could produce a stale or mismatched match. Remove the
build-time endpoint lookup and the _reused_endpoint_name cache
re-validation, and let deploy() perform a single fresh discovery with
the requested instance type. build() now only handles Model reuse.

Also model_builder.build(reuse_resources) shouldn't be blocked on endpoint creation. That happens only at deploy() time.

Also add logging in the reuse status/polling helpers to surface
the current status of a matched resource and progress while waiting on
a Creating resource. Gives user visibility into the polling.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
