### PR TITLE
fix(train): load Nova hyperparameters file in ModelTrainer

### DIFF
--- a/sagemaker-train/src/sagemaker/train/model_trainer.py
+++ b/sagemaker-train/src/sagemaker/train/model_trainer.py
@@ -1361,7 +1361,7 @@ class ModelTrainer(BaseModel):
             )
         if is_nova:
             if hyperparameters and isinstance(hyperparameters, str):
-                hyperparameters = cls._validate_and_load_hyperparameters_file(hyperparameters)
+                hyperparameters = cls._validate_and_fetch_hyperparameters_file(hyperparameters)
                 model_trainer_args["hyperparameters"].update(hyperparameters)
             elif hyperparameters and isinstance(hyperparameters, dict):
                 model_trainer_args["hyperparameters"].update(hyperparameters)

--- a/sagemaker-train/tests/unit/train/test_model_trainer.py
+++ b/sagemaker-train/tests/unit/train/test_model_trainer.py
@@ -1570,6 +1570,44 @@ def test_nova_recipe(mock_training_job, mock_unique_name, modules_session):
             ]
 
 
+def test_nova_recipe_with_hyperparameters_file(modules_session):
+    recipe_data = {
+        "run": {
+            "name": "dummy-model",
+            "model_type": "amazon.nova",
+            "model_name_or_path": "dummy-model",
+        }
+    }
+    hyperparameters = {
+        "custom_parameter": "custom-value",
+        "custom_int": 5,
+    }
+
+    with NamedTemporaryFile(suffix=".yaml", delete=False) as recipe, NamedTemporaryFile(
+        suffix=".json", delete=False
+    ) as hyperparameters_file:
+        with open(recipe.name, "w") as file:
+            yaml.dump(recipe_data, file)
+        with open(hyperparameters_file.name, "w") as file:
+            json.dump(hyperparameters, file)
+
+        trainer = ModelTrainer.from_recipe(
+            training_recipe=recipe.name,
+            role=DEFAULT_ROLE,
+            sagemaker_session=modules_session,
+            compute=DEFAULT_COMPUTE_CONFIG,
+            training_image=DEFAULT_IMAGE,
+            hyperparameters=hyperparameters_file.name,
+        )
+
+        assert trainer.hyperparameters["base_model"] == "dummy-model"
+        assert trainer.hyperparameters["custom_parameter"] == "custom-value"
+        assert trainer.hyperparameters["custom_int"] == 5
+
+        os.unlink(recipe.name)
+        os.unlink(hyperparameters_file.name)
+
+
 def test_nova_recipe_with_distillation(modules_session):
     recipe_data = {"training_config": {"distillation_data": "true", "kms_key": "alias/my-kms-key"}}
 


### PR DESCRIPTION
Fixes #5770.

`ModelTrainer.from_recipe` has a Nova-specific path that handles string `hyperparameters` values as file paths. That branch called `cls._validate_and_load_hyperparameters_file(...)`, but `ModelTrainer` only defines `_validate_and_fetch_hyperparameters_file(...)`. As a result, Nova recipes using a hyperparameters file path raised `AttributeError` before the file could be validated, parsed, and merged with recipe-derived hyperparameters.

This replaces the erroneous call with the existing `_validate_and_fetch_hyperparameters_file` helper.

A focused unit regression test now creates a temporary Nova recipe and temporary hyperparameters file, calls `ModelTrainer.from_recipe` with `hyperparameters` set to that file path, and asserts the parsed values are present in `trainer.hyperparameters` without raising `AttributeError`.

Existing dict-hyperparameters and non-Nova behavior are unchanged.

`ruff check sagemaker-train/src/sagemaker/train/model_trainer.py sagemaker-train/tests/unit/train/test_model_trainer.py` reports no new findings on the changed files.
Ran `pytest -x` locally with no new failures.
