### PR TITLE
fix(model-trainer): force LF endings for generated train script

### DIFF
--- a/sagemaker-train/src/sagemaker/train/model_trainer.py
+++ b/sagemaker-train/src/sagemaker/train/model_trainer.py
@@ -1195,7 +1195,7 @@ class ModelTrainer(BaseModel):
             execute_driver=execute_driver,
         )
 
-        with open(os.path.join(tmp_dir.name, TRAIN_SCRIPT), "w") as f:
+        with open(os.path.join(tmp_dir.name, TRAIN_SCRIPT), "w", newline="\n") as f:
             f.write(train_script)
 
     @classmethod

--- a/sagemaker-train/tests/unit/train/test_model_trainer.py
+++ b/sagemaker-train/tests/unit/train/test_model_trainer.py
@@ -714,6 +714,8 @@ def test_train_with_distributed_config(
         )
 
         assert os.path.exists(expected_train_script_path)
+        with open(expected_train_script_path, "rb") as f:
+            assert b"\r\n" not in f.read()
         with open(expected_train_script_path, "r") as f:
             train_script_content = f.read()
             assert test_case["expected_template"] in train_script_content


### PR DESCRIPTION
ModelTrainer generated `sm_train.sh` using Python text-mode defaults via `open(..., "w")`. On Windows, that translated the `\n` line endings in `TRAIN_SCRIPT_TEMPLATE` to `\r\n`; the uploaded script then ran inside a Linux training container, where CRLF line endings broke bash parsing before user code started.

This updates `ModelTrainer._prepare_train_script` to write `sm_train.sh` with `newline="\n"`, so the SDK-generated script uses LF line endings regardless of the client OS.

A focused regression assertion was added to the existing generated-driver-script unit test. It reads `sm_train.sh` as bytes and verifies that no CRLF bytes are present while keeping the existing content assertions.

Fixes #5904

`ruff check sagemaker-train/src/sagemaker/train/model_trainer.py sagemaker-train/tests/unit/train/test_model_trainer.py` reports no new findings on the changed files.
Ran `pytest -x` locally with no new failures.
