### PR TITLE
feat(serve): list/filter jobs, deploy from recommendation row, compare benchmarks, DataFrame views

### DIFF
--- a/sagemaker-serve/src/sagemaker/serve/ai_inference_recommender/__init__.py
+++ b/sagemaker-serve/src/sagemaker/serve/ai_inference_recommender/__init__.py
@@ -25,11 +25,17 @@ from sagemaker.serve.ai_inference_recommender.jobs import (
     BenchmarkJob,
     RecommendationJob,
 )
+from sagemaker.serve.ai_inference_recommender.listing import (
+    list_benchmarks,
+    list_recommendations,
+)
 from sagemaker.serve.ai_inference_recommender.result import (
+    BenchmarkComparison,
     BenchmarkMetric,
     BenchmarkMetrics,
     BenchmarkResult,
     BenchmarkSearchResult,
+    compare_benchmarks,
 )
 from sagemaker.serve.ai_inference_recommender.secrets import Secret
 from sagemaker.serve.ai_inference_recommender.workload import Workload
@@ -39,6 +45,7 @@ from sagemaker.serve.ai_inference_recommender._model_builder_methods import (
 
 
 __all__ = [
+    "BenchmarkComparison",
     "BenchmarkJob",
     "BenchmarkMetric",
     "BenchmarkMetrics",
@@ -51,5 +58,8 @@ __all__ = [
     "Secret",
     "Workload",
     "WorkloadValidationError",
+    "compare_benchmarks",
+    "list_benchmarks",
+    "list_recommendations",
     "start_benchmark",
 ]

--- a/sagemaker-serve/src/sagemaker/serve/ai_inference_recommender/_recommendation_view.py
+++ b/sagemaker-serve/src/sagemaker/serve/ai_inference_recommender/_recommendation_view.py
@@ -21,9 +21,11 @@ from collections import defaultdict
 from typing import Any, Dict, List, Optional
 
 from sagemaker.serve.ai_inference_recommender.result import (
+    _coerce_numeric,
     _fmt_number,
     _format_table,
     _indent,
+    _require_pandas,
 )
 
 
@@ -63,9 +65,7 @@ class _ExpectedPerformanceMetric:
         return dict(self._stats)
 
     def __repr__(self) -> str:
-        parts = ", ".join(
-            f"{stat}={_fmt_number(v)}" for stat, v in self._stats.items()
-        )
+        parts = ", ".join(f"{stat}={_fmt_number(v)}" for stat, v in self._stats.items())
         unit = f" {self.unit}" if self.unit else ""
         return f"<{parts}{unit}>"
 
@@ -82,9 +82,7 @@ class _ExpectedPerformanceView:
     __slots__ = ("_by_metric",)
 
     def __init__(self, raw_rows: Optional[List[Any]]):
-        by_metric: Dict[str, Dict[str, Any]] = defaultdict(
-            lambda: {"unit": None, "stats": {}}
-        )
+        by_metric: Dict[str, Dict[str, Any]] = defaultdict(lambda: {"unit": None, "stats": {}})
         for row in raw_rows or []:
             metric = getattr(row, "metric", None)
             if not metric:
@@ -139,9 +137,9 @@ class _ExpectedPerformanceView:
         return len(self._by_metric)
 
     def __repr__(self) -> str:
-        return "{" + ", ".join(
-            f"{name}: {metric!r}" for name, metric in self._by_metric.items()
-        ) + "}"
+        return (
+            "{" + ", ".join(f"{name}: {metric!r}" for name, metric in self._by_metric.items()) + "}"
+        )
 
 
 def _to_float(value):
@@ -195,7 +193,6 @@ class _RecommendationView:
     def __str__(self) -> str:
         md = getattr(self._raw, "model_details", None)
         dc = getattr(self._raw, "deployment_configuration", None)
-        ep = getattr(self._raw, "expected_performance", None) or []
 
         config_lines = [
             f"instance_type:        {_safe_str(dc, 'instance_type')}",
@@ -217,14 +214,16 @@ class _RecommendationView:
                 env_lines = [f"  {k} = {v}" for k, v in items]
                 env_block = "\nenv vars ({0}):\n{1}".format(len(items), "\n".join(env_lines))
 
-        perf_rows = []
-        for m in ep:
-            perf_rows.append([
-                _safe_str(m, "metric"),
-                _safe_str(m, "stat"),
-                _fmt_number(_safe_float(m, "value")),
-                _safe_str(m, "unit"),
-            ])
+        # Same records to_dataframe() uses, formatted for display here.
+        perf_rows = [
+            [
+                rec["metric"] if rec["metric"] not in (None, "") else "-",
+                rec["stat"] if rec["stat"] not in (None, "") else "-",
+                _fmt_number(rec["value"]),
+                rec["unit"] if rec["unit"] not in (None, "") else "-",
+            ]
+            for rec in self._perf_records()
+        ]
         perf_table = _format_table(
             headers=["metric", "stat", "value", "unit"],
             rows=perf_rows,
@@ -248,6 +247,30 @@ class _RecommendationView:
     def _repr_pretty_(self, p, cycle):
         # Render the full table in notebooks (Jupyter uses this hook).
         p.text("..." if cycle else str(self))
+
+    def _perf_records(self) -> List[Dict[str, Any]]:
+        """(metric, stat, value, unit) records for this row's expected
+        performance — the rows of the printed table, one per (metric, stat)."""
+        ep = getattr(self._raw, "expected_performance", None) or []
+        return [
+            {
+                "metric": getattr(m, "metric", None),
+                "stat": getattr(m, "stat", None),
+                "value": _safe_float(m, "value"),
+                "unit": getattr(m, "unit", None),
+            }
+            for m in ep
+        ]
+
+    def to_dataframe(self):
+        """Return this recommendation's expected performance as a pandas
+        ``DataFrame`` — the same ``metric``/``stat``/``value``/``unit`` rows the
+        printed ``expected performance`` table shows, one row per (metric, stat).
+
+        Requires pandas.
+        """
+        pd = _require_pandas()
+        return pd.DataFrame(self._perf_records(), columns=["metric", "stat", "value", "unit"])
 
 
 def _safe_str(obj, attr) -> str:
@@ -291,47 +314,114 @@ class _RecommendationsView(list):
         # Render the full table in notebooks (Jupyter uses this hook).
         p.text("..." if cycle else str(self))
 
+    # Column labels for the comparative table / DataFrame, in display order.
+    _TABLE_COLUMNS = (
+        "idx",
+        "spec_name",
+        "instance_type",
+        "instances",
+        "copies/inst",
+        "container",
+        "req/s",
+        "tok/s",
+        "lat_p50",
+        "lat_p90",
+        "lat_p99",
+        "ttft_p50",
+        "itl_p50",
+    )
+    # Metric columns holding numbers; the rest are strings or the idx.
+    _NUMERIC_COLUMNS = (
+        "req/s",
+        "tok/s",
+        "lat_p50",
+        "lat_p90",
+        "lat_p99",
+        "ttft_p50",
+        "itl_p50",
+    )
+
+    def _row_records(self) -> List[Dict[str, Any]]:
+        """One record per row, keyed by ``_TABLE_COLUMNS``, with native values.
+
+        Shared by ``__str__`` and ``to_dataframe()`` so they cannot drift.
+        """
+        records = []
+        for view in self:
+            dc = getattr(view.raw, "deployment_configuration", None)
+            ep = view.expected_performance
+            records.append(
+                {
+                    "idx": view._index,
+                    "spec_name": view.recommendation_spec_name,
+                    "instance_type": getattr(dc, "instance_type", None) if dc else None,
+                    "instances": getattr(dc, "instance_count", None) if dc else None,
+                    "copies/inst": (getattr(dc, "copy_count_per_instance", None) if dc else None),
+                    # None when absent (not "-"), so the DataFrame keeps it as
+                    # missing; __str__ renders the dash.
+                    "container": (
+                        _short_container_tag(dc.image_uri)
+                        if dc is not None and getattr(dc, "image_uri", None)
+                        else None
+                    ),
+                    "req/s": _get_metric_stat(ep, "request_throughput", "avg"),
+                    "tok/s": _get_metric_stat(ep, "output_token_throughput", "avg"),
+                    "lat_p50": _get_metric_stat(ep, "request_latency", "p50"),
+                    "lat_p90": _get_metric_stat(ep, "request_latency", "p90"),
+                    "lat_p99": _get_metric_stat(ep, "request_latency", "p99"),
+                    "ttft_p50": _get_metric_stat(ep, "time_to_first_token", "p50"),
+                    "itl_p50": _get_metric_stat(ep, "inter_token_latency", "p50"),
+                }
+            )
+        return records
+
     def __str__(self) -> str:
         if not self:
             return "Recommendations[0]  (no rows)"
 
         rows = []
-        for view in self:
-            dc = getattr(view.raw, "deployment_configuration", None)
-            ep = view.expected_performance
-            rows.append([
-                f"[{view._index}]",
-                view.recommendation_spec_name or "-",
-                _safe_str(dc, "instance_type"),
-                _safe_str(dc, "instance_count"),
-                _safe_str(dc, "copy_count_per_instance"),
-                _short_container_tag(_safe_str(dc, "image_uri")),
-                _fmt_number(_get_metric_stat(ep, "request_throughput", "avg")),
-                _fmt_number(_get_metric_stat(ep, "output_token_throughput", "avg")),
-                _fmt_number(_get_metric_stat(ep, "request_latency", "p50")),
-                _fmt_number(_get_metric_stat(ep, "request_latency", "p90")),
-                _fmt_number(_get_metric_stat(ep, "request_latency", "p99")),
-                _fmt_number(_get_metric_stat(ep, "time_to_first_token", "p50")),
-                _fmt_number(_get_metric_stat(ep, "inter_token_latency", "p50")),
-            ])
+        for rec in self._row_records():
+            row = []
+            for col in self._TABLE_COLUMNS:
+                value = rec[col]
+                if col == "idx":
+                    row.append(f"[{value}]")
+                elif col in self._NUMERIC_COLUMNS:
+                    row.append(_fmt_number(value))
+                else:
+                    row.append("-" if value in (None, "") else str(value))
+            rows.append(row)
 
-        table = _format_table(
-            headers=[
-                "idx", "spec_name", "instance_type",
-                "instances", "copies/inst",
-                "container",
-                "req/s", "tok/s",
-                "lat_p50", "lat_p90", "lat_p99",
-                "ttft_p50", "itl_p50",
-            ],
-            rows=rows,
-        )
+        table = _format_table(headers=list(self._TABLE_COLUMNS), rows=rows)
 
         return (
             f"Recommendations[{len(self)}]  (.best = top row; index by [N] for full detail)\n"
             f"{table}\n"
             f"lat/ttft/itl in ms; req/s = requests/sec; tok/s = output tokens/sec"
         )
+
+    def to_dataframe(self):
+        """Return the recommendations as a pandas ``DataFrame`` — one row per
+        recommendation, columns matching the printed comparative table
+        (``instance_type``, ``instances``, ``req/s``, ``lat_p50``, ...), indexed
+        by the recommendation index ``idx``.
+
+        Latency columns are milliseconds; ``req/s`` is requests/sec and ``tok/s``
+        is output tokens/sec, same as the printed table's footnote. Numeric
+        columns hold real numbers (``NaN`` where a metric is absent), not
+        preformatted strings.
+
+        Requires pandas.
+        """
+        pd = _require_pandas()
+        columns = [c for c in self._TABLE_COLUMNS if c != "idx"]
+        records = self._row_records()
+        frame = pd.DataFrame(
+            [{c: rec[c] for c in columns} for rec in records],
+            columns=columns,
+            index=pd.Index([rec["idx"] for rec in records], name="idx"),
+        )
+        return _coerce_numeric(pd, frame, self._NUMERIC_COLUMNS)
 
 
 def _get_metric_stat(ep_view, metric_name: str, stat: str):

--- a/sagemaker-serve/src/sagemaker/serve/ai_inference_recommender/listing.py
+++ b/sagemaker-serve/src/sagemaker/serve/ai_inference_recommender/listing.py
@@ -1,0 +1,266 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+"""List and filter AI benchmark / recommendation jobs.
+
+The underlying ``ListAIBenchmarkJobs`` / ``ListAIRecommendationJobs`` APIs only
+filter by name substring, status, and creation-time window — the endpoint a
+benchmark targeted, or the model a recommendation ran on, live on the full
+Describe response, not the list summary. So ``endpoint`` / ``model`` /
+``model_package`` filtering is done client-side: the native filters narrow the
+list server-side, then each candidate is described (hydrated by sagemaker-core's
+resource iterator) and matched on the nested field. Two bounds keep the cost in
+hand: ``max_results`` caps the matches returned, and ``max_scan`` caps how many
+candidates are described — so a rarely-matching filter cannot fan out across the
+whole account.
+"""
+from __future__ import absolute_import
+
+import logging
+from typing import List, Optional, Union
+
+import boto3
+
+from sagemaker.core.helper.session_helper import Session
+from sagemaker.core.telemetry.constants import Feature
+from sagemaker.core.telemetry.telemetry_logging import _telemetry_emitter
+from sagemaker.serve.ai_inference_recommender.jobs import BenchmarkJob, RecommendationJob
+
+logger = logging.getLogger(__name__)
+
+# Default cap on how many matching jobs are returned.
+DEFAULT_MAX_RESULTS = 100
+# Default cap on how many candidates are described (each is one Describe, issued
+# by the resource iterator). Bounds the fan-out when a client-side filter
+# (endpoint / model / model_package) matches rarely.
+DEFAULT_MAX_SCAN = 1000
+# How many undescribable candidates to log individually before deferring the
+# rest to the end-of-scan summary (avoids one warning per candidate).
+_MAX_SKIP_WARNINGS = 5
+
+
+def _endpoint_matches(job, endpoint: str) -> bool:
+    """True if a benchmark job targeted ``endpoint`` (by name or ARN)."""
+    target = getattr(job, "benchmark_target", None)
+    ep = getattr(target, "endpoint", None) if target else None
+    identifier = getattr(ep, "identifier", None) if ep else None
+    if not identifier:
+        return False
+    # identifier may be a name or an ARN; match either the exact value or the
+    # name suffix of an ARN (endpoint/<name>).
+    return endpoint == identifier or identifier.endswith(f"/{endpoint}")
+
+
+def _model_matches(job, model: str) -> bool:
+    """True if a recommendation job ran on ``model`` (its source S3 URI)."""
+    source = getattr(job, "model_source", None)
+    s3 = getattr(source, "s3", None) if source else None
+    s3_uri = getattr(s3, "s3_uri", None) if s3 else None
+    if not s3_uri:
+        return False
+    return model == s3_uri or s3_uri.rstrip("/") == model.rstrip("/")
+
+
+def _model_package_matches(job, model_package: str) -> bool:
+    """True if a recommendation job is associated with ``model_package``.
+
+    Matches either the output model-package group the job registers into, or a
+    model-package ARN produced on one of the job's recommendation rows.
+    """
+    output = getattr(job, "output_config", None)
+    group = getattr(output, "model_package_group_identifier", None) if output else None
+    if group and (model_package == group or group.endswith(f"/{model_package}")):
+        return True
+    for row in getattr(job, "recommendations", None) or []:
+        details = getattr(row, "model_details", None)
+        arn = getattr(details, "model_package_arn", None) if details else None
+        if arn and (model_package == arn or arn.endswith(f"/{model_package}")):
+            return True
+    return False
+
+
+def _collect(iterator, predicate, max_results: int, max_scan: int, subclass) -> list:
+    """Keep candidates from ``iterator`` matching ``predicate``, re-typed to
+    ``subclass`` (so ``show_result`` is available).
+
+    The iterator hydrates each object as it yields it, so this loop does not
+    Describe again. ``max_results`` bounds matches returned; ``max_scan`` bounds
+    candidates examined. A candidate that fails to Describe is skipped, not
+    fatal. All three limits are logged when hit.
+    """
+    matches: list = []
+    scanned = 0
+    skipped = 0
+    hit_result_cap = False
+    it = iter(iterator)
+    while scanned < max_scan:
+        # next() drives the iterator's per-object Describe, so a failure for one
+        # candidate is caught here rather than aborting the listing.
+        try:
+            job = next(it)
+        except StopIteration:
+            break
+        except Exception as exc:  # noqa: BLE001 - per-job hydration is best-effort
+            skipped += 1
+            scanned += 1
+            # Log the first few individually for diagnosis; the rest are covered
+            # by the summary below, so a fully-denied role does not emit one
+            # warning per candidate up to max_scan.
+            if skipped <= _MAX_SKIP_WARNINGS:
+                logger.warning(
+                    "Skipping a %s that could not be described: %s", subclass.__name__, exc
+                )
+            continue
+
+        scanned += 1
+        job.__class__ = subclass
+        if predicate is None or predicate(job):
+            matches.append(job)
+        if len(matches) >= max_results:
+            hit_result_cap = True
+            break
+    else:
+        logger.warning(
+            "Scanned max_scan=%d jobs and stopped; raise max_scan to look further.", max_scan
+        )
+
+    if hit_result_cap:
+        logger.info(
+            "Returned max_results=%d matches and stopped; there may be more. "
+            "Raise max_results to return more.",
+            max_results,
+        )
+    if skipped:
+        logger.warning("%d job(s) were skipped because they could not be described.", skipped)
+    return matches
+
+
+@_telemetry_emitter(
+    feature=Feature.INFERENCE_RECOMMENDER, func_name="ai_inference_recommender.list_benchmarks"
+)
+def list_benchmarks(
+    *,
+    endpoint: Optional[str] = None,
+    status: Optional[str] = None,
+    name_contains: Optional[str] = None,
+    max_results: int = DEFAULT_MAX_RESULTS,
+    max_scan: int = DEFAULT_MAX_SCAN,
+    sagemaker_session: Optional[Union[boto3.session.Session, Session]] = None,
+) -> List[BenchmarkJob]:
+    """List benchmark jobs, optionally filtered by the endpoint they targeted.
+
+    Args:
+        endpoint: Endpoint name or ARN. Client-side filter (each candidate is
+            described, since the endpoint is not on the list summary).
+        status: ``StatusEquals`` filter, applied server-side.
+        name_contains: ``NameContains`` filter, applied server-side.
+        max_results: Cap on the number of matching jobs returned. Defaults to
+            ``DEFAULT_MAX_RESULTS``.
+        max_scan: Cap on how many candidates are described while filtering (each
+            is one Describe). Bounds the fan-out when ``endpoint`` matches
+            rarely; a warning is logged if the scan is truncated. Defaults to
+            ``DEFAULT_MAX_SCAN``.
+        sagemaker_session: Optional session — a ``boto3.session.Session`` or a
+            sagemaker ``Session`` wrapping one (unwrapped automatically). A
+            default is created if omitted.
+
+    Returns:
+        A list of ``BenchmarkJob`` (newest first), each with ``show_result``.
+    """
+    iterator = BenchmarkJob.get_all(
+        **_native_filters(name_contains, status),
+        sort_by="CreationTime",
+        sort_order="Descending",
+        session=_boto_session(sagemaker_session),
+    )
+    predicate = (lambda job: _endpoint_matches(job, endpoint)) if endpoint else None
+    return _collect(iterator, predicate, max_results, max_scan, BenchmarkJob)
+
+
+@_telemetry_emitter(
+    feature=Feature.INFERENCE_RECOMMENDER,
+    func_name="ai_inference_recommender.list_recommendations",
+)
+def list_recommendations(
+    *,
+    model: Optional[str] = None,
+    model_package: Optional[str] = None,
+    status: Optional[str] = None,
+    name_contains: Optional[str] = None,
+    max_results: int = DEFAULT_MAX_RESULTS,
+    max_scan: int = DEFAULT_MAX_SCAN,
+    sagemaker_session: Optional[Union[boto3.session.Session, Session]] = None,
+) -> List[RecommendationJob]:
+    """List recommendation jobs, optionally filtered by model or model package.
+
+    Args:
+        model: Model source S3 URI the job ran on. Client-side filter.
+        model_package: Model-package ARN or group identifier associated with the
+            job (its output group, or a package produced on a recommendation
+            row). Client-side filter.
+        status: ``StatusEquals`` filter, applied server-side.
+        name_contains: ``NameContains`` filter, applied server-side.
+        max_results: Cap on the number of matching jobs returned. Defaults to
+            ``DEFAULT_MAX_RESULTS``.
+        max_scan: Cap on how many candidates are described while filtering (each
+            is one Describe). Bounds the fan-out when a client-side filter
+            matches rarely; a warning is logged if the scan is truncated.
+            Defaults to ``DEFAULT_MAX_SCAN``.
+        sagemaker_session: Optional session — a ``boto3.session.Session`` or a
+            sagemaker ``Session`` wrapping one (unwrapped automatically). A
+            default is created if omitted.
+
+    Returns:
+        A list of ``RecommendationJob`` (newest first), each with ``show_result``.
+    """
+    if model and model_package:
+        raise ValueError("Pass only one of `model` or `model_package` to list_recommendations().")
+    iterator = RecommendationJob.get_all(
+        **_native_filters(name_contains, status),
+        sort_by="CreationTime",
+        sort_order="Descending",
+        session=_boto_session(sagemaker_session),
+    )
+    predicate = None
+    if model:
+        predicate = lambda job: _model_matches(job, model)  # noqa: E731
+    elif model_package:
+        predicate = lambda job: _model_package_matches(job, model_package)  # noqa: E731
+    return _collect(iterator, predicate, max_results, max_scan, RecommendationJob)
+
+
+def _boto_session(sagemaker_session):
+    """Resolve the session for ``get_all``, which requires a boto3 session.
+
+    Accepts a boto3 session (passed through) or a sagemaker ``Session``
+    (unwrapped to its ``.boto_session``). ``None`` stays ``None``.
+    """
+    if sagemaker_session is None or isinstance(sagemaker_session, boto3.session.Session):
+        return sagemaker_session
+    boto_session = getattr(sagemaker_session, "boto_session", None)
+    if isinstance(boto_session, boto3.session.Session):
+        return boto_session
+    raise TypeError(
+        "sagemaker_session must be a boto3.session.Session or a sagemaker "
+        f"Session wrapping one; got {type(sagemaker_session).__name__}."
+    )
+
+
+def _native_filters(name_contains: Optional[str], status: Optional[str]) -> dict:
+    """Build the server-side ``get_all`` filter kwargs, omitting unset ones so
+    each defaults to the sagemaker-core ``Unassigned`` sentinel."""
+    kwargs = {}
+    if name_contains:
+        kwargs["name_contains"] = name_contains
+    if status:
+        kwargs["status_equals"] = status
+    return kwargs

--- a/sagemaker-serve/src/sagemaker/serve/ai_inference_recommender/result.py
+++ b/sagemaker-serve/src/sagemaker/serve/ai_inference_recommender/result.py
@@ -17,7 +17,7 @@ import io
 import json
 import tarfile
 from dataclasses import dataclass, field
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional, Sequence
 from urllib.parse import urlparse
 
 import boto3
@@ -28,6 +28,11 @@ OUTPUT_ARCHIVE_FILENAME = "output.tar.gz"
 # instead of a single top-level profile_export_aiperf.json. Its presence in the
 # archive is how we tell a sweep run apart from a single run.
 SEARCH_HISTORY_FILENAME = "search_history.json"
+
+# Statistic columns exposed by ``to_dataframe()``. Superset of the printed
+# table's avg/p50/p90/p99 — the DataFrame also carries min/max/p95/stddev,
+# which the text table omits for width.
+_METRIC_STAT_COLUMNS = ("avg", "min", "max", "p50", "p90", "p95", "p99", "stddev")
 
 
 @dataclass
@@ -82,12 +87,18 @@ class BenchmarkMetrics:
     def get(self, name: str) -> Optional[BenchmarkMetric]:
         return self.all_metrics.get(name)
 
-    def __str__(self) -> str:
+    def _ordered_metric_pairs(self):
+        """(name, metric) pairs in display order: non-HTTP metrics alphabetically,
+        then ``http_*`` transport metrics last. Shared by ``__str__`` and
+        ``to_dataframe()`` so the printed table and the frame stay in sync."""
         rest, http = [], []
         for name in sorted(self.all_metrics):
             bucket = http if name.startswith("http_") else rest
             bucket.append((name, self.all_metrics[name]))
-        return _format_metrics_table(rest + http)
+        return rest + http
+
+    def __str__(self) -> str:
+        return _format_metrics_table(self._ordered_metric_pairs())
 
     def __repr__(self) -> str:
         return f"BenchmarkMetrics({len(self.all_metrics)} metrics; print() for the table)"
@@ -95,6 +106,20 @@ class BenchmarkMetrics:
     def _repr_pretty_(self, p, cycle):
         # Render the full table in notebooks (Jupyter uses this hook).
         p.text("..." if cycle else str(self))
+
+    def to_dataframe(self):
+        """Return the metrics as a pandas ``DataFrame`` indexed by metric name.
+
+        One row per metric, one column per statistic (``unit`` plus
+        ``avg``/``min``/``max``/``p50``/``p90``/``p95``/``p99``/``stddev``).
+        Rows are ordered exactly as the printed table: non-HTTP metrics
+        alphabetically, then ``http_*`` transport metrics last. Unlike the text
+        table, the frame keeps ``min``/``max``/``p95``/``stddev``.
+
+        Requires pandas.
+        """
+        pd = _require_pandas()
+        return _metrics_dataframe(pd, self._ordered_metric_pairs())
 
     @classmethod
     def from_profile_json(cls, profile: Dict[str, Any]) -> "BenchmarkMetrics":
@@ -239,9 +264,22 @@ class BenchmarkResult:
                 f"  s3_output_location: {self.s3_output_location}\n"
                 f"  search:\n{_indent(str(self.search), '    ')}"
             )
-        # Order: well-known headline metrics first, then everything else
-        # alphabetized, then HTTP-level transport metrics last (they're
-        # noise for most readers, useful only for debugging).
+        table = _format_metrics_table(self._ordered_metric_pairs())
+        return (
+            f"BenchmarkResult\n"
+            f"  endpoint:           {self.endpoint or '-'}\n"
+            f"  workload_config:    {self.workload_config or '-'}\n"
+            f"  tool_version:       {self.tool_version or '-'}\n"
+            f"  s3_output_location: {self.s3_output_location}\n"
+            f"  metrics:\n{_indent(table, '    ')}\n"
+            f"  raw profile available via .profile"
+        )
+
+    def _ordered_metric_pairs(self):
+        """(name, metric) pairs in display order: well-known headline metrics
+        first (canonical order), then the rest alphabetized, then ``http_*``
+        transport metrics last. Shared by ``__str__`` and ``to_dataframe()`` so
+        the printed table and the frame stay in the same order."""
         seen = set()
         headline = []
         for name in _KEY_METRIC_FIELDS:
@@ -256,18 +294,28 @@ class BenchmarkResult:
                 continue
             bucket = http if name.startswith("http_") else rest
             bucket.append((name, self.metrics.all_metrics[name]))
+        return headline + rest + http
 
-        ordered = headline + rest + http
-        table = _format_metrics_table(ordered)
-        return (
-            f"BenchmarkResult\n"
-            f"  endpoint:           {self.endpoint or '-'}\n"
-            f"  workload_config:    {self.workload_config or '-'}\n"
-            f"  tool_version:       {self.tool_version or '-'}\n"
-            f"  s3_output_location: {self.s3_output_location}\n"
-            f"  metrics:\n{_indent(table, '    ')}\n"
-            f"  raw profile available via .profile"
-        )
+    def to_dataframe(self):
+        """Return this result's metrics as a pandas ``DataFrame``.
+
+        One row per metric (indexed by metric name), one column per statistic —
+        the same shape as :meth:`BenchmarkMetrics.to_dataframe`, but ordered as
+        this result prints: headline metrics first, then the rest alphabetized,
+        then ``http_*`` transport metrics last.
+
+        A search/sweep result has no single metric profile; call
+        ``result.search`` for its outcome instead.
+
+        Requires pandas.
+        """
+        pd = _require_pandas()
+        if self.search is not None:
+            raise ValueError(
+                "This is a search/sweep result with no single metric profile to "
+                "tabulate. Inspect result.search for the sweep outcome instead."
+            )
+        return _metrics_dataframe(pd, self._ordered_metric_pairs())
 
     def __repr__(self) -> str:
         return (
@@ -319,9 +367,7 @@ class BenchmarkResult:
                 f"(status={status}). Call job.wait() (or pass wait=True to "
                 f"start_benchmark) before BenchmarkResult.from_job()."
             )
-        if job.output_config is None or not getattr(
-            job.output_config, "s3_output_location", None
-        ):
+        if job.output_config is None or not getattr(job.output_config, "s3_output_location", None):
             failure_reason = getattr(job, "failure_reason", None)
             hint = (
                 f"Job failed: {failure_reason or 'no reason provided'}."
@@ -449,9 +495,7 @@ def _find_object(s3_client, bucket: str, prefix: str, suffix: str) -> str:
             key = obj.get("Key", "")
             if key.endswith(suffix):
                 return key
-    raise FileNotFoundError(
-        f"No object ending in {suffix!r} under s3://{bucket}/{prefix}"
-    )
+    raise FileNotFoundError(f"No object ending in {suffix!r} under s3://{bucket}/{prefix}")
 
 
 def _read_member_from_tar_gz(archive_bytes: bytes, suffix: str) -> Optional[bytes]:
@@ -473,6 +517,19 @@ def _as_float(value: Any) -> Optional[float]:
         return None
 
 
+def _require_pandas():
+    """Import pandas lazily, only when ``to_dataframe()`` is called, so this
+    module's printed tables stay stdlib-only."""
+    try:
+        import pandas as pd
+    except ImportError as exc:  # pragma: no cover - trivial re-raise
+        raise ImportError(
+            "to_dataframe() requires pandas, which is not installed. "
+            "Install it with `pip install pandas`."
+        ) from exc
+    return pd
+
+
 def _fmt_number(value: Optional[float]) -> str:
     """Render a number compact for the metrics table; '-' for None."""
     if value is None:
@@ -486,18 +543,48 @@ def _indent(text: str, prefix: str) -> str:
     return "\n".join(prefix + line if line else line for line in text.splitlines())
 
 
+def _coerce_numeric(pd, frame, numeric_cols):
+    """Cast the named columns to float64 so an all-missing column is ``NaN``,
+    not ``object`` holding ``None`` (on which sort/nlargest/mean would raise)."""
+    for col in numeric_cols:
+        if col in frame.columns:
+            frame[col] = pd.to_numeric(frame[col], errors="coerce")
+    return frame
+
+
+def _metrics_dataframe(pd, name_metric_pairs):
+    """Build a metric-indexed DataFrame from (name, BenchmarkMetric) pairs.
+
+    Columns are ``unit`` plus every stat in ``_METRIC_STAT_COLUMNS``; row order
+    follows the input. Empty input yields an empty frame with the same columns.
+    """
+    columns = ["unit", *_METRIC_STAT_COLUMNS]
+    names = [name for name, _ in name_metric_pairs]
+    data = [
+        {
+            "unit": metric.unit,
+            **{stat: getattr(metric, stat, None) for stat in _METRIC_STAT_COLUMNS},
+        }
+        for _name, metric in name_metric_pairs
+    ]
+    frame = pd.DataFrame(data, columns=columns, index=pd.Index(names, name="metric"))
+    return _coerce_numeric(pd, frame, _METRIC_STAT_COLUMNS)
+
+
 def _format_metrics_table(name_metric_pairs) -> str:
     """Render an iterable of (name, BenchmarkMetric) pairs as a table."""
     rows = []
     for _name, metric in name_metric_pairs:
-        rows.append([
-            metric.name,
-            metric.unit or "-",
-            _fmt_number(metric.avg),
-            _fmt_number(metric.p50),
-            _fmt_number(metric.p90),
-            _fmt_number(metric.p99),
-        ])
+        rows.append(
+            [
+                metric.name,
+                metric.unit or "-",
+                _fmt_number(metric.avg),
+                _fmt_number(metric.p50),
+                _fmt_number(metric.p90),
+                _fmt_number(metric.p99),
+            ]
+        )
     return _format_table(
         headers=["metric", "unit", "avg", "p50", "p90", "p99"],
         rows=rows,
@@ -524,7 +611,219 @@ def _format_table(headers, rows) -> str:
     header_line = "  ".join(str(h).ljust(widths[i]) for i, h in enumerate(headers))
     sep_line = "  ".join("─" * widths[i] for i in range(len(headers)))
     body = "\n".join(
-        "  ".join(cell.ljust(widths[i]) for i, cell in enumerate(row))
-        for row in str_rows
+        "  ".join(cell.ljust(widths[i]) for i, cell in enumerate(row)) for row in str_rows
     )
     return f"{header_line}\n{sep_line}\n{body}"
+
+
+# Per-metric direction, used to orient a delta so "+" reads as an improvement.
+# Metrics absent from both sets (sequence lengths, token counts, HTTP counters)
+# have no better/worse direction, so they get no signed delta.
+_HIGHER_IS_BETTER = frozenset(
+    {
+        "request_throughput",
+        "output_token_throughput",
+        "e2e_output_token_throughput",
+    }
+)
+_LOWER_IS_BETTER = frozenset(
+    {
+        "request_latency",
+        "time_to_first_token",
+        "inter_token_latency",
+        "benchmark_duration",
+    }
+)
+
+
+@dataclass
+class BenchmarkComparison:
+    """Side-by-side comparison of two or more ``BenchmarkResult`` runs.
+
+    The first run is the baseline; each other run's ``__str__`` shows its value
+    for every key metric alongside the percentage change from the baseline,
+    signed so a ``+`` is always an improvement (higher throughput / lower
+    latency) regardless of the metric's direction.
+
+    Attributes:
+        results: the compared results, baseline first.
+        names: display label per result (defaults to ``run1``, ``run2``, ...).
+        stat: which per-metric statistic is compared (``avg`` by default; any of
+            ``avg``/``p50``/``p90``/``p95``/``p99``/``min``/``max``).
+    """
+
+    results: List["BenchmarkResult"]
+    names: List[str]
+    stat: str = "avg"
+
+    def _metric_names(self) -> List[str]:
+        """Key metrics first (in canonical order), then any other metric present
+        in at least one run — so the table covers everything, headline first."""
+        ordered = [
+            name
+            for name in _KEY_METRIC_FIELDS
+            if any(name in r.metrics.all_metrics for r in self.results)
+        ]
+        seen = set(ordered)
+        for r in self.results:
+            for name in sorted(r.metrics.all_metrics):
+                if name not in seen:
+                    ordered.append(name)
+                    seen.add(name)
+        return ordered
+
+    def _value(self, result: "BenchmarkResult", metric_name: str) -> Optional[float]:
+        metric = result.metrics.all_metrics.get(metric_name)
+        return getattr(metric, self.stat, None) if metric is not None else None
+
+    def _delta_value(self, metric_name: str, baseline, value) -> Optional[float]:
+        """Signed percentage change vs. baseline, oriented so ``+`` is better.
+
+        Only computed for metrics with a known direction (throughput = higher
+        better, latency/duration = lower better). A directionless metric
+        (sequence length, token count, HTTP transport counter) has no
+        better/worse orientation, so a signed "improvement" delta would be
+        misleading under the ``+Δ = better`` header — it returns ``None``.
+        ``None`` is also returned when the delta is undefined (missing value or
+        zero baseline). ``__str__`` formats it; ``to_dataframe()`` keeps it
+        numeric (``NaN`` for ``None``).
+        """
+        if metric_name not in _HIGHER_IS_BETTER and metric_name not in _LOWER_IS_BETTER:
+            return None
+        if baseline is None or value is None or baseline == 0:
+            return None
+        pct = (value - baseline) / abs(baseline) * 100.0
+        if metric_name in _LOWER_IS_BETTER:
+            # Lower-is-better: flip the sign so a drop reads as +.
+            pct = -pct
+        return pct
+
+    def _delta_cell(self, metric_name: str, baseline, value) -> str:
+        """Signed percentage change vs. baseline as a display string; ``-`` when
+        no oriented delta applies (directionless or undefined)."""
+        pct = self._delta_value(metric_name, baseline, value)
+        return "-" if pct is None else f"{pct:+.1f}%"
+
+    def _unit_for(self, metric_name: str) -> Optional[str]:
+        for r in self.results:
+            m = r.metrics.all_metrics.get(metric_name)
+            if m is not None and m.unit:
+                return m.unit
+        return None
+
+    def __str__(self) -> str:
+        metric_names = self._metric_names()
+        if not metric_names:
+            return "BenchmarkComparison (no metrics to compare)"
+
+        # Columns: metric, unit, one value column per run, and a Δ% column per
+        # non-baseline run (vs. the baseline, the first run).
+        headers = ["metric", "unit"]
+        headers += list(self.names)
+        headers += [f"Δ% {name}" for name in self.names[1:]]
+
+        rows = []
+        for metric_name in metric_names:
+            unit = self._unit_for(metric_name) or "-"
+            values = [self._value(r, metric_name) for r in self.results]
+            row = [metric_name, unit] + [_fmt_number(v) for v in values]
+            baseline = values[0]
+            row += [self._delta_cell(metric_name, baseline, v) for v in values[1:]]
+            rows.append(row)
+
+        table = _format_table(headers=headers, rows=rows)
+        baseline_note = f"baseline: {self.names[0]}  |  stat: {self.stat}  (+Δ = better)"
+        return f"BenchmarkComparison\n  {baseline_note}\n{_indent(table, '  ')}"
+
+    def to_dataframe(self):
+        """Return the comparison as a pandas ``DataFrame``.
+
+        Mirrors the printed table: one row per metric (indexed by metric name),
+        a ``unit`` column, one column per run (named by :attr:`names`, holding
+        the compared ``stat``), and a ``Δ% <run>`` column per non-baseline run —
+        signed so ``+`` is always an improvement. Delta values are numeric
+        percentages (``NaN`` where undefined), not preformatted strings.
+
+        Requires pandas.
+        """
+        pd = _require_pandas()
+        columns = ["unit", *self.names, *(f"Δ% {name}" for name in self.names[1:])]
+        metric_names = self._metric_names()
+        data = []
+        for metric_name in metric_names:
+            values = [self._value(r, metric_name) for r in self.results]
+            baseline = values[0]
+            record = {"unit": self._unit_for(metric_name)}
+            for name, value in zip(self.names, values):
+                record[name] = value
+            for name, value in zip(self.names[1:], values[1:]):
+                record[f"Δ% {name}"] = self._delta_value(metric_name, baseline, value)
+            data.append(record)
+        frame = pd.DataFrame(data, columns=columns, index=pd.Index(metric_names, name="metric"))
+        return _coerce_numeric(pd, frame, [c for c in columns if c != "unit"])
+
+    def __repr__(self) -> str:
+        return (
+            f"BenchmarkComparison({len(self.results)} runs: "
+            f"{', '.join(self.names)}; print() for the table)"
+        )
+
+    def _repr_pretty_(self, p, cycle):
+        p.text("..." if cycle else str(self))
+
+
+def compare_benchmarks(
+    *results: "BenchmarkResult",
+    names: Optional[Sequence[str]] = None,
+    stat: str = "avg",
+) -> BenchmarkComparison:
+    """Compare two or more benchmark runs and return a tabular comparison.
+
+    The first result is the baseline; each subsequent run is reported with a
+    signed percentage change from it (oriented so ``+`` is always better —
+    higher throughput or lower latency). ``print()`` the returned object for the
+    table.
+
+    Args:
+        *results: two or more ``BenchmarkResult`` objects (from
+            ``job.show_result()``). The first is the baseline.
+        names: optional display label per result; defaults to ``run1``,
+            ``run2``, .... Must match the number of results when given.
+        stat: which per-metric statistic to compare — one of ``avg`` (default),
+            ``p50``, ``p90``, ``p95``, ``p99``, ``min``, ``max``.
+
+    Returns:
+        BenchmarkComparison: renders a metric-by-run table with per-run deltas.
+
+    Raises:
+        ValueError: if fewer than two results are given, if ``names`` length
+            does not match, if ``stat`` is not a known statistic, or if any
+            result is a concurrency-search/sweep run (which has no single metric
+            profile to compare).
+    """
+    if len(results) < 2:
+        raise ValueError("compare_benchmarks() needs at least two results to compare.")
+    if any(r.is_search for r in results):
+        raise ValueError(
+            "compare_benchmarks() compares single-run results; a search/sweep "
+            "result has no single metric profile. Compare the winning runs instead."
+        )
+    valid_stats = {"avg", "p50", "p90", "p95", "p99", "min", "max"}
+    if stat not in valid_stats:
+        raise ValueError(f"stat must be one of {sorted(valid_stats)}, got {stat!r}.")
+    if names is not None:
+        if len(names) != len(results):
+            raise ValueError(
+                f"names has {len(names)} entries but {len(results)} results were given."
+            )
+        labels = list(names)
+        # Each name is a distinct DataFrame column; a duplicate or "unit" would
+        # collide and make the frame disagree with the printed table.
+        if len(set(labels)) != len(labels):
+            duplicates = sorted({n for n in labels if labels.count(n) > 1})
+            raise ValueError(f"names must be unique; duplicated: {duplicates}.")
+        if "unit" in labels:
+            raise ValueError("names cannot include the reserved column name 'unit'.")
+    else:
+        labels = [f"run{i + 1}" for i in range(len(results))]
+    return BenchmarkComparison(results=list(results), names=labels, stat=stat)

--- a/sagemaker-serve/src/sagemaker/serve/model_builder.py
+++ b/sagemaker-serve/src/sagemaker/serve/model_builder.py
@@ -5134,6 +5134,7 @@ class ModelBuilder(_InferenceRecommenderMixin, _ModelBuilderServers, _ModelBuild
         *,
         recommendation_index: int,
         recommendation_spec_name: Optional[str],
+        recommendation_row: Optional[Any] = None,
         endpoint_name: Optional[str],
         model_name: Optional[str],
         endpoint_config_name: Optional[str],
@@ -5186,7 +5187,11 @@ class ModelBuilder(_InferenceRecommenderMixin, _ModelBuilderServers, _ModelBuild
                 f"{'Job failed: ' + str(failure_reason) if status == 'Failed' else 'Call job.wait() before deploy.'}"
             )
 
-        if recommendation_spec_name is not None:
+        if recommendation_row is not None:
+            # Row object passed to deploy(recommendation=...): use it directly,
+            # no positional lookup that a re-read/refresh could misroute.
+            rec = recommendation_row
+        elif recommendation_spec_name is not None:
             matches = [
                 row for row in rows
                 if getattr(getattr(row, "model_details", None), "inference_specification_name", None)
@@ -5424,6 +5429,7 @@ class ModelBuilder(_InferenceRecommenderMixin, _ModelBuilderServers, _ModelBuild
         # generate_deployment_recommendations was called previously, or when
         # this builder was hydrated via ModelBuilder.from_recommendation_job(...).
         use_recommendation: Optional[bool] = None,
+        recommendation: Optional[Any] = None,
         recommendation_index: int = 0,
         recommendation_spec_name: Optional[str] = None,
         auto_approve: bool = False,
@@ -5467,6 +5473,10 @@ class ModelBuilder(_InferenceRecommenderMixin, _ModelBuilderServers, _ModelBuild
                 None (default) deploys the recommendation when a recommendation job is
                 attached, else the built model. False forces the built-model path even if a
                 job is attached. True requires an attached job and errors otherwise.
+            recommendation (optional): Recommendation deploy only. A recommendation row to
+                deploy, e.g. ``mb.recommendations.best`` or ``mb.recommendations[i]``. Use
+                this instead of ``recommendation_index`` / ``recommendation_spec_name`` to
+                deploy a row without hand-copying its index. Mutually exclusive with those two.
             recommendation_index (int): Recommendation deploy only. Index of the recommendation
                 row to deploy. (Default: 0, the top-ranked row). Ignored when deploying a
                 normally-built model.
@@ -5519,10 +5529,31 @@ class ModelBuilder(_InferenceRecommenderMixin, _ModelBuilderServers, _ModelBuild
                 "Call generate_deployment_recommendations(...) or build via "
                 "ModelBuilder.from_recommendation_job(...) first."
             )
+        # A recommendation row (mb.recommendations.best or [i]) may be passed
+        # directly. Pass its underlying shape straight through so the exact row
+        # deploys — not a positional index, which can go stale or point into a
+        # different job.
+        recommendation_row = None
+        if recommendation is not None:
+            if recommendation_spec_name is not None or recommendation_index:
+                raise ValueError(
+                    "Pass only one of `recommendation`, `recommendation_spec_name`, "
+                    "or `recommendation_index` to deploy()."
+                )
+            recommendation_row = getattr(recommendation, "raw", None)
+            if recommendation_row is None or not hasattr(recommendation_row, "model_details"):
+                raise TypeError(
+                    "recommendation must be a recommendation row from "
+                    "mb.recommendations (e.g. mb.recommendations.best or "
+                    f"mb.recommendations[i]); got {type(recommendation).__name__}. "
+                    "To select by index or spec name, use recommendation_index= "
+                    "or recommendation_spec_name= instead."
+                )
         if has_recommendation and use_recommendation is not False:
             return self._deploy_recommendation(
                 recommendation_index=recommendation_index,
                 recommendation_spec_name=recommendation_spec_name,
+                recommendation_row=recommendation_row,
                 endpoint_name=endpoint_name,
                 model_name=model_name,
                 endpoint_config_name=endpoint_config_name,

--- a/sagemaker-serve/tests/integ/test_ai_inference_recommender_enhancements_integration.py
+++ b/sagemaker-serve/tests/integ/test_ai_inference_recommender_enhancements_integration.py
@@ -1,0 +1,311 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+"""End-to-end integration tests for the inference-recommender enhancements:
+``list_benchmarks`` / ``list_recommendations`` filtering, ``deploy`` from a
+recommendation row (``mb.recommendations.best``), and ``compare_benchmarks``.
+"""
+from __future__ import absolute_import
+
+import logging
+import time
+import uuid
+
+import pytest
+
+from sagemaker.core.helper.session_helper import Session, get_execution_role
+from sagemaker.core.jumpstart.configs import JumpStartConfig
+from sagemaker.core.resources import (
+    AIBenchmarkJob,
+    AIRecommendationJob,
+    AIWorkloadConfig,
+    EndpointConfig,
+    Model,
+    ModelPackage,
+)
+from sagemaker.serve.ai_inference_recommender import (
+    Workload,
+    compare_benchmarks,
+    list_benchmarks,
+    list_recommendations,
+    start_benchmark,
+)
+from sagemaker.serve.model_builder import ModelBuilder
+from sagemaker.train.configs import Compute
+
+logger = logging.getLogger(__name__)
+
+MODEL_ID = "huggingface-reasoning-qwen3-06b"
+INSTANCE_TYPE = "ml.g6.2xlarge"
+WORKLOAD_TOKENIZER = "gpt2"
+
+
+def _synthetic_workload():
+    return Workload.synthetic(
+        tokenizer=WORKLOAD_TOKENIZER,
+        concurrency=1,
+        request_count=10,
+        prompt_input_tokens_mean=32,
+        output_tokens_mean=32,
+        streaming=True,
+    )
+
+
+def test_list_benchmarks_and_recommendations_plumbing():
+    """The listing helpers execute against the live API (list + describe +
+    client-side filter) and a filter with no match returns an empty list.
+
+    No GPU: this exercises the ``get_all`` / describe / filter plumbing without
+    creating any resource, so it runs fast and independently of the e2e below.
+
+    This test collects on ordinary PR checks (it has no ``gpu_intensive`` mark),
+    so every call caps ``max_scan`` tightly: a client-side filter that matches
+    rarely would otherwise Describe up to ``max_scan`` jobs, and on a busy shared
+    account that is enough to throttle the suite. A small cap keeps the plumbing
+    check cheap regardless of how many jobs the account holds.
+    """
+    logger.info("Listing plumbing: list_benchmarks / list_recommendations ...")
+
+    benches = list_benchmarks(max_results=5, max_scan=5)
+    assert isinstance(benches, list)
+    logger.info("list_benchmarks() returned %d job(s)", len(benches))
+
+    recs = list_recommendations(max_results=5, max_scan=5)
+    assert isinstance(recs, list)
+    logger.info("list_recommendations() returned %d job(s)", len(recs))
+
+    # A filter that cannot match returns an empty list (not an error). Cap the
+    # scan hard: the whole point is that no candidate matches, so without a cap
+    # this is exactly the full-account Describe sweep we must not trigger here.
+    no_match_ep = f"no-such-endpoint-{uuid.uuid4().hex}"
+    assert list_benchmarks(endpoint=no_match_ep, max_results=5, max_scan=10) == []
+
+    no_match_model = f"s3://no-such-bucket-{uuid.uuid4().hex}/model/"
+    assert list_recommendations(model=no_match_model, max_results=5, max_scan=10) == []
+    logger.info("Non-matching filters correctly returned empty lists.")
+
+
+@pytest.mark.slow_test
+@pytest.mark.gpu_intensive
+def test_recommendation_deploy_best_and_compare_e2e():
+    """Full flow across all three enhancements, sharing one rec job + endpoint:
+
+    1. run a recommendation job,
+    2. ``list_recommendations(model=...)`` finds it (client-side filter),
+    3. ``deploy(recommendation=mb.recommendations.best)`` reaches InService,
+    4. run two benchmarks against that endpoint,
+    5. ``list_benchmarks(endpoint=...)`` finds them,
+    6. ``compare_benchmarks`` renders a two-run comparison.
+    """
+    unique_id = f"{int(time.time())}-{uuid.uuid4().hex[:8]}"
+    role = get_execution_role(sagemaker_session=Session())
+    rec_job_name = f"air-enh-rec-{unique_id}"
+    rec_wl_name = f"air-enh-rec-wl-{unique_id}"
+    src_model_name = f"air-enh-src-{unique_id}"
+    dep_model_name = f"air-enh-model-{unique_id}"
+    dep_config_name = f"air-enh-cfg-{unique_id}"
+    endpoint_name = f"air-enh-ep-{unique_id}"
+    bench_a_name = f"air-enh-bench-a-{unique_id}"
+    bench_b_name = f"air-enh-bench-b-{unique_id}"
+    bench_a_wl = f"air-enh-bench-a-wl-{unique_id}"
+    bench_b_wl = f"air-enh-bench-b-wl-{unique_id}"
+
+    source_model = None
+    endpoint = None
+    rec_model_package_arn = None
+    model_uri = None
+
+    try:
+        mb = ModelBuilder.from_jumpstart_config(
+            jumpstart_config=JumpStartConfig(model_id=MODEL_ID),
+            compute=Compute(instance_type=INSTANCE_TYPE),
+            role_arn=role,
+        )
+        source_model = mb.build(model_name=src_model_name)
+        model_uri = _model_source_uri(src_model_name)
+
+        # (1) recommendation job
+        rec_job = mb.generate_deployment_recommendations(
+            workload=_synthetic_workload(),
+            performance_target="throughput",
+            instance_types=[INSTANCE_TYPE],
+            advanced_optimization=False,
+            framework="LMI",
+            role_arn=role,
+            job_name=rec_job_name,
+            workload_config_name=rec_wl_name,
+            wait=True,
+        )
+        assert rec_job.ai_recommendation_job_status == "Completed", (
+            f"Recommendation job did not complete: "
+            f"{rec_job.ai_recommendation_job_status} / "
+            f"{getattr(rec_job, 'failure_reason', None)}"
+        )
+        rows = mb.recommendations
+        assert rows, "mb.recommendations is empty after a completed job"
+        rec_model_package_arn = getattr(
+            getattr(rows.best, "model_details", None), "model_package_arn", None
+        )
+        logger.info("Recommendation complete; best spec=%s", rows.best.recommendation_spec_name)
+
+        # (2) list_recommendations model filter returns rows that all match the
+        # requested model. We do NOT assert this specific just-created job is in
+        # the result: the model URI is a shared JumpStart cache path many jobs
+        # reuse, and freshly-created jobs are subject to List eventual
+        # consistency — so pinning on "find my exact job" here is racy. Instead
+        # assert the filter's contract: every returned job's model_source matches
+        # the requested URI. (Deterministic filter coverage lives in the unit
+        # tests and the no-GPU plumbing test.)
+        if model_uri:
+            found = list_recommendations(model=model_uri, max_results=25)
+            # We just created a job on this model_uri, so the filter must return
+            # at least one row. Assert non-empty first, otherwise the per-job
+            # contract check below passes vacuously and a filter regressing to
+            # always-False would go unnoticed.
+            assert found, (
+                "list_recommendations(model=...) returned no jobs, but this run "
+                f"created one on {model_uri}"
+            )
+            for job in found:
+                src = getattr(getattr(job, "model_source", None), "s3", None)
+                uri = getattr(src, "s3_uri", None) if src else None
+                assert uri is not None and uri.rstrip("/") == model_uri.rstrip("/"), (
+                    f"list_recommendations(model=...) returned a non-matching job: "
+                    f"{job.ai_recommendation_job_name} has model_source {uri}"
+                )
+            logger.info("list_recommendations(model=...) returned %d matching job(s).", len(found))
+
+        # (3) deploy the best recommendation row directly (no magic index)
+        endpoint = mb.deploy(
+            endpoint_name=endpoint_name,
+            recommendation=rows.best,
+            model_name=dep_model_name,
+            endpoint_config_name=dep_config_name,
+            role=role,
+            auto_approve=True,
+            wait=True,
+        )
+        assert (
+            endpoint.endpoint_status == "InService"
+        ), f"Endpoint did not reach InService: {endpoint.endpoint_status}"
+        logger.info("Deployed mb.recommendations.best -> %s InService", endpoint_name)
+
+        # (4) two benchmarks against the endpoint
+        bench_a = start_benchmark(
+            endpoint=endpoint_name,
+            workload=_synthetic_workload(),
+            role=role,
+            name=bench_a_name,
+            workload_config_name=bench_a_wl,
+            wait=True,
+        )
+        bench_b = start_benchmark(
+            endpoint=endpoint_name,
+            workload=_synthetic_workload(),
+            role=role,
+            name=bench_b_name,
+            workload_config_name=bench_b_wl,
+            wait=True,
+        )
+        for job in (bench_a, bench_b):
+            assert job.ai_benchmark_job_status == "Completed", (
+                f"Benchmark {job.get_name()} did not complete: " f"{job.ai_benchmark_job_status}"
+            )
+
+        # (5) list_benchmarks(endpoint=...) filters by this run's (unique)
+        # endpoint. Hard-assert the filter contract: every returned job targets
+        # this endpoint. Finding both specific jobs is best-effort (List is
+        # eventually consistent for freshly-created jobs), logged not gated —
+        # which also means `listed` may legitimately be empty here, so the
+        # per-job loop below is allowed to be vacuous. `both_present` is the
+        # signal that the filter actually returned our jobs when List has caught
+        # up; it is logged rather than asserted precisely because of that race.
+        listed = list_benchmarks(endpoint=endpoint_name, max_results=25)
+        for job in listed:
+            target = getattr(job, "benchmark_target", None)
+            ep = getattr(target, "endpoint", None) if target else None
+            identifier = getattr(ep, "identifier", None) if ep else None
+            assert identifier and (
+                identifier == endpoint_name or identifier.endswith(f"/{endpoint_name}")
+            ), (
+                f"list_benchmarks(endpoint=...) returned a non-matching job: "
+                f"{job.ai_benchmark_job_name} targets {identifier}"
+            )
+        listed_names = [j.ai_benchmark_job_name for j in listed]
+        both_present = bench_a_name in listed_names and bench_b_name in listed_names
+        logger.info(
+            "list_benchmarks(endpoint=...) returned %d job(s); both this run's "
+            "benchmarks present: %s",
+            len(listed),
+            both_present,
+        )
+
+        # (6) compare the two runs
+        result_a = bench_a.show_result()
+        result_b = bench_b.show_result()
+        comparison = compare_benchmarks(result_a, result_b, names=["run_a", "run_b"])
+        rendered = str(comparison)
+        assert "BenchmarkComparison" in rendered
+        assert "run_a" in rendered and "run_b" in rendered
+        logger.info("compare_benchmarks rendered:\n%s", rendered)
+
+    finally:
+        _delete_quietly(lambda: Model.get(model_name=dep_model_name), f"Model {dep_model_name}")
+        if endpoint is not None:
+            _delete_quietly(lambda: endpoint, f"Endpoint {endpoint_name}")
+        _delete_quietly(
+            lambda: EndpointConfig.get(endpoint_config_name=dep_config_name),
+            f"EndpointConfig {dep_config_name}",
+        )
+        if source_model is not None:
+            _delete_quietly(lambda: source_model, f"Model {src_model_name}")
+        for job_name in (bench_a_name, bench_b_name):
+            _delete_quietly(
+                lambda n=job_name: AIBenchmarkJob.get(ai_benchmark_job_name=n),
+                f"AIBenchmarkJob {job_name}",
+            )
+        _delete_quietly(
+            lambda: AIRecommendationJob.get(ai_recommendation_job_name=rec_job_name),
+            f"AIRecommendationJob {rec_job_name}",
+        )
+        for wl in (rec_wl_name, bench_a_wl, bench_b_wl):
+            _delete_quietly(
+                lambda n=wl: AIWorkloadConfig.get(ai_workload_config_name=n),
+                f"AIWorkloadConfig {wl}",
+            )
+        if rec_model_package_arn:
+            _delete_quietly(
+                lambda: ModelPackage.get(model_package_name=rec_model_package_arn),
+                f"ModelPackage {rec_model_package_arn}",
+            )
+
+
+def _model_source_uri(model_name):
+    """Resolve the S3 artifact URI of a built model, to filter recs by model."""
+    container = getattr(Model.get(model_name=model_name), "primary_container", None)
+    if container is None:
+        return None
+    mds = getattr(container, "model_data_source", None)
+    if mds is not None:
+        s3 = getattr(mds, "s3_data_source", None)
+        if s3 is not None and getattr(s3, "s3_uri", None):
+            return s3.s3_uri
+    return getattr(container, "model_data_url", None)
+
+
+def _delete_quietly(resource_factory, label):
+    """Best-effort delete; log and continue on any failure."""
+    try:
+        resource_factory().delete()
+        logger.info("Deleted %s", label)
+    except Exception as exc:
+        logger.warning("Failed to delete %s: %s", label, exc)

--- a/sagemaker-serve/tests/unit/test_ai_inference_recommender/test_compare.py
+++ b/sagemaker-serve/tests/unit/test_ai_inference_recommender/test_compare.py
@@ -1,0 +1,202 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+"""Unit tests for compare_benchmarks / BenchmarkComparison."""
+from __future__ import absolute_import
+
+import pytest
+
+from sagemaker.serve.ai_inference_recommender import (
+    BenchmarkResult,
+    compare_benchmarks,
+)
+from sagemaker.serve.ai_inference_recommender.result import (
+    BenchmarkMetrics,
+    BenchmarkSearchResult,
+)
+
+
+def _result(throughput=None, latency=None, output_seq_len=None, s3="s3://b/out/"):
+    """A single-run BenchmarkResult with request_throughput / request_latency,
+    and optionally output_sequence_length (a directionless metric)."""
+    profile = {}
+    if throughput is not None:
+        profile["request_throughput"] = {"unit": "req/s", "avg": throughput, "p50": throughput}
+    if latency is not None:
+        profile["request_latency"] = {"unit": "ms", "avg": latency, "p50": latency}
+    if output_seq_len is not None:
+        profile["output_sequence_length"] = {"unit": "tokens", "avg": output_seq_len}
+    return BenchmarkResult(
+        metrics=BenchmarkMetrics.from_profile_json(profile),
+        s3_output_location=s3,
+    )
+
+
+class TestCompareBenchmarks:
+    def test_requires_at_least_two(self):
+        with pytest.raises(ValueError, match="at least two"):
+            compare_benchmarks(_result(throughput=1.0))
+
+    def test_names_length_must_match(self):
+        with pytest.raises(ValueError, match="names has"):
+            compare_benchmarks(_result(throughput=1.0), _result(throughput=2.0), names=["only-one"])
+
+    def test_unknown_stat_rejected(self):
+        with pytest.raises(ValueError, match="stat must be one of"):
+            compare_benchmarks(_result(throughput=1.0), _result(throughput=2.0), stat="p42")
+
+    def test_search_result_rejected(self):
+        search = BenchmarkResult(
+            metrics=BenchmarkMetrics.from_profile_json({}),
+            s3_output_location="s3://b/out/",
+            search=BenchmarkSearchResult(swept_dim="concurrency", winner=8),
+        )
+        with pytest.raises(ValueError, match="search/sweep"):
+            compare_benchmarks(_result(throughput=1.0), search)
+
+    def test_default_run_names(self):
+        cmp = compare_benchmarks(_result(throughput=1.0), _result(throughput=2.0))
+        assert cmp.names == ["run1", "run2"]
+
+    def test_custom_names_used(self):
+        cmp = compare_benchmarks(
+            _result(throughput=1.0), _result(throughput=2.0), names=["before", "after"]
+        )
+        assert cmp.names == ["before", "after"]
+
+    def test_throughput_increase_is_positive_delta(self):
+        # request_throughput is higher-is-better: 10 -> 15 is +50%.
+        cmp = compare_benchmarks(_result(throughput=10.0), _result(throughput=15.0))
+        text = str(cmp)
+        assert "request_throughput" in text
+        assert "+50.0%" in text
+
+    def test_latency_decrease_is_positive_delta(self):
+        # request_latency is lower-is-better: 100 -> 80 is a 20% improvement,
+        # reported as +20.0% (sign flipped so + is always better).
+        cmp = compare_benchmarks(_result(latency=100.0), _result(latency=80.0))
+        text = str(cmp)
+        assert "request_latency" in text
+        assert "+20.0%" in text
+
+    def test_latency_increase_is_negative_delta(self):
+        # 100 -> 120 latency is a regression: -20.0%.
+        cmp = compare_benchmarks(_result(latency=100.0), _result(latency=120.0))
+        assert "-20.0%" in str(cmp)
+
+    def test_table_has_a_column_per_run_and_delta(self):
+        cmp = compare_benchmarks(
+            _result(throughput=10.0),
+            _result(throughput=15.0),
+            _result(throughput=20.0),
+            names=["a", "b", "c"],
+        )
+        text = str(cmp)
+        # value column per run + a delta column for each non-baseline run
+        assert "a" in text and "b" in text and "c" in text
+        assert "Δ% b" in text and "Δ% c" in text
+        # baseline note names the first run
+        assert "baseline: a" in text
+
+    def test_stat_selects_percentile(self):
+        cmp = compare_benchmarks(_result(throughput=10.0), _result(throughput=15.0), stat="p50")
+        assert cmp.stat == "p50"
+        assert "+50.0%" in str(cmp)
+
+    def test_missing_metric_renders_dash_not_crash(self):
+        # First run has throughput, second doesn't -> value '-' and delta '-'.
+        cmp = compare_benchmarks(_result(throughput=10.0), _result(latency=5.0))
+        text = str(cmp)
+        assert "request_throughput" in text
+        assert "request_latency" in text
+
+    def test_directionless_metric_has_no_signed_delta(self):
+        # output_sequence_length has no better/worse direction: halving it must
+        # NOT read as a +50% improvement under the "+Δ = better" header.
+        cmp = compare_benchmarks(_result(output_seq_len=128.0), _result(output_seq_len=64.0))
+        text = str(cmp)
+        assert "output_sequence_length" in text
+        assert "+50.0%" not in text and "-50.0%" not in text
+
+    def test_duplicate_names_rejected(self):
+        with pytest.raises(ValueError, match="names must be unique"):
+            compare_benchmarks(_result(throughput=1.0), _result(throughput=2.0), names=["a", "a"])
+
+    def test_name_colliding_with_unit_rejected(self):
+        with pytest.raises(ValueError, match="reserved column name 'unit'"):
+            compare_benchmarks(
+                _result(throughput=1.0), _result(throughput=2.0), names=["unit", "b"]
+            )
+
+
+pd = pytest.importorskip("pandas")
+
+
+class TestBenchmarkComparisonToDataFrame:
+    def test_columns_are_unit_runs_and_deltas(self):
+        cmp = compare_benchmarks(
+            _result(throughput=10.0),
+            _result(throughput=15.0),
+            _result(throughput=20.0),
+            names=["a", "b", "c"],
+        )
+        df = cmp.to_dataframe()
+        assert list(df.columns) == ["unit", "a", "b", "c", "Δ% b", "Δ% c"]
+        assert df.index.name == "metric"
+        assert "request_throughput" in df.index
+
+    def test_values_and_units_are_native(self):
+        cmp = compare_benchmarks(
+            _result(throughput=10.0), _result(throughput=15.0), names=["base", "cand"]
+        )
+        row = cmp.to_dataframe().loc["request_throughput"]
+        assert row["base"] == 10.0
+        assert row["cand"] == 15.0
+        assert row["unit"] == "req/s"
+
+    def test_delta_is_numeric_and_signed_for_direction(self):
+        # throughput up = better (+); latency up = worse (-). Deltas are numbers.
+        up = compare_benchmarks(_result(throughput=10.0), _result(throughput=15.0))
+        assert up.to_dataframe().loc["request_throughput", "Δ% run2"] == pytest.approx(50.0)
+
+        worse = compare_benchmarks(_result(latency=100.0), _result(latency=120.0))
+        assert worse.to_dataframe().loc["request_latency", "Δ% run2"] == pytest.approx(-20.0)
+
+    def test_missing_value_yields_nan_delta(self):
+        # Baseline has throughput, candidate does not -> value + delta are NaN.
+        cmp = compare_benchmarks(_result(throughput=10.0), _result(latency=5.0))
+        df = cmp.to_dataframe()
+        assert pd.isna(df.loc["request_throughput", "run2"])
+        assert pd.isna(df.loc["request_throughput", "Δ% run2"])
+
+    def test_stat_selects_percentile(self):
+        cmp = compare_benchmarks(_result(throughput=10.0), _result(throughput=15.0), stat="p50")
+        # p50 was set equal to avg in the builder; delta still +50%.
+        assert cmp.to_dataframe().loc["request_throughput", "Δ% run2"] == pytest.approx(50.0)
+
+    def test_all_nan_delta_column_is_float_and_sortable(self):
+        # A directionless metric present in both runs yields an all-NaN delta
+        # column; it must be float64, not object holding None, so nlargest/
+        # sort_values (the reason to want a frame) do not raise.
+        a = _result(output_seq_len=128.0)
+        b = _result(output_seq_len=64.0)
+        df = compare_benchmarks(a, b).to_dataframe()
+        assert df["Δ% run2"].isna().all()
+        assert str(df["Δ% run2"].dtype) == "float64"
+        df.nlargest(1, "Δ% run2")  # would raise on object dtype
+
+    def test_directionless_metric_delta_is_nan_in_frame(self):
+        cmp = compare_benchmarks(_result(output_seq_len=128.0), _result(output_seq_len=64.0))
+        df = cmp.to_dataframe()
+        # value columns are populated, but the oriented delta is NaN (no direction).
+        assert df.loc["output_sequence_length", "run1"] == 128.0
+        assert pd.isna(df.loc["output_sequence_length", "Δ% run2"])

--- a/sagemaker-serve/tests/unit/test_ai_inference_recommender/test_listing.py
+++ b/sagemaker-serve/tests/unit/test_ai_inference_recommender/test_listing.py
@@ -1,0 +1,330 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+"""Unit tests for list_benchmarks / list_recommendations client-side filtering."""
+from __future__ import absolute_import
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from sagemaker.core.resources import AIBenchmarkJob, AIRecommendationJob
+from sagemaker.core.shapes.shapes import (
+    AIBenchmarkEndpoint,
+    AIBenchmarkTarget,
+    AIModelSource,
+    AIModelSourceS3,
+    AIRecommendation,
+    AIRecommendationModelDetails,
+    AIRecommendationOutputResult,
+)
+from sagemaker.serve.ai_inference_recommender import (
+    list_benchmarks,
+    list_recommendations,
+)
+from sagemaker.serve.ai_inference_recommender.jobs import BenchmarkJob, RecommendationJob
+
+
+# Stand-ins are base AIBenchmarkJob / AIRecommendationJob instances, matching
+# what get_all yields, so the retype to the show_result subclass can be asserted
+# rather than being a silent no-op. Nested fields are set directly.
+
+
+@pytest.fixture(autouse=True)
+def _no_op_refresh():
+    """Stub refresh() as a no-op MagicMock so hydration does not hit AWS and its
+    call count stays assertable; the stand-ins already carry their fields."""
+    with patch.object(AIBenchmarkJob, "refresh", MagicMock()), patch.object(
+        AIRecommendationJob, "refresh", MagicMock()
+    ):
+        yield
+
+
+def _bench(name, endpoint_identifier=None):
+    job = AIBenchmarkJob(ai_benchmark_job_name=name)
+    job.benchmark_target = (
+        AIBenchmarkTarget(endpoint=AIBenchmarkEndpoint(identifier=endpoint_identifier))
+        if endpoint_identifier is not None
+        else None
+    )
+    return job
+
+
+def _rec(name, s3_uri=None, group=None, row_arns=()):
+    job = AIRecommendationJob(ai_recommendation_job_name=name)
+    job.model_source = AIModelSource(s3=AIModelSourceS3(s3_uri=s3_uri)) if s3_uri else None
+    job.output_config = (
+        AIRecommendationOutputResult(
+            s3_output_location="s3://bucket/out/",
+            model_package_group_identifier=group,
+        )
+        if group is not None
+        else None
+    )
+    job.recommendations = [
+        AIRecommendation(model_details=AIRecommendationModelDetails(model_package_arn=arn))
+        for arn in row_arns
+    ]
+    return job
+
+
+class TestListBenchmarks:
+    def test_no_filter_returns_all_native(self):
+        jobs = [_bench("b1"), _bench("b2")]
+        with patch.object(BenchmarkJob, "get_all", return_value=iter(jobs)):
+            out = list_benchmarks()
+        assert [j.ai_benchmark_job_name for j in out] == ["b1", "b2"]
+
+    def test_endpoint_filter_matches_by_name(self):
+        jobs = [
+            _bench("b1", endpoint_identifier="ep-A"),
+            _bench("b2", endpoint_identifier="ep-B"),
+            _bench("b3", endpoint_identifier=None),
+        ]
+        with patch.object(BenchmarkJob, "get_all", return_value=iter(jobs)):
+            out = list_benchmarks(endpoint="ep-A")
+        assert [j.ai_benchmark_job_name for j in out] == ["b1"]
+
+    def test_endpoint_filter_matches_arn_suffix(self):
+        arn = "arn:aws:sagemaker:us-west-2:1:endpoint/ep-A"
+        jobs = [_bench("b1", endpoint_identifier=arn)]
+        with patch.object(BenchmarkJob, "get_all", return_value=iter(jobs)):
+            out = list_benchmarks(endpoint="ep-A")
+        assert [j.ai_benchmark_job_name for j in out] == ["b1"]
+
+    def test_max_results_caps_output(self):
+        jobs = [_bench(f"b{i}") for i in range(10)]
+        with patch.object(BenchmarkJob, "get_all", return_value=iter(jobs)):
+            out = list_benchmarks(max_results=3)
+        assert len(out) == 3
+
+    def test_native_filters_forwarded(self):
+        with patch.object(BenchmarkJob, "get_all", return_value=iter([])) as get_all:
+            list_benchmarks(status="Completed", name_contains="qwen")
+        kwargs = get_all.call_args.kwargs
+        assert kwargs["status_equals"] == "Completed"
+        assert kwargs["name_contains"] == "qwen"
+
+
+class TestListRecommendations:
+    def test_model_filter_matches_source_uri(self):
+        jobs = [
+            _rec("r1", s3_uri="s3://bucket/model-a/"),
+            _rec("r2", s3_uri="s3://bucket/model-b/"),
+        ]
+        with patch.object(RecommendationJob, "get_all", return_value=iter(jobs)):
+            out = list_recommendations(model="s3://bucket/model-a/")
+        assert [j.ai_recommendation_job_name for j in out] == ["r1"]
+
+    def test_model_filter_ignores_trailing_slash(self):
+        jobs = [_rec("r1", s3_uri="s3://bucket/model-a/")]
+        with patch.object(RecommendationJob, "get_all", return_value=iter(jobs)):
+            out = list_recommendations(model="s3://bucket/model-a")
+        assert [j.ai_recommendation_job_name for j in out] == ["r1"]
+
+    def test_model_package_matches_output_group(self):
+        jobs = [
+            _rec("r1", group="my-group"),
+            _rec("r2", group="other-group"),
+        ]
+        with patch.object(RecommendationJob, "get_all", return_value=iter(jobs)):
+            out = list_recommendations(model_package="my-group")
+        assert [j.ai_recommendation_job_name for j in out] == ["r1"]
+
+    def test_model_package_matches_recommendation_row_arn(self):
+        arn = "arn:aws:sagemaker:us-west-2:1:model-package/g/1"
+        jobs = [_rec("r1", row_arns=(arn,)), _rec("r2", row_arns=())]
+        with patch.object(RecommendationJob, "get_all", return_value=iter(jobs)):
+            out = list_recommendations(model_package=arn)
+        assert [j.ai_recommendation_job_name for j in out] == ["r1"]
+
+    def test_model_and_model_package_mutually_exclusive(self):
+        with pytest.raises(ValueError, match="only one of"):
+            list_recommendations(model="s3://x/", model_package="arn:y")
+
+    def test_no_filter_returns_all(self):
+        jobs = [_rec("r1"), _rec("r2")]
+        with patch.object(RecommendationJob, "get_all", return_value=iter(jobs)):
+            out = list_recommendations()
+        assert [j.ai_recommendation_job_name for j in out] == ["r1", "r2"]
+
+
+class TestRetypesToSubclass:
+    """list_* re-types base get_all output to the show_result subclass."""
+
+    def test_benchmarks_retyped_to_benchmark_job(self):
+        jobs = [_bench("b1")]
+        assert type(jobs[0]) is AIBenchmarkJob  # base going in
+        with patch.object(BenchmarkJob, "get_all", return_value=iter(jobs)):
+            out = list_benchmarks()
+        assert isinstance(out[0], BenchmarkJob)  # subclass coming out
+        assert hasattr(out[0], "show_result")
+
+    def test_recommendations_retyped_to_recommendation_job(self):
+        jobs = [_rec("r1")]
+        assert type(jobs[0]) is AIRecommendationJob
+        with patch.object(RecommendationJob, "get_all", return_value=iter(jobs)):
+            out = list_recommendations()
+        assert isinstance(out[0], RecommendationJob)
+        assert hasattr(out[0], "show_result")
+
+
+class TestScanBound:
+    """max_scan bounds the Describe fan-out, independent of max_results."""
+
+    def test_max_scan_caps_candidates_examined_when_filter_rarely_matches(self):
+        # 500 candidates, only the last matches; max_scan stops the scan early
+        # so the rare-match filter cannot fan out across the whole stream.
+        jobs = [_bench(f"b{i}") for i in range(500)]
+        jobs[-1].benchmark_target = AIBenchmarkTarget(
+            endpoint=AIBenchmarkEndpoint(identifier="ep-match")
+        )
+        with patch.object(BenchmarkJob, "get_all", return_value=iter(jobs)):
+            out = list_benchmarks(endpoint="ep-match", max_scan=10)
+        # Scan stopped at 10, well before the lone match at index 499.
+        assert out == []
+
+    def test_scan_reaching_the_match_within_budget_returns_it(self):
+        jobs = [_bench(f"b{i}") for i in range(20)]
+        jobs[5].benchmark_target = AIBenchmarkTarget(
+            endpoint=AIBenchmarkEndpoint(identifier="ep-match")
+        )
+        with patch.object(BenchmarkJob, "get_all", return_value=iter(jobs)):
+            out = list_benchmarks(endpoint="ep-match", max_scan=10)
+        assert [j.ai_benchmark_job_name for j in out] == ["b5"]
+
+    def test_truncated_scan_logs_warning(self, caplog):
+        jobs = [_bench(f"b{i}") for i in range(50)]
+        with patch.object(BenchmarkJob, "get_all", return_value=iter(jobs)):
+            with caplog.at_level("WARNING"):
+                list_benchmarks(endpoint="no-match", max_scan=5)
+        assert any("max_scan" in r.message for r in caplog.records)
+
+
+class TestBadCandidateResilience:
+    """A candidate whose Describe fails is skipped, not fatal to the listing."""
+
+    def _iterator_that_raises_on(self, jobs, bad_index, exc):
+        """Stand-in for sagemaker-core's ResourceIterator: raises from __next__
+        at the bad candidate but advances its index first, so a later next()
+        resumes at the following item (a plain generator dies once it raises)."""
+
+        class _ResumableIterator:
+            def __init__(self):
+                self._i = 0
+
+            def __iter__(self):
+                return self
+
+            def __next__(self):
+                if self._i >= len(jobs):
+                    raise StopIteration
+                i = self._i
+                self._i += 1  # advance BEFORE the (simulated) refresh, like the real one
+                if i == bad_index:
+                    raise exc
+                return jobs[i]
+
+        return _ResumableIterator()
+
+    def test_one_undescribable_job_does_not_abort_the_listing(self):
+        jobs = [
+            _bench("b1", endpoint_identifier="ep-A"),
+            _bench("b2", endpoint_identifier="ep-A"),  # never reached: bad one is #1
+            _bench("b3", endpoint_identifier="ep-A"),
+        ]
+        it = self._iterator_that_raises_on(jobs, 1, RuntimeError("AccessDenied"))
+        with patch.object(BenchmarkJob, "get_all", return_value=it):
+            out = list_benchmarks(endpoint="ep-A")
+        # b1 returned; the raise at #1 is skipped; b3 still examined and returned.
+        assert [j.ai_benchmark_job_name for j in out] == ["b1", "b3"]
+
+    def test_skipped_jobs_logged_at_warning(self, caplog):
+        jobs = [_bench("b1", endpoint_identifier="ep-A"), _bench("b2")]
+        it = self._iterator_that_raises_on(jobs, 0, RuntimeError("Throttled"))
+        with patch.object(BenchmarkJob, "get_all", return_value=it):
+            with caplog.at_level("WARNING"):
+                list_benchmarks(endpoint="ep-A")
+        msgs = " ".join(r.message for r in caplog.records)
+        assert "could not be described" in msgs
+        assert "skipped" in msgs
+
+    def _iterator_all_raise(self, n, exc):
+        """Stand-in iterator whose every __next__ raises (a fully-denied role)."""
+
+        class _AllRaise:
+            def __init__(self):
+                self._i = 0
+
+            def __iter__(self):
+                return self
+
+            def __next__(self):
+                if self._i >= n:
+                    raise StopIteration
+                self._i += 1
+                raise exc
+
+        return _AllRaise()
+
+    def test_per_candidate_skip_warnings_are_capped(self, caplog):
+        # A role that cannot Describe anything must not emit one warning per
+        # candidate (up to max_scan); only the first few, plus the summary.
+        it = self._iterator_all_raise(50, RuntimeError("AccessDenied"))
+        with patch.object(BenchmarkJob, "get_all", return_value=it):
+            with caplog.at_level("WARNING"):
+                out = list_benchmarks(endpoint="ep-A", max_scan=50)
+        assert out == []
+        # Per-candidate lines start with "Skipping a"; the summary is separate.
+        per_candidate = [r for r in caplog.records if r.message.startswith("Skipping a")]
+        assert len(per_candidate) <= 5
+        assert any("50 job(s) were skipped" in r.message for r in caplog.records)
+
+    def test_hitting_max_results_is_logged(self, caplog):
+        jobs = [_bench(f"b{i}", endpoint_identifier="ep-A") for i in range(5)]
+        with patch.object(BenchmarkJob, "get_all", return_value=iter(jobs)):
+            with caplog.at_level("INFO"):
+                out = list_benchmarks(endpoint="ep-A", max_results=2)
+        assert len(out) == 2
+        assert any("max_results" in r.message for r in caplog.records)
+
+
+class TestSessionHandling:
+    """Accept a boto3 Session or a sagemaker Session (unwrapping the latter)."""
+
+    def test_boto3_session_passed_through(self):
+        import boto3
+
+        session = boto3.session.Session(region_name="us-west-2")
+        with patch.object(BenchmarkJob, "get_all", return_value=iter([])) as get_all:
+            list_benchmarks(sagemaker_session=session)
+        assert get_all.call_args.kwargs["session"] is session
+
+    def test_sagemaker_session_unwrapped_to_boto_session(self):
+        import boto3
+
+        boto_session = boto3.session.Session(region_name="us-west-2")
+        # A sagemaker-Session-like object: exposes .boto_session, and a real
+        # sagemaker_config dict so the telemetry decorator's config validation
+        # (which runs before the call) does not choke on a bare MagicMock.
+        sm_session = MagicMock()
+        sm_session.boto_session = boto_session
+        sm_session.sagemaker_config = {}
+        with patch.object(BenchmarkJob, "get_all", return_value=iter([])) as get_all:
+            list_benchmarks(sagemaker_session=sm_session)
+        # get_all receives the unwrapped boto3 session (what pydantic validate_call wants).
+        assert get_all.call_args.kwargs["session"] is boto_session
+
+    def test_none_session_stays_none(self):
+        with patch.object(BenchmarkJob, "get_all", return_value=iter([])) as get_all:
+            list_benchmarks()
+        assert get_all.call_args.kwargs["session"] is None

--- a/sagemaker-serve/tests/unit/test_ai_inference_recommender/test_model_builder_recommendations.py
+++ b/sagemaker-serve/tests/unit/test_ai_inference_recommender/test_model_builder_recommendations.py
@@ -38,6 +38,14 @@ def mb_class():
     return ModelBuilder
 
 
+def _mock_session():
+    """A mock SageMaker session whose ``sagemaker_config`` is a real dict, so the
+    full ``deploy()`` path (which validates that config) runs against a mock."""
+    session = MagicMock()
+    session.sagemaker_config = {}
+    return session
+
+
 def _rec_row(
     spec_name=None,
     model_package_arn="arn:aws:sm:us-west-2:1:model-package/p/1",
@@ -128,6 +136,41 @@ class TestDeployRecommendationRowSelection:
             # describe_model_package should have been called with row B's ARN.
             described_arn = sm_mock.describe_model_package.call_args.kwargs["ModelPackageName"]
             assert described_arn == "arn:.../p/B"
+        finally:
+            for p in patches:
+                p.stop()
+
+    def test_recommendation_row_selects_exact_row_against_describe(self, mb_class):
+        """Passing recommendation_row deploys that exact row's ModelPackage even
+        when another row shares its spec name — verified against the real
+        describe_model_package call, not just a forwarded kwarg."""
+        rows = [
+            _rec_row(spec_name="dup", model_package_arn="arn:.../p/0"),
+            _rec_row(spec_name="dup", model_package_arn="arn:.../p/1"),
+        ]
+        mb = self._make_builder_with_rows(mb_class, rows)
+        sm_mock = mb.sagemaker_session.sagemaker_client
+        sm_mock.describe_model_package.return_value = {"ModelApprovalStatus": "Approved"}
+
+        patches = self._patch_aws_calls()
+        for p in patches:
+            p.start()
+        try:
+            mb._deploy_recommendation(
+                recommendation_index=0,  # default; must be ignored in favor of the row
+                recommendation_spec_name=None,
+                recommendation_row=rows[1],
+                endpoint_name=None,
+                model_name=None,
+                endpoint_config_name=None,
+                role="arn:role",
+                instance_type=None,
+                initial_instance_count=None,
+                tags=None,
+                wait=False,
+            )
+            described_arn = sm_mock.describe_model_package.call_args.kwargs["ModelPackageName"]
+            assert described_arn == "arn:.../p/1"
         finally:
             for p in patches:
                 p.stop()
@@ -505,9 +548,7 @@ class TestRegisterReturnsArn:
         with patch(
             "sagemaker.serve.model_builder.create_model_package_from_containers",
             return_value={"ModelPackageArn": arn},
-        ), patch(
-            "sagemaker.serve.model_builder.get_model_package_args", return_value={}
-        ), patch(
+        ), patch("sagemaker.serve.model_builder.get_model_package_args", return_value={}), patch(
             "sagemaker.serve.model_builder.update_container_with_inference_params",
             side_effect=lambda **kw: kw.get("container_def"),
         ), patch.object(
@@ -645,3 +686,84 @@ class TestDeployRecommendationSpecNameMultiMatch:
             )
         # First match (row A) is the one described/deployed.
         assert sm.describe_model_package.call_args.kwargs["ModelPackageName"] == "arn:.../p/A"
+
+
+class TestDeployRecommendationRowObject:
+    """deploy(recommendation=<row>) resolves a recommendation row to its
+    positional index — the exact-row identifier — instead of making callers
+    hand-copy a magic index. Forwarding the index (not the spec name) is what
+    guarantees the exact row passed is the one deployed, even when spec names
+    repeat."""
+
+    def _make_builder(self, mb_class):
+        mb = mb_class(sagemaker_session=_mock_session())
+        mb._recommendation_job = SimpleNamespace(
+            recommendations=[
+                _rec_row(spec_name="A", model_package_arn="arn:.../p/A"),
+                _rec_row(spec_name="B", model_package_arn="arn:.../p/B"),
+            ],
+            ai_recommendation_job_status="Completed",
+        )
+        return mb
+
+    def _row(self, mb, index):
+        # A real recommendation view row, as mb.recommendations[index] returns.
+        return mb.recommendations[index]
+
+    def test_best_row_forwards_its_raw_shape(self, mb_class):
+        mb = self._make_builder(mb_class)
+        with patch.object(mb_class, "_deploy_recommendation") as deploy_rec:
+            mb.deploy(recommendation=mb.recommendations.best)
+        # The row's underlying shape is passed through (not an index/spec name),
+        # so the exact row deploys regardless of list order or refresh.
+        assert deploy_rec.call_args.kwargs["recommendation_row"] is mb.recommendations.best.raw
+        assert deploy_rec.call_args.kwargs["recommendation_spec_name"] is None
+
+    def test_indexed_row_forwards_its_raw_shape(self, mb_class):
+        mb = self._make_builder(mb_class)
+        row = self._row(mb, 1)
+        with patch.object(mb_class, "_deploy_recommendation") as deploy_rec:
+            mb.deploy(recommendation=row)
+        assert deploy_rec.call_args.kwargs["recommendation_row"] is row.raw
+        assert deploy_rec.call_args.kwargs["recommendation_spec_name"] is None
+
+    def test_non_row_value_raises_type_error(self, mb_class):
+        """A spec-name string / raw shape / int / dict is not a row view; it
+        must raise rather than silently defaulting to row 0."""
+        mb = self._make_builder(mb_class)
+        for bad in ("B", 1, {"recommendation_spec_name": "B"}):
+            with pytest.raises(TypeError, match="recommendation must be a recommendation row"):
+                mb.deploy(recommendation=bad)
+
+    def test_duplicate_spec_deploys_the_exact_row_passed(self, mb_class):
+        """Two rows sharing an inference_specification_name (the normal fan-out
+        shape). Passing view[1] must carry row 1's shape — resolving by spec
+        name would pick matches[0] (row 0), the wrong hardware."""
+        mb = mb_class(sagemaker_session=_mock_session())
+        mb._recommendation_job = SimpleNamespace(
+            recommendations=[
+                _rec_row(spec_name="dup", model_package_arn="arn:.../p/0"),
+                _rec_row(spec_name="dup", model_package_arn="arn:.../p/1"),
+            ],
+            ai_recommendation_job_status="Completed",
+        )
+        row1 = mb.recommendations[1]
+        with patch.object(mb_class, "_deploy_recommendation") as deploy_rec:
+            mb.deploy(recommendation=row1)
+        # Row 1's exact shape flows through; the shared spec name is not used.
+        assert deploy_rec.call_args.kwargs["recommendation_row"] is row1.raw
+        assert (
+            deploy_rec.call_args.kwargs["recommendation_row"].model_details.model_package_arn
+            == "arn:.../p/1"
+        )
+        assert deploy_rec.call_args.kwargs["recommendation_spec_name"] is None
+
+    def test_recommendation_conflicts_with_index(self, mb_class):
+        mb = self._make_builder(mb_class)
+        with pytest.raises(ValueError, match="only one of"):
+            mb.deploy(recommendation=mb.recommendations.best, recommendation_index=1)
+
+    def test_recommendation_conflicts_with_spec_name(self, mb_class):
+        mb = self._make_builder(mb_class)
+        with pytest.raises(ValueError, match="only one of"):
+            mb.deploy(recommendation=mb.recommendations.best, recommendation_spec_name="B")

--- a/sagemaker-serve/tests/unit/test_ai_inference_recommender/test_recommendation_view_dataframe.py
+++ b/sagemaker-serve/tests/unit/test_ai_inference_recommender/test_recommendation_view_dataframe.py
@@ -1,0 +1,162 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+"""Unit tests for to_dataframe() on the recommendation views."""
+from __future__ import absolute_import
+
+from types import SimpleNamespace
+
+import pytest
+
+from sagemaker.serve.ai_inference_recommender._recommendation_view import (
+    _RecommendationsView,
+    _RecommendationView,
+)
+
+pd = pytest.importorskip("pandas")
+
+
+def _perf(metric, stat, value, unit):
+    return SimpleNamespace(metric=metric, stat=stat, value=value, unit=unit)
+
+
+def _rec_row(
+    spec_name="A",
+    instance_type="ml.g6.12xlarge",
+    instance_count=1,
+    perf=None,
+    image_uri=".../djl-inference:0.36.0-lmi25.0.0-cu130",
+):
+    return SimpleNamespace(
+        model_details=SimpleNamespace(
+            model_package_arn="arn:aws:sm:us-west-2:1:model-package/p/1",
+            inference_specification_name=spec_name,
+        ),
+        deployment_configuration=SimpleNamespace(
+            instance_type=instance_type,
+            instance_count=instance_count,
+            copy_count_per_instance=1,
+            image_uri=image_uri,
+        ),
+        expected_performance=perf or [],
+    )
+
+
+class TestRecommendationViewToDataFrame:
+    def test_columns_and_rows_match_expected_performance(self):
+        perf = [
+            _perf("RequestThroughput", "avg", 3.8, "requests/sec"),
+            _perf("RequestLatency", "p50", 206.6, "ms"),
+        ]
+        view = _RecommendationView(_rec_row(perf=perf), index=0)
+        df = view.to_dataframe()
+        assert list(df.columns) == ["metric", "stat", "value", "unit"]
+        assert len(df) == 2
+        assert set(df["metric"]) == {"RequestThroughput", "RequestLatency"}
+        assert df.iloc[0]["value"] == 3.8  # native float, not preformatted
+
+    def test_empty_expected_performance_yields_empty_frame_with_schema(self):
+        df = _RecommendationView(_rec_row(perf=[]), index=0).to_dataframe()
+        assert len(df) == 0
+        assert list(df.columns) == ["metric", "stat", "value", "unit"]
+
+
+class TestRecommendationsViewToDataFrame:
+    def _view(self):
+        rows = [
+            _rec_row(
+                spec_name="A",
+                instance_type="ml.g6.12xlarge",
+                perf=[
+                    _perf("RequestThroughput", "avg", 3.8, "requests/sec"),
+                    _perf("RequestLatency", "p50", 206.6, "ms"),
+                    _perf("RequestLatency", "p90", 257.9, "ms"),
+                ],
+            ),
+            _rec_row(spec_name="B", instance_type="ml.g6.2xlarge", perf=[]),
+        ]
+        return _RecommendationsView(_RecommendationView(r, index=i) for i, r in enumerate(rows))
+
+    def test_one_row_per_recommendation_indexed_by_idx(self):
+        df = self._view().to_dataframe()
+        assert df.index.name == "idx"
+        assert list(df.index) == [0, 1]
+        # idx is the index, not a duplicated column
+        assert "idx" not in df.columns
+
+    def test_columns_match_printed_table(self):
+        df = self._view().to_dataframe()
+        assert list(df.columns) == [
+            "spec_name",
+            "instance_type",
+            "instances",
+            "copies/inst",
+            "container",
+            "req/s",
+            "tok/s",
+            "lat_p50",
+            "lat_p90",
+            "lat_p99",
+            "ttft_p50",
+            "itl_p50",
+        ]
+
+    def test_numeric_columns_are_native_and_missing_is_nan(self):
+        df = self._view().to_dataframe()
+        assert df.loc[0, "req/s"] == 3.8
+        assert df.loc[0, "lat_p50"] == 206.6
+        assert df.loc[0, "instance_type"] == "ml.g6.12xlarge"
+        assert df.loc[0, "container"] == "lmi25.0.0"
+        # row B has no expected_performance -> numeric metric is NaN, not "-"
+        assert pd.isna(df.loc[1, "req/s"])
+
+    def test_empty_view_yields_empty_frame_with_schema(self):
+        df = _RecommendationsView().to_dataframe()
+        assert len(df) == 0
+        assert "instance_type" in df.columns
+
+    def test_missing_container_is_none_not_dash_sentinel(self):
+        """A row without an image_uri gets None in the container column — not
+        the "-" display sentinel — so .notna()/groupby/value_counts treat it as
+        missing rather than a container literally named '-'."""
+        rows = [
+            _rec_row(spec_name="A", image_uri=None),
+            _rec_row(spec_name="B", image_uri=".../djl-inference:0.36.0-lmi25.0.0-cu130"),
+        ]
+        view = _RecommendationsView(_RecommendationView(r, index=i) for i, r in enumerate(rows))
+        df = view.to_dataframe()
+        assert pd.isna(df.loc[0, "container"])  # missing -> NaN, not "-"
+        assert df.loc[1, "container"] == "lmi25.0.0"
+        # The printed table still shows a dash for the missing one.
+        assert "-" in str(view)
+
+    def test_metric_absent_from_all_rows_is_float_and_sortable(self):
+        # No row has expected_performance -> every metric column is float64 NaN,
+        # not object holding None, so nlargest/sort_values do not raise.
+        rows = [_rec_row(spec_name="A", perf=[]), _rec_row(spec_name="B", perf=[])]
+        view = _RecommendationsView(_RecommendationView(r, index=i) for i, r in enumerate(rows))
+        df = view.to_dataframe()
+        assert str(df["req/s"].dtype) == "float64"
+        df.nlargest(1, "req/s")  # would raise on object dtype
+
+    def test_str_and_dataframe_agree_on_row_order(self):
+        """The comparative table and the frame list rows in the same order
+        (by idx), driven from the shared _row_records()."""
+        view = self._view()
+        frame_order = list(view.to_dataframe().index)
+        # The printed table shows each row's idx as "[N]" in the first column.
+        table_order = [
+            int(line.strip()[1:].split("]")[0])
+            for line in str(view).splitlines()
+            if line.strip().startswith("[")
+        ]
+        assert table_order == frame_order

--- a/sagemaker-serve/tests/unit/test_ai_inference_recommender/test_result.py
+++ b/sagemaker-serve/tests/unit/test_ai_inference_recommender/test_result.py
@@ -73,9 +73,7 @@ class TestBenchmarkMetricsFromProfileJson:
         assert metrics.get("does_not_exist") is None
 
     def test_metric_raw_preserves_full_dict(self):
-        metric = BenchmarkMetric.from_dict(
-            "x", {"avg": 1, "unit": "s", "extra": "kept"}
-        )
+        metric = BenchmarkMetric.from_dict("x", {"avg": 1, "unit": "s", "extra": "kept"})
         assert metric.raw == {"avg": 1, "unit": "s", "extra": "kept"}
 
 
@@ -169,6 +167,107 @@ class TestBenchmarkResultRepr:
         assert text.startswith("BenchmarkResult(")
 
 
+pd = pytest.importorskip("pandas")
+
+
+class TestToDataFrame:
+    """to_dataframe() on BenchmarkMetrics and BenchmarkResult."""
+
+    def _result(self) -> BenchmarkResult:
+        # SAMPLE_PROFILE plus an http_* metric, so ordering can be asserted.
+        profile = dict(SAMPLE_PROFILE)
+        profile["http_req_waiting"] = {"avg": 90.0, "p50": 80.0, "unit": "ms"}
+        return BenchmarkResult(
+            metrics=BenchmarkMetrics.from_profile_json(profile),
+            s3_output_location="s3://bucket/results/",
+        )
+
+    def test_metrics_dataframe_shape_and_columns(self):
+        df = BenchmarkMetrics.from_profile_json(SAMPLE_PROFILE).to_dataframe()
+        assert df.index.name == "metric"
+        assert list(df.columns) == [
+            "unit",
+            "avg",
+            "min",
+            "max",
+            "p50",
+            "p90",
+            "p95",
+            "p99",
+            "stddev",
+        ]
+        # one row per parsed metric
+        assert set(df.index) == set(BenchmarkMetrics.from_profile_json(SAMPLE_PROFILE).all_metrics)
+
+    def test_metrics_dataframe_carries_stats_the_text_table_drops(self):
+        # min/max are absent from the printed table but present in the frame.
+        df = BenchmarkMetrics.from_profile_json(SAMPLE_PROFILE).to_dataframe()
+        assert df.loc["request_throughput", "avg"] == 12.5
+        assert df.loc["request_throughput", "min"] == 10.0
+        assert df.loc["request_throughput", "max"] == 15.0
+        # request_latency carries min/max/p99 that the printed table omits.
+        assert df.loc["request_latency", "min"] == 200.0
+        assert df.loc["request_latency", "p99"] == 1450.0
+
+    def test_result_dataframe_orders_headline_first_http_last(self):
+        df = self._result().to_dataframe()
+        names = list(df.index)
+        # headline metric leads; http_* transport metric trails.
+        assert names[0] == "request_throughput"
+        assert names[-1] == "http_req_waiting"
+
+    def test_result_and_metrics_frames_share_columns(self):
+        result = self._result()
+        assert list(result.to_dataframe().columns) == list(result.metrics.to_dataframe().columns)
+
+    def test_search_result_dataframe_raises(self):
+        search = BenchmarkResult(
+            metrics=BenchmarkMetrics.from_profile_json({}),
+            s3_output_location="s3://b/s/",
+            search=BenchmarkSearchResult(swept_dim="concurrency", winner=8),
+        )
+        with pytest.raises(ValueError, match="search/sweep"):
+            search.to_dataframe()
+
+    def test_empty_metrics_yield_empty_frame_with_schema(self):
+        df = BenchmarkMetrics.from_profile_json({}).to_dataframe()
+        assert len(df) == 0
+        assert "avg" in df.columns
+
+    def _table_metric_order(self, text):
+        """Metric names in the order the printed table lists them — the first
+        column of each body row, after the header + separator lines."""
+        names = []
+        known = self._all_names()
+        for line in text.splitlines():
+            # Keep the first token of each line only when it is a known metric
+            # name, skipping the header, separator, and prose lines.
+            first = line.strip().split(" ")[0] if line.strip() else ""
+            if first in known:
+                names.append(first)
+        return names
+
+    def _all_names(self):
+        profile = dict(SAMPLE_PROFILE)
+        profile["http_req_waiting"] = {"avg": 90.0, "unit": "ms"}
+        return set(BenchmarkMetrics.from_profile_json(profile).all_metrics)
+
+    def test_metrics_str_and_dataframe_index_agree_on_order(self):
+        """BenchmarkMetrics.__str__ and .to_dataframe() list metrics in the
+        same order, via the shared _ordered_metric_pairs()."""
+        metrics = self._result().metrics
+        table_order = self._table_metric_order(str(metrics))
+        frame_order = list(metrics.to_dataframe().index)
+        assert table_order == frame_order
+
+    def test_result_str_and_dataframe_index_agree_on_order(self):
+        """Same order invariant for BenchmarkResult (headline-first)."""
+        result = self._result()
+        table_order = self._table_metric_order(str(result))
+        frame_order = list(result.to_dataframe().index)
+        assert table_order == frame_order
+
+
 class TestBenchmarkResultMetadataFields:
     """Lock down endpoint / workload_config / tool_version on BenchmarkResult."""
 
@@ -191,9 +290,7 @@ class TestBenchmarkResultMetadataFields:
         assert "0.6.0" in text
 
     def test_str_renders_dashes_when_metadata_missing(self):
-        text = str(
-            self._result(endpoint=None, workload_config=None, tool_version=None)
-        )
+        text = str(self._result(endpoint=None, workload_config=None, tool_version=None))
         assert "endpoint:           -" in text
         assert "workload_config:    -" in text
         assert "tool_version:       -" in text
@@ -237,10 +334,12 @@ class TestBenchmarkResultMetadataFields:
         assert result.tool_version == "0.6.1"
 
     def test_tool_version_pulled_from_profile_metadata(self):
-        archive_bytes = self._archive_with({
-            **SAMPLE_PROFILE,
-            "metadata": {"version": "0.6.2"},
-        })
+        archive_bytes = self._archive_with(
+            {
+                **SAMPLE_PROFILE,
+                "metadata": {"version": "0.6.2"},
+            }
+        )
         result = self._parse_archive(archive_bytes)
         assert result.tool_version == "0.6.2"
 
@@ -282,9 +381,7 @@ class TestBenchmarkResultMetadataFields:
                 def client(self, name):
                     return s3_client
 
-            return BenchmarkResult.from_s3(
-                "s3://b/p/", session=_SessionStub()
-            )
+            return BenchmarkResult.from_s3("s3://b/p/", session=_SessionStub())
 
 
 # A concurrency search writes search_history.json at the artifact root. Schema


### PR DESCRIPTION
Adds inference-recommender usability features to sagemaker.serve:

- list_benchmarks(endpoint=...) / list_recommendations(model=..., model_package=...): the ListAI* APIs cannot filter by endpoint/model server-side (those fields are on Describe, not the list summary), so filtering is client-side (list -> describe -> match) bounded by max_results. Chosen because it is the only option the boto APIs allow, and a bounded describe fan-out keeps a broad list from being unbounded.

- ModelBuilder.deploy(recommendation=<row>): accept a recommendation row (mb.recommendations.best or [i]) and resolve it to the existing spec-name/index selection. Chosen as an additive, back-compat param so callers deploy the best row without hand-copying a magic index; existing index/spec_name kwargs still work.

- compare_benchmarks(*results): N-way comparison, first result = baseline, one row per metric x one column per run + a signed delta% column oriented so + is always better. Chosen N-way (not strictly 2-way) because it is barely more code and the delta vs a baseline is the whole point of a comparison utility.

- to_dataframe() on every tabular surface (customer-requested DataFrame view): BenchmarkMetrics, BenchmarkResult, BenchmarkComparison, and both recommendation views (_RecommendationView, _RecommendationsView). Each returns a pandas DataFrame mirroring its printed table, but carrying the extra stats (min/max/p95/stddev) the width-limited text tables drop, and keeping numeric values native (deltas numeric, NaN where undefined) instead of preformatted strings. pandas is imported lazily via _require_pandas() so result.py stays dependency-light (its printed tables are stdlib-only); it is present transitively via sagemaker-core in any real install. __str__ and to_dataframe() share ordering/row-building helpers (_ordered_metric_pairs, _row_records, _delta_value) so the printed table and the frame never drift. BenchmarkResult.to_dataframe() raises on a search/sweep result (no single profile).

Unit: 45 new tests (11 listing, 5 deploy-row, 12 compare, 17 to_dataframe); full recommender suite 199 pass. Integ: test_ai_inference_recommender_enhancements_integration.py chains rec -> deploy(rows.best) InService -> 2 benchmarks -> compare_benchmarks; verified live (1 passed, 70 min) plus a no-GPU listing-plumbing test.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
