### PR TITLE
fix(train): set input_data_config to None

### DIFF
--- a/sagemaker-train/src/sagemaker/train/model_trainer.py
+++ b/sagemaker-train/src/sagemaker/train/model_trainer.py
@@ -736,7 +736,11 @@ class ModelTrainer(BaseModel):
             "training_job_name": current_training_job_name,
             "algorithm_specification": algorithm_specification,
             "hyper_parameters": string_hyper_parameters,
-            "input_data_config": final_input_data_config,
+            "input_data_config": (
+                final_input_data_config
+                if final_input_data_config
+                else None
+            ),
             "resource_config": resource_config,
             "vpc_config": vpc_config,
             "role_arn": self.role,

--- a/sagemaker-train/tests/unit/train/test_model_trainer.py
+++ b/sagemaker-train/tests/unit/train/test_model_trainer.py
@@ -350,7 +350,7 @@ def test_train_with_intelligent_defaults_training_job_space(
         training_job_name=ANY,
         algorithm_specification=ANY,
         hyper_parameters={},
-        input_data_config=[],
+        input_data_config=None,
         resource_config=ResourceConfig(
             volume_size_in_gb=30,
             instance_type="ml.m5.xlarge",


### PR DESCRIPTION
*Issue #, if available:* N/A - small fix, can create if required. 

*Description of changes:* When no input channels are provided, input_data_config must be None rather than an empty list to avoid SageMaker API validation errors. This appears to be a regression caused by this [recent fix](https://github.com/aws/sagemaker-python-sdk/commit/4171658b738e622daf60197a3506db5d7726f29a). Before, `input_data_config=[]` would be dropped from the config silently, avoiding the validation issue in the API. Now, however, it is not dropped, which breaks the validation. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
