### PR TITLE
docs: Show V2 deprecation note on every documentation page

### DIFF
--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -8,3 +8,20 @@
   {{ super() }}
   <meta name="robots" content="noindex">
 {% endblock %}
+
+{# Deprecation banner. Overriding the "document" block places this note at the #}
+{# top of the main content area of EVERY page -- including theme-generated pages #}
+{# with no .rst source (genindex, py-modindex, search) that rst_prolog cannot #}
+{# reach. The markup mirrors a Sphinx ".. note::" admonition so it picks up the #}
+{# exact same sphinx_rtd_theme styling as the original landing-page note. #}
+{% block document %}
+  <div class="admonition note">
+    <p class="admonition-title">Note</p>
+    <p>Version 2.x of the SageMaker Python SDK is on a deprecation path.
+    For the latest features and continued support, see the SageMaker Python SDK
+    <a class="reference external" href="https://sagemaker.readthedocs.io/">V3 documentation</a>.
+    For version lifecycle, see
+    <a class="reference external" href="https://sagemaker.readthedocs.io/en/stable/lifecycle.html">this page</a>.</p>
+  </div>
+  {{ super() }}
+{% endblock %}

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -2,12 +2,6 @@
 Amazon SageMaker Python SDK
 ###########################
 
-.. note::
-   Version 2.x of the SageMaker Python SDK is on a deprecation path.
-   For the latest features and continued support, see the SageMaker Python SDK
-   `V3 documentation <https://sagemaker.readthedocs.io/>`_.
-   For version lifecycle, see `this page <https://sagemaker.readthedocs.io/en/stable/lifecycle.html>`_.
-
 Amazon SageMaker Python SDK is an open source library for training and deploying machine-learned models on Amazon SageMaker.
 
 With the SDK, you can train and deploy models using popular deep learning frameworks, algorithms provided by Amazon, or your own algorithms built into SageMaker-compatible Docker images.


### PR DESCRIPTION
Move the deprecation note from the landing page (index.rst) into the layout.html theme override so it renders at the top of every page, including theme-generated pages (genindex, py-modindex, search) that have no .rst source. The injected markup mirrors a Sphinx note admonition so styling matches the original landing-page note.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
