### PR TITLE
fix: revert preset reward function deletion from hyperparams dict

### DIFF
--- a/sagemaker-train/src/sagemaker/train/rlvr_trainer.py
+++ b/sagemaker-train/src/sagemaker/train/rlvr_trainer.py
@@ -240,9 +240,6 @@ class RLVRTrainer(BaseTrainer):
             if hasattr(self.hyperparameters, 'reward_lambda_arn'):
                 delattr(self.hyperparameters, 'reward_lambda_arn')
                 self.hyperparameters._specs.pop('reward_lambda_arn', None)
-            if hasattr(self.hyperparameters, 'preset_reward_function'):
-                delattr(self.hyperparameters, 'preset_reward_function')
-                self.hyperparameters._specs.pop('preset_reward_function', None)
             if hasattr(self.hyperparameters, 'data_path'):
                 delattr(self.hyperparameters, 'data_path')
                 self.hyperparameters._specs.pop('data_path', None)
@@ -410,7 +407,22 @@ class RLVRTrainer(BaseTrainer):
 
         Returns:
             TrainingJob: The SageMaker training job object, or None if dry_run=True.
+
+        Raises:
+            ValueError: If neither a custom reward function nor a preset reward
+                function hyperparameter is configured.
         """
+        # A reward signal is required: either a custom reward function (Lambda ARN,
+        # evaluator ARN, or Evaluator object) or the preset_reward_function hyperparameter.
+        preset_reward_function = getattr(self.hyperparameters, "preset_reward_function", None)
+        if not self.custom_reward_function and not preset_reward_function:
+            raise ValueError(
+                "RLVR training requires a reward signal. Provide either "
+                "'custom_reward_function' (a Lambda ARN, evaluator ARN, or Evaluator object) "
+                "when initializing RLVRTrainer, or set the 'preset_reward_function' "
+                "hyperparameter (e.g. trainer.hyperparameters.preset_reward_function = 'prime_code')."
+            )
+
         # Dispatch based on compute type
         if isinstance(self.compute, HyperPodCompute):
             return self._train_hyperpod(

--- a/sagemaker-train/tests/integ/train/test_rlvr_trainer_integration.py
+++ b/sagemaker-train/tests/integ/train/test_rlvr_trainer_integration.py
@@ -92,6 +92,8 @@ def test_rlvr_trainer_lora_complete_workflow(sagemaker_session):
         accept_eula=True,
         base_job_name=f"rlvr-lora-integ-{unique_id}",
     )
+
+    rlvr_trainer.hyperparameters.preset_reward_function = "prime_code"
     
     # Create training job
     training_job = rlvr_trainer.train(wait=False)


### PR DESCRIPTION
RLVR training needs a reward signal. The old code accepted preset_reward_function on the hyperparameters object, then silently deleted it during processing — leaving jobs to fail downstream (or run without a valid reward).
 
 This PR:

  1. Preserves the preset_reward_function hyperparameter through _process_hyperparameters so it actually reaches the job.
  2. Fails fast, client-side, with a clear message when no reward source is configured, instead of relying on a later server-side failure.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.