### PR TITLE
fix(ci): guard fast-integ-tests to same-repo PRs

### DIFF
--- a/.github/workflows/pr-checks-master.yml
+++ b/.github/workflows/pr-checks-master.yml
@@ -272,12 +272,34 @@ jobs:
   fast-integ-tests:
     runs-on: ubuntu-latest
     needs: [detect-changes]
-    if: contains(fromJson(needs.detect-changes.outputs.submodules), 'sagemaker-train')
+    # Same-repo PRs only, because this is the one job here that puts PR code on a
+    # runner. actions/checkout refuses to place a fork's head commit in a
+    # pull_request_target job -- correctly: this job holds the base repo's
+    # GITHUB_TOKEN and assumes CI_AWS_ROLE_ARN, so a fork could edit conftest.py
+    # and read those credentials out. That is the "pwn request" shape, and on a
+    # public repo it is a live credential-exfiltration path, so the guard skips
+    # the job rather than overriding the refusal with allow-unsafe-pr-checkout.
+    #
+    # Known consequence: nearly every PR to this repo comes from a fork, so this
+    # is not yet a gate on the PRs that matter. Closing that gap means running
+    # the suite where the other three test jobs already run PR code -- inside
+    # CodeBuild via source-version-override, which never exposes the runner's
+    # token or secrets to it (see integ-tests above). That needs a
+    # <repo>-ci-sagemaker-train-fast-integ-tests project in the CDK that owns the
+    # existing ones. Until it exists this suite is effectively a local signal --
+    # whether the daily CI-health run over refs/heads/master reaches
+    # tests/integ/train/shallow depends on that buildspec's selection, which also
+    # lives outside this repo.
+    if: >-
+      contains(fromJson(needs.detect-changes.outputs.submodules), 'sagemaker-train')
+      && github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - uses: actions/checkout@v3
         with:
           # pull_request_target checks out the base ref by default; these tests
-          # must run against the PR's code.
+          # must run against the PR's code. Safe only because the job is guarded
+          # to same-repo PRs above -- a branch in this repo already requires push
+          # access, so checking it out grants nothing its author lacks.
           ref: 'refs/pull/${{ github.event.pull_request.number }}/head'
 
       - name: Set up Python

--- a/sagemaker-train/tests/integ/train/shallow/README.md
+++ b/sagemaker-train/tests/integ/train/shallow/README.md
@@ -8,6 +8,21 @@ What this suite changes about the gate is not which job runs, but what the exist
 one selects: the `gpu_intensive` marks added here deselect the deep tests that
 submit a job and wait for it, and this suite covers those code paths instead.
 
+> **Current limitation — the job only runs on same-repo PRs.** `fast-integ-tests`
+> is the one job in `pr-checks-master.yml` that puts PR code on a GitHub runner,
+> and that runner assumes `CI_AWS_ROLE_ARN`. `actions/checkout` refuses to place a
+> fork's head commit in a `pull_request_target` job for exactly that reason, so the
+> job is guarded to same-repo PRs. Almost every PR here comes from a fork, so in
+> practice this is presently a **local** signal rather than a gate. The fix is to
+> run it the way the other three test jobs run PR code — inside CodeBuild via
+> `source-version-override`, which never exposes the runner's token or secrets to
+> it — which needs a CodeBuild project provisioned alongside the existing ones.
+>
+> Until then, run this suite locally when changing a submission path, and note that
+> the deselection described above trades gate coverage for coverage that depends on
+> whether the daily CI-health buildspec reaches this directory — that selection
+> lives outside this repo and is worth confirming.
+
 ## What a passing test proves
 
 Each test submits a real `CreateTrainingJob`, asserts the service returned a


### PR DESCRIPTION
## What this changes

Guards the `fast-integ-tests` job (added in #6176) to same-repo PRs. It is currently
failing at the checkout step on every fork PR, which is nearly every PR.

## Why it fails

`fast-integ-tests` could never run on its own PR — `pull_request_target` uses the
*base* branch's workflow definition — so #6176 merged without it having executed once.
Its first real run ([PR #6192](https://github.com/aws/sagemaker-python-sdk/actions/runs/32318236727/job/96280625690))
died at step 2 in 3 seconds, with steps 3–6 skipped:

> `##[error]` Refusing to check out fork pull request code from a `pull_request_target`
> workflow. This workflow runs with the base repository's GITHUB_TOKEN, secrets,
> default-branch cache scope, and runner access. Fetching and executing a fork's code
> in that trusted context commonly leads to "pwn request" vulnerabilities.

**The refusal is correct.** `fast-integ-tests` was the only job in this repo that put
PR code on a runner, and that same runner assumes `CI_AWS_ROLE_ARN` for three hours.
A fork PR could have edited `conftest.py` and read those credentials out.

Every other job here already avoids this, in one of two ways:

| Job | How it handles PR code |
|---|---|
| `detect-changes`, `ai-code-review.yml` | checks out the **base** ref only; diffs/reads the PR, never executes it |
| `codestyle-doc-tests`, `unit-tests`, `integ-tests` | **no checkout**; PR code runs in CodeBuild via `source-version-override` |
| all 3 jobs in `pr-checks-master-v2.yml`, `fortress-scan.yml` | same CodeBuild pattern |

`allow-unsafe-pr-checkout: true` is the one-line fix the error suggests. This PR
deliberately does **not** use it: on a public repo with an AWS role on the same runner
that is a live credential-exfiltration path, and the flag appears nowhere in this repo
today. Guarding the job keeps it from being the sole exception.

## The change

```yaml
if: >-
  contains(fromJson(needs.detect-changes.outputs.submodules), 'sagemaker-train')
  && github.event.pull_request.head.repo.full_name == github.repository
```

Same-repo PRs stay covered — a branch in this repo already requires push access, so
checking it out grants its author nothing new. Verified against the real event
payloads: #6192 and #6176 (forks) skip; #6119 (same-repo) runs. If a fork has been
deleted, `head.repo` is null and the job skips, which fails in the safe direction.

Nothing was being blocked by the failure, and nothing is blocked by the skip: required
checks on `master` are only `collab-check`, `wait-for-approval` and `CodeQL`.

## This is a stopgap, and the README says so

59 of the last 60 merged PRs came from forks, so after this change the suite runs on
roughly 2% of PRs — a local signal, not a gate. That is recorded in both the job
comment and the suite README rather than left to read as coverage, because a skipped
job shows green.

**The actual fix** is to run the suite where the other three test jobs run PR code —
inside CodeBuild via `source-version-override`, which never exposes the runner's token
or secrets to it. That needs a `sagemaker-python-sdk-ci-sagemaker-train-fast-integ-tests`
project provisioned in the CDK that owns the existing ones; there are no in-repo
buildspecs, so it cannot land from this repo alone.

## Worth a second opinion from whoever owns the buildspecs

47 deep tests across 20 files carry `gpu_intensive`, but the only in-repo
`-m "not gpu_intensive"` is inside `fast-integ-tests` itself; `tox.ini` passes pytest
through unfiltered. Whether the deep CodeBuild gate actually deselects those tests
depends on its external buildspec. If it does, the gate has lost that coverage while
the shallow replacement is not running on fork PRs — the combination is what to check.

## Testing

- YAML parses; the folded `if:` resolves to a single valid expression
- Guard logic verified against the live payloads for #6192, #6176 and #6119
- No test-code changes in this PR
