### PR TITLE
feat: track explicit debugger and profiler configuration

### DIFF
--- a/src/sagemaker/estimator.py
+++ b/src/sagemaker/estimator.py
@@ -775,6 +775,8 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):  # pylint: disable=too-man
         self.checkpoint_local_path = checkpoint_local_path
 
         self.rules = rules
+        self._debugger_hook_config_explicitly_provided = debugger_hook_config is not None
+        self._profiler_config_explicitly_provided = profiler_config is not None
 
         # Today, we ONLY support debugger_hook_config to be provided as a boolean value
         # from sagemaker_config. We resolve value for this parameter as per the order
@@ -1366,7 +1368,14 @@ class EstimatorBase(with_metaclass(ABCMeta, object)):  # pylint: disable=too-man
             )
         return None
 
-    @_telemetry_emitter(feature=Feature.ESTIMATOR_V2, func_name="estimator.fit")
+    @_telemetry_emitter(
+        feature=Feature.ESTIMATOR_V2,
+        func_name="estimator.fit",
+        telemetry_params={
+            "debuggerHookConfigExplicitlyProvided": ("_debugger_hook_config_explicitly_provided"),
+            "profilerConfigExplicitlyProvided": "_profiler_config_explicitly_provided",
+        },
+    )
     @runnable_by_pipeline
     def fit(
         self,

--- a/src/sagemaker/telemetry/telemetry_logging.py
+++ b/src/sagemaker/telemetry/telemetry_logging.py
@@ -16,7 +16,7 @@ import logging
 import platform
 import sys
 from time import perf_counter
-from typing import List
+from typing import Dict, List
 import functools
 import requests
 
@@ -67,7 +67,7 @@ STATUS_TO_CODE = {
 }
 
 
-def _telemetry_emitter(feature: str, func_name: str):
+def _telemetry_emitter(feature: str, func_name: str, telemetry_params: Dict[str, str] = None):
     """Telemetry Emitter
 
     Decorator to emit telemetry logs for SageMaker Python SDK functions. This class needs
@@ -75,6 +75,11 @@ def _telemetry_emitter(feature: str, func_name: str):
     in this repo. When collecting telemetry for classes using sagemaker-core Session object,
     we should be aware of its differences, such as sagemaker_session.sagemaker_config does not
     exist in new Session class.
+
+    Args:
+        feature: Feature enum value for the telemetry event.
+        func_name: Name of the instrumented function.
+        telemetry_params: Mapping of telemetry field names to instance attribute names.
     """
 
     def decorator(func):
@@ -135,6 +140,14 @@ def _telemetry_emitter(feature: str, func_name: str):
                 # Add endpoint ARN to the extra info if available
                 if hasattr(sagemaker_session, "endpoint_arn") and sagemaker_session.endpoint_arn:
                     extra += f"&x-endpointArn={sagemaker_session.endpoint_arn}"
+
+                if telemetry_params and args:
+                    for field_name, attribute_name in telemetry_params.items():
+                        value = getattr(args[0], attribute_name, None)
+                        if isinstance(value, bool):
+                            value = str(value).lower()
+                        if value is not None:
+                            extra += f"&x-{field_name}={value}"
 
                 start_timer = perf_counter()
                 try:

--- a/tests/unit/sagemaker/telemetry/test_telemetry_logging.py
+++ b/tests/unit/sagemaker/telemetry/test_telemetry_logging.py
@@ -42,11 +42,24 @@ MOCK_ENDPOINT_ARN = "arn:aws:sagemaker:us-west-2:123456789012:endpoint/test"
 class LocalSagemakerClientMock:
     def __init__(self):
         self.sagemaker_session = MOCK_SESSION
+        self._debugger_explicitly_provided = True
+        self._profiler_explicitly_provided = False
 
     @_telemetry_emitter(MOCK_FEATURE, MOCK_FUNC_NAME)
     def mock_create_model(self, mock_exception_func=None):
         if mock_exception_func:
             mock_exception_func()
+
+    @_telemetry_emitter(
+        MOCK_FEATURE,
+        MOCK_FUNC_NAME,
+        telemetry_params={
+            "debuggerExplicitlyProvided": "_debugger_explicitly_provided",
+            "profilerExplicitlyProvided": "_profiler_explicitly_provided",
+        },
+    )
+    def mock_train(self):
+        return None
 
 
 class TestTelemetryLogging(unittest.TestCase):
@@ -146,6 +159,19 @@ class TestTelemetryLogging(unittest.TestCase):
         mock_send_telemetry_request.assert_called_once_with(
             1, [1, 2], MOCK_SESSION, None, None, expected_extra_str
         )
+
+    @patch("sagemaker.telemetry.telemetry_logging._send_telemetry_request")
+    @patch("sagemaker.telemetry.telemetry_logging.resolve_value_from_config")
+    def test_telemetry_emitter_adds_instance_params(
+        self, mock_resolve_config, mock_send_telemetry_request
+    ):
+        mock_resolve_config.return_value = False
+
+        LocalSagemakerClientMock().mock_train()
+
+        extra = mock_send_telemetry_request.call_args.args[5]
+        assert "&x-debuggerExplicitlyProvided=true" in extra
+        assert "&x-profilerExplicitlyProvided=false" in extra
 
     @patch("sagemaker.telemetry.telemetry_logging._send_telemetry_request")
     @patch("sagemaker.telemetry.telemetry_logging.resolve_value_from_config")

--- a/tests/unit/test_estimator.py
+++ b/tests/unit/test_estimator.py
@@ -672,6 +672,8 @@ def test_estimator_initialization_with_sagemaker_config_injection(sagemaker_sess
     assert estimator.environment == expected_environment
     assert estimator.disable_profiler == expected_disable_profiler_attribute
     assert estimator.debugger_hook_config == expected_debugger_hook_config
+    assert estimator._debugger_hook_config_explicitly_provided is False
+    assert estimator._profiler_config_explicitly_provided is False
 
 
 def test_estimator_with_debugger_hook_config_provided_as_bool_from_direct_input(
@@ -694,6 +696,7 @@ def test_estimator_with_debugger_hook_config_provided_as_bool_from_direct_input(
         debugger_hook_config=True,
     )
     assert estimator.debugger_hook_config == {}
+    assert estimator._debugger_hook_config_explicitly_provided is True
 
 
 def test_estimator_with_debugger_hook_config_provided_as_dict_from_direct_input(
@@ -715,6 +718,7 @@ def test_estimator_with_debugger_hook_config_provided_as_dict_from_direct_input(
         debugger_hook_config=HOOK_CONFIG,
     )
     assert estimator.debugger_hook_config == HOOK_CONFIG
+    assert estimator._debugger_hook_config_explicitly_provided is True
 
 
 def test_estimator_initialization_with_sagemaker_config_injection_no_kms_supported(
@@ -1351,8 +1355,11 @@ def test_framework_with_only_profiler_rule_specified(sagemaker_session):
     ]
 
 
+@patch("sagemaker.telemetry.telemetry_logging._send_telemetry_request")
 @patch("time.time", return_value=TIME)
-def test_framework_with_profiler_config_without_s3_output_path(time, sagemaker_session):
+def test_framework_with_profiler_config_without_s3_output_path(
+    time, send_telemetry_request, sagemaker_session
+):
     f = DummyFramework(
         entry_point=SCRIPT_PATH,
         role=ROLE,
@@ -1361,6 +1368,7 @@ def test_framework_with_profiler_config_without_s3_output_path(time, sagemaker_s
         instance_type=INSTANCE_TYPE,
         profiler_config=ProfilerConfig(system_monitor_interval_millis=1000),
     )
+    assert f._profiler_config_explicitly_provided is True
     f.fit("s3://mydata")
     sagemaker_session.train.assert_called_once()
     _, args = sagemaker_session.train.call_args
@@ -1369,6 +1377,9 @@ def test_framework_with_profiler_config_without_s3_output_path(time, sagemaker_s
         "S3OutputPath": "s3://{}/".format(BUCKET_NAME),
         "ProfilingIntervalInMilliseconds": 1000,
     }
+    telemetry_extra = send_telemetry_request.call_args.args[5]
+    assert "&x-debuggerHookConfigExplicitlyProvided=false" in telemetry_extra
+    assert "&x-profilerConfigExplicitlyProvided=true" in telemetry_extra
 
 
 @pytest.mark.parametrize("region", PROFILER_UNSUPPORTED_REGIONS)


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

- Record whether `debugger_hook_config` and `profiler_config` were provided directly to an estimator before SDK defaults and training preparation transform those values.
- Extend the telemetry emitter with opt-in instance attribute fields.
- Emit `x-debuggerHookConfigExplicitlyProvided` and `x-profilerConfigExplicitlyProvided` on `estimator.fit`.

*Testing done:*

- `PYTHONPATH=/tmp/sagemaker-v2-test-deps:src python -m pytest -q tests/unit/test_estimator.py` (276 passed)
- `PYTHONPATH=/tmp/sagemaker-v2-test-deps:src python -m pytest -q tests/unit/sagemaker/telemetry/test_telemetry_logging.py` (19 passed)
- Black, Flake8, and `git diff --check`

## Merge Checklist

#### General

- [x] I certify that the changes I am introducing will be backward compatible.
- [x] I used the commit message format described in CONTRIBUTING.
- [x] No S3 or STS clients are introduced by this change.
- [x] No documentation updates are required for internal telemetry fields.

#### Tests

- [x] I have added tests that prove the feature works.
- [x] I have added unit tests to ensure backward compatibility.
- [x] The tests are not configured for a specific account.
- [x] No dependencies are added.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.