### PR TITLE
fix(jumpstart): preserve instance-variant environment variable names on the hub path

### DIFF
--- a/src/sagemaker/jumpstart/hub/parser_utils.py
+++ b/src/sagemaker/jumpstart/hub/parser_utils.py
@@ -33,7 +33,9 @@ def snake_to_upper_camel(snake_case_string: str) -> str:
 
 
 def walk_and_apply_json(
-    json_obj: Dict[Any, Any], apply, stop_keys: Optional[List[str]] = ["metrics"]
+    json_obj: Dict[Any, Any],
+    apply,
+    stop_keys: Optional[List[str]] = ["metrics", "environment_variables"],
 ) -> Dict[Any, Any]:
     """Recursively walks a json object and applies a given function to the keys.
 

--- a/tests/unit/sagemaker/jumpstart/hub/test_env_var_name_preservation.py
+++ b/tests/unit/sagemaker/jumpstart/hub/test_env_var_name_preservation.py
@@ -1,0 +1,78 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+"""Regression test for the hub-path environment-variable name rewrite (issue #6191).
+
+The existing coverage for get_instance_specific_environment_variables builds its
+fixtures with snake_case keys, which only exercises the from_json (public catalogue)
+path. This exercises from_describe_hub_content_response, where DescribeHubContent
+returns UpperCamelCase keys and the environment-variable names are themselves map
+keys, so a recursive key rewrite renames them.
+"""
+from __future__ import absolute_import
+
+from sagemaker.jumpstart.types import JumpStartInstanceTypeVariants
+
+
+HUB_INSTANCE_TYPE_VARIANTS = {
+    "Variants": {
+        "g6": {
+            "Properties": {
+                "EnvironmentVariables": {
+                    "SM_VLLM_MAX_MODEL_LEN": "1024",
+                    "FAMILY_LEVEL_ONLY": "yes",
+                }
+            }
+        },
+        "ml.g6.24xlarge": {
+            "Properties": {
+                "EnvironmentVariables": {
+                    "HF_HUB_OFFLINE": "1",
+                    "SM_VLLM_MAX_MODEL_LEN": "2275",
+                    "SM_VLLM_TENSOR_PARALLEL_SIZE": "4",
+                    "TRANSFORMERS_OFFLINE": "1",
+                }
+            }
+        },
+    }
+}
+
+
+def test_hub_environment_variable_names_are_not_snake_cased():
+    """Names must survive verbatim, e.g. not HF_HUB_OFFLINE -> h_f__h_u_b__o_f_f_l_i_n_e."""
+    variants = JumpStartInstanceTypeVariants(HUB_INSTANCE_TYPE_VARIANTS, is_hub_content=True)
+
+    assert variants.get_instance_specific_environment_variables(instance_type="ml.g6.24xlarge") == {
+        "FAMILY_LEVEL_ONLY": "yes",
+        "HF_HUB_OFFLINE": "1",
+        "SM_VLLM_MAX_MODEL_LEN": "2275",
+        "SM_VLLM_TENSOR_PARALLEL_SIZE": "4",
+        "TRANSFORMERS_OFFLINE": "1",
+    }
+
+
+def test_hub_instance_specific_env_var_overrides_family_level():
+    """The instance-type value must win over the family-level one for the same name."""
+    variants = JumpStartInstanceTypeVariants(HUB_INSTANCE_TYPE_VARIANTS, is_hub_content=True)
+
+    env = variants.get_instance_specific_environment_variables(instance_type="ml.g6.24xlarge")
+
+    assert env["SM_VLLM_MAX_MODEL_LEN"] == "2275"
+    assert env["FAMILY_LEVEL_ONLY"] == "yes"
+
+
+def test_hub_environment_variables_absent_for_unknown_instance_type():
+    variants = JumpStartInstanceTypeVariants(HUB_INSTANCE_TYPE_VARIANTS, is_hub_content=True)
+
+    assert (
+        variants.get_instance_specific_environment_variables(instance_type="ml.p4d.24xlarge") == {}
+    )


### PR DESCRIPTION
*Issue #, if available:* #6191

*Description of changes:*

`walk_and_apply_json` applies its key-conversion function to every key at every depth of the document. Instance-variant environment variables are stored as a **map keyed by the variable name**, so on the `DescribeHubContent` path (`JumpStartInstanceTypeVariants.from_describe_hub_content_response`, which calls `walk_and_apply_json(response, camel_to_snake)`) the variable names themselves were rewritten:

```
HF_HUB_OFFLINE                 ->  h_f__h_u_b__o_f_f_l_i_n_e
MAX_BATCH_SIZE                 ->  m_a_x__b_a_t_c_h__s_i_z_e
SM_VLLM_MAX_MODEL_LEN          ->  s_m__v_l_l_m__m_a_x__m_o_d_e_l__l_e_n
SM_VLLM_TENSOR_PARALLEL_SIZE   ->  s_m__v_l_l_m__t_e_n_s_o_r__p_a_r_a_l_l_e_l__s_i_z_e
TRANSFORMERS_OFFLINE           ->  t_r_a_n_s_f_o_r_m_e_r_s__o_f_f_l_i_n_e
```

`camel_to_snake` is `re.sub(r"(?<!^)(?=[A-Z])", "_", s).lower()`, so applied to an already-`SCREAMING_SNAKE` name it inserts an underscore before every character.

The impact is not cosmetic. `_retrieve_default_environment_variables` merges the instance-variant map **over** the base `inference_environment_variables` list with `dict.update()`, relying on the two spellings colliding so the instance-specific value wins. Once a name has been rewritten it can no longer collide, so the instance-specific override is silently discarded and the container starts with the base default. Both spellings then appear side by side in the resulting `Environment`, for example a base default of `SM_VLLM_MAX_MODEL_LEN = 4096` alongside an inert `s_m__v_l_l_m__m_a_x__m_o_d_e_l__l_e_n = 131072`.

Names sourced from `inference_environment_variables` are unaffected, because that is a **list of objects** whose `Name` is a value rather than a key. That is why `SAGEMAKER_*`, `HF_MODEL_ID`, `MODEL_CACHE_ROOT` and `ENDPOINT_SERVER_TIMEOUT` arrive intact while every instance-variant name is mangled.

The public catalogue path (`from_json`) applies no key conversion at all, which is why the identical model deploys correctly when `hub_name` is omitted.

**The change:** add `environment_variables` to `walk_and_apply_json`'s default `stop_keys`, matching the existing treatment of `metrics`. `stop_keys` is compared against the key *after* `apply()` has run, so the node itself still renames to `environment_variables`, which is what `get_instance_specific_environment_variables` looks up, while its children pass through verbatim.

Note this does change the environment variable names resolved on the hub path, which is the intent of the fix: instance-specific overrides now take effect where previously they were dropped.

*Testing done:*

Verified against `master-v2` at `fc582aa` (Release 2.257.6).

Full `tests/unit/sagemaker/jumpstart` suite, run with a neutral AWS environment (`AWS_DEFAULT_REGION=us-west-2` and dummy credentials, since several tests otherwise pick up ambient config):

| | |
|---|---|
| before the change | 5 failed, 371 passed |
| after the change | 5 failed, 371 passed |
| after, including the 3 new tests | 5 failed, 374 passed |

The set of failing tests is **byte-identical** before and after (compared by test name, not just count), so no new failures and none accidentally fixed. Those 5 failures are pre-existing on an unmodified checkout: `hub/test_utils.py::test_construct_hub_arn_from_name_with_session_none`, `model/test_model.py::ModelTest::test_model_display_benchmark_metrics`, `test_cache.py::test_jumpstart_local_metadata_override_specs_not_exist_both_directories`, and `test_types.py::test_inference_configs_parsing` and `::test_jumpstart_model_specs`. I was running pytest 9.1.1 rather than the pinned 6.2.5, which I suspect is the cause but did not isolate.

The new regression tests are red without the fix and green with it: 2 of the 3 fail on unmodified source, all 3 pass with the change.

Both changed files pass `black==24.3.0`, the version pinned in `requirements/extras/test_requirements.txt`.

**On the existing coverage gap:** every current fixture for `get_instance_specific_environment_variables` defines variants with already-snake_case keys, so they exercise only the `from_json` path. Nothing constructed `JumpStartInstanceTypeVariants` with `is_hub_content=True` and UpperCamelCase `EnvironmentVariables`, which is the only path that hits the rewrite. The new test file covers that path, plus family-versus-instance-type precedence and the unknown-instance-type case.

I was not able to determine whether the reverse serialisation pass in `parsers.py` `_to_json`, which passes `snake_to_upper_camel`, ever sees raw environment variable names. If it does, the stop key would need the `EnvironmentVariables` spelling too. The suite does not distinguish either way, so if that path is reachable it is currently uncovered. Happy to follow up if you can confirm.

*Open questions for reviewers:*

**Base branch.** This targets `master-v2`, since that is the line currently released as 2.257.x. `CONTRIBUTING.md` asks contributors to work against `master`, where this file lives at `sagemaker-core/src/sagemaker/core/jumpstart/hub/parser_utils.py` in the v3 layout and is byte-identical, so the same one-line change applies there. Happy to retarget this PR or open a companion one to `master`, whichever you prefer.

**Blast radius of the default change.** Adding to the *default* `stop_keys` affects every `walk_and_apply_json` call site, not only the hub deserialisation path. That seemed correct because the children of that node are always variable names rather than schema field names, and the full unit suite shows no change in behaviour. If you would rather keep it narrow, I am happy to pass `stop_keys` explicitly at the `from_describe_hub_content_response` call instead.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change. _(not applicable, no clients are initialized)_
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate) _(not applicable)_

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate) _(not applicable, unit tests only)_
- [ ] If adding any dependency in requirements.txt files, I have spell checked and ensured they exist in PyPi _(not applicable, no dependencies added)_

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
