### PR TITLE
docs: Add per-agent instruction files (Claude, Gemini, Copilot) pointing to AGENTS.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,25 @@
+# GitHub Copilot instructions — Amazon SageMaker Python SDK
+
+Guidance for [GitHub Copilot](https://docs.github.com/en/copilot) working in
+**this repository** — the source of the Amazon SageMaker Python SDK.
+
+This repository keeps its AI-agent guidance in a single source of truth,
+[`AGENTS.md`](../AGENTS.md), following the [AGENTS.md](https://agents.md) convention.
+Copilot instructions do not support file imports, so **read
+[`AGENTS.md`](../AGENTS.md) at the repository root and follow it**.
+
+Key points from that file (see `AGENTS.md` for the authoritative, complete version):
+
+- **v3 by default.** The current major version is v3 (`pip install sagemaker`). SDK v3 is a
+  modular redesign and is **not** backward compatible with v2. Generate v3 patterns in all
+  example code, docstrings, tests, and docs unless v2 is explicitly in scope.
+- **SDK-first.** Use the SageMaker Python SDK v3 as the primary interface (e.g.
+  `sagemaker.train.ModelTrainer`, `sagemaker.serve.ModelBuilder`); do not drop to raw
+  `boto3`, the AWS CLI, or hand-rolled scripts unless the SDK genuinely does not cover the
+  task.
+- **No banned v2 patterns** (e.g. `sagemaker.estimator.Estimator`, `estimator.fit(...)`,
+  framework estimator classes, `sagemaker.model.Model`) in new code. See the v2 → v3
+  mapping table in `AGENTS.md` and [`migration.md`](../migration.md).
+- **Contributing:** add/update unit tests under `tests/unit/` for code changes, run the
+  configured formatters/linters, and keep `migration.md` and docstrings consistent for
+  public API changes. See [`CONTRIBUTING.md`](../CONTRIBUTING.md).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,15 @@
+# CLAUDE.md — Amazon SageMaker Python SDK
+
+Guidance for [Claude Code](https://docs.anthropic.com/en/docs/claude-code) working in
+**this repository** — the source of the Amazon SageMaker Python SDK.
+
+This repository follows the [AGENTS.md](https://agents.md) convention. To keep a single
+source of truth and avoid the two files drifting apart, all guidance lives in
+[`AGENTS.md`](./AGENTS.md) and is imported here:
+
+@AGENTS.md
+
+For the full guidance — project context, the **v3-by-default** golden rule, banned v2
+patterns and their v3 replacements, the SDK-first interface map, the contributing
+workflow, and a canonical v3 train + deploy example — read [`AGENTS.md`](./AGENTS.md)
+directly.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,15 @@
+# GEMINI.md — Amazon SageMaker Python SDK
+
+Guidance for [Gemini CLI](https://github.com/google-gemini/gemini-cli) working in
+**this repository** — the source of the Amazon SageMaker Python SDK.
+
+This repository follows the [AGENTS.md](https://agents.md) convention. To keep a single
+source of truth and avoid the files drifting apart, all guidance lives in
+[`AGENTS.md`](./AGENTS.md) and is imported here:
+
+@AGENTS.md
+
+For the full guidance — project context, the **v3-by-default** golden rule, banned v2
+patterns and their v3 replacements, the SDK-first interface map, the contributing
+workflow, and a canonical v3 train + deploy example — read [`AGENTS.md`](./AGENTS.md)
+directly.


### PR DESCRIPTION
## Problem

The repo added [`AGENTS.md`](https://github.com/aws/sagemaker-python-sdk/blob/master/AGENTS.md) following the [agents.md](https://agents.md) open standard. Codex, Cursor, Windsurf, Aider, Zed and others read `AGENTS.md` natively, but a few popular agents look for their own root file and won't pick it up automatically:

- **Claude Code** → `CLAUDE.md`
- **Gemini CLI** → `GEMINI.md`
- **GitHub Copilot** → `.github/copilot-instructions.md`

Without these, contributors using those tools miss the v3-by-default guidance, banned v2 patterns, and SDK-first conventions the maintainers documented.

## Fix

Add thin per-agent entrypoints that route to the existing `AGENTS.md` instead of duplicating it, so `AGENTS.md` stays the **single source of truth** and the files can't drift:

- `CLAUDE.md` — imports `AGENTS.md` via Claude Code's `@import` syntax.
- `GEMINI.md` — imports `AGENTS.md` via Gemini CLI's `@import` syntax.
- `.github/copilot-instructions.md` — Copilot instructions don't support imports, so this is a short prose pointer to `AGENTS.md` with a summary of its key rules.

Tools that already read `AGENTS.md` natively (Codex, Cursor, Windsurf, Aider, Zed, …) need no new file.

## Change

- New: `CLAUDE.md`, `GEMINI.md`, `.github/copilot-instructions.md`.
- No changes to `AGENTS.md` or any source.

## Tests

N/A — documentation-only addition, no code paths affected.

## Manual verification

- Confirmed `AGENTS.md` exists at repo root; the `@AGENTS.md` imports in `CLAUDE.md`/`GEMINI.md` resolve from the same directory, and the `../AGENTS.md` link in `.github/copilot-instructions.md` resolves to the root.
- No source, test, or config files touched.

---
X-AI-Prompt: Replicate AGENTS.md for Claude, Gemini, and Copilot; raise/update PR
X-AI-Tool: Kiro
