### PR TITLE
docs(train): drop --dist loadfile from the shallow suite's README

### DIFF
--- a/sagemaker-train/tests/integ/train/shallow/README.md
+++ b/sagemaker-train/tests/integ/train/shallow/README.md
@@ -19,7 +19,7 @@ submit a job and wait for it, and this suite covers those code paths instead.
 > — which is nearly all of them — without exposing those credentials to PR code.
 >
 > **Consequence for editing this suite:** the marker selection above (`-n 8`,
-> `--dist loadfile`, `-m "not gpu_intensive and not us_east_1"`) lives in
+> `-m "not gpu_intensive and not us_east_1"`) lives in
 > `createCIShallowIntegBuildSpec` in the `SageMakerMLFPySDKInfraCDK` package, not in
 > this repo. Adding a file under `shallow/` is picked up automatically, but changing
 > *how* the suite is invoked means a change there, which deploys through a pipeline


### PR DESCRIPTION
## Issue

The shallow suite's README documents `--dist loadfile` as part of how the suite is
invoked. That flag has been removed from the CodeBuild invocation, so the README now
names a flag that no longer exists.

## Description of changes

Drops `--dist loadfile` from the list of pytest options the README says lives in
`createCIShallowIntegBuildSpec` (in the internal `SageMakerMLFPySDKInfraCDK` package).

Why the flag went away: it pins one file's tests to a single xdist worker, and each
test in this suite holds a concurrency slot until its training job reaches a terminal
state (~75s). That serialized the largest file — the 17-test RLVR file alone took
19m45s, against the CodeBuild project's 30-minute timeout, with the rest of the suite
still to run.

The flag was never needed. Job names are unique *per invocation* rather than per test
function (see `unique_name` in `harness.py`), precisely so tests can spread across
workers, and the wall-clock estimate in `harness.py` — `(#jobs * drain) / cap`, ~8-12
min at 84 jobs — assumes they do.

Documentation only. The invocation itself lives in the CDK package, so the behaviour
change ships there, not here.

## Testing done

Ran the full shallow suite under the new invocation (Python 3.10, `-n 8`, no
`--dist loadfile`) against us-west-2 in the SDK test account: **83 passed, 1 skipped
in 6m50s**. The single skip is structural — `RLAIFTrainer` takes no compute argument,
so `test_explicit_compute_is_accepted` skips itself.

No code changed in this PR, so there is nothing else to test.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
