### PR TITLE
fix(ci,train): stop integ-tests rerunning the shallow suite

### DIFF
--- a/sagemaker-train/tests/integ/train/shallow/README.md
+++ b/sagemaker-train/tests/integ/train/shallow/README.md
@@ -25,7 +25,7 @@ calls pytest directly, so the ignore does not apply to it.
 > — which is nearly all of them — without exposing those credentials to PR code.
 >
 > **Consequence for editing this suite:** the marker selection above (`-n 8`,
-> `--dist loadfile`, `-m "not gpu_intensive and not us_east_1"`) lives in
+> `-m "not gpu_intensive and not us_east_1"`) lives in
 > `createCIShallowIntegBuildSpec` in the `SageMakerMLFPySDKInfraCDK` package, not in
 > this repo. Adding a file under `shallow/` is picked up automatically, but changing
 > *how* the suite is invoked means a change there, which deploys through a pipeline

--- a/sagemaker-train/tests/integ/train/shallow/README.md
+++ b/sagemaker-train/tests/integ/train/shallow/README.md
@@ -8,6 +8,12 @@ What this suite changes about the gate is not which job runs, but what the exist
 one selects: the `gpu_intensive` marks added here deselect the deep tests that
 submit a job and wait for it, and this suite covers those code paths instead.
 
+`integ-tests` does not rerun this suite. It invokes pytest through tox over the
+whole `tests/integ` tree, which would otherwise sweep this directory in and submit
+every job here a second time on the same commit. `tox.ini` passes
+`--ignore=tests/integ/train/shallow` to keep that from happening; `fast-integ-tests`
+calls pytest directly, so the ignore does not apply to it.
+
 > **Where this runs.** The `fast-integ-tests` job in `pr-checks-master.yml` does not
 > execute this suite on the GitHub runner — it starts the CodeBuild project
 > `sagemaker-python-sdk-ci-sagemaker-train-fast-integ-tests` via

--- a/sagemaker-train/tox.ini
+++ b/sagemaker-train/tox.ini
@@ -94,7 +94,15 @@ commands =
     pip install 'torchvision==0.18.1+cpu' -f 'https://download.pytorch.org/whl/torch_stable.html'
     pip install 'dill>=0.3.9'
 
-    pytest {posargs}
+    # --ignore keeps the shallow suite out of directory sweeps like
+    # `tox -- tests/integ`, which is how the deep integ-tests CodeBuild project
+    # invokes pytest. Without it, that project reruns all ~100 shallow tests
+    # that fast-integ-tests has already run on the same commit -- duplicate
+    # CreateTrainingJob calls against the shared job quota, for no extra
+    # coverage. fast-integ-tests calls pytest directly rather than through tox,
+    # so it is unaffected. --ignore only prunes recursion, so naming the
+    # directory explicitly (`tox -- tests/integ/train/shallow`) still runs it.
+    pytest --ignore=tests/integ/train/shallow {posargs}
 deps =
     -r ../requirements/extras/test_requirements.txt
     ../sagemaker-core


### PR DESCRIPTION
## Issue

**1. The shallow (submit-then-stop) suite runs twice on every `sagemaker-train` PR.**

It lives under `tests/integ/train/shallow`, and the deep `integ-tests` CodeBuild
project invokes pytest through tox over the whole `tests/integ` tree. So the same
~100 tests run once in `fast-integ-tests` and then again inside `integ-tests`'
parallel pass, on the same commit.

Example: [run 32994923468](https://github.com/aws/sagemaker-python-sdk/actions/runs/32994923468) —
the `integ-tests (sagemaker-train)` job ran 82 shallow tests that `fast-integ-tests`
had already run.

This is not free. Each shallow test submits a real `CreateTrainingJob`, so the
duplicate pass doubles the suite's draw on the training-job quota the two projects
share — the exact contention the harness's concurrency cap exists to avoid — while
adding no coverage, since both passes select the same tests by the same marker
expression.

**2. The suite's README names a pytest flag that no longer exists.** It lists
`--dist loadfile` as part of how the suite is invoked; that flag has since been
removed from the CodeBuild invocation.

## Description of changes

**`tox.ini`** — pass `--ignore=tests/integ/train/shallow` to the pytest invocation,
and document it in the suite's README.

Three properties make `tox.ini` the right place for this:

- **The deep project goes through tox**, so it picks the ignore up from the PR's own
  checked-out source. Its buildspec is not defined in this repo, and the internal CDK
  package only defines the *staging* copy of that project — so the buildspec is not
  something a PR here can change.
- **`fast-integ-tests` does not go through tox.** It runs
  `python3.10 -m pytest tests/integ/train/shallow ...` directly, so it is unaffected
  and still runs the whole suite.
- **`--ignore` only prunes directory recursion.** It does not override an explicitly
  named path, so `tox -- tests/integ/train/shallow` still collects all 100 tests. No
  local or scheduled invocation that names the directory loses coverage.

Only the parallel pass was ever affected — the shallow tests carry no `serial` mark,
so the serial pass never collected them (0 references in that half of the log,
against 211 in the other).

**README** — drop the stale `--dist loadfile` from the list of pytest options the
README says lives in `createCIShallowIntegBuildSpec`. (Previously #6215, folded in
here as `cdcad04a` since both changes touch this README.)

Why that flag went away: it pins one file's tests to a single xdist worker, and each
test holds a concurrency slot until its training job reaches a terminal state (~75s).
That serialized the largest file — the 17-test RLVR file alone took 19m45s, against
the CodeBuild project's 30-minute timeout. It was never needed: job names are unique
*per invocation* rather than per test function (see `unique_name` in `harness.py`),
precisely so tests can spread across workers, and the wall-clock estimate in
`harness.py` assumes they do.

## Testing done

Collection against the deep project's exact selection,
`tests/integ -m "not serial and not gpu_intensive and not us_east_1"`:

| | collected | selected |
|---|---|---|
| before | 348 | 200 |
| after | 248 | 116 |

Exactly 100 collected and 84 selected drop out — the shallow suite and nothing else,
matching the 82 shallow tests observed in the `integ-tests` log above.

Also verified:

- `tox -- tests/integ/train/shallow` (explicit path) still collects all 100 tests.
- `tox --showconfig -e py310` resolves `commands` to
  `pytest --ignore=tests/integ/train/shallow`, with the added comment block stripped;
  `configparser` — which CI's pinned `tox==3.28.0` uses — parses it identically, so
  the comments cannot be mistaken for commands.
- The full shallow suite under the current invocation (Python 3.10, `-n 8`, no
  `--dist loadfile`) against us-west-2: **83 passed, 1 skipped in 6m50s**. The single
  skip is structural — `RLAIFTrainer` takes no compute argument, so
  `test_explicit_compute_is_accepted` skips itself.

One pre-existing collection error in `test_list_hyperparameters_integration.py` is a
stale local install of `sagemaker-train` in my venv, present identically before and
after this change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
