### PR TITLE
Relax protobuf upper bound for sagemaker-core

### DIFF
--- a/sagemaker-core/pyproject.toml
+++ b/sagemaker-core/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "requests>=2.20.0,<3.0.0",
     "attrs>=20.3.0",
     "packaging>=20.0",
-    "protobuf>=3.12,<7.0.0",
+    "protobuf>=3.12,<=7.35.1",
     "pandas>=1.0.0",
     "numpy>=1.9.0",
     # Dependencies migrated from sagemaker_utils


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Relax the protobuf dependency constraint for `sagemaker-core` from `<7.0.0` to `<=7.35.1`.

This allows downstream distributions using protobuf 7.35.1 to build and install `sagemaker-core`, while retaining an explicit upper bound. This is a dependency metadata-only change; no runtime code is modified.

*Testing:*

Verified in the openRuyi OBS packaging environment.
After relaxing the protobuf upper bound, sagemaker-core built successfully on both x86_64 and RISC-V using the distribution-provided protobuf 7.35.1.

This provides downstream cross-architecture build validation for protobuf 7.35.1. No runtime code changes are included in this PR.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.