### PR TITLE
fix(local): detect docker compose v2+ when version has no 'v' prefix

### DIFF
--- a/sagemaker-core/src/sagemaker/core/local/image.py
+++ b/sagemaker-core/src/sagemaker/core/local/image.py
@@ -163,7 +163,7 @@ class _SageMakerContainer(object):
             )
 
         if output:
-            match = re.search(r"v(\d+)", output.strip())
+            match = re.search(r"version\s+v?(\d+)", output.strip())
             if match and int(match.group(1)) >= 2:
                 logger.info("'Docker Compose' found using Docker CLI.")
                 compose_cmd_prefix.extend(["docker", "compose"])

--- a/sagemaker-core/src/sagemaker/core/modules/local_core/local_container.py
+++ b/sagemaker-core/src/sagemaker/core/modules/local_core/local_container.py
@@ -618,7 +618,7 @@ class _LocalContainer(BaseModel):
             )
 
         if output:
-            match = re.search(r"v(\d+)", output.strip())
+            match = re.search(r"version\s+v?(\d+)", output.strip())
             if match and int(match.group(1)) >= 2:
                 logger.info("'Docker Compose' found using Docker CLI.")
                 compose_cmd_prefix.extend(["docker", "compose"])

--- a/sagemaker-core/tests/unit/local/test_image.py
+++ b/sagemaker-core/tests/unit/local/test_image.py
@@ -401,6 +401,18 @@ class TestSageMakerContainer:
 
         assert result == ["docker", "compose"]
 
+    @patch("subprocess.check_output")
+    def test_get_compose_cmd_prefix_docker_compose_v2_no_v_prefix(self, mock_check_output):
+        """Docker Compose installed via brew reports the version without a 'v' prefix.
+
+        Regression test for https://github.com/aws/sagemaker-python-sdk/issues/4137.
+        """
+        mock_check_output.return_value = "Docker Compose version 2.22.0"
+
+        result = _SageMakerContainer._get_compose_cmd_prefix()
+
+        assert result == ["docker", "compose"]
+
     @patch("shutil.which")
     @patch("subprocess.check_output")
     def test_get_compose_cmd_prefix_docker_compose_cli(self, mock_check_output, mock_which):

--- a/sagemaker-core/tests/unit/modules/local_core/test_local_container.py
+++ b/sagemaker-core/tests/unit/modules/local_core/test_local_container.py
@@ -586,6 +586,34 @@ class TestLocalContainer:
         assert result == ["docker", "compose"]
 
     @patch("sagemaker.core.modules.local_core.local_container.subprocess.check_output")
+    def test_get_compose_cmd_prefix_docker_compose_v2_no_v_prefix(
+        self, mock_check_output, mock_session, basic_channel
+    ):
+        """Brew-installed Docker Compose reports the version without a 'v' prefix.
+
+        Regression test for https://github.com/aws/sagemaker-python-sdk/issues/4137.
+        """
+        container = _LocalContainer(
+            training_job_name="test-job",
+            instance_type="local",
+            instance_count=1,
+            image="test-image:latest",
+            container_root="/tmp/test",
+            input_data_config=[basic_channel],
+            environment={},
+            hyper_parameters={},
+            container_entrypoint=[],
+            container_arguments=[],
+            sagemaker_session=mock_session,
+        )
+
+        mock_check_output.return_value = "Docker Compose version 2.22.0"
+
+        result = container._get_compose_cmd_prefix()
+
+        assert result == ["docker", "compose"]
+
+    @patch("sagemaker.core.modules.local_core.local_container.subprocess.check_output")
     @patch("sagemaker.core.modules.local_core.local_container.shutil.which")
     def test_get_compose_cmd_prefix_docker_compose_standalone(
         self, mock_which, mock_check_output, mock_session, basic_channel

--- a/sagemaker-train/src/sagemaker/train/local/local_container.py
+++ b/sagemaker-train/src/sagemaker/train/local/local_container.py
@@ -626,7 +626,7 @@ class _LocalContainer(BaseModel):
             )
 
         if output:
-            match = re.search(r"v(\d+)", output.strip())
+            match = re.search(r"version\s+v?(\d+)", output.strip())
             if match and int(match.group(1)) >= 2:
                 logger.info("'Docker Compose' found using Docker CLI.")
                 compose_cmd_prefix.extend(["docker", "compose"])

--- a/sagemaker-train/tests/unit/train/local/test_local_container.py
+++ b/sagemaker-train/tests/unit/train/local/test_local_container.py
@@ -129,6 +129,19 @@ class TestGetComposeCmdPrefix:
         assert result == ["docker", "compose"]
 
     @patch("sagemaker.train.local.local_container.subprocess.check_output")
+    def test_get_compose_cmd_prefix_with_docker_compose_v2_no_v_prefix(
+        self, mock_check_output, _basic_channel
+    ):
+        """Brew-installed Docker Compose reports the version without a 'v' prefix.
+
+        Regression test for https://github.com/aws/sagemaker-python-sdk/issues/4137.
+        """
+        container = _make_container(_basic_channel)
+        mock_check_output.return_value = "Docker Compose version 2.22.0"
+        result = container._get_compose_cmd_prefix()
+        assert result == ["docker", "compose"]
+
+    @patch("sagemaker.train.local.local_container.subprocess.check_output")
     def test_get_compose_cmd_prefix_with_docker_compose_v5(self, mock_check_output, _basic_channel):
         """Docker Compose v5 should be accepted."""
         container = _make_container(_basic_channel)


### PR DESCRIPTION
Docker Compose installed via Homebrew reports its version without a leading 'v' (e.g. "Docker Compose version 2.22.0"). The detection regex `v(\d+)` required a literal 'v' before the digits, so `_get_compose_cmd_prefix` failed to recognize a valid Compose v2+ plugin in that case.

Change the regex to `version\s+v?(\d+)`, making the 'v' optional and anchoring to the "version" keyword so a stray number elsewhere in the output can't cause a false positive. v1 is still correctly rejected.

Applied to all three v3 copies (core local image, core modules local container, train local container) with regression tests for the no-'v'-prefix format.

Fixes #4137

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
