### PR TITLE
Add missing title and intro cell to V3 hyperparameter tuning pipeline notebook

### DIFF
--- a/v3-examples/ml-ops-examples/v3-hyperparameter-tuning-example/v3-hyperparameter-tuning-pipeline.ipynb
+++ b/v3-examples/ml-ops-examples/v3-hyperparameter-tuning-example/v3-hyperparameter-tuning-pipeline.ipynb
@@ -1,9 +1,27 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "id": "11403553",
+   "metadata": {},
+   "source": [
+    "# SageMaker V3 Hyperparameter Tuning Pipeline\n",
+    "\n",
+    "This notebook demonstrates how to use the V3 SageMaker Python SDK to create a hyperparameter tuning pipeline with PyTorch on the MNIST dataset."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8f350ed9",
+   "metadata": {},
+   "source": [
+    "## Setup and Imports"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11403553",
+   "id": "3ff4b1a1",
    "metadata": {},
    "outputs": [],
    "source": [


### PR DESCRIPTION
*Issue #, if available:* Fixes #6232

*Description of changes:* Added missing title, description, and "Setup and imports" section heading markdown cells to the V3 hyperparameter tuning pipeline notebook. The notebook previously had no title cell, causing the readthedocs navigation sidebar to display "Download Data" (the first markdown heading) as the page label instead of the notebook title.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
