### PR TITLE
fix(jumpstart): add eusc-de-east-1 buckets and name JumpStart in the bucket error

### DIFF
--- a/src/sagemaker/jumpstart/region_config.json
+++ b/src/sagemaker/jumpstart/region_config.json
@@ -119,6 +119,10 @@
         "gated_content_bucket": "jumpstart-private-cache-prod-eu-west-3",
         "neo_content_bucket": "sagemaker-sd-models-prod-eu-west-3"
     },
+    "eusc-de-east-1": {
+        "content_bucket": "jumpstart-cache-prod-eusc-de-east-1",
+        "gated_content_bucket": "jumpstart-private-cache-prod-eusc-de-east-1"
+    },
     "il-central-1": {
         "content_bucket": "jumpstart-cache-prod-il-central-1",
         "gated_content_bucket": "jumpstart-private-cache-prod-il-central-1"

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -165,7 +165,7 @@ def get_jumpstart_content_bucket(
         except KeyError:
             formatted_launched_regions_str = get_jumpstart_launched_regions_message()
             raise ValueError(
-                f"Unable to get content bucket for Neo in {region} region. "
+                f"Unable to get content bucket for JumpStart in {region} region. "
                 f"{formatted_launched_regions_str}"
             )
 

--- a/tests/unit/sagemaker/jumpstart/test_utils.py
+++ b/tests/unit/sagemaker/jumpstart/test_utils.py
@@ -74,8 +74,17 @@ class TestBucketUtils(TestCase):
     def test_get_jumpstart_content_bucket(self):
         bad_region = "bad_region"
         assert bad_region not in JUMPSTART_REGION_NAME_SET
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError,
+            match=r"^Unable to get content bucket for JumpStart in bad_region region\.",
+        ):
             utils.get_jumpstart_content_bucket(bad_region)
+
+    def test_get_jumpstart_content_bucket_eusc(self):
+        assert (
+            utils.get_jumpstart_content_bucket("eusc-de-east-1")
+            == "jumpstart-cache-prod-eusc-de-east-1"
+        )
 
     def test_get_jumpstart_content_bucket_no_args(self):
         assert (
@@ -95,6 +104,12 @@ class TestBucketUtils(TestCase):
         assert bad_region not in JUMPSTART_REGION_NAME_SET
         with pytest.raises(ValueError):
             utils.get_jumpstart_gated_content_bucket(bad_region)
+
+    def test_get_jumpstart_gated_content_bucket_eusc(self):
+        assert (
+            utils.get_jumpstart_gated_content_bucket("eusc-de-east-1")
+            == "jumpstart-private-cache-prod-eusc-de-east-1"
+        )
 
     def test_get_jumpstart_gated_content_bucket_no_args(self):
         assert (


### PR DESCRIPTION
## Problem

In `eusc-de-east-1`, the sample notebook cell `JumpStartModel(model_id="deepseek-llm-r1-distill-llama-8b", model_version="*", hub_name="SageMakerPublicHub")` fails with `ValueError: Unable to get content bucket for Neo in eusc-de-east-1 region.` The model does not use Neo.

The v2 region configuration has no `eusc-de-east-1` entry, so `get_jumpstart_content_bucket` raises for the region. Its error names Neo, a copy of the Neo accessor message. v3 got the region entry in #5615.

## Solution

Add the public and gated JumpStart buckets for `eusc-de-east-1` to the region configuration, with no Neo bucket. Name JumpStart in the `get_jumpstart_content_bucket` error. #6243 corrects the same error text in v3.

## Tests

Unit tests read the `eusc-de-east-1` public and gated buckets and match the JumpStart error text. The three tests fail on `origin/master-v2` and pass on this branch.

```text
SAGEMAKER_SUPPRESS_V2_WARNING=1 PYTHONPATH=src python -m pytest -s -vv tests/unit/sagemaker/jumpstart/test_utils.py::TestBucketUtils
```

Result: `12 passed in 1.93s`.

`integ-tests` on `master-v2` fails without this change. SageMaker rejects the `ml.t2.medium` fixture with `ValidationException: Deprecated instance type "T2"` since 2026-09-03, `test_jumpstart_gated_model` gets `InsufficientInstanceCapacity`, and the `build_jar` teardown deletes `hello-spark-java.jar` under xdist. Those tests are outside this change. The `codestyle-doc-tests` findings are in unchanged files.

## Merge Checklist

- [x] I read the contribution guide.
- [x] The change is backward compatible.
- [x] The commits use the repository commit-message format.
- [x] The change creates no S3 or STS client.
- [x] The change has regression coverage and adds no dependency.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
