### PR TITLE
fix(jumpstart): name JumpStart in the content bucket error

### DIFF
--- a/sagemaker-core/src/sagemaker/core/jumpstart/utils.py
+++ b/sagemaker-core/src/sagemaker/core/jumpstart/utils.py
@@ -204,7 +204,7 @@ def get_jumpstart_content_bucket(
         except KeyError:
             formatted_launched_regions_str = get_jumpstart_launched_regions_message()
             raise ValueError(
-                f"Unable to get content bucket for Neo in {region} region. "
+                f"Unable to get content bucket for JumpStart in {region} region. "
                 f"{formatted_launched_regions_str}"
             )
 

--- a/sagemaker-core/tests/unit/test_jumpstart_utils.py
+++ b/sagemaker-core/tests/unit/test_jumpstart_utils.py
@@ -491,7 +491,7 @@ class TestGetJumpstartContentBucket:
     def test_get_jumpstart_content_bucket_invalid_region(self):
         """Test with invalid region"""
         with patch.object(constants, "JUMPSTART_REGION_NAME_TO_LAUNCHED_REGION_DICT", {}):
-            with pytest.raises(ValueError, match="Unable to get content bucket for Neo"):
+            with pytest.raises(ValueError, match="Unable to get content bucket for JumpStart"):
                 utils.get_jumpstart_content_bucket("invalid-region")
 
 


### PR DESCRIPTION
## Problem

`get_jumpstart_content_bucket` raises `Unable to get content bucket for Neo in <region> region.` for a region without a JumpStart entry. The message is a copy of the Neo accessor error, and the function does not read Neo. In v2 this message is the user-visible failure for `deepseek-llm-r1-distill-llama-8b` in `eusc-de-east-1` (#6242).

## Solution

Name JumpStart in the `get_jumpstart_content_bucket` error. The `eusc-de-east-1` region entry (JumpStart buckets, no Neo bucket) exists in v3 since #5615 and does not change. #6242 adds that entry to v2 and corrects the same error text there.

## Tests

The unit test for an unlaunched region matches the JumpStart error text. It fails on `origin/master` and passes on this branch.

```text
cd sagemaker-core && PYTHONPATH=src python -m pytest -s -vv tests/unit/test_jumpstart_utils.py::TestGetJumpstartContentBucket tests/unit/jumpstart/test_utils_extended.py::TestGetJumpStartContentBucket
```

Result: `5 passed in 2.25s`.

The two changed files have the same flake8 and Black findings as on `origin/master` (14 flake8 findings, 2 Black files).

The four `codestyle-doc-tests` jobs and `integ-tests-us-east-1` fail on `master` without this change. `integ-tests-us-east-1` selects no test from this change and fails on account state: the CodeBuild role lacks `sqs:CreateQueue`, and `CreateCustomModel` returns `ServiceQuotaExceededException`. No `master` run since 2026-08-10 passed that job. `integ-tests (sagemaker-serve)` fails in `test_deploy_reuse_returns_existing_endpoint` on `InsufficientInstanceCapacity` for `ml.g5.4xlarge`, or on `AttributeError: 'ModelBuilder' object has no attribute '_cached_compute_requirements'` in unchanged `sagemaker-serve` code.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
