### PR TITLE
fix(jumpstart): send NextToken when Hub.list_models pages through hub contents

### DIFF
--- a/src/sagemaker/jumpstart/hub/hub.py
+++ b/src/sagemaker/jumpstart/hub/hub.py
@@ -126,6 +126,8 @@ class Hub:
 
         while first_iteration or next_token:
             first_iteration = False
+            if next_token:
+                kwargs["next_token"] = next_token
             list_hub_content_response = self._sagemaker_session.list_hub_contents(**kwargs)
             hub_model_summaries.extend(list_hub_content_response.get("HubContentSummaries", []))
             next_token = list_hub_content_response.get("NextToken")

--- a/tests/unit/sagemaker/jumpstart/hub/test_hub.py
+++ b/tests/unit/sagemaker/jumpstart/hub/test_hub.py
@@ -212,6 +212,45 @@ def test_describe_model_one_thrown_error(mock_describe_hub_content_response, sag
         )
 
 
+def test_list_models_sends_next_token_to_the_following_page(sagemaker_session):
+    pages = {
+        ("ModelReference", None): {
+            "HubContentSummaries": [{"HubContentName": "reference-a"}],
+            "NextToken": "page-2",
+        },
+        ("ModelReference", "page-2"): {"HubContentSummaries": [{"HubContentName": "reference-b"}]},
+        ("Model", None): {
+            "HubContentSummaries": [{"HubContentName": "model-a"}],
+            "NextToken": "page-2",
+        },
+        ("Model", "page-2"): {
+            "HubContentSummaries": [{"HubContentName": "model-b"}],
+            "NextToken": "page-3",
+        },
+        ("Model", "page-3"): {"HubContentSummaries": [{"HubContentName": "model-c"}]},
+    }
+
+    def list_hub_contents(**kwargs):
+        assert kwargs["hub_name"] == HUB_NAME
+        assert kwargs["max_results"] == 2
+        # Each page is served once. A second request for a page raises KeyError, not a loop.
+        return pages.pop((kwargs["hub_content_type"], kwargs.get("next_token")))
+
+    sagemaker_session.list_hub_contents = Mock(side_effect=list_hub_contents)
+    hub = Hub(hub_name=HUB_NAME, sagemaker_session=sagemaker_session)
+
+    response = hub.list_models(max_results=2)
+
+    assert [summary["HubContentName"] for summary in response["hub_content_summaries"]] == [
+        "reference-a",
+        "reference-b",
+        "model-a",
+        "model-b",
+        "model-c",
+    ]
+    assert pages == {}
+
+
 def test_create_hub_content_reference(sagemaker_session):
     hub = Hub(hub_name=HUB_NAME, sagemaker_session=sagemaker_session)
     model_name = "mock-model-one-huggingface"


### PR DESCRIPTION
## Problem

`Hub.list_models()` never returns on a hub with more than one page of contents. `Hub._list_and_paginate_models` reads `NextToken` from each `list_hub_contents` response but never sends it, so every call requests the first page and the loop never ends. On `SageMakerPublicHub` (743 models, 8 pages of 100) the call ran for 5 minutes without a result. Every 2.x release with the hub module (2.224.1 through 2.257.6) has the same loop.

## Solution

Pass the token as `next_token` on each call after the first. `Session.list_hub_contents` maps it to `NextToken`. #6263 is the same fix for v3.

## Tests

A unit test serves each page once and raises `KeyError` on a second request for the same page. The old loop fails on its second call. On `origin/master-v2` it fails with `KeyError: ('ModelReference', None)`. On this branch `tests/unit/sagemaker/jumpstart/hub/test_hub.py` passes: `10 passed`.

```text
SAGEMAKER_SUPPRESS_V2_WARNING=1 PYTHONPATH=src python -m pytest tests/unit/sagemaker/jumpstart/hub/test_hub.py
```

Live check with this branch against `SageMakerPublicHub` in `us-west-2`: `Hub.list_models(max_results=100)` returned in 2.8 s after 9 `ListHubContents` calls (1 `ModelReference`, 8 `Model`, 7 with `NextToken`). It returned 743 unique `Model` rows, each with `OriginalCreationTime`.

`black==24.3.0`, `flake8==7.1.2`, and `pydocstyle==6.1.1` pass on the two changed files.

## Merge Checklist

- [x] I read the contribution guide.
- [x] The change is backward compatible.
- [x] The commits use the repository commit-message format.
- [x] The change creates no S3 or STS client.
- [x] The change has regression coverage and adds no dependency.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
