### PR TITLE
fix(core): send NextToken when Hub.list_models pages through hub contents

### DIFF
--- a/sagemaker-core/src/sagemaker/core/jumpstart/hub/hub.py
+++ b/sagemaker-core/src/sagemaker/core/jumpstart/hub/hub.py
@@ -126,6 +126,8 @@ class Hub:
 
         while first_iteration or next_token:
             first_iteration = False
+            if next_token:
+                kwargs["next_token"] = next_token
             list_hub_content_response = self._sagemaker_session.list_hub_contents(**kwargs)
             hub_model_summaries.extend(list_hub_content_response.get("HubContentSummaries", []))
             next_token = list_hub_content_response.get("NextToken")

--- a/sagemaker-core/tests/unit/jumpstart/hub/test_hub.py
+++ b/sagemaker-core/tests/unit/jumpstart/hub/test_hub.py
@@ -1,0 +1,59 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from __future__ import absolute_import
+
+from unittest.mock import Mock
+
+from sagemaker.core.jumpstart.hub.hub import Hub
+
+HUB_NAME = "mock-hub-name"
+
+
+def test_list_models_sends_next_token_to_the_following_page():
+    pages = {
+        ("ModelReference", None): {
+            "HubContentSummaries": [{"HubContentName": "reference-a"}],
+            "NextToken": "page-2",
+        },
+        ("ModelReference", "page-2"): {"HubContentSummaries": [{"HubContentName": "reference-b"}]},
+        ("Model", None): {
+            "HubContentSummaries": [{"HubContentName": "model-a"}],
+            "NextToken": "page-2",
+        },
+        ("Model", "page-2"): {
+            "HubContentSummaries": [{"HubContentName": "model-b"}],
+            "NextToken": "page-3",
+        },
+        ("Model", "page-3"): {"HubContentSummaries": [{"HubContentName": "model-c"}]},
+    }
+
+    def list_hub_contents(**kwargs):
+        assert kwargs["hub_name"] == HUB_NAME
+        assert kwargs["max_results"] == 2
+        # Each page is served once. A second request for a page raises KeyError, not a loop.
+        return pages.pop((kwargs["hub_content_type"], kwargs.get("next_token")))
+
+    sagemaker_session = Mock(name="sagemaker_session", boto_region_name="us-east-1")
+    sagemaker_session.list_hub_contents = Mock(side_effect=list_hub_contents)
+    hub = Hub(hub_name=HUB_NAME, sagemaker_session=sagemaker_session)
+
+    response = hub.list_models(max_results=2)
+
+    assert [summary["HubContentName"] for summary in response["hub_content_summaries"]] == [
+        "reference-a",
+        "reference-b",
+        "model-a",
+        "model-b",
+        "model-c",
+    ]
+    assert pages == {}


### PR DESCRIPTION
## Problem

`Hub.list_models()` in `sagemaker-core` never returns on a hub with more than one page of contents. `Hub._list_and_paginate_models` reads `NextToken` from each `list_hub_contents` response but never sends it, so every call requests the first page and the loop never ends. On `SageMakerPublicHub` (743 models, 8 pages of 100) the call ran for 5 minutes without a result. The loop is the same in `sagemaker-core` 2.21.0 and in every v2 release with the hub module.

## Solution

Pass the token as `next_token` on each call after the first. `Session.list_hub_contents` maps it to `NextToken`. #6262 is the same fix for v2.

## Tests

A new unit test, `sagemaker-core/tests/unit/jumpstart/hub/test_hub.py`, serves each page once and raises `KeyError` on a second request for the same page. The old loop fails on its second call. On `origin/master` it fails with `KeyError: ('ModelReference', None)`. On this branch it passes: `1 passed`.

```text
cd sagemaker-core && PYTHONPATH=src python -m pytest tests/unit/jumpstart/hub/test_hub.py
```

Live check with this branch against `SageMakerPublicHub` in `us-west-2`: `Hub.list_models()` returned in 2.6 s after 9 `ListHubContents` calls (1 `ModelReference`, 8 `Model`, 7 with `NextToken`). It returned 743 unique `Model` rows, each with `OriginalCreationTime`.

`black==26.3.1` and `flake8==7.1.2` pass on the new test. `hub.py` has 14 pre-existing `pydocstyle` findings and one pre-existing `black` diff on `origin/master`. This change adds none.

## Merge Checklist

- [x] I read the contribution guide.
- [x] The change is backward compatible.
- [x] The commits use the repository commit-message format.
- [x] The change creates no S3 or STS client.
- [x] The change has regression coverage and adds no dependency.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
